### PR TITLE
Adminstation

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -832,6 +832,34 @@ void CalendarLineFusioHandler::handle_line(Data&, const csv_row& row, bool is_fi
 }
 }
 
+void AdminStopAreaFusioHandler::init(Data&){
+    admin_c = csv.get_pos_col("admin_id");
+    stop_area_c = csv.get_pos_col("station_id");
+    for (const auto& stop_area : gtfs_data.stop_area_map){
+        tmp_stop_area_map[stop_area.second->external_code] = stop_area.second;
+    }
+}
+
+void AdminStopAreaFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line){
+    if(! is_first_line && ! has_col(stop_area_c, row)) {
+        LOG4CPLUS_FATAL(logger, "Error while reading " + csv.filename +
+                        "  file has no stop_area_c column");
+        throw InvalidHeaders(csv.filename);
+    }
+
+    auto sa = tmp_stop_area_map.find(row[stop_area_c]);
+    if (sa == tmp_stop_area_map.end()) {
+        LOG4CPLUS_ERROR(logger, "AdminStopAreaFusioHandler : Impossible to find the stop_area " << row[stop_area_c]);
+        return;
+    }
+
+    ed::types::AdminStopArea* admin_stop_area = new ed::types::AdminStopArea();
+    admin_stop_area->admin = row[admin_c];
+    admin_stop_area->stop_area.push_back(sa->second);
+    gtfs_data.admin_stop_area_vector.push_back(admin_stop_area);
+
+}
+
 void FusioParser::fill_default_agency(Data & data){
     // création d'un réseau par defaut
     ed::types::Network * network = new ed::types::Network();
@@ -885,6 +913,7 @@ void FusioParser::parse_files(Data& data) {
     parse<grid_calendar::PeriodFusioHandler>(data, "grid_periods.txt");
     parse<grid_calendar::ExceptionDatesFusioHandler>(data, "grid_exception_dates.txt");
     parse<grid_calendar::CalendarLineFusioHandler>(data, "grid_rel_calendar_line.txt");
+    parse<AdminStopAreaFusioHandler>(data, "admin_stations.txt");
 }
 }
 }

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -267,6 +267,16 @@ struct CalendarLineFusioHandler : public GenericHandler {
 };
 }
 
+struct AdminStopAreaFusioHandler : public GenericHandler {
+    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
+    int admin_c, stop_area_c;
+    std::unordered_map<std::string, ed::types::StopArea*> tmp_stop_area_map;
+    void init(Data&);
+    void handle_line(Data& data, const csv_row& row, bool is_first_line);
+    const std::vector<std::string> required_headers() const { return {"admin_id", "station_id"}; }
+
+};
+
 /**
  * custom parser
  * simply define the list of elemental parsers to use

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -270,7 +270,11 @@ struct CalendarLineFusioHandler : public GenericHandler {
 struct AdminStopAreaFusioHandler : public GenericHandler {
     AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
     int admin_c, stop_area_c;
+
+    // temporaty map to have a StopArea by it's external code
     std::unordered_map<std::string, ed::types::StopArea*> tmp_stop_area_map;
+
+    std::unordered_map<std::string, ed::types::AdminStopArea*> admin_stop_area_map; //Note: I don't know if that is usefull to keep so for the moment it's a temporary structure, but it might be moved to ed::Data
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"admin_id", "station_id"}; }

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -70,6 +70,7 @@ struct GtfsData {
     std::unordered_map<std::string, navitia::type::hasProperties> hasProperties_map;
     std::unordered_map<std::string, navitia::type::hasVehicleProperties> hasVehicleProperties_map;
     std::unordered_map<std::string, ed::types::Calendar*> calendars_map;
+    std::vector<ed::types::AdminStopArea*>  admin_stop_area_vector;
 
     boost::gregorian::date_period production_date;///<Période de validité des données
 };

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -46,9 +46,11 @@ www.navitia.io
   */
 namespace ed { namespace connectors {
 
+/**
+ * Temporary structure used in the GTFS parser, mainly to keep a relation between ids and the pointers
+ */
 struct GtfsData {
     GtfsData() : production_date(boost::gregorian::date(), boost::gregorian::date()) {}
-    // Plusieurs maps pour savoir à quel position est quel objet identifié par son ID GTFS
     std::unordered_map<std::string, ed::types::CommercialMode*> commercial_mode_map;
     std::unordered_map<std::string, ed::types::StopPoint*> stop_map;
     std::unordered_map<std::string, ed::types::StopArea*> stop_area_map;
@@ -70,9 +72,8 @@ struct GtfsData {
     std::unordered_map<std::string, navitia::type::hasProperties> hasProperties_map;
     std::unordered_map<std::string, navitia::type::hasVehicleProperties> hasVehicleProperties_map;
     std::unordered_map<std::string, ed::types::Calendar*> calendars_map;
-    std::vector<ed::types::AdminStopArea*>  admin_stop_area_vector;
 
-    boost::gregorian::date_period production_date;///<Période de validité des données
+    boost::gregorian::date_period production_date;// Data validity period
 };
 
 inline bool has_col(int col_idx, const std::vector<std::string>& row) {

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -75,6 +75,9 @@ public:
     std::map<std::string, navitia::fare::DateTicket> fare_map;
     std::map<navitia::fare::OD_key, std::map<navitia::fare::OD_key, std::vector<std::string>>> od_tickets;
 
+
+    std::vector<ed::types::AdminStopArea*>  admin_stop_areas;
+
     /**
          * trie les différentes donnée et affecte l'idx
          *

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -917,7 +917,7 @@ void EdPersistor::insert_admin_stop_areas(const std::vector<types::AdminStopArea
         for(const types::StopArea* sa: asa->stop_area) {
             std::vector<std::string> values {
                 asa->admin,
-                sa->uri
+                std::to_string(sa->idx)
             };
 
             this->lotus.insert(values);

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -328,6 +328,10 @@ void EdPersistor::persist(const ed::Data& data, const navitia::type::MetaData& m
     LOG4CPLUS_INFO(logger, "Begin: insert journey pattern point connections");
     this->insert_journey_pattern_point_connections(data.journey_pattern_point_connections);
     LOG4CPLUS_INFO(logger, "End: insert journey pattern point connections");
+    LOG4CPLUS_INFO(logger, "Begin: insert admin stop area");
+    this->insert_admin_stop_areas(data.admin_stop_areas);
+    LOG4CPLUS_INFO(logger, "End: insert admin stop area");
+
     LOG4CPLUS_INFO(logger, "Begin: insert fares");
     persist_fare(data);
     LOG4CPLUS_INFO(logger, "End: insert fares");
@@ -902,6 +906,23 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         this->lotus.insert(values);
     }
 
+    this->lotus.finish_bulk_insert();
+}
+
+
+void EdPersistor::insert_admin_stop_areas(const std::vector<types::AdminStopArea*> admin_stop_areas) {
+    this->lotus.prepare_bulk_insert("navitia.admin_stop_area", {"admin_id", "stop_area_id"});
+
+    for(const types::AdminStopArea* asa : admin_stop_areas) {
+        for(const types::StopArea* sa: asa->stop_area) {
+            std::vector<std::string> values {
+                asa->admin,
+                sa->uri
+            };
+
+            this->lotus.insert(values);
+        }
+    }
     this->lotus.finish_bulk_insert();
 }
 

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -86,6 +86,8 @@ private:
     void insert_journey_pattern_point_connections(const std::vector<types::JourneyPatternPointConnection*>& connections);
     void insert_synonyms(const std::map<std::string, std::string>& synonyms);
 
+    void insert_admin_stop_areas(const std::vector<types::AdminStopArea*> admin_stop_areas);
+
     /// Inserer les données fiche horaire par période
     void insert_week_patterns(const std::vector<types::Calendar*>& calendars);
     void insert_calendars(const std::vector<types::Calendar*>& calendars);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -69,6 +69,7 @@ void EdReader::fill(navitia::type::Data& data, const double min_non_connected_gr
     this->fill_stop_times(data, work);
 
     this->fill_admins(data, work);
+    this->fill_admin_stop_areas(data, work);
 
     //@TODO: les connections ont des doublons, en attendant que ce soit corrigé, on ne les enregistre pas
     this->fill_stop_point_connections(data, work);
@@ -104,7 +105,6 @@ void EdReader::fill(navitia::type::Data& data, const double min_non_connected_gr
 }
 
 
-
 void EdReader::fill_admins(navitia::type::Data& nav_data, pqxx::work& work){
     std::string request = "SELECT id, name, uri, comment, post_code, insee, level, ST_X(coord::geometry) as lon, "
         "ST_Y(coord::geometry) as lat "
@@ -126,6 +126,36 @@ void EdReader::fill_admins(navitia::type::Data& nav_data, pqxx::work& work){
 
         nav_data.geo_ref->admins.push_back(admin);
         this->admin_map[const_it["id"].as<idx_t>()] = admin;
+
+        admin_by_insee_code[admin->insee] = admin;
+    }
+
+}
+
+
+void EdReader::fill_admin_stop_areas(navitia::type::Data&, pqxx::work& work) {
+    std::string request = "SELECT admin_id, stop_area_id from navitia.admin_stop_area";
+
+    pqxx::result result = work.exec(request);
+    for(auto const_it = result.begin(); const_it != result.end(); ++const_it) {
+        auto it_admin = admin_by_insee_code.find(const_it["admin_id"].as<std::string>());
+        if (it_admin == admin_by_insee_code.end()) {
+            LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "impossible to find admin " << const_it["admin_id"]
+                    << ", we cannot associate " << const_it["stop_area_id"] << " to it");
+            continue;
+        }
+        navitia::georef::Admin* admin = it_admin->second;
+
+        auto it_sa = stop_area_map.find(const_it["stop_area_id"].as<idx_t>());
+        if (it_sa == stop_area_map.end()) {
+            LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "impossible to find stop_area " << const_it["stop_area_id"]
+                    << ", we cannot associate it to " << const_it["admin_id"]);
+            continue;
+        }
+
+        navitia::type::StopArea* sa = it_sa->second;
+
+        admin->main_stop_areas.push_back(sa);
     }
 
 }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -136,26 +136,39 @@ void EdReader::fill_admins(navitia::type::Data& nav_data, pqxx::work& work){
 void EdReader::fill_admin_stop_areas(navitia::type::Data&, pqxx::work& work) {
     std::string request = "SELECT admin_id, stop_area_id from navitia.admin_stop_area";
 
+    size_t nb_unknown_admin(0), nb_unknown_stop(0), nb_valid_admin(0);
+
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it) {
         auto it_admin = admin_by_insee_code.find(const_it["admin_id"].as<std::string>());
         if (it_admin == admin_by_insee_code.end()) {
-            LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "impossible to find admin " << const_it["admin_id"]
-                    << ", we cannot associate " << const_it["stop_area_id"] << " to it");
+            LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("log"), "impossible to find admin " << const_it["admin_id"]
+                    << ", we cannot associate stop_area " << const_it["stop_area_id"] << " to it");
+            nb_unknown_admin++;
             continue;
         }
         navitia::georef::Admin* admin = it_admin->second;
 
         auto it_sa = stop_area_map.find(const_it["stop_area_id"].as<idx_t>());
         if (it_sa == stop_area_map.end()) {
-            LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "impossible to find stop_area " << const_it["stop_area_id"]
-                    << ", we cannot associate it to " << const_it["admin_id"]);
+            LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("log"), "impossible to find stop_area " << const_it["stop_area_id"]
+                    << ", we cannot associate it to admin " << const_it["admin_id"]);
+            nb_unknown_stop++;
             continue;
         }
 
         navitia::type::StopArea* sa = it_sa->second;
 
         admin->main_stop_areas.push_back(sa);
+        nb_valid_admin++;
+    }
+    LOG4CPLUS_INFO(log4cplus::Logger::getInstance("log"), nb_valid_admin << " admin with at least one main stop");
+
+    if (nb_unknown_admin) {
+        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), nb_unknown_admin << " admin not found for admin main stops");
+    }
+    if (nb_unknown_stop) {
+        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), nb_unknown_stop << " stops not found for admin main stops");
     }
 
 }
@@ -1301,7 +1314,7 @@ void EdReader::check_coherence(navitia::type::Data& data) const {
     size_t non_associated_lines(0);
     for (navitia::type::Line* line: data.pt_data->lines) {
         if (line->calendar_list.empty()) {
-            LOG4CPLUS_DEBUG(log, "the line " << line->uri << " is not associated with any calendar");
+            LOG4CPLUS_TRACE(log, "the line " << line->uri << " is not associated with any calendar");
             non_associated_lines++;
         }
     }

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -83,6 +83,10 @@ private:
 
     std::unordered_map<uint64_t, uint64_t> node_map;
 
+    //for admin main stop areas, we need this temporary map
+    //(we can't use an index since the link is between georef and navitia, and those modules are loaded separatly)
+    std::unordered_map<std::string, navitia::georef::Admin*> admin_by_insee_code;
+
 
     // ces deux vectors servent pour ne pas charger les graphes secondaires
     std::set<uint64_t> way_to_ignore; //TODO if bottleneck change to flat_set
@@ -110,6 +114,7 @@ private:
 
 
     void fill_admins(navitia::type::Data& data, pqxx::work& work);
+    void fill_admin_stop_areas(navitia::type::Data& data, pqxx::work& work);
     void fill_stop_point_connections(navitia::type::Data& data, pqxx::work& work);
     void fill_journey_pattern_point_connections(navitia::type::Data& data, pqxx::work& work);
     void fill_poi_types(navitia::type::Data& data, pqxx::work& work);

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -31,7 +31,6 @@ www.navitia.io
 #pragma once
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <bitset>
-
 #include <boost/date_time/gregorian/greg_serialize.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
@@ -409,6 +408,11 @@ struct Poi{
     std::string address_name;
     Poi(): id(0), name(""), weight(0), visible(true), poi_type(nullptr), address_number(""), address_name(""){}
 
+};
+
+struct AdminStopArea{
+    std::string admin;
+    std::vector<StopArea*> stop_area;
 };
 
 }}//end namespace ed::types

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -410,6 +410,11 @@ struct Poi{
 
 };
 
+/**
+ * A AdminStopArea is a relation between an admin code and a list of stop area.
+ *
+ * Beware that a stop_area can be shared between different AdminStopArea
+ */
 struct AdminStopArea{
     std::string admin;
     std::vector<StopArea*> stop_area;

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -417,7 +417,7 @@ struct Poi{
  */
 struct AdminStopArea{
     std::string admin;
-    std::vector<StopArea*> stop_area;
+    std::vector<const StopArea*> stop_area;
 };
 
 }}//end namespace ed::types

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -35,6 +35,7 @@ www.navitia.io
 
 
 namespace nt = navitia::type;
+
 namespace navitia {
 
     namespace georef {
@@ -54,7 +55,8 @@ namespace navitia {
             std::string insee;
             nt::GeographicalCoord coord;
             polygon_type boundary;
-            std::vector<Admin*> admin_list;
+            std::vector<const Admin*> admin_list;
+            std::vector<const nt::StopArea*> main_stop_areas;
 
             Admin():level(-1){}
             Admin(int lev):level(lev){}

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -39,20 +39,10 @@ namespace navitia {
 
     namespace georef {
         typedef boost::geometry::model::polygon<navitia::type::GeographicalCoord> polygon_type;
-        struct Levels{
-            std::map<std::string, std::string> LevelList;
-            Levels(){
-//                LevelList["2"]="Pays";
-//                LevelList["4"]="Région";
-//                LevelList["6"]="Département";
-                LevelList["8"]="Commune";
-                LevelList["9"]="Arrondissement";
-                LevelList["10"]="Quartier";
-            }
-        };
 
         struct Admin : nt::Header, nt::Nameable {
             /**
+              http://wiki.openstreetmap.org/wiki/Key:admin_level#admin_level
               Level = 2  : Pays
               Level = 4  : Région
               Level = 6  : Département
@@ -69,7 +59,7 @@ namespace navitia {
             Admin():level(-1){}
             Admin(int lev):level(lev){}
             template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-                ar & idx & level & post_code & insee & name & uri & coord &admin_list;
+                ar & idx & level & post_code & insee & name & uri & coord & admin_list;
             }
         };
     }

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -61,7 +61,7 @@ namespace navitia {
             Admin():level(-1){}
             Admin(int lev):level(lev){}
             template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-                ar & idx & level & post_code & insee & name & uri & coord & admin_list;
+                ar & idx & level & post_code & insee & name & uri & coord & admin_list & main_stop_areas;
             }
         };
     }

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -585,3 +585,8 @@ CREATE TABLE IF NOT EXISTS navitia.od_ticket(
     od_id BIGINT NOT NULL REFERENCES navitia.origin_destination,
     ticket_id TEXT NOT NULL REFERENCES navitia.ticket
 );
+
+CREATE TABLE IF NOT EXISTS navitia.admin_stop_area(
+    admin_id Text NOT NULL,
+    stop_area_id BIGINT NOT NULL REFERENCES navitia.stop_area
+);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -192,18 +192,18 @@ list_cal_bitset find_matching_calendar(const Data&, const VehicleJourney* vehicl
     list_cal_bitset res;
     //for the moment we keep lot's of trace, but they will be removed after a while
     auto log = log4cplus::Logger::getInstance("kraken::type::Data::Calendar");
-    LOG4CPLUS_DEBUG(log, "vj " << vehicle_journey->uri << " :" << vehicle_journey->validity_pattern->days.to_string());
+    LOG4CPLUS_TRACE(log, "vj " << vehicle_journey->uri << " :" << vehicle_journey->validity_pattern->days.to_string());
 
     for (const auto calendar : vehicle_journey->journey_pattern->route->line->calendar_list) {
         auto diff = get_difference(calendar->validity_pattern.days, vehicle_journey->validity_pattern->days);
         size_t nb_diff = diff.count();
 
-        LOG4CPLUS_DEBUG(log, "cal " << calendar->uri << " :" <<calendar->validity_pattern.days.to_string());
+        LOG4CPLUS_TRACE(log, "cal " << calendar->uri << " :" <<calendar->validity_pattern.days.to_string());
 
         //we associate the calendar to the vj if the diff are below a relative threshold
         //compared to the number of active days in the calendar
         size_t threshold = std::round(relative_threshold * calendar->validity_pattern.days.count());
-        LOG4CPLUS_DEBUG(log, "**** diff: " << nb_diff << " and threshold: " << threshold << (nb_diff <= threshold ? ", we keep it!!":""));
+        LOG4CPLUS_TRACE(log, "**** diff: " << nb_diff << " and threshold: " << threshold << (nb_diff <= threshold ? ", we keep it!!":""));
 
         if (nb_diff > threshold) {
             continue;
@@ -271,7 +271,7 @@ void Data::build_associated_calendar() {
         auto close_cal = find_matching_calendar(*this, vehicle_journey);
 
         if (close_cal.empty()) {
-            LOG4CPLUS_DEBUG(log, "the vj " << vehicle_journey->uri << " has been attached to no calendar");
+            LOG4CPLUS_TRACE(log, "the vj " << vehicle_journey->uri << " has been attached to no calendar");
             nb_not_matched_vj++;
             continue;
         }

--- a/source/type/tests/datetime.cpp
+++ b/source/type/tests/datetime.cpp
@@ -210,6 +210,6 @@ BOOST_AUTO_TEST_CASE(time_dur_overflow) {
     boost::posix_time::time_duration other_dur (big_dur);//no problem to copy the duration with boost
 
     //but the max should be to high for navitia duration
-    BOOST_CHECK_THROW(navitia::time_duration nav_dur = navitia::time_duration::from_boost_duration(big_dur), navitia::exception);
+    BOOST_CHECK_THROW(navitia::time_duration::from_boost_duration(big_dur), navitia::exception);
 }
 


### PR DESCRIPTION
# Admin to admin journeys

The idea is to associate a list of 'main stop areas' to the admins and to use only those when going to/leaving an admin.

A new file is thus required (in FusioParser because it is not standard GTFS) ''admin_stations.txt'.

If no main stop areas are available, so continue to start from the center of the admin and go to the reachable stations.
