### PR TITLE
Fusion alias synonyms

### DIFF
--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -17,7 +17,7 @@
 
 namespace navitia { namespace autocomplete {
 
-struct Comapre {
+struct Compare {
     bool operator()(const  std::string& str_a, const std::string& str_b) const {
         if(str_a.length() == str_b.length()){
             return str_a >= str_b;
@@ -27,7 +27,7 @@ struct Comapre {
     }
 };
 
-using autocomplete_map = std::map<std::string, std::string, Comapre>;
+using autocomplete_map = std::map<std::string, std::string, Compare>;
 /** Map de type Autocomplete
   *
   * On associe une chaine de caractères, par exemple "rue jean jaures" à une valeur T (typiquement un pointeur

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -225,7 +225,7 @@ pbnavitia::Response autocomplete(const std::string &q,
     }
     int nbmax_temp = nbmax;
     nbmax = std::max(100, nbmax);
-    bool addType = d.pt_data->stop_area_autocomplete.is_address_type(q, d.geo_ref->synonymes);
+    bool addType = d.pt_data->stop_area_autocomplete.is_address_type(q, d.geo_ref->synonyms);
     std::vector<const georef::Admin*> admin_ptr = admin_uris_to_admin_ptr(admins, d);
 
     ///Récupérer max(100, count) éléments pour chaque type d'ObjectTC
@@ -235,33 +235,33 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::StopArea:
             if (search_type==0) {
                 result = d.pt_data->stop_area_autocomplete.find_complete(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
             } else {
                 result = d.pt_data->stop_area_autocomplete.find_partial_with_pattern(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
             }
             break;
         case nt::Type_e::StopPoint:
             if (search_type==0) {
                 result = d.pt_data->stop_point_autocomplete.find_complete(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
             } else {
                 result = d.pt_data->stop_point_autocomplete.find_partial_with_pattern(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
             }
             break;
         case nt::Type_e::Admin:
             if (search_type==0) {
                 result = d.geo_ref->fl_admin.find_complete(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
             } else {
                 result = d.geo_ref->fl_admin.find_partial_with_pattern(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
             }
             break;
@@ -272,22 +272,22 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::POI:
             if (search_type==0) {
                 result = d.geo_ref->fl_poi.find_complete(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->pois, admin_ptr));
             } else {
                 result = d.geo_ref->fl_poi.find_partial_with_pattern(q, /*d.geo_ref->alias,*/
-                        d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.geo_ref->pois, admin_ptr));
             }
             break;
         case nt::Type_e::Line:
             if (search_type==0) {
                 result = d.pt_data->line_autocomplete.find_complete(q,
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, [](type::idx_t){return true;});
             } else {
                 result = d.pt_data->line_autocomplete.find_complete(q, /*d.geo_ref->alias,*/
-                        d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonyms, d.geo_ref->word_weight,
                         nbmax, [](type::idx_t){return true;});
             }
             break;

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -225,7 +225,7 @@ pbnavitia::Response autocomplete(const std::string &q,
     }
     int nbmax_temp = nbmax;
     nbmax = std::max(100, nbmax);
-    bool addType = d.pt_data->stop_area_autocomplete.is_address_type(q, d.geo_ref->alias, d.geo_ref->synonymes);
+    bool addType = d.pt_data->stop_area_autocomplete.is_address_type(q, d.geo_ref->synonymes);
     std::vector<const georef::Admin*> admin_ptr = admin_uris_to_admin_ptr(admins, d);
 
     ///Récupérer max(100, count) éléments pour chaque type d'ObjectTC
@@ -234,34 +234,34 @@ pbnavitia::Response autocomplete(const std::string &q,
         switch(type){
         case nt::Type_e::StopArea:
             if (search_type==0) {
-                result = d.pt_data->stop_area_autocomplete.find_complete(q, d.geo_ref->alias,
+                result = d.pt_data->stop_area_autocomplete.find_complete(q,
                         d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
             } else {
                 result = d.pt_data->stop_area_autocomplete.find_partial_with_pattern(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
             }
             break;
         case nt::Type_e::StopPoint:
             if (search_type==0) {
                 result = d.pt_data->stop_point_autocomplete.find_complete(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
             } else {
                 result = d.pt_data->stop_point_autocomplete.find_partial_with_pattern(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
             }
             break;
         case nt::Type_e::Admin:
             if (search_type==0) {
                 result = d.geo_ref->fl_admin.find_complete(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
             } else {
                 result = d.geo_ref->fl_admin.find_partial_with_pattern(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
             }
             break;
@@ -272,10 +272,10 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::POI:
             if (search_type==0) {
                 result = d.geo_ref->fl_poi.find_complete(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->pois, admin_ptr));
             } else {
-                result = d.geo_ref->fl_poi.find_partial_with_pattern(q, d.geo_ref->alias,
+                result = d.geo_ref->fl_poi.find_partial_with_pattern(q, /*d.geo_ref->alias,*/
                         d.geo_ref->synonymes, d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.geo_ref->pois, admin_ptr));
             }
@@ -283,10 +283,10 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::Line:
             if (search_type==0) {
                 result = d.pt_data->line_autocomplete.find_complete(q,
-                        d.geo_ref->alias, d.geo_ref->synonymes, d.geo_ref->word_weight,
+                        d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, [](type::idx_t){return true;});
             } else {
-                result = d.pt_data->line_autocomplete.find_complete(q, d.geo_ref->alias,
+                result = d.pt_data->line_autocomplete.find_complete(q, /*d.geo_ref->alias,*/
                         d.geo_ref->synonymes, d.geo_ref->word_weight,
                         nbmax, [](type::idx_t){return true;});
             }

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -16,44 +16,43 @@
 namespace pt = boost::posix_time;
 using namespace navitia::autocomplete;
 
-BOOST_AUTO_TEST_CASE(parse_find_with_alias_and_synonyms_test){
-    /// Liste des alias (Pas serialisé)
+BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     int word_weight = 5;
     int nbmax = 10;
     std::vector<std::string> admins;
     std::string admin_uri = "";
 
-    std::map<std::string, std::string> synonyms;
-    synonyms["hotel de ville"]="mairie";
-    synonyms["c c"]="centre commercial";
-    synonyms["cc"]="centre commercial";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
-    synonyms["ld"]="Lieu-Dit";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
+    navitia::type::map synonyms;
+    synonyms.map["hotel de ville"]="mairie";
+    synonyms.map["c c"]="centre commercial";
+    synonyms.map["cc"]="centre commercial";
+    synonyms.map["c.h.u"]="hopital";
+    synonyms.map["c.h.r"]="hopital";
+    synonyms.map["ld"]="Lieu-Dit";
+    synonyms.map["de"]="";
+    synonyms.map["la"]="";
+    synonyms.map["les"]="";
+    synonyms.map["des"]="";
+    synonyms.map["d"]="";
+    synonyms.map["l"]="";
 
-    synonyms["st"]="saint";
-    synonyms["ste"]="sainte";
-    synonyms["cc"]="centre commercial";
-    synonyms["chu"]="hopital";
-    synonyms["chr"]="hopital";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
-    synonyms["all"]="allée";
-    synonyms["allee"]="allée";
-    synonyms["ave"]="avenue";
-    synonyms["av"]="avenue";
-    synonyms["bvd"]="boulevard";
-    synonyms["bld"]="boulevard";
-    synonyms["bd"]="boulevard";
-    synonyms["b"]="boulevard";
-    synonyms["r"]="rue";
-    synonyms["pl"]="place";
+    synonyms.map["st"]="saint";
+    synonyms.map["ste"]="sainte";
+    synonyms.map["cc"]="centre commercial";
+    synonyms.map["chu"]="hopital";
+    synonyms.map["chr"]="hopital";
+    synonyms.map["c.h.u"]="hopital";
+    synonyms.map["c.h.r"]="hopital";
+    synonyms.map["all"]="allée";
+    synonyms.map["allee"]="allée";
+    synonyms.map["ave"]="avenue";
+    synonyms.map["av"]="avenue";
+    synonyms.map["bvd"]="boulevard";
+    synonyms.map["bld"]="boulevard";
+    synonyms.map["bd"]="boulevard";
+    synonyms.map["b"]="boulevard";
+    synonyms.map["r"]="rue";
+    synonyms.map["pl"]="place";
 
     Autocomplete<unsigned int> ac;
     ac.add_string("hotel de ville paris", 0, synonyms);
@@ -136,26 +135,26 @@ BOOST_AUTO_TEST_CASE(regex_replace_tests){
 
 BOOST_AUTO_TEST_CASE(regex_toknize_tests){
 
-    std::map<std::string, std::string> synonyms;
-    synonyms["hotel de ville"]="mairie";
-    synonyms["c c"]="centre commercial";
-    synonyms["cc"]="centre commercial";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
-    synonyms["ld"]="Lieu-Dit";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
-    synonyms["st"]="saint";
-    synonyms["r"]="rue";
+    navitia::type::map synonyms;
+    synonyms.map["hotel de ville"]="mairie";
+    synonyms.map["c c"]="centre commercial";
+    synonyms.map["cc"]="centre commercial";
+    synonyms.map["c.h.u"]="hopital";
+    synonyms.map["c.h.r"]="hopital";
+    synonyms.map["ld"]="Lieu-Dit";
+    synonyms.map["de"]="";
+    synonyms.map["la"]="";
+    synonyms.map["les"]="";
+    synonyms.map["des"]="";
+    synonyms.map["d"]="";
+    synonyms.map["l"]="";
+    synonyms.map["st"]="saint";
+    synonyms.map["r"]="rue";
 
     Autocomplete<unsigned int> ac;
     std::vector<std::string> vec;
 
-    //synonyme : "cc" = "centre commercial" / alias : de = ""
+    //synonyme : "cc" = "centre commercial" / synonym : de = ""
     //"cc Carré de Soie" -> "centre commercial carré de soie"
     vec = ac.tokenize("cc Carré de Soie", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "centre");
@@ -164,7 +163,7 @@ BOOST_AUTO_TEST_CASE(regex_toknize_tests){
     BOOST_CHECK_EQUAL(vec[3], "soie");
 
     vec.clear();
-    //synonyme : "c c"= "centre commercial" / alias : de = ""
+    //synonyme : "c c"= "centre commercial" / synonym : de = ""
     //"c c Carré de Soie" -> "centre commercial carré de soie"
     vec = ac.tokenize("c c Carré de Soie", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "centre");
@@ -175,18 +174,18 @@ BOOST_AUTO_TEST_CASE(regex_toknize_tests){
 
 BOOST_AUTO_TEST_CASE(regex_address_type_tests){
 
-    std::map<std::string, std::string> synonyms;
-    synonyms["hotel de ville"]="mairie";
-    synonyms["c c"]="centre commercial";
-    synonyms["cc"]="centre commercial";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
-    synonyms["ld"]="Lieu-Dit";
-    synonyms["av"]="avenue";
-    synonyms["r"]="rue";
-    synonyms["bvd"]="boulevard";
-    synonyms["bld"]="boulevard";
-    synonyms["bd"]="boulevard";
+    navitia::type::map synonyms;
+    synonyms.map["hotel de ville"]="mairie";
+    synonyms.map["c c"]="centre commercial";
+    synonyms.map["cc"]="centre commercial";
+    synonyms.map["c.h.u"]="hopital";
+    synonyms.map["c.h.r"]="hopital";
+    synonyms.map["ld"]="Lieu-Dit";
+    synonyms.map["av"]="avenue";
+    synonyms.map["r"]="rue";
+    synonyms.map["bvd"]="boulevard";
+    synonyms.map["bld"]="boulevard";
+    synonyms.map["bd"]="boulevard";
     //AddressType = {"rue", "avenue", "place", "boulevard","chemin", "impasse"}
 
     Autocomplete<unsigned int> ac;
@@ -196,23 +195,23 @@ BOOST_AUTO_TEST_CASE(regex_address_type_tests){
 
 BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
-    std::map<std::string, std::string> synonyms;
-    synonyms["gare sncf"]="gare";
-    synonyms["gare snc"]="gare";
-    synonyms["gare sn"]="gare";
-    synonyms["gare s"]="gare";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
-    synonyms["st"]="saint";
-    synonyms["av"]="avenue";
-    synonyms["r"]="rue";
-    synonyms["bvd"]="boulevard";
-    synonyms["bld"]="boulevard";
-    synonyms["bd"]="boulevard";
+    navitia::type::map synonyms;
+    synonyms.map["gare sncf"]="gare";
+    synonyms.map["gare snc"]="gare";
+    synonyms.map["gare sn"]="gare";
+    synonyms.map["gare s"]="gare";
+    synonyms.map["de"]="";
+    synonyms.map["la"]="";
+    synonyms.map["les"]="";
+    synonyms.map["des"]="";
+    synonyms.map["d"]="";
+    synonyms.map["l"]="";
+    synonyms.map["st"]="saint";
+    synonyms.map["av"]="avenue";
+    synonyms.map["r"]="rue";
+    synonyms.map["bvd"]="boulevard";
+    synonyms.map["bld"]="boulevard";
+    synonyms.map["bd"]="boulevard";
 
     Autocomplete<unsigned int> ac;
     std::vector<std::string> vec;
@@ -279,7 +278,7 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 }
 
 BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
-    std::map<std::string, std::string> synonyms;
+    navitia::type::map synonyms;
     std::vector<std::string> vec;
     std::string admin_uri = "";
 
@@ -375,7 +374,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
 
 BOOST_AUTO_TEST_CASE(Faute_de_frappe_One){
 
-        std::map<std::string, std::string> synonyms;
+        navitia::type::map synonyms;
         int word_weight = 5;
         int nbmax = 10;
 
@@ -425,7 +424,7 @@ sort
 
 BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
 
-    std::map<std::string, std::string> synonyms;
+    navitia::type::map synonyms;
     std::vector<std::string> admins;
     std::string admin_uri = "";
     int word_weight = 5;
@@ -460,7 +459,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
 ///Test pour verifier que - entres les deux mots est ignoré.
 BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
 
-    std::map<std::string, std::string> synonyms;
+    navitia::type::map synonyms;
     std::vector<std::string> admins;
     std::string admin_uri = "";
     int word_weight = 5;
@@ -482,38 +481,38 @@ BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
     BOOST_REQUIRE_EQUAL(res.at(2).idx, 3);
 }
 
-BOOST_AUTO_TEST_CASE(autocomplete_alias_and_weight_test){
+BOOST_AUTO_TEST_CASE(autocompletesynonym_and_weight_test){
 
-        std::map<std::string, std::string> synonyms;
+        navitia::type::map synonyms;
         std::vector<std::string> admins;
         std::string admin_uri;
         int word_weight = 5;
         int nbmax = 10;
 
-        synonyms["de"]="";
-        synonyms["la"]="";
-        synonyms["les"]="";
-        synonyms["des"]="";
-        synonyms["d"]="";
-        synonyms["l"]="";
+        synonyms.map["de"]="";
+        synonyms.map["la"]="";
+        synonyms.map["les"]="";
+        synonyms.map["des"]="";
+        synonyms.map["d"]="";
+        synonyms.map["l"]="";
 
-        synonyms["st"]="saint";
-        synonyms["ste"]="sainte";
-        synonyms["cc"]="centre commercial";
-        synonyms["chu"]="hopital";
-        synonyms["chr"]="hopital";
-        synonyms["c.h.u"]="hopital";
-        synonyms["c.h.r"]="hopital";
-        synonyms["all"]="allée";
-        synonyms["allee"]="allée";
-        synonyms["ave"]="avenue";
-        synonyms["av"]="avenue";
-        synonyms["bvd"]="boulevard";
-        synonyms["bld"]="boulevard";
-        synonyms["bd"]="boulevard";
-        synonyms["b"]="boulevard";
-        synonyms["r"]="rue";
-        synonyms["pl"]="place";
+        synonyms.map["st"]="saint";
+        synonyms.map["ste"]="sainte";
+        synonyms.map["cc"]="centre commercial";
+        synonyms.map["chu"]="hopital";
+        synonyms.map["chr"]="hopital";
+        synonyms.map["c.h.u"]="hopital";
+        synonyms.map["c.h.r"]="hopital";
+        synonyms.map["all"]="allée";
+        synonyms.map["allee"]="allée";
+        synonyms.map["ave"]="avenue";
+        synonyms.map["av"]="avenue";
+        synonyms.map["bvd"]="boulevard";
+        synonyms.map["bld"]="boulevard";
+        synonyms.map["bd"]="boulevard";
+        synonyms.map["b"]="boulevard";
+        synonyms.map["r"]="rue";
+        synonyms.map["pl"]="place";
 
         Autocomplete<unsigned int> ac;
         ac.add_string("rue jeanne d'arc", 0, synonyms);

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -22,37 +22,37 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     std::vector<std::string> admins;
     std::string admin_uri = "";
 
-    navitia::type::map synonyms;
-    synonyms.map["hotel de ville"]="mairie";
-    synonyms.map["c c"]="centre commercial";
-    synonyms.map["cc"]="centre commercial";
-    synonyms.map["c.h.u"]="hopital";
-    synonyms.map["c.h.r"]="hopital";
-    synonyms.map["ld"]="Lieu-Dit";
-    synonyms.map["de"]="";
-    synonyms.map["la"]="";
-    synonyms.map["les"]="";
-    synonyms.map["des"]="";
-    synonyms.map["d"]="";
-    synonyms.map["l"]="";
+    autocomplete_map synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["c c"]="centre commercial";
+    synonyms["cc"]="centre commercial";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
 
-    synonyms.map["st"]="saint";
-    synonyms.map["ste"]="sainte";
-    synonyms.map["cc"]="centre commercial";
-    synonyms.map["chu"]="hopital";
-    synonyms.map["chr"]="hopital";
-    synonyms.map["c.h.u"]="hopital";
-    synonyms.map["c.h.r"]="hopital";
-    synonyms.map["all"]="allée";
-    synonyms.map["allee"]="allée";
-    synonyms.map["ave"]="avenue";
-    synonyms.map["av"]="avenue";
-    synonyms.map["bvd"]="boulevard";
-    synonyms.map["bld"]="boulevard";
-    synonyms.map["bd"]="boulevard";
-    synonyms.map["b"]="boulevard";
-    synonyms.map["r"]="rue";
-    synonyms.map["pl"]="place";
+    synonyms["st"]="saint";
+    synonyms["ste"]="sainte";
+    synonyms["cc"]="centre commercial";
+    synonyms["chu"]="hopital";
+    synonyms["chr"]="hopital";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["all"]="allée";
+    synonyms["allee"]="allée";
+    synonyms["ave"]="avenue";
+    synonyms["av"]="avenue";
+    synonyms["bvd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bd"]="boulevard";
+    synonyms["b"]="boulevard";
+    synonyms["r"]="rue";
+    synonyms["pl"]="place";
 
     Autocomplete<unsigned int> ac;
     ac.add_string("hotel de ville paris", 0, synonyms);
@@ -135,21 +135,21 @@ BOOST_AUTO_TEST_CASE(regex_replace_tests){
 
 BOOST_AUTO_TEST_CASE(regex_toknize_tests){
 
-    navitia::type::map synonyms;
-    synonyms.map["hotel de ville"]="mairie";
-    synonyms.map["c c"]="centre commercial";
-    synonyms.map["cc"]="centre commercial";
-    synonyms.map["c.h.u"]="hopital";
-    synonyms.map["c.h.r"]="hopital";
-    synonyms.map["ld"]="Lieu-Dit";
-    synonyms.map["de"]="";
-    synonyms.map["la"]="";
-    synonyms.map["les"]="";
-    synonyms.map["des"]="";
-    synonyms.map["d"]="";
-    synonyms.map["l"]="";
-    synonyms.map["st"]="saint";
-    synonyms.map["r"]="rue";
+    autocomplete_map synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["c c"]="centre commercial";
+    synonyms["cc"]="centre commercial";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
+    synonyms["st"]="saint";
+    synonyms["r"]="rue";
 
     Autocomplete<unsigned int> ac;
     std::vector<std::string> vec;
@@ -174,18 +174,18 @@ BOOST_AUTO_TEST_CASE(regex_toknize_tests){
 
 BOOST_AUTO_TEST_CASE(regex_address_type_tests){
 
-    navitia::type::map synonyms;
-    synonyms.map["hotel de ville"]="mairie";
-    synonyms.map["c c"]="centre commercial";
-    synonyms.map["cc"]="centre commercial";
-    synonyms.map["c.h.u"]="hopital";
-    synonyms.map["c.h.r"]="hopital";
-    synonyms.map["ld"]="Lieu-Dit";
-    synonyms.map["av"]="avenue";
-    synonyms.map["r"]="rue";
-    synonyms.map["bvd"]="boulevard";
-    synonyms.map["bld"]="boulevard";
-    synonyms.map["bd"]="boulevard";
+    autocomplete_map synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["c c"]="centre commercial";
+    synonyms["cc"]="centre commercial";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["av"]="avenue";
+    synonyms["r"]="rue";
+    synonyms["bvd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bd"]="boulevard";
     //AddressType = {"rue", "avenue", "place", "boulevard","chemin", "impasse"}
 
     Autocomplete<unsigned int> ac;
@@ -195,23 +195,23 @@ BOOST_AUTO_TEST_CASE(regex_address_type_tests){
 
 BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
-    navitia::type::map synonyms;
-    synonyms.map["gare sncf"]="gare";
-    synonyms.map["gare snc"]="gare";
-    synonyms.map["gare sn"]="gare";
-    synonyms.map["gare s"]="gare";
-    synonyms.map["de"]="";
-    synonyms.map["la"]="";
-    synonyms.map["les"]="";
-    synonyms.map["des"]="";
-    synonyms.map["d"]="";
-    synonyms.map["l"]="";
-    synonyms.map["st"]="saint";
-    synonyms.map["av"]="avenue";
-    synonyms.map["r"]="rue";
-    synonyms.map["bvd"]="boulevard";
-    synonyms.map["bld"]="boulevard";
-    synonyms.map["bd"]="boulevard";
+    autocomplete_map synonyms;
+    synonyms["gare sncf"]="gare";
+    synonyms["gare snc"]="gare";
+    synonyms["gare sn"]="gare";
+    synonyms["gare s"]="gare";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
+    synonyms["st"]="saint";
+    synonyms["av"]="avenue";
+    synonyms["r"]="rue";
+    synonyms["bvd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bd"]="boulevard";
 
     Autocomplete<unsigned int> ac;
     std::vector<std::string> vec;
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 }
 
 BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
-    navitia::type::map synonyms;
+    autocomplete_map synonyms;
     std::vector<std::string> vec;
     std::string admin_uri = "";
 
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
 
 BOOST_AUTO_TEST_CASE(Faute_de_frappe_One){
 
-        navitia::type::map synonyms;
+        autocomplete_map synonyms;
         int word_weight = 5;
         int nbmax = 10;
 
@@ -424,7 +424,7 @@ sort
 
 BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
 
-    navitia::type::map synonyms;
+    autocomplete_map synonyms;
     std::vector<std::string> admins;
     std::string admin_uri = "";
     int word_weight = 5;
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
 ///Test pour verifier que - entres les deux mots est ignoré.
 BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
 
-    navitia::type::map synonyms;
+    autocomplete_map synonyms;
     std::vector<std::string> admins;
     std::string admin_uri = "";
     int word_weight = 5;
@@ -483,36 +483,36 @@ BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
 
 BOOST_AUTO_TEST_CASE(autocompletesynonym_and_weight_test){
 
-        navitia::type::map synonyms;
+        autocomplete_map synonyms;
         std::vector<std::string> admins;
         std::string admin_uri;
         int word_weight = 5;
         int nbmax = 10;
 
-        synonyms.map["de"]="";
-        synonyms.map["la"]="";
-        synonyms.map["les"]="";
-        synonyms.map["des"]="";
-        synonyms.map["d"]="";
-        synonyms.map["l"]="";
+        synonyms["de"]="";
+        synonyms["la"]="";
+        synonyms["les"]="";
+        synonyms["des"]="";
+        synonyms["d"]="";
+        synonyms["l"]="";
 
-        synonyms.map["st"]="saint";
-        synonyms.map["ste"]="sainte";
-        synonyms.map["cc"]="centre commercial";
-        synonyms.map["chu"]="hopital";
-        synonyms.map["chr"]="hopital";
-        synonyms.map["c.h.u"]="hopital";
-        synonyms.map["c.h.r"]="hopital";
-        synonyms.map["all"]="allée";
-        synonyms.map["allee"]="allée";
-        synonyms.map["ave"]="avenue";
-        synonyms.map["av"]="avenue";
-        synonyms.map["bvd"]="boulevard";
-        synonyms.map["bld"]="boulevard";
-        synonyms.map["bd"]="boulevard";
-        synonyms.map["b"]="boulevard";
-        synonyms.map["r"]="rue";
-        synonyms.map["pl"]="place";
+        synonyms["st"]="saint";
+        synonyms["ste"]="sainte";
+        synonyms["cc"]="centre commercial";
+        synonyms["chu"]="hopital";
+        synonyms["chr"]="hopital";
+        synonyms["c.h.u"]="hopital";
+        synonyms["c.h.r"]="hopital";
+        synonyms["all"]="allée";
+        synonyms["allee"]="allée";
+        synonyms["ave"]="avenue";
+        synonyms["av"]="avenue";
+        synonyms["bvd"]="boulevard";
+        synonyms["bld"]="boulevard";
+        synonyms["bd"]="boulevard";
+        synonyms["b"]="boulevard";
+        synonyms["r"]="rue";
+        synonyms["pl"]="place";
 
         Autocomplete<unsigned int> ac;
         ac.add_string("rue jeanne d'arc", 0, synonyms);

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -16,63 +16,61 @@
 namespace pt = boost::posix_time;
 using namespace navitia::autocomplete;
 
-BOOST_AUTO_TEST_CASE(parse_find_with_alias_and_synonymes_test){
+BOOST_AUTO_TEST_CASE(parse_find_with_alias_and_synonyms_test){
     /// Liste des alias (Pas serialisé)
     int word_weight = 5;
     int nbmax = 10;
-    std::map<std::string, std::string> alias;
     std::vector<std::string> admins;
     std::string admin_uri = "";
-    alias["de"]="";
-    alias["la"]="";
-    alias["les"]="";
-    alias["des"]="";
-    alias["d"]="";
-    alias["l"]="";
 
-    alias["st"]="saint";
-    alias["ste"]="sainte";
-    alias["cc"]="centre commercial";
-    alias["chu"]="hopital";
-    alias["chr"]="hopital";
-    alias["c.h.u"]="hopital";
-    alias["c.h.r"]="hopital";
-    alias["all"]="allée";
-    alias["allee"]="allée";
-    alias["ave"]="avenue";
-    alias["av"]="avenue";
-    alias["bvd"]="boulevard";
-    alias["bld"]="boulevard";
-    alias["bd"]="boulevard";
-    alias["b"]="boulevard";
-    alias["r"]="rue";
-    alias["pl"]="place";
+    std::map<std::string, std::string> synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["c c"]="centre commercial";
+    synonyms["cc"]="centre commercial";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
 
-    std::map<std::string, std::string> synonymes;
-    synonymes["hotel de ville"]="mairie";
-    synonymes["c c"]="centre commercial";
-    synonymes["cc"]="centre commercial";
-    synonymes["c.h.u"]="hopital";
-    synonymes["c.h.r"]="hopital";
-    synonymes["ld"]="Lieu-Dit";
-
+    synonyms["st"]="saint";
+    synonyms["ste"]="sainte";
+    synonyms["cc"]="centre commercial";
+    synonyms["chu"]="hopital";
+    synonyms["chr"]="hopital";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["all"]="allée";
+    synonyms["allee"]="allée";
+    synonyms["ave"]="avenue";
+    synonyms["av"]="avenue";
+    synonyms["bvd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bd"]="boulevard";
+    synonyms["b"]="boulevard";
+    synonyms["r"]="rue";
+    synonyms["pl"]="place";
 
     Autocomplete<unsigned int> ac;
-    ac.add_string("hotel de ville paris", 0, alias, synonymes);
-    ac.add_string("r jean jaures", 1, alias, synonymes);
-    ac.add_string("rue jeanne d'arc", 2, alias, synonymes);
-    ac.add_string("avenue jean jaures", 3, alias, synonymes);
-    ac.add_string("boulevard poniatowski", 4, alias, synonymes);
-    ac.add_string("pente de Bray", 5, alias, synonymes);
-    ac.add_string("Centre Commercial Caluire 2", 6, alias, synonymes);
-    ac.add_string("Rue René", 7, alias, synonymes);
+    ac.add_string("hotel de ville paris", 0, synonyms);
+    ac.add_string("r jean jaures", 1, synonyms);
+    ac.add_string("rue jeanne d'arc", 2, synonyms);
+    ac.add_string("avenue jean jaures", 3, synonyms);
+    ac.add_string("boulevard poniatowski", 4, synonyms);
+    ac.add_string("pente de Bray", 5, synonyms);
+    ac.add_string("Centre Commercial Caluire 2", 6, synonyms);
+    ac.add_string("Rue René", 7, synonyms);
     ac.build();
 
     //Dans le dictionnaire : "hotel de ville paris" -> "mairie paris"
     //Recherche : "mai paris" -> "mai paris"
     // distance = 3 / word_weight = 0*5 = 0
     // Qualité = 100 - (3 + 0) = 97
-    auto res = ac.find_complete("mai paris",alias, synonymes,word_weight, nbmax, [](int){return true;});
+    auto res = ac.find_complete("mai paris", synonyms,word_weight, nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_REQUIRE_EQUAL(res.at(0).quality, 97);
 
@@ -80,7 +78,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_alias_and_synonymes_test){
     //Recherche : "hotel de ville par" -> "mairie par"
     // distance = 3 / word_weight = 0*5 = 0
     // Qualité = 100 - (2 + 0) = 98
-    auto res1 = ac.find_complete("hotel de ville par",alias, synonymes,word_weight, nbmax, [](int){return true;});
+    auto res1 = ac.find_complete("hotel de ville par", synonyms,word_weight, nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.at(0).quality, 98);
 
@@ -89,19 +87,19 @@ BOOST_AUTO_TEST_CASE(parse_find_with_alias_and_synonymes_test){
     // distance = 5 / word_weight = 0*5 = 0
     // Qualité = 100 - (5 + 0) = 95
 
-    auto res2 = ac.find_complete("c c ca 2",alias, synonymes,word_weight, nbmax, [](int){return true;});
+    auto res2 = ac.find_complete("c c ca 2",synonyms,word_weight, nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res2.size(), 1);
     BOOST_REQUIRE_EQUAL(res2.at(0).quality, 95);
 
-    auto res3 = ac.find_complete("cc ca 2",alias, synonymes,word_weight, nbmax,[](int){return true;});
+    auto res3 = ac.find_complete("cc ca 2", synonyms,word_weight, nbmax,[](int){return true;});
     BOOST_REQUIRE_EQUAL(res3.size(), 1);
     BOOST_REQUIRE_EQUAL(res3.at(0).quality, 95);
 
-    auto res4 = ac.find_complete("rue rene",alias, synonymes,word_weight, nbmax, [](int){return true;});
+    auto res4 = ac.find_complete("rue rene", synonyms,word_weight, nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res4.size(), 1);
     BOOST_REQUIRE_EQUAL(res4.at(0).quality, 100);
 
-    auto res5 = ac.find_complete("rue rené",alias, synonymes,word_weight, nbmax, [](int){return true;});
+    auto res5 = ac.find_complete("rue rené", synonyms,word_weight, nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res5.size(), 1);
     BOOST_REQUIRE_EQUAL(res5.at(0).quality, 100);
 }
@@ -137,30 +135,29 @@ BOOST_AUTO_TEST_CASE(regex_replace_tests){
 }
 
 BOOST_AUTO_TEST_CASE(regex_toknize_tests){
-    std::map<std::string, std::string> alias;
-    alias["de"]="";
-    alias["la"]="";
-    alias["les"]="";
-    alias["des"]="";
-    alias["d"]="";
-    alias["l"]="";
-    alias["st"]="saint";
-    alias["r"]="rue";
 
-    std::map<std::string, std::string> synonymes;
-    synonymes["hotel de ville"]="mairie";
-    synonymes["c c"]="centre commercial";
-    synonymes["cc"]="centre commercial";
-    synonymes["c.h.u"]="hopital";
-    synonymes["c.h.r"]="hopital";
-    synonymes["ld"]="Lieu-Dit";
+    std::map<std::string, std::string> synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["c c"]="centre commercial";
+    synonyms["cc"]="centre commercial";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
+    synonyms["st"]="saint";
+    synonyms["r"]="rue";
 
     Autocomplete<unsigned int> ac;
     std::vector<std::string> vec;
 
     //synonyme : "cc" = "centre commercial" / alias : de = ""
     //"cc Carré de Soie" -> "centre commercial carré de soie"
-    vec = ac.tokenize("cc Carré de Soie", alias, synonymes);
+    vec = ac.tokenize("cc Carré de Soie", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "centre");
     BOOST_CHECK_EQUAL(vec[1], "commercial");
     BOOST_CHECK_EQUAL(vec[2], "carre");
@@ -169,7 +166,7 @@ BOOST_AUTO_TEST_CASE(regex_toknize_tests){
     vec.clear();
     //synonyme : "c c"= "centre commercial" / alias : de = ""
     //"c c Carré de Soie" -> "centre commercial carré de soie"
-    vec = ac.tokenize("c c Carré de Soie", alias, synonymes);
+    vec = ac.tokenize("c c Carré de Soie", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "centre");
     BOOST_CHECK_EQUAL(vec[1], "commercial");
     BOOST_CHECK_EQUAL(vec[2], "carre");
@@ -177,84 +174,80 @@ BOOST_AUTO_TEST_CASE(regex_toknize_tests){
 }
 
 BOOST_AUTO_TEST_CASE(regex_address_type_tests){
-    std::map<std::string, std::string> alias;
-    alias["av"]="avenue";
-    alias["r"]="rue";
-    alias["bvd"]="boulevard";
-    alias["bld"]="boulevard";
-    alias["bd"]="boulevard";
 
-    std::map<std::string, std::string> synonymes;
-    synonymes["hotel de ville"]="mairie";
-    synonymes["c c"]="centre commercial";
-    synonymes["cc"]="centre commercial";
-    synonymes["c.h.u"]="hopital";
-    synonymes["c.h.r"]="hopital";
-    synonymes["ld"]="Lieu-Dit";
-
+    std::map<std::string, std::string> synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["c c"]="centre commercial";
+    synonyms["cc"]="centre commercial";
+    synonyms["c.h.u"]="hopital";
+    synonyms["c.h.r"]="hopital";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["av"]="avenue";
+    synonyms["r"]="rue";
+    synonyms["bvd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bd"]="boulevard";
     //AddressType = {"rue", "avenue", "place", "boulevard","chemin", "impasse"}
 
     Autocomplete<unsigned int> ac;
-    bool addtype = ac.is_address_type("r", alias, synonymes);
+    bool addtype = ac.is_address_type("r", synonyms);
     BOOST_CHECK_EQUAL(addtype, true);
 }
 
 BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
-    std::map<std::string, std::string> alias;
-    alias["de"]="";
-    alias["la"]="";
-    alias["les"]="";
-    alias["des"]="";
-    alias["d"]="";
-    alias["l"]="";
-    alias["st"]="saint";
-    alias["av"]="avenue";
-    alias["r"]="rue";
-    alias["bvd"]="boulevard";
-    alias["bld"]="boulevard";
-    alias["bd"]="boulevard";
 
-
-    std::map<std::string, std::string> synonymes;
-    synonymes["gare sncf"]="gare";
-    synonymes["gare snc"]="gare";
-    synonymes["gare sn"]="gare";
-    synonymes["gare s"]="gare";
+    std::map<std::string, std::string> synonyms;
+    synonyms["gare sncf"]="gare";
+    synonyms["gare snc"]="gare";
+    synonyms["gare sn"]="gare";
+    synonyms["gare s"]="gare";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
+    synonyms["st"]="saint";
+    synonyms["av"]="avenue";
+    synonyms["r"]="rue";
+    synonyms["bvd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bd"]="boulevard";
 
     Autocomplete<unsigned int> ac;
     std::vector<std::string> vec;
 
     //synonyme : "gare sncf" = "gare"
     //"gare sncf" -> "gare"
-    vec = ac.tokenize("gare sncf", alias, synonymes);
+    vec = ac.tokenize("gare sncf", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec.size(),1);
     vec.clear();
 
     //synonyme : "gare snc" = "gare"
     //"gare snc" -> "gare"
-    vec = ac.tokenize("gare snc", alias, synonymes);
+    vec = ac.tokenize("gare snc", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec.size(),1);
     vec.clear();
 
     //synonyme : "gare sn" = "gare"
     //"gare sn" -> "gare"
-    vec = ac.tokenize("gare sn", alias, synonymes);
+    vec = ac.tokenize("gare sn", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec.size(),1);
     vec.clear();
 
     //synonyme : "gare s" = "gare"
     //"gare s" -> "gare"
-    vec = ac.tokenize("gare s", alias, synonymes);
+    vec = ac.tokenize("gare s", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec.size(),1);
     vec.clear();
 
     //synonyme : "gare sn nantes" = "gare nantes"
     //"gare sn nantes" -> "gare nantes"
-    vec = ac.tokenize("gare sn nantes", alias, synonymes);
+    vec = ac.tokenize("gare sn nantes", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec[1], "nantes");
     BOOST_CHECK_EQUAL(vec.size(),2);
@@ -262,7 +255,7 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
     //synonyme : "gare sn nantes" = "gare nantes"
     //"gare sn  nantes" -> "gare nantes"
-    vec = ac.tokenize("gare sn  nantes", alias, synonymes);
+    vec = ac.tokenize("gare sn  nantes", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec[1], "nantes");
     BOOST_CHECK_EQUAL(vec.size(),2);
@@ -270,7 +263,7 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
     //synonyme : "gare sn nantes" = "gare nantes"
     //"gare s  nantes" -> "gare nantes"
-    vec = ac.tokenize("gare  s  nantes", alias, synonymes);
+    vec = ac.tokenize("gare  s  nantes", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec[1], "nantes");
     BOOST_CHECK_EQUAL(vec.size(),2);
@@ -278,7 +271,7 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
     //synonyme : "gare sn nantes" = "gare nantes"
     //"gare s    nantes" -> "gare nantes"
-    vec = ac.tokenize("gare  s    nantes", alias, synonymes);
+    vec = ac.tokenize("gare  s    nantes", synonyms);
     BOOST_CHECK_EQUAL(vec[0], "gare");
     BOOST_CHECK_EQUAL(vec[1], "nantes");
     BOOST_CHECK_EQUAL(vec.size(),2);
@@ -286,20 +279,18 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 }
 
 BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
-    /// Liste des alias (Pas serialisé)
-    std::map<std::string, std::string> alias;
-    std::map<std::string, std::string> synonymes;
+    std::map<std::string, std::string> synonyms;
     std::vector<std::string> vec;
     std::string admin_uri = "";
 
     Autocomplete<unsigned int> ac;
-    ac.add_string("rue jean jaures", 0, alias, synonymes);
-    ac.add_string("place jean jaures", 1, alias, synonymes);
-    ac.add_string("rue jeanne d'arc", 2, alias, synonymes);
-    ac.add_string("avenue jean jaures", 3, alias, synonymes);
-    ac.add_string("boulevard poniatowski", 4, alias, synonymes);
-    ac.add_string("pente de Bray", 5, alias, synonymes);
-    ac.build();    
+    ac.add_string("rue jean jaures", 0, synonyms);
+    ac.add_string("place jean jaures", 1, synonyms);
+    ac.add_string("rue jeanne d'arc", 2, synonyms);
+    ac.add_string("avenue jean jaures", 3, synonyms);
+    ac.add_string("boulevard poniatowski", 4, synonyms);
+    ac.add_string("pente de Bray", 5, synonyms);
+    ac.build();
 
     vec.push_back("rue");
     vec.push_back("jean");
@@ -356,24 +347,6 @@ BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
 }
 
 /*
-    > Le fonctionnement d'alias :
-
-
-  */
-
-BOOST_AUTO_TEST_CASE(alias_test){
-    Autocomplete<unsigned int> ac;
-    std::map <std::string,std::string> map;
-    map["st"]="saint";
-    std::string str = ac.alias_word("st", map);
-    BOOST_CHECK_EQUAL("saint",str);
-
-    map["de"]="";
-    str = ac.alias_word("de", map);
-    BOOST_CHECK_EQUAL("", str);
-}
-
-/*
     > Le fonctionnement partiel :> On prends tous les autocomplete s'il y au moins un match
       et trie la liste des Autocomplete par la qualité.
     > La qualité est calculé avec le nombre des mots dans la recherche et le nombre des matchs dans Autocomplete.
@@ -401,28 +374,27 @@ BOOST_AUTO_TEST_CASE(alias_test){
 */
 
 BOOST_AUTO_TEST_CASE(Faute_de_frappe_One){
-        /// Liste des alias (Pas serialisé)
-        std::map<std::string, std::string> alias;
-        std::map<std::string, std::string> synonymes;
+
+        std::map<std::string, std::string> synonyms;
         int word_weight = 5;
         int nbmax = 10;
 
         Autocomplete<unsigned int> ac;
 
-        ac.add_string("gare Château", 0, alias, synonymes);
-        ac.add_string("gare bateau", 1, alias, synonymes);
-        ac.add_string("gare de taureau", 2, alias, synonymes);
-        ac.add_string("gare tauro", 3, alias, synonymes);
-        ac.add_string("gare gateau", 4, alias, synonymes);
+        ac.add_string("gare Château", 0, synonyms);
+        ac.add_string("gare bateau", 1, synonyms);
+        ac.add_string("gare de taureau", 2, synonyms);
+        ac.add_string("gare tauro", 3, synonyms);
+        ac.add_string("gare gateau", 4, synonyms);
 
         ac.build();
 
-        auto res = ac.find_partial_with_pattern("batau", alias, synonymes,word_weight, nbmax, [](int){return true;});
+        auto res = ac.find_partial_with_pattern("batau", synonyms,word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res.size(), 1);
         BOOST_CHECK_EQUAL(res.at(0).idx, 1);
         BOOST_CHECK_EQUAL(res.at(0).quality, 90);
 
-        auto res1 = ac.find_partial_with_pattern("gare patea", alias, synonymes,word_weight, nbmax, [](int){return true;});
+        auto res1 = ac.find_partial_with_pattern("gare patea", synonyms,word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res1.size(), 3);
         BOOST_CHECK_EQUAL(res1.at(0).idx, 4);
         BOOST_CHECK_EQUAL(res1.at(1).idx, 1);
@@ -452,28 +424,27 @@ sort
 */
 
 BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
-    /// Liste des alias (Pas serialisé)
-    std::map<std::string, std::string> alias;
-    std::map<std::string, std::string> synonymes;
+
+    std::map<std::string, std::string> synonyms;
     std::vector<std::string> admins;
     std::string admin_uri = "";
     int word_weight = 5;
     int nbmax = 10;
 
     Autocomplete<unsigned int> ac;
-    ac.add_string("rue jeanne d'arc", 0, alias, synonymes);
-    ac.add_string("place jean jaures", 1, alias, synonymes);
-    ac.add_string("rue jean paul gaultier paris", 2, alias, synonymes);
-    ac.add_string("avenue jean jaures", 3, alias, synonymes);
-    ac.add_string("boulevard poniatowski", 4, alias, synonymes);
-    ac.add_string("pente de Bray", 5, alias, synonymes);
-    ac.add_string("rue jean jaures", 6, alias, synonymes);
-    ac.add_string("rue jean zay ", 7, alias, synonymes);
-    ac.add_string("place jean paul gaultier ", 8, alias, synonymes);
+    ac.add_string("rue jeanne d'arc", 0, synonyms);
+    ac.add_string("place jean jaures", 1, synonyms);
+    ac.add_string("rue jean paul gaultier paris", 2, synonyms);
+    ac.add_string("avenue jean jaures", 3, synonyms);
+    ac.add_string("boulevard poniatowski", 4, synonyms);
+    ac.add_string("pente de Bray", 5, synonyms);
+    ac.add_string("rue jean jaures", 6, synonyms);
+    ac.add_string("rue jean zay ", 7, synonyms);
+    ac.add_string("place jean paul gaultier ", 8, synonyms);
 
     ac.build();
 
-    auto res = ac.find_complete("rue jean", alias, synonymes, word_weight, nbmax,[](int){return true;});
+    auto res = ac.find_complete("rue jean", synonyms, word_weight, nbmax,[](int){return true;});
     std::vector<int> expected = {6,7,0,2};
     BOOST_REQUIRE_EQUAL(res.size(), 4);
     BOOST_REQUIRE_EQUAL(res.at(0).quality, 92);
@@ -488,24 +459,23 @@ BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
 
 ///Test pour verifier que - entres les deux mots est ignoré.
 BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
-    /// Liste des alias (Pas serialisé)
-    std::map<std::string, std::string> alias;
-    std::map<std::string, std::string> synonymes;
+
+    std::map<std::string, std::string> synonyms;
     std::vector<std::string> admins;
     std::string admin_uri = "";
     int word_weight = 5;
     int nbmax = 10;
 
     Autocomplete<unsigned int> ac;
-    ac.add_string("rue jeanne d'arc", 0, alias, synonymes);
-    ac.add_string("place jean jaures", 1, alias, synonymes);
-    ac.add_string("avenue jean jaures", 3, alias, synonymes);
-    ac.add_string("rue jean-jaures", 6, alias, synonymes);
-    ac.add_string("rue jean zay ", 7, alias, synonymes);
+    ac.add_string("rue jeanne d'arc", 0, synonyms);
+    ac.add_string("place jean jaures", 1, synonyms);
+    ac.add_string("avenue jean jaures", 3, synonyms);
+    ac.add_string("rue jean-jaures", 6, synonyms);
+    ac.add_string("rue jean zay ", 7, synonyms);
 
     ac.build();
 
-    auto res = ac.find_complete("jean-jau", alias, synonymes, word_weight, nbmax, [](int){return true;});
+    auto res = ac.find_complete("jean-jau", synonyms, word_weight, nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res.size(), 3);
     BOOST_REQUIRE_EQUAL(res.at(0).idx, 6);
     BOOST_REQUIRE_EQUAL(res.at(1).idx, 1);
@@ -513,66 +483,62 @@ BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
 }
 
 BOOST_AUTO_TEST_CASE(autocomplete_alias_and_weight_test){
-        /// Liste des alias (Pas serialisé)
-        std::map<std::string, std::string> alias;
-        std::map<std::string, std::string> synonymes;
+
+        std::map<std::string, std::string> synonyms;
         std::vector<std::string> admins;
         std::string admin_uri;
         int word_weight = 5;
         int nbmax = 10;
 
-        alias["de"]="";
-        alias["la"]="";
-        alias["les"]="";
-        alias["des"]="";
-        alias["d"]="";
-        alias["l"]="";
+        synonyms["de"]="";
+        synonyms["la"]="";
+        synonyms["les"]="";
+        synonyms["des"]="";
+        synonyms["d"]="";
+        synonyms["l"]="";
 
-        alias["st"]="saint";
-        alias["ste"]="sainte";
-        alias["cc"]="centre commercial";
-        alias["chu"]="hopital";
-        alias["chr"]="hopital";
-        alias["c.h.u"]="hopital";
-        alias["c.h.r"]="hopital";
-        alias["all"]="allée";
-        alias["allee"]="allée";
-        alias["ave"]="avenue";
-        alias["av"]="avenue";
-        alias["bvd"]="boulevard";
-        alias["bld"]="boulevard";
-        alias["bd"]="boulevard";
-        alias["b"]="boulevard";
-        alias["r"]="rue";
-        alias["pl"]="place";
+        synonyms["st"]="saint";
+        synonyms["ste"]="sainte";
+        synonyms["cc"]="centre commercial";
+        synonyms["chu"]="hopital";
+        synonyms["chr"]="hopital";
+        synonyms["c.h.u"]="hopital";
+        synonyms["c.h.r"]="hopital";
+        synonyms["all"]="allée";
+        synonyms["allee"]="allée";
+        synonyms["ave"]="avenue";
+        synonyms["av"]="avenue";
+        synonyms["bvd"]="boulevard";
+        synonyms["bld"]="boulevard";
+        synonyms["bd"]="boulevard";
+        synonyms["b"]="boulevard";
+        synonyms["r"]="rue";
+        synonyms["pl"]="place";
 
         Autocomplete<unsigned int> ac;
-        ac.add_string("rue jeanne d'arc", 0, alias, synonymes);
-        ac.add_string("place jean jaures", 1, alias, synonymes);
-        ac.add_string("rue jean paul gaultier paris", 2, alias, synonymes);
-        ac.add_string("avenue jean jaures", 3, alias, synonymes);
-        ac.add_string("boulevard poniatowski", 4, alias, synonymes);
-        ac.add_string("pente de Bray", 5, alias, synonymes);
-        ac.add_string("rue jean jaures", 6, alias, synonymes);
-        ac.add_string("rue jean zay ", 7, alias, synonymes);
-        ac.add_string("place jean paul gaultier ", 8, alias, synonymes);
-        ac.add_string("hopital paul gaultier", 8, alias, synonymes);
+        ac.add_string("rue jeanne d'arc", 0, synonyms);
+        ac.add_string("place jean jaures", 1, synonyms);
+        ac.add_string("rue jean paul gaultier paris", 2, synonyms);
+        ac.add_string("avenue jean jaures", 3, synonyms);
+        ac.add_string("boulevard poniatowski", 4, synonyms);
+        ac.add_string("pente de Bray", 5, synonyms);
+        ac.add_string("rue jean jaures", 6, synonyms);
+        ac.add_string("rue jean zay ", 7, synonyms);
+        ac.add_string("place jean paul gaultier ", 8, synonyms);
+        ac.add_string("hopital paul gaultier", 8, synonyms);
 
         ac.build();
-        int alias_size = alias.size();
 
-        BOOST_REQUIRE_EQUAL(alias_size, 23);
-
-        auto res = ac.find_complete("rue jean", alias, synonymes, word_weight, nbmax, [](int){return true;});
+        auto res = ac.find_complete("rue jean", synonyms, word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res.size(), 4);
         BOOST_REQUIRE_EQUAL(res.at(0).quality, 92);
 
-        auto res1 = ac.find_complete("r jean", alias, synonymes, word_weight, nbmax, [](int){return true;});
+        auto res1 = ac.find_complete("r jean", synonyms, word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res1.size(), 4);
 
         BOOST_REQUIRE_EQUAL(res1.at(0).quality, 92);
 
-        auto res2 = ac.find_complete("av jean", alias, synonymes, word_weight, nbmax, [](int){return true;});
+        auto res2 = ac.find_complete("av jean", synonyms, word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res2.size(), 1);
         //rue jean zay
         // distance = 6 / word_weight = 1*5 = 5
@@ -580,7 +546,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_alias_and_weight_test){
         BOOST_REQUIRE_EQUAL(res2.at(0).quality, 89);
 
         word_weight = 10;
-        auto res3 = ac.find_complete("av jean", alias, synonymes, word_weight, nbmax,[](int){return true;});
+        auto res3 = ac.find_complete("av jean", synonyms, word_weight, nbmax,[](int){return true;});
         BOOST_REQUIRE_EQUAL(res3.size(), 1);
         //rue jean zay
         // distance = 6 / word_weight = 1*10 = 10
@@ -588,7 +554,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_alias_and_weight_test){
         BOOST_REQUIRE_EQUAL(res3.at(0).quality, 84);
 
         word_weight = 10;
-        auto res4 = ac.find_complete("chu gau", alias, synonymes, word_weight, nbmax, [](int){return true;});
+        auto res4 = ac.find_complete("chu gau", synonyms, word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res4.size(), 1);
         //hopital paul gaultier
         // distance = 9 / word_weight = 1*10 = 10

--- a/source/ed/connectors/external_parser.cpp
+++ b/source/ed/connectors/external_parser.cpp
@@ -13,35 +13,6 @@ ExternalParser::ExternalParser() {
         logger = log4cplus::Logger::getInstance("log");
 }
 
-void ExternalParser::fill_aliases(const std::string &file, Data & data){
-    // Verification des entêtes:
-    std::string key, value;
-    CsvReader csv(file, '=', true);
-    if(!csv.is_open()) {
-        LOG4CPLUS_FATAL(logger, "Impossible d'ouvrir le fichier " + csv.filename +" dans fill_aliases");
-        return;
-    }
-    std::vector<std::string> mandatory_headers = {"key" , "value"};
-    if(!csv.validate(mandatory_headers)) {
-        LOG4CPLUS_FATAL(logger, "Erreur lors du parsing de fill_aliases " + csv.filename +" . Il manque les colonnes : " + csv.missing_headers(mandatory_headers));
-    }
-
-    int key_c = csv.get_pos_col("key"), value_c = csv.get_pos_col("value");
-    while(!csv.eof()){
-        auto row = csv.next();
-        if (!row.empty()){
-            if (key_c != -1){
-                key = row[key_c];
-                value = row[value_c];
-                boost::to_lower(key);
-                boost::to_lower(value);
-                data.alias[key]=value;
-            }
-        }
-    }
-    LOG4CPLUS_TRACE(logger, "On a  " + boost::lexical_cast<std::string>(data.alias.size())+ " aliases");
-}
-
 void ExternalParser::fill_synonyms(const std::string &file, Data & data)
 {
     std::string key, value;

--- a/source/ed/connectors/external_parser.cpp
+++ b/source/ed/connectors/external_parser.cpp
@@ -35,11 +35,11 @@ void ExternalParser::fill_synonyms(const std::string &file, Data & data)
                 value = row[value_c];
                 boost::to_lower(key);
                 boost::to_lower(value);
-                data.synonymes[key]=value;
+                data.synonyms[key]=value;
             }
         }
     }
-    LOG4CPLUS_TRACE(logger, "On a  " + boost::lexical_cast<std::string>(data.synonymes.size())+ " synonymes");
+    LOG4CPLUS_TRACE(logger, "synonyms : " + boost::lexical_cast<std::string>(data.synonyms.size()));
 }
 
 }}

--- a/source/ed/connectors/external_parser.h
+++ b/source/ed/connectors/external_parser.h
@@ -13,7 +13,6 @@ private:
 public:
     ExternalParser();
 
-    void fill_aliases(const std::string &file, Data & data);
     void fill_synonyms(const std::string &file, Data & data);
 };
 }}

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -40,8 +40,7 @@ public:
     std::vector<types::JourneyPatternPointConnection*> journey_pattern_point_connections;
     std::vector<types::StopPointConnection*> stop_point_connections;
 
-    /// Liste des alias et synonymes
-    std::map<std::string, std::string> alias;
+    /// Liste des synonymes
     std::map<std::string, std::string> synonymes;
 
     //fare:

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -40,8 +40,8 @@ public:
     std::vector<types::JourneyPatternPointConnection*> journey_pattern_point_connections;
     std::vector<types::StopPointConnection*> stop_point_connections;
 
-    /// Liste des synonymes
-    std::map<std::string, std::string> synonymes;
+    /// List of synonyms
+    std::map<std::string, std::string> synonyms;
 
     //fare:
     std::vector<std::tuple<navitia::fare::State, navitia::fare::State, navitia::fare::Transition>> transitions; // transition with state before and after

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -89,7 +89,7 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.pt_data->validity_patterns.size());
     LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.pt_data->journey_pattern_point_connections.size());
     LOG4CPLUS_INFO(logger, "calendars: " << data.pt_data->calendars.size());
-    LOG4CPLUS_INFO(logger, "synonyms : " << data.geo_ref->synonymes.size());
+    LOG4CPLUS_INFO(logger, "synonyms : " << data.geo_ref->synonyms.map.size());
     LOG4CPLUS_INFO(logger, "fare tickets: " << data.fare->fare_map.size());
     LOG4CPLUS_INFO(logger, "fare transitions: " << data.fare->nb_transitions());
     LOG4CPLUS_INFO(logger, "fare od: " << data.fare->od_tickets.size());

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -89,7 +89,7 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.pt_data->validity_patterns.size());
     LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.pt_data->journey_pattern_point_connections.size());
     LOG4CPLUS_INFO(logger, "calendars: " << data.pt_data->calendars.size());
-    LOG4CPLUS_INFO(logger, "synonyms : " << data.geo_ref->synonyms.map.size());
+    LOG4CPLUS_INFO(logger, "synonyms : " << data.geo_ref->synonyms.size());
     LOG4CPLUS_INFO(logger, "fare tickets: " << data.fare->fare_map.size());
     LOG4CPLUS_INFO(logger, "fare transitions: " << data.fare->nb_transitions());
     LOG4CPLUS_INFO(logger, "fare od: " << data.fare->od_tickets.size());

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -89,7 +89,6 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.pt_data->validity_patterns.size());
     LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.pt_data->journey_pattern_point_connections.size());
     LOG4CPLUS_INFO(logger, "calendars: " << data.pt_data->calendars.size());
-    LOG4CPLUS_INFO(logger, "alias : " << data.geo_ref->alias.size());
     LOG4CPLUS_INFO(logger, "synonyms : " << data.geo_ref->synonymes.size());
     LOG4CPLUS_INFO(logger, "fare tickets: " << data.fare->fare_map.size());
     LOG4CPLUS_INFO(logger, "fare transitions: " << data.fare->nb_transitions());

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -298,9 +298,6 @@ void EdPersistor::persist(const ed::Data& data, const navitia::type::MetaData& m
     LOG4CPLUS_INFO(logger, "Begin: insert journey pattern point connections");
     this->insert_journey_pattern_point_connections(data.journey_pattern_point_connections);
     LOG4CPLUS_INFO(logger, "End: insert journey pattern point connections");
-    LOG4CPLUS_INFO(logger, "Begin: insert aliases");
-    this->insert_alias(data.alias);
-    LOG4CPLUS_INFO(logger, "End: insert aliases");
     LOG4CPLUS_INFO(logger, "Begin: insert synonyms");
     this->insert_synonyms(data.synonymes);
     LOG4CPLUS_INFO(logger, "End: insert synonyms");
@@ -939,24 +936,6 @@ void EdPersistor::insert_rel_calendar_line(const std::vector<types::Calendar*>& 
         }
     }
     this->lotus.finish_bulk_insert();
-}
-
-
-void EdPersistor::insert_alias(const std::map<std::string, std::string>& alias){
-    this->lotus.prepare_bulk_insert("navitia.alias", {"id", "key", "value"});
-    int count=1;
-    std::map <std::string, std::string> ::const_iterator it = alias.begin();
-    while(it != alias.end()){
-        std::vector<std::string> values;
-        values.push_back(std::to_string(count));
-        values.push_back(it->first);
-        values.push_back(it->second);
-        this->lotus.insert(values);
-        count++;
-        ++it;
-    }
-    this->lotus.finish_bulk_insert();
-
 }
 
 void EdPersistor::insert_synonyms(const std::map<std::string, std::string>& synonyms){

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -299,7 +299,7 @@ void EdPersistor::persist(const ed::Data& data, const navitia::type::MetaData& m
     this->insert_journey_pattern_point_connections(data.journey_pattern_point_connections);
     LOG4CPLUS_INFO(logger, "End: insert journey pattern point connections");
     LOG4CPLUS_INFO(logger, "Begin: insert synonyms");
-    this->insert_synonyms(data.synonymes);
+    this->insert_synonyms(data.synonyms);
     LOG4CPLUS_INFO(logger, "End: insert synonyms");
     LOG4CPLUS_INFO(logger, "Begin: insert fares");
     persist_fare(data);
@@ -363,7 +363,7 @@ void EdPersistor::clean_poi(){
 void EdPersistor::clean_db(){
     PQclear(this->lotus.exec(
                 "TRUNCATE navitia.stop_area, navitia.line, navitia.company, "
-                "navitia.physical_mode, navitia.contributor, navitia.alias, "
+                "navitia.physical_mode, navitia.contributor, "
                 "navitia.synonym, navitia.commercial_mode, "
                 "navitia.vehicle_properties, navitia.properties, "
                 "navitia.validity_pattern, navitia.network, navitia.parameters, "

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -51,7 +51,6 @@ private:
 
     void insert_stop_point_connections(const std::vector<types::StopPointConnection*>& connections);
     void insert_journey_pattern_point_connections(const std::vector<types::JourneyPatternPointConnection*>& connections);
-    void insert_alias(const std::map<std::string, std::string>& alias);
     void insert_synonyms(const std::map<std::string, std::string>& synonyms);
 
     /// Inserer les données fiche horaire par période

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1029,7 +1029,7 @@ void EdReader::fill_synonyms(navitia::type::Data& data, pqxx::work& work){
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         const_it["key"].to(key);
         const_it["value"].to(value);
-        data.geo_ref->synonyms.map[key] = value;
+        data.geo_ref->synonyms[key] = value;
     }
 }
 

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -53,8 +53,7 @@ void EdReader::fill(navitia::type::Data& data, const double min_non_connected_gr
 //    this->clean_graph(data, work);
     this->fill_graph_vls(data, work);
 
-    //Charger les alias et les synonymes
-    this->fill_alias(data, work);
+    //Charger les synonymes
     this->fill_synonyms(data, work);
 
     /// les relations admin et les autres objets
@@ -1021,17 +1020,6 @@ void EdReader::fill_graph_vls(navitia::type::Data& data, pqxx::work& work){
         cpt_bike_sharing++;
     }
     LOG4CPLUS_INFO(log4cplus::Logger::getInstance("logger"), cpt_bike_sharing << " bike sharing stations added");
-}
-
-void EdReader::fill_alias(navitia::type::Data& data, pqxx::work& work){
-    std::string key, value;
-    std::string request = "SELECT key, value FROM navitia.alias;";
-    pqxx::result result = work.exec(request);
-    for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
-        const_it["key"].to(key);
-        const_it["value"].to(value);
-        data.geo_ref->alias[key]=value;
-    }
 }
 
 void EdReader::fill_synonyms(navitia::type::Data& data, pqxx::work& work){

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1029,7 +1029,7 @@ void EdReader::fill_synonyms(navitia::type::Data& data, pqxx::work& work){
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         const_it["key"].to(key);
         const_it["value"].to(value);
-        data.geo_ref->synonymes[key]=value;
+        data.geo_ref->synonyms.map[key] = value;
     }
 }
 

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -92,8 +92,7 @@ private:
     void fill_vector_to_ignore(navitia::type::Data& data, pqxx::work& work, const double percent_delete);
     void fill_graph_vls(navitia::type::Data& data, pqxx::work& work);
 
-    //les alias et synonymes:
-    void fill_alias(navitia::type::Data& data, pqxx::work& work);
+    //Synonymes:
     void fill_synonyms(navitia::type::Data& data, pqxx::work& work);
 
     //les tarifs:

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -92,7 +92,7 @@ private:
     void fill_vector_to_ignore(navitia::type::Data& data, pqxx::work& work, const double percent_delete);
     void fill_graph_vls(navitia::type::Data& data, pqxx::work& work);
 
-    //Synonymes:
+    //Synonyms:
     void fill_synonyms(navitia::type::Data& data, pqxx::work& work);
 
     //les tarifs:

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -117,8 +117,7 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "journey_pattern points: " << data.journey_pattern_points.size());
     LOG4CPLUS_INFO(logger, "modes: " << data.physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.validity_patterns.size());
-    LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());
-    LOG4CPLUS_INFO(logger, "alias : " <<data.alias.size());
+    LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());    
     LOG4CPLUS_INFO(logger, "synonyms : " <<data.synonymes.size());
 
     start = pt::microsec_clock::local_time();

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -23,14 +23,13 @@ int main(int argc, char * argv[])
     navitia::init_app();
     auto logger = log4cplus::Logger::getInstance("log");
 
-    std::string input, date, connection_string, aliases_file,
+    std::string input, date, connection_string,
                 synonyms_file, fare_dir;
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help,h", "Affiche l'aide")
         ("date,d", po::value<std::string>(&date), "Date de début")
         ("input,i", po::value<std::string>(&input), "Repertoire d'entrée")
-        ("aliases,a", po::value<std::string>(&aliases_file), "Fichier aliases")
         ("synonyms,s", po::value<std::string>(&synonyms_file), "Fichier synonymes")
         ("version,v", "Affiche la version")
         ("fare,f", po::value<std::string>(&fare_dir), "Repertoire des fichiers fare")
@@ -94,10 +93,6 @@ int main(int argc, char * argv[])
     ed::connectors::ExternalParser extConnecteur;
     if(vm.count("synonyms")){
         extConnecteur.fill_synonyms(synonyms_file, data);
-    }
-
-    if(vm.count("aliases")){
-        extConnecteur.fill_aliases(aliases_file, data);
     }
 
     if(vm.count("fare")){

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -118,7 +118,7 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "modes: " << data.physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.validity_patterns.size());
     LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());    
-    LOG4CPLUS_INFO(logger, "synonyms : " <<data.synonymes.size());
+    LOG4CPLUS_INFO(logger, "synonyms : " <<data.synonyms.size());
 
     start = pt::microsec_clock::local_time();
     ed::EdPersistor p(connection_string);

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -104,7 +104,7 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "modes: " << data.physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.validity_patterns.size());
     LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());
-    LOG4CPLUS_INFO(logger, "synonyms : " <<data.synonymes.size());
+    LOG4CPLUS_INFO(logger, "synonyms : " <<data.synonyms.size());
 
     start = pt::microsec_clock::local_time();
     ed::EdPersistor p(connection_string);

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -104,7 +104,6 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "modes: " << data.physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.validity_patterns.size());
     LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());
-    LOG4CPLUS_INFO(logger, "alias : " <<data.alias.size());
     LOG4CPLUS_INFO(logger, "synonyms : " <<data.synonymes.size());
 
     start = pt::microsec_clock::local_time();

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -22,14 +22,13 @@ int main(int argc, char * argv[])
     navitia::init_app();
     auto logger = log4cplus::Logger::getInstance("log");
 
-    std::string input, date, connection_string, aliases_file,
+    std::string input, date, connection_string,
                 synonyms_file;
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help,h", "Affiche l'aide")
         ("date,d", po::value<std::string>(&date), "Date de début")
         ("input,i", po::value<std::string>(&input), "Repertoire d'entrée")
-        ("aliases,a", po::value<std::string>(&aliases_file), "Fichier aliases")
         ("synonyms,s", po::value<std::string>(&synonyms_file), "Fichier synonymes")
         ("version,v", "Affiche la version")
         ("config-file", po::value<std::string>(), "chemin vers le fichier de configuration")
@@ -91,10 +90,6 @@ int main(int argc, char * argv[])
     ed::connectors::ExternalParser extConnecteur;
     if(vm.count("synonyms")){
         extConnecteur.fill_synonyms(synonyms_file, data);
-    }
-
-    if(vm.count("aliases")){
-        extConnecteur.fill_aliases(aliases_file, data);
     }
 
     LOG4CPLUS_INFO(logger, "line: " << data.lines.size());

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -332,7 +332,7 @@ void GeoRef::build_autocomplete_list(){
                     key += " "+ admin->post_code;
                 }
             }
-            fl_way.add_string(way->way_type +" "+ way->name + " " + key, pos,alias, synonymes);
+            fl_way.add_string(way->way_type +" "+ way->name + " " + key, pos, synonymes);
         }
         pos++;
     }
@@ -349,7 +349,7 @@ void GeoRef::build_autocomplete_list(){
                     key += " " + admin->name;
                 }
             }
-            fl_poi.add_string(poi->name + " " + key, poi->idx ,alias, synonymes);
+            fl_poi.add_string(poi->name + " " + key, poi->idx , synonymes);
         }
     }
     fl_poi.build();
@@ -362,7 +362,7 @@ void GeoRef::build_autocomplete_list(){
         {
             key = admin->post_code;
         }
-        fl_admin.add_string(admin->name + " " + key, admin->idx ,alias, synonymes);
+        fl_admin.add_string(admin->name + " " + key, admin->idx , synonymes);
     }
     fl_admin.build();
 }
@@ -436,8 +436,8 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std
     }else{
         search_str = str;
     }
-    if (search_type==0){to_return = fl_way.find_complete(search_str, alias, synonymes, word_weight, nbmax, keep_element);}
-    else {to_return = fl_way.find_partial_with_pattern(search_str, alias, synonymes, word_weight, nbmax, keep_element);}
+    if (search_type==0){to_return = fl_way.find_complete(search_str, synonymes, word_weight, nbmax, keep_element);}
+    else {to_return = fl_way.find_partial_with_pattern(search_str, synonymes, word_weight, nbmax, keep_element);}
 
     /// récupération des coordonnées du numéro recherché pour chaque rue
     for(auto &result_item  : to_return){

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -332,7 +332,7 @@ void GeoRef::build_autocomplete_list(){
                     key += " "+ admin->post_code;
                 }
             }
-            fl_way.add_string(way->way_type +" "+ way->name + " " + key, pos, synonymes);
+            fl_way.add_string(way->way_type +" "+ way->name + " " + key, pos, this->synonyms);
         }
         pos++;
     }
@@ -349,7 +349,7 @@ void GeoRef::build_autocomplete_list(){
                     key += " " + admin->name;
                 }
             }
-            fl_poi.add_string(poi->name + " " + key, poi->idx , synonymes);
+            fl_poi.add_string(poi->name + " " + key, poi->idx , this->synonyms);
         }
     }
     fl_poi.build();
@@ -362,7 +362,7 @@ void GeoRef::build_autocomplete_list(){
         {
             key = admin->post_code;
         }
-        fl_admin.add_string(admin->name + " " + key, admin->idx , synonymes);
+        fl_admin.add_string(admin->name + " " + key, admin->idx , this->synonyms);
     }
     fl_admin.build();
 }
@@ -436,8 +436,8 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std
     }else{
         search_str = str;
     }
-    if (search_type==0){to_return = fl_way.find_complete(search_str, synonymes, word_weight, nbmax, keep_element);}
-    else {to_return = fl_way.find_partial_with_pattern(search_str, synonymes, word_weight, nbmax, keep_element);}
+    if (search_type==0){to_return = fl_way.find_complete(search_str, this->synonyms, word_weight, nbmax, keep_element);}
+    else {to_return = fl_way.find_partial_with_pattern(search_str, this->synonyms, word_weight, nbmax, keep_element);}
 
     /// récupération des coordonnées du numéro recherché pour chaque rue
     for(auto &result_item  : to_return){

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -436,8 +436,11 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std
     }else{
         search_str = str;
     }
-    if (search_type==0){to_return = fl_way.find_complete(search_str, this->synonyms, word_weight, nbmax, keep_element);}
-    else {to_return = fl_way.find_partial_with_pattern(search_str, this->synonyms, word_weight, nbmax, keep_element);}
+    if (search_type == 0){
+        to_return = fl_way.find_complete(search_str, this->synonyms, word_weight, nbmax, keep_element);
+    }else{
+        to_return = fl_way.find_partial_with_pattern(search_str, this->synonyms, word_weight, nbmax, keep_element);
+    }
 
     /// récupération des coordonnées du numéro recherché pour chaque rue
     for(auto &result_item  : to_return){

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -246,7 +246,7 @@ struct GeoRef {
 
     /// number of vertex by transportation mode
     nt::idx_t nb_vertex_by_mode;
-    nt::map synonyms;
+    navitia::autocomplete::autocomplete_map synonyms;
     int word_weight = 5; //Pas serialisé : lu dans le fichier ini
 
     void init();

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -246,15 +246,14 @@ struct GeoRef {
 
     /// number of vertex by transportation mode
     nt::idx_t nb_vertex_by_mode;
-
-    std::map<std::string, std::string> synonymes;
+    nt::map synonyms;
     int word_weight = 5; //Pas serialisé : lu dans le fichier ini
 
     void init();
 
     template<class Archive> void save(Archive & ar, const unsigned int) const {
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & synonymes & poi_proximity_list
+                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & poi_proximity_list
                 & nb_vertex_by_mode;
     }
 
@@ -263,7 +262,7 @@ struct GeoRef {
         // On avait donc une fuite de mémoire
         graph.clear();
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & synonymes & poi_proximity_list
+                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & poi_proximity_list
                 & nb_vertex_by_mode;
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -247,8 +247,6 @@ struct GeoRef {
     /// number of vertex by transportation mode
     nt::idx_t nb_vertex_by_mode;
 
-    /// Liste des alias
-    std::map<std::string, std::string> alias;
     std::map<std::string, std::string> synonymes;
     int word_weight = 5; //Pas serialisé : lu dans le fichier ini
 
@@ -256,7 +254,7 @@ struct GeoRef {
 
     template<class Archive> void save(Archive & ar, const unsigned int) const {
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & alias & synonymes & poi_proximity_list
+                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & synonymes & poi_proximity_list
                 & nb_vertex_by_mode;
     }
 
@@ -265,7 +263,7 @@ struct GeoRef {
         // On avait donc une fuite de mémoire
         graph.clear();
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & alias & synonymes & poi_proximity_list
+                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & synonymes & poi_proximity_list
                 & nb_vertex_by_mode;
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -107,12 +107,6 @@ CREATE TABLE IF NOT EXISTS navitia.synonym (
     value TEXT NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS navitia.alias (
-    id BIGINT PRIMARY KEY,
-    key TEXT NOT NULL,
-    value TEXT NOT NULL
-);
-
 CREATE TABLE IF NOT EXISTS navitia.poi_type (
     id BIGINT PRIMARY KEY,
     uri TEXT NOT NULL,

--- a/source/sql/ed/02-migration.sql
+++ b/source/sql/ed/02-migration.sql
@@ -156,4 +156,4 @@ DO $$
     END;
 $$;
 
-
+DROP TABLE IF EXISTS navitia.alias;

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -65,7 +65,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for( navitia::georef::Admin* admin : sa->admin_list){
                 if (admin->level ==8){key +=" " + admin->name;}
             }
-            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.alias, georef.synonymes);
+            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.synonymes);
         }
     }
     this->stop_area_autocomplete.build();
@@ -79,7 +79,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for(navitia::georef::Admin* admin : sp->admin_list){
                 if (admin->level == 8){key += key + " " + admin->name;}
             }
-            this->stop_point_autocomplete.add_string(sp->name + " " + key, sp->idx, georef.alias, georef.synonymes);
+            this->stop_point_autocomplete.add_string(sp->name + " " + key, sp->idx, georef.synonymes);
         }
     }
     this->stop_point_autocomplete.build();
@@ -87,7 +87,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
     this->line_autocomplete.clear();
     for(const Line* line : this->lines){
         if (!line->name.empty()){
-            this->line_autocomplete.add_string(line->name, line->idx, georef.alias, georef.synonymes);
+            this->line_autocomplete.add_string(line->name, line->idx, georef.synonymes);
         }
     }
     this->line_autocomplete.build();

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -65,7 +65,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for( navitia::georef::Admin* admin : sa->admin_list){
                 if (admin->level ==8){key +=" " + admin->name;}
             }
-            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.synonymes);
+            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.synonyms);
         }
     }
     this->stop_area_autocomplete.build();
@@ -79,7 +79,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for(navitia::georef::Admin* admin : sp->admin_list){
                 if (admin->level == 8){key += key + " " + admin->name;}
             }
-            this->stop_point_autocomplete.add_string(sp->name + " " + key, sp->idx, georef.synonymes);
+            this->stop_point_autocomplete.add_string(sp->name + " " + key, sp->idx, georef.synonyms);
         }
     }
     this->stop_point_autocomplete.build();
@@ -87,7 +87,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
     this->line_autocomplete.clear();
     for(const Line* line : this->lines){
         if (!line->name.empty()){
-            this->line_autocomplete.add_string(line->name, line->idx, georef.synonymes);
+            this->line_autocomplete.add_string(line->name, line->idx, georef.synonyms);
         }
     }
     this->line_autocomplete.build();

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -986,24 +986,6 @@ struct EntryPoint {
 
     EntryPoint() : type(Type_e::Unknown), house_number(-1) {}
 };
-
-struct StrComapre {
-    bool operator()(const  std::string& str_a, const std::string& str_b) const {
-        if(str_a.length() == str_b.length()){
-            return str_a >= str_b;
-        }else{
-            return (str_a.length() > str_b.length());
-        }
-    }
-};
-
-struct map{
-    std::map<std::string, std::string, StrComapre> map;
-    template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-        ar & map;
-    }
-};
-
 } //namespace navitia::type
 
 //trait to access the number of elements in the Mode_e enum

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -987,6 +987,23 @@ struct EntryPoint {
     EntryPoint() : type(Type_e::Unknown), house_number(-1) {}
 };
 
+struct StrComapre {
+    bool operator()(const  std::string& str_a, const std::string& str_b) const {
+        if(str_a.length() == str_b.length()){
+            return str_a >= str_b;
+        }else{
+            return (str_a.length() > str_b.length());
+        }
+    }
+};
+
+struct map{
+    std::map<std::string, std::string, StrComapre> map;
+    template<class Archive> void serialize(Archive & ar, const unsigned int ) {
+        ar & map;
+    }
+};
+
 } //namespace navitia::type
 
 //trait to access the number of elements in the Mode_e enum


### PR DESCRIPTION
1) Fusion des deux map alias et synonymes en synonyms
2) Surcharge de l'objet std::map, navitia::type::map en redéfinissant la fonction de comparaison
            . Comparaison par le nombre de caractères
3) Dans georef : remplacement de  std::map par navitia::type::map
4) Suppression de la table alias
5) Suppression des fonctions liées à l'objet alias
            . Import
            . Écriture dans ED
            . Chargement à partir de ED
