### PR TITLE
Switch directions navitia 256

### DIFF
--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -227,7 +227,7 @@ int compute_directions(const navitia::georef::Path& path, const nt::Geographical
     //conversion into angle
     raw_angle *= 360 / (2 * boost::math::constants::pi<double>());
 
-    int rounded_angle = static_cast<int>(raw_angle);
+    int rounded_angle = std::round(raw_angle);
 
     rounded_angle = 180 - rounded_angle;
     if ( det < 0 )
@@ -288,7 +288,7 @@ Path GeoRef::build_path(std::vector<vertex_t> reverse_path, bool add_one_elt) co
         p.duration += edge.duration;
         if (path_item_changed) {
             //we update the last path item
-            p.path_items.back().angle = compute_directions(p, coord);
+            path_item.angle = compute_directions(p, coord);
         }
     }
     //in some case we want to add even if we have only one vertex (which means there is no valid edge)

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -56,8 +56,8 @@ Path StreetNetwork::get_path(type::idx_t idx, bool use_second) {
         }
 
         if (! result.path_items.empty()) {
-            //no direction for the last elt
-            result.path_items.back().angle = 0;
+            //no direction for the first elt
+            result.path_items.front().angle = 0;
             result.path_items.back().coordinates.push_back(arrival_path_finder.starting_edge.projected);
         }
     }
@@ -90,7 +90,7 @@ Path StreetNetwork::get_direct_path() {
     departure_path_finder.add_projections_to_path(result, true);
     arrival_path_finder.add_projections_to_path(result, false);
 
-    result.path_items.back().angle = 0;
+    result.path_items.front().angle = 0;
 
     return result;
 }

--- a/source/georef/tests/CMakeLists.txt
+++ b/source/georef/tests/CMakeLists.txt
@@ -6,12 +6,12 @@ add_library(georef_test_utils ${GEOREF_SRC_TEST})
 
 add_executable(georef_test georef_test.cpp)
 target_link_libraries(georef_test georef_test_utils georef utils
-	${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY}
+        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY}
     ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus)
 ADD_TEST(georef_test ${EXECUTABLE_OUTPUT_PATH}/georef_test --report_level=no)
 
 add_executable(street_network_test street_network_test.cpp)
 target_link_libraries(street_network_test georef_test_utils georef data autocomplete utils
-	${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY}
+        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY}
     ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus)
 ADD_TEST(street_network_test ${EXECUTABLE_OUTPUT_PATH}/street_network_test --report_level=no)

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -810,7 +810,7 @@ BOOST_AUTO_TEST_CASE(angle_computation_2) {
 
     int angle = compute_directions(p, {-1, 4});
 
-    BOOST_CHECK_CLOSE(1.0 * angle, 112 - 180, 1);
+    BOOST_CHECK_EQUAL(1.0 * angle, 113 - 180);
 }
 
 

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -544,15 +544,19 @@ BOOST_FIXTURE_TEST_CASE(biking, streetnetworkmode_fixture) {
 
     auto pathitem = section.street_network().path_items(0);
     BOOST_CHECK_EQUAL(pathitem.name(), "rue bs");
+    BOOST_CHECK_EQUAL(pathitem.direction(), 0); //first direction is always 0°
     pathitem = section.street_network().path_items(1);
-    BOOST_CHECK_EQUAL(pathitem.name(), "rue kb");
-    BOOST_CHECK_EQUAL(pathitem.direction(), 90); //one random direction check to ensure it has been computed
+    BOOST_CHECK_EQUAL(pathitem.name(), "rue kb"); //after that we went strait so still 0°
+    BOOST_CHECK_EQUAL(pathitem.direction(), 0);
     pathitem = section.street_network().path_items(2);
     BOOST_CHECK_EQUAL(pathitem.name(), "rue jk");
+    BOOST_CHECK_EQUAL(pathitem.direction(), 90); //then we turned right
     pathitem = section.street_network().path_items(3);
     BOOST_CHECK_EQUAL(pathitem.name(), "rue ij");
+    BOOST_CHECK_EQUAL(pathitem.direction(), 90); //then we turned right
     pathitem = section.street_network().path_items(4);
     BOOST_CHECK_EQUAL(pathitem.name(), "rue hi");
+    BOOST_CHECK_EQUAL(pathitem.direction(), -90); //then we turned left
     pathitem = section.street_network().path_items(5);
     BOOST_CHECK_EQUAL(pathitem.name(), "rue gh");
     pathitem = section.street_network().path_items(6);

--- a/source/third_party/RTree/RTree.h
+++ b/source/third_party/RTree/RTree.h
@@ -12,12 +12,6 @@
 #include <algorithm>
 
 #define ASSERT assert // RTree uses ASSERT( condition )
-#ifndef Min
-  #define Min std::min
-#endif //Min
-#ifndef Max
-  #define Max std::max
-#endif //Max
 
 //
 // RTree.h
@@ -1096,8 +1090,8 @@ typename RTREE_QUAL::Rect RTREE_QUAL::CombineRect(const Rect* a_rectA, const Rec
 
   for(int index = 0; index < NUMDIMS; ++index)
   {
-    newRect.m_min[index] = Min(a_rectA->m_min[index], a_rectB->m_min[index]);
-    newRect.m_max[index] = Max(a_rectA->m_max[index], a_rectB->m_max[index]);
+    newRect.m_min[index] = std::min(a_rectA->m_min[index], a_rectB->m_min[index]);
+    newRect.m_max[index] = std::max(a_rectA->m_max[index], a_rectB->m_max[index]);
   }
 
   return newRect;


### PR DESCRIPTION
http://jira.canaltp.fr/browse/NAVITIAII-546

instead of computing the next direction for a path item, now we compute the direction that have been taken to
come to the path item

we still need to compute direction for projections
