### PR TITLE
kraken: return the accessibility of the section and not only the vj

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -96,7 +96,12 @@ static void fill_section(pbnavitia::Section *pb_section, const type::VehicleJour
     }
     auto* vj_pt_display_information = pb_section->mutable_pt_display_informations();
     auto* add_info_vehicle_journey = pb_section->mutable_add_info_vehicle_journey();
-    fill_pb_object(vj, d, vj_pt_display_information, 0, now, action_period);
+    if(! stop_times.empty()){
+        fill_pb_object(vj, d, vj_pt_display_information, stop_times.front()->journey_pattern_point->stop_point, stop_times.back()->journey_pattern_point->stop_point, 0, now, action_period);
+    }else{
+        fill_pb_object(vj, d, vj_pt_display_information, 0, now, action_period);
+    }
+
     fill_pb_object(vj, d, stop_times, add_info_vehicle_journey, 0, now, action_period);
     fill_shape(pb_section, stop_times);
 }

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -203,9 +203,24 @@ void fill_pb_object(const type::VehicleJourney* vj, const type::Data& data,
                     const boost::posix_time::time_period& action_period = null_time_period);
 
 void fill_pb_object(const type::VehicleJourney* vj, const type::Data& data,
+                    pbnavitia::PtDisplayInfo* pt_display_info, const type::StopPoint* origin,
+                    const type::StopPoint* destination, int max_depth,
+                    const boost::posix_time::ptime& now,
+                    const boost::posix_time::time_period& action_period);
+
+void fill_pb_object(const type::VehicleJourney* vj, const type::Data& data,
                     pbnavitia::PtDisplayInfo* pt_display_info, int max_depth,
                     const boost::posix_time::ptime& now,
                     const boost::posix_time::time_period& action_period);
+
+void fill_pb_object(const type::VehicleJourney* vj, const type::Data& data,
+                    pbnavitia::hasEquipments* has_equipments, int max_depth,
+                    const pt::ptime& now, const pt::time_period& action_period);
+
+void fill_pb_object(const type::VehicleJourney* vj, const type::Data&,
+                    pbnavitia::hasEquipments* has_equipments, const type::StopPoint* origin,
+                    const type::StopPoint* destination, int,
+                    const pt::ptime&, const pt::time_period&);
 
 
 void fill_pb_error(const pbnavitia::Error::error_id id, const std::string& comment,

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -70,12 +70,12 @@ message PtDisplayInfo {
     optional string color = 5;
     optional string commercial_mode = 6;
     optional string physical_mode = 7;
-  	optional string description = 8;
-  	optional Uris uris = 9;
-  	optional VehicleJourneyType vehicle_journey_type = 10;
-  	optional hasEquipments has_equipments = 11;
-  	optional string name = 12;
-  	repeated Message messages = 13;
+    optional string description = 8;
+    optional Uris uris = 9;
+    optional VehicleJourneyType vehicle_journey_type = 10;
+    optional hasEquipments has_equipments = 11;
+    optional string name = 12;
+    repeated Message messages = 13;
 }
 
 message Uris {
@@ -218,8 +218,8 @@ message addInfoVehicleJourney{
 }
 
 message Header{
-	required PtDisplayInfo pt_display_informations = 1;
-	required addInfoVehicleJourney add_info_vehicle_journey = 2;
+    required PtDisplayInfo pt_display_informations = 1;
+    required addInfoVehicleJourney add_info_vehicle_journey = 2;
 }
 
 message Table {
@@ -307,9 +307,9 @@ message Error{
 }
 
 message Disruption{
-	optional Network network = 1;
-	repeated Line lines = 2;
-	repeated StopArea stop_areas = 3;	
+    optional Network network = 1;
+    repeated Line lines = 2;
+    repeated StopArea stop_areas = 3;   
 }
 
 message Response{


### PR DESCRIPTION
On journey the "pt_display_information" contains the accessibility of
the full section, so for a section wheelchair accessible, the origin
stop_point, the destination stop_point and the vehicle_journey need to
be wheelchair accessible
