### PR TITLE
Mod block

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -269,28 +269,6 @@ SA builder::sa(const std::string &name, double x, double y, const bool wheelchai
 }
 
 
-void builder::journey_pattern_point_connection(const std::string & name1, const std::string & name2, float length) {
-    navitia::type::Line *line1 = (*(lines.find(name1))).second;
-    navitia::type::Line *line2 = (*(lines.find(name2))).second;
-
-    if(line1 != nullptr && line2 != nullptr) {
-        for(navitia::type::Route * route1 : line1->route_list) {
-            for(navitia::type::JourneyPattern* jp1 : route1->journey_pattern_list) {
-                for(navitia::type::Route * route2 : line2->route_list) {
-                    for(navitia::type::JourneyPattern* jp2 : route2->journey_pattern_list) {
-                        navitia::type::JourneyPatternPointConnection* connection = new navitia::type::JourneyPatternPointConnection();
-                        connection->departure = jp1->journey_pattern_point_list.back();
-                        connection->destination = jp2->journey_pattern_point_list.front();
-                        connection->duration = length;
-                        this->data->pt_data->journey_pattern_point_connections.push_back(connection);
-                    }
-                }
-            }
-
-        }
-    }
-}
-
 void builder::connection(const std::string & name1, const std::string & name2, float length) {
     navitia::type::StopPointConnection* connexion = new navitia::type::StopPointConnection();
     connexion->idx = data->pt_data->stop_point_connections.size();

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -85,6 +85,7 @@ struct builder{
     std::map<std::string, navitia::type::StopArea *> sas;
     std::map<std::string, navitia::type::StopPoint *> sps;
     std::map<std::string, navitia::type::Network *> nts;
+    std::multimap<std::string, navitia::type::VehicleJourney*> block_vjs;
     boost::gregorian::date begin;
 
     std::unique_ptr<navitia::type::Data> data = std::make_unique<navitia::type::Data>();

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -107,7 +107,6 @@ struct builder{
 
     /// Crée une connexion
     void connection(const std::string & name1, const std::string & name2, float length);
-    void journey_pattern_point_connection(const std::string & name1, const std::string & name2, float length=120);
     void build(navitia::type::PT_Data & pt_data);
     void build_relations(navitia::type::PT_Data & data);
     void finish();

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -110,6 +110,7 @@ struct builder{
     void connection(const std::string & name1, const std::string & name2, float length);
     void build(navitia::type::PT_Data & pt_data);
     void build_relations(navitia::type::PT_Data & data);
+    void build_blocks();
     void finish();
     void generate_dummy_basis();
 };

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -80,8 +80,7 @@ void Data::build_block_id() {
     types::VehicleJourney* prev_vj = nullptr;
     for(auto* vj : vehicle_journeys) {
         if(prev_vj && prev_vj->block_id != "" &&
-           prev_vj->block_id == vj->block_id &&
-           ){
+           prev_vj->block_id == vj->block_id){
             // Sanity check
             // If the departure time of the 1st stoptime of vj is greater
             // then the arrivaltime of the last stop time of prev_vj

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -78,11 +78,22 @@ void Data::build_block_id() {
     );
 
     types::VehicleJourney* prev_vj = nullptr;
-    for(auto it=vehicle_journeys.begin(); it!=vehicle_journeys.end(); ++it) {
-        auto vj = *it;
-        if(prev_vj && prev_vj->block_id != "" && prev_vj->block_id == vj->block_id) {
-            prev_vj->next_vj = vj;
-            vj->prev_vj = prev_vj;
+    for(auto* vj : vehicle_journeys) {
+        if(prev_vj && prev_vj->block_id != "" &&
+           prev_vj->block_id == vj->block_id &&
+           ){
+            // Sanity check
+            // If the departure time of the 1st stoptime of vj is greater
+            // then the arrivaltime of the last stop time of prev_vj
+            // there is a time travel, and we don't like it!
+            // This is not supposed to happen
+            // @TODO: Add a parameter to avoid too long connection
+            // they can be for instance due to bad data
+            if(vj->stop_time_list.front()->departure_time >=
+                    prev_vj->stop_time_list.back()->arrival_time) {
+                prev_vj->next_vj = vj;
+                vj->prev_vj = prev_vj;
+            }
         }
         prev_vj = vj;
     }

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -64,7 +64,7 @@ void Data::normalize_uri(){
 
 void Data::build_block_id() {
     /// We want to group vehicle journeys by their block_id
-    /// Two vehicle_journeys vj1 are consecutive if
+    /// Two vehicle_journeys with the same block_id vj1 are consecutive if
     /// the last arrival_time of vj1 <= to the departure_time of vj2
     std::sort(vehicle_journeys.begin(), vehicle_journeys.end(),
             [](const types::VehicleJourney* vj1, const types::VehicleJourney* vj2) {
@@ -75,7 +75,7 @@ void Data::build_block_id() {
                         vj2->stop_time_list.front()->departure_time;
             }
         }
-        );
+    );
 
     types::VehicleJourney* prev_vj = nullptr;
     for(auto it=vehicle_journeys.begin(); it!=vehicle_journeys.end(); ++it) {

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -249,6 +249,12 @@ void Data::clean(){
     //Meme chose mais avec les vj
     num_elements = vehicle_journeys.size();
     for(size_t to_erase : erasest) {
+        if(vehicle_journeys[to_erase]->next_vj) {
+            vehicle_journeys[to_erase]->next_vj->prev_vj = nullptr;
+        }
+        if(vehicle_journeys[to_erase]->prev_vj) {
+            vehicle_journeys[to_erase]->prev_vj->next_vj = nullptr;
+        }
         delete vehicle_journeys[to_erase];
         vehicle_journeys[to_erase] = vehicle_journeys[num_elements - 1];
         num_elements--;

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -104,6 +104,8 @@ public:
     /// Construit les journey_patternpoint
     void build_journey_pattern_points();
 
+    void build_block_id();
+
     void normalize_uri();
 
     /**

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -52,10 +52,6 @@ void normalize_uri(std::vector<T*>& vec){
 
 bool same_journey_pattern(types::VehicleJourney * vj1, types::VehicleJourney * vj2);
 
-/// Ajoute une connection entre deux journey_pattern_point
-void  add_journey_pattern_point_connection(types::JourneyPatternPoint *rp1, types::JourneyPatternPoint *rp2, int length,
-                           std::multimap<std::string, types::JourneyPatternPointConnection> &journey_pattern_point_connections);
-
 /** Structure de donnée temporaire destinée à être remplie par un connecteur
       *
       * Les vecteurs contiennent des pointeurs vers un objet TC.
@@ -67,7 +63,6 @@ public:
 #define ED_COLLECTIONS(type_name, collection_name) std::vector<types::type_name*> collection_name;
     ITERATE_NAVITIA_PT_TYPES(ED_COLLECTIONS)
     std::vector<types::StopTime*> stops;
-    std::vector<types::JourneyPatternPointConnection*> journey_pattern_point_connections;
     std::vector<types::StopPointConnection*> stop_point_connections;
 
     //fare:
@@ -108,9 +103,6 @@ public:
 
     /// Construit les journey_patternpoint
     void build_journey_pattern_points();
-
-    /// Construit les connections pour les correspondances garanties
-    void build_journey_pattern_point_connections();
 
     void normalize_uri();
 

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -117,7 +117,6 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "journey_pattern points: " << data.pt_data->journey_pattern_points.size());
     LOG4CPLUS_INFO(logger, "modes: " << data.pt_data->physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.pt_data->validity_patterns.size());
-    LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.pt_data->journey_pattern_point_connections.size());
     LOG4CPLUS_INFO(logger, "calendars: " << data.pt_data->calendars.size());
     LOG4CPLUS_INFO(logger, "synonyms : " << data.geo_ref->synonyms.size());
     LOG4CPLUS_INFO(logger, "fare tickets: " << data.fare->fare_map.size());

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -325,9 +325,6 @@ void EdPersistor::persist(const ed::Data& data, const navitia::type::MetaData& m
     LOG4CPLUS_INFO(logger, "Begin: insert stop point connections");
     this->insert_stop_point_connections(data.stop_point_connections);
     LOG4CPLUS_INFO(logger, "End: insert stop point connections");
-    LOG4CPLUS_INFO(logger, "Begin: insert journey pattern point connections");
-    this->insert_journey_pattern_point_connections(data.journey_pattern_point_connections);
-    LOG4CPLUS_INFO(logger, "End: insert journey pattern point connections");
     LOG4CPLUS_INFO(logger, "Begin: insert admin stop area");
     this->insert_admin_stop_areas(data.admin_stop_areas);
     LOG4CPLUS_INFO(logger, "End: insert admin stop area");
@@ -666,24 +663,6 @@ void EdPersistor::insert_stop_point_connections(const std::vector<types::StopPoi
     this->lotus.finish_bulk_insert();
 }
 
-void EdPersistor::insert_journey_pattern_point_connections(const std::vector<types::JourneyPatternPointConnection*>& connections){
-    this->lotus.prepare_bulk_insert("navitia.journey_pattern_point_connection",
-            {"departure_journey_pattern_point_id",
-            "destination_journey_pattern_point_id", "connection_kind_id",
-            "length"});
-
-    //@TODO properties!!
-    for(types::JourneyPatternPointConnection* co : connections){
-        std::vector<std::string> values;
-        values.push_back(std::to_string(co->departure->idx));
-        values.push_back(std::to_string(co->destination->idx));
-        values.push_back(std::to_string(static_cast<int>(co->connection_kind)));
-        values.push_back(std::to_string(co->length));
-        this->lotus.insert(values);
-    }
-
-    this->lotus.finish_bulk_insert();
-}
 
 void EdPersistor::insert_routes(const std::vector<types::Route*>& routes){
     this->lotus.prepare_bulk_insert("navitia.route",

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -844,7 +844,8 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
             {"id", "uri", "external_code", "name", "comment", "validity_pattern_id",
              "adapted_validity_pattern_id", "company_id", "journey_pattern_id",
              "theoric_vehicle_journey_id", "vehicle_properties_id",
-             "odt_type_id", "odt_message"});
+             "odt_type_id", "odt_message", "previous_vehicle_journey_id",
+             "next_vehicle_journey_id"});
 
     for(types::VehicleJourney* vj : vehicle_journeys){
         std::vector<std::string> values;
@@ -882,6 +883,16 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(std::to_string(vj->to_ulog()));
         values.push_back(std::to_string(static_cast<int>(vj->vehicle_journey_type)));
         values.push_back(vj->odt_message);
+        if(vj->prev_vj) {
+            values.push_back(std::to_string(vj->prev_vj->idx));
+        } else {
+            values.push_back(lotus.null_value);
+        }
+        if(vj->next_vj) {
+            values.push_back(std::to_string(vj->next_vj->idx));
+        } else {
+            values.push_back(lotus.null_value);
+        }
         this->lotus.insert(values);
     }
 

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -897,16 +897,12 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
             values += "next_vehicle_journey_id = "+boost::lexical_cast<std::string>(vj->next_vj->idx);
         }
         if(!values.empty()) {
-            if(vj->prev_vj && vj->prev_vj->idx > vehicle_journeys.size()) {
-                std::cout << "pou" << std::endl;
-            }
             std::string query = "UPDATE navitia.vehicle_journey SET ";
             query += values;
             query += " WHERE id = ";
             query += boost::lexical_cast<std::string>(vj->idx);
             query += ";";
-            LOG4CPLUS_INFO(logger, "query : " << query);
-
+            LOG4CPLUS_TRACE(logger, "query : " << query);
             PQclear(this->lotus.exec(query, "", PGRES_COMMAND_OK));
         }
     }

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -83,7 +83,6 @@ private:
     void insert_stop_times(const std::vector<types::StopTime*>& stop_times);
 
     void insert_stop_point_connections(const std::vector<types::StopPointConnection*>& connections);
-    void insert_journey_pattern_point_connections(const std::vector<types::JourneyPatternPointConnection*>& connections);
     void insert_synonyms(const std::map<std::string, std::string>& synonyms);
 
     void insert_admin_stop_areas(const std::vector<types::AdminStopArea*> admin_stop_areas);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -73,7 +73,6 @@ void EdReader::fill(navitia::type::Data& data, const double min_non_connected_gr
 
     //@TODO: les connections ont des doublons, en attendant que ce soit corrigé, on ne les enregistre pas
     this->fill_stop_point_connections(data, work);
-    this->fill_journey_pattern_point_connections(data, work);
     this->fill_poi_types(data, work);
     this->fill_pois(data, work);
     this->fill_poi_properties(data, work);
@@ -594,29 +593,6 @@ void EdReader::fill_stop_point_connections(nt::Data& data, pqxx::work& work){
             //add the connection in the stop points
             stop_point_connection->departure->stop_point_connection_list.push_back(stop_point_connection);
             stop_point_connection->destination->stop_point_connection_list.push_back(stop_point_connection);
-        }
-    }
-}
-
-void EdReader::fill_journey_pattern_point_connections(nt::Data& data, pqxx::work& work){
-    std::string request = "select departure_journey_pattern_point_id,"
-        "destination_journey_pattern_point_id, connection_kind_id, length "
-        "from navitia.journey_pattern_point_connection";
-
-    pqxx::result result = work.exec(request);
-    for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
-        auto id_departure = const_it["departure_journey_pattern_point_id"];
-        auto id_destination = const_it["destination_journey_pattern_point_id"];
-        auto it_departure = journey_pattern_point_map.find(id_departure.as<idx_t>());
-        auto it_destination = journey_pattern_point_map.find(id_destination.as<idx_t>());
-        if(it_departure!=journey_pattern_point_map.end() &&
-                it_destination!=journey_pattern_point_map.end()) {
-            auto* jppc= new nt::JourneyPatternPointConnection();
-            jppc->departure = it_departure->second;
-            jppc->destination = it_destination->second;
-            jppc->connection_type = static_cast<nt::ConnectionType>(const_it["connection_kind_id"].as<int>());
-            jppc->duration = const_it["length"].as<int>();
-            data.pt_data->journey_pattern_point_connections.push_back(jppc);
         }
     }
 }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -607,6 +607,8 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "vj.theoric_vehicle_journey_id as theoric_vehicle_journey_id ,"
         "vj.odt_type_id as odt_type_id, vj.odt_message as odt_message,"
         "vj.external_code as external_code,"
+        "vj.next_vehicle_journey_id as prev_vj_id,"
+        "vj.previous_vehicle_journey_id as next_vj_id,"
         "vp.wheelchair_accessible as wheelchair_accessible,"
         "vp.bike_accepted as bike_accepted,"
         "vp.air_conditioned as air_conditioned,"
@@ -619,6 +621,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "where vj.vehicle_properties_id = vp.id ";
 
     pqxx::result result = work.exec(request);
+    std::multimap<idx_t, nt::VehicleJourney*> prev_vjs, next_vjs;
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         nt::VehicleJourney* vj = new nt::VehicleJourney();
 
@@ -668,8 +671,20 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         if (const_it["school_vehicle"].as<bool>()){
             vj->set_vehicle(navitia::type::hasVehicleProperties::SCHOOL_VEHICLE);
         }
+        if (!const_it["prev_vj_id"].is_null()) {
+            prev_vjs.insert(std::make_pair(const_it["prev_vj_id"].as<idx_t>(), vj));
+        }
+        if (!const_it["next_vj_id"].is_null()) {
+            next_vjs.insert(std::make_pair(const_it["next_vj_id"].as<idx_t>(), vj));
+        }
         data.pt_data->vehicle_journeys.push_back(vj);
         this->vehicle_journey_map[const_it["id"].as<idx_t>()] = vj;
+    }
+    for(auto vjid_vj: prev_vjs) {
+       vjid_vj.second->prev_vj = vehicle_journey_map[vjid_vj.first];
+    }
+    for(auto vjid_vj: next_vjs) {
+       vjid_vj.second->next_vj = vehicle_journey_map[vjid_vj.first];
     }
 }
 

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -116,7 +116,6 @@ private:
     void fill_admins(navitia::type::Data& data, pqxx::work& work);
     void fill_admin_stop_areas(navitia::type::Data& data, pqxx::work& work);
     void fill_stop_point_connections(navitia::type::Data& data, pqxx::work& work);
-    void fill_journey_pattern_point_connections(navitia::type::Data& data, pqxx::work& work);
     void fill_poi_types(navitia::type::Data& data, pqxx::work& work);
     void fill_pois(navitia::type::Data& data, pqxx::work& work);
     void fill_poi_properties(navitia::type::Data& data, pqxx::work& work);

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -140,7 +140,6 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "journey_pattern points: " << data.journey_pattern_points.size());
     LOG4CPLUS_INFO(logger, "modes: " << data.physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.validity_patterns.size());
-    LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());
 
     start = pt::microsec_clock::local_time();
     ed::EdPersistor p(connection_string);

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -124,7 +124,6 @@ int main(int argc, char * argv[])
     LOG4CPLUS_INFO(logger, "journey_pattern points: " << data.journey_pattern_points.size());
     LOG4CPLUS_INFO(logger, "modes: " << data.physical_modes.size());
     LOG4CPLUS_INFO(logger, "validity pattern : " << data.validity_patterns.size());
-    LOG4CPLUS_INFO(logger, "journey_pattern point connections : " << data.journey_pattern_point_connections.size());
 
     start = pt::microsec_clock::local_time();
     ed::EdPersistor p(connection_string);

--- a/source/ed/main.cpp
+++ b/source/ed/main.cpp
@@ -150,7 +150,6 @@ int main(int argc, char * argv[])
     std::cout << "journey_pattern points: " << data.journey_pattern_points.size() << std::endl;
     std::cout << "modes: " << data.physical_modes.size() << std::endl;
     std::cout << "validity pattern : " << data.validity_patterns.size() << std::endl;
-    std::cout << "journey_pattern point connections : " << data.journey_pattern_point_connections.size() << std::endl;
     std::cout << "voies (rues) : " << nav_data.geo_ref.ways.size() << std::endl;
 
 

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -186,17 +186,6 @@ bool StopPointConnection::operator<(const StopPointConnection& other) const{
     }
 }
 
-bool JourneyPatternPointConnection::operator<(const JourneyPatternPointConnection& other) const {
-    if (this->departure == other.departure) {
-        if(this->destination == other.destination) {
-            return this < &other;
-        } else {
-            return *(this->destination) < *(other.destination);
-        }
-    } else {
-        return *(this->departure) < *(other.departure);
-    }
-}
 bool StopTime::operator<(const StopTime& other) const {
     if(this->vehicle_journey == other.vehicle_journey){
         BOOST_ASSERT(this->journey_pattern_point->order != other.journey_pattern_point->order);
@@ -376,17 +365,6 @@ nt::StopPointConnection* StopPointConnection::get_navitia_type() const {
     nt_connection->max_duration = this->max_duration;
     nt_connection->set_properties(this->properties());
     return nt_connection;
-}
-
-navitia::type::JourneyPatternPointConnection* JourneyPatternPointConnection::get_navitia_type() const {
-    nt::JourneyPatternPointConnection* nt_rpc = new nt::JourneyPatternPointConnection();
-    nt_rpc->idx = this->idx;
-    nt_rpc->uri = this->uri;
-    nt_rpc->departure->idx = this->departure->idx;
-    nt_rpc->destination->idx = this->destination->idx;
-    nt_rpc->duration = this->length;
-    nt_rpc->connection_type = this->connection_kind;
-    return nt_rpc;
 }
 
 nt::JourneyPatternPoint* JourneyPatternPoint::get_navitia_type() const {

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -73,20 +73,6 @@ struct StopPointConnection: public Header, hasProperties {
 
 };
 
-struct JourneyPatternPointConnection: public Header {
-    JourneyPatternPoint *departure;
-    JourneyPatternPoint *destination;
-    ConnectionType connection_kind;
-    int length;
-
-    navitia::type::JourneyPatternPointConnection* get_navitia_type() const;
-
-    JourneyPatternPointConnection() : departure(NULL), destination(NULL),
-                            connection_kind(ConnectionType::undefined), length(0) {}
-
-    bool operator<(const JourneyPatternPointConnection &other) const;
-};
-
 struct Calendar : public Nameable, public Header {
     const static nt::Type_e type = nt::Type_e::Calendar;
     typedef std::bitset<7> Week;

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -227,9 +227,15 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     ValidityPattern* adapted_validity_pattern;
     std::vector<VehicleJourney*> adapted_vehicle_journey_list;
     VehicleJourney* theoric_vehicle_journey;
+    VehicleJourney* prev_vj;
+    VehicleJourney* next_vj;
 
-    VehicleJourney(): journey_pattern(NULL), company(NULL), physical_mode(NULL), tmp_line(NULL), tmp_route(NULL), wheelchair_boarding(false),
-     vehicle_journey_type(navitia::type::VehicleJourneyType::regular), validity_pattern(NULL), first_stop_time(NULL), is_adapted(false), adapted_validity_pattern(NULL), theoric_vehicle_journey(NULL){}
+    VehicleJourney(): journey_pattern(NULL), company(NULL), physical_mode(NULL),
+    tmp_line(NULL), tmp_route(NULL), wheelchair_boarding(false),
+    vehicle_journey_type(navitia::type::VehicleJourneyType::regular),
+    validity_pattern(NULL), first_stop_time(NULL), is_adapted(false),
+    adapted_validity_pattern(NULL), theoric_vehicle_journey(NULL),
+    prev_vj(nullptr), next_vj(nullptr){}
 
     navitia::type::VehicleJourney* get_navitia_type() const;
 

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -209,33 +209,26 @@ struct JourneyPattern : public Header, Nameable{
 struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     const static nt::Type_e type = nt::Type_e::VehicleJourney;
     std::string external_code;
-    JourneyPattern* journey_pattern;
-    Company* company;
-    PhysicalMode* physical_mode; // Normalement on va lire cette info dans JourneyPattern
-    Line * tmp_line; // N'est pas à remplir obligatoirement
-    Route* tmp_route;
+    JourneyPattern* journey_pattern = nullptr;
+    Company* company = nullptr;
+    PhysicalMode* physical_mode = nullptr; // Read in journey_pattern
+    Line * tmp_line = nullptr; // May be empty
+    Route* tmp_route = nullptr;
     //Vehicle* vehicle;
-    bool wheelchair_boarding;
-    navitia::type::VehicleJourneyType vehicle_journey_type;
-    ValidityPattern* validity_pattern;
-    std::vector<StopTime*> stop_time_list; // N'est pas à remplir obligatoirement
-    StopTime * first_stop_time;
+    bool wheelchair_boarding = false;
+    navitia::type::VehicleJourneyType vehicle_journey_type = navitia::type::VehicleJourneyType::regular;
+    ValidityPattern* validity_pattern = nullptr;
+    std::vector<StopTime*> stop_time_list; // May be empty
+    StopTime * first_stop_time = nullptr;
     std::string block_id;
     std::string odt_message;
 
     bool is_adapted;
-    ValidityPattern* adapted_validity_pattern;
+    ValidityPattern* adapted_validity_pattern = nullptr;
     std::vector<VehicleJourney*> adapted_vehicle_journey_list;
-    VehicleJourney* theoric_vehicle_journey;
-    VehicleJourney* prev_vj;
-    VehicleJourney* next_vj;
-
-    VehicleJourney(): journey_pattern(NULL), company(NULL), physical_mode(NULL),
-    tmp_line(NULL), tmp_route(NULL), wheelchair_boarding(false),
-    vehicle_journey_type(navitia::type::VehicleJourneyType::regular),
-    validity_pattern(NULL), first_stop_time(NULL), is_adapted(false),
-    adapted_validity_pattern(NULL), theoric_vehicle_journey(NULL),
-    prev_vj(nullptr), next_vj(nullptr){}
+    VehicleJourney* theoric_vehicle_journey = nullptr;
+    VehicleJourney* prev_vj = nullptr;
+    VehicleJourney* next_vj = nullptr;
 
     navitia::type::VehicleJourney* get_navitia_type() const;
 

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -46,18 +46,9 @@ void dataRAPTOR::load(const type::PT_Data &data)
     foot_path_backward.clear();
     footpath_index_backward.clear();
     footpath_index_forward.clear();
-    footpath_rp_backward.clear();
-    footpath_rp_forward.clear();
     std::vector<std::map<navitia::type::idx_t, const navitia::type::StopPointConnection*> > footpath_temp_forward, footpath_temp_backward;
     footpath_temp_forward.resize(data.stop_points.size());
     footpath_temp_backward.resize(data.stop_points.size());
-
-    // Build of connections between journey pattern points
-    // This is use for extension of service and guaranteed connection
-    for(const type::JourneyPatternPointConnection* jppc : data.journey_pattern_point_connections) {
-        footpath_rp_forward.insert(std::make_pair(jppc->departure->idx, jppc));
-        footpath_rp_backward.insert(std::make_pair(jppc->destination->idx, jppc));
-    }
 
     // Build of a structure to look for connections
     for(const type::StopPointConnection* connection : data.stop_point_connections) {

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -47,8 +47,6 @@ struct dataRAPTOR {
     std::vector<pair_int> footpath_index_forward;
     std::vector<const navitia::type::StopPointConnection*> foot_path_backward;
     std::vector<pair_int> footpath_index_backward;
-    std::multimap<navitia::type::idx_t,const navitia::type::JourneyPatternPointConnection*> footpath_rp_forward;
-    std::multimap<navitia::type::idx_t,const navitia::type::JourneyPatternPointConnection*> footpath_rp_backward;
     std::vector<uint32_t> arrival_times;
     std::vector<uint32_t> departure_times;
     std::vector<uint32_t> start_times_frequencies;
@@ -67,12 +65,6 @@ struct dataRAPTOR {
     dataRAPTOR()  {}
     void load(const navitia::type::PT_Data &data);
 
-    const std::multimap<navitia::type::idx_t, const navitia::type::JourneyPatternPointConnection*> & footpath_rp(bool forward) const {
-        if(forward)
-            return footpath_rp_forward;
-        else
-            return footpath_rp_backward;
-    }
 
     inline int get_stop_time_order(const type::JourneyPattern & journey_pattern, int orderVj, int order) const{
         return first_stop_time[journey_pattern.idx] + (order * nb_trips[journey_pattern.idx]) + orderVj;
@@ -90,14 +82,6 @@ struct dataRAPTOR {
             return std::numeric_limits<uint32_t>::max();
         else
             return departure_times[get_stop_time_order(journey_pattern, orderVj, order)];
-    }
-
-    inline type::idx_t get_route_connection_idx(type::idx_t jpp_idx_origin, type::idx_t jpp_idx_destination, bool clockwise,const navitia::type::PT_Data &/*data*/)  const {
-        BOOST_FOREACH(auto conn, footpath_rp(clockwise).equal_range(jpp_idx_origin)) {
-            if(conn.second->destination->idx == jpp_idx_destination)
-                return conn.second->idx;
-        }
-        return type::invalid_idx;
     }
 
     inline type::idx_t get_stop_point_connection_idx(type::idx_t stop_point_idx_origin, type::idx_t stop_point_idx_destination, bool clockwise,const navitia::type::PT_Data &/*data*/)  const {

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -481,6 +481,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
                 const auto & jpp_to_explore = visitor.journey_pattern_points(
                                                 this->data.pt_data->journey_pattern_points,
                                                 journey_pattern,Q[journey_pattern->idx]);
+
                 BOOST_FOREACH(const type::JourneyPatternPoint* jpp, jpp_to_explore) {
                     if(!jpp->stop_point->accessible(accessibilite_params.properties)) {
                         continue;
@@ -545,9 +546,9 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
             }
             Q[journey_pattern->idx] = visitor.init_queue_item();
         }
-        this->apply_vj_extension(visitor, global_pruning);
         // Correspondances
         this->foot_path(visitor, accessibilite_params.properties);
+        this->apply_vj_extension(visitor, global_pruning);
     }
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -425,7 +425,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
                                                accessibilite_params.vehicle_properties,
                                                visitor.clockwise(), disruption_active, data);
 
-                        if(tmp_st_dt.first != nullptr) {
+                        if(tmp_st_dt.first != nullptr && (boarding == nullptr || tmp_st_dt.first != *it_st)) {
                             boarding = jpp;
                             it_st = visitor.first_stoptime(tmp_st_dt.first);
                             workingDt = tmp_st_dt.second;

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -418,9 +418,8 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
                     // journey pattern point before
                     const DateTime previous_dt = prec_labels[jpp_idx].dt;
                     const boarding_type b_type = get_type(this->count-1, jpp_idx);
-                    if(b_type != boarding_type::uninitialized && b_type != boarding_type::vj &&
+                    if((b_type == boarding_type::connection || b_type == boarding_type::departure) &&
                        (boarding == nullptr || visitor.better_or_equal(previous_dt, workingDt, *it_st))) {
-
                         const auto tmp_st_dt = best_stop_time(jpp, previous_dt,
                                                accessibilite_params.vehicle_properties,
                                                visitor.clockwise(), disruption_active, data);

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -374,7 +374,7 @@ struct raptor_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->prev_vj && vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
+       return vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
     }
 
     std::pair<std::vector<type::StopTime*>::const_iterator, std::vector<type::StopTime*>::const_iterator>
@@ -422,7 +422,7 @@ struct raptor_reverse_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->next_vj && vj->next_vj->journey_pattern->journey_pattern_point_list.front();
+       return vj->next_vj->journey_pattern->journey_pattern_point_list.front();
     }
 
     std::pair<std::vector<type::StopTime*>::const_reverse_iterator, std::vector<type::StopTime*>::const_reverse_iterator>

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -397,9 +397,10 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
                             const DateTime bound = (visitor.comp(best_labels[jpp_idx], b_dest.best_now) || !global_pruning) ?
                                                         best_labels[jpp_idx] : b_dest.best_now;
                             // We want to update the labels, if it's better than the one computed before
-                            // Or if it's an destination point if it's equal
+                            // Or if it's an destination point if it's equal and not unitialized before
                             const bool best_add_result = this->b_dest.add_best(visitor, jpp->idx, workingDt, this->count);
-                            if(visitor.comp(workingDt, bound) || best_add_result) {
+                            if(visitor.comp(workingDt, bound) ||
+                                    (best_add_result && get_type(this->count-1, jpp_idx) == boarding_type::uninitialized)) {
                                 working_labels[jpp_idx].dt = workingDt;
                                 working_labels[jpp_idx].boarding_jpp = boarding->idx;
                                 working_labels[jpp_idx].type = boarding_type::vj;

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -191,8 +191,10 @@ void RAPTOR::clear(const type::Data & data, bool clockwise, DateTime borne) {
         labels[0] = data.dataRaptor->labels_const_reverse;
     }
     for(auto& lbl_list : labels) {
-        for(auto& l : lbl_list) {
+        for(Label& l : lbl_list) {
             l.type = boarding_type::uninitialized;
+            l.dt = clockwise ? DateTimeUtils::inf : DateTimeUtils::min;
+            l.boarding_jpp = type::invalid_idx;
         }
     }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -39,6 +39,13 @@ void RAPTOR::make_queue() {
     marked_sp.reset();
 }
 
+/*
+ * Check if the given vj is valid for the given datetime,
+ * If it is for every stoptime of the vj,
+ * If the journey_pattern_point associated to it is improved by this stop time
+ * we mark it.
+ * If the given vj also has an extension we apply it.
+ */
 template<typename Visitor>
 void RAPTOR::apply_vj_extension(const Visitor& v, const bool global_pruning,
                                 const type::VehicleJourney* prev_vj, type::idx_t boarding_jpp_idx,
@@ -367,7 +374,7 @@ struct raptor_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
+       return vj->prev_vj && vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
     }
 
     std::pair<std::vector<type::StopTime*>::const_iterator, std::vector<type::StopTime*>::const_iterator>
@@ -415,7 +422,7 @@ struct raptor_reverse_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->next_vj->journey_pattern->journey_pattern_point_list.front();
+       return vj->next_vj && vj->next_vj->journey_pattern->journey_pattern_point_list.front();
     }
 
     std::pair<std::vector<type::StopTime*>::const_reverse_iterator, std::vector<type::StopTime*>::const_reverse_iterator>

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -489,20 +489,21 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
                     if(boarding != nullptr) {
                         ++it_st;
                         const type::StopTime* st = *it_st;
+                        const auto current_time = st->section_end_time(visitor.clockwise(),
+                                                DateTimeUtils::hour(workingDt));
+                        DateTimeUtils::update(workingDt, current_time, visitor.clockwise());
                         if(st->valid_end(visitor.clockwise())&&
                                 (l_zone == std::numeric_limits<uint16_t>::max() ||
                                  l_zone != st->local_traffic_zone)) {
-                            const auto current_time = st->section_end_time(visitor.clockwise(),
-                                                    DateTimeUtils::hour(workingDt));
-                            DateTimeUtils::update(workingDt, current_time, visitor.clockwise());
                             const DateTime bound = (visitor.comp(best_labels[jpp_idx], b_dest.best_now) || !global_pruning) ?
                                                         best_labels[jpp_idx] : b_dest.best_now;
-                            if(visitor.comp(workingDt, bound) || bound == workingDt) {
+                            const bool best_add_result = this->b_dest.add_best(visitor, jpp->idx, workingDt, this->count);
+                            if(visitor.comp(workingDt, bound) || best_add_result) {
                                 working_labels[jpp_idx].dt = workingDt;
                                 working_labels[jpp_idx].boarding_jpp = boarding->idx;
                                 working_labels[jpp_idx].type = boarding_type::vj;
                                 best_labels[jpp_idx] = working_labels[jpp_idx].dt;
-                                if(!this->b_dest.add_best(visitor, jpp->idx, working_labels[jpp_idx].dt, this->count)) {
+                                if(!best_add_result) {
                                     this->marked_sp.set(jpp->stop_point->idx);
                                     end = false;
                                 }

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -348,13 +348,8 @@ template<typename Visitor>
 void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & accessibilite_params, bool disruption_active,
         bool global_pruning, uint32_t max_transfers) {
     bool end = false;
-    count = 0; //< Itération de l'algo raptor (une itération par correspondance)
-    const type::JourneyPatternPoint* boarding = nullptr; //< Le JPP time auquel on a embarqué
-    DateTime workingDt = visitor.worst_datetime();
-    uint16_t l_zone = std::numeric_limits<uint16_t>::max();
+    count = 0; //< Count iteration of raptor algorithm
 
-    //this->foot_path(visitor, accessibilite_params.properties);
-    uint32_t nb_jpp_visites = 0;
     while(!end && count <= max_transfers) {
         ++count;
         end = true;
@@ -373,10 +368,10 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
             if(Q[journey_pattern->idx] != std::numeric_limits<int>::max()
                     && Q[journey_pattern->idx] != -1
                     && journey_patterns_valides.test(journey_pattern->idx)) {
-                nb_jpp_visites ++;
-                boarding = nullptr;
-                workingDt = visitor.worst_datetime();
+                const type::JourneyPatternPoint* boarding = nullptr; //< The boarding journey pattern point
+                DateTime workingDt = visitor.worst_datetime();
                 typename Visitor::stop_time_iterator it_st;
+                uint16_t l_zone = std::numeric_limits<uint16_t>::max();
                 const auto & jpp_to_explore = visitor.journey_pattern_points(
                                                 this->data.pt_data->journey_pattern_points,
                                                 journey_pattern,Q[journey_pattern->idx]);

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -441,7 +441,6 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
             }
             Q[journey_pattern->idx] = visitor.init_queue_item();
         }
-        // Correspondances
         this->foot_path(visitor, accessibilite_params.properties);
     }
 }

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -374,7 +374,7 @@ struct raptor_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
+       return vj->prev_vj && vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
     }
 
     std::pair<std::vector<type::StopTime*>::const_iterator, std::vector<type::StopTime*>::const_iterator>
@@ -422,7 +422,7 @@ struct raptor_reverse_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->next_vj->journey_pattern->journey_pattern_point_list.front();
+       return vj->next_vj && vj->next_vj->journey_pattern->journey_pattern_point_list.front();
     }
 
     std::pair<std::vector<type::StopTime*>::const_reverse_iterator, std::vector<type::StopTime*>::const_reverse_iterator>

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -29,6 +29,7 @@ www.navitia.io
 */
 
 #include "raptor.h"
+#include "raptor_visitors.h"
 #include <boost/foreach.hpp>
 
 namespace bt = boost::posix_time;
@@ -342,109 +343,6 @@ void RAPTOR::set_journey_patterns_valides(uint32_t date, const std::vector<std::
     }
     journey_patterns_valides &= ~forbidden_journey_patterns;
 }
-
-
-struct raptor_visitor {
-    inline bool better_or_equal(const DateTime &a, const DateTime &current_dt, const type::StopTime* st) const {
-        return a <= st->section_end_date(DateTimeUtils::date(current_dt), clockwise());
-    }
-
-    inline
-    std::pair<std::vector<type::JourneyPatternPoint*>::const_iterator, std::vector<type::JourneyPatternPoint*>::const_iterator>
-    journey_pattern_points(const std::vector<type::JourneyPatternPoint*> &, const type::JourneyPattern* journey_pattern, size_t order) const {
-        return std::make_pair(journey_pattern->journey_pattern_point_list.begin() + order,
-                              journey_pattern->journey_pattern_point_list.end());
-    }
-
-    typedef std::vector<type::StopTime*>::const_iterator stop_time_iterator;
-    inline stop_time_iterator first_stoptime(const type::StopTime* st) const {
-        const type::JourneyPatternPoint* jpp = st->journey_pattern_point;
-        const type::VehicleJourney* vj = st->vehicle_journey;
-        return vj->stop_time_list.begin() + jpp->order;
-    }
-
-    template<typename T1, typename T2> inline bool comp(const T1& a, const T2& b) const {
-        return a < b;
-    }
-
-    template<typename T1, typename T2> inline auto combine(const T1& a, const T2& b) const -> decltype(a+b) {
-        return a + b;
-    }
-
-    const type::VehicleJourney* get_extension_vj(const type::VehicleJourney* vj) const {
-       return vj->next_vj;
-    }
-
-    const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       if(vj->prev_vj) {
-            return vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
-       } else {
-           return nullptr;
-       }
-    }
-
-    std::pair<std::vector<type::StopTime*>::const_iterator, std::vector<type::StopTime*>::const_iterator>
-    stop_time_list(const type::VehicleJourney* vj) const {
-        return std::make_pair(vj->stop_time_list.begin(), vj->stop_time_list.end());
-    }
-
-    constexpr bool clockwise() const{return true;}
-    constexpr int init_queue_item() const{return std::numeric_limits<int>::max();}
-    constexpr DateTime worst_datetime() const{return DateTimeUtils::inf;}
-};
-
-
-struct raptor_reverse_visitor {
-    inline bool better_or_equal(const DateTime &a, const DateTime &current_dt, const type::StopTime* st) const {
-        return a >= st->section_end_date(DateTimeUtils::date(current_dt), clockwise());
-    }
-
-    inline
-    std::pair<std::vector<type::JourneyPatternPoint*>::const_reverse_iterator, std::vector<type::JourneyPatternPoint*>::const_reverse_iterator>
-    journey_pattern_points(const std::vector<type::JourneyPatternPoint*> &/*journey_pattern_points*/, const type::JourneyPattern* journey_pattern, size_t order) const {
-        size_t offset = journey_pattern->journey_pattern_point_list.size() - order - 1;
-        const auto begin = journey_pattern->journey_pattern_point_list.rbegin() + offset;
-        const auto end = journey_pattern->journey_pattern_point_list.rend();
-        return std::make_pair(begin, end);
-    }
-
-    typedef std::vector<type::StopTime*>::const_reverse_iterator stop_time_iterator;
-    inline stop_time_iterator first_stoptime(const type::StopTime* st) const {
-        const type::JourneyPatternPoint* jpp = st->journey_pattern_point;
-        const type::VehicleJourney* vj = st->vehicle_journey;
-        return vj->stop_time_list.rbegin() + vj->stop_time_list.size() - jpp->order - 1;
-    }
-
-    template<typename T1, typename T2> inline bool comp(const T1& a, const T2& b) const {
-        return a > b;
-    }
-
-    template<typename T1, typename T2> inline auto combine(const T1& a, const T2& b) const -> decltype(a-b) {
-        return a - b;
-    }
-
-    const type::VehicleJourney* get_extension_vj(const type::VehicleJourney* vj) const {
-       return vj->prev_vj;
-    }
-
-    const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-        if(vj->next_vj != nullptr) {
-            return vj->next_vj->journey_pattern->journey_pattern_point_list.front();
-        } else {
-            return nullptr;
-        }
-    }
-
-    std::pair<std::vector<type::StopTime*>::const_reverse_iterator, std::vector<type::StopTime*>::const_reverse_iterator>
-    stop_time_list(const type::VehicleJourney* vj) const {
-        return std::make_pair(vj->stop_time_list.rbegin(), vj->stop_time_list.rend());
-    }
-
-    constexpr bool clockwise() const{return false;}
-    constexpr int init_queue_item() const{return -1;}
-    constexpr DateTime worst_datetime() const{return DateTimeUtils::min;}
-};
-
 
 template<typename Visitor>
 void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & accessibilite_params, bool disruption_active,

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -374,7 +374,11 @@ struct raptor_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->prev_vj && vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
+       if(vj->prev_vj) {
+            return vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
+       } else {
+           return nullptr;
+       }
     }
 
     std::pair<std::vector<type::StopTime*>::const_iterator, std::vector<type::StopTime*>::const_iterator>
@@ -422,7 +426,11 @@ struct raptor_reverse_visitor {
     }
 
     const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
-       return vj->next_vj && vj->next_vj->journey_pattern->journey_pattern_point_list.front();
+        if(vj->next_vj != nullptr) {
+            return vj->next_vj->journey_pattern->journey_pattern_point_list.front();
+        } else {
+            return nullptr;
+        }
     }
 
     std::pair<std::vector<type::StopTime*>::const_reverse_iterator, std::vector<type::StopTime*>::const_reverse_iterator>

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -144,8 +144,6 @@ struct RAPTOR
     /// Il faut spécifier le visiteur selon le sens souhaité
     template<typename Visitor> void foot_path(const Visitor & v, const type::Properties &required_properties);
 
-    ///Correspondances garanties et prolongements de service
-    template<typename Visitor> void journey_pattern_path_connections(const Visitor &visitor/*, const type::Properties &required_properties*/);
 
     ///Trouve pour chaque journey_pattern, le premier journey_pattern point auquel on peut embarquer, se sert de marked_rp
     void make_queue();

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -67,8 +67,6 @@ struct RAPTOR
     boost::dynamic_bitset<> journey_patterns_valides;
     ///L'ordre du premier j: public AbstractRouterourney_pattern point de la journey_pattern
     queue_t Q;
-    /// Queue of vehicle journeys used for extension of services
-    std::queue<const type::VehicleJourney*> vj_queue;
 
     //Constructeur
     RAPTOR(const navitia::type::Data &data) :

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -30,6 +30,7 @@ www.navitia.io
 
 #pragma once
 #include <unordered_map>
+#include <queue>
 #include <limits>
 #include "type/type.h"
 #include "type/data.h"
@@ -60,19 +61,18 @@ struct RAPTOR
     best_dest b_dest;
     ///Nombre de correspondances effectuées jusqu'à présent
     unsigned int count;
-    ///Est-ce que le journey_pattern point est marqué ou non ?
-    boost::dynamic_bitset<> marked_rp;
     ///Est-ce que le stop point est arrivé ou non ?
     boost::dynamic_bitset<> marked_sp;
     ///La journey_pattern est elle valide ?
     boost::dynamic_bitset<> journey_patterns_valides;
     ///L'ordre du premier j: public AbstractRouterourney_pattern point de la journey_pattern
     queue_t Q;
+    /// Queue of vehicle journeys used for extension of services
+    std::queue<const type::VehicleJourney*> vj_queue;
 
     //Constructeur
     RAPTOR(const navitia::type::Data &data) :
         data(data), best_labels(data.pt_data->journey_pattern_points.size()), count(0),
-        marked_rp(data.pt_data->journey_pattern_points.size()),
         marked_sp(data.pt_data->stop_points.size()),
         journey_patterns_valides(data.pt_data->journey_patterns.size()),
         Q(data.pt_data->journey_patterns.size()) {
@@ -144,6 +144,8 @@ struct RAPTOR
     /// Il faut spécifier le visiteur selon le sens souhaité
     template<typename Visitor> void foot_path(const Visitor & v, const type::Properties &required_properties);
 
+    template<typename Visitor>
+    void apply_vj_extension(const Visitor& v, const bool global_pruning);
 
     ///Trouve pour chaque journey_pattern, le premier journey_pattern point auquel on peut embarquer, se sert de marked_rp
     void make_queue();

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -145,7 +145,10 @@ struct RAPTOR
     template<typename Visitor> void foot_path(const Visitor & v, const type::Properties &required_properties);
 
     template<typename Visitor>
-    void apply_vj_extension(const Visitor& v, const bool global_pruning);
+    void apply_vj_extension(const Visitor& v, const bool global_pruning,
+                            const type::VehicleJourney* prev_vj, type::idx_t boarding_jpp_idx,
+                            DateTime workingDt, const uint16_t l_zone,
+                            const bool disruption_active);
 
     ///Trouve pour chaque journey_pattern, le premier journey_pattern point auquel on peut embarquer, se sert de marked_rp
     void make_queue();

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -502,7 +502,7 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
             type::idx_t initial_rp;
             DateTime initial_dt;
             boost::tie(initial_rp, initial_dt) = get_final_jppidx_and_date(best_round,
-                    best_rp, clockwise, raptor.labels);
+                    best_rp, clockwise, disruption_active, accessibilite_params, raptor);
 
             int duration = ::abs(label - init_dt);
 

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -229,7 +229,8 @@ makePath(type::idx_t destination_idx, size_t countb, bool clockwise, bool disrup
 
                 // If we boarded via a connection, this label isn't set, while it's set with a stay_in
                 // If we boarded via a connection we want to decrease the count
-                if(raptor_.get_type(countb, current_jpp_idx) == boarding_type::uninitialized) {
+                // In some cases we can access here via a connection
+                if(raptor_.get_type(countb, current_jpp_idx) != boarding_type::connection_stay_in) {
                     --countb;
                 }
                 boarding_jpp = navitia::type::invalid_idx ;

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -62,38 +62,6 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
     return std::make_pair(nullptr, std::numeric_limits<uint32_t>::max());
 }
 
-
-std::pair<boost::posix_time::ptime, boost::posix_time::ptime>
-handle_st(const type::StopTime* st, DateTime& workingDate, bool clockwise, const type::Data &data){
-    boost::posix_time::ptime departure, arrival;
-    if(clockwise) {
-        if(st->is_frequency())
-            DateTimeUtils::update(workingDate, st->f_departure_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-        else
-            DateTimeUtils::update(workingDate, st->departure_time, !clockwise);
-        departure = navitia::to_posix_time(workingDate, data);
-        if(st->is_frequency())
-            DateTimeUtils::update(workingDate, st->f_arrival_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-        else
-            DateTimeUtils::update(workingDate, st->arrival_time, !clockwise);
-        arrival = navitia::to_posix_time(workingDate, data);
-    } else {
-        if(st->is_frequency())
-            DateTimeUtils::update(workingDate, st->f_arrival_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-        else
-            DateTimeUtils::update(workingDate, st->arrival_time, !clockwise);
-        arrival = navitia::to_posix_time(workingDate, data);
-        if(st->is_frequency())
-            DateTimeUtils::update(workingDate, st->f_departure_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-        else
-            DateTimeUtils::update(workingDate, st->departure_time, !clockwise);
-        departure = navitia::to_posix_time(workingDate, data);
-    }
-    return std::make_pair(departure, arrival);
-}
-
-
-
 Path
 makePath(type::idx_t destination_idx, size_t countb, bool clockwise, bool disruption_active,
          const type::AccessibiliteParams & accessibilite_params,

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -31,6 +31,7 @@ www.navitia.io
 #include "raptor_path.h"
 #include "raptor_solutions.h"
 #include "raptor.h"
+#include "raptor_path_defs.h"
 
 
 namespace navitia { namespace routing {
@@ -42,7 +43,7 @@ makePathes(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &d
            const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_,
            bool clockwise, bool disruption_active) {
     std::vector<Path> result;
-    auto solutions = get_solutions(departures, destinations, !clockwise, raptor_.labels, accessibilite_params, raptor_.data, disruption_active);
+    auto solutions = get_solutions(departures, destinations, !clockwise, accessibilite_params, disruption_active, raptor_);
     for(Solution solution : solutions) {
         result.push_back(makePath(solution.rpidx, solution.count, clockwise, disruption_active, accessibilite_params, raptor_));
     }
@@ -62,211 +63,119 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
 }
 
 
+std::pair<boost::posix_time::ptime, boost::posix_time::ptime>
+handle_st(const type::StopTime* st, DateTime& workingDate, bool clockwise, const type::Data &data){
+    boost::posix_time::ptime departure, arrival;
+    if(clockwise) {
+        if(st->is_frequency())
+            DateTimeUtils::update(workingDate, st->f_departure_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
+        else
+            DateTimeUtils::update(workingDate, st->departure_time, !clockwise);
+        departure = navitia::to_posix_time(workingDate, data);
+        if(st->is_frequency())
+            DateTimeUtils::update(workingDate, st->f_arrival_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
+        else
+            DateTimeUtils::update(workingDate, st->arrival_time, !clockwise);
+        arrival = navitia::to_posix_time(workingDate, data);
+    } else {
+        if(st->is_frequency())
+            DateTimeUtils::update(workingDate, st->f_arrival_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
+        else
+            DateTimeUtils::update(workingDate, st->arrival_time, !clockwise);
+        arrival = navitia::to_posix_time(workingDate, data);
+        if(st->is_frequency())
+            DateTimeUtils::update(workingDate, st->f_departure_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
+        else
+            DateTimeUtils::update(workingDate, st->departure_time, !clockwise);
+        departure = navitia::to_posix_time(workingDate, data);
+    }
+    return std::make_pair(departure, arrival);
+}
+
+
+
 Path
 makePath(type::idx_t destination_idx, size_t countb, bool clockwise, bool disruption_active,
          const type::AccessibiliteParams & accessibilite_params,
          const RAPTOR &raptor_) {
-    Path result;
-    type::idx_t current_jpp_idx = destination_idx;
-    DateTime l = raptor_.labels[countb][current_jpp_idx].dt,
-                   workingDate = l;
-
-    const type::StopTime* current_st;
-    type::idx_t boarding_jpp = navitia::type::invalid_idx;
-
-    bool stop = false;
-
-    PathItem item;
-    // On boucle tant
-    while(!stop) {
-        // Est-ce qu'on a une section marche à pied ?
-        if(raptor_.get_type(countb, current_jpp_idx) == boarding_type::connection ||
-           raptor_.get_type(countb, current_jpp_idx) == boarding_type::connection_stay_in ||
-           raptor_.get_type(countb, current_jpp_idx) == boarding_type::connection_guarantee) {
-            auto departure = raptor_.data.pt_data->journey_pattern_points[current_jpp_idx]->stop_point;
-            const auto boarding_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
-            auto destination_jpp = raptor_.data.pt_data->journey_pattern_points[boarding_jpp_idx];
-            auto destination = destination_jpp->stop_point;
-            auto connections = departure->stop_point_connection_list;
-            l = raptor_.labels[countb][current_jpp_idx].dt;
-            auto find_predicate = [&](type::StopPointConnection* connection)->bool {
-                return departure == connection->departure && destination == connection->destination;
-            };
-
-            auto it = std::find_if(connections.begin(), connections.end(), find_predicate);
-            if(it == connections.end()) {
-                auto r2 = raptor_.labels[countb][raptor_.get_boarding_jpp(countb, current_jpp_idx)];
-                if(clockwise) {
-                    const auto dep_ptime = to_posix_time(r2.dt, raptor_.data);
-                    const auto arr_ptime = to_posix_time(l, raptor_.data);
-                    item = PathItem(dep_ptime, arr_ptime);
-                } else {
-                    const auto dep_ptime = to_posix_time(l, raptor_.data);
-                    const auto arr_ptime = to_posix_time(r2.dt, raptor_.data);
-                    item = PathItem(dep_ptime, arr_ptime);
-                }
-            } else {
-                const auto stop_point_connection = *it;
-                const auto display_duration = stop_point_connection->display_duration;
-                if(clockwise) {
-                    const auto dep_ptime = to_posix_time(l - display_duration, raptor_.data);
-                    const auto arr_ptime = to_posix_time(l, raptor_.data);
-                    item = PathItem(dep_ptime, arr_ptime);
-                } else {
-                    const auto dep_ptime = to_posix_time(l, raptor_.data);
-                    const auto arr_ptime = to_posix_time(l + display_duration, raptor_.data);
-                    item = PathItem(dep_ptime, arr_ptime);
-                }
-                item.connection = stop_point_connection;
-            }
+    struct Visitor: public BasePathVisitor {
+        Path result;
+        void connection(type::StopPoint* departure, type::StopPoint* destination,
+                    boost::posix_time::ptime dep_time, boost::posix_time::ptime arr_time,
+                    type::StopPointConnection* stop_point_connection) {
+            PathItem item(dep_time, arr_time);
             item.stop_points.push_back(departure);
             item.stop_points.push_back(destination);
-            if(raptor_.get_type(countb, current_jpp_idx) == boarding_type::connection)
-                item.type = walking;
-            else if(raptor_.get_type(countb, current_jpp_idx) == boarding_type::connection_stay_in)
-                item.type = stay_in;
-            else if(raptor_.get_type(countb, current_jpp_idx) == boarding_type::connection_guarantee)
-                item.type = guarantee;
-
-            //BOOST_ASSERT(item.arrival >= item.departure);
-            //BOOST_ASSERT(result.items.empty() || !clockwise && (result.items.back().arrival >= item.departure));
-            //BOOST_ASSERT(result.items.empty() || clockwise &&  (result.items.back().arrival <= item.departure));
+            item.connection = stop_point_connection;
+            item.type = walking;
             result.items.push_back(item);
-            boarding_jpp = type::invalid_idx;
-            current_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
-        } else {
-            // Est-ce que qu'on a à faire à un nouveau trajet ?
-            if(boarding_jpp == type::invalid_idx) {
-                l = raptor_.labels[countb][current_jpp_idx].dt;
-                //BOOST_ASSERT(result.items.empty() || !clockwise && (l <= result.items.back().arrival));
-                //BOOST_ASSERT(result.items.empty() || clockwise &&  (l >= result.items.back().arrival));
-                boarding_jpp = raptor_.get_boarding_jpp(countb, current_jpp_idx);
+        }
 
-                std::tie(current_st, workingDate) = get_current_stidx_gap(countb, current_jpp_idx, raptor_.labels, accessibilite_params, clockwise,  raptor_.data, disruption_active) ;
-                item = PathItem();
-                item.type = public_transport;
-                while(boarding_jpp != current_jpp_idx) {
-                    //On stocke le sp, et les temps
-                    item.stop_points.push_back(raptor_.data.pt_data->journey_pattern_points[current_jpp_idx]->stop_point);
-                    item.stop_times.push_back(current_st);
-                    if(clockwise) {
-                        if(current_st->is_frequency())
-                            DateTimeUtils::update(workingDate, current_st->f_departure_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-                        else
-                            DateTimeUtils::update(workingDate, current_st->departure_time, !clockwise);
-                        item.departures.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                        if(current_st->is_frequency())
-                            DateTimeUtils::update(workingDate, current_st->f_arrival_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-                        else
-                            DateTimeUtils::update(workingDate, current_st->arrival_time, !clockwise);
-                        item.arrivals.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                    } else {
-                        if(current_st->is_frequency())
-                            DateTimeUtils::update(workingDate, current_st->f_arrival_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-                        else
-                            DateTimeUtils::update(workingDate, current_st->arrival_time, !clockwise);
-                        item.arrivals.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                        if(current_st->is_frequency())
-                            DateTimeUtils::update(workingDate, current_st->f_departure_time(DateTimeUtils::hour(workingDate), !clockwise), !clockwise);
-                        else
-                            DateTimeUtils::update(workingDate, current_st->departure_time, !clockwise);
-                        item.departures.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                    }
+        void init_vj() {
+            PathItem item;
+            item.type = public_transport;
+            result.items.push_back(item);
+        }
 
-                    size_t order = current_st->journey_pattern_point->order;
-                    // On parcourt les données dans le sens contraire du calcul
-                    if(clockwise){
-                        BOOST_ASSERT(order>0);
-                        order--;
-                    }
-                    else{
-                        order++;
-                        BOOST_ASSERT(order < current_st->vehicle_journey->stop_time_list.size());
-                    }
+        void loop_vj(const type::StopTime* st, boost::posix_time::ptime departure, boost::posix_time::ptime arrival) {
+            auto& item = result.items.back();
+            item.stop_points.push_back(st->journey_pattern_point->stop_point);
+            item.stop_times.push_back(st);
+            item.arrivals.push_back(arrival);
+            item.departures.push_back(departure);
+            BOOST_ASSERT(item.arrival >= item.departure);
+        }
 
-                    current_st = current_st->vehicle_journey->stop_time_list[order];
-                    current_jpp_idx = current_st->journey_pattern_point->idx;
-                }
-                // Je stocke le dernier stop point, et ses temps d'arrivée et de départ
-                item.stop_points.push_back(raptor_.data.pt_data->journey_pattern_points[current_jpp_idx]->stop_point);
-                item.stop_times.push_back(current_st);
-
-                if(clockwise) {
-                    if(current_st->is_frequency())
-                        DateTimeUtils::update(workingDate, current_st->f_departure_time(DateTimeUtils::hour(workingDate)), !clockwise);
-                    else
-                        DateTimeUtils::update(workingDate, current_st->departure_time, !clockwise);
-                    item.departures.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                    if(current_st->is_frequency())
-                        DateTimeUtils::update(workingDate, current_st->f_arrival_time(DateTimeUtils::hour(workingDate)), !clockwise);
-                    else
-                        DateTimeUtils::update(workingDate, current_st->arrival_time, !clockwise);
-
-                    item.arrivals.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                    item.arrival = item.arrivals.front();
-                    item.departure = item.departures.back();
-                } else {
-                    if(current_st->is_frequency())
-                        DateTimeUtils::update(workingDate, current_st->f_arrival_time(DateTimeUtils::hour(workingDate)), !clockwise);
-                    else
-                        DateTimeUtils::update(workingDate, current_st->arrival_time, !clockwise);
-                    item.arrivals.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                    if(current_st->is_frequency())
-                        DateTimeUtils::update(workingDate, current_st->f_departure_time(DateTimeUtils::hour(workingDate)), !clockwise);
-                    else
-                        DateTimeUtils::update(workingDate, current_st->departure_time, !clockwise);
-
-                    item.departures.push_back(navitia::to_posix_time(workingDate, raptor_.data));
-                    item.arrival = item.arrivals.back();
-                    item.departure = item.departures.front();
-                }
-
-                //On stocke l'item créé
-                BOOST_ASSERT(item.arrival >= item.departure);
-                BOOST_ASSERT(result.items.empty() || !clockwise || (result.items.back().arrival >= item.departure));
-                BOOST_ASSERT(result.items.empty() || clockwise ||  (result.items.back().arrival <= item.departure));
-                result.items.push_back(item);
-
-                // If we boarded via a connection, this label isn't set, while it's set with a stay_in
-                // If we boarded via a connection we want to decrease the count
-                // In some cases we can access here via a connection
-                if(raptor_.get_type(countb, current_jpp_idx) != boarding_type::connection_stay_in) {
-                    --countb;
-                }
-                boarding_jpp = navitia::type::invalid_idx ;
-
+        void finish_vj(bool clockwise) {
+            auto& item = result.items.back();
+            if(clockwise) {
+                item.arrival = item.arrivals.front();
+                item.departure = item.departures.back();
+            } else {
+                item.arrival = item.arrivals.back();
+                item.departure = item.departures.front();
             }
         }
-        if(raptor_.get_type(countb, current_jpp_idx) == boarding_type::departure)
-            stop = true;
 
-    }
-
+        void change_vj(const type::StopTime* prev_st, const type::StopTime* current_st,
+                       boost::posix_time::ptime prev_dt, boost::posix_time::ptime current_dt,
+                       bool clockwise) {
+            PathItem item(prev_dt, current_dt);
+            item.type = stay_in;
+            item.stop_points.push_back(prev_st->journey_pattern_point->stop_point);
+            item.stop_points.push_back(current_st->journey_pattern_point->stop_point);
+            finish_vj(clockwise);
+            result.items.push_back(item);
+            init_vj();
+        }
+    };
+    Visitor v;
+    read_path(v, destination_idx, countb, clockwise, disruption_active, accessibilite_params, raptor_);
     if(clockwise){
-        std::reverse(result.items.begin(), result.items.end());
-        for(auto & item : result.items) {
+        std::reverse(v.result.items.begin(), v.result.items.end());
+        for(auto & item : v.result.items) {
             std::reverse(item.stop_points.begin(), item.stop_points.end());
             std::reverse(item.arrivals.begin(), item.arrivals.end());
             std::reverse(item.departures.begin(), item.departures.end());
         }
     }
 
-    if(result.items.size() > 0)
-        result.duration = navitia::time_duration::from_boost_duration(result.items.back().arrival - result.items.front().departure);
+    if(v.result.items.size() > 0)
+        v.result.duration = navitia::time_duration::from_boost_duration(v.result.items.back().arrival - v.result.items.front().departure);
     else
-        result.duration = navitia::seconds(0);
+        v.result.duration = navitia::seconds(0);
 
-    result.nb_changes = 0;
-    if(result.items.size() > 2) {
-        for(unsigned int i = 1; i <= (result.items.size()-2); ++i) {
-            if(result.items[i].type == walking)
-                ++ result.nb_changes;
+    v.result.nb_changes = 0;
+    if(v.result.items.size() > 2) {
+        for(unsigned int i = 1; i <= (v.result.items.size()-2); ++i) {
+            if(v.result.items[i].type == walking)
+                ++ v.result.nb_changes;
         }
     }
-    patch_datetimes(result);
-
-    return result;
+    patch_datetimes(v.result);
+    return v.result;
 }
+
 
 void patch_datetimes(Path &path){
 

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -56,10 +56,6 @@ namespace navitia { namespace routing {
     /// Ajuste les temps d’attente
     void patch_datetimes(Path &path);
 
-    /// /!\ This function has a side effect, it modifies workingDate
-    std::pair<boost::posix_time::ptime, boost::posix_time::ptime>
-    handle_st(const type::StopTime* st, DateTime& workingDate, bool clockwise, const type::Data &data);
-
     std::pair<const type::StopTime*, uint32_t>
     get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std::vector<label_vector_t> &labels,
                           const type::AccessibiliteParams & accessibilite_params, bool clockwise,  const navitia::type::Data &data, bool disruption_active);

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -56,6 +56,7 @@ namespace navitia { namespace routing {
     /// Ajuste les temps d’attente
     void patch_datetimes(Path &path);
 
+    /// /!\ This function has a side effect, it modifies workingDate
     std::pair<boost::posix_time::ptime, boost::posix_time::ptime>
     handle_st(const type::StopTime* st, DateTime& workingDate, bool clockwise, const type::Data &data);
 

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -31,6 +31,7 @@ www.navitia.io
 #pragma once
 #include "type/type.h"
 #include "routing/routing.h"
+#include "routing/raptor_utils.h"
 #include <vector>
 namespace navitia { namespace routing {
     class RAPTOR;
@@ -54,4 +55,45 @@ namespace navitia { namespace routing {
 
     /// Ajuste les temps d’attente
     void patch_datetimes(Path &path);
+
+    std::pair<boost::posix_time::ptime, boost::posix_time::ptime>
+    handle_st(const type::StopTime* st, DateTime& workingDate, bool clockwise, const type::Data &data);
+
+    std::pair<const type::StopTime*, uint32_t>
+    get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std::vector<label_vector_t> &labels,
+                          const type::AccessibiliteParams & accessibilite_params, bool clockwise,  const navitia::type::Data &data, bool disruption_active);
+
+    template<typename Visitor>
+    void read_path(Visitor& v, type::idx_t destination_idx, size_t countb, bool clockwise, bool disruption_active,
+              const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_);
+
+    struct BasePathVisitor {
+        void connection(type::StopPoint* /*departure*/, type::StopPoint* /*destination*/,
+                    boost::posix_time::ptime /*dep_time*/, boost::posix_time::ptime /*arr_time*/,
+                    type::StopPointConnection* /*stop_point_connection*/) {
+            return ;
+        }
+
+        void init_vj() {
+            return ;
+        }
+
+        void loop_vj(const type::StopTime* /*st*/, boost::posix_time::ptime /*departure*/, boost::posix_time::ptime /*arrival*/) {
+            return ;
+        }
+
+        void change_vj(const type::StopTime* /*prev_st*/, const type::StopTime* /*current_st*/,
+                       boost::posix_time::ptime /*prev_dt*/, boost::posix_time::ptime /*current_dt*/,
+                       bool /*clockwise*/) {
+            return ;
+        }
+
+        void finish_vj(bool /*clockwise*/) {
+            return ;
+        }
+
+        void final_step(type::idx_t /*current_jpp*/, size_t /*count*/, const std::vector<std::vector<Label>> &/*labels*/) {
+            return ;
+        }
+    };
 }}

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -5,6 +5,97 @@
 
 
 namespace navitia { namespace routing {
+
+template<typename Visitor>
+void handle_connection(const size_t countb, const navitia::type::idx_t current_jpp_idx, Visitor& v,
+                       bool clockwise, const RAPTOR &raptor_) {
+    auto departure = raptor_.data.pt_data->journey_pattern_points[current_jpp_idx]->stop_point;
+    const auto boarding_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
+    auto destination_jpp = raptor_.data.pt_data->journey_pattern_points[boarding_jpp_idx];
+    auto destination = destination_jpp->stop_point;
+    auto connections = departure->stop_point_connection_list;
+    auto l = raptor_.labels[countb][current_jpp_idx].dt;
+    auto find_predicate = [&](type::StopPointConnection* connection)->bool {
+        return departure == connection->departure && destination == connection->destination;
+    };
+
+    auto it = std::find_if(connections.begin(), connections.end(), find_predicate);
+    type::StopPointConnection* stop_point_connection = nullptr;
+    boost::posix_time::ptime dep_ptime, arr_ptime;
+    if(it == connections.end()) {
+        auto r2 = raptor_.labels[countb][raptor_.get_boarding_jpp(countb, current_jpp_idx)];
+        if(clockwise) {
+            dep_ptime = to_posix_time(r2.dt, raptor_.data);
+            arr_ptime = to_posix_time(l, raptor_.data);
+        } else {
+            dep_ptime = to_posix_time(l, raptor_.data);
+            arr_ptime = to_posix_time(r2.dt, raptor_.data);
+        }
+    } else {
+        stop_point_connection = *it;
+        const auto display_duration = stop_point_connection->display_duration;
+        if(clockwise) {
+            dep_ptime = to_posix_time(l - display_duration, raptor_.data);
+            arr_ptime = to_posix_time(l, raptor_.data);
+        } else {
+            dep_ptime = to_posix_time(l, raptor_.data);
+            arr_ptime = to_posix_time(l + display_duration, raptor_.data);
+        }
+    }
+
+    v.connection(departure, destination, dep_ptime, arr_ptime, stop_point_connection);
+}
+
+
+template<typename Visitor>
+void handle_vj(const size_t countb, const navitia::type::idx_t current_jpp_idx, Visitor& v,
+               bool disruption_active, const type::AccessibiliteParams & accessibilite_params,
+               const RAPTOR &raptor_) {
+    v.init_vj();
+    auto boarding_jpp = raptor_.get_boarding_jpp(countb, current_jpp_idx);
+    const type::StopTime* current_st;
+    DateTime workingDate;
+    std::tie(current_st, workingDate) = get_current_stidx_gap(countb, current_jpp_idx, raptor_.labels,
+                                                              accessibilite_params, clockwise,
+                                                              raptor_.data, disruption_active);
+    while(boarding_jpp != current_jpp_idx) {
+        auto departure_arrival = handle_st(current_st, workingDate, clockwise, raptor_.data);
+        v.loop_vj(current_st, departure_arrival.first, departure_arrival.second);
+        size_t order = current_st->journey_pattern_point->order;
+        if((clockwise && order > 0) || (!clockwise && order < (current_st->vehicle_journey->stop_time_list.size()-1))) {
+            // On parcourt les données dans le sens contraire du calcul
+            if(clockwise){
+                order--;
+            }
+            else{
+                order++;
+            }
+            current_st = current_st->vehicle_journey->stop_time_list[order];
+        }
+        else {
+            auto prev_st = current_st;
+            // If it was a connection_stay_in we want to take the the previous vj
+            if(clockwise) {
+                current_st = current_st->vehicle_journey->prev_vj->stop_time_list.back();
+            } else {
+                current_st = current_st->vehicle_journey->next_vj->stop_time_list.front();
+            }
+            auto prev_time = raptor_.labels[countb][prev_st->journey_pattern_point->idx].dt,
+                 current_time = raptor_.labels[countb][current_st->journey_pattern_point->idx].dt;
+            v.change_vj(prev_st, current_st, to_posix_time(prev_time, raptor_.data),
+                        to_posix_time(current_time, raptor_.data), clockwise);
+        }
+        current_jpp_idx = current_st->journey_pattern_point->idx;
+    }
+    auto departure_arrival = handle_st(current_st, workingDate, clockwise, raptor_.data);
+    v.loop_vj(current_st, departure_arrival.first, departure_arrival.second);
+    --countb;
+    boarding_jpp = navitia::type::invalid_idx ;
+    v.finish_vj(clockwise);
+}
+}
+
+
 template<typename Visitor>
 void read_path(Visitor& v, type::idx_t destination_idx, size_t countb, bool clockwise, bool disruption_active,
           const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_) {
@@ -12,97 +103,16 @@ void read_path(Visitor& v, type::idx_t destination_idx, size_t countb, bool cloc
     auto label_type = raptor_.get_type(countb, current_jpp_idx);
     while(label_type != boarding_type::departure) {
         if(label_type == boarding_type::connection) {
-            auto departure = raptor_.data.pt_data->journey_pattern_points[current_jpp_idx]->stop_point;
-            const auto boarding_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
-            auto destination_jpp = raptor_.data.pt_data->journey_pattern_points[boarding_jpp_idx];
-            auto destination = destination_jpp->stop_point;
-            auto connections = departure->stop_point_connection_list;
-            auto l = raptor_.labels[countb][current_jpp_idx].dt;
-            auto find_predicate = [&](type::StopPointConnection* connection)->bool {
-                return departure == connection->departure && destination == connection->destination;
-            };
-
-            auto it = std::find_if(connections.begin(), connections.end(), find_predicate);
-            type::StopPointConnection* stop_point_connection = nullptr;
-            boost::posix_time::ptime dep_ptime, arr_ptime;
-            if(it == connections.end()) {
-                auto r2 = raptor_.labels[countb][raptor_.get_boarding_jpp(countb, current_jpp_idx)];
-                if(clockwise) {
-                    dep_ptime = to_posix_time(r2.dt, raptor_.data);
-                    arr_ptime = to_posix_time(l, raptor_.data);
-                } else {
-                    dep_ptime = to_posix_time(l, raptor_.data);
-                    arr_ptime = to_posix_time(r2.dt, raptor_.data);
-                }
-            } else {
-                stop_point_connection = *it;
-                const auto display_duration = stop_point_connection->display_duration;
-                if(clockwise) {
-                    dep_ptime = to_posix_time(l - display_duration, raptor_.data);
-                    arr_ptime = to_posix_time(l, raptor_.data);
-                } else {
-                    dep_ptime = to_posix_time(l, raptor_.data);
-                    arr_ptime = to_posix_time(l + display_duration, raptor_.data);
-                }
-            }
-
-            v.connection(departure, destination, dep_ptime, arr_ptime, stop_point_connection);
+            handle_connection(countb, current_jpp_idx, v, clockwise, raptor_);
             current_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
         } else if(label_type == boarding_type::vj ||
                   label_type == boarding_type::connection_stay_in) {
-            v.init_vj();
-            auto boarding_jpp = raptor_.get_boarding_jpp(countb, current_jpp_idx);
-            const type::StopTime* current_st;
-            DateTime workingDate;
-            std::tie(current_st, workingDate) = get_current_stidx_gap(countb, current_jpp_idx, raptor_.labels,
-                                                                      accessibilite_params, clockwise,
-                                                                      raptor_.data, disruption_active);
-            while(boarding_jpp != current_jpp_idx) {
-                auto departure_arrival = handle_st(current_st, workingDate, clockwise, raptor_.data);
-                v.loop_vj(current_st, departure_arrival.first, departure_arrival.second);
-                size_t order = current_st->journey_pattern_point->order;
-                if((clockwise && order > 0) || (!clockwise && order < (current_st->vehicle_journey->stop_time_list.size()-1))) {
-                    // On parcourt les données dans le sens contraire du calcul
-                    if(clockwise){
-                        order--;
-                    }
-                    else{
-                        order++;
-                    }
-                    current_st = current_st->vehicle_journey->stop_time_list[order];
-                }
-                else {
-                    auto prev_st = current_st;
-                    // If it was a connection_stay_in we want to take the the previous vj
-                    if(clockwise) {
-                        current_st = current_st->vehicle_journey->prev_vj->stop_time_list.back();
-                    } else {
-                        current_st = current_st->vehicle_journey->next_vj->stop_time_list.front();
-                    }
-//                    if(current_st->vehicle_journey->journey_pattern != raptor_.data.pt_data->journey_pattern_points[boarding_jpp]->journey_pattern) {
-//                        auto& jpp_list = current_st->vehicle_journey->journey_pattern->journey_pattern_point_list;
-//                        if(clockwise) {
-//                            boarding_jpp = jpp_list.front()->idx;
-//                        } else {
-//                            boarding_jpp = jpp_list.back()->idx;
-//                        }
-//                    }
-                    auto prev_time = raptor_.labels[countb][prev_st->journey_pattern_point->idx].dt,
-                         current_time = raptor_.labels[countb][current_st->journey_pattern_point->idx].dt;
-                    v.change_vj(prev_st, current_st, to_posix_time(prev_time, raptor_.data),
-                                to_posix_time(current_time, raptor_.data), clockwise);
-                }
-                current_jpp_idx = current_st->journey_pattern_point->idx;
-            }
-            auto departure_arrival = handle_st(current_st, workingDate, clockwise, raptor_.data);
-            v.loop_vj(current_st, departure_arrival.first, departure_arrival.second);
-            --countb;
-            boarding_jpp = navitia::type::invalid_idx ;
-            v.finish_vj(clockwise);
-        }
+
         label_type = raptor_.get_type(countb, current_jpp_idx);
     }
     v.final_step(current_jpp_idx, countb, raptor_.labels);
 }
+
+
 
 } }

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -1,0 +1,108 @@
+#pragma once
+#include "raptor_path.h"
+#include "type/type.h"
+#include "raptor.h"
+
+
+namespace navitia { namespace routing {
+template<typename Visitor>
+void read_path(Visitor& v, type::idx_t destination_idx, size_t countb, bool clockwise, bool disruption_active,
+          const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_) {
+    type::idx_t current_jpp_idx = destination_idx;
+    auto label_type = raptor_.get_type(countb, current_jpp_idx);
+    while(label_type != boarding_type::departure) {
+        if(label_type == boarding_type::connection) {
+            auto departure = raptor_.data.pt_data->journey_pattern_points[current_jpp_idx]->stop_point;
+            const auto boarding_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
+            auto destination_jpp = raptor_.data.pt_data->journey_pattern_points[boarding_jpp_idx];
+            auto destination = destination_jpp->stop_point;
+            auto connections = departure->stop_point_connection_list;
+            auto l = raptor_.labels[countb][current_jpp_idx].dt;
+            auto find_predicate = [&](type::StopPointConnection* connection)->bool {
+                return departure == connection->departure && destination == connection->destination;
+            };
+
+            auto it = std::find_if(connections.begin(), connections.end(), find_predicate);
+            type::StopPointConnection* stop_point_connection = nullptr;
+            boost::posix_time::ptime dep_ptime, arr_ptime;
+            if(it == connections.end()) {
+                auto r2 = raptor_.labels[countb][raptor_.get_boarding_jpp(countb, current_jpp_idx)];
+                if(clockwise) {
+                    dep_ptime = to_posix_time(r2.dt, raptor_.data);
+                    arr_ptime = to_posix_time(l, raptor_.data);
+                } else {
+                    dep_ptime = to_posix_time(l, raptor_.data);
+                    arr_ptime = to_posix_time(r2.dt, raptor_.data);
+                }
+            } else {
+                stop_point_connection = *it;
+                const auto display_duration = stop_point_connection->display_duration;
+                if(clockwise) {
+                    dep_ptime = to_posix_time(l - display_duration, raptor_.data);
+                    arr_ptime = to_posix_time(l, raptor_.data);
+                } else {
+                    dep_ptime = to_posix_time(l, raptor_.data);
+                    arr_ptime = to_posix_time(l + display_duration, raptor_.data);
+                }
+            }
+
+            v.connection(departure, destination, dep_ptime, arr_ptime, stop_point_connection);
+            current_jpp_idx = raptor_.get_boarding_jpp(countb, current_jpp_idx);
+        } else if(label_type == boarding_type::vj ||
+                  label_type == boarding_type::connection_stay_in) {
+            v.init_vj();
+            auto boarding_jpp = raptor_.get_boarding_jpp(countb, current_jpp_idx);
+            const type::StopTime* current_st;
+            DateTime workingDate;
+            std::tie(current_st, workingDate) = get_current_stidx_gap(countb, current_jpp_idx, raptor_.labels,
+                                                                      accessibilite_params, clockwise,
+                                                                      raptor_.data, disruption_active);
+            while(boarding_jpp != current_jpp_idx) {
+                auto departure_arrival = handle_st(current_st, workingDate, clockwise, raptor_.data);
+                v.loop_vj(current_st, departure_arrival.first, departure_arrival.second);
+                size_t order = current_st->journey_pattern_point->order;
+                if((clockwise && order > 0) || (!clockwise && order < (current_st->vehicle_journey->stop_time_list.size()-1))) {
+                    // On parcourt les données dans le sens contraire du calcul
+                    if(clockwise){
+                        order--;
+                    }
+                    else{
+                        order++;
+                    }
+                    current_st = current_st->vehicle_journey->stop_time_list[order];
+                }
+                else {
+                    auto prev_st = current_st;
+                    // If it was a connection_stay_in we want to take the the previous vj
+                    if(clockwise) {
+                        current_st = current_st->vehicle_journey->prev_vj->stop_time_list.back();
+                    } else {
+                        current_st = current_st->vehicle_journey->next_vj->stop_time_list.front();
+                    }
+//                    if(current_st->vehicle_journey->journey_pattern != raptor_.data.pt_data->journey_pattern_points[boarding_jpp]->journey_pattern) {
+//                        auto& jpp_list = current_st->vehicle_journey->journey_pattern->journey_pattern_point_list;
+//                        if(clockwise) {
+//                            boarding_jpp = jpp_list.front()->idx;
+//                        } else {
+//                            boarding_jpp = jpp_list.back()->idx;
+//                        }
+//                    }
+                    auto prev_time = raptor_.labels[countb][prev_st->journey_pattern_point->idx].dt,
+                         current_time = raptor_.labels[countb][current_st->journey_pattern_point->idx].dt;
+                    v.change_vj(prev_st, current_st, to_posix_time(prev_time, raptor_.data),
+                                to_posix_time(current_time, raptor_.data), clockwise);
+                }
+                current_jpp_idx = current_st->journey_pattern_point->idx;
+            }
+            auto departure_arrival = handle_st(current_st, workingDate, clockwise, raptor_.data);
+            v.loop_vj(current_st, departure_arrival.first, departure_arrival.second);
+            --countb;
+            boarding_jpp = navitia::type::invalid_idx ;
+            v.finish_vj(clockwise);
+        }
+        label_type = raptor_.get_type(countb, current_jpp_idx);
+    }
+    v.final_step(current_jpp_idx, countb, raptor_.labels);
+}
+
+} }

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -262,10 +262,13 @@ get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, const 
 
     DateTime last_time = labels[cnt][current_jpp].dt;
     while(labels[cnt][current_jpp].type != boarding_type::departure) {
-        if(labels[cnt][current_jpp].type == boarding_type::vj) {
+        auto b_type = labels[cnt][current_jpp].type;
+        if(b_type == boarding_type::vj) {
             DateTimeUtils::update(last_time, DateTimeUtils::hour(labels[cnt][current_jpp].dt), clockwise);
             current_jpp = labels[cnt][current_jpp].boarding_jpp;
-            --cnt;
+            if(labels[cnt][current_jpp].type == boarding_type::uninitialized) {
+                --cnt;
+            }
         } else {
             current_jpp = labels[cnt][current_jpp].boarding_jpp;
             last_time = labels[cnt][current_jpp].dt;
@@ -296,12 +299,16 @@ navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std:
         if(boarding_type_value == boarding_type::vj) {
             const type::idx_t current_jpp_idx = labels[cnt][current_jpp->idx].boarding_jpp;
             current_jpp = data.pt_data->journey_pattern_points[current_jpp_idx];
-            --cnt;
+            boarding_type_value = labels[cnt][current_jpp->idx].type;
+            if(boarding_type_value == boarding_type::uninitialized) {
+                --cnt;
+            }
             boarding_type_value = labels[cnt][current_jpp->idx].type;
         } else {
             const type::idx_t boarding_jpp_idx = labels[cnt][current_jpp->idx].boarding_jpp;
             const type::JourneyPatternPoint* boarding = data.pt_data->journey_pattern_points[boarding_jpp_idx];
-            if(boarding_type_value == boarding_type::connection) {
+            if(boarding_type_value == boarding_type::connection ||
+               boarding_type_value == boarding_type::connection_stay_in) {
                 type::idx_t connection_idx = data.dataRaptor->get_stop_point_connection_idx(boarding->stop_point->idx,
                                                                                            current_jpp->stop_point->idx,
                                                                                            clockwise, *data.pt_data);
@@ -310,7 +317,6 @@ navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std:
             }
             current_jpp = boarding;
             boarding_type_value = labels[cnt][current_jpp->idx].type;
-
         }
     }
     //Marche au départ

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -266,7 +266,7 @@ get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, const 
         if(b_type == boarding_type::vj) {
             DateTimeUtils::update(last_time, DateTimeUtils::hour(labels[cnt][current_jpp].dt), clockwise);
             current_jpp = labels[cnt][current_jpp].boarding_jpp;
-            if(labels[cnt][current_jpp].type == boarding_type::uninitialized) {
+            if(labels[cnt][current_jpp].type != boarding_type::connection_stay_in) {
                 --cnt;
             }
         } else {
@@ -295,12 +295,12 @@ navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std:
     }
     //Marche pendant les correspondances
     auto boarding_type_value = labels[count][jpp_idx].type;
-    while(boarding_type_value != boarding_type::departure /*&& boarding_type_value != boarding_type::uninitialized*/) {
+    while(boarding_type_value != boarding_type::departure) {
         if(boarding_type_value == boarding_type::vj) {
             const type::idx_t current_jpp_idx = labels[cnt][current_jpp->idx].boarding_jpp;
             current_jpp = data.pt_data->journey_pattern_points[current_jpp_idx];
             boarding_type_value = labels[cnt][current_jpp->idx].type;
-            if(boarding_type_value == boarding_type::uninitialized) {
+            if(boarding_type_value != boarding_type::connection_stay_in) {
                 --cnt;
             }
             boarding_type_value = labels[cnt][current_jpp->idx].type;

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -29,6 +29,10 @@ www.navitia.io
 */
 
 #include "raptor_solutions.h"
+#include "raptor_path.h"
+#include "raptor.h"
+#include "raptor_path_defs.h"
+
 
 namespace bt = boost::posix_time;
 namespace navitia { namespace routing {
@@ -36,17 +40,16 @@ namespace navitia { namespace routing {
 Solutions
 get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
              const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
-             bool clockwise, const std::vector<label_vector_t> &labels,
-             const type::AccessibiliteParams & accessibilite_params, const type::Data &data,
-             bool disruption_active) {
+             bool clockwise, const type::AccessibiliteParams & accessibilite_params,
+             bool disruption_active, const RAPTOR& raptor) {
       Solutions result;
-      auto pareto_front = get_pareto_front(clockwise, departs, destinations, labels,
-              accessibilite_params, data, disruption_active);
+      auto pareto_front = get_pareto_front(clockwise, departs, destinations,
+              accessibilite_params, disruption_active, raptor);
       result.insert(pareto_front.begin(), pareto_front.end());
 
       if(!pareto_front.empty()) {
           auto walking_solutions = get_walking_solutions(clockwise, departs, destinations,
-                  *pareto_front.rbegin(), labels, data);
+                  *pareto_front.rbegin(), disruption_active, accessibilite_params, raptor);
           if(!walking_solutions.empty()) {
             result.insert(walking_solutions.begin(), walking_solutions.end());
           }
@@ -56,7 +59,8 @@ get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> >
 
 
 Solutions
-get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs, const DateTime &dep, bool clockwise, const type::Data & data, bool) {
+get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+              const DateTime &dep, bool clockwise, const type::Data & data, bool) {
     Solutions result;
     for(auto dep_dist : departs) {
         for(auto journey_pattern : data.pt_data->stop_points[dep_dist.first]->journey_pattern_point_list) {
@@ -86,8 +90,7 @@ bool improves(const DateTime & best_so_far, bool clockwise, const DateTime & cur
 Solutions
 get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
                const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
-               const std::vector<label_vector_t> &labels,
-               const type::AccessibiliteParams & accessibilite_params, const type::Data &data, bool disruption_active){
+               const type::AccessibiliteParams & accessibilite_params, bool disruption_active, const RAPTOR& raptor) {
     Solutions result;
 
     DateTime best_dt, best_dt_jpp;
@@ -98,16 +101,16 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
         best_dt = DateTimeUtils::inf;
         best_dt_jpp = DateTimeUtils::inf;
     }
-    for(unsigned int round=1; round < labels.size(); ++round) {
+    for(unsigned int round=1; round < raptor.labels.size(); ++round) {
         // For every round with look for the best journey pattern point that belongs to one of the destination stop points
         // We must not forget to walking duration
         type::idx_t best_jpp = type::invalid_idx;
         for(auto spid_dist : destinations) {
-            for(auto journey_pattern_point : data.pt_data->stop_points[spid_dist.first]->journey_pattern_point_list) {
+            for(auto journey_pattern_point : raptor.data.pt_data->stop_points[spid_dist.first]->journey_pattern_point_list) {
                 type::idx_t jppidx = journey_pattern_point->idx;
-                auto type = labels[round][journey_pattern_point->idx].type;
-                auto& l = labels[round][jppidx];
-                if((type == boarding_type::vj) &&
+                auto type = raptor.labels[round][journey_pattern_point->idx].type;
+                auto& l = raptor.labels[round][jppidx];
+                if((type == boarding_type::vj || type == boarding_type::connection_stay_in) &&
                    l.dt != DateTimeUtils::inf &&
                    l.dt != DateTimeUtils::min &&
                    improves(best_dt, clockwise, l.dt, spid_dist.second.total_seconds()) ) {
@@ -118,7 +121,8 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
                     const type::StopTime* st;
                     DateTime dt = 0;
 
-                    std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt, accessibilite_params.vehicle_properties, !clockwise, disruption_active, data, true);
+                    std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt, accessibilite_params.vehicle_properties,
+                                                      !clockwise, disruption_active, raptor.data, true);
                     BOOST_ASSERT(st);
                     if(st != nullptr) {
                         if(clockwise) {
@@ -140,13 +144,15 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
             Solution s;
             s.rpidx = best_jpp;
             s.count = round;
-            s.walking_time = getWalkingTime(round, best_jpp, departs, destinations, clockwise, labels, data);
+            s.walking_time = getWalkingTime(round, best_jpp, departs, destinations, clockwise, disruption_active,
+                                            accessibilite_params, raptor);
             s.arrival = best_dt_jpp;
             s.ratio = 0;
             type::idx_t final_rpidx;
-            std::tie(final_rpidx, s.upper_bound) = get_final_jppidx_and_date(round, best_jpp, clockwise, labels);
+            std::tie(final_rpidx, s.upper_bound) = get_final_jppidx_and_date(round, best_jpp, clockwise,
+                                                                             disruption_active, accessibilite_params, raptor);
             for(auto spid_dep : departs) {
-                if(data.pt_data->journey_pattern_points[final_rpidx]->stop_point->idx == spid_dep.first) {
+                if(raptor.data.pt_data->journey_pattern_points[final_rpidx]->stop_point->idx == spid_dep.first) {
                     if(clockwise) {
                         s.upper_bound = s.upper_bound + (spid_dep.second.total_seconds());
                     }else {
@@ -166,29 +172,32 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
 
 
 Solutions
-get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, Solution best,
-                    const std::vector<label_vector_t> &labels, const type::Data &data){
+get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
+                      const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, const Solution& best,
+                      const bool disruption_active, const type::AccessibiliteParams &accessibilite_params,
+                      const RAPTOR& raptor) {
     Solutions result;
 
     std::/*unordered_*/map<type::idx_t, Solution> tmp;
 
-    for(uint32_t i=0; i<labels.size(); ++i) {
+    for(uint32_t i=0; i<raptor.labels.size(); ++i) {
         for(auto spid_dist : destinations) {
             Solution best_departure;
             best_departure.ratio = 2;
             best_departure.rpidx = type::invalid_idx;
-            for(auto journey_pattern_point : data.pt_data->stop_points[spid_dist.first]->journey_pattern_point_list) {
+            for(auto journey_pattern_point : raptor.data.pt_data->stop_points[spid_dist.first]->journey_pattern_point_list) {
                 type::idx_t jppidx = journey_pattern_point->idx;
-                if(labels[i][journey_pattern_point->idx].type != boarding_type::uninitialized) {
-                    navitia::time_duration walking_time = getWalkingTime(i, jppidx, departs, destinations, clockwise, labels, data);
+                if(raptor.labels[i][journey_pattern_point->idx].type != boarding_type::uninitialized) {
+                    navitia::time_duration walking_time = getWalkingTime(i, jppidx, departs, destinations, clockwise,
+                                                                         disruption_active, accessibilite_params, raptor);
                     if(best.walking_time <= walking_time) {
                         continue;
                     }
                     float lost_time;
                     if(clockwise)
-                        lost_time = labels[i][jppidx].dt - (spid_dist.second.total_seconds()) - best.arrival;
+                        lost_time = raptor.labels[i][jppidx].dt - (spid_dist.second.total_seconds()) - best.arrival;
                     else
-                        lost_time = labels[i][jppidx].dt + (spid_dist.second.total_seconds()) - best.arrival;
+                        lost_time = raptor.labels[i][jppidx].dt + (spid_dist.second.total_seconds()) - best.arrival;
 
 
                     //Si je gagne 5 minutes de marche a pied, je suis pret à perdre jusqu'à 10 minutes.
@@ -201,21 +210,23 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, n
                             s.count = i;
                             s.ratio = ratio;
                             s.walking_time = walking_time;
-                            s.arrival = labels[i][jppidx].dt;
+                            s.arrival = raptor.labels[i][jppidx].dt;
                             type::idx_t final_rpidx;
                             DateTime last_time;
-                            std::tie(final_rpidx, last_time) = get_final_jppidx_and_date(i, jppidx, clockwise, labels);
+                            std::tie(final_rpidx, last_time) = get_final_jppidx_and_date(i, jppidx, clockwise,
+                                                                                         disruption_active, accessibilite_params, raptor);
+
                             if(clockwise) {
                                 s.upper_bound = last_time;
                                 for(auto spid_dep : departs) {
-                                    if(data.pt_data->journey_pattern_points[final_rpidx]->stop_point->idx == spid_dep.first) {
+                                    if(raptor.data.pt_data->journey_pattern_points[final_rpidx]->stop_point->idx == spid_dep.first) {
                                         s.upper_bound = s.upper_bound + (spid_dep.second.total_seconds());
                                     }
                                 }
                             } else {
                                 s.upper_bound = last_time;
                                 for(auto spid_dep : departs) {
-                                    if(data.pt_data->journey_pattern_points[final_rpidx]->stop_point->idx == spid_dep.first) {
+                                    if(raptor.data.pt_data->journey_pattern_points[final_rpidx]->stop_point->idx == spid_dep.first) {
                                         s.upper_bound = s.upper_bound - (spid_dep.second.total_seconds());
                                     }
                                 }
@@ -227,7 +238,7 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, n
                 }
             }
             if(best_departure.rpidx != type::invalid_idx) {
-                type::idx_t journey_pattern = data.pt_data->journey_pattern_points[best_departure.rpidx]->journey_pattern->idx;
+                type::idx_t journey_pattern = raptor.data.pt_data->journey_pattern_points[best_departure.rpidx]->journey_pattern->idx;
                 if(tmp.find(journey_pattern) == tmp.end()) {
                     tmp.insert(std::make_pair(journey_pattern, best_departure));
                 } else if(tmp[journey_pattern].ratio > best_departure.ratio) {
@@ -253,37 +264,42 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, n
     return result;
 }
 
+struct VisitorFinalJppAndDate : public BasePathVisitor {
+    type::idx_t current_jpp;
+    DateTime last_time;
+    void final_step(const type::idx_t current_jpp, size_t count, const std::vector<label_vector_t> &labels) {
+        this->current_jpp = current_jpp;
+        last_time = labels[count][current_jpp].dt;
+    }
+};
 
 // Reparcours l’itinéraire rapidement pour avoir le JPP et la date de départ (si on cherchait l’arrivée au plus tôt)
 std::pair<type::idx_t, DateTime>
-get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, const std::vector<label_vector_t> &labels) {
-    type::idx_t current_jpp = jpp_idx;
-    int cnt = count;
-
-    DateTime last_time = labels[cnt][current_jpp].dt;
-    while(labels[cnt][current_jpp].type != boarding_type::departure) {
-        auto b_type = labels[cnt][current_jpp].type;
-        if(b_type == boarding_type::vj) {
-            DateTimeUtils::update(last_time, DateTimeUtils::hour(labels[cnt][current_jpp].dt), clockwise);
-            current_jpp = labels[cnt][current_jpp].boarding_jpp;
-            if(labels[cnt][current_jpp].type != boarding_type::connection_stay_in) {
-                --cnt;
-            }
-        } else {
-            current_jpp = labels[cnt][current_jpp].boarding_jpp;
-            last_time = labels[cnt][current_jpp].dt;
-        }
-    }
-    return std::make_pair(current_jpp, last_time);
+get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active,
+                          const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor) {
+    VisitorFinalJppAndDate v;
+    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    return std::make_pair(v.current_jpp, v.last_time);
 }
+
+
+struct VisitorWalkingTime : public BasePathVisitor {
+    navitia::time_duration walking_time = {};
+    void connection(type::StopPoint* , type::StopPoint* ,
+                boost::posix_time::ptime dep_time, boost::posix_time::ptime arr_time,
+                type::StopPointConnection*) {
+
+        walking_time += navitia::seconds((arr_time - dep_time).total_seconds());
+    }
+};
 
 
 navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
                      const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
-                     bool clockwise, const std::vector<label_vector_t> &labels, const type::Data &data) {
+                     bool clockwise, bool disruption_active, const type::AccessibiliteParams & accessibilite_params,
+                     const RAPTOR& raptor) {
 
-    const type::JourneyPatternPoint* current_jpp = data.pt_data->journey_pattern_points[jpp_idx];
-    int cnt = count;
+    const type::JourneyPatternPoint* current_jpp = raptor.data.pt_data->journey_pattern_points[jpp_idx];
     navitia::time_duration walking_time = {};
 
     //Marche à la fin
@@ -293,32 +309,10 @@ navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std:
             break;
         }
     }
-    //Marche pendant les correspondances
-    auto boarding_type_value = labels[count][jpp_idx].type;
-    while(boarding_type_value != boarding_type::departure) {
-        if(boarding_type_value == boarding_type::vj) {
-            const type::idx_t current_jpp_idx = labels[cnt][current_jpp->idx].boarding_jpp;
-            current_jpp = data.pt_data->journey_pattern_points[current_jpp_idx];
-            boarding_type_value = labels[cnt][current_jpp->idx].type;
-            if(boarding_type_value != boarding_type::connection_stay_in) {
-                --cnt;
-            }
-            boarding_type_value = labels[cnt][current_jpp->idx].type;
-        } else {
-            const type::idx_t boarding_jpp_idx = labels[cnt][current_jpp->idx].boarding_jpp;
-            const type::JourneyPatternPoint* boarding = data.pt_data->journey_pattern_points[boarding_jpp_idx];
-            if(boarding_type_value == boarding_type::connection ||
-               boarding_type_value == boarding_type::connection_stay_in) {
-                type::idx_t connection_idx = data.dataRaptor->get_stop_point_connection_idx(boarding->stop_point->idx,
-                                                                                           current_jpp->stop_point->idx,
-                                                                                           clockwise, *data.pt_data);
-                if(connection_idx != type::invalid_idx)
-                    walking_time += navitia::seconds(data.pt_data->stop_point_connections[connection_idx]->duration);
-            }
-            current_jpp = boarding;
-            boarding_type_value = labels[cnt][current_jpp->idx].type;
-        }
-    }
+
+    VisitorWalkingTime v;
+    read_path(v, current_jpp->idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    walking_time += v.walking_time;
     //Marche au départ
     for(auto dep_dist : departs) {
         if(dep_dist.first == current_jpp->stop_point->idx) {

--- a/source/routing/raptor_solutions.h
+++ b/source/routing/raptor_solutions.h
@@ -37,6 +37,10 @@ www.navitia.io
 
 namespace navitia { namespace routing {
 
+//Forward declare
+
+struct RAPTOR;
+
 struct Solution {
     type::idx_t rpidx;
     uint32_t count;
@@ -72,9 +76,9 @@ typedef std::set<Solution> Solutions;
 
 Solutions
 get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
-             const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, bool clockwise,
-             const std::vector<label_vector_t> &labels, const type::AccessibiliteParams & accessibilite_params,
-             const type::Data &data, bool disruption_active);
+              const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, bool clockwise,
+              const type::AccessibiliteParams & accessibilite_params,
+              bool disruption_active, const RAPTOR& raptor);
 
 //This one is hacky, it's used to retrieve the departures.
 Solutions
@@ -83,21 +87,22 @@ get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> >
 
 Solutions
 get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
-                    const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, Solution best,
-                    const std::vector<label_vector_t> &labels, const type::Data &data);
+                      const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations, const Solution &best,
+                      const bool disruption_active, const type::AccessibiliteParams &accessibilite_params,
+                      const navitia::routing::RAPTOR &raptor);
 
 Solutions
 get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
                const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
-               const std::vector<label_vector_t> &labels,
-               const type::AccessibiliteParams & accessibilite_params, const type::Data &data, bool disruption_active);
+               const type::AccessibiliteParams & accessibilite_params, bool disruption_active, const RAPTOR& raptor);
 
 std::pair<type::idx_t, DateTime>
-get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, const std::vector<label_vector_t> &labels);
+get_final_jppidx_and_date(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params, const navitia::routing::RAPTOR &raptor);
 
 navitia::time_duration
 getWalkingTime(int count, type::idx_t rpid, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
                const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
-               bool clockwise, const std::vector<label_vector_t> &labels, const type::Data &data);
+               bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params,
+               const navitia::routing::RAPTOR &raptor);
 
 }}

--- a/source/routing/raptor_visitors.h
+++ b/source/routing/raptor_visitors.h
@@ -1,0 +1,111 @@
+#pragma once
+
+namespace navitia { namespace routing {
+struct raptor_visitor {
+    inline bool better_or_equal(const DateTime &a, const DateTime &current_dt, const type::StopTime* st) const {
+        return a <= st->section_end_date(DateTimeUtils::date(current_dt), clockwise());
+    }
+
+    inline
+    std::pair<std::vector<type::JourneyPatternPoint*>::const_iterator, std::vector<type::JourneyPatternPoint*>::const_iterator>
+    journey_pattern_points(const std::vector<type::JourneyPatternPoint*> &, const type::JourneyPattern* journey_pattern, size_t order) const {
+        return std::make_pair(journey_pattern->journey_pattern_point_list.begin() + order,
+                              journey_pattern->journey_pattern_point_list.end());
+    }
+
+    typedef std::vector<type::StopTime*>::const_iterator stop_time_iterator;
+    inline stop_time_iterator first_stoptime(const type::StopTime* st) const {
+        const type::JourneyPatternPoint* jpp = st->journey_pattern_point;
+        const type::VehicleJourney* vj = st->vehicle_journey;
+        return vj->stop_time_list.begin() + jpp->order;
+    }
+
+    template<typename T1, typename T2> inline bool comp(const T1& a, const T2& b) const {
+        return a < b;
+    }
+
+    template<typename T1, typename T2> inline auto combine(const T1& a, const T2& b) const -> decltype(a+b) {
+        return a + b;
+    }
+
+    inline
+    const type::VehicleJourney* get_extension_vj(const type::VehicleJourney* vj) const {
+       return vj->next_vj;
+    }
+
+    inline
+    const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
+       if(vj->prev_vj) {
+            return vj->prev_vj->journey_pattern->journey_pattern_point_list.back();
+       } else {
+           return nullptr;
+       }
+    }
+
+    inline
+    std::pair<std::vector<type::StopTime*>::const_iterator, std::vector<type::StopTime*>::const_iterator>
+    stop_time_list(const type::VehicleJourney* vj) const {
+        return std::make_pair(vj->stop_time_list.begin(), vj->stop_time_list.end());
+    }
+
+    constexpr bool clockwise() const{return true;}
+    constexpr int init_queue_item() const{return std::numeric_limits<int>::max();}
+    constexpr DateTime worst_datetime() const{return DateTimeUtils::inf;}
+};
+
+
+struct raptor_reverse_visitor {
+    inline bool better_or_equal(const DateTime &a, const DateTime &current_dt, const type::StopTime* st) const {
+        return a >= st->section_end_date(DateTimeUtils::date(current_dt), clockwise());
+    }
+
+    inline
+    std::pair<std::vector<type::JourneyPatternPoint*>::const_reverse_iterator, std::vector<type::JourneyPatternPoint*>::const_reverse_iterator>
+    journey_pattern_points(const std::vector<type::JourneyPatternPoint*> &/*journey_pattern_points*/, const type::JourneyPattern* journey_pattern, size_t order) const {
+        size_t offset = journey_pattern->journey_pattern_point_list.size() - order - 1;
+        const auto begin = journey_pattern->journey_pattern_point_list.rbegin() + offset;
+        const auto end = journey_pattern->journey_pattern_point_list.rend();
+        return std::make_pair(begin, end);
+    }
+
+    typedef std::vector<type::StopTime*>::const_reverse_iterator stop_time_iterator;
+    inline stop_time_iterator first_stoptime(const type::StopTime* st) const {
+        const type::JourneyPatternPoint* jpp = st->journey_pattern_point;
+        const type::VehicleJourney* vj = st->vehicle_journey;
+        return vj->stop_time_list.rbegin() + vj->stop_time_list.size() - jpp->order - 1;
+    }
+
+    template<typename T1, typename T2> inline bool comp(const T1& a, const T2& b) const {
+        return a > b;
+    }
+
+    template<typename T1, typename T2> inline auto combine(const T1& a, const T2& b) const -> decltype(a-b) {
+        return a - b;
+    }
+
+    inline
+    const type::VehicleJourney* get_extension_vj(const type::VehicleJourney* vj) const {
+       return vj->prev_vj;
+    }
+
+    inline
+    const type::JourneyPatternPoint* get_last_jpp(const type::VehicleJourney* vj) const {
+        if(vj->next_vj != nullptr) {
+            return vj->next_vj->journey_pattern->journey_pattern_point_list.front();
+        } else {
+            return nullptr;
+        }
+    }
+
+    inline
+    std::pair<std::vector<type::StopTime*>::const_reverse_iterator, std::vector<type::StopTime*>::const_reverse_iterator>
+    stop_time_list(const type::VehicleJourney* vj) const {
+        return std::make_pair(vj->stop_time_list.rbegin(), vj->stop_time_list.rend());
+    }
+
+    constexpr bool clockwise() const{return false;}
+    constexpr int init_queue_item() const{return -1;}
+    constexpr DateTime worst_datetime() const{return DateTimeUtils::min;}
+};
+
+}}

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -692,6 +692,24 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
 }
 
 
+BOOST_AUTO_TEST_CASE(stay_in_complex) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "", true)("stop1", 8*3600)("stop2", 9*3600)("stop3", 10*3600);
+    b.vj("B", "1111111", "block1", true)("stop3", 10*3600+5*60)("stop2", 11*3600);
+    b.vj("C", "1111111", "block1", true)("stop4", 11*3600+5*60)("stop5", 11*3600+10*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 11*3600+10*60);
+}
+
+
 BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
@@ -751,8 +769,6 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
 
-
-
 BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
@@ -767,6 +783,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
+
 
 BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -674,7 +674,7 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 9*3600 + 20 * 60);
 }
 
-
+/*
 BOOST_AUTO_TEST_CASE(prolongement_service) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
@@ -690,7 +690,7 @@ BOOST_AUTO_TEST_CASE(prolongement_service) {
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
-
+*/
 
 BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -678,6 +678,22 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
 BOOST_AUTO_TEST_CASE(stay_in_basic) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop2", 8*3600+15*60)("stop3", 8*3600 + 20*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
+}
+
+BOOST_AUTO_TEST_CASE(stay_in_teleport) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
     b.finish();
     b.data->pt_data->index();

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), false);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), false);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8099), false);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8099), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(change){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), false);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), false);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8399), false);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8399), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 /****
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items.back().arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::hour(to_datetime(res.items.back().arrival, *(b.data))), 7*3600 + 15*60);
 
-    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, false);
+    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), false);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), false);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (40*60)-1), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (40*60)-1), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -401,30 +401,30 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9199), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9199), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9199), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9199), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -517,7 +517,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)-1), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)-1), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, false, true);
 
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                  p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }));
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -590,7 +590,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
         }
     ));
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -615,7 +615,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
 
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)-1), false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)-1), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(pam_veille) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -649,7 +649,7 @@ BOOST_AUTO_TEST_CASE(pam_3) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
 
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 9*3600 + 20 * 60);
 }
@@ -687,7 +687,7 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -703,7 +703,7 @@ BOOST_AUTO_TEST_CASE(stay_in_teleport) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -720,7 +720,7 @@ BOOST_AUTO_TEST_CASE(stay_in_departure_last_of_first_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -737,7 +737,7 @@ BOOST_AUTO_TEST_CASE(stay_in_complex) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 11*3600+10*60);
 }
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
                           return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 15*60;}));
@@ -778,7 +778,7 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
 }
@@ -797,7 +797,7 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -813,7 +813,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), false, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), false, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8099), false, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8099), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(change){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8399), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8399), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 /****
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items.back().arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::hour(to_datetime(res.items.back().arrival, *(b.data))), 7*3600 + 15*60);
 
-    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -237,7 +237,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -264,7 +264,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (20*60)-1), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -349,7 +349,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -362,7 +362,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (40*60)-1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, (40*60)-1), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -401,30 +401,30 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9199), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9199), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9199), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9199), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -517,7 +517,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -526,7 +526,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)-1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (2*3600+20)-1), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, false);
 
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                  p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }));
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -590,32 +590,32 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
         }
     ));
-
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
+                            [&](const Path& p){
+           return p.items.size() == 5  &&
+                  p.items[0].stop_points.size() == 2  &&
+                  p.items[1].stop_points.size() == 1  &&
+                  p.items[2].stop_points.size() == 3  &&
+                  p.items[3].stop_points.size() == 1  &&
+                  p.items[4].stop_points.size() == 2  &&
+                  p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx  &&
+                  p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx  &&
+                  p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx  &&
+                  p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx  &&
+                  p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx  &&
+                  p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx  &&
+                  p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx  &&
+                  p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx  &&
+                  p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60  &&
+                  p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
+    }));
 
-    res = res1.front();
 
-    BOOST_REQUIRE_EQUAL(res.items.size(), 5);
-    BOOST_REQUIRE_EQUAL(res.items[0].stop_points.size(), 2);
-    BOOST_REQUIRE_EQUAL(res.items[1].stop_points.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.items[2].stop_points.size(), 3);
-    BOOST_REQUIRE_EQUAL(res.items[3].stop_points.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.items[4].stop_points.size(), 2);
-    BOOST_CHECK_EQUAL(res.items[0].stop_points[0]->idx, d.stop_points_map["stop1"]->idx);
-    BOOST_CHECK_EQUAL(res.items[0].stop_points[1]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[1].stop_points[0]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[2].stop_points[0]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[2].stop_points[2]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[3].stop_points[0]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[4].stop_points[0]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[4].stop_points[1]->idx, d.stop_points_map["stop4"]->idx);
 
-    BOOST_CHECK_EQUAL(res.items[0].departure.time_of_day().total_seconds(), 8*3600+20*60);
-    BOOST_CHECK_EQUAL(res.items[4].arrival.time_of_day().total_seconds(), 8*3600+45*60);
-
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)-1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)-1), false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(pam_veille) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -649,7 +649,7 @@ BOOST_AUTO_TEST_CASE(pam_3) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -670,7 +670,7 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
 
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false, true);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 9*3600 + 20 * 60);
 }
@@ -703,7 +703,7 @@ BOOST_AUTO_TEST_CASE(stay_in_teleport) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -739,7 +739,7 @@ BOOST_AUTO_TEST_CASE(stay_in_complex) {
 
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
-    BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 11*3600+10*60);
+    BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 11*3600+10*60);
 }
 
 
@@ -817,6 +817,28 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
+/*
+ * This case isn't handle yet, because we only apply the next_vj of the last taken vehicle_journey.
+
+BOOST_AUTO_TEST_CASE(first_vj_stay_in) {
+    ed::builder b("20120614");
+    b.vj("A")("stop1", 8*3600+15*60)("stop2", 8*3600+20*60);
+    b.vj("B")("stop1", 8*3600)("stop3", 8*3600 + 5*60);
+    b.vj("C")("stop2", 8*3600)("stop3", 8*3600+10*60)("stop4", 8*3600+15*60);
+    b.vj("C", "111111", "block1")("stop2", 8*3600+25*60)("stop3", 8*3600+30*60)("stop4", 8*3600+45*60);
+    b.vj("D", "111111", "block1")("stop5", 8*3600+50*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK_EQUAL(res1.back().items.back().arrival.time_of_day().total_seconds(), 8*3600 + 50*60);
+}
+*/
 
 BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -547,48 +547,49 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
 
-    auto res = res1.front();
-
-
-    BOOST_REQUIRE_EQUAL(res.items.size(), 5);
-    BOOST_REQUIRE_EQUAL(res.items[0].stop_points.size(), 2);
-    BOOST_REQUIRE_EQUAL(res.items[1].stop_points.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.items[2].stop_points.size(), 3);
-    BOOST_REQUIRE_EQUAL(res.items[3].stop_points.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.items[4].stop_points.size(), 2);
-    BOOST_CHECK_EQUAL(res.items[0].stop_points[0]->idx, d.stop_points_map["stop1"]->idx);
-    BOOST_CHECK_EQUAL(res.items[0].stop_points[1]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[1].stop_points[0]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[2].stop_points[0]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[2].stop_points[2]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[3].stop_points[0]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[4].stop_points[0]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[4].stop_points[1]->idx, d.stop_points_map["stop4"]->idx);
-    BOOST_CHECK_EQUAL(res.items[0].departure.time_of_day().total_seconds(), 8*3600+20*60);
-    BOOST_CHECK_EQUAL(res.items[4].arrival.time_of_day().total_seconds(), 8*3600+45*60);
+    BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
+                            [&](const Path& p){
+        return   p.items.size() == 5 &&
+                 p.items[0].stop_points.size() == 2 &&
+                 p.items[1].stop_points.size() == 1 &&
+                 p.items[2].stop_points.size() == 3 &&
+                 p.items[3].stop_points.size() == 1 &&
+                 p.items[4].stop_points.size() == 2 &&
+                 p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx &&
+                 p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx &&
+                 p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
+                 p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
+                 p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx &&
+                 p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
+                 p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
+                 p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx &&
+                 p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60 &&
+                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
+    }));
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
-
-    res = res1.front();
-
-    BOOST_REQUIRE_EQUAL(res.items.size(), 5);
-    BOOST_REQUIRE_EQUAL(res.items[0].stop_points.size(), 2);
-    BOOST_REQUIRE_EQUAL(res.items[1].stop_points.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.items[2].stop_points.size(), 3);
-    BOOST_REQUIRE_EQUAL(res.items[3].stop_points.size(), 1);
-    BOOST_REQUIRE_EQUAL(res.items[4].stop_points.size(), 2);
-    BOOST_CHECK_EQUAL(res.items[0].stop_points[0]->idx, d.stop_points_map["stop1"]->idx);
-    BOOST_CHECK_EQUAL(res.items[0].stop_points[1]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[1].stop_points[0]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[2].stop_points[0]->idx, d.stop_points_map["stop2"]->idx);
-    BOOST_CHECK_EQUAL(res.items[2].stop_points[2]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[3].stop_points[0]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[4].stop_points[0]->idx, d.stop_points_map["stop3"]->idx);
-    BOOST_CHECK_EQUAL(res.items[4].stop_points[1]->idx, d.stop_points_map["stop4"]->idx);
-    BOOST_CHECK_EQUAL(res.items[0].departure.time_of_day().total_seconds(), 8*3600+20*60);
-    BOOST_CHECK_EQUAL(res.items[4].arrival.time_of_day().total_seconds(), 8*3600+45*60);
+    BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
+                            [&](const Path& p){
+        return  p.items.size(), 5 &&
+                p.items[0].stop_points.size() == 2 &&
+                p.items[1].stop_points.size() == 1 &&
+                p.items[2].stop_points.size() == 3 &&
+                p.items[3].stop_points.size() == 1 &&
+                p.items[4].stop_points.size() == 2 &&
+                p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx &&
+                p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx &&
+                p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
+                p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
+                p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx &&
+                p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
+                p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
+                p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx &&
+                p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60 &&
+                p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
+        }
+    ));
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false, true);
 
@@ -707,6 +708,22 @@ BOOST_AUTO_TEST_CASE(stay_in_teleport) {
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
 
+
+BOOST_AUTO_TEST_CASE(stay_in_departure_last_of_first_vj) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
+}
 
 BOOST_AUTO_TEST_CASE(stay_in_complex) {
     ed::builder b("20120614");

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -434,12 +434,12 @@ BOOST_AUTO_TEST_CASE(sn_fin) {
     BOOST_CHECK_EQUAL(res1.back().items[0].departure.time_of_day().total_seconds(), 8*3600);
 }
 
-/*
-BOOST_AUTO_TEST_CASE(prolongement_service) {
+
+BOOST_AUTO_TEST_CASE(stay_in_basic) {
     ed::builder b("20120614");
-    b.vj("A", "1111111", "", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
-    b.vj("B", "1111111", "", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
-    b.journey_pattern_point_connection("A", "B");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
@@ -450,7 +450,86 @@ BOOST_AUTO_TEST_CASE(prolongement_service) {
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
-*/
+
+
+
+BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
+    b.vj("C", "1111111", "", true)("stop1", 8*3600+10*60)("stop2", 8*3600+15*60);
+    b.vj("D", "1111111", "", true)("stop2", 8*3600+20*60)("stop3", 8*3600+25*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, false, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 2);
+    BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
+                          return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 25*60;}));
+    BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
+                          return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 20*60;}));
+}
+
+
+
+BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop5", 8*3600 + 20*60);
+    b.vj("C", "1111111", "block1", true)("stop6", 8*3600+25*60)("stop3", 8*3600 + 30*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, false, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
+}
+
+
+BOOST_AUTO_TEST_CASE(stay_in_loop) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
+    b.vj("C", "1111111", "block1", true)("stop5", 8*3600+25*60)("stop1", 8*3600 + 30*60);
+    b.vj("D", "1111111", "block1", true)("stop4", 8*3600+35*60)("stop3", 8*3600 + 40*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, false, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
+    b.vj("B", "0000", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    BOOST_REQUIRE_EQUAL(res1.size(), 0);
+}
+
+
 BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");
     b.vj("A")("stop1",8*3600+10*60, 8*3600 + 10*60,1)("stop2",8*3600+15*60,8*3600+15*60,1)("stop3", 8*3600+20*60);

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -434,6 +434,7 @@ BOOST_AUTO_TEST_CASE(sn_fin) {
     BOOST_CHECK_EQUAL(res1.back().items[0].departure.time_of_day().total_seconds(), 8*3600);
 }
 
+/*
 BOOST_AUTO_TEST_CASE(prolongement_service) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
@@ -449,7 +450,7 @@ BOOST_AUTO_TEST_CASE(prolongement_service) {
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
-
+*/
 BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");
     b.vj("A")("stop1",8*3600+10*60, 8*3600 + 10*60,1)("stop2",8*3600+15*60,8*3600+15*60,1)("stop3", 8*3600+20*60);

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -446,7 +446,7 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, false, true, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, true, false, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -466,7 +466,7 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, true, false, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
                           return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 25*60;}));
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, true, false, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
 }
@@ -507,7 +507,7 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, true, false, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -525,7 +525,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, true, false, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -244,7 +244,9 @@ CREATE TABLE IF NOT EXISTS navitia.vehicle_journey (
     name TEXT NOT NULL,
     odt_type_id BIGINT NULL,
     vehicle_properties_id BIGINT NULL REFERENCES navitia.vehicle_properties,
-    theoric_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey
+    theoric_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey,
+    previous_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey,
+    next_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey
 );
 
 ALTER TABLE navitia.vehicle_journey DROP COLUMN IF EXISTS physical_mode_id;

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -298,15 +298,6 @@ CREATE TABLE IF NOT EXISTS navitia.journey_pattern_point (
 );
 
 
-CREATE TABLE IF NOT EXISTS navitia.journey_pattern_point_connection (
-    departure_journey_pattern_point_id BIGINT NOT NULL REFERENCES navitia.journey_pattern_point,
-    destination_journey_pattern_point_id BIGINT NOT NULL REFERENCES navitia.journey_pattern_point,
-    connection_kind_id BIGINT NOT NULL REFERENCES navitia.connection_kind,
-    length INTEGER NOT NULL,
-    CONSTRAINT journey_pattern_point_connection_pk PRIMARY KEY (departure_journey_pattern_point_id, destination_journey_pattern_point_id)
-);
-
-
 CREATE TABLE IF NOT EXISTS navitia.stop_time (
     id BIGSERIAL PRIMARY KEY,
     vehicle_journey_id BIGINT NOT NULL REFERENCES navitia.vehicle_journey,

--- a/source/sql/ed/02-data.sql
+++ b/source/sql/ed/02-data.sql
@@ -41,7 +41,6 @@ BEGIN
         (11, 'Company'),
         (12, 'Route'),
         (13, 'POI'),
-        (14, 'JourneyPatternPointConnection'),
         (15, 'StopPointConnection'),
         (16, 'Contributor'),
         (17, 'StopTime'),

--- a/source/sql/ed/02-migration.sql
+++ b/source/sql/ed/02-migration.sql
@@ -76,7 +76,7 @@ DO $$
     DECLARE count_multi int;
 BEGIN
     count_multi := coalesce((select count(*) from georef.admin where geometrytype(boundary::geometry) = 'MULTIPOLYGON' limit 1), 0);
-    CASE WHEN count_multi = 0 
+    CASE WHEN count_multi = 0
         THEN
             -- Ajout d'une colonne temporaire
             ALTER TABLE georef.admin ADD COLUMN boundary_tmp GEOGRAPHY(POLYGON, 4326);
@@ -170,7 +170,7 @@ DO $$
     DECLARE count_admin int;
 BEGIN
     count_admin := coalesce((select  count(*) from  pg_catalog.pg_tables where schemaname = 'navitia' and tablename='admin'), 0);
-    CASE WHEN count_admin > 0 
+    CASE WHEN count_admin > 0
         THEN
 			INSERT INTO georef.admin SELECT * FROM navitia.admin;
 			INSERT INTO georef.rel_admin_admin SELECT * FROM navitia.rel_admin_admin;
@@ -200,7 +200,7 @@ DO $$
     DECLARE count_synonym int;
 BEGIN
     count_synonym := coalesce((select  count(*) from  pg_catalog.pg_tables where schemaname = 'navitia' and tablename='synonym'), 0);
-    CASE WHEN count_synonym > 0 
+    CASE WHEN count_synonym > 0
         THEN
 			INSERT INTO georef.synonym SELECT * FROM navitia.synonym;
     ELSE
@@ -208,11 +208,11 @@ BEGIN
     END CASE;
 END
 $$;
-DROP TABLE IF EXISTS navitia.admin CASCADE;	
+DROP TABLE IF EXISTS navitia.admin CASCADE;
 DROP TABLE IF EXISTS navitia.rel_admin_admin CASCADE;
-DROP TABLE IF EXISTS navitia.poi CASCADE;			
+DROP TABLE IF EXISTS navitia.poi CASCADE;
 DROP TABLE IF EXISTS navitia.synonym;
-			
+
 DROP TABLE IF EXISTS navitia.alias;
 DROP TABLE IF EXISTS navitia.rel_stop_point_admin;
 DROP TABLE IF EXISTS navitia.rel_stop_area_admin;
@@ -221,3 +221,4 @@ DROP FUNCTION IF EXISTS georef.match_stop_area_to_admin();
 DROP FUNCTION IF EXISTS georef.match_stop_point_to_admin();
 DROP FUNCTION IF EXISTS georef.update_admin_coord();
 DROP FUNCTION IF EXISTS georef.match_admin_to_admin();
+DROP TABLE IF EXISTS navitia.journey_pattern_point_connection CASCADE;

--- a/source/sql/ed/02-migration.sql
+++ b/source/sql/ed/02-migration.sql
@@ -167,6 +167,28 @@ DO $$
 $$;
 
 DO $$
+    BEGIN
+        BEGIN
+            ALTER TABLE navitia.vehicle_journey ADD
+                COLUMN previous_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey;
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'column previous_vehicle_journey already exists in navitia.vehicle_journey';
+        END;
+    END;
+$$;
+
+DO $$
+    BEGIN
+        BEGIN
+            ALTER TABLE navitia.vehicle_journey ADD
+                COLUMN next_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey;
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'column next_vehicle_journey already exists in navitia.vehicle_journey';
+        END;
+    END;
+$$;
+
+DO $$
     DECLARE count_admin int;
 BEGIN
     count_admin := coalesce((select  count(*) from  pg_catalog.pg_tables where schemaname = 'navitia' and tablename='admin'), 0);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -393,11 +393,6 @@ void fill_pb_object(const nt::StopPointConnection* c, const nt::Data& data,
 }
 
 
-void fill_pb_object(const nt::JourneyPatternPointConnection*, const nt::Data&,
-                    pbnavitia::Connection* , int,
-                    const pt::ptime&, const pt::time_period&){
-}
-
 
 void fill_pb_object(const nt::ValidityPattern* vp, const nt::Data&,
                     pbnavitia::ValidityPattern* validity_pattern, int,

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -38,7 +38,6 @@ PT_Data& PT_Data::operator=(PT_Data&& other){
     ITERATE_NAVITIA_PT_TYPES(COPY_FROM_OTHER)
 
     stop_point_connections = other.stop_point_connections;
-    journey_pattern_point_connections = other.journey_pattern_point_connections;
     stop_times = other.stop_times;
 
     // First letter
@@ -61,13 +60,6 @@ void PT_Data::sort(){
     std::for_each(collection_name.begin(), collection_name.end(), Indexer<nt::idx_t>());\
     BOOST_ASSERT(collection_name.size() == collection_name##_size);
     ITERATE_NAVITIA_PT_TYPES(SORT_AND_INDEX)
-
-    size_t journey_pattern_point_connections_size = journey_pattern_point_connections.size();
-    std::sort(journey_pattern_point_connections.begin(), journey_pattern_point_connections.end());
-    BOOST_ASSERT(journey_pattern_point_connections.size() == journey_pattern_point_connections_size);
-    std::for_each(journey_pattern_point_connections.begin(), journey_pattern_point_connections.end(), Indexer<idx_t>());
-    std::sort(journey_pattern_point_connections.begin(), journey_pattern_point_connections.end());
-    BOOST_ASSERT(journey_pattern_point_connections.size() == journey_pattern_point_connections_size);
 
     size_t stop_point_connections_size = stop_point_connections.size();
     std::sort(stop_point_connections.begin(), stop_point_connections.end());

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -49,7 +49,6 @@ struct PT_Data : boost::noncopyable{
     ITERATE_NAVITIA_PT_TYPES(COLLECTION_AND_MAP)
 
     std::vector<StopTime*> stop_times;
-    std::vector<JourneyPatternPointConnection*> journey_pattern_point_connections;
     std::vector<StopPointConnection*> stop_point_connections;
 
     //associated cal for vj
@@ -81,7 +80,7 @@ struct PT_Data : boost::noncopyable{
                 // Les proximity list
                 & stop_area_proximity_list & stop_point_proximity_list & line_autocomplete
                 // Les types un peu spéciaux
-                & stop_point_connections & journey_pattern_point_connections
+                & stop_point_connections
                 //les messages
                 & message_holder;
     }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -502,8 +502,7 @@ std::vector<idx_t> StopPoint::get(Type_e type, const PT_Data &) const {
     return result;
 }
 
-template<>
-std::vector<idx_t> Connection<StopPoint>::get(Type_e type, const PT_Data & ) const {
+std::vector<idx_t> StopPointConnection::get(Type_e type, const PT_Data & ) const {
     std::vector<idx_t> result;
     switch(type) {
     case Type_e::StopPoint:
@@ -514,10 +513,7 @@ std::vector<idx_t> Connection<StopPoint>::get(Type_e type, const PT_Data & ) con
     }
     return result;
 }
-template<>
-bool Connection<JourneyPatternPoint>::operator<(const Connection<JourneyPatternPoint> & other) const { return this < &other; }
-template<>
-bool Connection<StopPoint>::operator<(const Connection<StopPoint> & other) const { return this < &other; }
+bool StopPointConnection::operator<(const StopPointConnection& other) const { return this < &other; }
 
 EntryPoint::EntryPoint(const Type_e type, const std::string &uri) : type(type), uri(uri) {
    // Gestion des adresses

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -63,7 +63,6 @@ const idx_t invalid_idx = std::numeric_limits<idx_t>::max();
 
 struct Message;
 
-// Types qui sont exclus : JourneyPatternPointConnection
 #define ITERATE_NAVITIA_PT_TYPES(FUN)\
     FUN(ValidityPattern, validity_patterns)\
     FUN(Line, lines)\
@@ -95,7 +94,6 @@ enum class Type_e {
     Company                         = 11,
     Route                           = 12,
     POI                             = 13,
-    JourneyPatternPointConnection   = 14,
     StopPointConnection             = 15,
     Contributor                     = 16,
 
@@ -408,31 +406,28 @@ struct JourneyPatternPoint;
 struct VehicleJourney;
 struct StopTime;
 
-template<typename T>
-struct Connection: public Header, hasProperties{
+struct StopPointConnection: public Header, hasProperties{
     const static Type_e type = Type_e::Connection;
-    T* departure;
-    T* destination;
+    StopPoint* departure;
+    StopPoint* destination;
     int display_duration;
     int duration;
     int max_duration;
     ConnectionType connection_type;
 
-    Connection() : departure(nullptr), destination(nullptr), display_duration(0), duration(0),
+    StopPointConnection() : departure(nullptr), destination(nullptr), display_duration(0), duration(0),
         max_duration(0){};
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-        ar & idx & uri & departure & destination & display_duration & duration & max_duration & _properties;
+        ar & idx & uri & departure & destination & display_duration & duration &
+            max_duration & connection_type & _properties;
     }
 
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
 
-    bool operator<(const Connection<T> &other) const;
+    bool operator<(const StopPointConnection &other) const;
 
 };
-
-typedef Connection<JourneyPatternPoint>  JourneyPatternPointConnection;
-typedef Connection<StopPoint>  StopPointConnection;
 
 struct ExceptionDate {
     enum class ExceptionType {
@@ -682,6 +677,8 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     std::vector<StopTime*> stop_time_list;
     VehicleJourneyType vehicle_journey_type;
     std::string odt_message;
+    VehicleJourney* block_after = nullptr;
+    VehicleJourney* block_before = nullptr;
     ///map of the calendars that nearly match the validity pattern of the vj, key is the calendar name
     std::map<std::string, AssociatedCalendar*> associated_calendars;
 
@@ -702,7 +699,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
             & adapted_validity_pattern & adapted_vehicle_journey_list
             & theoric_vehicle_journey & comment & vehicle_journey_type
             & odt_message & _vehicle_properties & messages & associated_calendars
-            & codes;
+            & codes & block_after & block_before;
     }
     std::string get_direction() const;
     bool has_date_time_estimated() const;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -677,8 +677,12 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     std::vector<StopTime*> stop_time_list;
     VehicleJourneyType vehicle_journey_type;
     std::string odt_message;
-    VehicleJourney* block_after = nullptr;
-    VehicleJourney* block_before = nullptr;
+
+    // These variables are used in the case of an extension of service
+    // They indicate what's the vj you can take directly after or before this one
+    // They have the same block id
+    VehicleJourney* next_vj = nullptr;
+    VehicleJourney* prev_vj = nullptr;
     ///map of the calendars that nearly match the validity pattern of the vj, key is the calendar name
     std::map<std::string, AssociatedCalendar*> associated_calendars;
 
@@ -699,7 +703,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
             & adapted_validity_pattern & adapted_vehicle_journey_list
             & theoric_vehicle_journey & comment & vehicle_journey_type
             & odt_message & _vehicle_properties & messages & associated_calendars
-            & codes & block_after & block_before;
+            & codes & next_vj & prev_vj;
     }
     std::string get_direction() const;
     bool has_date_time_estimated() const;


### PR DESCRIPTION
# Technical Refactoring

There are lot of things in this PR : 
- First there is a refactorization of read_path: it's now done in a function accepting a visitor.
- Then we remove the journey_pattern_point_connections
- Finally we introduce a next_vj and prev_vj in vehicle_journeys, and we use this in the algorithm.

In the algorithm, at the end of a computation of a journey_pattern if the last taken vehicle_journey has a next_vj, we apply it.
## Benchmark

Centre instance (one with block_id)

|  | mod_block_id | dev |
| :-- | :-: | :-: |
| Memory | 224MB | 928 MB |
| Time per request | ~60ms | ~170ms |

SNCF instance (without block_id)

|  | mod_block_id | dev |
| :-- | :-: | :-: |
| Memory | 275MB | 271MB |
| Time per request | ~150ms | ~140ms |

So when there are no block_id there is an overhead.
