### PR TITLE
Line sort

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -547,7 +547,8 @@ void LineFusioHandler::handle_line(Data& data, const csv_row& row, bool is_first
     if(line->commercial_mode == nullptr){
         line->commercial_mode = gtfs_data.get_or_create_default_commercial_mode(data);
     }
-    if (is_valid(sort_c, row)) {
+    if (is_valid(sort_c, row) && row[sort_c] != "-1") {
+        //sort == -1 means no sort
         line->sort =  boost::lexical_cast<int>(row[sort_c]);
     }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -588,16 +588,14 @@ struct Line : public Header, Nameable, HasMessages, Codes{
     std::string color;
     int sort = std::numeric_limits<int>::max();
 
-    CommercialMode* commercial_mode;
+    CommercialMode* commercial_mode = nullptr;
 
     std::vector<Company*> company_list;
-    Network* network;
+    Network* network = nullptr;
 
     std::vector<Route*> route_list;
     std::vector<PhysicalMode*> physical_mode_list;
     std::vector<Calendar*> calendar_list;
-
-    Line(): sort(0), commercial_mode(nullptr), network(nullptr){}
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & code & forward_name & backward_name
@@ -627,10 +625,9 @@ struct Line : public Header, Nameable, HasMessages, Codes{
 
 struct Route : public Header, Nameable, HasMessages, Codes{
     const static Type_e type = Type_e::Route;
-    Line* line;
+    Line* line = nullptr;
     std::vector<JourneyPattern*> journey_pattern_list;
 
-    Route() : line(nullptr) {}
     idx_t main_destination() const;
     type::OdtLevel_e get_odt_level() const;
 
@@ -645,16 +642,14 @@ struct Route : public Header, Nameable, HasMessages, Codes{
 
 struct JourneyPattern : public Header, Nameable{
     const static Type_e type = Type_e::JourneyPattern;
-    bool is_frequence;
-    OdtLevel_e odt_level; // Computed at serialization
-    Route* route;
-    CommercialMode* commercial_mode;
-    PhysicalMode* physical_mode;
+    bool is_frequence = false;
+    OdtLevel_e odt_level= OdtLevel_e::none; // Computed at serialization
+    Route* route = nullptr;
+    CommercialMode* commercial_mode = nullptr;
+    PhysicalMode* physical_mode = nullptr;
 
     std::vector<JourneyPatternPoint*> journey_pattern_point_list;
     std::vector<VehicleJourney*> vehicle_journey_list;
-
-    JourneyPattern(): is_frequence(false), odt_level(OdtLevel_e::none), route(nullptr), commercial_mode(nullptr), physical_mode(nullptr) {}
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & is_frequence & odt_level &  route & commercial_mode


### PR DESCRIPTION
coorections on line sort:
- 'sort' variable was default inited with the right value but wrongly inited in the constructor, so deletion of the constructor
- -1 as line_sort means no line sort in fusio. 
