### PR TITLE
TimeTable: fix null stop time values

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -86,6 +86,11 @@ class DateTime(fields.Raw):
         return None  # for the moment I prefer not to display anything instead of something wrong
 
 
+# a time null value is represented by the max value (since 0 is a perfectly valid value)
+# WARNING! be careful to change that value if the time type change (from uint64 to uint32 for example)
+__date_time_null_value__ = 2**64 - 1
+
+
 class SplitDateTime(DateTime):
     """
     custom date format from 2 fields:
@@ -109,6 +114,9 @@ class SplitDateTime(DateTime):
 
         date = fields.get_value(self.date, obj)
         time = fields.get_value(self.time, obj)
+
+        if time == __date_time_null_value__:
+            return ""
 
         if not date:
             return self.format_time(time)

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1089,6 +1089,9 @@ void fill_pb_object(const navitia::type::StopTime* stop_time,
                     boost::optional<const std::string> calendar_id,
                     const navitia::type::StopPoint* destination){
     if (stop_time == nullptr) {
+        //we need to represent a 'null' value (for not found datetime)
+        // before it was done with a empty string, but now it is the max value (since 0 is a valid value)
+        rs_date_time->set_time(std::numeric_limits<u_int64_t>::max());
         return;
     }
 
@@ -1098,6 +1101,7 @@ void fill_pb_object(const navitia::type::StopTime* stop_time,
         //for calendar we don't want to have a date
         rs_date_time->set_date(to_int_date(to_posix_time(date_time, data)));
     }
+
     pbnavitia::Properties* hn = rs_date_time->mutable_properties();
     fill_pb_object(stop_time, data, hn, max_depth, now, action_period);
 

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -211,8 +211,9 @@ message PairStopTime {
 
 message ScheduleStopTime {
     optional Properties properties = 2;
-    // date time is split because sometimes 
+    // date time is split because sometimes
     // we want only time and no dates for the schedule
+    // Note: to define a null schedule time, time must be equal to it's max value (max uint64 value) 
     optional uint64 time = 3; //time is the number of seconds since midnight
     optional uint64 date = 4; //date is a posix time stamp to midnight
 }


### PR DESCRIPTION
null values were displayed as "000000" and we want an empty string
instead.

fix the default value to max uint64 and display empty string in
jormungandr in that case
