### PR TITLE
improvement of stay in connection

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -171,6 +171,9 @@ class additional_informations_vj(fields.Raw):
         if (addinfo.has_date_time_estimated):
             result.append("has_date_time_estimated")
 
+        if (addinfo.stay_in):
+            result.append('stay_in')
+
         descriptor = addinfo.DESCRIPTOR
         enum_t = descriptor.fields_by_name['vehicle_journey_type'].enum_type
         values = enum_t.values_by_name

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -175,13 +175,16 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
                         departure_ptime = p_deptime;
                     // L'heure d'arrivée au dernier stop point
                     arrival_ptime = p_arrtime;
-                    if(i>0) {
+                    if(i > 0) {
                         const auto & previous_coord = item.stop_points[i-1]->coord;
                         const auto & current_coord = item.stop_points[i]->coord;
                         length += previous_coord.distance_to(current_coord);
                     }
                 }
-                if (item.stop_points.size() > 1) {
+                if (! item.stop_points.empty()) {
+                    //some time there is only one stop points, typically in case of "extension of services"
+                    //if the passenger as to board on the last stop_point of a VJ (yes, it's possible...)
+                    //in this case we want to display this only point as the departure and the destination of this section
                     auto arr_time = item.arrivals[0];
                     auto dep_time = item.departures[0];
                     bt::time_period action_period(dep_time, arr_time);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -202,7 +202,16 @@ pbnavitia::Response make_pathes(const std::vector<navitia::routing::Path>& paths
             } else {
                 pb_section->set_type(pbnavitia::TRANSFER);
                 switch(item.type) {
-                    case stay_in : pb_section->set_transfer_type(pbnavitia::stay_in); break;
+                    case stay_in :{
+                        pb_section->set_transfer_type(pbnavitia::stay_in);
+                        //We "stay in" the precedent section, this one is only a transfer
+                        int section_idx = pb_journey->sections_size() - 2;
+                        if(section_idx >= 0){
+                            auto* prec_section = pb_journey->mutable_sections(section_idx);
+                            prec_section->mutable_add_info_vehicle_journey()->set_stay_in(true);
+                        }
+                        break;
+                    }
                     case guarantee : pb_section->set_transfer_type(pbnavitia::guaranteed); break;
                     case waiting : pb_section->set_type(pbnavitia::WAITING); break;
                     default : pb_section->set_transfer_type(pbnavitia::walking); break;

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -226,6 +226,7 @@ message RouteScheduleRow {
 message addInfoVehicleJourney{
     required VehicleJourneyType vehicle_journey_type = 1;
     optional bool has_date_time_estimated = 2;
+    optional bool stay_in = 3 [default=false];
 }
 
 message Header{


### PR DESCRIPTION
- We flag the section before the "stay in", the one where we actually stay.
- Even if we don't move in the vj, we display a origin and destination point (the same), because if we board the vj on the last stop_point it's the connection than move us. Before that the from and to was empty.

refet to: http://jira.canaltp.fr/browse/NAVITIAII-1081
