### PR TITLE
Tyr load data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/source/tyr/.env
 stats
 debug
 release*

--- a/source/tyr/manage_tyr.py
+++ b/source/tyr/manage_tyr.py
@@ -35,7 +35,7 @@ import sys
 from flask_script import Manager
 from flask_migrate import Migrate, MigrateCommand
 from tyr.command import AggregatePlacesCommand, ReloadAtCommand, AtReloader,\
-    ReloadKrakenCommand, BuildDataCommand
+    ReloadKrakenCommand, BuildDataCommand, LoadDataCommand
 
 manager = Manager(app)
 
@@ -48,6 +48,7 @@ manager.add_command('reload_at', ReloadAtCommand())
 manager.add_command('at_reloader', AtReloader())
 manager.add_command('reload_kraken', ReloadKrakenCommand())
 manager.add_command('build_data', BuildDataCommand())
+manager.add_command('load_data', LoadDataCommand())
 
 if __name__ == '__main__':
     app.config['DEBUG'] = True

--- a/source/tyr/tyr/command/load_data.py
+++ b/source/tyr/tyr/command/load_data.py
@@ -27,9 +27,22 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from tyr.command.aggregate_places import AggregatePlacesCommand
-from tyr.command.reload_at import ReloadAtCommand
-from tyr.command.at_reloader import AtReloader
-from tyr.command.reload_kraken import ReloadKrakenCommand
-from tyr.command.build_data import BuildDataCommand
-from tyr.command.load_data import LoadDataCommand
+from flask.ext.script import Command, Option
+from navitiacommon import models
+from tyr.tasks import load_data
+import logging
+
+
+class LoadDataCommand(Command):
+    """A command used for run trigger a reload of data from a directory"""
+
+    def get_options(self):
+        return [
+            Option(dest='instance_name', help="name of the instance"),
+            Option(dest='data_dir', help="path of the data to load")
+        ]
+
+    def run(self, instance_name, data_dir):
+        logging.info("Run command load data")
+        instance = models.Instance.query.filter_by(name=instance_name).first()
+        load_data.delay(instance.id, data_dir)

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -80,76 +80,70 @@ def finish_job(job_id):
     models.db.session.commit()
 
 
+def import_data(files, instance, backup_file):
+    actions = []
+    job = models.Job()
+    instance_config = load_instance_config(instance.name)
+    job.instance = instance
+    job.state = 'pending'
+    task = {
+        'gtfs': gtfs2ed,
+        'fusio': fusio2ed,
+        'osm': osm2ed,
+        'geopal': geopal2ed,
+        'fare': fare2ed,
+        'poi': poi2ed,
+        'synonym': synonym2ed,
+    }
+
+    for _file in files:
+        filename = None
+
+        dataset = models.DataSet()
+        dataset.type = type_of_data(_file)
+        if dataset.type in task:
+            if backup_file:
+                filename = move_to_backupdirectory(_file,
+                                                   instance_config.backup_directory)
+            else:
+                filename = _file
+            actions.append(task[dataset.type].si(instance_config, filename))
+        else:
+            #unknown type, we skip it
+            current_app.logger.debug("unknwn file type: {} for file {}"
+                                     .format(dataset.type, _file))
+            continue
+
+        #currently the name of a dataset is the path to it
+        dataset.name = filename
+        models.db.session.add(dataset)
+        job.data_sets.append(dataset)
+
+    if actions:
+        models.db.session.add(job)
+        models.db.session.commit()
+        for action in actions:
+            action.kwargs['job_id'] = job.id
+        #We pass the job id to each tasks, but job need to be commited for
+        #having an id
+        binarisation = [ed2nav.si(instance_config, job.id),
+                        nav2rt.si(instance_config, job.id)]
+        aggregate = aggregate_places.si(instance_config, job.id)
+        #We pass the job id to each tasks, but job need to be commited for
+        #having an id
+        actions.append(group(chain(*binarisation), aggregate))
+        actions.append(reload_data.si(instance_config, job.id))
+        actions.append(finish_job.si(job.id))
+        chain(*actions).delay()
+
+
 @celery.task()
 def update_data():
     for instance in models.Instance.query.all():
-        current_app.logger.debug("Update data of : %s"%instance.name)
+        current_app.logger.debug("Update data of : {}".format(instance.name))
         instance_config = load_instance_config(instance.name)
         files = glob.glob(instance_config.source_directory + "/*")
-        actions = []
-        job = models.Job()
-        job.instance = instance
-        job.state = 'pending'
-        for _file in files:
-            dataset = models.DataSet()
-            filename = None
-
-            dataset.type = type_of_data(_file)
-            if dataset.type == 'gtfs':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(gtfs2ed.si(instance_config, filename))
-            elif dataset.type == 'fusio':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(fusio2ed.si(instance_config,
-                                           filename))
-            elif dataset.type == 'osm':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(osm2ed.si(instance_config, filename))
-            elif dataset.type == 'geopal':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(geopal2ed.si(instance_config, filename))
-            elif dataset.type == 'fare':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(fare2ed.si(instance_config, filename))
-            elif dataset.type == 'poi':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(poi2ed.si(instance_config, filename))
-            elif dataset.type == 'synonym':
-                filename = move_to_backupdirectory(_file,
-                        instance_config.backup_directory)
-                actions.append(synonym2ed.si(instance_config, filename))
-            else:
-                #unknown type, we skip it
-                continue
-
-            #currently the name of a dataset is the path to it
-            dataset.name = filename
-            models.db.session.add(dataset)
-            job.data_sets.append(dataset)
-
-        if actions:
-            models.db.session.add(job)
-            models.db.session.commit()
-            for action in actions:
-                action.kwargs['job_id'] = job.id
-            #We pass the job id to each tasks, but job need to be commited for
-            #having an id
-            binarisation = [ed2nav.si(instance_config, job.id),
-                            nav2rt.si(instance_config, job.id)]
-            aggregate = aggregate_places.si(instance_config, job.id)
-            #We pass the job id to each tasks, but job need to be commited for
-            #having an id
-            actions.append(group(chain(*binarisation), aggregate))
-            actions.append(reload_data.si(instance_config, job.id))
-            actions.append(finish_job.si(job.id))
-            chain(*actions).delay()
-
+        import_data(files, instance, backup_file=True)
 
 
 @celery.task()
@@ -206,6 +200,19 @@ def build_all_data():
         chain(ed2nav.si(instance_config, job.id),
                             nav2rt.si(instance_config, job.id)).delay()
         current_app.logger.info("Job  build data of : %s queued"%instance.name)
+
+
+@celery.task()
+def load_data(instance_id, data_path):
+    instance = models.Instance.query.get(instance_id)
+    job = models.Job()
+    job.instance = instance
+    job.state = 'pending'
+    models.db.session.add(job)
+    models.db.session.commit()
+    files = glob.glob(data_path + "/*")
+
+    import_data(files, instance, backup_file=True)
 
 
 @task_postrun.connect

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -212,7 +212,7 @@ def load_data(instance_id, data_path):
     models.db.session.commit()
     files = glob.glob(data_path + "/*")
 
-    import_data(files, instance, backup_file=True)
+    import_data(files, instance, backup_file=False)
 
 
 @task_postrun.connect

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -81,6 +81,20 @@ def finish_job(job_id):
 
 
 def import_data(files, instance, backup_file):
+    """
+    import the data contains in the list of 'files' in the 'instance'
+
+    :param files: files to import
+    :param instance: instance to receive the data
+    :param backup_file: If True the files are moved to a backup directory, else they are not moved
+
+    run the whole data import process:
+
+    - data import in bdd (fusio2ed, gtfs2ed, poi2ed, ...)
+    - export bdd to nav file
+    - update the jormungandr db with the new data for the instance
+    - reload the krakens
+    """
     actions = []
     job = models.Job()
     instance_config = load_instance_config(instance.name)


### PR DESCRIPTION
Add a load_data target for tyr

2 params are needed: the name of the kraken instance and the data dir.

the target will launch the whole data import process:
- data import in bdd (fusio2ed, gtfs2ed, poi2ed, ...)
- export bdd to nav file
- update the jormungandr db with the new data for the instance
- reload the krakens

the original data will be neither moved nor modified.

This target will be used mainly in Artemis (the business test framework)

example call:
`TYR_CONFIG_FILE=/srv/tyr/settings.py python /srv/tyr/manage.py load_data airport-01 /srv/ed/airport-01/data/`
