### PR TITLE
Jormungandr: fix next link for journey pagination

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -320,16 +320,14 @@ class add_journey_pagination(object):
     def extremes(self, resp):
         datetime_before = None
         datetime_after = None
+        section_is_pt = lambda section: section['type'] == "public_transport"\
+                           or section['type'] == "on_demand_transport"
+        filter_journey = lambda journey: 'arrival_date_time' in journey and\
+                             journey['arrival_date_time'] != '' and\
+                             "sections" in journey and\
+                             any(section_is_pt(section) for section in journey['sections'])
         try:
-            section_is_pt = lambda section : section['type'] == "public_transport"\
-                               or section['type'] == "on_demand_transport"
-            or_func = lambda a,b : a or b
-            journey_as_pt = lambda journey : reduce(or_func, journey['sections'])
-            list_journeys = [journey for journey in resp['journeys']
-                             if 'arrival_date_time' in journey.keys() and
-                             journey['arrival_date_time'] != '' and
-                             journey.has_key("sections") and
-                             journey_as_pt(journey)]
+            list_journeys = filter(filter_journey, resp['journeys'])
             asap_journey = min(list_journeys,
                                key=itemgetter('arrival_date_time'))
         except:

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -321,23 +321,28 @@ class add_journey_pagination(object):
         datetime_before = None
         datetime_after = None
         try:
+            section_is_pt = lambda section : section['type'] == "public_transport"\
+                               or section['type'] == "on_demand_transport"
+            or_func = lambda a,b : a or b
+            journey_as_pt = lambda journey : reduce(or_func, journey['sections'])
             list_journeys = [journey for journey in resp['journeys']
                              if 'arrival_date_time' in journey.keys() and
-                             journey['arrival_date_time'] != '']
+                             journey['arrival_date_time'] != '' and
+                             journey.has_key("sections") and
+                             journey_as_pt(journey)]
             asap_journey = min(list_journeys,
                                key=itemgetter('arrival_date_time'))
         except:
             return (None, None)
         if asap_journey['arrival_date_time'] \
                 and asap_journey['departure_date_time']:
-            minute = timedelta(minutes=1)
+            second = timedelta(seconds=1)
             s_departure = asap_journey['departure_date_time']
             f_departure = datetime.strptime(s_departure, f_datetime)
             s_arrival = asap_journey['arrival_date_time']
-            f_departure = datetime.strptime(s_arrival, f_datetime)
-            datetime_after = f_departure + minute
             f_arrival = datetime.strptime(s_arrival, f_datetime)
-            datetime_before = f_arrival - minute
+            datetime_after = f_departure + second
+            datetime_before = f_arrival - second
 
         return (datetime_before, datetime_after)
 


### PR DESCRIPTION
There was a mess between arrival and departure.

Plus we know check only journeys with public transport.
And we were asking for the one leaving one minute after, now we take the one leaving one second after.
