### PR TITLE
Route_schedules: fix for frequency routes

### DIFF
--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -25,14 +25,16 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t> &j
             if(!jpp->stop_point->accessible(accessibilite_params.properties)) {
                 continue;
             }
-            auto st = routing::earliest_stop_time(jpp, next_requested_datetime[jpp_idx], data, disruption_active, false, calendar_id, accessibilite_params.vehicle_properties).first;
-            if(st != nullptr) {
-                DateTime dt_temp = next_requested_datetime[jpp_idx];
-                DateTimeUtils::update(dt_temp, st->departure_time);
+            auto st = routing::earliest_stop_time(jpp, next_requested_datetime[jpp_idx], data, disruption_active, false, calendar_id, accessibilite_params.vehicle_properties);
+            if(st.first != nullptr) {
+                DateTime dt_temp = st.second;
                 if(dt_temp <= max_dt && result.size() < max_departures) {
                     result.push_back(std::make_pair(dt_temp, st));
                     test_add = true;
                     // Le prochain horaire observé doit être au minimum une seconde après
+                    if(st.first->is_frequency()) {
+                        DateTimeUtils::update(dt_temp, st.first->end_time);
+                    }
                     next_requested_datetime[jpp_idx] = dt_temp + 1;
                 }
             }

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -5,6 +5,7 @@
 #include "ptreferential/ptreferential.h"
 #include "utils/paginate.h"
 #include "type/datetime.h"
+#include "routing/best_stoptime.h"
 
 namespace pt = boost::posix_time;
 
@@ -35,7 +36,11 @@ get_all_stop_times(const vector_idx &journey_patterns,
         result.push_back(std::vector<datetime_stop_time>());
         DateTime dt = ho.first;
         for(const type::StopTime* stop_time : ho.second->vehicle_journey->stop_time_list) {
-            DateTimeUtils::update(dt, stop_time->departure_time);
+            if(!stop_time->is_frequency()) {
+                DateTimeUtils::update(dt, stop_time->departure_time);
+            } else {
+                DateTimeUtils::update(dt, routing::f_departure_time(dt, stop_time));
+            }
             result.back().push_back(std::make_pair(dt, stop_time));
         }
     }


### PR DESCRIPTION
We were always taking in account the departure time, that was a mistake for frequency vehicle journeys.
