### PR TITLE
Ed: build admin map

### DIFF
--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -542,7 +542,7 @@ void GeoRef::build_autocomplete_list(){
 
 
 /** Chargement de la liste poitype_map : mappage entre codes externes et idx des POITypes*/
-void GeoRef::build_poitypes(){
+void GeoRef::build_poitypes_map(){
    this->poitype_map.clear();
    for(const POIType* ptype : poitypes){
        this->poitype_map[ptype->uri] = ptype->idx;
@@ -550,7 +550,7 @@ void GeoRef::build_poitypes(){
 }
 
 /** Chargement de la liste poi_map : mappage entre codes externes et idx des POIs*/
-void GeoRef::build_pois(){
+void GeoRef::build_pois_map(){
     this->poi_map.clear();
    for(const POI* poi : pois){
        this->poi_map[poi->uri] = poi->idx;
@@ -576,10 +576,9 @@ void GeoRef::normalize_extcode_way(){
 }
 
 
-void GeoRef::normalize_extcode_admin(){
+void GeoRef::build_admin_map(){
     this->admin_map.clear();
     for(Admin* admin : admins){
-        admin->uri = "admin:" + admin->uri;
         this->admin_map[admin->uri] = admin->idx;
     }
 }

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -283,11 +283,11 @@ struct GeoRef {
     /// Normalisation des codes externes
     void normalize_extcode_way();
     /// Normalisation des codes externes des admins
-    void normalize_extcode_admin();
+    void build_admin_map();
 
     /// Chargement de la liste map code externe idx sur poitype et poi
-    void build_poitypes();
-    void build_pois();
+    void build_poitypes_map();
+    void build_pois_map();
 
     /// Construit l’indexe spatial permettant de retrouver plus vite la commune à une coordonnées
     void build_rtree();

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -112,8 +112,9 @@ void Data::build_uri(){
 #define CLEAR_EXT_CODE(type_name, collection_name) this->pt_data.collection_name##_map.clear();
 ITERATE_NAVITIA_PT_TYPES(CLEAR_EXT_CODE)
     this->pt_data.build_uri();
-    geo_ref.build_pois();
-    geo_ref.build_poitypes();
+    geo_ref.build_pois_map();
+    geo_ref.build_poitypes_map();
+    geo_ref.build_admin_map();
 }
 
 void Data::build_proximity_list(){


### PR DESCRIPTION
It wasn't build so we were not able to compute a journey from or to an administrative region.
I also rename the build_pois, and build_poi_type to build_pois_map, and build_poitypes_map.
