### PR TITLE
Only do crowfly if we leave the requested area

### DIFF
--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -34,10 +34,10 @@ www.navitia.io
 #include "fare/fare.h"
 #include "type/data.h"
 #include "routing/raptor_api.h"
-
 #include "routing/raptor.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "georef/street_network.h"
 
 struct logger_initialized {
     logger_initialized()   { init_logger(); }

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -138,19 +138,6 @@ class GeoJson(fields.Raw):
         elif obj.type == response_pb2.TRANSFER:
             coords.append(obj.origin.stop_point.coord)
             coords.append(obj.destination.stop_point.coord)
-        elif obj.type == response_pb2.CROW_FLY:
-            for place in [obj.origin, obj.destination]:
-                type_ = place.embedded_type
-                if type_ == type_pb2.STOP_POINT:
-                    coords.append(place.stop_point.coord)
-                elif type_ == type_pb2.STOP_AREA:
-                    coords.append(place.stop_area.coord)
-                elif type_ == type_pb2.POI:
-                    coords.append(place.poi.coord)
-                elif type_ == type_pb2.ADDRESS:
-                    coords.append(place.address.coord)
-                elif type_ == type_pb2.ADMINISTRATIVE_REGION:
-                    coords.append(place.administrative_region.coord)
         else:
             return None
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -29,6 +29,8 @@ www.navitia.io
 */
 
 #include "raptor_api.h"
+#include "raptor.h"
+#include "georef/street_network.h"
 #include "type/pb_converter.h"
 #include "boost/date_time/posix_time/posix_time.hpp"
 #include "type/datetime.h"
@@ -36,6 +38,7 @@ www.navitia.io
 #include <chrono>
 #include "type/meta_data.h"
 #include "fare/fare.h"
+
 
 
 namespace navitia { namespace routing {
@@ -55,27 +58,6 @@ void fill_section(pbnavitia::Section *pb_section, const type::VehicleJourney* vj
     auto* add_info_vehicle_journey = pb_section->mutable_add_info_vehicle_journey();
     fill_pb_object(vj, d, vj_pt_display_information, 0, now, action_period);
     fill_pb_object(vj, d, add_info_vehicle_journey, 0, now, action_period);
-}
-
-/**
- * Choose if we must use a crowfly or a streetnework for a section. This function is call for the first and last section of a journey
- *
- * @param point: the object where we are going/coming: the requested origin for the first section or the destination for the last section
- * @param stop_point: for the first section, the stop point where we are going, or for the last section the stop point from where we come
- */
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point){
-    if(point.type == type::Type_e::StopArea){
-        //if we have a stop area in the request, we only do a crowfly section if the used stop point belongs to this stop area
-        return point.uri == stop_point->stop_area->uri;
-    }else if(point.type == type::Type_e::Admin){
-        //if we have a admin in the request, we only do a crowfly section if the used stop point belongs to this admin
-        auto admin_it = find_if(begin(stop_point->stop_area->admin_list), end(stop_point->stop_area->admin_list),
-                [point](const navitia::georef::Admin* admin){return admin->uri == point.uri;});
-        return admin_it != end(stop_point->stop_area->admin_list);
-    }else{
-        //if the request is on any other type we don't want a crowfly section
-        return false;
-    }
 }
 
 

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -29,14 +29,24 @@ www.navitia.io
 */
 
 #pragma once
-#include "raptor.h"
 #include "type/type.pb.h"
 #include "type/response.pb.h"
 #include "type/request.pb.h"
-#include "boost/date_time/posix_time/ptime.hpp"
-#include "georef/street_network.h"
+#include <limits>
+
+namespace navitia{
+    namespace type{
+        class EntryPoint;
+        class AccessibiliteParams;
+    }
+    namespace georef{
+        class StreetNetwork;
+    }
+}
 
 namespace navitia { namespace routing {
+
+class RAPTOR;
 
 pbnavitia::Response make_response(RAPTOR &raptor,
                                   const type::EntryPoint &origin,

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -74,4 +74,19 @@ std::string PathItem::print() const {
 }
 
 
-}}
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point){
+    if(point.type == type::Type_e::StopArea){
+        //if we have a stop area in the request, we only do a crowfly section if the used stop point belongs to this stop area
+        return point.uri == stop_point->stop_area->uri;
+    }else if(point.type == type::Type_e::Admin){
+        //if we have a admin in the request, we only do a crowfly section if the used stop point belongs to this admin
+        auto admin_it = find_if(begin(stop_point->stop_area->admin_list), end(stop_point->stop_area->admin_list),
+                [point](const navitia::georef::Admin* admin){return admin->uri == point.uri;});
+        return admin_it != end(stop_point->stop_area->admin_list);
+    }else{
+        //if the request is on any other type we don't want a crowfly section
+        return false;
+    }
+}
+
+}}//namespace

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -117,6 +117,14 @@ struct Path {
 
 bool operator==(const PathItem & a, const PathItem & b);
 
+/**
+ * Choose if we must use a crowfly or a streetnework for a section. This function is call for the first and last section of a journey
+ *
+ * @param point: the object where we are going/coming: the requested origin for the first section or the destination for the last section
+ * @param stop_point: for the first section, the stop point where we are going, or for the last section the stop point from where we come
+ */
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point);
+
 
 }}
 

--- a/source/routing/routing_cli_utils.cpp
+++ b/source/routing/routing_cli_utils.cpp
@@ -31,8 +31,9 @@ www.navitia.io
 #include "routing_cli_utils.h"
 #include "type/response.pb.h"
 #include <boost/program_options.hpp>
-#include "raptor.h"
 #include "routing/raptor_api.h"
+#include "raptor.h"
+#include "georef/street_network.h"
 #include "tests/utils_test.h"
 
 namespace nr = navitia::routing;

--- a/source/routing/single_run.cpp
+++ b/source/routing/single_run.cpp
@@ -30,6 +30,7 @@ www.navitia.io
 
 #include "raptor.h"
 #include "routing/raptor_api.h"
+#include "georef/street_network.h"
 #include "type/data.h"
 #include "utils/timer.h"
 #include "type/response.pb.h"

--- a/source/routing/tests/raptor_adapted_test.cpp
+++ b/source/routing/tests/raptor_adapted_test.cpp
@@ -39,6 +39,7 @@ www.navitia.io
 #include "routing/raptor_api.h"
 #include "utils/functions.h"
 #include "tests/utils_test.h"
+#include "georef/street_network.h"
 
 
 /*

--- a/source/routing/tests/raptor_odt_test.cpp
+++ b/source/routing/tests/raptor_odt_test.cpp
@@ -34,7 +34,8 @@ www.navitia.io
 #include "routing/raptor_api.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
-
+#include "routing/raptor.h"
+#include "georef/street_network.h"
 
 
 struct logger_initialized {

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -35,6 +35,9 @@ www.navitia.io
 #include "ed/build_helper.h"
 #include "routing_api_test_data.h"
 #include "tests/utils_test.h"
+#include "routing/raptor.h"
+#include "georef/street_network.h"
+#include "type/data.h"
 
 struct logger_initialized {
     logger_initialized()   { init_logger(); }

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -113,15 +113,15 @@ BOOST_AUTO_TEST_CASE(simple_journey) {
 BOOST_AUTO_TEST_CASE(journey_stay_in) {
     std::vector<std::string> forbidden;
     ed::builder b("20120614");
-    b.vj("9658", "1111111", "block1", true)	("ehv", 60300,60600)
-    		                            	("ehb", 60780,60780)
-    		                            	("bet", 61080,61080)
-    		                            	("btl", 61560,61560)
-    		                            	("vg",  61920,61920)
-    		                            	("ht",  62340,62340);
-    b.vj("4462", "1111111", "block1", true)	("ht",  62760,62760)
-    										("hto", 62940,62940)
-    										("rs",  63180,63180);
+    b.vj("9658", "1111111", "block1", true) ("ehv", 60300,60600)
+                                            ("ehb", 60780,60780)
+                                            ("bet", 61080,61080)
+                                            ("btl", 61560,61560)
+                                            ("vg",  61920,61920)
+                                            ("ht",  62340,62340);
+    b.vj("4462", "1111111", "block1", true) ("ht",  62760,62760)
+                                            ("hto", 62940,62940)
+                                            ("rs",  63180,63180);
     b.finish();
     navitia::type::Data data;
     b.generate_dummy_basis();
@@ -940,3 +940,39 @@ BOOST_FIXTURE_TEST_CASE(biking_length_test, streetnetworkmode_fixture<normal_spe
     BOOST_REQUIRE_EQUAL(journey.sections(2).type(), pbnavitia::SectionType::STREET_NETWORK);
 
 }*/
+
+BOOST_AUTO_TEST_CASE(use_crow_fly){
+    navitia::type::EntryPoint ep;
+    navitia::type::StopPoint sp;
+    navitia::type::StopArea sa;
+    navitia::georef::Admin admin;
+    sp.stop_area = &sa;
+    sa.admin_list.push_back(&admin);
+
+    sa.uri = "sa:foo";
+    admin.uri = "admin";
+    ep.uri = "foo";
+    ep.type = navitia::type::Type_e::Address;
+
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+
+    ep.type = navitia::type::Type_e::POI;
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+
+    ep.type = navitia::type::Type_e::Coord;
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+
+    ep.type = navitia::type::Type_e::StopArea;
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+
+    ep.type = navitia::type::Type_e::Admin;
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+
+    ep.type = navitia::type::Type_e::Admin;
+    ep.uri = "admin";
+    BOOST_CHECK(nr::use_crow_fly(ep, &sp));
+
+    ep.type = navitia::type::Type_e::StopArea;
+    ep.uri = "sa:foo";
+    BOOST_CHECK(nr::use_crow_fly(ep, &sp));
+}

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -32,6 +32,7 @@ www.navitia.io
 #include "routing/raptor_api.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "type/pt_data.h"
 
 namespace ng = navitia::georef;
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -930,12 +930,6 @@ void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint
     section->set_length(0);
     section->set_end_date_time(navitia::to_posix_timestamp(time));
     section->set_type(pbnavitia::SectionType::CROW_FLY);
-    auto coord = section->mutable_street_network()->add_coordinates();
-    coord->set_lat(origin.coordinates.lat());
-    coord->set_lon(origin.coordinates.lon());
-    coord = section->mutable_street_network()->add_coordinates();
-    coord->set_lat(destination.coordinates.lat());
-    coord->set_lon(destination.coordinates.lon());
 }
 
 void fill_street_sections(EnhancedResponse& response, const type::EntryPoint& ori_dest,


### PR DESCRIPTION
- If the stop_point is part of the stop_area, then : crow_fly section, no path and no geoJson
- If the stop_point is not part of the stop_area, then : street_network section, with path and geoJson to the centroid of the stop_area

Same principle for admin.

refer to: http://jira.canaltp.fr/browse/NAVITIAII-1093
