### PR TITLE
kraken: Correction for API place with uri

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -347,36 +347,23 @@ pbnavitia::Response Worker::place_uri(const pbnavitia::PlaceUriRequest &request)
     auto it_sa = data->pt_data->stop_areas_map.find(request.uri());
     if(it_sa != data->pt_data->stop_areas_map.end()) {
         pbnavitia::Place* place = pb_response.add_places();
-        fill_pb_object(it_sa->second, *data, place->mutable_stop_area(), 1);
-        place->set_embedded_type(pbnavitia::STOP_AREA);
-        place->set_name(place->stop_area().name());
-        place->set_uri(place->stop_area().uri());
+        fill_pb_placemark(it_sa->second, *data, place, 1);
     } else {
         auto it_sp = data->pt_data->stop_points_map.find(request.uri());
         if(it_sp != data->pt_data->stop_points_map.end()) {
             pbnavitia::Place* place = pb_response.add_places();
-            fill_pb_object(it_sp->second, *data, place->mutable_stop_point(), 1);
-            place->set_embedded_type(pbnavitia::STOP_POINT);
-            place->set_name(place->stop_point().name());
-            place->set_uri(place->stop_point().uri());
+            fill_pb_placemark(it_sp->second, *data, place, 1);
         } else {
             auto it_poi = data->geo_ref->poi_map.find(request.uri());
             if(it_poi != data->geo_ref->poi_map.end()) {
                 pbnavitia::Place* place = pb_response.add_places();
-                fill_pb_object(data->geo_ref->pois[it_poi->second], *data,
-                        place->mutable_poi(), 1);
-                place->set_embedded_type(pbnavitia::POI);
-                place->set_name(place->poi().name());
-                place->set_uri(place->poi().uri());
+                fill_pb_placemark(data->geo_ref->pois[it_poi->second], *data,place, 1);
             } else {
                 auto it_admin = data->geo_ref->admin_map.find(request.uri());
                 if(it_admin != data->geo_ref->admin_map.end()) {
                     pbnavitia::Place* place = pb_response.add_places();
-                    fill_pb_object(data->geo_ref->admins[it_admin->second],
-                            *data, place->mutable_administrative_region(), 1);
-                    place->set_embedded_type(pbnavitia::ADMINISTRATIVE_REGION);
-                    place->set_name(place->administrative_region().name());
-                    place->set_uri(place->administrative_region().uri());
+                    fill_pb_placemark(data->geo_ref->admins[it_admin->second],*data, place, 1);
+
                 }else{
                     fill_pb_error(pbnavitia::Error::unable_to_parse, "Unable to parse : "+request.uri(),  pb_response.mutable_error());
                 }


### PR DESCRIPTION
For an appel place with uri we can use the function fill_pb_placemark
where attribut Name is formatted properly.
