### PR TITLE
Tyr: add validaton of email on user creation

### DIFF
--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -18,7 +18,11 @@ celery==3.1.7
 configobj==4.7.2
 itsdangerous==0.23
 kombu==3.0.8
+protobuf==2.5.0
+psycopg2==2.5.2
+pydns==2.3.6
 pytz==2013.9
 redis==2.9.0
 six==1.5.2
+validate-email==1.1
 wsgiref==0.1.2

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -61,4 +61,10 @@ CELERYBEAT_SCHEDULE = {
 CELERY_TIMEZONE = 'UTC'
 
 #http://docs.celeryproject.org/en/master/configuration.html#std:setting-CELERYBEAT_SCHEDULE_FILENAME
-CELERYBEAT_SCHEDULE_FILENAME='/tmp/celerybeat-schedule'
+CELERYBEAT_SCHEDULE_FILENAME = '/tmp/celerybeat-schedule'
+
+#Validate the presence of a mx record on the domain
+EMAIL_CHECK_MX = True
+
+#Validate the email by connecting to the smtp server, but doesn't send an email
+EMAIL_CHECK_SMTP = True

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1,9 +1,10 @@
 #coding: utf-8
 
-from flask import abort
+from flask import abort, current_app
 import flask_restful
 from flask_restful import fields, marshal_with, marshal, reqparse, types
 import sqlalchemy
+from validate_email import validate_email
 
 import logging
 
@@ -78,6 +79,12 @@ class User(flask_restful.Resource):
         parser.add_argument('email', type=unicode, required=True,
                 case_sensitive=False, help='email is required')
         args = parser.parse_args()
+
+        if not validate_email(args['email'],
+                          check_mx=current_app.config['EMAIL_CHECK_MX'],
+                          verify=current_app.config['EMAIL_CHECK_SMTP']):
+            return ({'error': 'email invalid'}, 400)
+
         try:
             user = models.User(login=args['login'], email=args['email'])
             db.session.add(user)
@@ -95,6 +102,12 @@ class User(flask_restful.Resource):
         parser.add_argument('email', type=unicode, required=True,
                 case_sensitive=False, help='email is required')
         args = parser.parse_args()
+
+        if not validate_email(args['email'],
+                          check_mx=current_app.config['EMAIL_CHECK_MX'],
+                          verify=current_app.config['EMAIL_CHECK_SMTP']):
+            return ({'error': 'email invalid'}, 400)
+
         try:
             user.email = args['email']
             db.session.commit()


### PR DESCRIPTION
it use the python package validate_email who check the format and
optionaly check the MX record of the DNS and can connect to the SMTP
server for check the user existance.

Two parameters are added in settings for managing these capabilities.
