### PR TITLE
Add label

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -469,5 +469,6 @@ void builder::connection(const std::string & name1, const std::string & name2, f
  void builder::build_autocomplete() {
     data->pt_data->build_autocomplete(*(data->geo_ref));
     data->geo_ref->build_autocomplete_list();
- }
+    data->compute_labels();
+}
 }

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -60,6 +60,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
+    b.data->compute_labels();
     b.data->meta->production_date = boost::gregorian::date_period(boost::gregorian::date(2012,06,14), boost::gregorian::days(7));
 
     RAPTOR raptor(*b.data);
@@ -147,6 +148,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff_no_data) {
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
+    b.data->compute_labels();
     b.data->meta->production_date = boost::gregorian::date_period(boost::gregorian::date(2012,06,14), boost::gregorian::days(7));
 
     RAPTOR raptor(*b.data);

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -58,6 +58,8 @@ namespace navitia {
 
             std::string post_code;
             std::string insee;
+            std::string label;
+
             nt::GeographicalCoord coord;
             polygon_type boundary;
             std::vector<const Admin*> admin_list;
@@ -66,7 +68,7 @@ namespace navitia {
             Admin():level(-1){}
             Admin(int lev):level(lev){}
             template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-                ar & idx & level & from_original_dataset & post_code & insee & name & uri & coord & admin_list & main_stop_areas;
+                ar & idx & level & from_original_dataset & post_code & insee & name & uri & coord & admin_list & main_stop_areas & label;
             }
         };
     }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -61,6 +61,11 @@ void Way::add_house_number(const HouseNumber& house_number){
     }
 }
 
+std::string Way::get_label() const {
+    //the label of the way is it's name + the city
+    return name + navitia::type::get_admin_name(this);
+}
+
 /** Recherche des coordonnées les plus proches à un un numéro
     * les coordonnées par extrapolation
 */

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -149,6 +149,7 @@ public:
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
       ar & idx & name & comment & uri & way_type & admin_list & house_number_left & house_number_right & edges;
     }
+    std::string get_label() const;
 
 private:
       nt::GeographicalCoord get_geographical_coord(const std::vector< HouseNumber>&, const int);

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -387,11 +387,12 @@ struct POI : public nt::Nameable, nt::Header{
     nt::idx_t poitype_idx;
     int address_number;
     std::string address_name;
+    std::string label;
 
     POI(): weight(0), poitype_idx(type::invalid_idx), address_number(-1){}
 
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
-        ar &idx & uri &name & weight & coord & admin_list & properties & poitype_idx & visible & address_number & address_name;
+        ar &idx & uri & name & weight & coord & admin_list & properties & poitype_idx & visible & address_number & address_name & label;
     }
 
     std::vector<type::idx_t> get(type::Type_e type, const GeoRef &) const;

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -470,6 +470,7 @@ stop_area["stop_point"] = PbField(deepcopy(stop_point))
 journey_pattern_point["stop_point"] = PbField(deepcopy(stop_point))
 address = deepcopy(generic_type_admin)
 address["house_number"] = fields.Integer()
+address["label"] = fields.String()
 
 stop_point["address"] = PbField(address)
 poi["address"] = PbField(address)

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -383,6 +383,7 @@ generic_type = {
 admin = deepcopy(generic_type)
 admin["level"] = fields.Integer
 admin["zip_code"] = fields.String
+admin["label"] = fields.String()
 
 generic_type_admin = deepcopy(generic_type)
 admins = NonNullList(NonNullNested(admin))
@@ -393,11 +394,13 @@ stop_point = deepcopy(generic_type_admin)
 stop_point["messages"] = NonNullList(NonNullNested(generic_message))
 stop_point["comment"] = fields.String()
 stop_point["codes"] = NonNullList(NonNullNested(code))
+stop_point["label"] = fields.String()
 stop_area = deepcopy(generic_type_admin)
 stop_area["messages"] = NonNullList(NonNullNested(generic_message))
 stop_area["comment"] = fields.String()
 stop_area["codes"] = NonNullList(NonNullNested(code))
 stop_area["timezone"] = fields.String()
+stop_area["label"] = fields.String()
 
 journey_pattern_point = {
     "id": fields.String(attribute="uri"),
@@ -457,6 +460,7 @@ poi_type = deepcopy(generic_type)
 poi = deepcopy(generic_type_admin)
 poi["poi_type"] = PbField(poi_type)
 poi["properties"] = get_key_value()
+poi["label"] = fields.String()
 
 company = deepcopy(generic_type)
 company["codes"] = NonNullList(NonNullNested(code))

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -568,6 +568,7 @@ def is_valid_stop_area(stop_area, depth_check=1):
     """
     get_not_null(stop_area, "name")
     coord = get_not_null(stop_area, "coord")
+    is_valid_label(get_not_null(stop_area, "label"))
     is_valid_coord(coord)
 
 
@@ -576,6 +577,7 @@ def is_valid_stop_point(stop_point, depth_check=1):
     check the structure of a stop point
     """
     get_not_null(stop_point, "name")
+    is_valid_label(get_not_null(stop_point, "label"))
     coord = get_not_null(stop_point, "coord")
     is_valid_coord(coord)
 
@@ -632,7 +634,7 @@ def is_valid_places(places, depth_check=1):
 def is_valid_place(place, depth_check=1):
     if depth_check < 0:
         return
-    get_not_null(place, "name")
+    n = get_not_null(place, "name")
     get_not_null(place, "id")
     type = get_not_null(place, "embedded_type")
     if type == "address":
@@ -641,9 +643,16 @@ def is_valid_place(place, depth_check=1):
     elif type == "stop_area":
         stop_area = get_not_null(place, "stop_area")
         is_valid_stop_area(stop_area, depth_check)
+
+        #for stops name should be the label
+        is_valid_label(n)
+        assert stop_area['label'] == n
     elif type == "stop_point":
         stop_point = get_not_null(place, "stop_point")
         is_valid_stop_point(stop_point, depth_check)
+
+        is_valid_label(n)
+        assert stop_point['label'] == n
     elif type == "poi":
         poi = get_not_null(place, "poi")
         # TODO
@@ -727,6 +736,14 @@ def is_valid_region_status(status):
     is_valid_date(get_not_null(status, 'start_production_date'))
     get_valid_datetime(get_not_null(status, 'last_load_at'), possible_errors=True)
     get_valid_datetime(get_not_null(status, 'publication_date'), possible_errors=True)
+
+
+label_regexp = re.compile(".* \(.*\)")
+
+
+def is_valid_label(label):
+    m = label_regexp.match(label)
+    return m is not None
 
 
 s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -738,6 +738,9 @@ def is_valid_region_status(status):
     get_valid_datetime(get_not_null(status, 'publication_date'), possible_errors=True)
 
 
+# for () are mandatory for the label even if is reality it is not
+# (for example if the admin has no post code or a stop no admin)
+# This make the test data a bit more difficult to create, but that way we can check the label creation
 label_regexp = re.compile(".* \(.*\)")
 
 

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -42,7 +42,7 @@ class TestJourneys(AbstractTestFixture):
     def test_journeys(self):
         #NOTE: we query /v1/coverage/main_routing_test/journeys and not directly /v1/journeys
         #not to use the jormungandr database
-        response = self.query_region(journey_basic_query)
+        response = self.query_region(journey_basic_query, display=True)
 
         is_valid_journey_response(response, self.tester, journey_basic_query)
 

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -371,6 +371,7 @@ struct routing_api_data {
         b.data->build_uri();
         b.data->build_proximity_list();
         b.data->meta->production_date = boost::gregorian::date_period(boost::gregorian::date(2012,06,14), boost::gregorian::days(7));
+        b.data->compute_labels();
 
         //add bike sharing edges
         b.data->geo_ref->default_time_bss_pickup = navitia::seconds(30);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -280,6 +280,7 @@ void Data::complete(){
     admin = (pt::microsec_clock::local_time() - start).total_milliseconds();
 
     compute_labels();
+
     start = pt::microsec_clock::local_time();
     pt_data->sort();
     sort = (pt::microsec_clock::local_time() - start).total_milliseconds();
@@ -442,14 +443,18 @@ void Data::compute_labels() {
             boost::algorithm::split(str_vec, admin->post_code, boost::algorithm::is_any_of(";"));
             int min_value = std::numeric_limits<int>::max();
             int max_value = std::numeric_limits<int>::min();
+            try {
             for (const std::string& str_post_code : str_vec) {
                 int int_post_code;
-                try {
+
                     int_post_code = boost::lexical_cast<int>(str_post_code);
                     min_value = std::min(min_value, int_post_code);
                     max_value = std::max(max_value, int_post_code);
                 }
-                catch (boost::bad_lexical_cast) {}
+            }
+            catch (boost::bad_lexical_cast) {
+                //if one fail, we display all postcode
+                min_value = std::numeric_limits<int>::max();
             }
             if (min_value != std::numeric_limits<int>::max()) {
                 post_code = boost::lexical_cast<std::string>(min_value)

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -274,13 +274,12 @@ void Data::complete(){
     build_associated_calendar();
     build_odt();
 
-    compute_labels();
-
     start = pt::microsec_clock::local_time();
     LOG4CPLUS_INFO(logger, "Building administrative regions");
     build_administrative_regions();
     admin = (pt::microsec_clock::local_time() - start).total_milliseconds();
 
+    compute_labels();
     start = pt::microsec_clock::local_time();
     pt_data->sort();
     sort = (pt::microsec_clock::local_time() - start).total_milliseconds();

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -73,7 +73,7 @@ struct wrong_version : public navitia::exception {
 class Data : boost::noncopyable{
 public:
 
-    static const unsigned int data_version = 28; //< Data version number. *INCREMENT* every time serialized data are modified
+    static const unsigned int data_version = 29; //< Data version number. *INCREMENT* every time serialized data are modified
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded
@@ -172,7 +172,11 @@ public:
     void build_odt();
 
     void build_grid_validity_pattern();
+
     void complete();
+
+    /** For some pt object we compute the label */
+    void compute_labels();
 
     /** Retourne le type de l'id donné */
     Type_e get_type_of_id(const std::string & id) const;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -217,6 +217,17 @@ std::vector<std::pair<const Calendar*, ValidityPattern::year_bitset>>
 find_matching_calendar(const Data&, const std::string& name, const ValidityPattern& validity_pattern,
                        const std::vector<Calendar*>& calendar_list, double relative_threshold = 0.1);
 
+
+template<typename T>
+std::string get_admin_name(const T* v) {
+    std::string admin_name = "";
+    for(auto admin : v->admin_list) {
+        if (admin->level == 8){
+            admin_name += " (" + admin->name + ")";
+        }
+    }
+    return admin_name;
+}
 }} //namespace navitia::type
 
 BOOST_CLASS_VERSION(navitia::type::Data, navitia::type::Data::data_version)

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -218,16 +218,6 @@ find_matching_calendar(const Data&, const std::string& name, const ValidityPatte
                        const std::vector<Calendar*>& calendar_list, double relative_threshold = 0.1);
 
 
-template<typename T>
-std::string get_admin_name(const T* v) {
-    std::string admin_name = "";
-    for(auto admin : v->admin_list) {
-        if (admin->level == 8){
-            admin_name += " (" + admin->name + ")";
-        }
-    }
-    return admin_name;
-}
 }} //namespace navitia::type
 
 BOOST_CLASS_VERSION(navitia::type::Data, navitia::type::Data::data_version)

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1037,6 +1037,8 @@ void fill_pb_object(const georef::POI* geopoi, const type::Data &data,
                 pb_address->mutable_coord()->set_lat(geopoi->coord.lat());
                 pb_address->mutable_coord()->set_lon(geopoi->coord.lon());
             }
+            pb_address->set_label(std::to_string(geopoi->address_number) + " "
+                                  + geopoi->label);
         }
     }
     for(const auto& propertie : geopoi->properties){

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -32,20 +32,21 @@ www.navitia.io
 #include "data.h"
 #include "type/type.pb.h"
 #include "type/response.pb.h"
+#include "type/pt_data.h"
 
 //forward declare
-namespace navitia{
-    namespace routing{
+namespace navitia {
+    namespace routing {
         struct PathItem;
     }
-    namespace georef{
+    namespace georef {
         struct PathItem;
         struct Way;
         struct POI;
         struct Path;
         struct POIType;
     }
-    namespace fare{
+    namespace fare {
         struct results;
         struct Ticket;
     }
@@ -234,23 +235,35 @@ void fill_pb_placemark(const navitia::georef::Admin* value, const type::Data &da
         const boost::posix_time::time_period& action_period = null_time_period,
         const bool show_codes=false);
 
-std::string name_formater(const navitia::type::StopArea* sa);
-std::string name_formater(const navitia::georef::POI* poi);
-
+/**
+ * get_label() is a function that returns:
+ * * the label if the object has it
+ * * call get_label if possible
+ * * else return the name of the object
+ *
+ * Note: the trick is that int is a better match for 0 than
+ * long and long is better than double, and template resolution takes the best match
+ */
+namespace detail {
 template<typename T>
-std::string get_admin_name(const T* v) {
-    std::string admin_name = "";
-    for(auto admin : v->admin_list) {
-        if (admin->level == 8){
-            admin_name += " (" + admin->name + ")";
-        }
-    }
-    return admin_name;
+auto get_label_if_exists(const T* v, int) -> decltype(v->label) {
+    return v->label;
 }
 
 template<typename T>
-std::string name_formater(const T* v) {
+auto get_label_if_exists(const T* v, long) -> decltype(v->get_label()) {
+    return v->get_label();
+}
+
+template<typename T>
+auto get_label_if_exists(const T* v, double) -> decltype(v->name) {
     return v->name;
+}
+}
+
+template<typename T>
+std::string get_label(const T* v) {
+    return detail::get_label_if_exists(v, 0);
 }
 
 template<typename T>
@@ -263,7 +276,8 @@ void fill_pb_placemark(const T* value, const type::Data &data, pbnavitia::PtObje
     int depth = (max_depth <= 3) ? max_depth : 3;
     fill_pb_object(value, data, get_sub_object(value, pt_object), depth,
                    now, action_period, show_codes);
-    pt_object->set_name(name_formater(value));
+    pt_object->set_name(get_label(value));
+    std::cout << "name " << pt_object->name() << " for object: " << value->uri << std::endl;
     pt_object->set_uri(value->uri);
     pt_object->set_embedded_type(get_embedded_type(value));
 }

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -237,12 +237,11 @@ void fill_pb_placemark(const navitia::georef::Admin* value, const type::Data &da
 
 /**
  * get_label() is a function that returns:
- * * the label if the object has it
- * * call get_label if possible
+ * * the label (or a function get_label()) if the object has it
  * * else return the name of the object
  *
  * Note: the trick is that int is a better match for 0 than
- * long and long is better than double, and template resolution takes the best match
+ * long and template resolution takes the best match
  */
 namespace detail {
 template<typename T>
@@ -251,12 +250,12 @@ auto get_label_if_exists(const T* v, int) -> decltype(v->label) {
 }
 
 template<typename T>
-auto get_label_if_exists(const T* v, long) -> decltype(v->get_label()) {
+auto get_label_if_exists(const T* v, int) -> decltype(v->get_label()) {
     return v->get_label();
 }
 
 template<typename T>
-auto get_label_if_exists(const T* v, double) -> decltype(v->name) {
+auto get_label_if_exists(const T* v, long) -> decltype(v->name) {
     return v->name;
 }
 }

--- a/source/type/tests/fill_pb_placemark_test.cpp
+++ b/source/type/tests/fill_pb_placemark_test.cpp
@@ -53,16 +53,16 @@ BOOST_AUTO_TEST_CASE(get_label_test) {
         std::string label = "bobitto's the best";
         //label should be prefered to name
     };
-    struct bobitta {
-        std::string label = "bobitta";
-        std::string get_label() const { return label + "'s the best"; }
-        //label should be prefered to get_label()
+    struct bobitte {
+        std::string name = "bobitte";
+        std::string get_label() const { return name + "'s the best"; }
+        //get_label should be prefered to name
     };
 
     BOOST_CHECK_EQUAL(navitia::get_label(std::make_unique<bob>().get()), "sponge bob");
     BOOST_CHECK_EQUAL(navitia::get_label(std::make_unique<bobette>().get()), "bobette");
     BOOST_CHECK_EQUAL(navitia::get_label(std::make_unique<bobitto>().get()), "bobitto's the best");
-    BOOST_CHECK_EQUAL(navitia::get_label(std::make_unique<bobitta>().get()), "bobitta");
+    BOOST_CHECK_EQUAL(navitia::get_label(std::make_unique<bobitte>().get()), "bobitte's the best");
 }
 
 BOOST_AUTO_TEST_CASE(name_formater_sa) {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -382,12 +382,13 @@ struct StopArea : public Header, Nameable, hasProperties, HasMessages, Codes{
     std::string additional_data;
     std::vector<navitia::georef::Admin*> admin_list;
     bool wheelchair_boarding = false;
+    std::string label;
     //name of the time zone of the stop area
     //the name must respect the format of the tz db, for example "Europe/Paris"
     std::string timezone;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-        ar & idx & uri & name & coord & stop_point_list & admin_list
+        ar & idx & label & uri & name & coord & stop_point_list & admin_list
         & _properties & wheelchair_boarding & messages & visible
                 & comment & codes & timezone;
     }
@@ -687,6 +688,7 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages, Codes{
     GeographicalCoord coord;
     int fare_zone;
     std::string platform_code;
+    std::string label;
 
     StopArea* stop_area;
     std::vector<navitia::georef::Admin*> admin_list;
@@ -696,7 +698,7 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages, Codes{
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         journey_pattern_point_list.resize(0);
-        ar & uri & name & stop_area & coord & fare_zone & idx & platform_code
+        ar & uri & label & name & stop_area & coord & fare_zone & idx & platform_code
             & journey_pattern_point_list & admin_list & _properties & messages
             & stop_point_connection_list & comment & codes;
     }

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -999,6 +999,17 @@ struct EntryPoint {
         return true;
     }
 };
+
+template<typename T>
+std::string get_admin_name(const T* v) {
+    std::string admin_name = "";
+    for(auto admin : v->admin_list) {
+        if (admin->level == 8){
+            admin_name += " (" + admin->name + ")";
+        }
+    }
+    return admin_name;
+}
 } //namespace navitia::type
 
 //trait to access the number of elements in the Mode_e enum
@@ -1008,4 +1019,5 @@ struct enum_size_trait<type::Mode_e> {
         return 4;
     }
 };
+
 } //namespace navitia

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -103,6 +103,7 @@ message AdministrativeRegion {
     optional string zip_code = 4;
     optional int32 level = 5;
     optional GeographicalCoord coord = 6;
+    optional string label = 7;
 }
 
 message StopArea {
@@ -115,6 +116,7 @@ message StopArea {
     optional string comment = 11;
     repeated Code codes = 12;
     optional string timezone = 15;
+    optional string label = 16;
 }
 
 message StopPoint {
@@ -128,8 +130,9 @@ message StopPoint {
     repeated Message messages = 9;
     optional string comment = 11;
     repeated Code codes = 12;
-	optional Address address = 13;
+    optional Address address = 13;
     optional string platform_code = 14;
+    optional string label = 15;
 }
 
 enum OdtLevel{
@@ -302,6 +305,7 @@ message Poi {
     repeated AdministrativeRegion administrative_regions = 10;
     optional Address address = 11;
     repeated Code properties = 12;
+    optional string label = 13;
 }
 
 message Network {
@@ -342,6 +346,7 @@ message Address {
     optional GeographicalCoord coord = 6;
     repeated AdministrativeRegion administrative_regions = 10;
     optional int32 house_number = 2;
+    optional string label = 16;
 }
 
 enum ExceptionType {


### PR DESCRIPTION
add a new field on some pt object: label

the label is meant to be a better name. It contains for the stops and the poi the city:
for the administrative regions, it contains the range of the postal codes.

Also fix the name of the places to get the label if is exists.

```
from": {
    "embedded_type": "stop_area",
    "id": "stop_area:SCF:SA:SAOCE87543009",
    "name": "gare d'Orléans (Orléans)", <-------- label of contained object
    "quality": 0,
    "stop_area": {
        "administrative_regions": [
            {
                ...
                "id": "admin:45234",
                "label": "Orléans (45000)", <---- name of the city + postal code
                "level": 8,
                "name": "Orléans",
                "zip_code": "45000"
            }
        ],
    ...
        "id": "stop_area:SCF:SA:SAOCE87543009",
        "label": "gare d'Orléans (Orléans)", <------ name of the stop area  + city
        "name": "gare d'Orléans",
        "timezone": "Europe/Paris"
    }

},
```

for adress too we put the city:

```
from": {

    "address": {
        "administrative_regions": [
            {
                "coord": {
                    "lat": "47.90137977",
                    "lon": "1.903903442"
                },
                "id": "admin:45234",
                "label": "Orléans (45000)",
                "level": 8,
                "name": "Orléans",
                "zip_code": "45000"
            }
        ],
        "coord": {
            "lat": "47.90821298299134",
            "lon": "1.9041324897365957"
        },
        "house_number": 7,
        "id": "1.9041324897365957;47.90821298299134",
        "label": "7 avenue de Paris (Orléans)",
        "name": "avenue de Paris"
    },
    "embedded_type": "address",
    "id": "1.9041324897365957;47.90821298299134",
    "name": "7 avenue de Paris (Orléans)",
    "quality": 0

},
},
```

fixes http://jira.canaltp.fr/browse/NAVITIAII-1101
