### PR TITLE
Navitiaii 364

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 stats
 debug
 release
+fast
 Doc
 qtcreator-build
 ui_mainwindow.h
@@ -14,3 +15,4 @@ tags
 .ycm_extra_conf.py
 DEBIAN/
 build_package/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 stats
 debug
 release
+fast
 Doc
 qtcreator-build
 ui_mainwindow.h
@@ -16,4 +17,3 @@ DEBIAN/
 build_package/
 *.log
 source/scripts/settings_jormungandr.sh
-

--- a/source/ed/connectors/osm2nav.cpp
+++ b/source/ed/connectors/osm2nav.cpp
@@ -171,19 +171,19 @@ void Visitor::edges(){
                         e.way_idx = w.second.idx;
                         boost::add_edge(source, target, e, geo_ref.graph);
                         if(w.second.properties[CYCLE_FWD]){ // arc cyclable
-                            boost::add_edge(source + geo_ref.bike_offset, target + geo_ref.bike_offset, e, geo_ref.graph);
+                            boost::add_edge(source + geo_ref.offsets[navitia::type::Mode_e::Bike], target + geo_ref.offsets[navitia::type::Mode_e::Bike], e, geo_ref.graph);
                         }
                         if(w.second.properties[CAR_FWD]){ // arc accessible en voiture
-                            boost::add_edge(source + geo_ref.car_offset, target + geo_ref.car_offset, e, geo_ref.graph);
+                            boost::add_edge(source + geo_ref.offsets[navitia::type::Mode_e::Car], target + geo_ref.offsets[navitia::type::Mode_e::Car], e, geo_ref.graph);
                         }
                         geo_ref.ways[e.way_idx]->edges.push_back(std::make_pair(source, target));
 
                         boost::add_edge(target, source, e, geo_ref.graph);
                         if(w.second.properties[CYCLE_BWD]){ // arc cyclable
-                            boost::add_edge(target + geo_ref.bike_offset, source + geo_ref.bike_offset, e, geo_ref.graph);
+                            boost::add_edge(target + geo_ref.offsets[navitia::type::Mode_e::Bike], source + geo_ref.offsets[navitia::type::Mode_e::Bike], e, geo_ref.graph);
                         }
                         if(w.second.properties[CAR_BWD]){ // arc accessible en voiture
-                            boost::add_edge(target + geo_ref.car_offset, source + geo_ref.car_offset, e, geo_ref.graph);
+                            boost::add_edge(target + geo_ref.offsets[navitia::type::Mode_e::Car], source + geo_ref.offsets[navitia::type::Mode_e::Car], e, geo_ref.graph);
                         }
                         geo_ref.ways[e.way_idx]->edges.push_back(std::make_pair(target, source));
                         source = target;
@@ -209,9 +209,9 @@ void Visitor::build_vls_edges(){
                 edge.way_idx = geo_ref.graph[e].way_idx;
                 edge.length = 0;
                 edge.time = 120; // le temps nécessaire pour prendre le vélo
-                boost::add_edge(u + geo_ref.vls_offset, u + geo_ref.bike_offset, edge, geo_ref.graph);
+                boost::add_edge(u + geo_ref.offsets[navitia::type::Mode_e::Vls], u + geo_ref.offsets[navitia::type::Mode_e::Bike], edge, geo_ref.graph);
                 edge.time = 180; // le temps nécessaire pour déposer le vélo
-                boost::add_edge(u + geo_ref.bike_offset, u + geo_ref.vls_offset, edge, geo_ref.graph);
+                boost::add_edge(u + geo_ref.offsets[navitia::type::Mode_e::Bike], u + geo_ref.offsets[navitia::type::Mode_e::Vls], edge, geo_ref.graph);
                 ++total_vls_stations;
             }
         }

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -262,7 +262,10 @@ void Data::build_relations(navitia::type::PT_Data &data){
 
     //for(navitia::type::Network & network: data.networks){}
 
-    //for(navitia::type::Connection & connection: data.connections){}
+    for(navitia::type::StopPointConnection* connection: data.stop_point_connections) {
+        connection->departure->stop_point_connection_list.push_back(connection);
+        connection->destination->stop_point_connection_list.push_back(connection);
+    }
 
     for(navitia::type::JourneyPatternPoint* journey_pattern_point : data.journey_pattern_points){
         journey_pattern_point->journey_pattern->journey_pattern_point_list.push_back(journey_pattern_point);

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -262,11 +262,6 @@ void Data::build_relations(navitia::type::PT_Data &data){
 
     //for(navitia::type::Network & network: data.networks){}
 
-    for(navitia::type::StopPointConnection* connection: data.stop_point_connections) {
-        connection->departure->stop_point_connection_list.push_back(connection);
-        connection->destination->stop_point_connection_list.push_back(connection);
-    }
-
     for(navitia::type::JourneyPatternPoint* journey_pattern_point : data.journey_pattern_points){
         journey_pattern_point->journey_pattern->journey_pattern_point_list.push_back(journey_pattern_point);
         journey_pattern_point->stop_point->journey_pattern_point_list.push_back(journey_pattern_point);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -869,10 +869,10 @@ void EdReader::fill_graph(navitia::type::Data& data, pqxx::work& work){
                 data.geo_ref.ways[way->idx]->edges.push_back(std::make_pair(source, target));
                 boost::add_edge(source, target, e, data.geo_ref.graph);
                 if (const_it["bike"].as<bool>()){
-                    boost::add_edge(data.geo_ref.bike_offset + source, data.geo_ref.bike_offset + target, e, data.geo_ref.graph);
+                    boost::add_edge(data.geo_ref.offsets[navitia::type::Mode_e::Bike] + source, data.geo_ref.offsets[navitia::type::Mode_e::Bike] + target, e, data.geo_ref.graph);
                 }
                 if (const_it["car"].as<bool>()){
-                    boost::add_edge(data.geo_ref.car_offset + source, data.geo_ref.car_offset + target, e, data.geo_ref.graph);
+                    boost::add_edge(data.geo_ref.offsets[navitia::type::Mode_e::Car] + source, data.geo_ref.offsets[navitia::type::Mode_e::Car] + target, e, data.geo_ref.graph);
                 }
             }
         }
@@ -898,8 +898,8 @@ void EdReader::fill_graph_vls(navitia::type::Data& data, pqxx::work& work){
             navitia::georef::Edge edge;
             edge.length = 0;
             edge.way_idx = data.geo_ref.graph[e].way_idx;
-            boost::add_edge(v + data.geo_ref.vls_offset, v + data.geo_ref.bike_offset, edge, data.geo_ref.graph);
-            boost::add_edge(v + data.geo_ref.bike_offset, v + data.geo_ref.vls_offset, edge, data.geo_ref.graph);
+            boost::add_edge(v + data.geo_ref.offsets[navitia::type::Mode_e::Vls], v + data.geo_ref.offsets[navitia::type::Mode_e::Bike], edge, data.geo_ref.graph);
+            boost::add_edge(v + data.geo_ref.offsets[navitia::type::Mode_e::Bike], v + data.geo_ref.offsets[navitia::type::Mode_e::Vls], edge, data.geo_ref.graph);
         }catch(...){
             std::cout<<"Impossible de trouver le noued le plus proche à la station vls poi_id = "<<const_it["id"].as<std::string>()<<std::endl;
         }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -491,6 +491,10 @@ void EdReader::fill_stop_point_connections(nt::Data& data, pqxx::work& work){
             }
 
             data.pt_data.stop_point_connections.push_back(stop_point_connection);
+
+            //add the connection in the stop points
+            stop_point_connection->departure->stop_point_connection_list.push_back(stop_point_connection);
+            stop_point_connection->destination->stop_point_connection_list.push_back(stop_point_connection);
         }
     }
 }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -360,9 +360,11 @@ std::vector<navitia::type::idx_t> GeoRef::find_admins(const type::GeographicalCo
 }
 
 void GeoRef::init_offset(nt::idx_t value){
-    vls_offset = value;
-    bike_offset = 2 * value;
-    car_offset = 3 * value;
+    //TODO ? with something like boost::enum we could even handle loops and only define the different transport modes in the enum
+    offsets[TransportationMode::Walk] = 0;
+    offsets[TransportationMode::BSS] = value;
+    offsets[TransportationMode::Bike] = 2 * value;
+    offsets[TransportationMode::Car] = 3 * value;
 
     /// Pour la gestion du vls
     for(vertex_t v = 0; v<value; ++v){

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -318,11 +318,6 @@ void ProjectionData::init(const type::GeographicalCoord & coord, const GeoRef & 
     this->target_distance = projected.distance_to(vertex2_coord);
 }
 
-void ProjectionData::inc_vertex(const vertex_t value){
-    this->source += value;
-    this->target += value;
-}
-
 
 Path GeoRef::compute(const type::GeographicalCoord & start_coord, const type::GeographicalCoord & dest_coord) const{
     ProjectionData start(start_coord, *this, this->pl);

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -361,10 +361,10 @@ std::vector<navitia::type::idx_t> GeoRef::find_admins(const type::GeographicalCo
 
 void GeoRef::init_offset(nt::idx_t value){
     //TODO ? with something like boost::enum we could even handle loops and only define the different transport modes in the enum
-    offsets[TransportationMode::Walk] = 0;
-    offsets[TransportationMode::BSS] = value;
-    offsets[TransportationMode::Bike] = 2 * value;
-    offsets[TransportationMode::Car] = 3 * value;
+    offsets[nt::Mode_e::Walking] = 0;
+    offsets[nt::Mode_e::Vls] = value;
+    offsets[nt::Mode_e::Bike] = 2 * value;
+    offsets[nt::Mode_e::Car] = 3 * value;
 
     /// Pour la gestion du vls
     for(vertex_t v = 0; v<value; ++v){
@@ -385,13 +385,13 @@ void GeoRef::init_offset(nt::idx_t value){
 void GeoRef::build_proximity_list(){
     pl.clear(); // vider avant de reconstruire
 
-    if(this->vls_offset == 0){
+    if(this->offsets[navitia::type::Mode_e::Vls] == 0){
         BOOST_FOREACH(vertex_t u, boost::vertices(this->graph)){
             pl.add(graph[u].coord, u);
         }
     }else{
         // Ne pas construire le proximitylist avec les noeuds utilisés par les arcs pour la recherche vélo, voiture
-        for(vertex_t v = 0; v < this->vls_offset; ++v){
+        for(vertex_t v = 0; v < this->offsets[navitia::type::Mode_e::Vls]; ++v){
             pl.add(graph[v].coord, v);
         }
     }

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -14,6 +14,7 @@
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <map>
 #include "adminref.h"
+#include "utils/logger.h"
 
 
 namespace nt = navitia::type;
@@ -336,11 +337,11 @@ struct target_unique_visitor : public boost::dijkstra_visitor<> {
     const vertex_t & destination;
     const vertex_t & source;
     bool source_visited;
-    const double max_distance;
     const std::vector<float>& distances;
 
-    target_unique_visitor(const vertex_t & destination, const vertex_t & source, double max_distance, const std::vector<float>& distances) :
-        destination(destination), source(source), source_visited(false), max_distance(max_distance), distances(distances){}
+    target_unique_visitor(const vertex_t & destination, const vertex_t & source, const std::vector<float>& distances) :
+        destination(destination), source(source), source_visited(false), distances(distances){}
+
     void finish_vertex(vertex_t u, const Graph&){
         if(u == destination)
             throw DestinationFound();
@@ -348,10 +349,10 @@ struct target_unique_visitor : public boost::dijkstra_visitor<> {
             if(!source_visited) {
                 source_visited = true;
             } else {
+                auto logger = log4cplus::Logger::getInstance("worker");
+                LOG4CPLUS_ERROR(logger, "source found twice in dijkstra");
                 throw DestinationNotFound();
             }
-        } else if(distances[u] > max_distance) {
-            throw DestinationNotFound();
         }
     }
 };

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -331,7 +331,6 @@ struct DestinationNotFound{};
 // Visiteur qui lève une exception dès qu'une des cibles souhaitées est atteinte
 struct target_visitor : public boost::dijkstra_visitor<> {
     const std::vector<vertex_t> & destinations;
-    size_t cpt;
     target_visitor(const std::vector<vertex_t> & destinations) : destinations(destinations){}
     void finish_vertex(vertex_t u, const Graph&){
         if(std::find(destinations.begin(), destinations.end(), u) != destinations.end())
@@ -374,12 +373,11 @@ struct ProjectionData {
     double target_distance;
 
     ProjectionData() : found(false), source_distance(-1), target_distance(-1){}
-    /// Initialise la structure à partir d'une coordonnée et d'un graphe sur lequel on projette
+    /// Project the coordinate on the graph
     ProjectionData(const type::GeographicalCoord & coord, const GeoRef &sn, const proximitylist::ProximityList<vertex_t> &prox);
-    /// Initialise la structure à partir d'une coordonnée, d'un graphe sur lequel on projette et d'un offset qui correspond au mode de transport
+    /// Project the coordinate on the graph corresponding to the transportation mode of the offset
     ProjectionData(const type::GeographicalCoord & coord, const GeoRef &sn, type::idx_t offset, const proximitylist::ProximityList<vertex_t> &prox);
-    /// Incrémentation des noeuds suivant le mode de transport au début et à la fin : marche, vélo ou voiture
-    void inc_vertex(const vertex_t);    
+
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
         ar & source & target & projected & source_distance & target_distance & found;
     }

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -23,14 +23,6 @@ namespace nf = navitia::autocomplete;
 
 namespace navitia { namespace georef {
 
-enum class TransportationMode {
-    Walk = 0,
-    BSS, //Bike Sharing System
-    Bike,
-    Car,
-    size //add a size value not to have to specialize the enum_size_trait
-};
-
 /** Propriétés Nœud (intersection entre deux routes) */
 struct Vertex {
     nt::GeographicalCoord coord;
@@ -216,10 +208,10 @@ struct GeoRef {
         3) pour la gestion du vélo
         4) pour la gestion de la voiture
     */
-    flat_enum_map<TransportationMode, nt::idx_t> offsets;
-    nt::idx_t vls_offset;
-    nt::idx_t bike_offset;
-    nt::idx_t car_offset;
+    flat_enum_map<nt::Mode_e, nt::idx_t> offsets;
+//    nt::idx_t offsets[navitia::type::Mode_e::Vls];
+//    nt::idx_t offsets[TransportationMode::Bike];
+//    nt::idx_t offsets[TransportationMode::Car];
 
     /// Liste des alias
     std::map<std::string, std::string> alias;

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -15,12 +15,21 @@
 #include <map>
 #include "adminref.h"
 #include "utils/logger.h"
+#include "utils/flat_enum_map.h"
 
 
 namespace nt = navitia::type;
 namespace nf = navitia::autocomplete;
 
 namespace navitia { namespace georef {
+
+enum class TransportationMode {
+    Walk = 0,
+    BSS, //Bike Sharing System
+    Bike,
+    Car,
+    size //add a size value not to have to specialize the enum_size_trait
+};
 
 /** Propriétés Nœud (intersection entre deux routes) */
 struct Vertex {
@@ -160,7 +169,6 @@ struct Rect{
     }
 };
 
-
 //Forward declarations
 struct POI;
 struct POIType;
@@ -208,28 +216,29 @@ struct GeoRef {
         3) pour la gestion du vélo
         4) pour la gestion de la voiture
     */
-    nt::idx_t vls_offset; // VLS
-    nt::idx_t bike_offset; // Vélo
-    nt::idx_t car_offset; // voiture
+    flat_enum_map<TransportationMode, nt::idx_t> offsets;
+    nt::idx_t vls_offset;
+    nt::idx_t bike_offset;
+    nt::idx_t car_offset;
 
     /// Liste des alias
     std::map<std::string, std::string> alias;
     std::map<std::string, std::string> synonymes;
     int word_weight; //Pas serialisé : lu dans le fichier ini
 
-    GeoRef(): vls_offset(0), bike_offset(0), car_offset(0), word_weight(0){}
+    GeoRef(): word_weight(0){}
 
     void init_offset(nt::idx_t);
 
     template<class Archive> void save(Archive & ar, const unsigned int) const {
-        ar & ways & way_map & graph & vls_offset & bike_offset & car_offset & fl_admin & fl_way & pl & projected_stop_points & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & alias & synonymes & poi_proximity_list;
+        ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & alias & synonymes & poi_proximity_list;
     }
 
     template<class Archive> void load(Archive & ar, const unsigned int) {
         // La désérialisation d'une boost adjacency list ne vide pas le graphe
         // On avait donc une fuite de mémoire
         graph.clear();
-        ar & ways & way_map & graph & vls_offset & bike_offset & car_offset & fl_admin & fl_way & pl & projected_stop_points & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & alias & synonymes & poi_proximity_list;
+        ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & alias & synonymes & poi_proximity_list;
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()
 

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -195,8 +195,9 @@ struct GeoRef {
     /// Indexe tous les nœuds
     proximitylist::ProximityList<vertex_t> pl;
 
-    /// Pour chaque stop_point, on associe la projection sur le filaire
-    std::vector<ProjectionData> projected_stop_points;
+    /// for all stop_point, we store it's projection on each graph
+    typedef flat_enum_map<nt::Mode_e, ProjectionData> ProjectionByMode;
+    std::vector<ProjectionByMode> projected_stop_points;
 
     /// Graphe pour effectuer le calcul d'itinéraire
     Graph graph;
@@ -209,9 +210,6 @@ struct GeoRef {
         4) pour la gestion de la voiture
     */
     flat_enum_map<nt::Mode_e, nt::idx_t> offsets;
-//    nt::idx_t offsets[navitia::type::Mode_e::Vls];
-//    nt::idx_t offsets[TransportationMode::Bike];
-//    nt::idx_t offsets[TransportationMode::Car];
 
     /// Liste des alias
     std::map<std::string, std::string> alias;
@@ -264,6 +262,13 @@ struct GeoRef {
         Retourne le nombre de stop_points effectivement accrochés
     */
     int project_stop_points(const std::vector<type::StopPoint*> & stop_points);
+
+    /** project the stop point on all transportation mode
+      * return a pair with :
+      * - the projected array
+      * - a boolean corresponding to the fact that at least one projection has been found
+    */
+    std::pair<ProjectionByMode, bool> project_stop_point(const type::StopPoint* stop_point) const;
 
     /** Calcule le meilleur itinéraire entre deux listes de nœuds
      *

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -155,13 +155,13 @@ double StreetNetwork::get_distance(const ng::ProjectionData& start,
         dist[start.source] = start.source_distance;
         try {
             geo_ref.dijkstra(start.source, dist, preds,
-                             ng::target_unique_visitor(target.source, start.source, radius, dist));
+                             ng::target_unique_visitor(target.source, start.source, dist));
         } catch(ng::DestinationFound) {}
         catch(ng::DestinationNotFound) { return max; }
         dist[start.target] = start.target_distance;
         try {
-            geo_ref.dijkstra(start.source, dist, preds,
-                             ng::target_unique_visitor(target.source, start.source, radius, dist));
+            geo_ref.dijkstra(start.target, dist, preds,
+                             ng::target_unique_visitor(target.source, start.target, dist));
         } catch(ng::DestinationFound) {}
         catch(ng::DestinationNotFound) { return max; }
     }
@@ -173,13 +173,13 @@ double StreetNetwork::get_distance(const ng::ProjectionData& start,
         dist[start.source] = start.source_distance;
         try {
             geo_ref.dijkstra(start.source, dist, preds,
-                             ng::target_unique_visitor(target.target, start.source, radius, dist));
+                             ng::target_unique_visitor(target.target, start.source, dist));
         } catch(ng::DestinationFound) {}
         catch(ng::DestinationNotFound) { return max; }
         dist[start.target] = start.target_distance;
         try {
             geo_ref.dijkstra(start.target, dist, preds,
-                             ng::target_unique_visitor(target.target, start.source, radius, dist));
+                             ng::target_unique_visitor(target.target, start.target, dist));
         } catch(ng::DestinationFound) {}
         catch(ng::DestinationNotFound) { return max; }
     }

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -184,8 +184,7 @@ double StreetNetwork::get_distance(const ng::ProjectionData& start,
 
     const auto tmp_dist_target = dist[target.target] + target.target_distance;
     if(tmp_dist_target < best_dist) {
-        best_dist= tmp_dist_target;
-        idx_proj[target_idx] = target;
+        best_dist = tmp_dist_target;
     }
 
     return best_dist;
@@ -245,7 +244,7 @@ ng::Path StreetNetwork::get_direct_path() {
     //Cherche s'il y a des nœuds en commun, et retient le chemin le plus court
     size_t num_vertices = boost::num_vertices(geo_ref.graph);
 
-    double min_dist = std::numeric_limits<float>::max();
+    float min_dist = std::numeric_limits<float>::max();
     ng::vertex_t target = std::numeric_limits<size_t>::max();
     for(ng::vertex_t u = 0; u != num_vertices; ++u) {
         if((distances[u] != std::numeric_limits<float>::max()) && (distances2[u] != std::numeric_limits<float>::max())

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -184,8 +184,7 @@ double StreetNetwork::get_distance(const ng::ProjectionData& start,
 
     const auto tmp_dist_target = dist[target.target] + target.target_distance;
     if(tmp_dist_target < best_dist) {
-        best_dist= tmp_dist_target;
-        idx_proj[target_idx] = target;
+        best_dist = tmp_dist_target;
     }
 
     return best_dist;
@@ -245,7 +244,7 @@ ng::Path StreetNetwork::get_direct_path() {
     //Cherche s'il y a des nœuds en commun, et retient le chemin le plus court
     size_t num_vertices = boost::num_vertices(geo_ref.graph);
 
-    double min_dist = std::numeric_limits<float>::max();
+    float min_dist = std::numeric_limits<float>::max();
     ng::vertex_t target = std::numeric_limits<size_t>::max();
     for(ng::vertex_t u = 0; u != num_vertices; ++u){
         if((distances[u] != std::numeric_limits<float>::max()) && (distances2[u] != std::numeric_limits<float>::max())

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -17,17 +17,6 @@ void StreetNetwork::init() {
 bool StreetNetwork::departure_launched() {return departure_launch;}
 bool StreetNetwork::arrival_launched() {return arrival_launch;}
 
-type::idx_t StreetNetwork::get_offset(const type::Mode_e & mode){
-    switch(mode){
-    case type::Mode_e::Bike:
-        return geo_ref.bike_offset;
-    case type::Mode_e::Car:
-        return geo_ref.car_offset;
-    default: return 0;
-    }
-}
-
-
 std::vector<std::pair<type::idx_t, double>>
 StreetNetwork::find_nearest_stop_points(const type::GeographicalCoord& start_coord,
                                         const proximitylist::ProximityList<type::idx_t>& pl,

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -48,11 +48,11 @@ public:
     std::vector<std::pair<type::idx_t, double>> find_nearest_stop_points(
             const type::GeographicalCoord& start_coord,
             const proximitylist::ProximityList<type::idx_t>& pl,
-            double radius, bool use_second, nt::idx_t offset);
+            double radius, bool use_second, nt::Mode_e mode);
 
-    double get_distance(const type::GeographicalCoord& start_coord, const type::GeographicalCoord& target_coord,
+    double get_distance(const type::GeographicalCoord& start_coord,
                         const type::idx_t& target_idx,
-                        bool use_second, nt::idx_t offset,
+                        bool use_second, nt::Mode_e mode,
                         bool init);
 
     /// Reconstruit l'itinéraire piéton à partir de l'idx
@@ -68,7 +68,7 @@ private:
             const ng::ProjectionData& start, double radius,
             const std::vector<std::pair<type::idx_t, type::GeographicalCoord>>& elements,
             std::vector<float>& dist, std::vector<ng::vertex_t>& preds,
-            std::map<type::idx_t, ng::ProjectionData>& idx_proj, nt::idx_t offset);
+            std::map<type::idx_t, ng::ProjectionData>& idx_proj, nt::Mode_e modem);
 
     double get_distance(const ng::ProjectionData& start,
             const ng::ProjectionData& target, const type::idx_t target_idx,

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -51,10 +51,10 @@ public:
             const proximitylist::ProximityList<type::idx_t>& pl,
             double radius, bool use_second, nt::idx_t offset);
 
-    double get_distance(const type::GeographicalCoord& start_coord,
-                        const type::idx_t& target_idx, const double radius,
+    double get_distance(const type::GeographicalCoord& start_coord, const type::GeographicalCoord& target_coord,
+                        const type::idx_t& target_idx,
                         bool use_second, nt::idx_t offset,
-                        bool init=false);
+                        bool init);
 
     /// Reconstruit l'itinéraire piéton à partir de l'idx
     ng::Path get_path(type::idx_t idx, bool use_second = false);
@@ -73,7 +73,7 @@ private:
 
     double get_distance(const ng::ProjectionData& start,
             const ng::ProjectionData& target, const type::idx_t target_idx,
-            const double radius, std::vector<float>& dist,
+            std::vector<float>& dist,
             std::vector<ng::vertex_t>& preds,
             std::map<type::idx_t, ng::ProjectionData>& idx_proj, bool init);
 

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -43,7 +43,6 @@ public:
      */
     bool arrival_launched();
 
-    type::idx_t get_offset(const type::Mode_e &);
     /** Calcule quels sont les stop point atteignables en radius mètres de marche à pied
      */
     std::vector<std::pair<type::idx_t, double>> find_nearest_stop_points(

--- a/source/georef/tests/CMakeLists.txt
+++ b/source/georef/tests/CMakeLists.txt
@@ -2,11 +2,16 @@ FIND_PACKAGE(Boost 1.44 COMPONENTS unit_test_framework thread regex serializatio
 
 
 SET(GEOREF_SRC_TEST
-    georef_test.cpp
     builder.h
     builder.cpp
 )
-add_executable(georef_test ${GEOREF_SRC_TEST})
-target_link_libraries(georef_test georef utils ${Boost_LIBRARIES} log4cplus)
+add_library(georef_test_utils ${GEOREF_SRC_TEST})
 
+add_executable(georef_test georef_test.cpp)
+target_link_libraries(georef_test georef_test_utils georef utils ${Boost_LIBRARIES} log4cplus)
 ADD_TEST(georef_test ${EXECUTABLE_OUTPUT_PATH}/georef_test --report_level=no)
+
+add_executable(street_network_test street_network_test.cpp)
+target_link_libraries(street_network_test georef_test_utils georef data autocomplete utils ${Boost_LIBRARIES} log4cplus)
+ADD_TEST(street_network_test ${EXECUTABLE_OUTPUT_PATH}/street_network_test --report_level=no)
+

--- a/source/georef/tests/CMakeLists.txt
+++ b/source/georef/tests/CMakeLists.txt
@@ -1,11 +1,20 @@
+FIND_PACKAGE(Boost 1.44 COMPONENTS unit_test_framework thread regex serialization REQUIRED)
+
+
 SET(GEOREF_SRC_TEST
-    georef_test.cpp
     builder.h
     builder.cpp
 )
-add_executable(georef_test ${GEOREF_SRC_TEST})
-target_link_libraries(georef_test georef utils
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY}
-    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus)
+add_library(georef_test_utils ${GEOREF_SRC_TEST})
 
+add_executable(georef_test georef_test.cpp)
+target_link_libraries(georef_test georef_test_utils georef utils  
+	${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY}
+    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus)
 ADD_TEST(georef_test ${EXECUTABLE_OUTPUT_PATH}/georef_test --report_level=no)
+
+add_executable(street_network_test street_network_test.cpp)
+target_link_libraries(street_network_test georef_test_utils georef data autocomplete utils 
+	${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY}
+    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus)
+ADD_TEST(street_network_test ${EXECUTABLE_OUTPUT_PATH}/street_network_test --report_level=no)

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 
 #include "georef/georef.h"
+#include "type/data.h"
 #include "builder.h"
 #include"georef/street_network.h"
 
@@ -239,8 +240,14 @@ BOOST_AUTO_TEST_CASE(compute_nearest){
     pl.add(c2, 1);
     pl.build();
 
-    sn.projected_stop_points.push_back(ProjectionData(c1, sn, sn.pl));
-    sn.projected_stop_points.push_back(ProjectionData(c2, sn, sn.pl));
+    StopPoint* sp1 = new StopPoint();
+    sp1->coord = c1;
+    StopPoint* sp2 = new StopPoint();
+    sp2->coord = c2;
+    std::vector<StopPoint*> stop_points;
+    stop_points.push_back(sp1);
+    stop_points.push_back(sp2);
+    sn.project_stop_points(stop_points);
 
     GeographicalCoord o(0,0);
 
@@ -631,8 +638,14 @@ BOOST_AUTO_TEST_CASE(two_scc) {
     pl.add(c2, 1);
     pl.build();
 
-    sn.projected_stop_points.push_back(ProjectionData(c1, sn, sn.pl));
-    sn.projected_stop_points.push_back(ProjectionData(c2, sn, sn.pl));
+    StopPoint* sp1 = new StopPoint();
+    sp1->coord = c1;
+    StopPoint* sp2 = new StopPoint();
+    sp2->coord = c2;
+    std::vector<StopPoint*> stop_points;
+    stop_points.push_back(sp1);
+    stop_points.push_back(sp2);
+    sn.project_stop_points(stop_points);
 
     GeographicalCoord o(0,0);
 

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -252,15 +252,15 @@ BOOST_AUTO_TEST_CASE(compute_nearest){
     GeographicalCoord o(0,0);
 
     StreetNetwork w(sn);
-    auto res = w.find_nearest_stop_points(o, pl, 10, false,0);
+    auto res = w.find_nearest_stop_points(o, pl, 10, false, Mode_e::Walking);
     BOOST_CHECK_EQUAL(res.size(), 0);
 
-    res = w.find_nearest_stop_points(o, pl, 100, false,0);
+    res = w.find_nearest_stop_points(o, pl, 100, false, Mode_e::Walking);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].first , 0);
     BOOST_CHECK_CLOSE(res[0].second, 50, 1);
 
-    res = w.find_nearest_stop_points(o, pl, 1000, false,0);
+    res = w.find_nearest_stop_points(o, pl, 1000, false, Mode_e::Walking);
     std::sort(res.begin(), res.end());
     BOOST_CHECK_EQUAL(res.size(), 2);
     BOOST_CHECK_EQUAL(res[0].first , 0);
@@ -651,6 +651,6 @@ BOOST_AUTO_TEST_CASE(two_scc) {
 
     StreetNetwork w(sn);
 
-    auto max = w.get_distance(c1, c2, 1, false, 0, false);
+    auto max = w.get_distance(c1, 1, false, Mode_e::Walking, false);
     BOOST_CHECK_EQUAL(max, std::numeric_limits<float>::max());
 }

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -638,6 +638,6 @@ BOOST_AUTO_TEST_CASE(two_scc) {
 
     StreetNetwork w(sn);
 
-    auto max = w.get_distance(c1, 1, false, 0, false);
+    auto max = w.get_distance(c1, c2, 1, false, 0, false);
     BOOST_CHECK_EQUAL(max, std::numeric_limits<float>::max());
 }

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(idempotence) {
     type::idx_t target_idx(sp->idx);
 
     const bool use_second = false;
-    type::idx_t offset = worker.get_offset(type::Mode_e::Walking);
+    type::idx_t offset = worker.geo_ref.offsets[type::Mode_e::Walking];
 
     double distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, false);
 

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -1,0 +1,142 @@
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_street_network
+#include <boost/test/unit_test.hpp>
+#include "georef/georef.h"
+#include "builder.h"
+#include "type/data.h"
+
+//to be able to test private member.
+#define private public
+#include"georef/street_network.h"
+#undef private
+
+using namespace navitia::georef;
+using namespace navitia::streetnetwork;
+
+using namespace navitia;
+
+struct computation_results {
+    double distance; //asked distance
+    std::vector<float> distances_matrix; //distances matrix
+    std::vector<vertex_t> predecessor;
+
+    computation_results(double d, const StreetNetwork& worker) : distance(d), distances_matrix(worker.distances), predecessor(worker.predecessors) {}
+
+    bool operator ==(const computation_results& other) {
+
+        BOOST_REQUIRE_CLOSE(other.distance, distance, 0.001);
+
+        BOOST_REQUIRE_EQUAL(other.distances_matrix.size(), distances_matrix.size());
+
+        for (size_t i = 0 ; i < distances_matrix.size() ; ++i) {
+            BOOST_REQUIRE_CLOSE(other.distances_matrix.at(i), distances_matrix.at(i), 0.001);
+        }
+
+        BOOST_REQUIRE(predecessor == other.predecessor);
+
+        return true;
+    }
+};
+
+std::string get_name(int i, int j) { return std::string(i + "_" + j); }
+bool almost_equal(float a, float b) {
+    return fabs(a - b) < 0.00001;
+}
+
+/**
+  * The aim of the test is to check that the street network answer give the same answer
+  * to multiple get_distance question
+  *
+  **/
+BOOST_AUTO_TEST_CASE(idempotence) {
+    //graph creation
+    type::Data data;
+    GeoRef geo_ref;
+    GraphBuilder b(geo_ref);
+    size_t square_size(10);
+
+    //we build a dumb square graph
+    for (size_t i = 0; i < square_size ; ++i) {
+        for (size_t j = 0; j < square_size ; ++j) {
+            std::string name(get_name(i, j));
+            b(name, i, j);
+        }
+    }
+    for (size_t i = 0; i < square_size - 1; ++i) {
+        for (size_t j = 0; j < square_size - 1; ++j) {
+            std::string name(get_name(i, j));
+
+            //we add edge to the next vertex (the value is not important)
+            b.add_edge(name, get_name(i, j + 1), (i + j) * j);
+            b.add_edge(name, get_name(i + 1, j), (i + j) * i);
+        }
+    }
+
+    StreetNetwork worker(geo_ref);
+
+    //we project 2 stations
+    type::GeographicalCoord start;
+    start.set_xy(2., 2.);
+
+    type::StopPoint* sp = new type::StopPoint();
+    sp->coord.set_xy(8., 8.);
+    sp->idx = 0;
+    data.pt_data.stop_points.push_back(sp);
+    geo_ref.project_stop_points(data.pt_data.stop_points);
+
+    const ProjectionData proj = geo_ref.projected_stop_points[sp->idx];
+    BOOST_REQUIRE(proj.found); //we have to be able to project this point
+
+    geo_ref.build_proximity_list();
+
+    type::idx_t target_idx(sp->idx);
+
+    const bool use_second = false;
+    type::idx_t offset = worker.get_offset(type::Mode_e::Walking);
+
+    double distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, false);
+
+    //we have to find a way to get there
+    BOOST_REQUIRE_NE(distance, std::numeric_limits<float>::max());
+
+    std::cout << "distance " << distance
+              << " proj distance to source " << proj.source_distance
+              << " proj distance to target " << proj.target_distance
+            << " distance to source " << worker.distances[proj.source]
+                 << " distance to target " << worker.distances[proj.target] << std::endl;
+
+    // the distance matrix also has to be updated
+    BOOST_REQUIRE(almost_equal(worker.distances[proj.source] + proj.source_distance, distance) //we have to take into account the projection distance
+            || almost_equal(worker.distances[proj.target] + proj.target_distance, distance));
+
+    computation_results first_res {distance, worker};
+
+    //we ask again with the init again
+    {
+        double other_distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, false);
+
+        computation_results other_res {other_distance, worker};
+
+        //we have to find a way to get there
+        BOOST_REQUIRE_NE(other_distance, std::numeric_limits<float>::max());
+        // the distance matrix  also has to be updated
+        BOOST_REQUIRE(almost_equal(worker.distances[proj.source] + proj.source_distance, other_distance)
+                || almost_equal(worker.distances[proj.target] + proj.target_distance, other_distance));
+
+        BOOST_REQUIRE(first_res == other_res);
+    }
+
+    //we ask again without a init
+    {
+        double other_distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, true);
+
+        computation_results other_res {other_distance, worker};
+        //we have to find a way to get there
+        BOOST_CHECK_NE(other_distance, std::numeric_limits<float>::max());
+
+        BOOST_REQUIRE(almost_equal(worker.distances[proj.source] + proj.source_distance, other_distance)
+                || almost_equal(worker.distances[proj.target] + proj.target_distance, other_distance));
+
+        BOOST_CHECK(first_res == other_res);
+    }
+}

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -84,8 +84,10 @@ BOOST_AUTO_TEST_CASE(idempotence) {
     data.pt_data.stop_points.push_back(sp);
     geo_ref.project_stop_points(data.pt_data.stop_points);
 
-    const ProjectionData proj = geo_ref.projected_stop_points[sp->idx];
-    BOOST_REQUIRE(proj.found); //we have to be able to project this point
+    const GeoRef::ProjectionByMode& projections = geo_ref.projected_stop_points[sp->idx];
+    const ProjectionData proj = projections[type::Mode_e::Walking];
+
+    BOOST_REQUIRE(proj.found); //we have to be able to project this point (on the walking graph)
 
     geo_ref.build_proximity_list();
 

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -94,9 +94,8 @@ BOOST_AUTO_TEST_CASE(idempotence) {
     type::idx_t target_idx(sp->idx);
 
     const bool use_second = false;
-    type::idx_t offset = worker.geo_ref.offsets[type::Mode_e::Walking];
 
-    double distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, false);
+    double distance = worker.get_distance(start, target_idx, use_second, type::Mode_e::Walking, false);
 
     //we have to find a way to get there
     BOOST_REQUIRE_NE(distance, std::numeric_limits<float>::max());
@@ -115,7 +114,7 @@ BOOST_AUTO_TEST_CASE(idempotence) {
 
     //we ask again with the init again
     {
-        double other_distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, false);
+        double other_distance = worker.get_distance(start, target_idx, use_second, type::Mode_e::Walking, false);
 
         computation_results other_res {other_distance, worker};
 
@@ -130,7 +129,7 @@ BOOST_AUTO_TEST_CASE(idempotence) {
 
     //we ask again without a init
     {
-        double other_distance = worker.get_distance(start, sp->coord, target_idx, use_second, offset, true);
+        double other_distance = worker.get_distance(start, target_idx, use_second, type::Mode_e::Walking, true);
 
         computation_results other_res {other_distance, worker};
         //we have to find a way to get there

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -223,17 +223,17 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
     }
     switch(result.mode){
         case type::Mode_e::Bike:
-            result.offset = (*data)->geo_ref.bike_offset;
+            result.offset = (*data)->geo_ref.offsets[navitia::type::Mode_e::Bike];
             result.distance = request.bike_distance();
             result.speed = request.bike_speed();
             break;
         case type::Mode_e::Car:
-            result.offset = (*data)->geo_ref.car_offset;
+            result.offset = (*data)->geo_ref.offsets[navitia::type::Mode_e::Car];
             result.distance = request.car_distance();
             result.speed = request.car_speed();
             break;
         case type::Mode_e::Vls:
-            result.offset = (*data)->geo_ref.vls_offset;
+            result.offset = (*data)->geo_ref.offsets[navitia::type::Mode_e::Vls];
             result.distance = request.vls_distance();
             result.speed = request.vls_speed();
             break;

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -224,17 +224,17 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
     }
     switch(result.mode){
         case type::Mode_e::Bike:
-            result.offset = (*data)->geo_ref.bike_offset;
+            result.offset = (*data)->geo_ref.offsets[navitia::type::Mode_e::Bike];
             result.distance = request.bike_distance();
             result.speed = request.bike_speed();
             break;
         case type::Mode_e::Car:
-            result.offset = (*data)->geo_ref.car_offset;
+            result.offset = (*data)->geo_ref.offsets[navitia::type::Mode_e::Car];
             result.distance = request.car_distance();
             result.speed = request.car_speed();
             break;
         case type::Mode_e::Vls:
-            result.offset = (*data)->geo_ref.vls_offset;
+            result.offset = (*data)->geo_ref.offsets[navitia::type::Mode_e::Vls];
             result.distance = request.vls_distance();
             result.speed = request.vls_speed();
             break;

--- a/source/proximity_list/proximity_list.h
+++ b/source/proximity_list/proximity_list.h
@@ -48,7 +48,7 @@ struct ProximityList
     }
 
     /// Retourne tous les éléments dans un rayon de x mètres
-    std::vector< std::pair<T, GeographicalCoord> > find_within(GeographicalCoord coord, double distance ) const {
+    std::vector< std::pair<T, GeographicalCoord> > find_within(GeographicalCoord coord, double distance = 500) const {
         double distance_degree = distance / 111320;
 
         double DEG_TO_RAD = 0.0174532925199432958;
@@ -78,9 +78,9 @@ struct ProximityList
         if(temp.empty())
             throw NotFound();
         else
+
             return temp.front().first;
     }
-
 
     /** Fonction qui permet de sérialiser (aka binariser la structure de données
       *

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -77,14 +77,14 @@ void RAPTOR::foot_path(const Visitor & v, const type::Properties &required_prope
                 //On marque tous les journey_pattern points du stop point
                 for(auto jpp : stop_point->journey_pattern_point_list) {
                     type::idx_t jpp_idx = jpp->idx;
-                    if(jpp_idx != best_jpp && v.comp(best_departure, best_labels[jpp_idx]) ) {
+                    if(!b_dest.is_eligible_solution(jpp_idx) && jpp_idx != best_jpp && v.comp(best_departure, best_labels[jpp_idx]) ) {
                        best_labels[jpp_idx] = best_departure;
                        current_labels[jpp_idx] = best_departure;
                        current_boardings[jpp_idx] = data.pt_data.journey_pattern_points[best_jpp];
                        current_boarding_types[jpp_idx] = boarding_type::connection;
 
-                       if(!b_dest.add_best(v, jpp_idx, best_departure, count)
-                               && v.comp(jpp->order, Q[jpp->journey_pattern->idx])) {
+                       if(/*!b_dest.is_eligible_solution(jpp_idx)
+                               && */v.comp(jpp->order, Q[jpp->journey_pattern->idx])) {
                            Q[jpp->journey_pattern->idx] = jpp->order;
                        }
                     }
@@ -106,15 +106,15 @@ void RAPTOR::foot_path(const Visitor & v, const type::Properties &required_prope
                     if(destination->accessible(required_properties)) {
                         for(auto destination_jpp : destination->journey_pattern_point_list) {
                             type::idx_t destination_jpp_idx = destination_jpp->idx;
-                            if(best_jpp != destination_jpp_idx) {
+                            if(best_jpp != destination_jpp_idx && !b_dest.is_eligible_solution(destination_jpp_idx)) {
                                 if(v.comp(next, best_labels[destination_jpp_idx]) || next == best_labels[destination_jpp_idx]) {
                                     best_labels[destination_jpp_idx] = next;
                                     current_labels[destination_jpp_idx] = next;
                                     current_boardings[destination_jpp_idx] = data.pt_data.journey_pattern_points[best_jpp];
                                     current_boarding_types[destination_jpp_idx] = boarding_type::connection;
 
-                                    if(!b_dest.add_best(v, destination_jpp_idx, next, count)
-                                           && v.comp(destination_jpp->order, Q[destination_jpp->journey_pattern->idx])) {
+                                    if(/*!b_dest.is_eligible_solution(destination_jpp_idx)
+                                           && */v.comp(destination_jpp->order, Q[destination_jpp->journey_pattern->idx])) {
                                         Q[destination_jpp->journey_pattern->idx] = destination_jpp->order;
                                    }
                                 }
@@ -369,7 +369,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
     DateTime workingDt = visitor.worst_datetime();
     uint32_t l_zone = std::numeric_limits<uint32_t>::max();
 
-    this->foot_path(visitor, accessibilite_params.properties);
+    //this->foot_path(visitor, accessibilite_params.properties);
     while(!end && count <= max_transfers) {
         ++count;
         end = true;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -2,6 +2,7 @@
 #include "type/pb_converter.h"
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "type/datetime.h"
+#include <unordered_set>
 
 
 namespace navitia { namespace routing {
@@ -155,7 +156,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
         if(path.items.size() > 0 && path.items.back().stop_points.size() > 0) {
             auto temp = worker.get_path(path.items.back().stop_points.back(), true);
             if(temp.path_items.size() > 0) {
-                //add a junction between the routing path and the walking one if needed
+               //add a junction between the routing path and the walking one if needed
                 nt::GeographicalCoord routing_last_coord = d.pt_data.stop_points[path.items.back().stop_points.back()]->coord;
                 if (temp.coordinates.front() != routing_last_coord) {
                     temp.coordinates.push_front(routing_last_coord);
@@ -163,12 +164,11 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
 
                 pbnavitia::Section* pb_section = pb_journey->add_sections();
                 fill_street_section(destination, temp, d, pb_section, 1);
-
                 auto begin_section_time = arrival_time;
                 const auto str_begin = iso_string(begin_section_time, d);
                 pb_section->set_begin_date_time(str_begin);
                 const auto walking_time = temp.length / destination.streetnetwork_params.speed;
-                arrival_time =  arrival_time + walking_time;
+                arrival_time = arrival_time + walking_time;
                 const auto str_end = iso_string(arrival_time, d);
                 pb_section->set_end_date_time(str_end);
                 pb_section->set_duration(arrival_time - begin_section_time);
@@ -180,12 +180,11 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
         pb_journey->set_arrival_date_time(str_arrival);
         pb_journey->set_duration(arrival_time - departure_time);
     }
-    if (pb_response.journeys().size() == 0) {
+
+	if (pb_response.journeys().size() == 0) {
         fill_pb_error(pbnavitia::Error::no_solution, "no solution found for this journey",
         pb_response.mutable_error());
         pb_response.set_response_type(pbnavitia::NO_SOLUTION);
-
-        return pb_response;
     }
 
     return pb_response;
@@ -196,6 +195,10 @@ std::vector<std::pair<type::idx_t, double> >
 get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
         streetnetwork::StreetNetwork & worker, bool use_second = false){
     std::vector<std::pair<type::idx_t, double> > result;
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    LOG4CPLUS_DEBUG(logger, "calcul des stop points pour l'entry point : [" << ep.coordinates.lat()
+              << "," << ep.coordinates.lon() << "]");
+    bool init = false;
     if(ep.type == type::Type_e::StopArea){
         auto it = pt_data.stop_areas_map.find(ep.uri);
         if(it!= pt_data.stop_areas_map.end()) {
@@ -210,13 +213,55 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
         }
     }else if(ep.type == type::Type_e::Address
                 || ep.type == type::Type_e::Coord || ep.type == type::Type_e::Admin){
+        init = true;
         result = worker.find_nearest_stop_points(ep.coordinates,
                 pt_data.stop_point_proximity_list,
                 ep.streetnetwork_params.distance, use_second,
                 ep.streetnetwork_params.offset);
     }
-    //On va chercher tous les journey_pattern_points en correspondance
+    //On va chercher tous les stop_points en correspondance
     //avec ceux déjà trouvés.
+    std::vector<std::pair<type::idx_t, double> > tmp_result;
+    std::unordered_set<type::idx_t> visited_stop_points;
+    for (const auto & sp_idx_distance : result) { visited_stop_points.insert(sp_idx_distance.first); }
+
+    size_t cpt(0), cpt_all_cnx(0);
+    for(const auto & sp_idx_distance : result) {
+        const auto sp_idx = sp_idx_distance.first;
+        const auto stop_point = pt_data.stop_points[sp_idx];
+        const auto connections_idx = stop_point->get(type::Type_e::StopPointConnection, pt_data);
+
+        for(const auto connection_idx : connections_idx) {
+            const auto* connection = pt_data.stop_point_connections[connection_idx];
+            LOG4CPLUS_DEBUG(logger, "ajout de la connection proche : "
+                      << connection->departure->name << "->" << connection->destination->name);
+            cpt_all_cnx++;
+
+            const auto destination = connection->destination;
+            if (visited_stop_points.find(destination->idx) != visited_stop_points.end()) {
+                continue;
+            }
+            visited_stop_points.insert(destination->idx);
+
+            cpt++;
+            auto distance = worker.get_distance(ep.coordinates, destination->idx,
+                                        use_second, ep.streetnetwork_params.offset,
+                                        init);
+            /*
+             * On mettra ce traitement quand on aura trouvé un moyen de refaire path...
+             * if(distance == std::numeric_limits<double>::max()) {
+            //Fallback si le stop point n'est pas rattaché au filaire de voirie
+            //On recalcule une distance en pensant qu'on marche à 1.68 m/s
+                distance = connection.duration * 1.68
+            }*/
+
+            tmp_result.push_back(std::pair<type::idx_t, double>(destination->idx, distance));
+            init = true;
+        }
+    }
+    LOG4CPLUS_DEBUG(logger, "taille results : " << result.size() << " et tmp : " << tmp_result.size()
+                    << " cpt = " << cpt << " cpt_all_cnx " << cpt_all_cnx);
+    result.insert(result.end(), tmp_result.begin(), tmp_result.end());
     return result;
 }
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -218,7 +218,7 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
         result = worker.find_nearest_stop_points(ep.coordinates,
                 pt_data.stop_point_proximity_list,
                 ep.streetnetwork_params.distance, use_second,
-                ep.streetnetwork_params.offset);
+                ep.streetnetwork_params.mode);
     }
     //On va chercher tous les stop_points en correspondance
     //avec ceux déjà trouvés.
@@ -239,8 +239,8 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
             }
             visited_stop_points.insert(destination->idx);
 
-            auto distance = worker.get_distance(ep.coordinates, destination->coord, destination->idx,
-                                        use_second, ep.streetnetwork_params.offset,
+            auto distance = worker.get_distance(ep.coordinates, destination->idx,
+                                        use_second, ep.streetnetwork_params.mode,
                                         init_done);
             /*
              * On mettra ce traitement quand on aura trouvé un moyen de refaire path...

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -3,6 +3,7 @@
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "type/datetime.h"
 #include <unordered_set>
+#include <chrono>
 
 
 namespace navitia { namespace routing {
@@ -182,7 +183,7 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     LOG4CPLUS_DEBUG(logger, "calcul des stop points pour l'entry point : [" << ep.coordinates.lat()
               << "," << ep.coordinates.lon() << "]");
-    bool init = false;
+    bool init_done = false;
     if(ep.type == type::Type_e::StopArea){
         auto it = pt_data.stop_areas_map.find(ep.uri);
         if(it!= pt_data.stop_areas_map.end()) {
@@ -197,7 +198,7 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
         }
     }else if(ep.type == type::Type_e::Address
                 || ep.type == type::Type_e::Coord || ep.type == type::Type_e::Admin){
-        init = true;
+        init_done = true;
         result = worker.find_nearest_stop_points(ep.coordinates,
                 pt_data.stop_point_proximity_list,
                 ep.streetnetwork_params.distance, use_second,
@@ -209,17 +210,12 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
     std::unordered_set<type::idx_t> visited_stop_points;
     for (const auto & sp_idx_distance : result) { visited_stop_points.insert(sp_idx_distance.first); }
 
-    size_t cpt(0), cpt_all_cnx(0);
     for(const auto & sp_idx_distance : result) {
         const auto sp_idx = sp_idx_distance.first;
         const auto stop_point = pt_data.stop_points[sp_idx];
         const auto connections_idx = stop_point->get(type::Type_e::StopPointConnection, pt_data);
-
         for(const auto connection_idx : connections_idx) {
             const auto* connection = pt_data.stop_point_connections[connection_idx];
-            LOG4CPLUS_DEBUG(logger, "ajout de la connection proche : "
-                      << connection->departure->name << "->" << connection->destination->name);
-            cpt_all_cnx++;
 
             const auto destination = connection->destination;
             if (visited_stop_points.find(destination->idx) != visited_stop_points.end()) {
@@ -227,10 +223,9 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
             }
             visited_stop_points.insert(destination->idx);
 
-            cpt++;
-            auto distance = worker.get_distance(ep.coordinates, destination->idx,
+            auto distance = worker.get_distance(ep.coordinates, destination->coord, destination->idx,
                                         use_second, ep.streetnetwork_params.offset,
-                                        init);
+                                        init_done);
             /*
              * On mettra ce traitement quand on aura trouvé un moyen de refaire path...
              * if(distance == std::numeric_limits<double>::max()) {
@@ -239,12 +234,11 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
                 distance = connection.duration * 1.68
             }*/
 
-            tmp_result.push_back(std::pair<type::idx_t, double>(destination->idx, distance));
-            init = true;
+            tmp_result.push_back({destination->idx, distance});
+            init_done = true;
         }
     }
-    LOG4CPLUS_DEBUG(logger, "taille results : " << result.size() << " et tmp : " << tmp_result.size()
-                    << " cpt = " << cpt << " cpt_all_cnx " << cpt_all_cnx);
+
     result.insert(result.end(), tmp_result.begin(), tmp_result.end());
     return result;
 }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -202,7 +202,7 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
         result = worker.find_nearest_stop_points(ep.coordinates,
                 pt_data.stop_point_proximity_list,
                 ep.streetnetwork_params.distance, use_second,
-                ep.streetnetwork_params.offset);
+                ep.streetnetwork_params.mode);
     }
     //On va chercher tous les stop_points en correspondance
     //avec ceux déjà trouvés.
@@ -223,8 +223,8 @@ get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
             }
             visited_stop_points.insert(destination->idx);
 
-            auto distance = worker.get_distance(ep.coordinates, destination->coord, destination->idx,
-                                        use_second, ep.streetnetwork_params.offset,
+            auto distance = worker.get_distance(ep.coordinates, destination->idx,
+                                        use_second, ep.streetnetwork_params.mode,
                                         init_done);
             /*
              * On mettra ce traitement quand on aura trouvé un moyen de refaire path...

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -305,100 +305,101 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     b.data.geo_ref.ways[0]->edges.push_back(std::make_pair(BB, AA));
 
 // A->E
-    boost::add_edge(AA , EE, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(EE , AA, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(1,5), b.data.geo_ref.graph);
+    boost::add_edge(AA , EE, ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
+    boost::add_edge(EE , AA, ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
+    boost::add_edge(AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
+    boost::add_edge(EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[1]->edges.push_back(std::make_pair(AA, EE));
     b.data.geo_ref.ways[1]->edges.push_back(std::make_pair(EE, AA));
 
 // E->F
-    boost::add_edge(EE , FF , ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(FF , EE , ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(2,5), b.data.geo_ref.graph);
+    boost::add_edge(EE , FF , ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
+    boost::add_edge(FF , EE , ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
+    boost::add_edge(EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
+    boost::add_edge(FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[2]->edges.push_back(std::make_pair(EE , FF));
     b.data.geo_ref.ways[2]->edges.push_back(std::make_pair(FF , EE));
 
 // F->C
-    boost::add_edge(FF , CC , ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(CC , FF , ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(3,5), b.data.geo_ref.graph);
+    boost::add_edge(FF , CC , ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
+    boost::add_edge(CC , FF , ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
+    boost::add_edge(FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
+    boost::add_edge(CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[3]->edges.push_back(std::make_pair(FF , CC));
     b.data.geo_ref.ways[3]->edges.push_back(std::make_pair(CC , FF));
 
 // C->B
-    boost::add_edge(CC , BB , ng::Edge(4,5), b.data.geo_ref.graph);
-    boost::add_edge(BB , CC , ng::Edge(4,5), b.data.geo_ref.graph);
+    boost::add_edge(CC , BB , ng::Edge(4,C.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(BB , CC , ng::Edge(4,C.distance_to(B)), b.data.geo_ref.graph);
     boost::add_edge(CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(4,5), b.data.geo_ref.graph);
     boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(4,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[4]->edges.push_back(std::make_pair(CC , BB));
     b.data.geo_ref.ways[4]->edges.push_back(std::make_pair(BB , CC));
 
 // A->G
-    boost::add_edge(AA , GG , ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(GG , AA , ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(5,5), b.data.geo_ref.graph);
+    double distance_ag = A.distance_to(G) - .5;//the cost of the edge is a bit less than the distance not to get a conflict with the projection
+    boost::add_edge(AA , GG , ng::Edge(5,distance_ag), b.data.geo_ref.graph);
+    boost::add_edge(GG , AA , ng::Edge(5,distance_ag), b.data.geo_ref.graph);
+    boost::add_edge(AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(5,distance_ag), b.data.geo_ref.graph);
+    boost::add_edge(GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(5,distance_ag), b.data.geo_ref.graph);
     b.data.geo_ref.ways[5]->edges.push_back(std::make_pair(AA , GG));
     b.data.geo_ref.ways[5]->edges.push_back(std::make_pair(GG , AA));
 
 // G->H
-    boost::add_edge(GG , HH , ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(HH , GG , ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(6,5), b.data.geo_ref.graph);
+    boost::add_edge(GG , HH , ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
+    boost::add_edge(HH , GG , ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
+    boost::add_edge(GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
+    boost::add_edge(HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[6]->edges.push_back(std::make_pair(GG , HH));
     b.data.geo_ref.ways[6]->edges.push_back(std::make_pair(HH , GG));
 
 // H->I
-    boost::add_edge(HH , II , ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(II , HH , ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(7,5), b.data.geo_ref.graph);
+    boost::add_edge(HH , II , ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
+    boost::add_edge(II , HH , ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
+    boost::add_edge(HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
+    boost::add_edge(II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[7]->edges.push_back(std::make_pair(HH , II));
     b.data.geo_ref.ways[7]->edges.push_back(std::make_pair(II , HH));
 
 // I->J
-    boost::add_edge(II , JJ , ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ , II , ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(8,5), b.data.geo_ref.graph);
+    boost::add_edge(II , JJ , ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
+    boost::add_edge(JJ , II , ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
+    boost::add_edge(II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
+    boost::add_edge(JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[8]->edges.push_back(std::make_pair(II , JJ));
     b.data.geo_ref.ways[8]->edges.push_back(std::make_pair(JJ , II));
 
 // J->K
-    boost::add_edge(JJ , KK , ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(KK , JJ , ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(9,5), b.data.geo_ref.graph);
+    boost::add_edge(JJ , KK , ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
+    boost::add_edge(KK , JJ , ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
+    boost::add_edge(JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
+    boost::add_edge(KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[9]->edges.push_back(std::make_pair(JJ , KK));
     b.data.geo_ref.ways[9]->edges.push_back(std::make_pair(KK , JJ));
 
 // K->B
-    boost::add_edge(KK , BB , ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(BB , KK , ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(10,5), b.data.geo_ref.graph);
+    boost::add_edge(KK , BB , ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(BB , KK , ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[10]->edges.push_back(std::make_pair(KK , BB));
     b.data.geo_ref.ways[10]->edges.push_back(std::make_pair(BB , KK));
 
 // A->R
-    boost::add_edge(AA, RR, ng::Edge(11,10), b.data.geo_ref.graph);
-    boost::add_edge(RR, AA, ng::Edge(11,10), b.data.geo_ref.graph);
+    boost::add_edge(AA, RR, ng::Edge(11,A.distance_to(R)), b.data.geo_ref.graph);
+    boost::add_edge(RR, AA, ng::Edge(11,A.distance_to(R)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[11]->edges.push_back(std::make_pair(AA, RR));
     b.data.geo_ref.ways[11]->edges.push_back(std::make_pair(RR, AA));
 
 // B->S
-    boost::add_edge(BB, SS, ng::Edge(12,10), b.data.geo_ref.graph);
-    boost::add_edge(SS, BB, ng::Edge(12,10), b.data.geo_ref.graph);
+    boost::add_edge(BB, SS, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(SS, BB, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[12]->edges.push_back(std::make_pair(BB, SS));
     b.data.geo_ref.ways[12]->edges.push_back(std::make_pair(SS, BB));
-    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(12,5), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
 
     b.sa("stopA", A.lon(), A.lat());
     b.sa("stopR", R.lon(), R.lat());
@@ -469,7 +470,7 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     BOOST_REQUIRE_EQUAL(section.destination().address().name(), "rue ag");
     BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 10);
     BOOST_REQUIRE_EQUAL(section.street_network().mode(), pbnavitia::StreetNetworkMode::Bike);
-    BOOST_REQUIRE_EQUAL(section.street_network().length(), 30);
+    BOOST_REQUIRE_EQUAL(section.street_network().length(), 19);
     BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 6);
 
     pathitem = section.street_network().path_items(0);
@@ -485,7 +486,7 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     pathitem = section.street_network().path_items(5);
     BOOST_REQUIRE_EQUAL(pathitem.name(), "rue ag");
 
-// Voiture
+    // Car
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Car;
     origin.streetnetwork_params.offset = b.data.geo_ref.offsets[navitia::type::Mode_e::Car];
     origin.streetnetwork_params.speed = 13;
@@ -502,17 +503,17 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     section = journey.sections(0);
     BOOST_REQUIRE_EQUAL(section.type(), pbnavitia::SectionType::STREET_NETWORK);
     BOOST_REQUIRE_EQUAL(section.origin().address().name(), "rue cb");
-    BOOST_REQUIRE_EQUAL(section.destination().address().name(), "rue ae");
-    BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 8);
+    BOOST_REQUIRE_EQUAL(section.destination().address().name(), "rue fc");
+    BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 6);
     BOOST_REQUIRE_EQUAL(section.street_network().mode(), pbnavitia::StreetNetworkMode::Car);
-    BOOST_REQUIRE_EQUAL(section.street_network().length(), 20);
-    BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 4);
+    BOOST_REQUIRE_EQUAL(section.street_network().length(), 7);
+    BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 2);
+    //since R is not accessible by car, we project R in the closest edge in the car graph
+    //this edge is F-C, so this is the end of the journey (the rest of it is as the crow flies)
     pathitem = section.street_network().path_items(0);
     BOOST_REQUIRE_EQUAL(pathitem.name(), "rue cb");
     pathitem = section.street_network().path_items(1);
     BOOST_REQUIRE_EQUAL(pathitem.name(), "rue fc");
-    pathitem = section.street_network().path_items(2);
-    BOOST_REQUIRE_EQUAL(pathitem.name(), "rue ef");
 }
 
 

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
       |             /                                                                            |
       B------------------------------------------------------------------------------------------- C
       |
-     |
+      |
       |
       S
 
@@ -140,6 +140,7 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
             *) la voie MAP est : A->B
             *) la voie cyclable, voiture et MAP : S->B
             *) entre A et B que le transport en commun
+            *) entre A et R que la marche a pied
 
 
 
@@ -451,10 +452,11 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Bike;
     origin.streetnetwork_params.offset = b.data.geo_ref.bike_offset;
     origin.streetnetwork_params.speed = 13;
-    origin.streetnetwork_params.distance = S.distance_to(B) + B.distance_to(K) + J.distance_to(I) + H.distance_to(G) + G.distance_to(A) + 1;
+    double total_distance = S.distance_to(B) + B.distance_to(K) + K.distance_to(J) + J.distance_to(I) + I.distance_to(H) + H.distance_to(G) + G.distance_to(A) + A.distance_to(R) + 1;
+    origin.streetnetwork_params.distance = total_distance;
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Bike;
     destination.streetnetwork_params.offset = b.data.geo_ref.bike_offset;
-    destination.streetnetwork_params.distance = 5;
+    destination.streetnetwork_params.distance = total_distance;
     resp = make_response(raptor, origin, destination, datetimes, true, 1.38, 1000, type::AccessibiliteParams()/*false*/, forbidden, sn_worker);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -307,80 +307,80 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
 // A->E
     boost::add_edge(AA , EE, ng::Edge(1,5), b.data.geo_ref.graph);
     boost::add_edge(EE , AA, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(AA + b.data.geo_ref.car_offset, EE + b.data.geo_ref.car_offset, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(EE + b.data.geo_ref.car_offset, AA + b.data.geo_ref.car_offset, ng::Edge(1,5), b.data.geo_ref.graph);
+    boost::add_edge(AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(1,5), b.data.geo_ref.graph);
+    boost::add_edge(EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(1,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[1]->edges.push_back(std::make_pair(AA, EE));
     b.data.geo_ref.ways[1]->edges.push_back(std::make_pair(EE, AA));
 
 // E->F
     boost::add_edge(EE , FF , ng::Edge(2,5), b.data.geo_ref.graph);
     boost::add_edge(FF , EE , ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(EE + b.data.geo_ref.car_offset, FF + b.data.geo_ref.car_offset, ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(FF + b.data.geo_ref.car_offset, EE + b.data.geo_ref.car_offset, ng::Edge(2,5), b.data.geo_ref.graph);
+    boost::add_edge(EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(2,5), b.data.geo_ref.graph);
+    boost::add_edge(FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], EE + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(2,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[2]->edges.push_back(std::make_pair(EE , FF));
     b.data.geo_ref.ways[2]->edges.push_back(std::make_pair(FF , EE));
 
 // F->C
     boost::add_edge(FF , CC , ng::Edge(3,5), b.data.geo_ref.graph);
     boost::add_edge(CC , FF , ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(FF + b.data.geo_ref.car_offset, CC + b.data.geo_ref.car_offset, ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(CC + b.data.geo_ref.car_offset, FF + b.data.geo_ref.car_offset, ng::Edge(3,5), b.data.geo_ref.graph);
+    boost::add_edge(FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(3,5), b.data.geo_ref.graph);
+    boost::add_edge(CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], FF + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(3,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[3]->edges.push_back(std::make_pair(FF , CC));
     b.data.geo_ref.ways[3]->edges.push_back(std::make_pair(CC , FF));
 
 // C->B
     boost::add_edge(CC , BB , ng::Edge(4,5), b.data.geo_ref.graph);
     boost::add_edge(BB , CC , ng::Edge(4,5), b.data.geo_ref.graph);
-    boost::add_edge(CC + b.data.geo_ref.car_offset, BB + b.data.geo_ref.car_offset, ng::Edge(4,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.car_offset, CC + b.data.geo_ref.car_offset, ng::Edge(4,5), b.data.geo_ref.graph);
+    boost::add_edge(CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(4,5), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], CC + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(4,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[4]->edges.push_back(std::make_pair(CC , BB));
     b.data.geo_ref.ways[4]->edges.push_back(std::make_pair(BB , CC));
 
 // A->G
     boost::add_edge(AA , GG , ng::Edge(5,5), b.data.geo_ref.graph);
     boost::add_edge(GG , AA , ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(AA + b.data.geo_ref.bike_offset, GG + b.data.geo_ref.bike_offset, ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(GG + b.data.geo_ref.bike_offset, AA + b.data.geo_ref.bike_offset, ng::Edge(5,5), b.data.geo_ref.graph);
+    boost::add_edge(AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(5,5), b.data.geo_ref.graph);
+    boost::add_edge(GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], AA + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(5,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[5]->edges.push_back(std::make_pair(AA , GG));
     b.data.geo_ref.ways[5]->edges.push_back(std::make_pair(GG , AA));
 
 // G->H
     boost::add_edge(GG , HH , ng::Edge(6,5), b.data.geo_ref.graph);
     boost::add_edge(HH , GG , ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(GG + b.data.geo_ref.bike_offset, HH + b.data.geo_ref.bike_offset, ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(HH + b.data.geo_ref.bike_offset, GG + b.data.geo_ref.bike_offset, ng::Edge(6,5), b.data.geo_ref.graph);
+    boost::add_edge(GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(6,5), b.data.geo_ref.graph);
+    boost::add_edge(HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], GG + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(6,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[6]->edges.push_back(std::make_pair(GG , HH));
     b.data.geo_ref.ways[6]->edges.push_back(std::make_pair(HH , GG));
 
 // H->I
     boost::add_edge(HH , II , ng::Edge(7,5), b.data.geo_ref.graph);
     boost::add_edge(II , HH , ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(HH + b.data.geo_ref.bike_offset, II + b.data.geo_ref.bike_offset, ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(II + b.data.geo_ref.bike_offset, HH + b.data.geo_ref.bike_offset, ng::Edge(7,5), b.data.geo_ref.graph);
+    boost::add_edge(HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(7,5), b.data.geo_ref.graph);
+    boost::add_edge(II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], HH + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(7,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[7]->edges.push_back(std::make_pair(HH , II));
     b.data.geo_ref.ways[7]->edges.push_back(std::make_pair(II , HH));
 
 // I->J
     boost::add_edge(II , JJ , ng::Edge(8,5), b.data.geo_ref.graph);
     boost::add_edge(JJ , II , ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(II + b.data.geo_ref.bike_offset, JJ + b.data.geo_ref.bike_offset, ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ + b.data.geo_ref.bike_offset, II + b.data.geo_ref.bike_offset, ng::Edge(8,5), b.data.geo_ref.graph);
+    boost::add_edge(II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(8,5), b.data.geo_ref.graph);
+    boost::add_edge(JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], II + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(8,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[8]->edges.push_back(std::make_pair(II , JJ));
     b.data.geo_ref.ways[8]->edges.push_back(std::make_pair(JJ , II));
 
 // J->K
     boost::add_edge(JJ , KK , ng::Edge(9,5), b.data.geo_ref.graph);
     boost::add_edge(KK , JJ , ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ + b.data.geo_ref.bike_offset, KK + b.data.geo_ref.bike_offset, ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(KK + b.data.geo_ref.bike_offset, JJ + b.data.geo_ref.bike_offset, ng::Edge(9,5), b.data.geo_ref.graph);
+    boost::add_edge(JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(9,5), b.data.geo_ref.graph);
+    boost::add_edge(KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], JJ + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(9,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[9]->edges.push_back(std::make_pair(JJ , KK));
     b.data.geo_ref.ways[9]->edges.push_back(std::make_pair(KK , JJ));
 
 // K->B
     boost::add_edge(KK , BB , ng::Edge(10,5), b.data.geo_ref.graph);
     boost::add_edge(BB , KK , ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(KK + b.data.geo_ref.bike_offset, BB + b.data.geo_ref.bike_offset, ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.bike_offset, KK + b.data.geo_ref.bike_offset, ng::Edge(10,5), b.data.geo_ref.graph);
+    boost::add_edge(KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(10,5), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], KK + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(10,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[10]->edges.push_back(std::make_pair(KK , BB));
     b.data.geo_ref.ways[10]->edges.push_back(std::make_pair(BB , KK));
 
@@ -395,10 +395,10 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     boost::add_edge(SS, BB, ng::Edge(12,10), b.data.geo_ref.graph);
     b.data.geo_ref.ways[12]->edges.push_back(std::make_pair(BB, SS));
     b.data.geo_ref.ways[12]->edges.push_back(std::make_pair(SS, BB));
-    boost::add_edge(BB + b.data.geo_ref.bike_offset, SS + b.data.geo_ref.bike_offset, ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(SS + b.data.geo_ref.bike_offset, BB + b.data.geo_ref.bike_offset, ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.car_offset, SS + b.data.geo_ref.car_offset, ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(SS + b.data.geo_ref.car_offset, BB + b.data.geo_ref.car_offset, ng::Edge(12,5), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(12,5), b.data.geo_ref.graph);
+    boost::add_edge(SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Bike], ng::Edge(12,5), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(12,5), b.data.geo_ref.graph);
+    boost::add_edge(SS + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], BB + b.data.geo_ref.offsets[navitia::type::Mode_e::Car], ng::Edge(12,5), b.data.geo_ref.graph);
 
     b.sa("stopA", A.lon(), A.lat());
     b.sa("stopR", R.lon(), R.lat());
@@ -450,12 +450,12 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     BOOST_REQUIRE_EQUAL(pathitem.length(), 10);
 // vÃ©lo
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Bike;
-    origin.streetnetwork_params.offset = b.data.geo_ref.bike_offset;
+    origin.streetnetwork_params.offset = b.data.geo_ref.offsets[navitia::type::Mode_e::Bike];
     origin.streetnetwork_params.speed = 13;
     double total_distance = S.distance_to(B) + B.distance_to(K) + K.distance_to(J) + J.distance_to(I) + I.distance_to(H) + H.distance_to(G) + G.distance_to(A) + A.distance_to(R) + 1;
     origin.streetnetwork_params.distance = total_distance;
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Bike;
-    destination.streetnetwork_params.offset = b.data.geo_ref.bike_offset;
+    destination.streetnetwork_params.offset = b.data.geo_ref.offsets[navitia::type::Mode_e::Bike];
     destination.streetnetwork_params.distance = total_distance;
     resp = make_response(raptor, origin, destination, datetimes, true, 1.38, 1000, type::AccessibiliteParams()/*false*/, forbidden, sn_worker);
 
@@ -487,11 +487,11 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
 
 // Voiture
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Car;
-    origin.streetnetwork_params.offset = b.data.geo_ref.car_offset;
+    origin.streetnetwork_params.offset = b.data.geo_ref.offsets[navitia::type::Mode_e::Car];
     origin.streetnetwork_params.speed = 13;
     origin.streetnetwork_params.distance = S.distance_to(B) + B.distance_to(C) + C.distance_to(F) + F.distance_to(E) + E.distance_to(A) + 1;
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Car;
-    destination.streetnetwork_params.offset = b.data.geo_ref.car_offset;
+    destination.streetnetwork_params.offset = b.data.geo_ref.offsets[navitia::type::Mode_e::Car];
     destination.streetnetwork_params.distance = 5;
     resp = make_response(raptor, origin, destination, datetimes, true, 1.38, 1000, type::AccessibiliteParams()/*false*/, forbidden, sn_worker);
 

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -305,100 +305,101 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     b.data.geo_ref.ways[0]->edges.push_back(std::make_pair(BB, AA));
 
 // A->E
-    boost::add_edge(AA , EE, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(EE , AA, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(AA + b.data.geo_ref.car_offset, EE + b.data.geo_ref.car_offset, ng::Edge(1,5), b.data.geo_ref.graph);
-    boost::add_edge(EE + b.data.geo_ref.car_offset, AA + b.data.geo_ref.car_offset, ng::Edge(1,5), b.data.geo_ref.graph);
+    boost::add_edge(AA , EE, ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
+    boost::add_edge(EE , AA, ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
+    boost::add_edge(AA + b.data.geo_ref.car_offset, EE + b.data.geo_ref.car_offset, ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
+    boost::add_edge(EE + b.data.geo_ref.car_offset, AA + b.data.geo_ref.car_offset, ng::Edge(1,A.distance_to(E)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[1]->edges.push_back(std::make_pair(AA, EE));
     b.data.geo_ref.ways[1]->edges.push_back(std::make_pair(EE, AA));
 
 // E->F
-    boost::add_edge(EE , FF , ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(FF , EE , ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(EE + b.data.geo_ref.car_offset, FF + b.data.geo_ref.car_offset, ng::Edge(2,5), b.data.geo_ref.graph);
-    boost::add_edge(FF + b.data.geo_ref.car_offset, EE + b.data.geo_ref.car_offset, ng::Edge(2,5), b.data.geo_ref.graph);
+    boost::add_edge(EE , FF , ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
+    boost::add_edge(FF , EE , ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
+    boost::add_edge(EE + b.data.geo_ref.car_offset, FF + b.data.geo_ref.car_offset, ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
+    boost::add_edge(FF + b.data.geo_ref.car_offset, EE + b.data.geo_ref.car_offset, ng::Edge(2,E.distance_to(F)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[2]->edges.push_back(std::make_pair(EE , FF));
     b.data.geo_ref.ways[2]->edges.push_back(std::make_pair(FF , EE));
 
 // F->C
-    boost::add_edge(FF , CC , ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(CC , FF , ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(FF + b.data.geo_ref.car_offset, CC + b.data.geo_ref.car_offset, ng::Edge(3,5), b.data.geo_ref.graph);
-    boost::add_edge(CC + b.data.geo_ref.car_offset, FF + b.data.geo_ref.car_offset, ng::Edge(3,5), b.data.geo_ref.graph);
+    boost::add_edge(FF , CC , ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
+    boost::add_edge(CC , FF , ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
+    boost::add_edge(FF + b.data.geo_ref.car_offset, CC + b.data.geo_ref.car_offset, ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
+    boost::add_edge(CC + b.data.geo_ref.car_offset, FF + b.data.geo_ref.car_offset, ng::Edge(3,F.distance_to(C)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[3]->edges.push_back(std::make_pair(FF , CC));
     b.data.geo_ref.ways[3]->edges.push_back(std::make_pair(CC , FF));
 
 // C->B
-    boost::add_edge(CC , BB , ng::Edge(4,5), b.data.geo_ref.graph);
-    boost::add_edge(BB , CC , ng::Edge(4,5), b.data.geo_ref.graph);
+    boost::add_edge(CC , BB , ng::Edge(4,C.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(BB , CC , ng::Edge(4,C.distance_to(B)), b.data.geo_ref.graph);
     boost::add_edge(CC + b.data.geo_ref.car_offset, BB + b.data.geo_ref.car_offset, ng::Edge(4,5), b.data.geo_ref.graph);
     boost::add_edge(BB + b.data.geo_ref.car_offset, CC + b.data.geo_ref.car_offset, ng::Edge(4,5), b.data.geo_ref.graph);
     b.data.geo_ref.ways[4]->edges.push_back(std::make_pair(CC , BB));
     b.data.geo_ref.ways[4]->edges.push_back(std::make_pair(BB , CC));
 
 // A->G
-    boost::add_edge(AA , GG , ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(GG , AA , ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(AA + b.data.geo_ref.bike_offset, GG + b.data.geo_ref.bike_offset, ng::Edge(5,5), b.data.geo_ref.graph);
-    boost::add_edge(GG + b.data.geo_ref.bike_offset, AA + b.data.geo_ref.bike_offset, ng::Edge(5,5), b.data.geo_ref.graph);
+    double distance_ag = A.distance_to(G) - .5;//the cost of the edge is a bit less than the distance not to get a conflict with the projection
+    boost::add_edge(AA , GG , ng::Edge(5,distance_ag), b.data.geo_ref.graph);
+    boost::add_edge(GG , AA , ng::Edge(5,distance_ag), b.data.geo_ref.graph);
+    boost::add_edge(AA + b.data.geo_ref.bike_offset, GG + b.data.geo_ref.bike_offset, ng::Edge(5,distance_ag), b.data.geo_ref.graph);
+    boost::add_edge(GG + b.data.geo_ref.bike_offset, AA + b.data.geo_ref.bike_offset, ng::Edge(5,distance_ag), b.data.geo_ref.graph);
     b.data.geo_ref.ways[5]->edges.push_back(std::make_pair(AA , GG));
     b.data.geo_ref.ways[5]->edges.push_back(std::make_pair(GG , AA));
 
 // G->H
-    boost::add_edge(GG , HH , ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(HH , GG , ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(GG + b.data.geo_ref.bike_offset, HH + b.data.geo_ref.bike_offset, ng::Edge(6,5), b.data.geo_ref.graph);
-    boost::add_edge(HH + b.data.geo_ref.bike_offset, GG + b.data.geo_ref.bike_offset, ng::Edge(6,5), b.data.geo_ref.graph);
+    boost::add_edge(GG , HH , ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
+    boost::add_edge(HH , GG , ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
+    boost::add_edge(GG + b.data.geo_ref.bike_offset, HH + b.data.geo_ref.bike_offset, ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
+    boost::add_edge(HH + b.data.geo_ref.bike_offset, GG + b.data.geo_ref.bike_offset, ng::Edge(6,G.distance_to(H)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[6]->edges.push_back(std::make_pair(GG , HH));
     b.data.geo_ref.ways[6]->edges.push_back(std::make_pair(HH , GG));
 
 // H->I
-    boost::add_edge(HH , II , ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(II , HH , ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(HH + b.data.geo_ref.bike_offset, II + b.data.geo_ref.bike_offset, ng::Edge(7,5), b.data.geo_ref.graph);
-    boost::add_edge(II + b.data.geo_ref.bike_offset, HH + b.data.geo_ref.bike_offset, ng::Edge(7,5), b.data.geo_ref.graph);
+    boost::add_edge(HH , II , ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
+    boost::add_edge(II , HH , ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
+    boost::add_edge(HH + b.data.geo_ref.bike_offset, II + b.data.geo_ref.bike_offset, ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
+    boost::add_edge(II + b.data.geo_ref.bike_offset, HH + b.data.geo_ref.bike_offset, ng::Edge(7,H.distance_to(I)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[7]->edges.push_back(std::make_pair(HH , II));
     b.data.geo_ref.ways[7]->edges.push_back(std::make_pair(II , HH));
 
 // I->J
-    boost::add_edge(II , JJ , ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ , II , ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(II + b.data.geo_ref.bike_offset, JJ + b.data.geo_ref.bike_offset, ng::Edge(8,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ + b.data.geo_ref.bike_offset, II + b.data.geo_ref.bike_offset, ng::Edge(8,5), b.data.geo_ref.graph);
+    boost::add_edge(II , JJ , ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
+    boost::add_edge(JJ , II , ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
+    boost::add_edge(II + b.data.geo_ref.bike_offset, JJ + b.data.geo_ref.bike_offset, ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
+    boost::add_edge(JJ + b.data.geo_ref.bike_offset, II + b.data.geo_ref.bike_offset, ng::Edge(8,I.distance_to(J)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[8]->edges.push_back(std::make_pair(II , JJ));
     b.data.geo_ref.ways[8]->edges.push_back(std::make_pair(JJ , II));
 
 // J->K
-    boost::add_edge(JJ , KK , ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(KK , JJ , ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(JJ + b.data.geo_ref.bike_offset, KK + b.data.geo_ref.bike_offset, ng::Edge(9,5), b.data.geo_ref.graph);
-    boost::add_edge(KK + b.data.geo_ref.bike_offset, JJ + b.data.geo_ref.bike_offset, ng::Edge(9,5), b.data.geo_ref.graph);
+    boost::add_edge(JJ , KK , ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
+    boost::add_edge(KK , JJ , ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
+    boost::add_edge(JJ + b.data.geo_ref.bike_offset, KK + b.data.geo_ref.bike_offset, ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
+    boost::add_edge(KK + b.data.geo_ref.bike_offset, JJ + b.data.geo_ref.bike_offset, ng::Edge(9,J.distance_to(K)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[9]->edges.push_back(std::make_pair(JJ , KK));
     b.data.geo_ref.ways[9]->edges.push_back(std::make_pair(KK , JJ));
 
 // K->B
-    boost::add_edge(KK , BB , ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(BB , KK , ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(KK + b.data.geo_ref.bike_offset, BB + b.data.geo_ref.bike_offset, ng::Edge(10,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.bike_offset, KK + b.data.geo_ref.bike_offset, ng::Edge(10,5), b.data.geo_ref.graph);
+    boost::add_edge(KK , BB , ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(BB , KK , ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(KK + b.data.geo_ref.bike_offset, BB + b.data.geo_ref.bike_offset, ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.bike_offset, KK + b.data.geo_ref.bike_offset, ng::Edge(10,K.distance_to(B)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[10]->edges.push_back(std::make_pair(KK , BB));
     b.data.geo_ref.ways[10]->edges.push_back(std::make_pair(BB , KK));
 
 // A->R
-    boost::add_edge(AA, RR, ng::Edge(11,10), b.data.geo_ref.graph);
-    boost::add_edge(RR, AA, ng::Edge(11,10), b.data.geo_ref.graph);
+    boost::add_edge(AA, RR, ng::Edge(11,A.distance_to(R)), b.data.geo_ref.graph);
+    boost::add_edge(RR, AA, ng::Edge(11,A.distance_to(R)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[11]->edges.push_back(std::make_pair(AA, RR));
     b.data.geo_ref.ways[11]->edges.push_back(std::make_pair(RR, AA));
 
 // B->S
-    boost::add_edge(BB, SS, ng::Edge(12,10), b.data.geo_ref.graph);
-    boost::add_edge(SS, BB, ng::Edge(12,10), b.data.geo_ref.graph);
+    boost::add_edge(BB, SS, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(SS, BB, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
     b.data.geo_ref.ways[12]->edges.push_back(std::make_pair(BB, SS));
     b.data.geo_ref.ways[12]->edges.push_back(std::make_pair(SS, BB));
-    boost::add_edge(BB + b.data.geo_ref.bike_offset, SS + b.data.geo_ref.bike_offset, ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(SS + b.data.geo_ref.bike_offset, BB + b.data.geo_ref.bike_offset, ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(BB + b.data.geo_ref.car_offset, SS + b.data.geo_ref.car_offset, ng::Edge(12,5), b.data.geo_ref.graph);
-    boost::add_edge(SS + b.data.geo_ref.car_offset, BB + b.data.geo_ref.car_offset, ng::Edge(12,5), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.bike_offset, SS + b.data.geo_ref.bike_offset, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(SS + b.data.geo_ref.bike_offset, BB + b.data.geo_ref.bike_offset, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(BB + b.data.geo_ref.car_offset, SS + b.data.geo_ref.car_offset, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
+    boost::add_edge(SS + b.data.geo_ref.car_offset, BB + b.data.geo_ref.car_offset, ng::Edge(12,B.distance_to(S)), b.data.geo_ref.graph);
 
     b.sa("stopA", A.lon(), A.lat());
     b.sa("stopR", R.lon(), R.lat());
@@ -469,7 +470,7 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     BOOST_REQUIRE_EQUAL(section.destination().address().name(), "rue ag");
     BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 10);
     BOOST_REQUIRE_EQUAL(section.street_network().mode(), pbnavitia::StreetNetworkMode::Bike);
-    BOOST_REQUIRE_EQUAL(section.street_network().length(), 30);
+    BOOST_REQUIRE_EQUAL(section.street_network().length(), 19);
     BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 6);
 
     pathitem = section.street_network().path_items(0);
@@ -485,7 +486,7 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     pathitem = section.street_network().path_items(5);
     BOOST_REQUIRE_EQUAL(pathitem.name(), "rue ag");
 
-// Voiture
+    // Car
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Car;
     origin.streetnetwork_params.offset = b.data.geo_ref.car_offset;
     origin.streetnetwork_params.speed = 13;
@@ -502,17 +503,17 @@ BOOST_AUTO_TEST_CASE(journey_streetnetworkmode){
     section = journey.sections(0);
     BOOST_REQUIRE_EQUAL(section.type(), pbnavitia::SectionType::STREET_NETWORK);
     BOOST_REQUIRE_EQUAL(section.origin().address().name(), "rue cb");
-    BOOST_REQUIRE_EQUAL(section.destination().address().name(), "rue ae");
-    BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 8);
+    BOOST_REQUIRE_EQUAL(section.destination().address().name(), "rue fc");
+    BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 6);
     BOOST_REQUIRE_EQUAL(section.street_network().mode(), pbnavitia::StreetNetworkMode::Car);
-    BOOST_REQUIRE_EQUAL(section.street_network().length(), 20);
-    BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 4);
+    BOOST_REQUIRE_EQUAL(section.street_network().length(), 7);
+    BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 2);
+    //since R is not accessible by car, we project R in the closest edge in the car graph
+    //this edge is F-C, so this is the end of the journey (the rest of it is as the crow flies)
     pathitem = section.street_network().path_items(0);
     BOOST_REQUIRE_EQUAL(pathitem.name(), "rue cb");
     pathitem = section.street_network().path_items(1);
     BOOST_REQUIRE_EQUAL(pathitem.name(), "rue fc");
-    pathitem = section.street_network().path_items(2);
-    BOOST_REQUIRE_EQUAL(pathitem.name(), "rue ef");
 }
 
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -371,11 +371,8 @@ std::vector<idx_t> StopPoint::get(Type_e type, const PT_Data & data) const {
     case Type_e::JourneyPatternPoint: return indexes(journey_pattern_point_list); break;
     case Type_e::Connection:
     case Type_e::StopPointConnection:
-        for(const StopPointConnection* conn : data.stop_point_connections) {
-            if(conn->departure->idx == this->idx || conn->destination->idx == this->idx) {
-                result.push_back(conn->idx);
-            }
-        }
+        for (const StopPointConnection* stop_cnx : stop_point_connection_list)
+            result.push_back(stop_cnx->idx);
             break;
     default: break;
     }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -373,7 +373,7 @@ std::vector<idx_t> StopPoint::get(Type_e type, const PT_Data & data) const {
     case Type_e::StopPointConnection:
         for (const StopPointConnection* stop_cnx : stop_point_connection_list)
             result.push_back(stop_cnx->idx);
-            break;
+        break;
     default: break;
     }
     return result;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -16,6 +16,7 @@
 #include <boost/geometry/geometries/polygon.hpp>
 
 #include "datetime.h"
+#include "utils/flat_enum_map.h"
 
 namespace mpl = boost::mpl;
 namespace navitia { namespace georef {
@@ -79,6 +80,7 @@ enum class Mode_e{
     Bike = 1,       // Vélo
     Car = 2,        // Voiture
     Vls = 3         // Vls
+    //Note: if a new transportation mode is added, don't forget to update the associated enum_size_trait<type::Mode_e>
 };
 
 struct PT_Data;
@@ -859,7 +861,16 @@ struct EntryPoint {
     EntryPoint() : type(Type_e::Unknown), house_number(-1) {}
 };
 
-} } //namespace navitia::type
+} //namespace navitia::type
+
+//trait to access the number of elements in the Mode_e enum
+template <>
+struct enum_size_trait<type::Mode_e> {
+    static constexpr typename get_enum_type<type::Mode_e>::type size() {
+        return 4;
+    }
+};
+} //namespace navitia
 
 
 // Adaptateurs permettant d'utiliser boost::geometry avec les geographical coord

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -641,18 +641,18 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages{
     std::vector<navitia::georef::Admin*> admin_list;
     Network* network;
     std::vector<JourneyPatternPoint*> journey_pattern_point_list;
+    std::vector<StopPointConnection*> stop_point_connection_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         journey_pattern_point_list.resize(0);
         ar & uri & name & stop_area & coord & fare_zone & idx
-            & journey_pattern_point_list & admin_list & _properties & messages;
+            & journey_pattern_point_list & admin_list & _properties & messages & stop_point_connection_list;
     }
 
     StopPoint(): fare_zone(0),  stop_area(nullptr), network(nullptr) {}
 
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
     bool operator<(const StopPoint & other) const { return this < &other; }
-
 
 };
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -266,17 +266,17 @@ struct GeographicalCoord{
     void set_lat(double lat) { this->_lat = lat;}
     void set_xy(double x, double y){this->set_lon(x*M_TO_DEG); this->set_lat(y*M_TO_DEG);}
 
+    constexpr static double coord_epsilon = 1e-15;
     /// Ordre des coordonnées utilisé par ProximityList
     bool operator<(GeographicalCoord other) const {
-        if ( fabs(lon() - other.lon()) > std::numeric_limits<double>::epsilon() )
+        if ( fabs(lon() - other.lon()) > coord_epsilon )
             return lon() < other.lon();
         return lat() < other.lat();
     }
     bool operator != (GeographicalCoord other) const {
-        return fabs(lon() - other.lon()) > std::numeric_limits<double>::epsilon()
-                || fabs(lat() - other.lat()) > std::numeric_limits<double>::epsilon() ;
+        return fabs(lon() - other.lon()) > coord_epsilon
+                || fabs(lat() - other.lat()) > coord_epsilon ;
     }
-
 
     constexpr static double DEG_TO_RAD = 0.01745329238;
     constexpr static double M_TO_DEG = 1.0/111319.9;


### PR DESCRIPTION
reopening of the connections modifications.

The patch with the search from additional stop points (by reaching the connections) was very slow.

It was due to several problems but mostly it was because some points were not reached by the dijkstra (they were not connected to the graph)

the changes are:
- all projections are done on the right graph (one graph by transportation mode)
- cache of the connections by stop points
- storage of the stop point projections for each graph
- misc corrections in the get distances
- small refactoring of the offset (they are now stored in a flat_enum_array, to be accessible with an Mode_e enum value)
