### PR TITLE
Check consistency of vehicle journeys

### DIFF
--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -1312,6 +1312,23 @@ void EdReader::check_coherence(navitia::type::Data& data) const {
     if (non_associated_lines) {
         LOG4CPLUS_WARN(log, non_associated_lines << " lines are not associated with any calendar (and "
                         << (data.pt_data->lines.size() - non_associated_lines) << " are associated with at least one");
+    }
+
+    //Check if every vehicle journey with a next_vj has a backlink
+    size_t nb_error_on_vj = 0;
+    for(auto vj : data.pt_data->vehicle_journeys) {
+        if (vj->next_vj && vj->next_vj->prev_vj != vj) {
+            LOG4CPLUS_ERROR(log, "Vehicle journey " << vj->uri << " has a next_vj, but the back link is invalid");
+            ++nb_error_on_vj;
+        }
+        if (vj->prev_vj && vj->prev_vj->next_vj != vj) {
+            LOG4CPLUS_ERROR(log, "Vehicle journey " << vj->uri << " has a prev_vj, but the back link is invalid");
+            ++nb_error_on_vj;
+        }
+    }
+    if(nb_error_on_vj > 0) {
+    LOG4CPLUS_INFO(log, "There was " << nb_error_on_vj << " vehicle journeys with consistency error over a total of " <<
+            data.pt_data->vehicle_journeys.size() << " vehicle journeys" );
     }
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -425,7 +425,7 @@ std::vector<Path> RAPTOR::compute(const type::StopArea* departure,
 
 
 int RAPTOR::best_round(type::idx_t journey_pattern_point_idx){
-    for(size_t i = 0; i < labels.size(); ++i){
+    for(size_t i = 0; i <= this->count; ++i){
         if(labels[i][journey_pattern_point_idx].dt == best_labels[journey_pattern_point_idx]){
             return i;
         }

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -101,7 +101,7 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
         best_dt = DateTimeUtils::inf;
         best_dt_jpp = DateTimeUtils::inf;
     }
-    for(unsigned int round=1; round < raptor.labels.size(); ++round) {
+    for(unsigned int round=1; round <= raptor.count; ++round) {
         // For every round with look for the best journey pattern point that belongs to one of the destination stop points
         // We must not forget to walking duration
         type::idx_t best_jpp = type::invalid_idx;
@@ -180,7 +180,7 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<type::idx_t, n
 
     std::/*unordered_*/map<type::idx_t, Solution> tmp;
     // We start at 1 because we don't want results of the first round
-    for(uint32_t i=1; i<raptor.labels.size(); ++i) {
+    for(uint32_t i=1; i <= raptor.count; ++i) {
         for(auto spid_dist : destinations) {
             Solution best_departure;
             best_departure.ratio = 2;


### PR DESCRIPTION
This should fix #377.
We check the consistency of vehicle journeys.
We also reduce the search space when we look for pareto front.
