### PR TITLE
Assert on reversal errors

### DIFF
--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -239,7 +239,7 @@ RAPTOR::compute_all(const std::vector<std::pair<type::idx_t, navitia::time_durat
         std::vector<Path> temp = makePathes(calc_dest, calc_dep, accessibilite_params, *this, !clockwise, disruption_active);
         result.insert(result.end(), temp.begin(), temp.end());
     }
-    BOOST_ASSERT( departures.size() > 0 );
+    BOOST_ASSERT( departures.size() > 0 );    //Assert that reversal search was symetric
     return result;
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -239,6 +239,7 @@ RAPTOR::compute_all(const std::vector<std::pair<type::idx_t, navitia::time_durat
         std::vector<Path> temp = makePathes(calc_dest, calc_dep, accessibilite_params, *this, !clockwise, disruption_active);
         result.insert(result.end(), temp.begin(), temp.end());
     }
+    BOOST_ASSERT( departures.size() > 0 );
     return result;
 }
 


### PR DESCRIPTION
If there are no solutions found at this point, a bug is present causing unsymetric searches in clockwise vs counterclockwise. If no paths exists, this assert will never be reached anyway after the invalid_idx check

--Do not merge as such a bug is present --
