### PR TITLE
Move frequency paramaters to VJ

### DIFF
--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -630,11 +630,10 @@ void FrequenciesGtfsHandler::handle_line(Data&, const csv_row& row, bool) {
         return;
     auto vj_it = gtfs_data.vj_map.find(row[trip_id_c]);
     if(vj_it != gtfs_data.vj_map.end()) {
-        int begin = vj_it->second->stop_time_list.front()->arrival_time;
         for(auto st_it = vj_it->second->stop_time_list.begin(); st_it != vj_it->second->stop_time_list.end(); ++st_it) {
-            (*st_it)->start_time = time_to_int(row[start_time_c]) + (*st_it)->arrival_time - begin;
-            (*st_it)->end_time = time_to_int(row[end_time_c]) + (*st_it)->arrival_time - begin;
-            (*st_it)->headway_secs = boost::lexical_cast<int>(row[headway_secs_c]);
+            (*st_it)->vehicle_journey->start_time = time_to_int(row[start_time_c]);
+            (*st_it)->vehicle_journey->end_time = time_to_int(row[end_time_c]) ;
+            (*st_it)->vehicle_journey->headway_secs = boost::lexical_cast<int>(row[headway_secs_c]);
             (*st_it)->is_frequency = true;
         }
     }

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -501,16 +501,18 @@ bool same_journey_pattern(types::VehicleJourney * vj1, types::VehicleJourney * v
     return true;
 }
 
-
+//For frequency based trips, make arrival and departure time relative from first stop.
 void Data::finalize_frequency() {
     for(auto * vj : this->vehicle_journeys) {
         if(!vj->stop_time_list.empty() && vj->stop_time_list.front()->is_frequency) {
             auto * first_st = vj->stop_time_list.front();
-            size_t nb_trips = std::ceil((first_st->end_time - first_st->start_time)/first_st->headway_secs);
+            int begin = first_st->arrival_time;
+            if (begin == 0){
+                continue; //Time is already relative to 0
+            }
             for(auto * st : vj->stop_time_list) {
-                st->start_time = first_st->start_time+(st->arrival_time - first_st->arrival_time);
-                st->end_time = first_st->start_time + nb_trips * st->headway_secs;
-                st->end_time += (st->departure_time - first_st->departure_time);
+                st->arrival_time   -= begin;
+                st->departure_time -= begin;
             }
         }
     }

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -724,8 +724,8 @@ void EdPersistor::insert_validity_patterns(const std::vector<types::ValidityPatt
 
 void EdPersistor::insert_stop_times(const std::vector<types::StopTime*>& stop_times){
     this->lotus.prepare_bulk_insert("navitia.stop_time",
-            {"arrival_time", "departure_time", "local_traffic_zone", "start_time",
-             "end_time", "headway_sec", "odt", "pick_up_allowed", "drop_off_allowed",
+            {"arrival_time", "departure_time", "local_traffic_zone", "odt",
+             "pick_up_allowed", "drop_off_allowed",
              "is_frequency", "journey_pattern_point_id", "vehicle_journey_id",
              "comment", "date_time_estimated"});
     size_t inserted_count = 0;
@@ -739,9 +739,6 @@ void EdPersistor::insert_stop_times(const std::vector<types::StopTime*>& stop_ti
         }else{
             values.push_back(lotus.null_value);
         }
-        values.push_back(std::to_string(stop->start_time));
-        values.push_back(std::to_string(stop->end_time));
-        values.push_back(std::to_string(stop->headway_secs));
         values.push_back(std::to_string(stop->ODT));
         values.push_back(std::to_string(stop->pick_up_allowed));
         values.push_back(std::to_string(stop->drop_off_allowed));
@@ -765,10 +762,8 @@ void EdPersistor::insert_stop_times(const std::vector<types::StopTime*>& stop_ti
             lotus.finish_bulk_insert();
             LOG4CPLUS_INFO(logger, inserted_count<<"/"<< size_st <<" inserted stop times");
             this->lotus.prepare_bulk_insert("navitia.stop_time",
-            {"arrival_time", "departure_time", "local_traffic_zone", "start_time",
-             "end_time", "headway_sec", "odt", "pick_up_allowed", "drop_off_allowed",
-             "is_frequency", "journey_pattern_point_id", "vehicle_journey_id",
-             "comment", "date_time_estimated"});
+            {"arrival_time", "departure_time", "local_traffic_zone", "odt", "pick_up_allowed", "drop_off_allowed",
+             "is_frequency", "journey_pattern_point_id", "vehicle_journey_id", "comment", "date_time_estimated"});
         }
     }
     this->lotus.finish_bulk_insert();
@@ -836,6 +831,7 @@ void EdPersistor::insert_vehicle_properties(const std::vector<types::VehicleJour
 void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourney*>& vehicle_journeys){
     this->lotus.prepare_bulk_insert("navitia.vehicle_journey",
             {"id", "uri", "external_code", "name", "comment", "validity_pattern_id",
+             "start_time", "end_time", "headway_secs",
              "adapted_validity_pattern_id", "company_id", "journey_pattern_id",
              "theoric_vehicle_journey_id", "vehicle_properties_id",
              "odt_type_id", "odt_message"});
@@ -847,11 +843,17 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(vj->external_code);
         values.push_back(vj->name);
         values.push_back(vj->comment);
+
         if(vj->validity_pattern != NULL){
             values.push_back(std::to_string(vj->validity_pattern->idx));
         }else{
             values.push_back(lotus.null_value);
         }
+
+        values.push_back(std::to_string(vj->start_time));
+        values.push_back(std::to_string(vj->end_time));
+        values.push_back(std::to_string(vj->headway_secs));
+
         if(vj->adapted_validity_pattern != NULL){
             values.push_back(std::to_string(vj->adapted_validity_pattern->idx));
         }else{

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -609,6 +609,9 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "vj.external_code as external_code,"
         "vj.next_vehicle_journey_id as prev_vj_id,"
         "vj.previous_vehicle_journey_id as next_vj_id,"
+        "vj.start_time as start_time,"
+        "vj.end_time as end_time,"
+        "vj.headway_sec as headway_sec,"
         "vp.wheelchair_accessible as wheelchair_accessible,"
         "vp.bike_accepted as bike_accepted,"
         "vp.air_conditioned as air_conditioned,"
@@ -638,6 +641,10 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         vj->company = company_map[const_it["company_id"].as<idx_t>()];
 
         vj->adapted_validity_pattern = validity_pattern_map[const_it["adapted_validity_pattern_id"].as<idx_t>()];
+
+        const_it["start_time"].to(vj->start_time);
+        const_it["end_time"].to(vj->end_time);
+        const_it["headway_sec"].to(vj->headway_secs);
 
         if(!const_it["validity_pattern_id"].is_null()){
             vj->validity_pattern = validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
@@ -690,8 +697,8 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
 
 void EdReader::fill_stop_times(nt::Data& data, pqxx::work& work){
     std::string request = "SELECT vehicle_journey_id, journey_pattern_point_id, arrival_time, departure_time, " // 0, 1, 2, 3
-        "local_traffic_zone, start_time, end_time, headway_sec, odt, pick_up_allowed, " // 4, 5, 6, 7, 8, 9, 10
-        "drop_off_allowed, is_frequency, date_time_estimated, comment " // 11, 12
+        "local_traffic_zone, odt, pick_up_allowed, " // 4, 5, 6, 7
+        "drop_off_allowed, is_frequency, date_time_estimated, comment " // 8, 9
         "FROM navitia.stop_time;";
 
     pqxx::result result = work.exec(request);
@@ -700,9 +707,6 @@ void EdReader::fill_stop_times(nt::Data& data, pqxx::work& work){
         const_it["arrival_time"].to(stop->arrival_time);
         const_it["departure_time"].to(stop->departure_time);
         const_it["local_traffic_zone"].to(stop->local_traffic_zone);
-        const_it["start_time"].to(stop->start_time);
-        const_it["end_time"].to(stop->end_time);
-        const_it["headway_sec"].to(stop->headway_secs);
         const_it["comment"].to(stop->comment);
 
         stop->set_date_time_estimated(const_it["date_time_estimated"].as<bool>());

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -337,9 +337,6 @@ nt::StopTime* StopTime::get_navitia_type() const {
     nt::StopTime* nt_stop = new nt::StopTime();
     nt_stop->arrival_time = this->arrival_time;
     nt_stop->departure_time = this->departure_time;
-    nt_stop->start_time = this->start_time;
-    nt_stop->end_time = this->end_time;
-    nt_stop->headway_secs = this->headway_secs;
     nt_stop->properties[nt::StopTime::ODT] = this->ODT;
     nt_stop->properties[nt::StopTime::DROP_OFF] = this->drop_off_allowed;
     nt_stop->properties[nt::StopTime::PICK_UP] = this->pick_up_allowed;
@@ -386,6 +383,9 @@ nt::VehicleJourney* VehicleJourney::get_navitia_type() const {
     nt_vj->name = this->name;
     nt_vj->uri = this->uri;
     nt_vj->comment = this->comment;
+    nt_vj->start_time = this->start_time;
+    nt_vj->end_time = this->end_time;
+    nt_vj->headway_secs = this->headway_secs;
 
     if(this->company != NULL)
         nt_vj->company->idx = this->company->idx;

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -223,6 +223,10 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     std::string block_id;
     std::string odt_message;
 
+    int start_time = std::numeric_limits<int>::max(); /// First departure of vehicle
+    int end_time = std::numeric_limits<int>::max(); /// Last departure of vehicle journey
+    int headway_secs = std::numeric_limits<int>::max(); /// Seconds between each departure.
+
     bool is_adapted;
     ValidityPattern* adapted_validity_pattern = nullptr;
     std::vector<VehicleJourney*> adapted_vehicle_journey_list;
@@ -298,9 +302,6 @@ struct StopPoint : public Header, Nameable, hasProperties{
 struct StopTime : public Nameable {
     int arrival_time; ///< En secondes depuis minuit
     int departure_time; ///< En secondes depuis minuit
-    int start_time; /// Si horaire en fréquence
-    int end_time; /// Si horaire en fréquence
-    int headway_secs; /// Si horaire en fréquence
     VehicleJourney* vehicle_journey;
     JourneyPatternPoint* journey_pattern_point;
     StopPoint * tmp_stop_point;// ne pas remplir obligatoirement
@@ -314,8 +315,7 @@ struct StopTime : public Nameable {
 
     uint16_t local_traffic_zone;
 
-    StopTime(): arrival_time(0), departure_time(0), start_time(std::numeric_limits<int>::max()), end_time(std::numeric_limits<int>::max()),
-        headway_secs(std::numeric_limits<int>::max()), vehicle_journey(NULL), journey_pattern_point(NULL), tmp_stop_point(NULL), order(0),
+    StopTime(): arrival_time(0), departure_time(0), vehicle_journey(NULL), journey_pattern_point(NULL), tmp_stop_point(NULL), order(0),
         ODT(false), pick_up_allowed(false), drop_off_allowed(false), is_frequency(false), wheelchair_boarding(false),date_time_estimated(false),
                 local_traffic_zone(std::numeric_limits<uint16_t>::max()) {}
 

--- a/source/routing/best_stoptime.h
+++ b/source/routing/best_stoptime.h
@@ -59,11 +59,10 @@ best_stop_time(const type::JourneyPatternPoint* jpp,
           const type::VehicleProperties & vehicle_properties,
           const bool clockwise, bool disruption_active, const type::Data &data, bool reconstructing_path = false);
 
-/// Pour les horaires en frequences
-
+/// For timetables in frequency-model
 inline u_int32_t f_arrival_time(uint32_t hour, const type::StopTime* st) {
-    const u_int32_t lower_bound = st->start_time;
-    const u_int32_t higher_bound = st->end_time - (st->departure_time - st->arrival_time);
+    const u_int32_t lower_bound = st->vehicle_journey->start_time + st->arrival_time;
+    const u_int32_t higher_bound = st->vehicle_journey->end_time  + st->arrival_time;
     // If higher bound is overmidnight the hour can be either in [lower_bound;midnight] or in
     // [midnight;higher_bound]
     if((higher_bound < DateTimeUtils::SECONDS_PER_DAY && hour>=lower_bound && hour<=higher_bound) ||
@@ -72,10 +71,10 @@ inline u_int32_t f_arrival_time(uint32_t hour, const type::StopTime* st) {
                  || (hour + DateTimeUtils::SECONDS_PER_DAY) <= higher_bound) )) {
         if(hour < lower_bound)
             hour += DateTimeUtils::SECONDS_PER_DAY;
-        const uint32_t x = std::floor(double(hour - lower_bound) / double(st->headway_secs));
-        BOOST_ASSERT(x*st->headway_secs+lower_bound <= hour);
-        BOOST_ASSERT(((hour - (x*st->headway_secs+lower_bound))%DateTimeUtils::SECONDS_PER_DAY) <= st->headway_secs);
-        return lower_bound + x * st->headway_secs;
+        const uint32_t x = std::floor(double(hour - lower_bound) / double(st->vehicle_journey->headway_secs));
+        BOOST_ASSERT(x*st->vehicle_journey->headway_secs+lower_bound <= hour);
+        BOOST_ASSERT(((hour - (x*st->vehicle_journey->headway_secs+lower_bound))%DateTimeUtils::SECONDS_PER_DAY) <= st->vehicle_journey->headway_secs);
+        return lower_bound + x * st->vehicle_journey->headway_secs;
     } else {
         return higher_bound;
     }
@@ -83,8 +82,8 @@ inline u_int32_t f_arrival_time(uint32_t hour, const type::StopTime* st) {
 
 
 inline u_int32_t f_departure_time(uint32_t hour, const type::StopTime* st) {
-    const u_int32_t lower_bound = st->start_time + (st->departure_time - st->arrival_time);
-    const u_int32_t higher_bound = st->end_time;
+    const u_int32_t lower_bound = st->vehicle_journey->start_time + st->departure_time;;
+    const u_int32_t higher_bound = st->vehicle_journey->end_time + st->departure_time;;
     // If higher bound is overmidnight the hour can be either in [lower_bound;midnight] or in
     // [midnight;higher_bound]
     if((higher_bound < DateTimeUtils::SECONDS_PER_DAY && hour>=lower_bound && hour<=higher_bound) ||
@@ -93,10 +92,10 @@ inline u_int32_t f_departure_time(uint32_t hour, const type::StopTime* st) {
                  || (hour + DateTimeUtils::SECONDS_PER_DAY) <= higher_bound) )) {
         if(hour < lower_bound)
             hour += DateTimeUtils::SECONDS_PER_DAY;
-        const uint32_t x = std::ceil(double(hour - lower_bound) / double(st->headway_secs));
-        BOOST_ASSERT((x*st->headway_secs+lower_bound) >= hour);
-        BOOST_ASSERT((((x*st->headway_secs+lower_bound) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= st->headway_secs);
-        return lower_bound + x * st->headway_secs;
+        const uint32_t x = std::ceil(double(hour - lower_bound) / double(st->vehicle_journey->headway_secs));
+        BOOST_ASSERT((x*st->vehicle_journey->headway_secs+lower_bound) >= hour);
+        BOOST_ASSERT((((x*st->vehicle_journey->headway_secs+lower_bound) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= st->vehicle_journey->headway_secs);
+        return lower_bound + x * st->vehicle_journey->headway_secs;
     } else {
         return lower_bound;
     }

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -108,11 +108,11 @@ void dataRAPTOR::load(const type::PT_Data &data)
                         if(!st1->is_frequency())
                             time1 = DateTimeUtils::hour(st1->departure_time);
                         else
-                            time1 = DateTimeUtils::hour(st1->end_time);
+                            time1 = DateTimeUtils::hour(st1->vehicle_journey->end_time+st1->departure_time);
                         if(!st2->is_frequency())
                             time2 = DateTimeUtils::hour(st2->departure_time);
                         else
-                            time2 = DateTimeUtils::hour(st2->end_time);
+                            time2 = DateTimeUtils::hour(st2->vehicle_journey->end_time+st2->departure_time);
                         if(time1 == time2) {
                             auto st1_first = st1->vehicle_journey->stop_time_list.front();
                             auto st2_first = st2->vehicle_journey->stop_time_list.front();
@@ -130,7 +130,7 @@ void dataRAPTOR::load(const type::PT_Data &data)
                 if(!st->is_frequency())
                     time = DateTimeUtils::hour(st->departure_time);
                 else
-                    time = DateTimeUtils::hour(st->end_time);
+                    time = DateTimeUtils::hour(st->vehicle_journey->end_time+st->departure_time);
                 departure_times.push_back(time);
             }
 
@@ -140,11 +140,11 @@ void dataRAPTOR::load(const type::PT_Data &data)
                       if(!st1->is_frequency())
                           time1 = DateTimeUtils::hour(st1->arrival_time);
                       else
-                          time1 = DateTimeUtils::hour(st1->start_time);
+                          time1 = DateTimeUtils::hour(st1->vehicle_journey->start_time+st1->arrival_time);
                       if(!st2->is_frequency())
                           time2 = DateTimeUtils::hour(st2->arrival_time);
                       else
-                          time2 = DateTimeUtils::hour(st2->start_time);
+                          time2 = DateTimeUtils::hour(st2->vehicle_journey->start_time+st2->arrival_time);
                       if(time1 == time2) {
                           auto st1_first = st1->vehicle_journey->stop_time_list.front();
                           auto st2_first = st2->vehicle_journey->stop_time_list.front();
@@ -161,7 +161,7 @@ void dataRAPTOR::load(const type::PT_Data &data)
                 if(!st->is_frequency())
                     time = DateTimeUtils::hour(st->arrival_time);
                 else
-                    time = DateTimeUtils::hour(st->start_time);
+                    time = DateTimeUtils::hour(st->vehicle_journey->start_time+st->arrival_time);
                 arrival_times.push_back(time);
             }
         }

--- a/source/sql/ed/01-tables.sql
+++ b/source/sql/ed/01-tables.sql
@@ -246,7 +246,10 @@ CREATE TABLE IF NOT EXISTS navitia.vehicle_journey (
     vehicle_properties_id BIGINT NULL REFERENCES navitia.vehicle_properties,
     theoric_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey,
     previous_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey,
-    next_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey
+    next_vehicle_journey_id BIGINT REFERENCES navitia.vehicle_journey,
+    start_time INTEGER,
+    end_time INTEGER,
+    headway_sec INTEGER
 );
 
 ALTER TABLE navitia.vehicle_journey DROP COLUMN IF EXISTS physical_mode_id;
@@ -307,9 +310,6 @@ CREATE TABLE IF NOT EXISTS navitia.stop_time (
     arrival_time INTEGER,
     departure_time INTEGER,
     local_traffic_zone INTEGER,
-    start_time INTEGER,
-    end_time INTEGER,
-    headway_sec INTEGER,
     odt BOOLEAN NOT NULL,
     pick_up_allowed BOOLEAN NOT NULL,
     drop_off_allowed BOOLEAN NOT NULL,

--- a/source/sql/ed/02-migration.sql
+++ b/source/sql/ed/02-migration.sql
@@ -41,6 +41,21 @@ $$;
 DO $$
     BEGIN
         BEGIN
+            ALTER TABLE navitia.vehicle_journey ADD COLUMN start_time integer;
+            ALTER TABLE navitia.vehicle_journey ADD COLUMN end_time integer;
+            ALTER TABLE navitia.vehicle_journey ADD COLUMN headway_sec integer;
+            ALTER TABLE navitia.stop_time DROP COLUMN start_time;
+            ALTER TABLE navitia.stop_time DROP COLUMN end_time;
+            ALTER TABLE navitia.stop_time DROP COLUMN headway_sec;
+        EXCEPTION
+            WHEN duplicate_column THEN RAISE NOTICE 'column start_time,end_time,headway_sec already exists in navitia.vehicle_journey';
+        END;
+    END;
+$$;
+
+DO $$
+    BEGIN
+        BEGIN
             ALTER TABLE navitia.stop_point ADD COLUMN platform_code TEXT NULL DEFAULT NULL;
         EXCEPTION
             WHEN duplicate_column THEN RAISE NOTICE 'column platform_code already exists in navitia.stop_point.';

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -63,7 +63,7 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t> &j
                     test_add = true;
                     // Le prochain horaire observé doit être au minimum une seconde après
                     if(st.first->is_frequency()) {
-                        DateTimeUtils::update(dt_temp, st.first->end_time);
+                        DateTimeUtils::update(dt_temp, st.first->vehicle_journey->end_time+st.first->departure_time);
                     }
                     next_requested_datetime[jpp_idx] = dt_temp + 1;
                 }

--- a/source/type/tests/datetime.cpp
+++ b/source/type/tests/datetime.cpp
@@ -110,8 +110,9 @@ BOOST_AUTO_TEST_CASE(moins) {
 
 BOOST_AUTO_TEST_CASE(freq_stop_time_validation){
     type::StopTime st;
-    st.start_time = 8000;
-    st.end_time = 9000;
+    st.vehicle_journey = new type::VehicleJourney();
+    st.vehicle_journey->start_time = 8000;
+    st.vehicle_journey->end_time = 9000;
     st.properties.set(type::StopTime::IS_FREQUENCY);
     BOOST_CHECK(st.valid_hour(7999, true));
     BOOST_CHECK(st.valid_hour(8000, true));
@@ -124,8 +125,8 @@ BOOST_AUTO_TEST_CASE(freq_stop_time_validation){
     BOOST_CHECK(st.valid_hour(9000, false));
     BOOST_CHECK(st.valid_hour(9001, false));
 
-    st.start_time = 23 * 3600;
-    st.end_time = 26 * 3600;
+    st.vehicle_journey->start_time = 23 * 3600;
+    st.vehicle_journey->end_time = 26 * 3600;
     BOOST_CHECK(st.valid_hour(3600, true));
     BOOST_CHECK(st.valid_hour(22*3600, true));
     BOOST_CHECK(!st.valid_hour(22*3600 + 24*3600, true));

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -683,26 +683,24 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     JourneyPattern* journey_pattern;
     Company* company;
     ValidityPattern* validity_pattern;
+    ValidityPattern* adapted_validity_pattern;
+    VehicleJourney* theoric_vehicle_journey;
     std::vector<StopTime*> stop_time_list;
-    VehicleJourneyType vehicle_journey_type;
-    std::string odt_message;
-
-    uint32_t start_time = std::numeric_limits<uint32_t>::max(); ///< If frequency-modeled, first departure
-    uint32_t end_time = std::numeric_limits<uint32_t>::max(); ///< If frequency-modeled, last departure
-    uint32_t headway_secs = std::numeric_limits<uint32_t>::max(); ///< Seconds between each departure.
-
     // These variables are used in the case of an extension of service
     // They indicate what's the vj you can take directly after or before this one
     // They have the same block id
     VehicleJourney* next_vj = nullptr;
     VehicleJourney* prev_vj = nullptr;
+    std::string odt_message;
     ///map of the calendars that nearly match the validity pattern of the vj, key is the calendar name
     std::map<std::string, AssociatedCalendar*> associated_calendars;
 
-    bool is_adapted;
-    ValidityPattern* adapted_validity_pattern;
+    VehicleJourneyType vehicle_journey_type;
+    uint32_t start_time = std::numeric_limits<uint32_t>::max(); ///< If frequency-modeled, first departure
+    uint32_t end_time = std::numeric_limits<uint32_t>::max(); ///< If frequency-modeled, last departure
+    uint32_t headway_secs = std::numeric_limits<uint32_t>::max(); ///< Seconds between each departure.
     std::vector<VehicleJourney*> adapted_vehicle_journey_list;
-    VehicleJourney* theoric_vehicle_journey;
+    bool is_adapted;
 
     VehicleJourney(): journey_pattern(nullptr), company(nullptr),
         validity_pattern(nullptr),

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -703,10 +703,8 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     bool is_adapted;
 
     VehicleJourney(): journey_pattern(nullptr), company(nullptr),
-        validity_pattern(nullptr),
-        vehicle_journey_type(VehicleJourneyType::regular), is_adapted(false),
-        adapted_validity_pattern(nullptr), theoric_vehicle_journey(nullptr){}
-
+        validity_pattern(nullptr), adapted_validity_pattern(nullptr), theoric_vehicle_journey(nullptr)
+        vehicle_journey_type(VehicleJourneyType::regular), is_adapted(false) {}
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & name & uri & journey_pattern & company & validity_pattern


### PR DESCRIPTION
-Move frequency parameters from stop_time to vehicle_journey, save at least 3\* uint32_t per vehicle_journey
-Enforce arrival/departure time in stop_time to be relative from 0
-Calculate low/upper threshold using relative times and VJ frequency paramaters
-Reduces size of stop_time with 8 bytes, increases size of VJ by 16 byes.

IMPORTANT: fails best_stop_time test, but i have a feeling the test is wrong there, please verify.
