### PR TITLE
Gtfs csvreader

### DIFF
--- a/fixtures/ed/gtfs/stops.txt
+++ b/fixtures/ed/gtfs/stops.txt
@@ -1,4 +1,4 @@
-"stop_id","stop_name","stop_desc","stop_lat","stop_lon","zone_id","stop_url","location_type","parent_station","wheelchair_boarding
+"stop_id","stop_name","stop_desc","stop_lat","stop_lon","zone_id","stop_url","location_type","parent_station","wheelchair_boarding"
 "doublon_sa", "Doublon",,"1","0",,,1,,
 "doublon_sa", "Doublon",,"1","0",,,1,,
 "doublon_sp", "Doublon",,"1","0",,,0,,


### PR DESCRIPTION
1) Use boost::spirit  for split line in place of Tokenizer
2)  Parse line with separator, return line and slash between double qute
3) Add test for csvreader

It is now way more flexible that the previous parse with Boost::Tokenizer and it fixes  #297.
