### PR TITLE
TimeTable: do not associate empty calendars

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -246,6 +246,12 @@ find_matching_calendar(const Data&, const std::string& name, const ValidityPatte
     LOG4CPLUS_TRACE(log, "meta vj " << name << " :" << validity_pattern.days.to_string());
 
     for (const auto calendar : calendar_list) {
+        // sometimes a calendar can be empty (for example if it's validity period does not
+        // intersect the data's validity period)
+        // we do not filter those calendar since it's a user input, but we do not match them
+        if (! calendar->validity_pattern.days.any()) {
+            continue;
+        }
         auto diff = get_difference(calendar->validity_pattern.days, validity_pattern.days);
         size_t nb_diff = diff.count();
 


### PR DESCRIPTION
fixes http://jira.canaltp.fr/browse/NAVITIAII-1281

we paired empty calendars with every vj so the stop_schedule were not perfects :smile: 
