### PR TITLE
Add coherence to sections

### DIFF
--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -97,15 +97,16 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
 
     BOOST_REQUIRE_EQUAL(pb_fare.ticket_id_size(), 2);
 
-    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
-    auto section = journey.sections(0);
-    BOOST_CHECK_EQUAL(section.id(), "section_0");
+    BOOST_REQUIRE_EQUAL(journey.sections_size(), 5);
+    // The first section is the crowfly
+    auto section = journey.sections(1);
+    BOOST_CHECK_EQUAL(section.id(), "section_1");
     BOOST_CHECK_EQUAL(section.origin().name(), "stop1");
     BOOST_CHECK_EQUAL(section.destination().name(), "stop2");
-    section = journey.sections(1);
-    BOOST_CHECK_EQUAL(section.id(), "section_1");//section_1 is the transfert
     section = journey.sections(2);
-    BOOST_CHECK_EQUAL(section.id(), "section_2");
+    BOOST_CHECK_EQUAL(section.id(), "section_2");//section_1 is the transfer
+    section = journey.sections(3);
+    BOOST_CHECK_EQUAL(section.id(), "section_3");
     BOOST_CHECK_EQUAL(section.origin().name(), "stop2");
     BOOST_CHECK_EQUAL(section.destination().name(), "stop5");
 
@@ -119,11 +120,11 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].cost().value(), 100);
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].cost().currency(), "euro");
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].section_id_size(), 1);
-    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].section_id(0), "section_0");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].section_id(0), "section_1");
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].name(), "price2");
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].cost().value(), 200);
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].cost().currency(), "euro");
-    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].section_id(0), "section_2");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].section_id(0), "section_3");
 
 }
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -122,8 +122,6 @@ class GeoJson(fields.Raw):
 
     def output(self, key, obj):
         coords = []
-        length = 0
-        enum = obj.DESCRIPTOR.fields_by_name['type'].enum_type.values_by_name
         if obj.type == SectionType.Value('STREET_NETWORK'):
             try:
                 if obj.HasField("street_network"):

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -59,6 +59,8 @@ import sys
 from copy import copy
 from datetime import datetime
 from collections import defaultdict
+from navitiacommon.type_pb2 import NavitiaType
+from navitiacommon.response_pb2 import SectionType
 
 f_datetime = "%Y%m%dT%H%M%S"
 
@@ -122,7 +124,7 @@ class GeoJson(fields.Raw):
         coords = []
         length = 0
         enum = obj.DESCRIPTOR.fields_by_name['type'].enum_type.values_by_name
-        if obj.type == enum['STREET_NETWORK'].number:
+        if obj.type == SectionType.Value('STREET_NETWORK'):
             try:
                 if obj.HasField("street_network"):
                     coords = obj.street_network.coordinates
@@ -130,11 +132,24 @@ class GeoJson(fields.Raw):
                     return None
             except ValueError:
                 return None
-        elif obj.type == enum['PUBLIC_TRANSPORT'].number:
+        elif obj.type == SectionType.Value('PUBLIC_TRANSPORT'):
             coords = [sdt.stop_point.coord for sdt in obj.stop_date_times]
-        elif obj.type == enum['TRANSFER'].number:
+        elif obj.type == SectionType.Value('TRANSFER'):
             coords.append(obj.origin.stop_point.coord)
             coords.append(obj.destination.stop_point.coord)
+        elif obj.type == SectionType.Value('CROW_FLY'):
+            for place in [obj.origin, obj.destination]:
+                type_ = place.embedded_type
+                if type_ == NavitiaType.Value('STOP_POINT'):
+                    coords.append(place.stop_point.coord)
+                elif type_ == NavitiaType.Value('STOP_AREA'):
+                    coords.append(place.stop_area.coord)
+                elif type_ == NavitiaType.Value('POI'):
+                    coords.append(place.poi.coord)
+                elif type_ == NavitiaType.Value('ADDRESS'):
+                    coords.append(place.address.coord)
+                elif type_ == NavitiaType.Value('ADMINISTRATIVE_REGION'):
+                    coords.append(place.administrative_region.coord)
         else:
             return None
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -59,8 +59,7 @@ import sys
 from copy import copy
 from datetime import datetime
 from collections import defaultdict
-from navitiacommon.type_pb2 import NavitiaType
-from navitiacommon.response_pb2 import SectionType
+from navitiacommon import type_pb2, response_pb2
 
 f_datetime = "%Y%m%dT%H%M%S"
 
@@ -122,7 +121,7 @@ class GeoJson(fields.Raw):
 
     def output(self, key, obj):
         coords = []
-        if obj.type == SectionType.Value('STREET_NETWORK'):
+        if obj.type == response_pb2.STREET_NETWORK:
             try:
                 if obj.HasField("street_network"):
                     coords = obj.street_network.coordinates
@@ -130,23 +129,23 @@ class GeoJson(fields.Raw):
                     return None
             except ValueError:
                 return None
-        elif obj.type == SectionType.Value('PUBLIC_TRANSPORT'):
+        elif obj.type == response_pb2.PUBLIC_TRANSPORT:
             coords = [sdt.stop_point.coord for sdt in obj.stop_date_times]
-        elif obj.type == SectionType.Value('TRANSFER'):
+        elif obj.type == response_pb2.TRANSFER:
             coords.append(obj.origin.stop_point.coord)
             coords.append(obj.destination.stop_point.coord)
-        elif obj.type == SectionType.Value('CROW_FLY'):
+        elif obj.type == response_pb2.CROW_FLY:
             for place in [obj.origin, obj.destination]:
                 type_ = place.embedded_type
-                if type_ == NavitiaType.Value('STOP_POINT'):
+                if type_ == type_pb2.STOP_POINT:
                     coords.append(place.stop_point.coord)
-                elif type_ == NavitiaType.Value('STOP_AREA'):
+                elif type_ == type_pb2.STOP_AREA:
                     coords.append(place.stop_area.coord)
-                elif type_ == NavitiaType.Value('POI'):
+                elif type_ == type_pb2.POI:
                     coords.append(place.poi.coord)
-                elif type_ == NavitiaType.Value('ADDRESS'):
+                elif type_ == type_pb2.ADDRESS:
                     coords.append(place.address.coord)
-                elif type_ == NavitiaType.Value('ADMINISTRATIVE_REGION'):
+                elif type_ == type_pb2.ADMINISTRATIVE_REGION:
                     coords.append(place.administrative_region.coord)
         else:
             return None

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -130,7 +130,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
             // we indicate a time.
             if (origin.type == type::Type_e::StopArea && origin.uri != sp_dest->stop_area->uri) {
                 const auto duration = worker.get_distance(sp_dest->idx);
-                if (!duration.is_pos_infinity() && !duration.is_neg_infinity() && !duration.is_not_a_date_time()) {
+                if (!duration.is_special()) {
                     auto* first_section = pb_journey->mutable_sections(0);
                     first_section->set_duration(duration.total_seconds());
                     first_section->mutable_street_network()->set_mode(convert(origin.streetnetwork_params.mode));
@@ -286,7 +286,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
             if (destination.type == type::Type_e::StopArea &&
                     destination.uri != sp_orig->stop_area->uri && pb_journey->sections_size() > 0) {
                 auto duration = worker.get_distance(sp_orig->idx, true);
-                if (!duration.is_pos_infinity() && !duration.is_neg_infinity() && !duration.is_not_a_date_time()) {
+                if (!duration.is_special()) {
                     auto* last_section = pb_journey->mutable_sections(pb_journey->sections_size()-1);
                     last_section->set_duration(duration.total_seconds());
                     last_section->mutable_street_network()->set_mode(convert(destination.streetnetwork_params.mode));

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -111,7 +111,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
          * 1) We start from an area, we will add a crow fly section from the centroid of the area
          *    to the origin stop point of the first section
          * 2) We start from a ponctual place (everything but stop_area or admin)
-         * We had a street network section from this place to the departure of the first pt_section
+         * We add a street network section from this place to the departure of the first pt_section
          * If the uri of the origin point and the uri of the departure of the first section are the
          * same we do nothing
          * */
@@ -126,7 +126,7 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                                           path.items.front().departures.front()+bt::minutes(1));
             fill_crowfly_section(origin, destination_tmp, path.items.front().departures.front(),
                                  d, enhanced_response, pb_journey, now, action_period);
-            // If we start from a stop_area, and the last stop point is not from that stop_area,
+            // If we start from a stop_area, and the first stop point is not from that stop_area,
             // we indicate a time.
             if (origin.type == type::Type_e::StopArea && origin.uri != sp_dest->stop_area->uri) {
                 const auto duration = worker.get_distance(sp_dest->idx);
@@ -157,14 +157,13 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     auto section = pb_journey->mutable_sections(pb_journey->mutable_sections()->size()-1);
                     bt::time_period action_period(boost::posix_time::from_iso_string(section->begin_date_time()),
                                                   boost::posix_time::from_iso_string(section->end_date_time()));
-                    // We had coherence with the origin of the request
+                    // We add coherence with the origin of the request
                     fill_pb_placemark(origin, d, section->mutable_origin(), 2, now, action_period, show_codes);
-                    // We had coherence with the first pt section
+                    // We add coherence with the first pt section
                     fill_pb_placemark(departure_stop_point, d, section->mutable_destination(), 2, now, action_period, show_codes);
                 }
             }
         }
-        // Here we make origin and departure consistent with the parameters and the first section
 
         const type::VehicleJourney* vj(nullptr);
         size_t item_idx(0);
@@ -312,12 +311,12 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                                 begin_section_time);
                         arrival_time = arrival_time + temp.duration.to_posix();
                     }
-                    // We had coherence with the last pt section
+                    // We add coherence with the last pt section
                     auto section = pb_journey->mutable_sections(pb_journey->mutable_sections()->size()-1);
                     bt::time_period action_period(boost::posix_time::from_iso_string(section->begin_date_time()),
                                                   boost::posix_time::from_iso_string(section->end_date_time()));
                     fill_pb_placemark(arrival_stop_point, d, section->mutable_origin(), 2, now, action_period, show_codes);
-                    //We had coherence with the destination object of the request
+                    //We add coherence with the destination object of the request
                     fill_pb_placemark(destination, d, section->mutable_destination(), 2, now, action_period, show_codes);
                 }
             }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -142,6 +142,13 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     const auto walking_time = temp.duration;
                     departure_time = path.items.front().departure - walking_time.to_posix();
                     fill_street_sections(enhanced_response, origin, temp, d, pb_journey, departure_time);
+                    auto section = pb_journey->mutable_sections(pb_journey->mutable_sections()->size()-1);
+                    bt::time_period action_period(boost::posix_time::from_iso_string(section->begin_date_time()),
+                                                  boost::posix_time::from_iso_string(section->end_date_time()));
+                    // We had coherence with the origin of the request
+                    fill_pb_placemark(origin, d, section->mutable_origin(), 2, now, action_period, show_codes);
+                    // We had coherence with the first pt section
+                    fill_pb_placemark(departure_stop_point, d, section->mutable_destination(), 2, now, action_period, show_codes);
                 }
             }
         }
@@ -282,6 +289,13 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                                 begin_section_time);
                         arrival_time = arrival_time + temp.duration.to_posix();
                     }
+                    // We had coherence with the last pt section
+                    auto section = pb_journey->mutable_sections(pb_journey->mutable_sections()->size()-1);
+                    bt::time_period action_period(boost::posix_time::from_iso_string(section->begin_date_time()),
+                                                  boost::posix_time::from_iso_string(section->end_date_time()));
+                    fill_pb_placemark(arrival_stop_point, d, section->mutable_origin(), 2, now, action_period, show_codes);
+                    //We had coherence with the destination object of the request
+                    fill_pb_placemark(destination, d, section->mutable_destination(), 2, now, action_period, show_codes);
                 }
             }
         }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -134,6 +134,8 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     auto* first_section = pb_journey->mutable_sections(0);
                     first_section->set_duration(duration.total_seconds());
                     first_section->mutable_street_network()->set_mode(convert(origin.streetnetwork_params.mode));
+                    departure_time = path.items.front().departures.front() - duration.to_posix();
+                    first_section->set_begin_date_time(navitia::to_iso_string_no_fractional(departure_time));
                 }
             }
 
@@ -290,6 +292,8 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     auto* last_section = pb_journey->mutable_sections(pb_journey->sections_size()-1);
                     last_section->set_duration(duration.total_seconds());
                     last_section->mutable_street_network()->set_mode(convert(destination.streetnetwork_params.mode));
+                    arrival_time = path.items.back().departures.back() + duration.to_posix();
+                    last_section->set_end_date_time(navitia::to_iso_string_no_fractional(arrival_time));
                 }
             }
         } else {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1304,4 +1304,15 @@ void fill_pb_object(const std::string comment, const nt::Data&,
     note->set_uri("note:"+std::to_string(hash_fn(comment)));
     note->set_note(comment);
 }
+
+pbnavitia::StreetNetworkMode convert(const navitia::type::Mode_e& mode) {
+    switch (mode) {
+        case navitia::type::Mode_e::Walking : return pbnavitia::Walking;
+        case navitia::type::Mode_e::Bike : return pbnavitia::Bike;
+        case navitia::type::Mode_e::Car : return pbnavitia::Car;
+        case navitia::type::Mode_e::Bss : return pbnavitia::Bss;
+    }
+    return pbnavitia::Walking;
+}
+
 }//namespace navitia

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1312,7 +1312,9 @@ pbnavitia::StreetNetworkMode convert(const navitia::type::Mode_e& mode) {
         case navitia::type::Mode_e::Car : return pbnavitia::Car;
         case navitia::type::Mode_e::Bss : return pbnavitia::Bss;
     }
-    return pbnavitia::Walking;
+    throw navitia::exception("Techinical Error, unable to convert mode " +
+            std::to_string(static_cast<int>(mode)));
+
 }
 
 }//namespace navitia

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -881,16 +881,16 @@ pbnavitia::Section* create_section(EnhancedResponse& response, pbnavitia::Journe
 
 void fill_pb_placemark(const type::EntryPoint& point, const type::Data &data,
                        pbnavitia::Place* place, int max_depth, const pt::ptime& now,
-                       const pt::time_period& action_period) {
+                       const pt::time_period& action_period, const bool show_codes) {
     if (point.type == type::Type_e::StopPoint) {
         const auto it = data.pt_data->stop_points_map.find(point.uri);
         if (it != data.pt_data->stop_points_map.end()) {
-            fill_pb_placemark(it->second, data, place, max_depth, now, action_period);
+            fill_pb_placemark(it->second, data, place, max_depth, now, action_period, show_codes);
         }
     } else if (point.type == type::Type_e::StopArea) {
         const auto it = data.pt_data->stop_areas_map.find(point.uri);
         if (it != data.pt_data->stop_areas_map.end()) {
-            fill_pb_placemark(it->second, data, place, max_depth, now, action_period);
+            fill_pb_placemark(it->second, data, place, max_depth, now, action_period, show_codes);
         }
     } else if (point.type == type::Type_e::POI) {
         const auto it = data.geo_ref->poi_map.find(point.uri);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -677,7 +677,7 @@ void fill_pb_placemark(const navitia::georef::Admin* admin,
 void fill_pb_placemark(const navitia::georef::POI* poi,
                        const type::Data &data, pbnavitia::Place* place,
                        int max_depth, const pt::ptime& now,
-                       const pt::time_period& action_period){
+                       const pt::time_period& action_period) {
     if(poi == nullptr)
         return;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -853,7 +853,7 @@ pbnavitia::Section* create_section(EnhancedResponse& response, pbnavitia::Journe
         int depth, const pt::ptime& now, const pt::time_period& action_period) {
 
     auto section = pb_journey->add_sections();
-    section->set_id(response.register_section(first_item));
+    section->set_id(response.register_section());
     section->set_type(pbnavitia::STREET_NETWORK);
 
     pbnavitia::Place* orig_place = section->mutable_origin();
@@ -877,6 +877,53 @@ pbnavitia::Section* create_section(EnhancedResponse& response, pbnavitia::Journe
     //NOTE: do we want to add a placemark for crow fly sections (they won't have a proper way) ?
 
     return section;
+}
+
+void fill_pb_placemark(const type::EntryPoint& point, const type::Data &data,
+                       pbnavitia::Place* place, int max_depth, const pt::ptime& now,
+                       const pt::time_period& action_period) {
+    if (point.type == type::Type_e::StopPoint) {
+        const auto it = data.pt_data->stop_points_map.find(point.uri);
+        if (it != data.pt_data->stop_points_map.end()) {
+            fill_pb_placemark(it->second, data, place, max_depth, now, action_period);
+        }
+    } else if (point.type == type::Type_e::StopArea) {
+        const auto it = data.pt_data->stop_areas_map.find(point.uri);
+        if (it != data.pt_data->stop_areas_map.end()) {
+            fill_pb_placemark(it->second, data, place, max_depth, now, action_period);
+        }
+    } else if (point.type == type::Type_e::POI) {
+        const auto it = data.geo_ref->poi_map.find(point.uri);
+        if (it != data.geo_ref->poi_map.end()) {
+            fill_pb_placemark(data.geo_ref->pois[it->second], data, place, max_depth, now, action_period);
+        }
+    } else if (point.type == type::Type_e::Admin) {
+        const auto it = data.geo_ref->admin_map.find(point.uri);
+        if (it != data.geo_ref->admin_map.end()) {
+            fill_pb_placemark(data.geo_ref->admins[it->second], data, place, max_depth, now, action_period);
+        }
+    }
+}
+
+void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
+                          boost::posix_time::ptime time, const type::Data& data, EnhancedResponse& response,
+                          pbnavitia::Journey* pb_journey, const pt::ptime& now,
+                          const pt::time_period& action_period) {
+    pbnavitia::Section* section = pb_journey->add_sections();
+    section->set_id(response.register_section());
+    fill_pb_placemark(origin, data, section->mutable_origin(), 2, now, action_period);
+    fill_pb_placemark(destination, data, section->mutable_destination(), 2, now, action_period);
+    section->set_begin_date_time(navitia::to_iso_string_no_fractional(time));
+    section->set_duration(0);
+    section->set_length(0);
+    section->set_end_date_time(navitia::to_iso_string_no_fractional(time));
+    section->set_type(pbnavitia::SectionType::CROW_FLY);
+    auto coord = section->mutable_street_network()->add_coordinates();
+    coord->set_lat(origin.coordinates.lat());
+    coord->set_lon(origin.coordinates.lon());
+    coord = section->mutable_street_network()->add_coordinates();
+    coord->set_lat(destination.coordinates.lat());
+    coord->set_lon(destination.coordinates.lon());
 }
 
 void fill_street_sections(EnhancedResponse& response, const type::EntryPoint& ori_dest,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -50,6 +50,8 @@ namespace navitia{
         class Ticket;
     }
 }
+namespace pt = boost::posix_time;
+
 #define null_time_period boost::posix_time::time_period(boost::posix_time::not_a_date_time, boost::posix_time::seconds(0))
 
 namespace navitia {
@@ -65,8 +67,9 @@ struct EnhancedResponse {
         return routing_section_map[{j, section_idx}];
     }
 
-    std::string register_section(const georef::PathItem& /*georef_item*/) {
-        //we don't need to register the georef item
+    std::string register_section() {
+        // For some section (transfer, waiting, streetnetwork, corwfly) we don't need info
+        // about the item
         return "section_" + boost::lexical_cast<std::string>(nb_sections++);
     }
 
@@ -133,6 +136,15 @@ void fill_pb_placemark(const navitia::georef::Admin* admin, const type::Data &da
 void fill_pb_placemark(const navitia::georef::POI* poi, const type::Data &data, pbnavitia::Place* place, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period);
+
+void fill_pb_placemark(const type::EntryPoint& origin, const type::Data &data, pbnavitia::Place* place, int max_depth = 0,
+        const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
+        const boost::posix_time::time_period& action_period = null_time_period);
+
+
+void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination, boost::posix_time::ptime time,
+                          const type::Data& data, EnhancedResponse &response,  pbnavitia::Journey* pb_journey,
+                          const pt::ptime& now, const pt::time_period& action_period);
 
 void fill_fare_section(EnhancedResponse& pb_response, pbnavitia::Journey* pb_journey, const fare::results& fare);
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -217,4 +217,6 @@ void fill_pb_object(const std::string comment, const type::Data& data,
 void fill_pb_object(const navitia::type::StopTime* st, const type::Data& data,
                     pbnavitia::Properties* properties, int max_depth,
                     const boost::posix_time::ptime& now, const boost::posix_time::time_period& action_period);
+
+pbnavitia::StreetNetworkMode convert(const navitia::type::Mode_e& mode);
 }//namespace navitia

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -139,7 +139,8 @@ void fill_pb_placemark(const navitia::georef::POI* poi, const type::Data &data, 
 
 void fill_pb_placemark(const type::EntryPoint& origin, const type::Data &data, pbnavitia::Place* place, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
-        const boost::posix_time::time_period& action_period = null_time_period);
+        const boost::posix_time::time_period& action_period = null_time_period,
+        const bool show_codes = false);
 
 
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination, boost::posix_time::ptime time,

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -63,6 +63,7 @@ enum SectionType {
     landing = 7;
     BSS_RENT = 8;
     BSS_PUT_BACK = 9;
+    CROW_FLY = 10;
 }
 
 enum TransferType {


### PR DESCRIPTION
**Add coherence in journey' sections**

We want to have coherence between the from (to) of a section and the from (to) of the request.
It also adds coherence between the to (from) of the streetnetwork section and the  from(to) of the first (last) public transport section. Therefore the to(from) of the streetnetwork section is now a stop_point, you still have the adress of the stop point in the place.

We also don't really know from where we start when we start from a area (a stop_area or an admin), thus we added a crow_fly section which starts from the centroid of this area and goes to the first stop_point of the first pt_section.
