### PR TITLE
Kraken: revert stop_times

### DIFF
--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -125,6 +125,7 @@ makePath(type::idx_t destination_idx, size_t countb, bool clockwise, bool disrup
             std::reverse(item.stop_points.begin(), item.stop_points.end());
             std::reverse(item.arrivals.begin(), item.arrivals.end());
             std::reverse(item.departures.begin(), item.departures.end());
+            std::reverse(item.stop_times.begin(), item.stop_times.end());
         }
     }
 


### PR DESCRIPTION
We use it just to get the vj, so the order is not very important
Maybe we can drop it, but for now, it has to be in the same order than
stop points
