### PR TITLE
Misc: add a small API for monitoring kraken without a full jormungandr

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -85,3 +85,13 @@ Section: devel
 Priority: optional
 Description: Navitia-connector-at
     This service connects to alerte trafic database, reads it and sends to rabbit mq messages
+
+Package: navitia-monitor-kraken
+Architecture: all
+Maintainer: Alexandre Jacquin <alexandre.jacquin@canaltp.fr>
+Depends: python-flask, python-protobuf, python-zmq
+Section: devel
+Priority: optional
+Description: small api for monitor kraken instances
+    small api for monitor kraken instances
+

--- a/debian/control
+++ b/debian/control
@@ -93,5 +93,5 @@ Depends: python-flask, python-protobuf, python-zmq
 Section: devel
 Priority: optional
 Description: small api for monitor kraken instances
-    small api for monitor kraken instances
+    small api for monitoring kraken instances
 

--- a/debian/navitia-monitor-kraken.install
+++ b/debian/navitia-monitor-kraken.install
@@ -1,0 +1,1 @@
+usr/lib/python*/dist-packages/monitor_kraken

--- a/debian/rules
+++ b/debian/rules
@@ -14,6 +14,7 @@ override_dh_auto_build:
 	cd source/jormungandr && python2.7 setup.py build
 	cd source/navitiacommon && python2.7 setup.py build
 	cd source/connectors && python2.7 setup.py build
+	cd source/monitor && python2.7 setup.py build
 
 override_dh_auto_install:
 	dh_auto_install
@@ -22,6 +23,7 @@ override_dh_auto_install:
 	cd source/navitiacommon && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
 	cd source/jormungandr && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
 	cd source/connectors && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
+	cd source/monitor && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -9,7 +9,7 @@ from monitor_kraken import response_pb2
 from monitor_kraken import type_pb2
 
 app = Flask(__name__)
-app.config.from_object('default_settings')
+app.config.from_object('monitor_kraken.default_settings')
 app.config.from_envvar('MONITOR_CONFIG_FILE', silent=True)
 context = zmq.Context()
 
@@ -20,9 +20,8 @@ def monitor():
 
     instance = request.args['instance']
     config_file = '{path}/{instance}/kraken.ini'.format(
-                                            path=app.config['INSTANCE_DIR'],
+                                            path=app.config['KRAKEN_DIR'],
                                             instance=instance)
-    print config_file
     parser = ConfigParser()
     parser.read(config_file)
     try:

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -1,0 +1,72 @@
+from flask import Flask, request
+import json
+import datetime
+from ConfigParser import ConfigParser
+import zmq
+
+from monitor_kraken import request_pb2
+from monitor_kraken import response_pb2
+from monitor_kraken import type_pb2
+
+app = Flask(__name__)
+app.config.from_object('default_settings')
+app.config.from_envvar('MONITOR_CONFIG_FILE', silent=True)
+context = zmq.Context()
+
+@app.route('/')
+def monitor():
+    if 'instance' not in request.args:
+        return json.dumps({'error': ['instance invalid']}), 400
+
+    instance = request.args['instance']
+    config_file = '{path}/{instance}/kraken.ini'.format(
+                                            path=app.config['INSTANCE_DIR'],
+                                            instance=instance)
+    print config_file
+    parser = ConfigParser()
+    parser.read(config_file)
+    try:
+        uri = parser.get('GENERAL', 'zmq_socket')
+    except:
+        return json.dumps({'error': ['instance invalid']}), 500
+
+    uri.replace('*', 'localhost')
+    sock = context.socket(zmq.REQ)
+    try:
+        sock.connect(uri)
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.STATUS
+        sock.send(req.SerializeToString())
+        if sock.poll(10000) < 1:
+            return json.dumps({'status': 'timeout'}), 503
+
+        pb = sock.recv()
+        resp = response_pb2.Response()
+        resp.ParseFromString(pb)
+
+        response = {}
+        return_code = 200
+        if resp.error and resp.error.message:
+            response['status'] = resp.error.message
+
+        response['start_production_date'] = resp.status.start_production_date
+        response['end_production_date'] = resp.status.end_production_date
+        response['last_load'] = resp.status.last_load_at
+        response['last_load_status'] = resp.status.last_load_status
+        response['loaded'] = resp.status.loaded
+
+        if resp.status.last_load_status == False and 'status' not in response:
+            response['status'] = 'last load failed'
+
+        if 'status' not in response:
+            response['status'] = 'running'
+        else:
+            return_code = 503
+
+        return json.dumps(response), return_code
+    finally:
+        sock.close()
+
+
+if __name__ == '__main__':
+    app.run()

--- a/source/monitor/monitor_kraken/default_settings.py
+++ b/source/monitor/monitor_kraken/default_settings.py
@@ -1,2 +1,2 @@
-INSTANCE_DIR = '/srv/kraken/'
+KRAKEN_DIR = '/srv/kraken/'
 DEBUG = True

--- a/source/monitor/monitor_kraken/default_settings.py
+++ b/source/monitor/monitor_kraken/default_settings.py
@@ -1,0 +1,2 @@
+INSTANCE_DIR = '/srv/kraken/'
+DEBUG = True

--- a/source/monitor/requirements.txt
+++ b/source/monitor/requirements.txt
@@ -1,0 +1,9 @@
+Flask==0.10.1
+Jinja2==2.7.2
+MarkupSafe==0.18
+Werkzeug==0.9.4
+argparse==1.2.1
+itsdangerous==0.23
+protobuf==2.5.0
+pyzmq==14.0.1
+wsgiref==0.1.2

--- a/source/monitor/setup.py
+++ b/source/monitor/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+import glob
+
+setup(name='monitor_kraken',
+        version='0.39.0',
+        description="Provide a small api for monitor kraken",
+        author='CanalTP',
+        author_email='alexandre.jacquin@canaltp.fr',
+        url='www.navitia.io',
+        packages=['monitor_kraken']
+)

--- a/source/monitor/setup.py
+++ b/source/monitor/setup.py
@@ -5,7 +5,7 @@ import glob
 
 setup(name='monitor_kraken',
         version='0.39.0',
-        description="Provide a small api for monitor kraken",
+        description="Provide a small api for monitoring kraken",
         author='CanalTP',
         author_email='alexandre.jacquin@canaltp.fr',
         url='www.navitia.io',

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -22,6 +22,13 @@ add_custom_command (TARGET pb_lib
     task.proto realtime.proto
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/type )
 
+#we don't want a dependancy to navitiacommon for monitor
+add_custom_command (TARGET pb_lib
+    PRE_BUILD
+    COMMAND protoc ARGS --python_out=${CMAKE_SOURCE_DIR}/monitor/monitor_kraken type.proto
+    response.proto request.proto
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/type )
+
 add_library(types type.cpp message.cpp datetime.cpp)
 
 SET(DATA_SRC


### PR DESCRIPTION
example of call:
GET /?instance=$instance_name
{
    "status": "running",
    "start_production_date": "20140205",
    "last_load":"20140225T150653.987929",
    "end_production_date": "20140601",
    "loaded": true,
    "last_load_status": true
}
