### PR TITLE
Kraken: change georef duration to int 32

### DIFF
--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -822,7 +822,7 @@ void EdReader::fill_vector_to_ignore(navitia::type::Data& , pqxx::work& work,
             navitia::georef::Edge e;
             float len;
             const_it["leng"].to(len);
-            e.duration = boost::posix_time::seconds(len / navitia::georef::default_speed[navitia::type::Mode_e::Walking]);
+            e.duration = navitia::seconds(len / navitia::georef::default_speed[navitia::type::Mode_e::Walking]);
             e.way_idx = const_it["way_id"].as<idx_t>();
             uint64_t source = node_map_temp[const_it["source_node_id"].as<uint64_t>()];
             uint64_t target = node_map_temp[const_it["target_node_id"].as<uint64_t>()];
@@ -952,12 +952,12 @@ void EdReader::fill_graph(navitia::type::Data& data, pqxx::work& work){
 
         //TODO et les pietons ??!
 
-        e.duration = boost::posix_time::seconds(len / ng::default_speed[nt::Mode_e::Walking]);
+        e.duration = navitia::seconds(len / ng::default_speed[nt::Mode_e::Walking]);
         boost::add_edge(source, target, e, data.geo_ref->graph);
         nb_walking_edges++;
 
         if (const_it["bike"].as<bool>()) {
-            e.duration = boost::posix_time::seconds(len / ng::default_speed[nt::Mode_e::Bike]);
+            e.duration = navitia::seconds(len / ng::default_speed[nt::Mode_e::Bike]);
             auto bike_source = data.geo_ref->offsets[nt::Mode_e::Bike] + source;
             auto bike_target = data.geo_ref->offsets[nt::Mode_e::Bike] + target;
             boost::add_edge(bike_source, bike_target, e, data.geo_ref->graph);
@@ -965,7 +965,7 @@ void EdReader::fill_graph(navitia::type::Data& data, pqxx::work& work){
             nb_biking_edges++;
         }
         if (const_it["car"].as<bool>()) {
-            e.duration = boost::posix_time::seconds(len / ng::default_speed[nt::Mode_e::Car]);
+            e.duration = navitia::seconds(len / ng::default_speed[nt::Mode_e::Car]);
             auto car_source = data.geo_ref->offsets[nt::Mode_e::Car] + source;
             auto car_target = data.geo_ref->offsets[nt::Mode_e::Car] + target;
             boost::add_edge(car_source, car_target, e, data.geo_ref->graph);
@@ -1043,7 +1043,7 @@ void EdReader::fill_graph_vls(navitia::type::Data& data, pqxx::work& work){
         auto min_dist = get_min_distance(data, nearest_walking_edge, nearest_biking_edge);
         navitia::georef::vertex_t walking_v = std::get<1>(min_dist);
         navitia::georef::vertex_t biking_v = std::get<2>(min_dist);
-        boost::posix_time::time_duration dur_between_edges = boost::posix_time::seconds(std::get<0>(min_dist) / navitia::georef::default_speed[navitia::type::Mode_e::Walking]);
+        navitia::time_duration dur_between_edges = navitia::seconds(std::get<0>(min_dist) / navitia::georef::default_speed[navitia::type::Mode_e::Walking]);
 
         navitia::georef::Edge edge;
         edge.way_idx = data.geo_ref->graph[nearest_walking_edge].way_idx; //arbitrarily we assume the way is the walking way

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -58,8 +58,8 @@ const flat_enum_map<nt::Mode_e, float> default_speed {
                                                     }}
                                                     };
 
-const boost::posix_time::seconds default_time_bss_pickup(120);
-const boost::posix_time::seconds default_time_bss_putback(60);
+const navitia::seconds default_time_bss_pickup(120);
+const navitia::seconds default_time_bss_putback(60);
 
 /** Propriétés Nœud (intersection entre deux routes) */
 struct Vertex {
@@ -83,12 +83,12 @@ struct Vertex {
 
 struct Edge {
     nt::idx_t way_idx = nt::invalid_idx; //< indexe vers le nom de rue
-    boost::posix_time::time_duration duration = {}; // duration of the edge
+    navitia::time_duration duration = {}; // duration of the edge
 
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
         ar & way_idx & duration;
     }
-    Edge(nt::idx_t wid, boost::posix_time::time_duration dur) : way_idx(wid), duration(dur) {}
+    Edge(nt::idx_t wid, navitia::time_duration dur) : way_idx(wid), duration(dur) {}
     Edge() {}
 };
 
@@ -162,7 +162,7 @@ private:
         un nom de voie et une liste de segments */
 struct PathItem {
     nt::idx_t way_idx = nt::invalid_idx; //< Way of this path item
-    boost::posix_time::time_duration duration = {}; //< Length of the journey on this item
+    navitia::time_duration duration = {}; //< Length of the journey on this item
     std::deque<nt::GeographicalCoord> coordinates;//< path item coordinates
     int angle = 0; //< Angle with the next PathItem (needed to give direction)
 
@@ -195,7 +195,7 @@ struct PathItem {
 
 /** Itinéraire complet */
 struct Path {
-    boost::posix_time::time_duration duration = {}; //< Longueur totale du parcours
+    navitia::time_duration duration = {}; //< Longueur totale du parcours
     std::deque<PathItem> path_items = {}; //< Liste des voies parcourues
 };
 

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -39,8 +39,8 @@ namespace navitia { namespace georef {
 const auto source_e = ProjectionData::Direction::Source;
 const auto target_e = ProjectionData::Direction::Target;
 
-bt::time_duration PathFinder::crow_fly_duration(const double distance) const {
-    return bt::seconds(distance / (default_speed[mode] * speed_factor));
+navitia::time_duration PathFinder::crow_fly_duration(const double distance) const {
+    return navitia::seconds(distance / (default_speed[mode] * speed_factor));
 }
 
 StreetNetwork::StreetNetwork(const GeoRef &geo_ref) :
@@ -60,14 +60,14 @@ void StreetNetwork::init(const type::EntryPoint& start, boost::optional<const ty
 bool StreetNetwork::departure_launched() const {return departure_path_finder.computation_launch;}
 bool StreetNetwork::arrival_launched() const {return arrival_path_finder.computation_launch;}
 
-std::vector<std::pair<type::idx_t, bt::time_duration>>
-StreetNetwork::find_nearest_stop_points(bt::time_duration radius, const proximitylist::ProximityList<type::idx_t>& pl, bool use_second) {
+std::vector<std::pair<type::idx_t, navitia::time_duration>>
+StreetNetwork::find_nearest_stop_points(navitia::time_duration radius, const proximitylist::ProximityList<type::idx_t>& pl, bool use_second) {
     // delegate to the arrival or departure pathfinder
     // results are store to build the routing path after the transportation routing computation
     return (use_second ? arrival_path_finder : departure_path_finder).find_nearest_stop_points(radius, pl);
 }
 
-bt::time_duration StreetNetwork::get_distance(type::idx_t target_idx, bool use_second) {
+navitia::time_duration StreetNetwork::get_distance(type::idx_t target_idx, bool use_second) {
     return (use_second ? arrival_path_finder : departure_path_finder).get_distance(target_idx);
 }
 
@@ -125,7 +125,7 @@ Path StreetNetwork::get_direct_path() {
     //Cherche s'il y a des nœuds en commun, et retient le chemin le plus court
     size_t num_vertices = boost::num_vertices(geo_ref.graph);
 
-    bt::time_duration min_dist = bt::pos_infin;
+    navitia::time_duration min_dist = bt::pos_infin;
     vertex_t target = std::numeric_limits<size_t>::max();
     for(vertex_t u = 0; u != num_vertices; ++u) {
         if((departure_path_finder.distances[u] != bt::pos_infin)
@@ -186,8 +186,8 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mod
     }
 }
 
-std::vector<std::pair<type::idx_t, bt::time_duration>>
-PathFinder::find_nearest_stop_points(bt::time_duration radius, const proximitylist::ProximityList<type::idx_t>& pl) {
+std::vector<std::pair<type::idx_t, navitia::time_duration>>
+PathFinder::find_nearest_stop_points(navitia::time_duration radius, const proximitylist::ProximityList<type::idx_t>& pl) {
     if (! starting_edge.found)
         return {};
 
@@ -198,7 +198,7 @@ PathFinder::find_nearest_stop_points(bt::time_duration radius, const proximityli
         return {};
 
     computation_launch = true;
-    std::vector<std::pair<type::idx_t, bt::time_duration>> result;
+    std::vector<std::pair<type::idx_t, navitia::time_duration>> result;
 
     // On lance un dijkstra depuis les deux nœuds de départ
     try {
@@ -215,7 +215,7 @@ PathFinder::find_nearest_stop_points(bt::time_duration radius, const proximityli
         ProjectionData projection = this->geo_ref.projected_stop_points[element.first][mode];
         // Est-ce que le stop point a pu être raccroché au street network
         if(projection.found){
-            bt::time_duration best_dist = max;
+            navitia::time_duration best_dist = max;
             if (distances[projection[source_e]] < max) {
                 best_dist = distances[projection[source_e]] + crow_fly_duration(projection.distances[source_e]); }
             if (distances[projection[target_e]] < max) {
@@ -229,7 +229,7 @@ PathFinder::find_nearest_stop_points(bt::time_duration radius, const proximityli
     return result;
 }
 
-bt::time_duration PathFinder::get_distance(type::idx_t target_idx) {
+navitia::time_duration PathFinder::get_distance(type::idx_t target_idx) {
     constexpr auto max = bt::pos_infin;
 
     if (! starting_edge.found)
@@ -243,7 +243,7 @@ bt::time_duration PathFinder::get_distance(type::idx_t target_idx) {
     return nearest_edge.first;
 }
 
-std::pair<bt::time_duration, ProjectionData::Direction> PathFinder::find_nearest_vertex(const ProjectionData& target) const {
+std::pair<navitia::time_duration, ProjectionData::Direction> PathFinder::find_nearest_vertex(const ProjectionData& target) const {
     constexpr auto max = bt::pos_infin;
     if (! target.found)
         return {max, source_e};
@@ -332,7 +332,7 @@ void PathFinder::add_custom_projections_to_path(Path& p, bool append_to_begin, c
     }
 }
 
-Path PathFinder::get_path(const ProjectionData& target, std::pair<bt::time_duration, ProjectionData::Direction> nearest_edge) {
+Path PathFinder::get_path(const ProjectionData& target, std::pair<navitia::time_duration, ProjectionData::Direction> nearest_edge) {
     if (! computation_launch || ! target.found || nearest_edge.first == bt::pos_infin)
         return {};
 
@@ -386,7 +386,7 @@ void PathFinder::add_projections_to_path(Path& p, bool append_to_begin) const {
     add_custom_projections_to_path(p, append_to_begin, starting_edge, direction);
 }
 
-std::pair<bt::time_duration, ProjectionData::Direction> PathFinder::update_path(const ProjectionData& target) {
+std::pair<navitia::time_duration, ProjectionData::Direction> PathFinder::update_path(const ProjectionData& target) {
     constexpr auto max = bt::pos_infin;
     if (! target.found)
         return {max, source_e};

--- a/source/georef/tests/builder.cpp
+++ b/source/georef/tests/builder.cpp
@@ -50,7 +50,7 @@ GraphBuilder & GraphBuilder::add_vertex(std::string node_name, float x, float y)
     return *this;
 }
 
-GraphBuilder & GraphBuilder::add_edge(std::string source_name, std::string target_name, boost::posix_time::time_duration dur, bool bidirectionnal){
+GraphBuilder & GraphBuilder::add_edge(std::string source_name, std::string target_name, navitia::time_duration dur, bool bidirectionnal){
     vertex_t source, target;
     auto it = this->vertex_map.find(source_name);
     if(it == this->vertex_map.end())
@@ -63,7 +63,7 @@ GraphBuilder & GraphBuilder::add_edge(std::string source_name, std::string targe
     target= this->vertex_map[target_name];
 
     Edge edge;
-    edge.duration = dur.is_negative() ? boost::posix_time::seconds(0) : dur;
+    edge.duration = dur.is_negative() ? navitia::seconds(0) : dur;
 
     boost::add_edge(source, target, edge, this->geo_ref.graph);
     if(bidirectionnal)

--- a/source/georef/tests/builder.h
+++ b/source/georef/tests/builder.h
@@ -52,14 +52,14 @@ struct GraphBuilder{
 
     /// Ajoute un arc. Si un nœud n'existe pas, il est créé automatiquement
     /// Si la longueur n'est pas précisée, il s'agit de la longueur à vol d'oiseau
-    GraphBuilder & add_edge(std::string source_name, std::string target_name, boost::posix_time::time_duration dur = {}, bool bidirectionnal = false);
+    GraphBuilder & add_edge(std::string source_name, std::string target_name, navitia::time_duration dur = {}, bool bidirectionnal = false);
 
     /// Surchage de la création de nœud pour plus de confort
     GraphBuilder & operator()(std::string node_name, float x, float y){ return add_vertex(node_name, x, y);}
 
 
     /// Surchage de la création d'arc pour plus de confort
-    GraphBuilder & operator()(std::string source_name, std::string target_name, boost::posix_time::time_duration dur = {}, bool bidirectionnal = false){
+    GraphBuilder & operator()(std::string source_name, std::string target_name, navitia::time_duration dur = {}, bool bidirectionnal = false){
         return add_edge(source_name, target_name, dur, bidirectionnal);
     }
 

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -56,7 +56,7 @@ struct custom_seconds
     constexpr custom_seconds(int s) : dur(s) {}
     custom_seconds(const custom_seconds&) = default;
     custom_seconds& operator=(const custom_seconds&) = default;
-    operator bt::time_duration() const { return bt::seconds(dur); }
+    operator navitia::time_duration() const { return navitia::seconds(dur); }
 };
 std::ostream & operator<<(std::ostream& os, custom_seconds s) {
     os << s.dur << " seconds";
@@ -144,10 +144,10 @@ BOOST_AUTO_TEST_CASE(outil_de_graph) {
     BOOST_CHECK_EQUAL(g[b].coord, expected);
 
     edge_t e = edge(a, b, g).first;
-    BOOST_CHECK_EQUAL(g[e].duration, bt::seconds(10));
+    BOOST_CHECK_EQUAL(g[e].duration, navitia::seconds(10));
 
     // Construction implicite de nœuds
-    builder("c", "d", bt::seconds(42));
+    builder("c", "d", navitia::seconds(42));
     BOOST_CHECK_EQUAL(num_vertices(g), 4);
     BOOST_CHECK_EQUAL(num_edges(g), 2);
 
@@ -409,17 +409,17 @@ BOOST_AUTO_TEST_CASE(compute_nearest){
     res = w.find_nearest_stop_points(100_s, pl, false);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].first , 0);
-    BOOST_CHECK_EQUAL(res[0].second, bt::seconds(50 / (default_speed[Mode_e::Walking] * 2))); //the projection is done with the same mean of transport, at the same speed
+    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(50 / (default_speed[Mode_e::Walking] * 2))); //the projection is done with the same mean of transport, at the same speed
 
     w.init(starting_point);
     res = w.find_nearest_stop_points(1000_s, pl, false);
     std::sort(res.begin(), res.end());
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     BOOST_CHECK_EQUAL(res[0].first , 0);
-    BOOST_CHECK_EQUAL(res[0].second, bt::seconds(50 / (default_speed[Mode_e::Walking] * 2)));
+    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(50 / (default_speed[Mode_e::Walking] * 2)));
     BOOST_CHECK_EQUAL(res[1].first , 1);
     //1 projections at the arrival, and 3 edges (100s each but at twice the speed)
-    BOOST_CHECK_EQUAL(res[1].second, bt::seconds(50 / (default_speed[Mode_e::Walking] * 2)) + 150_s);
+    BOOST_CHECK_EQUAL(res[1].second, navitia::seconds(50 / (default_speed[Mode_e::Walking] * 2)) + 150_s);
 }
 
 // Récupérer les cordonnées d'un numéro impair :
@@ -782,7 +782,7 @@ BOOST_AUTO_TEST_CASE(two_scc) {
      */
 
     b("a",0,0)("b",100,0)("c",200,0)("d",300,0)("e",400,0);
-    b("a","b",bt::seconds(100))("b","a",bt::seconds(100))("c","d",bt::seconds(100))("d","c",bt::seconds(100))("d","e",bt::seconds(100))("e","d",bt::seconds(100));
+    b("a","b",navitia::seconds(100))("b","a",navitia::seconds(100))("c","d",navitia::seconds(100))("d","c",navitia::seconds(100))("d","e",navitia::seconds(100))("e","d",navitia::seconds(100));
 
     GeographicalCoord c1(50,10, false);
     GeographicalCoord c2(350,20, false);
@@ -873,24 +873,24 @@ BOOST_AUTO_TEST_CASE(angle_computation_lon_lat) {
 
 //small test to make sure the time manipulation works in the SpeedDistanceCombiner
 BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test) {
-    bt::time_duration dur = 10_s;
+    navitia::time_duration dur = 10_s;
 
     SpeedDistanceCombiner comb(2);
 
-    BOOST_CHECK_EQUAL(comb.divide_by_speed(dur), 5_s);
+    BOOST_CHECK_EQUAL(dur / 2, 5_s);
 
-    bt::time_duration dur2 = 60_s;
-    BOOST_CHECK_EQUAL(comb(dur, dur2), bt::seconds(10+60/2));
+    navitia::time_duration dur2 = 60_s;
+    BOOST_CHECK_EQUAL(comb(dur, dur2), navitia::seconds(10+60/2));
 }
 
 BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test2) {
-    bt::time_duration dur = 10_s;
+    navitia::time_duration dur = 10_s;
 
     SpeedDistanceCombiner comb(0.5);
 
-    BOOST_CHECK_EQUAL(comb.divide_by_speed(dur), 20_s);
+    BOOST_CHECK_EQUAL(dur / 0.5, 20_s);
 
-    bt::time_duration dur2 = 60_s;
+    navitia::time_duration dur2 = 60_s;
     BOOST_CHECK_EQUAL(comb(dur, dur2), 130_s);
 }
 
@@ -913,6 +913,3 @@ BOOST_AUTO_TEST_CASE(transportation_mode_creation) {
     BOOST_CHECK_EQUAL(allowed_transportation_mode[nt::Mode_e::Bss][nt::Mode_e::Car], false);
     BOOST_CHECK_EQUAL(allowed_transportation_mode[nt::Mode_e::Bss][nt::Mode_e::Bike], false);
 }
-
-
-

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -46,11 +46,11 @@ namespace bt = boost::posix_time;
 using dir = ProjectionData::Direction;
 
 struct computation_results {
-    bt::time_duration duration; //asked duration
-    std::vector<bt::time_duration> durations_matrix; //duration matrix
+    navitia::time_duration duration; //asked duration
+    std::vector<navitia::time_duration> durations_matrix; //duration matrix
     std::vector<vertex_t> predecessor;
 
-    computation_results(bt::time_duration d, const PathFinder& worker) : duration(d), durations_matrix(worker.distances), predecessor(worker.predecessors) {}
+    computation_results(navitia::time_duration d, const PathFinder& worker) : duration(d), durations_matrix(worker.distances), predecessor(worker.predecessors) {}
 
     bool operator ==(const computation_results& other) {
 
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(idempotence) {
             std::string name(get_name(i, j));
 
             //we add edge to the next vertex (the value is not important)
-            b.add_edge(name, get_name(i, j + 1), bt::seconds((i + j) * j));
-            b.add_edge(name, get_name(i + 1, j), bt::seconds((i + j) * i));
+            b.add_edge(name, get_name(i, j + 1), navitia::seconds((i + j) * j));
+            b.add_edge(name, get_name(i + 1, j), navitia::seconds((i + j) * i));
         }
     }
 
@@ -138,8 +138,8 @@ BOOST_AUTO_TEST_CASE(idempotence) {
               << " distance to target " << worker.distances[proj[dir::Target]] << std::endl;
 
     // the distance matrix also has to be updated
-    BOOST_CHECK(worker.distances[proj[dir::Source]] + bt::seconds(proj.distances[dir::Source] / default_speed[type::Mode_e::Walking]) == distance//we have to take into account the projection distance
-                    || worker.distances[proj[dir::Target]] + bt::seconds(proj.distances[dir::Target] / default_speed[type::Mode_e::Walking]) == distance);
+    BOOST_CHECK(worker.distances[proj[dir::Source]] + navitia::seconds(proj.distances[dir::Source] / default_speed[type::Mode_e::Walking]) == distance//we have to take into account the projection distance
+                    || worker.distances[proj[dir::Target]] + navitia::seconds(proj.distances[dir::Target] / default_speed[type::Mode_e::Walking]) == distance);
 
     computation_results first_res {distance, worker};
 
@@ -153,8 +153,8 @@ BOOST_AUTO_TEST_CASE(idempotence) {
         //we have to find a way to get there
         BOOST_REQUIRE_NE(other_distance, bt::pos_infin);
         // the distance matrix  also has to be updated
-        BOOST_CHECK(worker.distances[proj[dir::Source]] + bt::seconds(proj.distances[dir::Source] / default_speed[type::Mode_e::Walking]) == other_distance
-                        || worker.distances[proj[dir::Target]] + bt::seconds(proj.distances[dir::Target] / default_speed[type::Mode_e::Walking]) == other_distance);
+        BOOST_CHECK(worker.distances[proj[dir::Source]] + navitia::seconds(proj.distances[dir::Source] / default_speed[type::Mode_e::Walking]) == other_distance
+                        || worker.distances[proj[dir::Target]] + navitia::seconds(proj.distances[dir::Target] / default_speed[type::Mode_e::Walking]) == other_distance);
 
         BOOST_REQUIRE(first_res == other_res);
     }
@@ -167,8 +167,8 @@ BOOST_AUTO_TEST_CASE(idempotence) {
         //we have to find a way to get there
         BOOST_CHECK_NE(other_distance, bt::pos_infin);
 
-        BOOST_CHECK(worker.distances[proj[dir::Source]] + bt::seconds(proj.distances[dir::Source] / default_speed[type::Mode_e::Walking]) == other_distance
-                        || worker.distances[proj[dir::Target]] + bt::seconds(proj.distances[dir::Target] / default_speed[type::Mode_e::Walking]) == other_distance);
+        BOOST_CHECK(worker.distances[proj[dir::Source]] + navitia::seconds(proj.distances[dir::Source] / default_speed[type::Mode_e::Walking]) == other_distance
+                        || worker.distances[proj[dir::Target]] + navitia::seconds(proj.distances[dir::Target] / default_speed[type::Mode_e::Walking]) == other_distance);
 
         BOOST_CHECK(first_res == other_res);
     }

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -324,7 +324,7 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
             break;
     }
     int max_non_pt = request.max_duration_to_pt();
-    result.max_duration = boost::posix_time::seconds(max_non_pt);
+    result.max_duration = navitia::seconds(max_non_pt);
     return result;
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -178,7 +178,7 @@ void RAPTOR::clear(const type::Data & data, bool clockwise, DateTime borne) {
 }
 
 void RAPTOR::clear_and_init(Solutions departs,
-                  std::vector<std::pair<type::idx_t, bt::time_duration> > destinations,
+                  std::vector<std::pair<type::idx_t, navitia::time_duration> > destinations,
                   DateTime bound,  const bool clockwise,
                   const type::Properties &required_properties) {
 
@@ -221,8 +221,8 @@ void RAPTOR::clear_and_init(Solutions departs,
 
 
 std::vector<Path>
-RAPTOR::compute_all(const std::vector<std::pair<type::idx_t, bt::time_duration> > &departures_,
-                    const std::vector<std::pair<type::idx_t, bt::time_duration> > &destinations,
+RAPTOR::compute_all(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departures_,
+                    const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
                     const DateTime &departure_datetime,
                     bool disruption_active, const DateTime &bound,
                     const uint32_t max_transfers,
@@ -266,7 +266,7 @@ RAPTOR::compute_all(const std::vector<std::pair<type::idx_t, bt::time_duration> 
 
 
 void
-RAPTOR::isochrone(const std::vector<std::pair<type::idx_t, bt::time_duration> > &departures_,
+RAPTOR::isochrone(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departures_,
           const DateTime &departure_datetime, const DateTime &bound, uint32_t max_transfers,
           const type::AccessibiliteParams & accessibilite_params,
           const std::vector<std::string> & forbidden,
@@ -493,7 +493,7 @@ std::vector<Path> RAPTOR::compute(const type::StopArea* departure,
         int departure_day, DateTime borne, bool disruption_active, bool clockwise,
         const type::AccessibiliteParams & accessibilite_params,
         uint32_t max_transfers) {
-    std::vector<std::pair<type::idx_t, bt::time_duration> > departures, destinations;
+    std::vector<std::pair<type::idx_t, navitia::time_duration> > departures, destinations;
 
     for(const type::StopPoint* sp : departure->stop_point_list) {
         departures.push_back({sp->idx, {}});

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -42,6 +42,7 @@ www.navitia.io
 #include "raptor_path.h"
 #include "raptor_solutions.h"
 #include "raptor_utils.h"
+#include "type/time_duration.h"
 
 namespace navitia { namespace routing {
 
@@ -84,7 +85,7 @@ struct RAPTOR
 
     ///Initialise les structure retour et b_dest
     void clear_and_init(Solutions departures,
-              std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > destinations,
+              std::vector<std::pair<type::idx_t, navitia::time_duration> > destinations,
               navitia::DateTime bound, const bool clockwise,
               const type::Properties &properties = 0);
 
@@ -104,8 +105,8 @@ struct RAPTOR
      *  à une heure donnée.
      */
     std::vector<Path> 
-    compute_all(const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration>> &departs,
-                const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration>> &destinations,
+    compute_all(const std::vector<std::pair<type::idx_t, navitia::time_duration>> &departs,
+                const std::vector<std::pair<type::idx_t, navitia::time_duration>> &destinations,
                 const DateTime &departure_datetime, bool disruption_active, const DateTime &bound=DateTimeUtils::inf,
                 const uint32_t max_transfers=std::numeric_limits<int>::max(),
                 const type::AccessibiliteParams & accessibilite_params = type::AccessibiliteParams(),
@@ -118,7 +119,7 @@ struct RAPTOR
      *  Renvoie toutes les arrivées vers tous les stop points.
      */
     void
-    isochrone(const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration>> &departures_,
+    isochrone(const std::vector<std::pair<type::idx_t, navitia::time_duration>> &departures_,
               const DateTime &departure_datetime, const DateTime &bound = DateTimeUtils::min,
               uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
               const type::AccessibiliteParams & accessibilite_params = type::AccessibiliteParams(),

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -36,8 +36,6 @@ www.navitia.io
 #include <chrono>
 #include "type/meta_data.h"
 #include "fare/fare.h"
-#include <valgrind/callgrind.h>
-
 
 namespace navitia { namespace routing {
 
@@ -250,7 +248,6 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
         pb_response.set_response_type(pbnavitia::NO_SOLUTION);
     }
 
-    CALLGRIND_STOP_INSTRUMENTATION;
     return pb_response;
 }
 
@@ -339,7 +336,6 @@ make_response(RAPTOR &raptor, const type::EntryPoint &origin,
               georef::StreetNetwork & worker,
               bool disruption_active,
               uint32_t max_duration, uint32_t max_transfers, bool show_codes) {
-    CALLGRIND_START_INSTRUMENTATION;
     pbnavitia::Response response;
 
     std::vector<bt::ptime> datetimes;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include <chrono>
 #include "type/meta_data.h"
 #include "fare/fare.h"
+#include <valgrind/callgrind.h>
 
 
 namespace navitia { namespace routing {
@@ -82,12 +83,12 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
             if (clockwise) {
                 departure = datetime;
             } else {
-                departure = datetime - temp.duration;
+                departure = datetime - temp.duration.to_posix();
             }
             fill_street_sections(enhanced_response, origin, temp, d, pb_journey, departure);
 
             const auto str_departure = navitia::to_iso_string_no_fractional(departure);
-            const auto str_arrival = navitia::to_iso_string_no_fractional(departure + temp.duration);
+            const auto str_arrival = navitia::to_iso_string_no_fractional(departure + temp.duration.to_posix());
             pb_journey->set_departure_date_time(str_departure);
             pb_journey->set_arrival_date_time(str_arrival);
         }
@@ -119,7 +120,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     }
 
                     const auto walking_time = temp.duration;
-                    departure_time = path.items.front().departure - walking_time;
+                    departure_time = path.items.front().departure - walking_time.to_posix();
                     fill_street_sections(enhanced_response, origin, temp, d, pb_journey, departure_time);
                 }
             }
@@ -227,7 +228,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     auto begin_section_time = arrival_time;
                     fill_street_sections(enhanced_response, destination, temp, d, pb_journey,
                             begin_section_time, show_codes);
-                    arrival_time = arrival_time + temp.duration;
+                    arrival_time = arrival_time + temp.duration.to_posix();
                 }
             }
         }
@@ -249,14 +250,15 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
         pb_response.set_response_type(pbnavitia::NO_SOLUTION);
     }
 
+    CALLGRIND_STOP_INSTRUMENTATION;
     return pb_response;
 }
 
 
-std::vector<std::pair<type::idx_t, bt::time_duration> >
+std::vector<std::pair<type::idx_t, navitia::time_duration> >
 get_stop_points( const type::EntryPoint &ep, const type::PT_Data & pt_data,
         georef::StreetNetwork & worker, bool use_second = false){
-    std::vector<std::pair<type::idx_t, bt::time_duration> > result;
+    std::vector<std::pair<type::idx_t, navitia::time_duration> > result;
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     LOG4CPLUS_DEBUG(logger, "calcul des stop points pour l'entry point : [" << ep.coordinates.lat()
               << "," << ep.coordinates.lon() << "]");
@@ -337,7 +339,7 @@ make_response(RAPTOR &raptor, const type::EntryPoint &origin,
               georef::StreetNetwork & worker,
               bool disruption_active,
               uint32_t max_duration, uint32_t max_transfers, bool show_codes) {
-
+    CALLGRIND_START_INSTRUMENTATION;
     pbnavitia::Response response;
 
     std::vector<bt::ptime> datetimes;
@@ -397,7 +399,6 @@ make_response(RAPTOR &raptor, const type::EntryPoint &origin,
     }
     if(clockwise)
         std::reverse(result.begin(), result.end());
-
     return make_pathes(result, raptor.data, worker, origin, destination, datetimes, clockwise, show_codes);
 }
 

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -37,8 +37,8 @@ namespace navitia { namespace routing {
 
 
 std::vector<Path>
-makePathes(const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departures,
-           const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &destinations,
+makePathes(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departures,
+           const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
            const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_,
            bool clockwise, bool disruption_active) {
     std::vector<Path> result;
@@ -237,9 +237,9 @@ makePath(type::idx_t destination_idx, unsigned int countb, bool clockwise, bool 
     }
 
     if(result.items.size() > 0)
-        result.duration = result.items.back().arrival - result.items.front().departure;
+        result.duration = navitia::time_duration::from_boost_duration(result.items.back().arrival - result.items.front().departure);
     else
-        result.duration = boost::posix_time::seconds(0);
+        result.duration = navitia::seconds(0);
 
     result.nb_changes = 0;
     if(result.items.size() > 2) {

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -47,8 +47,8 @@ namespace navitia { namespace routing {
 
     ///Construit tous chemins trouvés
     std::vector<Path> 
-    makePathes(const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departures,
-            const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &destinations,
+    makePathes(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departures,
+            const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
             const type::AccessibiliteParams & accessibilite_params,
             const RAPTOR &raptor_, bool clockwise, bool disruption_active);
 

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -34,8 +34,8 @@ namespace bt = boost::posix_time;
 namespace navitia { namespace routing {
 
 Solutions
-get_solutions(const std::vector<std::pair<type::idx_t, bt::time_duration> > &departs,
-             const std::vector<std::pair<type::idx_t, bt::time_duration> > &destinations,
+get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+             const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
              bool clockwise, const std::vector<label_vector_t> &labels,
              const type::AccessibiliteParams & accessibilite_params, const type::Data &data,
              bool disruption_active) {
@@ -56,7 +56,7 @@ get_solutions(const std::vector<std::pair<type::idx_t, bt::time_duration> > &dep
 
 
 Solutions
-get_solutions(const std::vector<std::pair<type::idx_t, bt::time_duration> > &departs, const DateTime &dep, bool clockwise, const type::Data & data, bool) {
+get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs, const DateTime &dep, bool clockwise, const type::Data & data, bool) {
     Solutions result;
     for(auto dep_dist : departs) {
         for(auto journey_pattern : data.pt_data->stop_points[dep_dist.first]->journey_pattern_point_list) {
@@ -84,8 +84,8 @@ bool improves(const DateTime & best_so_far, bool clockwise, const DateTime & cur
 }
 
 Solutions
-get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, bt::time_duration> > &departs,
-               const std::vector<std::pair<type::idx_t, bt::time_duration> > &destinations,
+get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+               const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
                const std::vector<label_vector_t> &labels,
                const type::AccessibiliteParams & accessibilite_params, const type::Data &data, bool disruption_active){
     Solutions result;
@@ -166,7 +166,7 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, bt::ti
 
 
 Solutions
-get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, bt::time_duration> > &departs, const std::vector<std::pair<type::idx_t, bt::time_duration> > &destinations, Solution best,
+get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, Solution best,
                     const std::vector<label_vector_t> &labels, const type::Data &data){
     Solutions result;
 
@@ -180,7 +180,7 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, b
             for(auto journey_pattern_point : data.pt_data->stop_points[spid_dist.first]->journey_pattern_point_list) {
                 type::idx_t jppidx = journey_pattern_point->idx;
                 if(labels[i][journey_pattern_point->idx].type != boarding_type::uninitialized) {
-                    bt::time_duration walking_time = getWalkingTime(i, jppidx, departs, destinations, clockwise, labels, data);
+                    navitia::time_duration walking_time = getWalkingTime(i, jppidx, departs, destinations, clockwise, labels, data);
                     if(best.walking_time <= walking_time) {
                         continue;
                     }
@@ -275,13 +275,13 @@ get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, const 
 }
 
 
-boost::posix_time::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std::vector<std::pair<type::idx_t, bt::time_duration> > &departs,
-                     const std::vector<std::pair<type::idx_t, bt::time_duration> > &destinations,
+navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+                     const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
                      bool clockwise, const std::vector<label_vector_t> &labels, const type::Data &data) {
 
     const type::JourneyPatternPoint* current_jpp = data.pt_data->journey_pattern_points[jpp_idx];
     int cnt = count;
-    bt::time_duration walking_time = {};
+    navitia::time_duration walking_time = {};
 
     //Marche à la fin
     for(auto dest_dist : destinations) {
@@ -304,7 +304,7 @@ boost::posix_time::time_duration getWalkingTime(int count, type::idx_t jpp_idx, 
                                                                                            current_jpp->stop_point->idx,
                                                                                            clockwise, *data.pt_data);
                 if(connection_idx != type::invalid_idx)
-                    walking_time += bt::seconds(data.pt_data->stop_point_connections[connection_idx]->duration);
+                    walking_time += navitia::seconds(data.pt_data->stop_point_connections[connection_idx]->duration);
             }
             current_jpp = boarding;
             boarding_type_value = labels[cnt][current_jpp->idx].type;

--- a/source/routing/raptor_solutions.h
+++ b/source/routing/raptor_solutions.h
@@ -42,7 +42,7 @@ struct Solution {
     uint32_t count;
     DateTime arrival, upper_bound;
     float ratio;
-    boost::posix_time::time_duration walking_time = {};
+    navitia::time_duration walking_time = {};
 
     Solution() : rpidx(type::invalid_idx), count(0),
                        arrival(DateTimeUtils::inf), upper_bound(DateTimeUtils::inf),
@@ -71,33 +71,33 @@ struct Solution {
 typedef std::set<Solution> Solutions;
 
 Solutions
-get_solutions(const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departs,
-             const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &destinations, bool clockwise,
+get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+             const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, bool clockwise,
              const std::vector<label_vector_t> &labels, const type::AccessibiliteParams & accessibilite_params,
              const type::Data &data, bool disruption_active);
 
 //This one is hacky, it's used to retrieve the departures.
 Solutions
-get_solutions(const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departs,
+get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
              const DateTime &dep, bool clockwise, const type::Data & data, bool disruption_active);
 
 Solutions
-get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departs,
-                    const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &destinations, Solution best,
+get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+                    const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, Solution best,
                     const std::vector<label_vector_t> &labels, const type::Data &data);
 
 Solutions
-get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departs,
-               const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &destinations,
+get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+               const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
                const std::vector<label_vector_t> &labels,
                const type::AccessibiliteParams & accessibilite_params, const type::Data &data, bool disruption_active);
 
 std::pair<type::idx_t, DateTime>
 get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, const std::vector<label_vector_t> &labels);
 
-boost::posix_time::time_duration
-getWalkingTime(int count, type::idx_t rpid, const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &departs,
-               const std::vector<std::pair<type::idx_t, boost::posix_time::time_duration> > &destinations,
+navitia::time_duration
+getWalkingTime(int count, type::idx_t rpid, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+               const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
                bool clockwise, const std::vector<label_vector_t> &labels, const type::Data &data);
 
 }}

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -72,12 +72,12 @@ inline void memset32(T*buf, uint n, T c)
 
 
 struct best_dest {
-    std::vector<boost::posix_time::time_duration> jpp_idx_duration;
+    std::vector<navitia::time_duration> jpp_idx_duration;
     DateTime best_now;
     type::idx_t best_now_jpp_idx;
     size_t count;
 
-    void add_destination(type::idx_t jpp_idx, const boost::posix_time::time_duration duration_to_dest, bool /*clockwise*/) {
+    void add_destination(type::idx_t jpp_idx, const navitia::time_duration duration_to_dest, bool /*clockwise*/) {
         jpp_idx_duration[jpp_idx] = duration_to_dest; //AD, check if there are some rounding problems
     }
 
@@ -130,7 +130,7 @@ struct best_dest {
 
     void reinit(const size_t nb_jpp_idx) {
         jpp_idx_duration.resize(nb_jpp_idx);
-        memset32<boost::posix_time::time_duration>(&jpp_idx_duration[0], nb_jpp_idx, boost::posix_time::pos_infin);
+        memset32<navitia::time_duration>(&jpp_idx_duration[0], nb_jpp_idx, boost::posix_time::pos_infin);
         best_now = DateTimeUtils::inf;
         best_now_jpp_idx = type::invalid_idx;
         count = std::numeric_limits<size_t>::max();

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -101,7 +101,7 @@ struct PathItem {
 
 /** Un itinéraire complet */
 struct Path {
-    boost::posix_time::time_duration duration;
+    navitia::time_duration duration;
     uint32_t nb_changes;
     boost::posix_time::ptime request_time;
     std::vector<PathItem> items;

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -606,9 +606,9 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     b.vj("A","11111111", "", true)("stop1", 8*3600)("stop2", 8*3600 + 20*60);
     b.vj("B","11111111", "", true)("stop1", 9*3600)("stop2", 9*3600 + 20*60);
 
-    std::vector<std::pair<navitia::type::idx_t, bt::time_duration>> departs, destinations;
-    departs.push_back(std::make_pair(0, bt::seconds(10 * 60)));
-    destinations.push_back(std::make_pair(1,bt::seconds(0)));
+    std::vector<std::pair<navitia::type::idx_t, navitia::time_duration>> departs, destinations;
+    departs.push_back(std::make_pair(0, navitia::seconds(10 * 60)));
+    destinations.push_back(std::make_pair(1,navitia::seconds(0)));
 
     b.data->pt_data->index();
     b.data->build_raptor();

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -392,9 +392,9 @@ BOOST_AUTO_TEST_CASE(sn_fin) {
     b.vj("A")("stop1", 8*3600)("stop2", 8*3600 + 20*60);
     b.vj("B")("stop1", 9*3600)("stop2", 9*3600 + 20*60);
 
-    std::vector<std::pair<navitia::type::idx_t, bt::time_duration>> departs, destinations;
-    departs.push_back(std::make_pair(0, bt::seconds(0)));
-    destinations.push_back(std::make_pair(1, bt::seconds(10 * 60)));
+    std::vector<std::pair<navitia::type::idx_t, navitia::time_duration>> departs, destinations;
+    departs.push_back(std::make_pair(0, navitia::seconds(0)));
+    destinations.push_back(std::make_pair(1, navitia::seconds(10 * 60)));
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -171,13 +171,13 @@ struct streetnetworkmode_fixture : public routing_api_data<speed_provider_trait>
 BOOST_FIXTURE_TEST_CASE(walking_test, streetnetworkmode_fixture<test_speed_provider>) {
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Walking;
     origin.streetnetwork_params.offset = 0;
-    origin.streetnetwork_params.max_duration = bt::seconds(15*60);//bt::seconds(200 / get_default_speed()[navitia::type::Mode_e::Walking]);
+    origin.streetnetwork_params.max_duration = navitia::seconds(15*60);//navitia::seconds(200 / get_default_speed()[navitia::type::Mode_e::Walking]);
     origin.streetnetwork_params.speed_factor = 1;
 
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Walking;
     destination.streetnetwork_params.offset = 0;
     destination.streetnetwork_params.speed_factor = 1;
-    destination.streetnetwork_params.max_duration = bt::seconds(15*60);//bt::seconds(50 / get_default_speed()[navitia::type::Mode_e::Walking]);
+    destination.streetnetwork_params.max_duration = navitia::seconds(15*60);//navitia::seconds(50 / get_default_speed()[navitia::type::Mode_e::Walking]);
 
     pbnavitia::Response resp = make_response();
 
@@ -209,11 +209,11 @@ BOOST_FIXTURE_TEST_CASE(walking_test, streetnetworkmode_fixture<test_speed_provi
 BOOST_FIXTURE_TEST_CASE(biking, streetnetworkmode_fixture<test_speed_provider>) {
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Bike;
     origin.streetnetwork_params.offset = b.data->geo_ref->offsets[navitia::type::Mode_e::Bike];
-    origin.streetnetwork_params.max_duration = bt::minutes(15);
+    origin.streetnetwork_params.max_duration = navitia::minutes(15);
     origin.streetnetwork_params.speed_factor = 1;
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Bike;
     destination.streetnetwork_params.offset = b.data->geo_ref->offsets[navitia::type::Mode_e::Bike];
-    destination.streetnetwork_params.max_duration = bt::minutes(15);
+    destination.streetnetwork_params.max_duration = navitia::minutes(15);
     destination.streetnetwork_params.speed_factor = 1;
 
     auto resp = make_response();
@@ -309,12 +309,12 @@ BOOST_FIXTURE_TEST_CASE(car, streetnetworkmode_fixture<test_speed_provider>) {
 
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Car;
     origin.streetnetwork_params.offset = b.data->geo_ref->offsets[navitia::type::Mode_e::Car];
-    origin.streetnetwork_params.max_duration = bt::seconds(total_distance / get_default_speed()[navitia::type::Mode_e::Car]);
+    origin.streetnetwork_params.max_duration = navitia::seconds(total_distance / get_default_speed()[navitia::type::Mode_e::Car]);
     origin.streetnetwork_params.speed_factor = 1;
 
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Car;
     destination.streetnetwork_params.offset = b.data->geo_ref->offsets[navitia::type::Mode_e::Car];
-    destination.streetnetwork_params.max_duration = bt::seconds(total_distance / get_default_speed()[navitia::type::Mode_e::Car]);
+    destination.streetnetwork_params.max_duration = navitia::seconds(total_distance / get_default_speed()[navitia::type::Mode_e::Car]);
     destination.streetnetwork_params.speed_factor = 1;
 
     auto resp = make_response();
@@ -352,11 +352,11 @@ BOOST_FIXTURE_TEST_CASE(bss_test, streetnetworkmode_fixture<test_speed_provider>
 
     origin.streetnetwork_params.mode = navitia::type::Mode_e::Bss;
     origin.streetnetwork_params.offset = b.data->geo_ref->offsets[navitia::type::Mode_e::Bss];
-    origin.streetnetwork_params.max_duration = bt::minutes(15);
+    origin.streetnetwork_params.max_duration = navitia::minutes(15);
     origin.streetnetwork_params.speed_factor = 1;
     destination.streetnetwork_params.mode = navitia::type::Mode_e::Bss;
     destination.streetnetwork_params.offset = b.data->geo_ref->offsets[navitia::type::Mode_e::Bss];
-    destination.streetnetwork_params.max_duration = bt::minutes(15);
+    destination.streetnetwork_params.max_duration = navitia::minutes(15);
     destination.streetnetwork_params.speed_factor = 1;
 
     auto resp = make_response();

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -46,15 +46,15 @@ struct test_speed_provider {
                                                             2 //nt::Mode_e::Vls
                                                         }}
                                                         };
-    bt::time_duration to_duration(float dist, navitia::type::Mode_e mode) {
-        return bt::seconds(std::round(dist / get_default_speed()[mode]));
+    navitia::time_duration to_duration(float dist, navitia::type::Mode_e mode) {
+        return navitia::seconds(std::round(dist / get_default_speed()[mode]));
     }
 };
 
 struct normal_speed_provider {
     const navitia::flat_enum_map<nt::Mode_e, float> get_default_speed() const { return navitia::georef::default_speed; }
-    bt::time_duration to_duration(float dist, navitia::type::Mode_e mode) {
-        return bt::milliseconds(dist / get_default_speed()[mode] * 1000);
+    navitia::time_duration to_duration(float dist, navitia::type::Mode_e mode) {
+        return navitia::milliseconds(dist / get_default_speed()[mode] * 1000);
     }
 };
 
@@ -336,7 +336,7 @@ struct routing_api_data {
         b.data->meta->shape = ss.str();
     }
 
-    bt::time_duration to_duration(double dist, navitia::type::Mode_e mode) {
+    navitia::time_duration to_duration(double dist, navitia::type::Mode_e mode) {
         return speed_trait.to_duration(dist, mode);
     }
 
@@ -355,8 +355,8 @@ struct routing_api_data {
         add_edges(edge_idx, geo_ref, idx_from, idx_to, a.distance_to(b), mode);
     }
 
-    const bt::time_duration bike_sharing_pickup = bt::seconds(30);
-    const bt::time_duration bike_sharing_return = bt::seconds(45);
+    const navitia::time_duration bike_sharing_pickup = navitia::seconds(30);
+    const navitia::time_duration bike_sharing_return = navitia::seconds(45);
 
     void add_bike_sharing_edge(int edge_idx, navitia::georef::GeoRef& geo_ref, int idx_from, int idx_to) {
         boost::add_edge(idx_from + geo_ref.offsets[navitia::type::Mode_e::Walking],

--- a/source/type/datetime.h
+++ b/source/type/datetime.h
@@ -95,10 +95,12 @@ std::string iso_hour_string(const DateTime dt, const type::Data &d);
 boost::posix_time::ptime to_posix_time(DateTime datetime, const type::Data &d);
 DateTime to_datetime(boost::posix_time::ptime ptime, const type::Data &d);
 
-inline DateTime operator-(DateTime time, boost::posix_time::time_duration dur) {
+template <typename duration>
+inline DateTime operator-(DateTime time, duration dur) {
     return time - dur.total_seconds();
 }
-inline DateTime operator+(DateTime time, boost::posix_time::time_duration dur) {
+template <typename duration>
+inline DateTime operator+(DateTime time, duration dur) {
     return time + dur.total_seconds();
 }
 

--- a/source/type/tests/datetime.cpp
+++ b/source/type/tests/datetime.cpp
@@ -179,3 +179,37 @@ BOOST_AUTO_TEST_CASE(weekday_conversion) {
     }
 
 }
+
+BOOST_AUTO_TEST_CASE(simple_duration_construction) {
+
+    boost::posix_time::time_duration boost_dur(12,24,49, 1);
+
+    navitia::time_duration nav_dur(navitia::time_duration::from_boost_duration(boost_dur));
+
+    BOOST_CHECK_EQUAL(nav_dur.hours(), 12);
+    BOOST_CHECK_EQUAL(nav_dur.minutes(), 24);
+    BOOST_CHECK_EQUAL(nav_dur.seconds(), 49);
+    BOOST_CHECK_EQUAL(nav_dur.fractional_seconds(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(time_dur_no_overflow_with_infinity) {
+    boost::posix_time::time_duration big_dur = boost::posix_time::pos_infin;
+
+    boost::posix_time::time_duration other_dur (big_dur);//no problem to copy the duration with boost
+
+    //but the max should be to high for navitia duration
+    navitia::time_duration nav_dur = navitia::time_duration::from_boost_duration(big_dur);
+
+    BOOST_CHECK_EQUAL(nav_dur, boost::posix_time::pos_infin);
+}
+
+BOOST_AUTO_TEST_CASE(time_dur_overflow) {
+    //we build a very big duration
+    boost::posix_time::time_duration big_dur (0,0,0,std::numeric_limits<int64_t>::max() - 21);
+
+    boost::posix_time::time_duration other_dur (big_dur);//no problem to copy the duration with boost
+
+    //but the max should be to high for navitia duration
+    BOOST_CHECK_THROW(navitia::time_duration nav_dur = navitia::time_duration::from_boost_duration(big_dur), navitia::exception);
+}
+

--- a/source/type/tests/datetime.cpp
+++ b/source/type/tests/datetime.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(weekday_conversion) {
 }
 
 BOOST_AUTO_TEST_CASE(simple_duration_construction) {
-
+    // we can 'cast' a boost posix duration to a navitia duration with the from_boost_duration method
     boost::posix_time::time_duration boost_dur(12,24,49, 1);
 
     navitia::time_duration nav_dur(navitia::time_duration::from_boost_duration(boost_dur));
@@ -197,9 +197,9 @@ BOOST_AUTO_TEST_CASE(time_dur_no_overflow_with_infinity) {
 
     boost::posix_time::time_duration other_dur (big_dur);//no problem to copy the duration with boost
 
-    //but the max should be to high for navitia duration
     navitia::time_duration nav_dur = navitia::time_duration::from_boost_duration(big_dur);
 
+    //and no problem with navitia either, it is recognised as infinity
     BOOST_CHECK_EQUAL(nav_dur, boost::posix_time::pos_infin);
 }
 

--- a/source/type/time_duration.h
+++ b/source/type/time_duration.h
@@ -211,7 +211,7 @@ public:
         auto dur = time_duration(d.hours(), d.minutes(), d.seconds(), d.fractional_seconds());
 
         //check for overflow
-        if (dur.total_seconds() < d.total_seconds()) {
+        if (dur.total_seconds() != d.total_seconds()) {
             throw navitia::exception("duration overflow while converting from boost::time_duration: " + boost::date_time::to_simple_string(d));
         }
         return dur;
@@ -228,7 +228,10 @@ public:
 
     //float division (rounding is done on the ticks)
     time_duration operator/(float divisor) const {
-      return time_duration(ticks_.as_number() / divisor);
+        if (divisor == 0.0) {
+            throw navitia::exception("cannot divide duration by 0");
+        }
+        return time_duration(ticks_.as_number() / divisor);
     }
 
   private:

--- a/source/type/time_duration.h
+++ b/source/type/time_duration.h
@@ -1,0 +1,316 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include <utils/exception.h>
+#include <boost/date_time/time_duration.hpp>
+#include <boost/date_time/time_resolution_traits.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+
+#include <boost/serialization/split_free.hpp>
+
+// adapted from boost (I don't understand why it is not like that in boost
+namespace boost {
+namespace date_time {
+
+template<class T, typename rep_type>
+inline std::string to_simple_string(time_duration<T, rep_type> td) {
+    std::ostringstream ss;
+    if(td.is_special()) {
+        switch(td.get_rep().as_special()) {
+        case not_a_date_time:
+            ss << "not-a-date-time";
+            break;
+        case pos_infin:
+            ss << "+infinity";
+            break;
+        case neg_infin:
+            ss << "-infinity";
+            break;
+        default:
+            ss << "";
+        }
+    }
+    else {
+        if(td.is_negative()) {
+            ss << '-';
+        }
+        ss  << std::setw(2) << std::setfill('0')
+            << absolute_value(td.hours()) << ":";
+        ss  << std::setw(2) << std::setfill('0')
+            << absolute_value(td.minutes()) << ":";
+        ss  << std::setw(2) << std::setfill('0')
+            << absolute_value(td.seconds());
+        //TODO the following is totally non-generic, yelling FIXME
+#if (defined(BOOST_MSVC) && (_MSC_VER < 1300))
+        boost::int64_t frac_sec =
+                date_time::absolute_value(td.fractional_seconds());
+        // JDG [7/6/02 VC++ compatibility]
+        char buff[32];
+        _i64toa(frac_sec, buff, 10);
+#else
+        typename time_duration<T, rep_type>::fractional_seconds_type frac_sec =
+                absolute_value(td.fractional_seconds());
+#endif
+        if (frac_sec != 0) {
+            ss  << "." << std::setw(time_duration<T, rep_type>::num_fractional_digits())
+                << std::setfill('0')
+
+                   // JDG [7/6/02 VC++ compatibility]
+       #if (defined(BOOST_MSVC) && (_MSC_VER < 1300))
+                << buff;
+#else
+                << frac_sec;
+#endif
+        }
+    }// else
+    return ss.str();
+}
+
+//! Time duration in iso format -hhmmss,fffffff Example: 10:09:03,0123456
+/*!\ingroup time_format
+   */
+template<class T, typename rep_type>
+inline std::string to_iso_string(time_duration<T, rep_type> td) {
+    std::ostringstream ss;
+    if(td.is_special()) {
+        /* simply using 'ss << td.get_rep()' won't work on compilers
+       * that don't support locales. This way does. */
+        // switch copied from date_names_put.hpp
+        switch(td.get_rep().as_special()) {
+        case not_a_date_time:
+            //ss << "not-a-number";
+            ss << "not-a-date-time";
+            break;
+        case pos_infin:
+            ss << "+infinity";
+            break;
+        case neg_infin:
+            ss << "-infinity";
+            break;
+        default:
+            ss << "";
+        }
+    }
+    else {
+        if(td.is_negative()) {
+            ss << '-';
+        }
+        ss  << std::setw(2) << std::setfill('0')
+            << absolute_value(td.hours());
+        ss  << std::setw(2) << std::setfill('0')
+            << absolute_value(td.minutes());
+        ss  << std::setw(2) << std::setfill('0')
+            << absolute_value(td.seconds());
+        //TODO the following is totally non-generic, yelling FIXME
+#if (defined(BOOST_MSVC) && (_MSC_VER < 1300))
+        boost::int64_t frac_sec = date_time::absolute_value(td.fractional_seconds());
+        // JDG [7/6/02 VC++ compatibility]
+        char buff[32];
+        _i64toa(frac_sec, buff, 10);
+#else
+        typename time_duration<T, rep_type>::fractional_seconds_type frac_sec =
+                absolute_value(td.fractional_seconds());
+#endif
+        if (frac_sec != 0) {
+            ss  << "." << std::setw(time_duration<T, rep_type>::num_fractional_digits())
+                << std::setfill('0')
+
+                   // JDG [7/6/02 VC++ compatibility]
+       #if (defined(BOOST_MSVC) && (_MSC_VER < 1300))
+                << buff;
+#else
+                << frac_sec;
+#endif
+        }
+    }// else
+    return ss.str();
+}
+}
+}
+
+
+namespace navitia {
+
+
+
+using time_res_traits = boost::date_time::milli_res;
+
+/**
+ * For georef we only need millisecond precision, micro or nano second are not needed.
+ *
+ * We thus can store the duration in an int32 instead of a int64.
+ *
+ * We also add float division (we need it for speed modifier computation)
+ *
+ * TODO: we could also add time_duration on int16 for the street network graph
+ * (with a second precision, it would handle ~9h)
+ */
+class time_duration : public boost::date_time::time_duration<time_duration, time_res_traits> {
+public:
+    typedef time_res_traits rep_type;
+    typedef time_res_traits::day_type day_type;
+    typedef time_res_traits::hour_type hour_type;
+    typedef time_res_traits::min_type min_type;
+    typedef time_res_traits::sec_type sec_type;
+    typedef time_res_traits::fractional_seconds_type fractional_seconds_type;
+    typedef time_res_traits::tick_type tick_type;
+    typedef time_res_traits::impl_type impl_type;
+
+    time_duration(hour_type hour, min_type min, sec_type sec, fractional_seconds_type fs=0) :
+      boost::date_time::time_duration<time_duration, time_res_traits>(hour,min,sec,fs) {}
+    time_duration() :
+      boost::date_time::time_duration<time_duration, time_res_traits>(0,0,0) {}
+    //! Construct from special_values
+    time_duration(boost::date_time::special_values sv) :
+      boost::date_time::time_duration<time_duration, time_res_traits>(sv) {}
+
+    //constructor for a 'classic' posix time_duration
+    static time_duration from_boost_duration(boost::posix_time::time_duration d) {
+        if (d.is_special()) {
+            if (d.is_pos_infinity()) {
+                return time_duration(boost::date_time::pos_infin);
+            }
+            if (d.is_neg_infinity()) {
+                return time_duration(boost::date_time::neg_infin);
+            }
+            if (d.is_not_a_date_time()) {
+                return time_duration(boost::date_time::not_a_date_time);
+            }
+            throw navitia::exception("unhandled case for duration construction");
+        }
+        auto dur = time_duration(d.hours(), d.minutes(), d.seconds(), d.fractional_seconds());
+
+        //check for overflow
+        if (dur.total_seconds() < d.total_seconds()) {
+            throw navitia::exception("duration overflow while converting from boost::time_duration: " + boost::date_time::to_simple_string(d));
+        }
+        return dur;
+    }
+    boost::posix_time::time_duration to_posix() const {
+        return boost::posix_time::time_duration(hours(), minutes(), seconds(), fractional_seconds());
+    }
+
+    //TODO
+    //benchmark if a build-in constructor with bt::pos_infin improve perf
+
+    friend class boost::date_time::time_duration<time_duration, time_res_traits>;
+
+
+    //float division (rounding is done on the ticks)
+    time_duration operator/(float divisor) const {
+      return time_duration(ticks_.as_number() / divisor);
+    }
+
+  private:
+    explicit time_duration(impl_type tick_count) :
+      boost::date_time::time_duration<time_duration, time_res_traits>(tick_count)
+    {}
+};
+
+
+//mirror boost helpers
+class hours : public time_duration {
+public:
+  explicit hours(time_res_traits::hour_type h) : time_duration(h,0,0) {}
+};
+
+class minutes : public time_duration {
+public:
+  explicit minutes(time_res_traits::min_type m) : time_duration(0,m,0) {}
+};
+
+class seconds : public time_duration {
+public:
+  explicit seconds(time_res_traits::sec_type s) : time_duration(0,0,s) {}
+};
+
+class milliseconds : public time_duration {
+public:
+  explicit milliseconds(time_res_traits::fractional_seconds_type ms) :
+        time_duration(0,0,0, ms * time_res_traits::res_adjust() / 1000) {}
+};
+
+
+//serialization functions (copied from boost)
+template<class Archive>
+void save(Archive & ar, const time_duration& td, unsigned int /*version*/) {
+    // serialize a bool so we know how to read this back in later
+    bool is_special = td.is_special();
+    ar & boost::serialization::make_nvp("is_special", is_special);
+    if(is_special) {
+        std::string s = boost::date_time::to_simple_string(td);
+        ar & boost::serialization::make_nvp("sv_time_duration", s);
+    }
+    else {
+        typename time_duration::hour_type h = td.hours();
+        typename time_duration::min_type m = td.minutes();
+        typename time_duration::sec_type s = td.seconds();
+        typename time_duration::fractional_seconds_type fs = td.fractional_seconds();
+        ar & boost::serialization::make_nvp("time_duration_hours", h);
+        ar & boost::serialization::make_nvp("time_duration_minutes", m);
+        ar & boost::serialization::make_nvp("time_duration_seconds", s);
+        ar & boost::serialization::make_nvp("time_duration_fractional_seconds", fs);
+    }
+}
+
+template<class Archive>
+void load(Archive & ar, time_duration & td, unsigned int /*version*/) {
+    bool is_special = false;
+    ar & boost::serialization::make_nvp("is_special", is_special);
+    if(is_special) {
+        std::string s;
+        ar & boost::serialization::make_nvp("sv_time_duration", s);
+        boost::posix_time::special_values sv = boost::gregorian::special_value_from_string(s);
+        td = time_duration(sv);
+    }
+    else {
+        typename time_duration::hour_type h(0);
+        typename time_duration::min_type m(0);
+        typename time_duration::sec_type s(0);
+        typename time_duration::fractional_seconds_type fs(0);
+        ar & boost::serialization::make_nvp("time_duration_hours", h);
+        ar & boost::serialization::make_nvp("time_duration_minutes", m);
+        ar & boost::serialization::make_nvp("time_duration_seconds", s);
+        ar & boost::serialization::make_nvp("time_duration_fractional_seconds", fs);
+        td = time_duration(h,m,s,fs);
+    }
+}
+
+inline std::ostream& operator<<(std::ostream& os, time_duration t) {
+    os << boost::date_time::to_simple_string(t);
+    return os;
+}
+}
+
+
+BOOST_SERIALIZATION_SPLIT_FREE(navitia::time_duration)

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -31,6 +31,7 @@ www.navitia.io
 #pragma once
 
 #include "datetime.h"
+#include "type/time_duration.h"
 #include "utils/flat_enum_map.h"
 #include "utils/exception.h"
 #include "utils/functions.h"
@@ -968,7 +969,7 @@ struct StreetNetworkParams{
     Mode_e mode;
     idx_t offset;
     float speed_factor;
-    boost::posix_time::time_duration max_duration;
+    navitia::time_duration max_duration;
     Type_e type_filter; // filtre sur le départ/arrivée : exemple les arrêts les plus proches à une site type
     std::string uri_filter; // l'uri de l'objet
     float radius_filter; // ce paramètre est utilisé pour le filtre
@@ -976,7 +977,7 @@ struct StreetNetworkParams{
                 mode(Mode_e::Walking),
                 offset(0),
                 speed_factor(1),
-                max_duration(boost::posix_time::seconds(1)),
+                max_duration(navitia::seconds(1)),
                 type_filter(Type_e::Unknown),
                 uri_filter(""),
                 radius_filter(150){}


### PR DESCRIPTION
since we don't need the microsecond precision for georef, creation of a
navitia::time_duration based on int32 (instead of int 64).
