### PR TITLE
Fix #292 part3

### DIFF
--- a/source/calendar/tests/CMakeLists.txt
+++ b/source/calendar/tests/CMakeLists.txt
@@ -5,6 +5,6 @@ SET(BOOST_LIBS ${BOOST_LIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM
 
 add_executable(calendar_api_test calendar_api_test.cpp)
 
-target_link_libraries(calendar_api_test calendar_api types ptreferential pb_lib data fare routing ed georef autocomplete utils ${BOOST_LIBS})
+target_link_libraries(calendar_api_test calendar_api types ptreferential pb_lib data fare routing ed georef autocomplete utils ${BOOST_LIBS} pthread)
 
 ADD_TEST(calendar_api_test ${EXECUTABLE_OUTPUT_PATH}/calendar_api_test --report_level=no)

--- a/source/disruption/tests/CMakeLists.txt
+++ b/source/disruption/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(BOOST_LIBS ${BOOST_LIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM
 
 add_executable(disruption_test disruption_test.cpp)
 
-target_link_libraries(disruption_test disruption_api types ptreferential pb_lib data fare routing ed georef autocomplete utils ${BOOST_LIBS})
+target_link_libraries(disruption_test disruption_api types ptreferential pb_lib data fare routing ed georef autocomplete utils ${BOOST_LIBS} pthread)
 
 
 ADD_BOOST_TEST(disruption_test)

--- a/source/proximity_list/tests/CMakeLists.txt
+++ b/source/proximity_list/tests/CMakeLists.txt
@@ -4,6 +4,6 @@ SET(BOOST_LIBS ${Boost_THREAD_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
-target_link_libraries(proximity_list_test proximitylist ptreferential routing georef pb_lib data fare types routing autocomplete utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(proximity_list_test proximitylist ptreferential routing georef pb_lib data fare types routing autocomplete utils ${BOOST_LIBS} log4cplus pthread)
 
 ADD_BOOST_TEST(proximity_list_test)

--- a/source/routing/tests/CMakeLists.txt
+++ b/source/routing/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ ADD_BOOST_TEST(reverse_raptor_test)
 
 add_executable(routing_api_test routing_api_test.cpp)
 target_link_libraries(routing_api_test ed data types routing fare pb_lib georef
-    autocomplete utils  ${BOOST_LIBS} log4cplus)
+    autocomplete utils  ${BOOST_LIBS} log4cplus pthread)
 ADD_BOOST_TEST(routing_api_test)
 
 add_executable(best_stoptime_test best_stoptime.cpp)
@@ -22,5 +22,5 @@ ADD_BOOST_TEST(best_stoptime_test)
 
 add_executable(raptor_adapted_test raptor_adapted_test.cpp)
 target_link_libraries(raptor_adapted_test ed data types routing fare pb_lib georef
-    autocomplete utils ${BOOST_LIBS} log4cplus)
+    autocomplete utils ${BOOST_LIBS} log4cplus pthread)
 ADD_BOOST_TEST(raptor_adapted_test)

--- a/source/time_tables/tests/CMakeLists.txt
+++ b/source/time_tables/tests/CMakeLists.txt
@@ -14,5 +14,5 @@ ADD_BOOST_TEST(thermometer)
 
 
 add_executable(departure_boards_test departure_boards_test.cpp)
-target_link_libraries(departure_boards_test time_tables ptreferential ed data fare routing utils pb_lib georef ${BOOST_LIBS} log4cplus)
+target_link_libraries(departure_boards_test time_tables ptreferential ed data fare routing utils pb_lib georef ${BOOST_LIBS} log4cplus pthread)
 ADD_BOOST_TEST(departure_boards_test)


### PR DESCRIPTION
These were also necessary for GCC 4.8
the package visu also had to be disabled, but i'm not sure if that's compiler related.
