### PR TITLE
TimeTable: change exceptions

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -731,8 +731,9 @@ void PeriodFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_li
         LOG4CPLUS_ERROR(logger, "period invalid, not added for calendar " << row[calendar_c]);
         return;
     }
-
-    boost::gregorian::date_period period(begin_date, end_date);
+    //the end of a gregorian period not in the period (it's the day after)
+    //since we want the end to be in the period, we add one day to it
+    boost::gregorian::date_period period(begin_date, end_date + boost::gregorian::days(1));
     cal->second->period_list.push_back(period);
 }
 

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -872,10 +872,12 @@ boost::gregorian::date_period GenericGtfsParser::find_production_date(const std:
     boost::gregorian::date b_date(boost::gregorian::min_date_time);
     if(beginning_date != "")
         b_date = boost::gregorian::from_undelimited_string(beginning_date);
-    LOG4CPLUS_TRACE(logger, "date de production: " +
+    LOG4CPLUS_INFO(logger, "date de production: " +
                     boost::gregorian::to_simple_string((start_date>b_date ? start_date : b_date))
                     + " - " + boost::gregorian::to_simple_string(end_date));
-    return boost::gregorian::date_period((start_date>b_date ? start_date : b_date), end_date);
+    //the end of a boost::gregorian::date_period is not in the period
+    //since end_date is the last day is the data, we want the end to be the next day
+    return boost::gregorian::date_period((start_date>b_date ? start_date : b_date), end_date + boost::gregorian::days(1));
 }
 
 void GtfsParser::parse_files(Data& data) {

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -273,13 +273,13 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
     auto properties = stop_date_time.properties();
     BOOST_REQUIRE_EQUAL(properties.exceptions_size(), 2);
     auto exception = properties.exceptions(0);
-    BOOST_REQUIRE_EQUAL(exception.uri(), "exception:020120618");
+    BOOST_REQUIRE_EQUAL(exception.uri(), "exception:120120618");
     BOOST_REQUIRE_EQUAL(exception.date(), "20120618");
-    BOOST_REQUIRE_EQUAL(exception.type(), pbnavitia::ExceptionType::Add);
+    BOOST_REQUIRE_EQUAL(exception.type(), pbnavitia::ExceptionType::Remove);
 
     exception = properties.exceptions(1);
-    BOOST_REQUIRE_EQUAL(exception.uri(), "exception:020120619");
+    BOOST_REQUIRE_EQUAL(exception.uri(), "exception:120120619");
     BOOST_REQUIRE_EQUAL(exception.date(), "20120619");
-    BOOST_REQUIRE_EQUAL(exception.type(), pbnavitia::ExceptionType::Add);
+    BOOST_REQUIRE_EQUAL(exception.type(), pbnavitia::ExceptionType::Remove);
 
 }

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -290,8 +290,8 @@ void Data::build_associated_calendar() {
                 }
                 ExceptionDate ex;
                 ex.date = vehicle_journey->validity_pattern->beginning_date + boost::gregorian::days(i);
-                //if the vj was active this day it's a removal, else an addition
-                ex.type = (vehicle_journey->validity_pattern->days[i] ? ExceptionDate::ExceptionType::sub : ExceptionDate::ExceptionType::add);
+                //if the vj is active this day it's an addition, else a removal
+                ex.type = (vehicle_journey->validity_pattern->days[i] ? ExceptionDate::ExceptionType::add : ExceptionDate::ExceptionType::sub);
                 associated_calendar->exceptions.push_back(ex);
             }
 


### PR DESCRIPTION
The exceptions on the calendar associations were messed up, they were
opposite to the one we should put.

In the meantime, the period ends have been changed to add one day to
them since the GTFS/Fusio end dates have to be in the period (and they
were not since boost period work as a classic range so the end is the
first date after the period).
