### PR TITLE
Import poi

### DIFF
--- a/debian/navitia-ed.install
+++ b/debian/navitia-ed.install
@@ -4,5 +4,6 @@ usr/bin/osm2ed usr/bin
 usr/bin/ed2nav usr/bin
 usr/bin/fare2ed usr/bin
 usr/bin/geopal2ed usr/bin
+usr/bin/poi2ed usr/bin
 usr/share/ed/* usr/share/ed
 usr/bin/nav2rt usr/bin

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -46,5 +46,8 @@ target_link_libraries(nav2rt ed types connectors pq pqxx data fare georef routin
 add_executable(geopal2ed geopal2ed.cpp)
 
 target_link_libraries(geopal2ed transportation_data_import ed connectors types pq pqxx data utils hiredis ${BOOST_LIBS} log4cplus)
+add_executable(poi2ed poi2ed.cpp)
 
-INSTALL_TARGETS(/usr/bin/ gtfs2ed osm2ed ed2nav nav2rt fusio2ed fare2ed geopal2ed)
+target_link_libraries(poi2ed transportation_data_import ed connectors types pq pqxx data utils hiredis ${BOOST_LIBS} log4cplus)
+
+INSTALL_TARGETS(/usr/bin/ gtfs2ed osm2ed ed2nav nav2rt fusio2ed fare2ed geopal2ed poi2ed)

--- a/source/ed/connectors/CMakeLists.txt
+++ b/source/ed/connectors/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(SOURCE_LIB
     conv_coord.cpp
     external_parser.cpp
     data_cleaner.cpp
+    poi_parser.cpp
 )
 
 add_library(connectors ${SOURCE_LIB})

--- a/source/ed/connectors/conv_coord.cpp
+++ b/source/ed/connectors/conv_coord.cpp
@@ -23,6 +23,9 @@ Projection::~Projection() {
 }
 
 navitia::type::GeographicalCoord ConvCoord::convert_to(navitia::type::GeographicalCoord coord) const{
+    if(this->origin.definition == this->destination.definition){
+        return coord;
+    }
     if(this->origin.is_degree){
         coord.set_lon(coord.lon() * DEG_TO_RAD);
         coord.set_lat(coord.lat() * DEG_TO_RAD);

--- a/source/ed/connectors/geopal_parser.h
+++ b/source/ed/connectors/geopal_parser.h
@@ -24,8 +24,6 @@ private:
     void fill_nodes();
     void fill_ways_edges();
     void fill_house_numbers();
-    void fill_poi_types();
-    void fill_pois();
     bool starts_with(std::string filename, const std::string& prefex);
     void fusion_ways();
     void fusion_ways_by_graph(const std::vector<types::Edge*>& edges);

--- a/source/ed/connectors/poi_parser.cpp
+++ b/source/ed/connectors/poi_parser.cpp
@@ -1,197 +1,94 @@
 #include "poi_parser.h"
 #include "type/data.h"
-#include <boost/lexical_cast.hpp>
-#include "type/data.h"
-#include "georef/georef.h"
 #include "utils/csv.h"
-#include "utils/configuration.h"
-#include <boost/algorithm/string.hpp>
-
+#include "utils/functions.h"
 
 
 namespace ed{ namespace connectors{
-PoiParser::PoiParser(const std::string & path): path(path){
-        init_logger();
+PoiParser::PoiParser(const std::string & path, const ed::connectors::ConvCoord& conv_coord): path(path), conv_coord(conv_coord){
         logger = log4cplus::Logger::getInstance("log");
 }
 
 
-void PoiParser::fill_poi_type(navitia::georef::GeoRef & georef_to_fill)
-{
-    // Verification des entêtes:
-    CsvReader csv(path + "/" + "poi_type.txt", ',', true);
-    if(!csv.is_open()) {
-        LOG4CPLUS_WARN(logger, "le fichier " + csv.filename +" n'existe pas ");
-        return;
+void PoiParser::fill_poi_type(){
+    CsvReader reader(this->path + "/poi_type.txt" , ';', true, true);
+    if(!reader.is_open()) {
+        throw PoiParserException("Error on open file " + reader.filename);
     }
     std::vector<std::string> mandatory_headers = {"poi_type_id" , "poi_type_name"};
-    if(!csv.validate(mandatory_headers)) {
-        LOG4CPLUS_ERROR(logger, "Erreur lors du parsing de " + csv.filename +" . Il manque les colonnes : " + csv.missing_headers(mandatory_headers));
+    if(!reader.validate(mandatory_headers)) {
+        throw PoiParserException("Impossible to parse file " + reader.filename +" . Not find column : " + reader.missing_headers(mandatory_headers));
     }
-
-    int id_c = csv.get_pos_col("poi_type_id"), name_c = csv.get_pos_col("poi_type_name");
-
-    int id = 1;
-    while(!csv.eof()){
-
-        auto row = csv.next();
-        if (!row.empty()){
-            navitia::georef::POIType* ptype = new navitia::georef::POIType();
-            ptype->idx = id-1;
-            if (id_c != -1 && row[id_c]!= "")
-                ptype->uri = row[id_c];
-            else
-                ptype->uri = boost::lexical_cast<std::string>(id);
-            ptype->name = row[name_c];
-            georef_to_fill.poitypes.push_back(ptype);
-            georef_to_fill.poitype_map[ptype->uri] = ptype->idx;
-            ++id;
-        }
-    }
-
-    //Chargement de la liste poitype_map
-//    georef_to_fill.normalize_extcode_poitypes();
-}
-
-void PoiParser::fill_poi(navitia::georef::GeoRef & georef_to_fill)
-{
-    // Verification des entêtes:
-    CsvReader csv(path + "/" + "poi.txt", ',', true);
-    if(!csv.is_open()) {
-        LOG4CPLUS_WARN(logger, "Le fichier " + csv.filename +" n'existe pas");
-        return;
-    }
-
-    std::vector<std::string> mandatory_headers = {"poi_id", "poi_name", "poi_lat", "poi_lon"};
-    if(!csv.validate(mandatory_headers)) {
-        LOG4CPLUS_ERROR(logger, "Erreur lors du parsing de " + csv.filename +" . Il manque les colonnes : " + csv.missing_headers(mandatory_headers));
-    }
-    int id_c = csv.get_pos_col("poi_id"), name_c = csv.get_pos_col("poi_name"), weight_c = csv.get_pos_col("poi_weight"),
-            visible_c = csv.get_pos_col("poi_visible"),
-            lat_c = csv.get_pos_col("poi_lat"), lon_c = csv.get_pos_col("poi_lon"), type_c = csv.get_pos_col("poi_type_id");
-
-    int id = 1;
-    while (!csv.eof()){
-        auto row = csv.next();
-        if (!row.empty()){
-            navitia::georef::POI* poi = new navitia::georef::POI();
-            poi->idx = id-1;
-            if (id_c != -1 && row[id_c] != "")
-                poi->uri = row[id_c];
-            else
-                poi->uri = boost::lexical_cast<std::string>(id);
-            poi->name = row[name_c];
-            if (weight_c != -1 && row[weight_c] != "")
-                poi->weight = boost::lexical_cast<int>(row[weight_c]);
-            else
-                poi->weight = 0;
-
-            try{
-                poi->coord.set_lon(boost::lexical_cast<double>(row[lon_c]));
-                poi->coord.set_lat(boost::lexical_cast<double>(row[lat_c]));
-            }
-            catch(boost::bad_lexical_cast ) {
-                std::cout << "Impossible de parser les coordonnées pour "
-                          << row[id_c] << " " << row[name_c];
-            }
-
-            // Lire la référence du type de POI
-            auto ptype = georef_to_fill.poitype_map.find(row[type_c]);
-            if (ptype == georef_to_fill.poitype_map.end()){
-                // ajouter l'Index par défaut ??
-                poi->poitype_idx = -1;
-            }
-            else
-                poi->poitype_idx = ptype->second;
-
-            if (visible_c != -1 && row[visible_c] != "")
-                poi->visible = boost::lexical_cast<bool>(row[visible_c]);
-            georef_to_fill.pois.push_back(poi);
-            ++id;
-        }
-    }
-    //Chargement de la liste poitype_map
-//    georef_to_fill.normalize_extcode_pois();
-
-}
-
-void PoiParser::fill(navitia::georef::GeoRef & georef_to_fill)
-{
-    // Lire les fichiers poi-type.txt
-    fill_poi_type(georef_to_fill);
-    LOG4CPLUS_TRACE(logger, "On a  " + boost::lexical_cast<std::string>(georef_to_fill.poitypes.size())+ " POITypes");
-
-    // Lire les fichiers poi.txt
-    fill_poi(georef_to_fill);
-    LOG4CPLUS_TRACE(logger, "On a  " + boost::lexical_cast<std::string>(georef_to_fill.pois.size())+ " POIs");
-}
-
-void PoiParser::fill_aliases(navitia::georef::GeoRef & georef_to_fill){
-    // Verification des entêtes:
-    std::string key, value;
-    CsvReader csv(path + "/" + "alias.txt", '=', true);
-    if(!csv.is_open()) {
-        LOG4CPLUS_FATAL(logger, "Impossible d'ouvrir le fichier " + csv.filename +" dans fill_aliases");
-        return;
-    }
-    std::vector<std::string> mandatory_headers = {"key" , "value"};
-    if(!csv.validate(mandatory_headers)) {
-        LOG4CPLUS_FATAL(logger, "Erreur lors du parsing de fill_aliases " + csv.filename +" . Il manque les colonnes : " + csv.missing_headers(mandatory_headers));
-    }
-
-    int key_c = csv.get_pos_col("key"), value_c = csv.get_pos_col("value");
-    while(!csv.eof()){
-        auto row = csv.next();
-        if (!row.empty()){
-            if (key_c != -1){
-                key = row[key_c];
-                value = row[value_c];
-                boost::to_lower(key);
-                boost::to_lower(value);
-                georef_to_fill.alias[key]= value;
+    int id_c = reader.get_pos_col("poi_type_id");
+    int name_c = reader.get_pos_col("poi_type_name");
+    while(!reader.eof()){
+        std::vector<std::string> row = reader.next();
+        if (reader.is_valid(id_c, row) && reader.is_valid(name_c, row)){
+            const auto& itm = this->data.poi_types.find(row[id_c]);
+            if(itm == this->data.poi_types.end()){
+                ed::types::PoiType* poi_type = new ed::types::PoiType;
+                poi_type->id = this->data.poi_types.size() + 1;
+                poi_type->name = row[name_c];
+                this->data.poi_types[row[id_c]] = poi_type;
             }
         }
     }
 }
 
-void PoiParser::fill_synonyms(navitia::georef::GeoRef &georef_to_fill)
-{
-    std::string key, value;
-    CsvReader csv(path + "/" + "synonyme.txt", '=', true);
-    if(!csv.is_open()) {
-        LOG4CPLUS_FATAL(logger, "Impossible d'ouvrir le fichier " + csv.filename +" dans fill_synonyms");
-        return;
+void PoiParser::fill_poi(){
+    CsvReader reader(this->path + "/poi.txt", ';', true, true);
+    if(!reader.is_open()) {
+        throw PoiParserException("Error on open file " + reader.filename);
     }
-    std::vector<std::string> mandatory_headers = {"key" , "value"};
-    if(!csv.validate(mandatory_headers)) {
-        LOG4CPLUS_FATAL(logger, "Erreur lors du parsing de " + csv.filename +" . Il manque les colonnes : " + csv.missing_headers(mandatory_headers));
+    std::vector<std::string> mandatory_headers = {"poi_id", "poi_name", "poi_weight", "poi_visible", "poi_lat", "poi_lon", "poi_type_id"};
+    if(!reader.validate(mandatory_headers)) {
+        throw PoiParserException("Impossible to parse file " + reader.filename +" . Not find column : " + reader.missing_headers(mandatory_headers));
     }
+    int id_c = reader.get_pos_col("poi_id");
+    int name_c = reader.get_pos_col("poi_name");
+    int weight_c = reader.get_pos_col("poi_weight");
+    int visible_c = reader.get_pos_col("poi_visible");
+    int lat_c = reader.get_pos_col("poi_lat");
+    int lon_c = reader.get_pos_col("poi_lon");
+    int type_id_c = reader.get_pos_col("poi_type_id");
 
-    int key_c = csv.get_pos_col("key"), value_c = csv.get_pos_col("value");
-    while(!csv.eof()){
-        auto row = csv.next();
-        if (!row.empty()){
-            if (key_c != -1){
-                key = row[key_c];
-                value = row[value_c];
-                boost::to_lower(key);
-                boost::to_lower(value);
-                georef_to_fill.synonymes[key]=value;
+    while(!reader.eof()){
+        std::vector<std::string> row = reader.next();
+        if (reader.is_valid(id_c, row) && reader.is_valid(name_c, row)
+            && reader.is_valid(weight_c, row) && reader.is_valid(visible_c, row)
+            && reader.is_valid(lat_c, row) && reader.is_valid(lon_c, row)
+            && reader.is_valid(type_id_c, row)){
+            const auto& itm = this->data.pois.find(row[id_c]);
+            if(itm == this->data.pois.end()){
+                const auto& poi_type = this->data.poi_types.find(row[type_id_c]);
+                if(poi_type != this->data.poi_types.end()){
+                    ed::types::Poi* poi = new ed::types::Poi;
+                    poi->id = this->data.pois.size() + 1;
+                    poi->name = row[name_c];
+                    try{
+                        poi->visible = boost::lexical_cast<bool>(row[visible_c]);
+                    }catch(boost::bad_lexical_cast ) {
+                        LOG4CPLUS_WARN(logger, "Impossible to parse the visible for " + row[id_c] + " " + row[name_c]);
+                        poi->visible = true;
+                    }
+                    try{
+                        poi->weight = boost::lexical_cast<int>(row[weight_c]);
+                    }catch(boost::bad_lexical_cast ) {
+                        LOG4CPLUS_WARN(logger, "Impossible to parse the weight for " + row[id_c] + " " + row[name_c]);
+                        poi->weight = 0;
+                    }
+                    poi->poi_type = poi_type->second;
+                    poi->coord = this->conv_coord.convert_to(navitia::type::GeographicalCoord(str_to_double(row[lon_c]), str_to_double(row[lat_c])));
+                    this->data.pois[row[id_c]] = poi;
+                }
             }
         }
     }
 }
 
-void PoiParser::fill_alias_synonyme(navitia::georef::GeoRef &georef_to_fill)
-{
-    // Lire les fichiers poi-type.txt
-    fill_aliases(georef_to_fill);
-    LOG4CPLUS_TRACE(logger, "On a  " + boost::lexical_cast<std::string>(georef_to_fill.alias.size())+ " alias");
-
-    // Lire les fichiers poi-type.txt
-    fill_synonyms(georef_to_fill);
-    LOG4CPLUS_TRACE(logger, "On a  " + boost::lexical_cast<std::string>(georef_to_fill.synonymes.size())+ " synonymes");
+void PoiParser::fill(){
+    fill_poi_type();
+    fill_poi();
 }
-
 
 }}

--- a/source/ed/connectors/poi_parser.cpp
+++ b/source/ed/connectors/poi_parser.cpp
@@ -13,7 +13,7 @@ PoiParser::PoiParser(const std::string & path, const ed::connectors::ConvCoord& 
 void PoiParser::fill_poi_type(){
     CsvReader reader(this->path + "/poi_type.txt" , ';', true, true);
     if(!reader.is_open()) {
-        throw PoiParserException("Error on open file " + reader.filename);
+        throw PoiParserException("Cannot open file : " + reader.filename);
     }
     std::vector<std::string> mandatory_headers = {"poi_type_id" , "poi_type_name"};
     if(!reader.validate(mandatory_headers)) {
@@ -38,7 +38,7 @@ void PoiParser::fill_poi_type(){
 void PoiParser::fill_poi(){
     CsvReader reader(this->path + "/poi.txt", ';', true, true);
     if(!reader.is_open()) {
-        throw PoiParserException("Error on open file " + reader.filename);
+        throw PoiParserException("Cannot open file : " + reader.filename);
     }
     std::vector<std::string> mandatory_headers = {"poi_id", "poi_name", "poi_weight", "poi_visible", "poi_lat", "poi_lon", "poi_type_id"};
     if(!reader.validate(mandatory_headers)) {

--- a/source/ed/connectors/poi_parser.h
+++ b/source/ed/connectors/poi_parser.h
@@ -1,26 +1,29 @@
 #pragma once
-#include <string>
-#include "type/data.h"
+#include "ed/data.h"
 #include <utils/logger.h>
+#include "ed/connectors/conv_coord.h"
 
 namespace ed{ namespace connectors{
+
+struct PoiParserException: public navitia::exception{
+    PoiParserException(const std::string& message): navitia::exception(message){};
+};
+
 
 class PoiParser
 {
 private:
     std::string path;///< Chemin vers les fichiers
     log4cplus::Logger logger;
+    ed::connectors::ConvCoord conv_coord;
 
+    void fill_poi_type();
+    void fill_poi();
 public:
-    PoiParser(const std::string & path);
-    PoiParser(): path(){}
+    ed::PoiPoiType data;
 
-    void fill_poi_type(navitia::georef::GeoRef & georef_to_fill);
-    void fill_poi(navitia::georef::GeoRef & georef_to_fill);
-    void fill(navitia::georef::GeoRef & georef_to_fill);
-    void fill_aliases(navitia::georef::GeoRef & georef_to_fill);
-    void fill_synonyms(navitia::georef::GeoRef & georef_to_fill);
-    void fill_alias_synonyme(navitia::georef::GeoRef & georef_to_fill);
+    PoiParser(const std::string & path, const ed::connectors::ConvCoord& conv_coord);
+    void fill();
 };
 }}
 

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -540,6 +540,9 @@ Georef::~Georef(){
          delete itm.second;
     for(auto itm : this->admins)
          delete itm.second;
+}
+
+PoiPoiType::~PoiPoiType(){
     for(auto itm : this->poi_types)
          delete itm.second;
     for(auto itm : this->pois)

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -129,8 +129,6 @@ struct Georef{
     std::unordered_map<std::string, types::Way* > ways;
     std::unordered_map<std::string, types::HouseNumber* > house_numbers;
     std::unordered_map<std::string, types::Admin *> admins;
-    std::unordered_map<std::string, types::PoiType *> poi_types;
-    std::unordered_map<std::string, types::Poi *> pois;
                       // Old uri way, New uri way
     std::unordered_map<std::string, types::Way*> fusion_ways;
     Georef(){};

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -139,7 +139,6 @@ struct Georef{
     std::unordered_map<std::string, types::Admin *> admins;
                       // Old uri way, New uri way
     std::unordered_map<std::string, types::Way*> fusion_ways;
-    Georef(){};
     ~Georef();
 };
 

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -123,6 +123,14 @@ public:
 
 };
 
+struct PoiPoiType{
+    std::unordered_map<std::string, types::PoiType *> poi_types;
+    std::unordered_map<std::string, types::Poi *> pois;
+
+    PoiPoiType(){};
+    ~PoiPoiType();
+};
+
 struct Georef{
     std::unordered_map<std::string, types::Node* > nodes;
     std::unordered_map<std::string, types::Edge* > edges;

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -28,12 +28,6 @@ void EdPersistor::persist(const ed::Georef& data){
     LOG4CPLUS_INFO(logger, "Begin: relation admin way");
     this->build_relation_way_admin(data);
     LOG4CPLUS_INFO(logger, "End: relation admin way");
-    LOG4CPLUS_INFO(logger, "Begin: add poitypes data");
-    this->insert_poi_types(data);
-    LOG4CPLUS_INFO(logger, "End: add poitypes data");
-    LOG4CPLUS_INFO(logger, "Begin: add pois data");
-    this->insert_pois(data);
-    LOG4CPLUS_INFO(logger, "End: add pois data");
     LOG4CPLUS_INFO(logger, "Begin: update boundary admins");
     this->update_boundary();
     LOG4CPLUS_INFO(logger, "End: update boundary admins");
@@ -168,7 +162,6 @@ void EdPersistor::insert_edges(const ed::Georef& data){
     LOG4CPLUS_INFO(logger, to_insert_count<<"/"<<all_count<<" edges inserées");
 }
 
-void EdPersistor::insert_poi_types(const ed::Georef& data){
     this->lotus.prepare_bulk_insert("navitia.poi_type", {"id", "uri", "name"});
     for(const auto& itm : data.poi_types) {
         this->lotus.insert({std::to_string(itm.second->id), "poi_type:" + itm.first, itm.second->name});
@@ -176,7 +169,6 @@ void EdPersistor::insert_poi_types(const ed::Georef& data){
     lotus.finish_bulk_insert();
 }
 
-void EdPersistor::insert_pois(const ed::Georef& data){
     this->lotus.prepare_bulk_insert("navitia.poi",
     {"id", "weight", "coord", "name", "uri", "poi_type_id", "visible"});
     for(const auto& itm : data.pois) {

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -20,8 +20,11 @@ struct EdPersistor{
     void persist_fare(const ed::Data& data);
     /// Données Georef
     void persist(const ed::Georef& data);
+    /// Poi
+    void persist(const ed::PoiPoiType& data);
     void build_ways();
     void clean_georef();
+    void clean_poi();
 
 private:
     void insert_metadata(const navitia::type::MetaData& meta);
@@ -74,6 +77,10 @@ private:
     void insert_edges(const ed::Georef& data);
     void build_relation_way_admin(const ed::Georef& data);
     void update_boundary();
+
+    /// Données POI
+    void insert_poi_types(const ed::PoiPoiType& data);
+    void insert_pois(const ed::PoiPoiType& data);
 
     std::string to_geographic_point(const navitia::type::GeographicalCoord& coord) const;
 

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -72,8 +72,6 @@ private:
     void insert_nodes(const ed::Georef& data);
     void insert_house_numbers(const ed::Georef& data);
     void insert_edges(const ed::Georef& data);
-    void insert_poi_types(const ed::Georef& data);
-    void insert_pois(const ed::Georef& data);
     void build_relation_way_admin(const ed::Georef& data);
     void update_boundary();
 

--- a/source/ed/poi2ed.cpp
+++ b/source/ed/poi2ed.cpp
@@ -1,0 +1,77 @@
+
+#include "config.h"
+#include <iostream>
+#include "ed/connectors/poi_parser.h"
+
+#include "utils/timer.h"
+#include "utils/init.h"
+
+#include <fstream>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/program_options.hpp>
+#include "utils/exception.h"
+#include "ed_persistor.h"
+
+namespace po = boost::program_options;
+namespace pt = boost::posix_time;
+
+int main(int argc, char * argv[])
+{
+    navitia::init_app();
+    auto logger = log4cplus::Logger::getInstance("log");
+
+    std::string input, connection_string;
+    uint32_t coord_system;
+    po::options_description desc("Allowed options");
+    desc.add_options()
+        ("help,h", "Affiche l'aide")
+        ("input,i", po::value<std::string>(&input), "Repertoire d'entrée")
+        ("version,v", "Affiche la version")
+        ("config-file", po::value<std::string>(), "chemin vers le fichier de configuration")
+        ("coord-system,c", po::value<uint32_t>(&coord_system)->default_value(4326), "Système de coordonnée: 4326 pour WGS84")
+        ("connection-string", po::value<std::string>(&connection_string)->required(), "parametres de connexion à la base de données: host=localhost user=navitia dbname=navitia password=navitia");
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+
+    if(vm.count("version")){
+        LOG4CPLUS_INFO(logger, argv[0] << " V" << KRAKEN_VERSION << " " << NAVITIA_BUILD_TYPE);
+        return 0;
+    }
+
+    if(vm.count("config-file")){
+        std::ifstream stream;
+        stream.open(vm["config-file"].as<std::string>());
+        if(!stream.is_open()){
+            throw navitia::exception("loading config file failed");
+        }else{
+            po::store(po::parse_config_file(stream, desc), vm);
+        }
+    }
+
+    if(vm.count("help") || !vm.count("input")) {
+        std::cout << desc <<  "\n";
+        return 1;
+    }
+    po::notify(vm);
+
+    pt::ptime start;
+    start = pt::microsec_clock::local_time();
+   ed::connectors::Projection origin("WGS84", std::to_string(coord_system), false);
+    ed::connectors::PoiParser poi_parser(input, origin);
+
+    try{
+            poi_parser.fill();
+            LOG4CPLUS_TRACE(logger, "On a  " << poi_parser.data.poi_types.size() << " POITypes");
+            LOG4CPLUS_TRACE(logger, "On a  " << poi_parser.data.pois.size() << " POIs");
+        }catch(const ed::connectors::PoiParserException& e){
+            LOG4CPLUS_FATAL(logger, "Erreur :"+ std::string(e.what()) + "  backtrace :" + e.backtrace());
+            return -1;
+        }
+
+    ed::EdPersistor p(connection_string);
+    p.persist(poi_parser.data);
+    std::cout<<std::endl<<"temps :"<<to_simple_string(pt::microsec_clock::local_time() - start)<<std::endl;
+
+    return 0;
+}

--- a/source/ed/poi2ed.cpp
+++ b/source/ed/poi2ed.cpp
@@ -61,17 +61,17 @@ int main(int argc, char * argv[])
     ed::connectors::PoiParser poi_parser(input, origin);
 
     try{
-            poi_parser.fill();
-            LOG4CPLUS_TRACE(logger, "On a  " << poi_parser.data.poi_types.size() << " POITypes");
-            LOG4CPLUS_TRACE(logger, "On a  " << poi_parser.data.pois.size() << " POIs");
-        }catch(const ed::connectors::PoiParserException& e){
-            LOG4CPLUS_FATAL(logger, "Erreur :"+ std::string(e.what()) + "  backtrace :" + e.backtrace());
-            return -1;
-        }
+        poi_parser.fill();
+        LOG4CPLUS_TRACE(logger, "On a  " << poi_parser.data.poi_types.size() << " POITypes");
+        LOG4CPLUS_TRACE(logger, "On a  " << poi_parser.data.pois.size() << " POIs");
+    }catch(const ed::connectors::PoiParserException& e){
+        LOG4CPLUS_FATAL(logger, "Erreur :"+ std::string(e.what()) + "  backtrace :" + e.backtrace());
+        return -1;
+    }
 
     ed::EdPersistor p(connection_string);
     p.persist(poi_parser.data);
-    std::cout<<std::endl<<"temps :"<<to_simple_string(pt::microsec_clock::local_time() - start)<<std::endl;
+    LOG4CPLUS_FATAL(logger, "temps :"<<to_simple_string(pt::microsec_clock::local_time() - start));
 
     return 0;
 }

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -179,6 +179,38 @@ def geopal2ed(instance_config, filename, job_id):
         raise
     finally:
         lock.release()
+        
+@celery.task()
+def poi2ed(instance_config, filename, job_id):
+    """ launch poi2ed """
+
+    job = models.Job.query.get(job_id)
+    instance = job.instance
+    lock = redis.lock('tyr.lock|' + instance.name)
+    if not lock.acquire(blocking=False):
+        poi2ed.retry(countdown=300, max_retries=10)
+
+    logger = get_instance_logger(instance)
+    try:
+        working_directory = os.path.dirname(filename)
+
+        zip_file = zipfile.ZipFile(filename)
+        zip_file.extractall(path=working_directory)
+
+        connection_string = make_connection_string(instance_config)
+        res = launch_exec('poi2ed',
+                ["-i", working_directory, "--connection-string", connection_string],
+                logger)
+        if res != 0:
+            #@TODO: exception
+            raise ValueError('poi2ed failed')
+    except:
+        logger.exception('')
+        job.state = 'failed'
+        models.db.session.commit()
+        raise
+    finally:
+        lock.release()
 
 
 @celery.task()

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -1,6 +1,6 @@
 from celery import chain, group
 from celery.signals import task_postrun
-from tyr.binarisation import gtfs2ed, osm2ed, ed2nav, nav2rt, fusio2ed, geopal2ed, fare2ed
+from tyr.binarisation import gtfs2ed, osm2ed, ed2nav, nav2rt, fusio2ed, geopal2ed, fare2ed, poi2ed
 from tyr.binarisation import reload_data, move_to_backupdirectory
 from tyr.aggregate_places import aggregate_places
 from flask import current_app
@@ -33,6 +33,8 @@ def type_of_data(filename):
             return 'gtfs'
     if filename.endswith('.geopal'):
         return 'geopal'
+    if filename.endswith('.poi'):
+        return 'poi'
     return None
 
 
@@ -82,6 +84,10 @@ def update_data():
                 filename = move_to_backupdirectory(_file,
                         instance_config.backup_directory)
                 actions.append(fare2ed.si(instance_config, filename))
+            elif dataset.type == 'poi':
+                filename = move_to_backupdirectory(_file,
+                        instance_config.backup_directory)
+                actions.append(poi2ed.si(instance_config, filename))
             else:
                 #unknown type, we skip it
                 continue


### PR DESCRIPTION
1 - Ne pas faire de conversion de coordonnée si le système en entrée et le même qu'en sortie
2 - Suppression du chargement des pois dans le connecteur des données de la voiries de provenance FUSiO
3 - Création d'une nouvelle structure PoiPoiType
4 - Création d'un nouveau connecteur poi2ed
4 - Ajout de poi2ed dans tyr
