### PR TITLE
Jormun&Kraken: add recoverable error

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/errors.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/errors.py
@@ -51,6 +51,7 @@ from flask import request
             |unknown_api                        |  400                  |
             |unable_to_parse                    |  400                  |
             |bad_format                         |  400                  |
+            |internal_error                     |  500                  |
             -------------------------------------------------------------
 
 '''
@@ -65,6 +66,7 @@ class ManageError(object):
             code = 200
             errors = {
                 response_pb2.Error.service_unavailable: 503,
+                response_pb2.Error.internal_error: 500,
                 response_pb2.Error.date_out_of_bounds: 404,
                 response_pb2.Error.no_origin: 404,
                 response_pb2.Error.no_destination: 404,

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -36,6 +36,15 @@ www.navitia.io
 #include <zmq.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+pbnavitia::Response make_internal_error(const navitia::recoverable_exception& e) {
+    pbnavitia::Response response;
+
+    response.mutable_error()->set_id(pbnavitia::Error::internal_error);
+    response.mutable_error()->set_message(e.what());
+
+    return response;
+}
+
 namespace pt = boost::posix_time;
 void doWork(zmq::context_t & context, DataManager<navitia::type::Data>& data_manager) {
     auto logger = log4cplus::Logger::getInstance("worker");
@@ -59,14 +68,21 @@ void doWork(zmq::context_t & context, DataManager<navitia::type::Data>& data_man
             pt::ptime start = pt::microsec_clock::local_time();
             pbnavitia::API api = pbnavitia::UNKNOWN_API;
             if(pb_req.ParseFromArray(request.data(), request.size())){
-                /*auto*/ api = pb_req.requested_api();
+                api = pb_req.requested_api();
                 if(api != pbnavitia::METADATAS){
-                    LOG4CPLUS_DEBUG(logger, "receive request: "
-                            << pb_req.DebugString());
+                    LOG4CPLUS_DEBUG(logger, "receive request: " << pb_req.DebugString());
                 }
-                result = w.dispatch(pb_req);
-                if(api != pbnavitia::METADATAS){
-                   LOG4CPLUS_TRACE(logger, "response: " << result.DebugString());
+                try {
+                    result = w.dispatch(pb_req);
+                    if(api != pbnavitia::METADATAS){
+                       LOG4CPLUS_TRACE(logger, "response: " << result.DebugString());
+                    }
+                } catch (const navitia::recoverable_exception& e) {
+                    //on a recoverable an internal server error is returned
+                    LOG4CPLUS_ERROR(logger, "internal server error: " << e.what());
+                    LOG4CPLUS_ERROR(logger, "on query: " << pb_req.DebugString());
+                    LOG4CPLUS_ERROR(logger, "backtrace: " << e.backtrace());
+                    result = make_internal_error(e);
                 }
             }else{
                LOG4CPLUS_WARN(logger, "receive invalid protobuf");

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -118,6 +118,14 @@ void handle_vj(const size_t countb, navitia::type::idx_t current_jpp_idx, Visito
             // Here we have to change of vehicle journey, this happen with connection_stay_in
             auto prev_st = current_st;
             // If it was a connection_stay_in we want to take the the previous vj
+
+            if ((clockwise && ! current_st->vehicle_journey->prev_vj)
+                    || (!clockwise && ! current_st->vehicle_journey->next_vj)) {
+                LOG4CPLUS_ERROR(log4cplus::Logger::getInstance("log"), "no service extention for vj "
+                                << current_st->vehicle_journey->uri << " impossible to find good boarding jpp (idx="
+                                << boarding_jpp_idx << ")");
+                throw navitia::recoverable_exception("impossible to rebuild the public transport path");
+            }
             if(clockwise) {
                 current_st = current_st->vehicle_journey->prev_vj->stop_time_list.back();
             } else {

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -315,6 +315,7 @@ message Error{
         unknown_object = 10;
         service_unavailable = 11;
         invalid_protobuf_request = 12;
+        internal_error = 13;
     }
     optional error_id id = 1;
     optional string message = 2;


### PR DESCRIPTION
add a recoverable_exception for error on query.

when thrown kraken returns a internal_error but can continue serving other requests

for the current bug on service extention we'll get:
{

```
"error": {
    "id": "internal_error",
    "message": "impossible to rebuild the public transport path"
},
"exceptions": [ ],
"notes": [ ]
```

}
