### PR TITLE
Fix for Ubuntu 14.04

### DIFF
--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 SET(SOURCE_LIB
         data.cpp
         types.cpp
@@ -18,7 +17,7 @@ FIND_LIBRARY(OSMPBF osmpbf)
 
 add_executable(osm2ed osm2ed.cpp)
 target_link_libraries(osm2ed transportation_data_import ed connectors pq pqxx ${OSMPBF} pb_lib utils
-    ${BOOST_LIBS} log4cplus)
+    ${BOOST_LIBS} log4cplus z)
 
 add_subdirectory(tests)
 

--- a/source/fare/tests/CMakeLists.txt
+++ b/source/fare/tests/CMakeLists.txt
@@ -7,6 +7,6 @@ ADD_BOOST_TEST(fare_test)
 add_executable(fare_integration_test fare_integration_test.cpp)
 target_link_libraries(fare_integration_test fare ed connectors data georef routing types pb_lib autocomplete utils
         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY}
-    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} ${Boost_DATE_TIME_LIBRARY} log4cplus)
+    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} ${Boost_DATE_TIME_LIBRARY} log4cplus pthread)
 ADD_BOOST_TEST(fare_integration_test)
 

--- a/source/proximity_list/CMakeLists.txt
+++ b/source/proximity_list/CMakeLists.txt
@@ -1,3 +1,2 @@
-FIND_PACKAGE(Boost 1.40.0 COMPONENTS unit_test_framework REQUIRED)
 add_library(proximitylist proximity_list.h proximitylist_api.cpp)
 add_subdirectory(tests)

--- a/source/proximity_list/tests/CMakeLists.txt
+++ b/source/proximity_list/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable (proximity_list_test test.cpp)
 
-target_link_libraries(proximity_list_test proximitylist ptreferential routing georef pb_lib data fare types routing autocomplete utils ${Boost_LIBRARIES} log4cplus)
+SET(BOOST_LIBS ${Boost_THREAD_LIBRARY}
+    ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY}
+    ${Boost_SERIALIZATION_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+target_link_libraries(proximity_list_test proximitylist ptreferential routing georef pb_lib data fare types routing autocomplete utils ${BOOST_LIBS} log4cplus)
 
 ADD_BOOST_TEST(proximity_list_test)

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.10.1
 Flask-Migrate==1.1.1
-Flask-RESTful==0.2.10
+-e git://github.com/l-vincent-l/flask-restful.git@b20d61f88b41f41a85f2cae4d6a831ab327ebaf7#egg=Flask_RESTful-master
 Flask-SQLAlchemy==1.0
 Flask-Script==0.6.6
 GeoAlchemy2==0.2.3


### PR DESCRIPTION
gcc 4.8 is more strict than gcc 4.7, add dependency to make it happy.

Thanks @skywave for the patch!
