### PR TITLE
Fix clang

### DIFF
--- a/source/calendar/tests/calendar_api_test.cpp
+++ b/source/calendar/tests/calendar_api_test.cpp
@@ -225,7 +225,9 @@ BOOST_FIXTURE_TEST_CASE(test_parse_end_date, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_parse_start_end_date, calendar_fixture) {
 
     pbnavitia::Response resp = navitia::calendar::calendars(*(b.data), "0000", "1111", 1, 10, 0, "", {});
-    BOOST_REQUIRE_EQUAL(resp.error().message(), "Unable to parse start_date, Day of month value is out of range 1..31");
+    BOOST_REQUIRE(resp.error().message() == "Unable to parse start_date, Day of month value is out of range 1..31"
+                  || resp.error().message() == "Unable to parse start_date, Year is out of valid range: 1400..10000");
+    //either are valid error (it seems that the order of the parse depends on the compiler)
 }
 
 // Response Error

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -663,8 +663,8 @@ BOOST_AUTO_TEST_CASE(itl) {
 BOOST_AUTO_TEST_CASE(mdi) {
     ed::builder b("20120614");
 
-    b.vj("B")("stop1",17*3600, 17*3600,std::numeric_limits<uint32_t>::max(), true, false)("stop2", 17*3600+15*60)("stop3",17*3600+30*60, 17*3600+30*60,std::numeric_limits<uint32_t>::max(), true, false);
-    b.vj("C")("stop4",16*3600, 16*3600,std::numeric_limits<uint32_t>::max(), true, true)("stop5", 16*3600+15*60)("stop6",16*3600+30*60, 16*3600+30*60,std::numeric_limits<uint32_t>::max(), false, true);
+    b.vj("B")("stop1",17*3600, 17*3600,std::numeric_limits<uint16_t>::max(), true, false)("stop2", 17*3600+15*60)("stop3",17*3600+30*60, 17*3600+30*60,std::numeric_limits<uint16_t>::max(), true, false);
+    b.vj("C")("stop4",16*3600, 16*3600,std::numeric_limits<uint16_t>::max(), true, true)("stop5", 16*3600+15*60)("stop6",16*3600+30*60, 16*3600+30*60,std::numeric_limits<uint16_t>::max(), false, true);
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -448,8 +448,8 @@ BOOST_AUTO_TEST_CASE(itl) {
 BOOST_AUTO_TEST_CASE(mdi) {
     ed::builder b("20120614");
 
-    b.vj("B")("stop1",17*3600, 17*3600,std::numeric_limits<uint32_t>::max(), true, false)("stop2", 17*3600+15*60)("stop3",17*3600+30*60, 17*3600+30*60,std::numeric_limits<uint32_t>::max(), true, true);
-    b.vj("C")("stop4",16*3600, 16*3600,std::numeric_limits<uint32_t>::max(), true, true)("stop5", 16*3600+15*60)("stop6",16*3600+30*60, 16*3600+30*60,std::numeric_limits<uint32_t>::max(), false, true);
+    b.vj("B")("stop1",17*3600, 17*3600,std::numeric_limits<uint16_t>::max(), true, false)("stop2", 17*3600+15*60)("stop3",17*3600+30*60, 17*3600+30*60,std::numeric_limits<uint16_t>::max(), true, true);
+    b.vj("C")("stop4",16*3600, 16*3600,std::numeric_limits<uint16_t>::max(), true, true)("stop5", 16*3600+15*60)("stop6",16*3600+30*60, 16*3600+30*60,std::numeric_limits<uint16_t>::max(), false, true);
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();

--- a/source/type/datetime.h
+++ b/source/type/datetime.h
@@ -95,12 +95,13 @@ std::string iso_hour_string(const DateTime dt, const type::Data &d);
 boost::posix_time::ptime to_posix_time(DateTime datetime, const type::Data &d);
 DateTime to_datetime(boost::posix_time::ptime ptime, const type::Data &d);
 
-template <typename duration>
-inline DateTime operator-(DateTime time, duration dur) {
+template <typename... Args>
+inline DateTime operator-(DateTime time, boost::date_time::time_duration<Args...> dur) {
     return time - dur.total_seconds();
 }
-template <typename duration>
-inline DateTime operator+(DateTime time, duration dur) {
+
+template <typename... Args>
+inline DateTime operator+(DateTime time, boost::date_time::time_duration<Args...> dur) {
     return time + dur.total_seconds();
 }
 

--- a/source/type/time_duration.h
+++ b/source/type/time_duration.h
@@ -29,10 +29,12 @@ www.navitia.io
 */
 
 #pragma once
-#include <utils/exception.h>
+#include <iomanip>
+#include "utils/exception.h"
 #include <boost/date_time/time_duration.hpp>
 #include <boost/date_time/time_resolution_traits.hpp>
 #include <boost/serialization/serialization.hpp>
+#include <boost/date_time/gregorian/parsers.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 
@@ -293,7 +295,7 @@ void load(Archive & ar, time_duration & td, unsigned int /*version*/) {
     if(is_special) {
         std::string s;
         ar & boost::serialization::make_nvp("sv_time_duration", s);
-        boost::posix_time::special_values sv = boost::gregorian::special_value_from_string(s);
+        auto sv = boost::gregorian::special_value_from_string(s);
         td = time_duration(sv);
     }
     else {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -30,8 +30,8 @@ www.navitia.io
 
 #pragma once
 
-#include "datetime.h"
 #include "type/time_duration.h"
+#include "datetime.h"
 #include "utils/flat_enum_map.h"
 #include "utils/exception.h"
 #include "utils/functions.h"


### PR DESCRIPTION
Fix #327 and close #328
Clang was not compiling the '+' DateTime operator (and after search he was right not to, thanks @skywave:
http://stackoverflow.com/questions/18596412/strange-error-with-a-templated-operator-overload)

he was attempting to instanciate the template with too much stuff and sometime had 2 pod which is not valid.

Restrict to any time_duration instanciation to be able to work with
boost::time_duration or navitia::time_duration
