### PR TITLE
Ed: fix build of validityPattern in gtfsParser

### DIFF
--- a/fixtures/ed/gtfs_google_example_no_dst/calendar.txt
+++ b/fixtures/ed/gtfs_google_example_no_dst/calendar.txt
@@ -1,3 +1,3 @@
 service_id,monday,tuesday,wednesday,thursday,friday,saturday,sunday,start_date,end_date
-FULLW,1,1,1,1,1,1,1,20070101,20101231
-WE,0,0,0,0,0,1,1,20070101,20101231
+FULLW,1,1,1,1,1,1,1,20100201,20101231
+WE,0,0,0,0,0,1,1,20100201,20101231

--- a/fixtures/ed/gtfs_google_example_no_dst/calendar_dates.txt
+++ b/fixtures/ed/gtfs_google_example_no_dst/calendar_dates.txt
@@ -1,2 +1,2 @@
 service_id,date,exception_type
-FULLW,20070604,2
+FULLW,20100604,2

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -606,7 +606,10 @@ void CalendarGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
     //Init the validity period
     boost::gregorian::date b_date = boost::gregorian::from_undelimited_string(row[start_date_c]);
     boost::gregorian::date_period period = boost::gregorian::date_period(
-                (b_date > gtfs_data.production_date.begin() ? b_date : gtfs_data.production_date.begin()), boost::gregorian::from_undelimited_string(row[end_date_c]));
+                (b_date > gtfs_data.production_date.begin() ? b_date : gtfs_data.production_date.begin()), boost::gregorian::from_undelimited_string(row[end_date_c]) + boost::gregorian::days(1));
+    //we add one day to the last day of the period because end_date_c is included in the period
+    //and as say the constructor of boost periods, the second args is "end" so it is not included
+
 
     //Since all time have to be converted to UTC, we need to handle day saving time (DST) rules
     //we thus need to split all periods for them to be on only one DST
@@ -625,12 +628,12 @@ void CalendarGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
     for (const auto& split_period: split_periods) {
         nm::ValidityPattern * vp = new nm::ValidityPattern(gtfs_data.production_date.begin());
 
-        for(boost::gregorian::day_iterator it(split_period.period.begin()); it<split_period.period.end(); ++it) {
+        for(boost::gregorian::day_iterator it(split_period.period.begin()); it < split_period.period.end(); ++it) {
             if(week.test((*it).day_of_week())) {
                 vp->add((*it));
-            }
-            else
+            }else{
                 vp->remove((*it));
+            }
         }
 
         if (split_periods.size() == 1) {

--- a/source/ed/tests/gtfsparser_test.cpp
+++ b/source/ed/tests/gtfsparser_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -298,6 +298,8 @@ BOOST_AUTO_TEST_CASE(parse_gtfs_no_dst){
     //Calendar
     BOOST_REQUIRE_EQUAL(data.validity_patterns.size(), 2);
     BOOST_CHECK_EQUAL(data.validity_patterns[0]->uri, "FULLW");
+    auto vp = data.validity_patterns[0];
+    BOOST_CHECK_EQUAL(vp->check((boost::gregorian::date(2010, 12, 31) - vp->beginning_date).days()), true);
 
     BOOST_CHECK_EQUAL(data.validity_patterns[1]->uri, "WE");
 


### PR DESCRIPTION
In gtfs the last day of a calendar must be included in the validity
period, but `boost::gregorian::period` doesn't include `end` in the
period (like an iterator). So we must add one day to the end read in the
gtfs file before creating the boost period.

http://jira.canaltp.fr/browse/NAVITIAII-1088
