### PR TITLE
Jormungandr: change date parse library

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/parsers.py
+++ b/source/jormungandr/jormungandr/interfaces/parsers.py
@@ -26,6 +26,8 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
+from dateutil import parser
+
 
 def depth_argument(value, name):
     if value < 3:
@@ -52,3 +54,24 @@ def option_value(values):
             raise ValueError(error)
         return value
     return to_return
+
+
+def parse_input_date(date):
+    """
+    datetime parse date seems broken, '155' with format '%H%M%S' is not
+    rejected but parsed as 1h, 5mn, 5s...
+
+    so use use for the input date parse dateutil even if the 'guess'
+    mechanism seems a bit dangerous
+    """
+    return parser.parse(date, dayfirst=False, yearfirst=True)
+
+
+def date_time_format(value):
+    """
+    we want to valid the date format
+    """
+    try:
+        return parse_input_date(value)
+    except ValueError as e:
+        raise ValueError("Unable to parse datetime, {}".format(e.message))

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -64,8 +64,20 @@ from navitiacommon import type_pb2, response_pb2
 from jormungandr.utils import date_to_timestamp, ResourceUtc
 from copy import deepcopy
 from jormungandr.travelers_profile import travelers_profile
+from dateutil import parser
 
 f_datetime = "%Y%m%dT%H%M%S"
+
+
+def parse_input_date(date):
+    """
+    datetime parse date seems broken, '155' with format '%H%M%S' is not
+    rejected but parsed as 1h, 5mn, 5s...
+
+    so use use for the input date parse dateutil even if the 'guess'
+    mechanism seems a bit dangerous
+    """
+    return parser.parse(date, dayfirst=False, yearfirst=True)
 
 
 class SectionLinks(fields.Raw):
@@ -223,6 +235,16 @@ def dt_represents(value):
         return True
     else:
         raise ValueError("Unable to parse datetime_represents")
+
+
+def date_time_format(value):
+    """
+    we want to valid the date format
+    """
+    try:
+        return parse_input_date(value)
+    except ValueError as e:
+        raise ValueError("Unable to parse datetime, {}".format(e.message))
 
 
 class add_debug_info(object):
@@ -531,7 +553,7 @@ class Journeys(ResourceUri, ResourceUtc):
         parser_get = self.parsers["get"]
         parser_get.add_argument("from", type=str, dest="origin")
         parser_get.add_argument("to", type=str, dest="destination")
-        parser_get.add_argument("datetime", type=str)
+        parser_get.add_argument("datetime", type=date_time_format)
         parser_get.add_argument("datetime_represents", dest="clockwise",
                                 type=dt_represents, default=True)
         parser_get.add_argument("max_nb_transfers", type=int, default=10,
@@ -646,7 +668,8 @@ class Journeys(ResourceUri, ResourceUtc):
             args['destination'] = self.transform_id(args['destination'])
 
         if not args['datetime']:
-            args['datetime'] = datetime.now().strftime('%Y%m%dT1337')
+            args['datetime'] = datetime.now()
+            args['datetime'] = args['datetime'].replace(hour=13, minute=37)
 
         if not region:
             #TODO how to handle lon/lat ? don't we have to override args['origin'] ?
@@ -677,7 +700,7 @@ class Journeys(ResourceUri, ResourceUtc):
                     g.regions_called = []
                 g.regions_called.append(r)
 
-            original_datetime = datetime.strptime(args['original_datetime'], f_datetime)
+            original_datetime = args['original_datetime']
             new_datetime = self.convert_to_utc(original_datetime)
             args['datetime'] = date_to_timestamp(new_datetime)
 
@@ -778,11 +801,12 @@ class Journeys(ResourceUri, ResourceUtc):
 
         #default Date
         if not "datetime" in args or not args['datetime']:
-            args['datetime'] = datetime.now().strftime('%Y%m%dT1337')
+            args['datetime'] = datetime.now()
+            args['datetime'] = args['datetime'].replace(hour=13, minute=37)
 
         # we save the original datetime for debuging purpose
         args['original_datetime'] = args['datetime']
-        original_datetime = datetime.strptime(args['original_datetime'], f_datetime)
+        original_datetime = args['original_datetime']
         new_datetime = self.convert_to_utc(original_datetime)
         args['datetime'] = date_to_timestamp(new_datetime)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -43,7 +43,7 @@ from fields import stop_point, stop_area, line, physical_mode, \
     display_informations_vj, additional_informations_vj, error,\
     generic_message, GeoJson
 
-from jormungandr.interfaces.parsers import option_value
+from jormungandr.interfaces.parsers import option_value, date_time_format
 #from exceptions import RegionNotFound
 from ResourceUri import ResourceUri, complete_links, update_journeys_status
 import datetime
@@ -64,22 +64,8 @@ from navitiacommon import type_pb2, response_pb2
 from jormungandr.utils import date_to_timestamp, ResourceUtc
 from copy import deepcopy
 from jormungandr.travelers_profile import travelers_profile
-from dateutil import parser
 
 f_datetime = "%Y%m%dT%H%M%S"
-
-
-def parse_input_date(date):
-    """
-    datetime parse date seems broken, '155' with format '%H%M%S' is not
-    rejected but parsed as 1h, 5mn, 5s...
-
-    so use use for the input date parse dateutil even if the 'guess'
-    mechanism seems a bit dangerous
-    """
-    return parser.parse(date, dayfirst=False, yearfirst=True)
-
-
 class SectionLinks(fields.Raw):
 
     def output(self, key, obj):
@@ -236,15 +222,6 @@ def dt_represents(value):
     else:
         raise ValueError("Unable to parse datetime_represents")
 
-
-def date_time_format(value):
-    """
-    we want to valid the date format
-    """
-    try:
-        return parse_input_date(value)
-    except ValueError as e:
-        raise ValueError("Unable to parse datetime, {}".format(e.message))
 
 
 class add_debug_info(object):

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -39,6 +39,7 @@ from fields import stop_point, route, pagination, PbField, stop_date_time, \
 from ResourceUri import ResourceUri, complete_links
 from datetime import datetime
 from jormungandr.interfaces.argument import ArgumentDoc
+from jormungandr.interfaces.parsers import option_value, date_time_format
 from errors import ManageError
 from flask.ext.restful.types import natural, boolean
 
@@ -53,7 +54,7 @@ class Schedules(ResourceUri):
             argument_class=ArgumentDoc)
         parser_get = self.parsers["get"]
         parser_get.add_argument("filter", type=str)
-        parser_get.add_argument("from_datetime", type=str,
+        parser_get.add_argument("from_datetime", type=date_time_format,
                                 description="The datetime from which you want\
                                 the schedules")
         parser_get.add_argument("duration", type=int, default=3600 * 24,
@@ -93,8 +94,11 @@ class Schedules(ResourceUri):
             self.collection = 'schedules'
             args["filter"] = self.get_filter(uri.split("/"))
             self.region = i_manager.get_region(region, lon, lat)
+        #@TODO: Change to timestamp
         if not args["from_datetime"]:
             args["from_datetime"] = datetime.now().strftime("%Y%m%dT1337")
+        else:
+            args["from_datetime"] = args["from_datetime"].strftime("%Y%m%dT%H%M%S")
         timezone.set_request_timezone(self.region)
 
         return i_manager.dispatch(args, self.endpoint,

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -21,3 +21,4 @@ redis==2.9.1
 six==1.6.1
 wsgiref==0.1.2
 kombu==3.0.8
+python-dateutil==1.5

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -527,8 +527,9 @@ def is_valid_place(place, depth_check=1):
     #TODO more checks
 
 
+s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
+r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset
+
 #default journey query used in various test
 journey_basic_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}"\
-    .format(from_coord="0.0000898312;0.0000898312",  # coordinate of S in the dataset
-            to_coord="0.00188646;0.00071865",  # coordinate of R in the dataset
-            datetime="20120614T080000")
+    .format(from_coord=s_coord, to_coord=r_coord, datetime="20120614T080000")


### PR DESCRIPTION
datetime parse date seems broken, '155' with format '%H%M%S' is not
rejected but parsed as 1h, 5mn, 5s...

so use use for the input date parse dateutil even if the 'guess'
mechanism seems a bit dangerous
