### PR TITLE
Georef: fix angle computation

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -561,7 +561,7 @@ int compute_directions(const navitia::georef::Path& path, const nt::Geographical
         const PathItem& previous_item = *(++(path.path_items.rbegin()));
         b_coord = previous_item.coordinates.back();
     }
-    if (a_coord == b_coord || b_coord == c_coord) {
+    if (a_coord == b_coord || b_coord == c_coord || a_coord == c_coord) {
         return 0;
     }
 


### PR DESCRIPTION
we did not check if a == c in the angle computation thus giving wrong directions.

fix http://jira.canaltp.fr/browse/NAVITIAII-1044
