### PR TITLE
jormungandr: Error handling in stat_manger for RabbitMQ

### DIFF
--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -339,15 +339,13 @@ class StatManager(object):
     def publish_request(self, stat_request):
         try:
             self.producer.publish(stat_request.SerializeToString())
-        except Exception as e:
+        except self.connection.connection_errors + self.connection.channel_errors:
             logging.getLogger(__name__).info('Server went away, will be reconnected..')
-
-            #Release the existing connection and re-initialize rabbitMQ
-            if self.connection.connect():
-                self.connection.release()
             #Initialize a new connection to RabbitMQ
             self._init_rabbitmq()
-            self.producer.publish(stat_request.SerializeToString())
+            #If connection is established publish the stat message.
+            if self.save_stat:
+                self.producer.publish(stat_request.SerializeToString())
 
     def fill_admin_from(self,stat_section, admins):
         for admin in admins:

--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -340,7 +340,10 @@ class StatManager(object):
         try:
             self.producer.publish(stat_request.SerializeToString())
         except self.connection.connection_errors + self.connection.channel_errors:
-            logging.getLogger(__name__).info('Server went away, will be reconnected..')
+            logging.getLogger(__name__).exception('Server went away, will be reconnected..')
+            #Relese and close the previous connection
+            if self.connection and self.connection.connected:
+                self.connection.release()
             #Initialize a new connection to RabbitMQ
             self._init_rabbitmq()
             #If connection is established publish the stat message.


### PR DESCRIPTION
When rabbitMQ is re-initialized and jormungandr is running,
jormungandr cannot push stat masage to rabbitMQ even if
the connection exists.

If it happens the connection will have to be re-initialized.
