### PR TITLE
Use std::fill instead of assign

### DIFF
--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -151,9 +151,9 @@ void RAPTOR::clear(const bool clockwise, const DateTime bound) {
     b_dest.reinit(journey_pattern_points_size, bound);
     this->make_queue();
     if(clockwise)
-        best_labels.assign(journey_pattern_points_size, DateTimeUtils::inf);
+        std::fill(best_labels.begin(),best_labels.end(),DateTimeUtils::inf);
     else
-        best_labels.assign(journey_pattern_points_size, DateTimeUtils::min);
+        std::fill(best_labels.begin(),best_labels.end(),DateTimeUtils::min);
 }
 
 


### PR DESCRIPTION
See http://stackoverflow.com/posts/8849789/revisions, with -03 on std::assign appears to be slower than std:fill
This patch results in unscientifically tested 1-2% speedup on a dataset with 306776 journey_pattern_point's
