### PR TITLE
Release script improvement

### DIFF
--- a/script_release.py
+++ b/script_release.py
@@ -11,7 +11,7 @@ import requests
 
 
 def get_tag_name(version):
-        return "__v{maj}.{min}.{hf}".format(maj=version[0], min=version[1], hf=version[2])
+        return "v{maj}.{min}.{hf}".format(maj=version[0], min=version[1], hf=version[2])
 
 
 class ReleaseManager:

--- a/script_release.py
+++ b/script_release.py
@@ -121,7 +121,7 @@ class ReleaseManager:
             pullrequests = self.get_merged_pullrequest()
             write_lines.extend(pullrequests)
         else:
-            write_lines.append(u' * \n')
+            write_lines.append(u'  * \n')
 
         author_name = self.git.config('user.name')
         author_mail = self.git.config('user.email')
@@ -209,7 +209,7 @@ class ReleaseManager:
             lines.append(line + u'\n')
 
         f_changelog.close()
-        return line
+        return lines
 
     def publish_release(self, temp_branch):
         #merge with the release branch
@@ -255,7 +255,7 @@ class ReleaseManager:
 
         if self.release_type == "hotfix":
             print "now time to do your actual hotfix!"
-            print "Note: you'll have to merge/taf/push manually after your fix:"
+            print "Note: you'll have to merge/tag/push manually after your fix:"
             print "git checkout release"
             print "git merge --no-ff {tmp_branch}".format(tmp_branch=tmp_name)
             print "git tag -a{}".format(get_tag_name(self.version))
@@ -273,7 +273,8 @@ class ReleaseManager:
 if __name__ == '__main__':
 
     if len(argv) < 2:
-        print "mandatory argument: {major|minor|hotfix} remote"
+        print "mandatory argument: {major|minor|hotfix}"
+        print "possible additional argument: remote (default is canalTP)"
         exit(5)
 
     r_type = argv[1]

--- a/script_release.py
+++ b/script_release.py
@@ -17,7 +17,7 @@ def get_tag_name(version):
 class ReleaseManager:
 
     def __init__(self, release_type, remote_name="canalTP"):
-        self.directory = "~/bak/kraken"
+        self.directory = "."
         self.release_type = release_type
         self.repo = Repo(self.directory)
         self.git = self.repo.git

--- a/script_release.py
+++ b/script_release.py
@@ -9,114 +9,192 @@ from os import remove, stat
 import codecs
 
 
-AUTHOR_NAME = "Vincent Lara"
-AUTHOR_MAIL = "vincent.lara@canaltp.fr"
+class ReleaseManager:
 
-repo = Repo(".")
-git = repo.git
+    def __init__(self, release_type, remote_name="canalTP"):
+        self.directory = "~/bak/kraken"
+        self.release_type = release_type
+        self.repo = Repo(self.directory)
+        self.git = repo.git
 
-tags = repo.tags
+        #we fetch latest version from remote
+        self.remote_name = remote_name
 
-latest_version = None
-last_tag = git.describe('--tags', abbrev=0)
+        print "fetching from {}".format(remote_name)
+        self.git.fetch(remote_name, "--tags")
 
-version = re.search('.*(\d+\.\d+\.\d+).*', last_tag)
-if version:
-    latest_version = version.group(1)
+        #and we update dev and release branches
+        print "rebase dev and release"
 
-if not latest_version:
-    print "no latest version found"
-    exit(1)
+        #TODO quit on error
+        self.git.rebase("canalTP/dev", "dev")
+        self.git.rebase("canalTP/release", "release")
 
-version_n = latest_version.split('.')
-print "latest version is %s" % version_n
+        self.version = None
 
-version_n = [int(i) for i in version_n]
+    def get_new_version_number(self):
+        latest_version = None
+        last_tag = self.git.describe('--tags', abbrev=0)
 
-if len(argv) != 2:
-    print "mandatory argument: {major|minor|hotfix}"
-    exit(5)
+        version = re.search('.*(\d+\.\d+\.\d+).*', last_tag)
+        if version:
+            latest_version = version.group(1)
 
-if argv[1] == "major":
-    version_n[0] += 1
-    version_n[1] = version_n[2] = 0
-elif argv[1] == "minor":
-    version_n[1] += 1
-    version_n[2] = 0
-elif argv[1] == "hotfix":
-    version_n[2] += 1
-else:
-    exit(5)
-version = "%i.%i.%i" % (version_n[0], version_n[1], version_n[2])
+        if not latest_version:
+            print "no latest version found"
+            exit(1)
 
-tmp_name = "release_%s" % version
-tmp_head = git.checkout(b=tmp_name)
+        version_n = latest_version.split('.')
+        print "latest version is {}".format(version_n)
 
-write_lines = [
-    u'navitia2 (%s) unstable; urgency=low\n' % version,
-    u'\n',
-]
-if argv[1] != "hotfix":
-    parents_sha = [c.hexsha for c in repo.commit(last_tag).parents]
-    parents_sha.append(last_tag)
-    for c in repo.iter_commits("dev"):
-        if c.hexsha in parents_sha:
-            break
-        write_lines.append(u' * %s\n'%(unicode(c.message.partition("\n")[0])))
-    if len(write_lines):
-        write_lines = write_lines[0:50]
-        write_lines.append(" * Attention il manque des commits, y en avait trop j'ai pas tout mis")
-else:
-    write_lines.append(u' * \n')
-write_lines.extend([
-    u'\n',
-    u' -- %s <%s>  %s +0100\n' %(AUTHOR_NAME, AUTHOR_MAIL,
-                             datetime.now().strftime("%a, %d %b %Y %H:%m:%S")),
-    u'\n',
-])
-f_changelog = None
-changelog_filename = "debian/changelog"
-back_filename = changelog_filename + "~"
-try:
-    f_changelog = codecs.open(changelog_filename, 'r', 'utf-8')
-except IOError:
-    print "Unable to open debian/changelog"
-    exit(1)
-f_changelogback = codecs.open(back_filename, "w", "utf-8")
+        self.version = [int(i) for i in version_n]
 
-for line in write_lines:
-    f_changelogback.write(line)
+        if self.release_type == "major":
+            self.version[0] += 1
+            self.version[1] = version_n[2] = 0
+        elif self.release_type == "minor":
+            self.version[1] += 1
+            self.version[2] = 0
+        elif self.release_type == "hotfix":
+            self.version[2] += 1
+        else:
+            exit(5)
 
-for line in f_changelog:
-    f_changelogback.write(line)
-f_changelog.close()
-f_changelogback.close()
-last_modified = stat(back_filename)
-(stdout, stderr) = subprocess.Popen(["vim", back_filename, "--nofork"],
-                                    stderr=subprocess.PIPE).communicate()
-after = stat(back_filename)
-if last_modified == after:
-    print "No changes made, we stop"
-    remove(back_filename)
-    exit(2)
+        str_version = "{maj}.{min}.{hf}".format(maj=version_n[0], min=version_n[1], hf=version_n[2])
 
-copyfile(back_filename, changelog_filename)
+        return str_version
 
-cmake = open("source/CMakeLists.txt", "r")
-cmake_lines = []
-for line in cmake:
-    line = re.sub("^SET\(KRAKEN_VERSION_MAJOR (\d+)\)$",
-                  lambda matchobj : "SET(KRAKEN_VERSION_MAJOR %i)"%version_n[0], line)
-    line = re.sub("^SET\(KRAKEN_VERSION_MINOR (\d+)\)$",
-                  lambda matchobj : "SET(KRAKEN_VERSION_MINOR %i)"%version_n[1], line)
-    line = re.sub("^SET\(KRAKEN_VERSION_PATCH (\d+)\)$",
-                  lambda matchobj : "SET(KRAKEN_VERSION_PATCH %i)"%version_n[2], line)
-    cmake_lines.append(line)
-cmake.close()
-cmake = open("source/CMakeLists.txt", "w")
-cmake.writelines(cmake_lines)
-cmake.close()
+    def get_parent_branch(self):
+        parent=""
+        if self.release_type == "major" or self.release_type == "minor":
+            parent = "dev"
+        else:
+            parent = "release"
 
-git.add(changelog_filename)
-git.add("source/CMakeLists.txt")
-git.commit(m="Version %s"%version)
+        parent_head = self.git.checkout(b=parent)
+
+        return parent_head
+
+    def get_merged_pullrequest(self):
+        pass
+
+    def create_changelog(self):
+        write_lines = [
+            u'navitia2 (%s) unstable; urgency=low\n' % version,
+            u'\n',
+        ]
+
+        if self.release_type != "hotfix":
+            pullrequests = get_merged_pullrequest()
+            write_lines.append(pullrequests)
+        else:
+            write_lines.append(u' * \n')
+
+        author_name = self.git.config('user.name')
+        author_mail = self.git.config('user.mail')
+        write_lines.extend([
+            u'\n',
+            u' -- {name} <{mail}>  {now} +0100\n'.format(name=author_name, mail=author_mail,
+                                                         now=datetime.now().strftime("%a, %d %b %Y %H:%m:%S")),
+            u'\n',
+        ])
+
+    def update_changelog(self):
+        changelog = create_changelog()
+
+        f_changelog = None
+        changelog_filename = self.directory + "/" + "debian/changelog"
+        back_filename = changelog_filename + "~"
+        try:
+            f_changelog = codecs.open(changelog_filename, 'r', 'utf-8')
+        except IOError:
+            print "Unable to open debian/changelog"
+            exit(1)
+        f_changelogback = codecs.open(back_filename, "w", "utf-8")
+
+        for line in changelog:
+            f_changelogback.write(line)
+
+        for line in f_changelog:
+            f_changelogback.write(line)
+        f_changelog.close()
+        f_changelogback.close()
+        last_modified = stat(back_filename)
+        (stdout, stderr) = subprocess.Popen(["vim", back_filename, "--nofork"],
+                                            stderr=subprocess.PIPE).communicate()
+        after = stat(back_filename)
+        if last_modified == after:
+            print "No changes made, we stop"
+            remove(back_filename)
+            exit(2)
+
+        copyfile(back_filename, changelog_filename)
+
+        self.git.add(changelog_filename)
+
+    def update_version(self):
+
+        cmake = open(self.directory + "/" + "source/CMakeLists.txt", "r")
+        cmake_lines = []
+        for line in cmake:
+            line = re.sub("^SET\(KRAKEN_VERSION_MAJOR (\d+)\)$",
+                          lambda matchobj: "SET(KRAKEN_VERSION_MAJOR %i)" % self.version[0], line)
+            line = re.sub("^SET\(KRAKEN_VERSION_MINOR (\d+)\)$",
+                          lambda matchobj: "SET(KRAKEN_VERSION_MINOR %i)" % self.version[1], line)
+            line = re.sub("^SET\(KRAKEN_VERSION_PATCH (\d+)\)$",
+                          lambda matchobj: "SET(KRAKEN_VERSION_PATCH %i)" % self.version[2], line)
+            cmake_lines.append(line)
+        cmake.close()
+
+        cmake = open(self.directory + "/" + "source/CMakeLists.txt", "w")
+        cmake.writelines(cmake_lines)
+        cmake.close()
+        self.git.add(self.directory + "/" + "source/CMakeLists.txt")
+
+    def publish_release(self):
+        print "publishing the release"
+        pass
+
+    def release_the_kraken(self):
+
+        new_version = self.get_new_version_number(release_type)
+
+        tmp_name = "release_%s" % new_version
+
+        parent_head = self.get_parent_branch(release_type)
+
+        self.git.checkout(b=tmp_name)
+
+        self.update_changelog()
+        self.update_version()
+
+        git.commit(m="Version %s"%version)
+
+        if self.release_type == "hotfix":
+            print "now time to do your actual hotfix!"
+            print "Note: you'll have to merge/taf/push manually after your fix:"
+            print "git checkout release"
+            print "git merge --no-ff {tmp_branch}".format(tmp_branch=tmp_name)
+            print "git tag TODO!" #TODO! explicit command
+
+            print "git merge --no-ff {tmp_branch} dev".format(tmp_branch=tmp_name)
+            print "git push {} release dev --tags".format(self.remote_name)
+
+            #TODO test the commands above :)
+            #TODO2 try to script that (put 2 hotfix param, like hotfix init and hotfix publish ?)
+            exit(0)
+
+        self.publish_release()
+
+
+if __name__ == '__main__':
+
+    if len(argv) < 2:
+        print "mandatory argument: {major|minor|hotfix} remote"
+        exit(5)
+
+    r_type = argv[1]
+    remote = argv[2] if len(argv) >= 2 else "origin" #"canalTP"
+
+    manager = ReleaseManager(release_type=r_type, remote_name=remote)
+    manager.release_the_kraken()


### PR DESCRIPTION
Refactoring of the release script.

The script is to be called when a release has do be done. It follow the [classic gitflow](http://nvie.com/posts/a-successful-git-branching-model/)  for release.

3 arguments are available:
- major 
- minor
- hotfix

The script branches from either `dev` (for minor and major) or `release` (for hotfix), change the version number, merge the  `temporary release branch` into `dev` and `debug` and tag the  `release` with the new version number.

For the moment it does not push the `dev` and  `release` branches to remote (you have to check that everything is ok before).
The hotfix part is under work, for the moment it only does the first part of the process (fetching, creating temporary branch and updating version number). After that you have to make the hotfix changes you want and follow the instruction in comment at the end of the script (to merge the temporary branch, tag, ...)
