### PR TITLE
geopal: remove doublon of nodes

### DIFF
--- a/source/ed/connectors/geopal_parser.cpp
+++ b/source/ed/connectors/geopal_parser.cpp
@@ -191,7 +191,6 @@ void GeopalParser::fill_ways_edges(){
                     ed::types::Node* source_node;
                     ed::types::Node* target_node;
                     auto source_it = this->data.nodes.find(source);
-                    auto target_it = this->data.nodes.find(target);
 
                     if(source_it == this->data.nodes.end()){
                         source_node = this->add_node(navitia::type::GeographicalCoord(str_to_double(row[x1]), str_to_double(row[y1])), source);
@@ -199,6 +198,7 @@ void GeopalParser::fill_ways_edges(){
                         source_node = source_it->second;
                     }
 
+                    auto target_it = this->data.nodes.find(target);
                     if(target_it == this->data.nodes.end()){
                         target_node = this->add_node(navitia::type::GeographicalCoord(str_to_double(row[x2]), str_to_double(row[y2])), target);
                     }else{


### PR DESCRIPTION
If an edge has the same point as begin and end two point were
created, and after that we have a doublon of id in the nodes
