### PR TITLE
Replace zmq_device with zmq_proxy.

### DIFF
--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -79,7 +79,7 @@ int main(int, char** argv){
     // Connect work threads to client threads via a queue
     do{
         try{
-            zmq::device(ZMQ_QUEUE, clients, workers);
+            zmq::proxy(clients, workers, NULL);
         }catch(zmq::error_t){}//lors d'un SIGHUP on restore la queue
     }while(true);
 

--- a/source/tests/mock_kraken.h
+++ b/source/tests/mock_kraken.h
@@ -61,7 +61,7 @@ struct mock_kraken {
         // Connect work threads to client threads via a queue
         do {
             try {
-                zmq::device(ZMQ_QUEUE, clients, workers);
+                zmq::proxy(clients, workers, NULL);
             } catch(zmq::error_t){}//lors d'un SIGHUP on restore la queue
         } while(true);
     }


### PR DESCRIPTION
In ZeroMQ3 zmq_device has been removed. We should use zmq_proxy instead.
