### PR TITLE
kraken: make data copyable and add method on data_manager for handling disruptions

### DIFF
--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -68,7 +68,7 @@ struct StopPointConnection: public Header, hasProperties {
     int max_duration;
     ConnectionType connection_kind;
 
-    StopPointConnection() : departure(NULL), destination(NULL), display_duration(0),duration(0),
+    StopPointConnection() : departure(NULL), destination(NULL), display_duration(0), duration(0),
         max_duration(0), connection_kind(ConnectionType::Default){}
 
    bool operator<(const StopPointConnection& other) const;

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -97,6 +97,8 @@ void MaintenanceWorker::handle_rt(AmqpClient::Envelope::ptr_t envelope){
     for(const auto& entity: feed_message.entity()){
         if(entity.HasExtension(chaos::disruption)){
             LOG4CPLUS_WARN(logger, "has_extension");
+            data_manager.apply_disruptions(0);
+            LOG4CPLUS_DEBUG(logger, "end");
         }else{
             LOG4CPLUS_WARN(logger, "unsupported gtfs rt feed");
         }

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -40,12 +40,6 @@ namespace bg = boost::gregorian;
 
 namespace navitia { namespace type {
 
-MessageHolder& MessageHolder::operator=(const navitia::type::MessageHolder&& other){
-    this->messages = std::move(other.messages);
-    return *this;
-}
-
-
 bool Message::is_valid(const boost::posix_time::ptime& now, const boost::posix_time::time_period& action_period) const{
     if(now.is_not_a_date_time() && action_period.is_null()){
         return false;

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -261,8 +261,6 @@ struct MessageHolder{
         ar & messages;
     }
 
-    MessageHolder& operator=(const navitia::type::MessageHolder&&);
-
 };
 
 }}//namespace


### PR DESCRIPTION
We serialize in a string then we deserialize it, it's ugly, but it
will do the job for now. The ClonningArchive will save us!!!
