### PR TITLE
No longer use stop_area as first/last item

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -174,28 +174,13 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                     auto arr_time = item.arrivals[0];
                     auto dep_time = item.departures[0];
                     bt::time_period action_period(dep_time, arr_time);
-                    // On the first item, if the type of the origin point is a stop area
-                    // we want to display a stop area, otherwise a stop point
-                    if(path_i == path.items.begin() && origin.type == nt::Type_e::StopArea
-                            && origin.uri == item.stop_points.front()->stop_area->uri) {
-                        fill_pb_placemark(item.stop_points.front()->stop_area, d,
-                                pb_section->mutable_origin(), 1, now, action_period,
-                                show_codes);
-                    } else {
-                        fill_pb_placemark(item.stop_points.front(), d,
-                                pb_section->mutable_origin(), 1, now, action_period,
-                                show_codes);
+                    fill_pb_placemark(item.stop_points.front(), d,
+                            pb_section->mutable_origin(), 1, now, action_period,
+                            show_codes);
                     }
-                    if(path_i == path.items.end()-1 && destination.type == nt::Type_e::StopArea
-                            && destination.uri == item.stop_points.back()->stop_area->uri) {
-                        fill_pb_placemark(item.stop_points.back()->stop_area, d,
+                    fill_pb_placemark(item.stop_points.back(), d,
                                 pb_section->mutable_destination(), 1, now,
                                 action_period, show_codes);
-                    } else {
-                        fill_pb_placemark(item.stop_points.back(), d,
-                                pb_section->mutable_destination(), 1, now,
-                                action_period, show_codes);
-                    }
                 }
                 pb_section->set_length(length);
                 if( item.get_vj() != nullptr) { // TODO : réfléchir si ça peut vraiment arriver


### PR DESCRIPTION
We now have the crow_fly sections to indicate we start/end from/to a stop_area.
With this patch we get for the request from stop_area:lls to stop_area:asdz the following response

crow_fly stop_area:lls to platform 4 of stop_area:lls
train stop_area:lls platform 4 to stop_area:asdz platform 3
crow_fly stop_area:asdz_platform4 to stop_area:asdz

This gives the most consistent response
