### PR TITLE
Don't expand house numbers to 1/2 the world

### DIFF
--- a/source/sql/ed/34-functions.sql
+++ b/source/sql/ed/34-functions.sql
@@ -49,7 +49,7 @@ from georef.edge ed
 where st_dwithin(
 		point_in,
 		ed.the_geog,100)
-AND st_expand(ed.the_geog::geometry, 100) && point_in::geometry
+AND st_expand(ed.the_geog::geometry, 0.0025) && point_in::geometry
 
 order by distance
 limit 1 )tmp


### PR DESCRIPTION
st_expand with geometry is in the units of the given geometry, thus for WGS84, we were expanding the housenumbers to 100 degrees, this negated any efficiency of the index. 
Reduce to 0.0025 which is 195 meters at 45 degrees of latitude, 107m at 67 degrees, 277m at the equator
