### PR TITLE
Kraken: force malloc release

### DIFF
--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #We use the BOOST_LIBS define is the parent
 SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 add_executable(data_manager_test data_manager_test.cpp)
-target_link_libraries(data_manager_test log4cplus ${Boost_LIBRARIES})
+target_link_libraries(data_manager_test log4cplus tcmalloc ${Boost_LIBRARIES})
 ADD_BOOST_TEST(data_manager_test)


### PR DESCRIPTION
when we reloaded the kraken's data with tyr the memory foot print was
twice as big as the real data.

We now force malloc to release the free memory after the swap to reduce
the overall kraken memory foot print.
