### PR TITLE
Python: change requirements for protobuff to 2.4.1

### DIFF
--- a/source/connectors/requirements.txt
+++ b/source/connectors/requirements.txt
@@ -4,6 +4,6 @@ anyjson==0.3.3
 argparse==1.2.1
 configobj==4.7.2
 kombu==3.0.10
-protobuf==2.5.0
+protobuf==2.4.1
 pymssql==2.0.1
 wsgiref==0.1.2

--- a/source/monitor/requirements.txt
+++ b/source/monitor/requirements.txt
@@ -4,6 +4,6 @@ MarkupSafe==0.18
 Werkzeug==0.9.4
 argparse==1.2.1
 itsdangerous==0.23
-protobuf==2.5.0
+protobuf==2.4.1
 pyzmq==14.0.1
 wsgiref==0.1.2

--- a/source/sindri/requirements.txt
+++ b/source/sindri/requirements.txt
@@ -4,6 +4,6 @@ anyjson==0.3.3
 argparse==1.2.1
 configobj==4.7.2
 kombu==3.0.10
-protobuf==2.5.0
+protobuf==2.4.1
 psycopg2==2.5.2
 wsgiref==0.1.2

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -20,7 +20,7 @@ celery==3.1.7
 configobj==4.7.2
 itsdangerous==0.23
 kombu==3.0.8
-protobuf==2.5.0
+protobuf==2.4.1
 psycopg2==2.5.2
 pydns==2.3.6
 pytz==2013.9


### PR DESCRIPTION
the 2.5.0 is not supported by our servers
