### PR TITLE
Prev next fix

### DIFF
--- a/source/jormungandr/jormungandr/helper.py
+++ b/source/jormungandr/jormungandr/helper.py
@@ -29,8 +29,10 @@
 
 import re
 
+
 class ReverseProxied(object):
-    '''Wrap the application in this middleware and configure the
+    """
+    Wrap the application in this middleware and configure the
     front-end server to add these headers, to let you quietly bind
     this to an HTTP scheme that is different than what is used locally.
 
@@ -40,7 +42,7 @@ class ReverseProxied(object):
     }
 
     :param app: the WSGI application
-    '''
+    """
     def __init__(self, app):
         self.app = app
         self.re = re.compile('^https?$')
@@ -50,3 +52,4 @@ class ReverseProxied(object):
         if scheme and self.re.match(scheme):
             environ['wsgi.url_scheme'] = scheme
         return self.app(environ, start_response)
+

--- a/source/jormungandr/jormungandr/index.py
+++ b/source/jormungandr/jormungandr/index.py
@@ -30,7 +30,6 @@
 from flask.ext.restful import Resource
 from flask import url_for
 
-
 def index(api):
     api.add_resource(Index, '/')
 
@@ -46,8 +45,10 @@ class Index(Resource):
                     "status": "current",
                     "links": [
                         {
-                            "href": url_for("v1.index", _external=True),
-                            "templated": False
+                            "href": url_for('v1.index', _external=True),
+                            "templated": False,
+                            "rel": 'api',
+                            "type": 'api'
                         }
                     ]
                 }

--- a/source/jormungandr/jormungandr/interfaces/v1/Index.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Index.py
@@ -31,6 +31,7 @@
 
 from flask import url_for
 from flask.ext.restful import Resource
+from make_links import create_external_link
 
 
 class Index(Resource):
@@ -38,18 +39,11 @@ class Index(Resource):
     def get(self):
         response = {
             "links": [
-                {"href": url_for('v1.coverage', _external=True),
-                 "rel": "coverage",
-                 "title": "Coverage of navitia"},
-                {"href": url_for('v1.coord', lon=.0, lat=.0, _external=True),
-                 # TODO find a way to display {long:lat} in the url
-                 "rel": "coord",
-                 "title": "Inverted geocoding for a given coordinate",
-                 "templated": True
-                 },
-                {"href": url_for('v1.journeys', _external=True),
-                 "rel": "journeys",
-                 "title": "Compute journeys"}
+                create_external_link('v1.coverage', rel='coverage', description='Coverage of navitia'),
+                # TODO find a way to display {long:lat} in the url
+                create_external_link('v1.coord', rel='coord', templated=True,
+                            description='Inverted geocoding for a given coordinate', lon=.0, lat=.0),
+                create_external_link('v1.journeys', rel='journeys', description='Compute journeys'),
             ]
         }
         return response, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -29,7 +29,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 import logging
-from flask import Flask, request, url_for, g
+from flask import Flask, request, g
 from flask.ext.restful import fields, reqparse, marshal_with, abort
 from flask.ext.restful.types import boolean
 from jormungandr import i_manager
@@ -50,7 +50,7 @@ import datetime
 from functools import wraps
 from fields import DateTime
 from jormungandr.timezone import set_request_timezone
-from make_links import add_id_links, clean_links
+from make_links import add_id_links, clean_links, create_external_link, create_internal_link
 from errors import ManageError
 from jormungandr.interfaces.argument import ArgumentDoc
 from jormungandr.interfaces.parsers import depth_argument
@@ -274,18 +274,11 @@ class add_journey_href(object):
                     kwargs["from"] = kwargs["lon"] + ';' + kwargs["lat"]
                 del kwargs["lon"]
                 del kwargs["lat"]
-            kwargs["_external"] = True
             for journey in objects[0]['journeys']:
                 if not "sections" in journey.keys():
                     kwargs["datetime"] = journey["requested_date_time"]
                     kwargs["to"] = journey["to"]["id"]
-                    journey['links'] = [
-                        {
-                            "type": "journeys",
-                            "href": url_for("v1.journeys", **kwargs),
-                            "templated": False
-                        }
-                    ]
+                    journey['links'] = [create_external_link("v1.journeys", rel="journeys", **kwargs)]
             return objects
         return wrapper
 
@@ -298,54 +291,48 @@ class add_journey_pagination(object):
             if objects[1] != 200:
                 return objects
             datetime_before, datetime_after = self.extremes(objects[0])
-            if not datetime_before is None and not datetime_after is None:
+            if datetime_before and datetime_after:
                 if not "links" in objects[0]:
                     objects[0]["links"] = []
 
-                args = dict()
-                for item in request.args.iteritems():
-                    args[item[0]] = item[1]
+                args = dict(deepcopy(request.args))
                 args["datetime"] = datetime_before.strftime(f_datetime)
                 args["datetime_represents"] = "arrival"
                 if "region" in kwargs:
                     args["region"] = kwargs["region"]
-                objects[0]["links"].append({
-                    "href": url_for("v1.journeys", _external=True, **args),
-                    "templated": False,
-                    "type": "prev"
-                })
+                # Note, it's not the right thing to do, the rel should be 'next' and
+                # the type 'journey' but for compatibility reason we cannot change before the v2
+                objects[0]["links"].append(create_external_link("v1.journeys",
+                                                       rel='prev',
+                                                       _type='prev',
+                                                       **args))
                 args["datetime"] = datetime_after.strftime(f_datetime)
                 args["datetime_represents"] = "departure"
-                objects[0]["links"].append({
-                    "href": url_for("v1.journeys", _external=True, **args),
-                    "templated": False,
-                    "type": "next"
-                })
+                objects[0]["links"].append(create_external_link("v1.journeys",
+                                                       rel='next',
+                                                       _type='next',
+                                                       **args))
 
             datetime_first, datetime_last = self.first_and_last(objects[0])
-            if not datetime_first is None and not datetime_last is None:
+            if datetime_first and datetime_last:
                 if not "links" in objects[0]:
                     objects[0]["links"] = []
 
-                args = dict()
-                for item in request.args.iteritems():
-                    args[item[0]] = item[1]
+                args = dict(deepcopy(request.args))
                 args["datetime"] = datetime_first.strftime(f_datetime)
                 args["datetime_represents"] = "departure"
                 if "region" in kwargs:
                     args["region"] = kwargs["region"]
-                objects[0]["links"].append({
-                    "href": url_for("v1.journeys", _external=True, **args),
-                    "templated": False,
-                    "type": "first"
-                })
+                objects[0]["links"].append(create_external_link("v1.journeys",
+                                                                rel='first',
+                                                                _type='first',
+                                                                **args))
                 args["datetime"] = datetime_last.strftime(f_datetime)
                 args["datetime_represents"] = "arrival"
-                objects[0]["links"].append({
-                    "href": url_for("v1.journeys", _external=True, **args),
-                    "templated": False,
-                    "type": "last"
-                })
+                objects[0]["links"].append(create_external_link("v1.journeys",
+                                                                rel='last',
+                                                                _type='last',
+                                                                **args))
             return objects
         return wrapper
 
@@ -430,11 +417,9 @@ class add_fare_links(object):
 
                     #them we add the link to the different tickets needed
                     for ticket_needed in ticket_by_section[s["id"]]:
-                        s['links'].append({"type": "ticket",
-                                           "rel": "tickets",
-                                           "internal": True,
-                                           "templated": False,
-                                           "id": ticket_needed})
+                        s['links'].append(create_internal_link(_type="ticket",
+                                                               rel="tickets",
+                                                               id=ticket_needed))
 
             return objects
         return wrapper

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -57,9 +57,10 @@ def create_external_link(url, rel, _type=None, templated=False, description=None
         "type": _type
     }
     if description:
-        d['description'] = description
+        d['title'] = description
 
     return d
+
 
 def create_internal_link(rel, _type, id, templated=False, description=None):
     """
@@ -79,10 +80,9 @@ def create_internal_link(rel, _type, id, templated=False, description=None):
         "type": _type
     }
     if description:
-        d['description'] = description
+        d['title'] = description
     if id:
         d['id'] = id
-
 
 
 class generate_links(object):

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -39,8 +39,8 @@ from flask.ext.restful.utils import unpack
 def create_external_link(url, rel, _type=None, templated=False, description=None, **kwargs):
     """
     :param url: url forwarded to flask's url_for
-    :param rel:  TODO: good explanation
-    :param _type:
+    :param rel: relation of the link to the current object
+    :param _type: type of linked object
     :param templated: if the link is templated ({} is the url)
     :param description: description of the link
     :param kwargs: args forwarded to url_for
@@ -63,8 +63,8 @@ def create_external_link(url, rel, _type=None, templated=False, description=None
 
 def create_internal_link(rel, _type, id, templated=False, description=None):
     """
-    :param rel: TODO: good explanation
-    :param _type:
+    :param rel: relation of the link to the current object
+    :param _type: type of linked object
     :param id: id of the link
     :param templated: if the link is templated ({} is the url)
     :return: a dict representing a link

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -435,7 +435,16 @@ def is_valid_journey_response(response, tester, query_str):
                 #TODO check datetime
                 continue
             if k == 'datetime_represents':
-                #TODO check datetime
+                query_dt_rep = query_dict.get('datetime_represents', 'departure')
+                if l in ['prev', 'last']:
+                    #the datetime_represents is negated
+                    if query_dt_rep == 'departure':
+                        assert v == 'arrival'
+                    else:
+                        assert v == 'departure'
+                else:
+                    query_dt_rep == v
+
                 continue
 
             assert query_dict[k] == v, "we must have the same query"

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -144,8 +144,7 @@ class TestDepartureBoard(AbstractTestFixture):
         """
         departure board for a given date
         """
-        self.query_region("routes", display=True)
-        response = self.query_region("routes/line:A:0/route_schedules?from_datetime=20120615T080000", display=True)
+        response = self.query_region("routes/line:A:0/route_schedules?from_datetime=20120615T080000")
 
         assert "route_schedules" in response
         is_valid_route_schedule(response["route_schedules"])

--- a/source/jormungandr/tests/no_stats_tests.py
+++ b/source/jormungandr/tests/no_stats_tests.py
@@ -64,7 +64,7 @@ class TestNoStats(AbstractTestFixture):
         stats deactivation should not alter results
         """
         stat_manager.save_stat = False # we disable the stats
-        response = self.query_region(journey_basic_query, display=False)
+        response = self.query_region(journey_basic_query)
 
         is_valid_journey_response(response, self.tester, journey_basic_query)
 
@@ -72,5 +72,5 @@ class TestNoStats(AbstractTestFixture):
         """
         Even if the stat manager is failing we want the journey result.
         """
-        response = self.query_region(journey_basic_query, display=False)
+        response = self.query_region(journey_basic_query)
         is_valid_journey_response(response, self.tester, journey_basic_query)

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -38,7 +38,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_vj_default_depth(self):
         """default depth is 1"""
-        response = self.query_region("v1/vehicle_journeys", display=True)
+        response = self.query_region("v1/vehicle_journeys")
 
         vjs = get_not_null(response, 'vehicle_journeys')
 
@@ -86,7 +86,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_line(self):
         """test line formating"""
-        response = self.query_region("v1/lines", display=True)
+        response = self.query_region("v1/lines")
 
         lines = get_not_null(response, 'lines')
 
@@ -101,7 +101,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_route(self):
         """test line formating"""
-        response = self.query_region("v1/routes", display=True)
+        response = self.query_region("v1/routes")
 
         routes = get_not_null(response, 'routes')
 


### PR DESCRIPTION
some list param were missing in links

small refactoring  of the links

this refactoring should be more complete, but we cannot do this before
the v2 and some thought about the internal link handling

links example:
api endpoint

``` json
"versions": [
    {
        "description": "Current version of the api",
        "links": [
            {
                "href": "http://localhost:5000/v1/",
                "rel": "api",
                "templated": false,
                "type": "api"
            }
        ],
        "status": "current",
        "value": "v1"
    }
]
```

call on 'v1'

``` json
{

    "links": [
        {
            "description": "Coverage of navitia",
            "href": "http://localhost:5000/v1/coverage/",
            "rel": "coverage",
            "templated": false,
            "type": "coverage"
        },
        {
            "description": "Inverted geocoding for a given coordinate",
            "href": "http://localhost:5000/v1/coord/0.0%3B0.0",
            "rel": "coord",
            "templated": true,
            "type": "coord"
        },
        {
            "description": "Compute journeys",
            "href": "http://localhost:5000/v1/journeys",
            "rel": "journeys",
            "templated": false,
            "type": "journeys"
        }
    ]

}
```

some links on journeys:

``` json
links": [
    {
        "href": "http://localhost:5000/v1/journeys?to=poi%3ATAOGen861&min_nb_journeys=3&from=stop_area%3ASCF%3ASA%3ASAOCE87543009&datetime_represents=arrival&datetime=20141030T153116",
        "rel": "prev",
        "templated": false,
        "type": "prev"
    },
    {
        "href": "http://localhost:5000/v1/coverage/stop_points/{stop_point.id}?collection=stop_points",
        "rel": "stop_points",
        "templated": true,
        "type": "stop_point"
    },
```

Note: for the 'next' links the type should be 'journeys' but since it was 'next' before we cannot change that before the v2 :cry: 
