### PR TITLE
journeys: add the posibility to have different fallback duration for each mode

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -133,6 +133,7 @@ Path StreetNetwork::get_direct_path(const type::EntryPoint& origin,
     if (!arrival_launched() || origin.streetnetwork_params.mode != destination.streetnetwork_params.mode) {
         arrival_path_finder.init(destination.coordinates, origin.streetnetwork_params.mode,
                                  origin.streetnetwork_params.speed_factor);
+        //@TODO: use the max_duration of the origin?
         arrival_path_finder.start_distance_dijkstra(destination.streetnetwork_params.max_duration);
     }
 

--- a/source/jormungandr/jormungandr/interfaces/v0/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v0/Journeys.py
@@ -120,10 +120,17 @@ class Journeys(Resource, ResourceUtc, FindAndFormatJourneys):
                                 description=
                                 "The list of modes you want at the"\
                                 " end of your journey")
-        parser_get.add_argument("max_duration_to_pt", type=int, default=10*60,
-                                description=
-                                "maximal duration of non public "\
-                                "transport in second")
+        parser_get.add_argument("max_duration_to_pt", type=int, description=
+                                "maximal duration of non public transport in second")
+
+        parser_get.add_argument("max_walking_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of walking on public transport in second")
+        parser_get.add_argument("max_bike_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of bike on public transport in second")
+        parser_get.add_argument("max_bss_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of bss on public transport in second")
+        parser_get.add_argument("max_car_duration_to_pt", type=int, default=30*60,
+                                description="maximal duration of car on public transport in second")
         parser_get.add_argument("walking_speed", type=float, default=1.12,
                                 description=
                                 "Walking speed in meter/second")
@@ -145,7 +152,7 @@ class Journeys(Resource, ResourceUtc, FindAndFormatJourneys):
         parser_get.add_argument("debug", type=boolean, default=False,
                                 hidden=True)
         self.region = None
-    
+
     def get(self, region=None):
         args = self.parsers["get"].parse_args()
 
@@ -153,6 +160,14 @@ class Journeys(Resource, ResourceUtc, FindAndFormatJourneys):
         args["min_nb_journeys"] = None
         args["max_nb_journeys"] = None
         args["show_codes"] = False
+
+        if args['max_duration_to_pt']:
+            #retrocompatibility: max_duration_to_pt override all individual value by mode
+            args['max_walking_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bike_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bss_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_car_duration_to_pt'] = args['max_duration_to_pt']
+
         if region is None:
             region = i_manager.get_region(object_id=args["origin"])
         self.region = region
@@ -160,7 +175,7 @@ class Journeys(Resource, ResourceUtc, FindAndFormatJourneys):
         new_datetime = self.convert_to_utc(original_datetime)
         args['original_datetime'] = date_to_timestamp(original_datetime)  # we save the original datetime for debuging purpose
         args['datetime'] = date_to_timestamp(new_datetime)
-        
+
         response = i_manager.dispatch(args, "journeys", instance_name=region)
         if response.journeys:
             before, after = extremes(response, request)
@@ -191,9 +206,16 @@ class Isochrone(Resource, ResourceUtc, FindAndFormatJourneys):
                                 type=option_value(["walking", "car", "bike",
                                                    "bss"]),
                                 action="append", default=["walking"])
-        parser_get.add_argument("max_duration_to_pt", type=int, default=10*60,
-                                description="maximal duration of non public \
-                                transport in second")
+        parser_get.add_argument("max_duration_to_pt", type=int,
+                                description="maximal duration of non public transport in second")
+        parser_get.add_argument("max_walking_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of walking on public transport in second")
+        parser_get.add_argument("max_bike_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of bike on public transport in second")
+        parser_get.add_argument("max_bss_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of bss on public transport in second")
+        parser_get.add_argument("max_car_duration_to_pt", type=int, default=30*60,
+                                description="maximal duration of car on public transport in second")
         parser_get.add_argument("walking_speed", type=float, default=1.12)
         parser_get.add_argument("bike_speed", type=float, default=4.1)
         parser_get.add_argument("bss_speed", type=float, default=4.1)
@@ -217,6 +239,14 @@ class Isochrone(Resource, ResourceUtc, FindAndFormatJourneys):
         args["min_nb_journeys"] = None
         args["max_nb_journeys"] = None
         args["show_codes"] = False
+
+        if args['max_duration_to_pt']:
+            #retrocompatibility: max_duration_to_pt override all individual value by mode
+            args['max_walking_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bike_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bss_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_car_duration_to_pt'] = args['max_duration_to_pt']
+
         response = i_manager.dispatch(args, "isochrone", instance_name=self.region)
         if response.journeys:
             (before, after) = extremes(response, request)

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -527,9 +527,18 @@ class Journeys(ResourceUri, ResourceUtc):
                                 type=option_value(modes),
                                 default=["walking"],
                                 dest="destination_mode", action="append")
-        parser_get.add_argument("max_duration_to_pt", type=int, default=15*60,
-                                description="maximal duration of non public \
-                                transport in second")
+        parser_get.add_argument("max_duration_to_pt", type=int,
+                                description="maximal duration of non public transport in second")
+
+        parser_get.add_argument("max_walking_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of walking on public transport in second")
+        parser_get.add_argument("max_bike_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of bike on public transport in second")
+        parser_get.add_argument("max_bss_duration_to_pt", type=int, default=15*60,
+                                description="maximal duration of bss on public transport in second")
+        parser_get.add_argument("max_car_duration_to_pt", type=int, default=30*60,
+                                description="maximal duration of car on public transport in second")
+
         parser_get.add_argument("walking_speed", type=float, default=1.12)
         parser_get.add_argument("bike_speed", type=float, default=4.1)
         parser_get.add_argument("bss_speed", type=float, default=4.1,)
@@ -583,6 +592,13 @@ class Journeys(ResourceUri, ResourceUtc):
         if args['traveler_type']:
             profile = travelers_profile[args['traveler_type']]
             profile.override_params(args)
+
+        if args['max_duration_to_pt']:
+            #retrocompatibility: max_duration_to_pt override all individual value by mode
+            args['max_walking_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bike_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bss_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_car_duration_to_pt'] = args['max_duration_to_pt']
 
         # TODO : Changer le protobuff pour que ce soit propre
         if args['destination_mode'] == 'vls':
@@ -732,6 +748,13 @@ class Journeys(ResourceUri, ResourceUtc):
             args['destination_mode'] = 'bss'
         if args['origin_mode'] == 'vls':
             args['origin_mode'] = 'bss'
+
+        if args['max_duration_to_pt']:
+            #retrocompatibility: max_duration_to_pt override all individual value by mode
+            args['max_walking_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bike_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_bss_duration_to_pt'] = args['max_duration_to_pt']
+            args['max_car_duration_to_pt'] = args['max_duration_to_pt']
 
         #count override min_nb_journey or max_nb_journey
         if 'count' in args and args['count']:

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -77,13 +77,12 @@ class Scenario(simple.Scenario):
                 req.journeys.datetimes.append(dte)
         req.journeys.clockwise = request["clockwise"]
         sn_params = req.journeys.streetnetwork_params
-        if "max_duration_to_pt" in request:
-            sn_params.max_duration_to_pt = request["max_duration_to_pt"]
-        else:
-            # for the moment we compute the non_TC duration
-            # with the walking_distance
-            max_duration = request["walking_distance"] / request["walking_speed"]
-            sn_params.max_duration_to_pt = max_duration
+#we keep this field for compatibily with kraken 1.2, to be removed after the release of the 1.3
+        sn_params.max_duration_to_pt = request["max_walking_duration_to_pt"]
+        sn_params.max_walking_duration_to_pt = request["max_walking_duration_to_pt"]
+        sn_params.max_bike_duration_to_pt = request["max_bike_duration_to_pt"]
+        sn_params.max_bss_duration_to_pt = request["max_bss_duration_to_pt"]
+        sn_params.max_car_duration_to_pt = request["max_car_duration_to_pt"]
         sn_params.walking_speed = request["walking_speed"]
         sn_params.bike_speed = request["bike_speed"]
         sn_params.car_speed = request["car_speed"]

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -322,25 +322,49 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
         result.mode = type::static_data::get()->modeByCaption(request.destination_mode());
         result.set_filter(request.destination_filter());
     }
+    int max_non_pt;
     switch(result.mode){
         case type::Mode_e::Bike:
             result.offset = data->geo_ref->offsets[type::Mode_e::Bike];
             result.speed_factor = request.bike_speed() / georef::default_speed[type::Mode_e::Bike];
+            if(request.has_max_bike_duration_to_pt()){
+                max_non_pt = request.max_bike_duration_to_pt();
+            }else{
+                //we keep this field for compatibily with kraken 1.2, to be removed after the release of the 1.3
+                max_non_pt = request.max_duration_to_pt();
+            }
             break;
         case type::Mode_e::Car:
             result.offset = data->geo_ref->offsets[type::Mode_e::Car];
             result.speed_factor = request.car_speed() / georef::default_speed[type::Mode_e::Car];
+            if(request.has_max_car_duration_to_pt()){
+                max_non_pt = request.max_car_duration_to_pt();
+            }else{
+                //we keep this field for compatibily with kraken 1.2, to be removed after the release of the 1.3
+                max_non_pt = request.max_duration_to_pt();
+            }
             break;
         case type::Mode_e::Bss:
             result.offset = data->geo_ref->offsets[type::Mode_e::Bss];
             result.speed_factor = request.bss_speed() / georef::default_speed[type::Mode_e::Bss];
+            if(request.has_max_bss_duration_to_pt()){
+                max_non_pt = request.max_bss_duration_to_pt();
+            }else{
+                //we keep this field for compatibily with kraken 1.2, to be removed after the release of the 1.3
+                max_non_pt = request.max_duration_to_pt();
+            }
             break;
         default:
             result.offset = data->geo_ref->offsets[type::Mode_e::Walking];
             result.speed_factor = request.walking_speed() / georef::default_speed[type::Mode_e::Walking];
+            if(request.has_max_walking_duration_to_pt()){
+                max_non_pt = request.max_walking_duration_to_pt();
+            }else{
+                //we keep this field for compatibily with kraken 1.2, to be removed after the release of the 1.3
+                max_non_pt = request.max_duration_to_pt();
+            }
             break;
     }
-    int max_non_pt = request.max_duration_to_pt();
     result.max_duration = navitia::seconds(max_non_pt);
     return result;
 }

--- a/source/type/request.proto
+++ b/source/type/request.proto
@@ -2,7 +2,7 @@ import "type.proto";
 package pbnavitia;
 
 message CalendarsRequest {
-    optional string start_date    	= 1;
+    optional string start_date      = 1;
     optional string end_date        = 2;
     optional int32 depth            = 3;
     optional int32 start_page       = 4;
@@ -47,15 +47,20 @@ message NextStopTimeRequest {
 }
 
 message StreetNetworkParams{
-    optional string origin_mode         = 1;
-    optional string destination_mode    = 2;
-    optional int32 max_duration_to_pt   = 4;
-    optional double walking_speed       = 3;
-    optional double bike_speed          = 5;
-    optional double car_speed           = 7;
-    optional double bss_speed           = 9;
-    optional string origin_filter       = 11;
-    optional string destination_filter  = 12;
+    optional string origin_mode                 = 1;
+    optional string destination_mode            = 2;
+    optional int32 max_duration_to_pt           = 4;//keep for compatibily issues, to be removed after the 1.3 release
+    optional double walking_speed               = 3;
+    optional double bike_speed                  = 5;
+    optional double car_speed                   = 7;
+    optional double bss_speed                   = 9;
+    optional string origin_filter               = 11;
+    optional string destination_filter          = 12;
+
+    optional int32 max_walking_duration_to_pt   = 13;
+    optional int32 max_bike_duration_to_pt      = 14;
+    optional int32 max_bss_duration_to_pt       = 15;
+    optional int32 max_car_duration_to_pt       = 16;
 }
 
 
@@ -72,7 +77,7 @@ message JourneysRequest {
     required bool disruption_active                     = 10;
     optional bool show_codes                            = 11;
     optional bool allow_odt                             = 12;
-    optional bool details								= 13;
+    optional bool details                               = 13;
 }
 
 message PlacesNearbyRequest {


### PR DESCRIPTION
Split the "max_duration_to_pt" for each fallback mode. We keep the
"max_duration_to_pt" in the interface for not breaking the compatibily.

The the max duration for car is now set to 30 min.

The "max_duration_to_pt" field in the protobuf is keeped for compatibily
during the migration to the next version. It will be removed in another
pull request.
