### PR TITLE
Kraken: fix production_period in navitia

### DIFF
--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -374,7 +374,7 @@ void EdPersistor::persist_fare(const ed::Data& data) {
 void EdPersistor::insert_metadata(const navitia::type::MetaData& meta){
     std::string request = "insert into navitia.parameters (beginning_date, end_date) "
                           "VALUES ('" + bg::to_iso_extended_string(meta.production_date.begin()) +
-                          "', '" + bg::to_iso_extended_string(meta.production_date.end()) + "');";
+                          "', '" + bg::to_iso_extended_string(meta.production_date.last()) + "');";
     PQclear(this->lotus.exec(request));
 }
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -113,7 +113,7 @@ pbnavitia::Response Worker::status() {
     const auto d = data_manager.get_data();
     status->set_publication_date(pt::to_iso_string(d->meta->publication_date));
     status->set_start_production_date(bg::to_iso_string(d->meta->production_date.begin()));
-    status->set_end_production_date(bg::to_iso_string(d->meta->production_date.end()));
+    status->set_end_production_date(bg::to_iso_string(d->meta->production_date.last()));
     status->set_data_version(d->version);
     status->set_navimake_version(d->meta->navimake_version);
     status->set_navitia_version(KRAKEN_VERSION);
@@ -134,7 +134,7 @@ pbnavitia::Response Worker::metadatas() {
     auto metadatas = result.mutable_metadatas();
     const auto d = data_manager.get_data();
     metadatas->set_start_production_date(bg::to_iso_string(d->meta->production_date.begin()));
-    metadatas->set_end_production_date(bg::to_iso_string(d->meta->production_date.end()));
+    metadatas->set_end_production_date(bg::to_iso_string(d->meta->production_date.last()));
     metadatas->set_shape(d->meta->shape);
     metadatas->set_status("running");
     for(const type::Contributor* contributor : d->pt_data->contributors){

--- a/source/time_tables/request_handle.cpp
+++ b/source/time_tables/request_handle.cpp
@@ -42,10 +42,7 @@ RequestHandle::RequestHandle(const std::string& /*api*/, const std::string &requ
     try {
         auto ptime = boost::posix_time::from_iso_string(str_dt);
         if( !data.meta->production_date.contains(ptime.date()) ) {
-            fill_pb_error(pbnavitia::Error::date_out_of_bounds, "date is out of bound",pb_response.mutable_error());
-        } else if( !data.meta->production_date.contains((ptime + boost::posix_time::seconds(duration)).date()) ) {
-             // On regarde si la date + duration ne déborde pas de la période de production
-            fill_pb_error(pbnavitia::Error::date_out_of_bounds, "date is not in data production period",pb_response.mutable_error());
+            fill_pb_error(pbnavitia::Error::date_out_of_bounds, "date is out of bound", pb_response.mutable_error());
         }
         if(! pb_response.has_error()){
             date_time = DateTimeUtils::set((ptime.date() - data.meta->production_date.begin()).days(), ptime.time_of_day().total_seconds());


### PR DESCRIPTION
On date periods end() return one day past the last day in the period so
all call to end() has to be replaced by last().

Remove a test on timetables who check if the date and the duration was
on the production_period, now we only check the date. So even if the
requested period for the timetable overflow the production_period the
request will be served but will possibly return no circulation.

http://jira.canaltp.fr/browse/NAVITIAII-964
