### PR TITLE
TimeTable: fix stop schedule for calendar

### DIFF
--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -129,6 +129,11 @@ std::vector<period_with_utc_shift> get_dst_periods(const boost::gregorian::date_
     //we add the last non DST period
     res.push_back({ {res.back().period.end(), boost::gregorian::date(years.back() + 1, 1, 1)},
                     tz->base_utc_offset() });
+
+    //we want the shift in seconds, and it is in minute in the tzdb
+    for (auto& p_shift: res) {
+        p_shift.utc_shift *= 60;
+    }
     return res;
 }
 
@@ -932,7 +937,7 @@ void StopTimeGtfsHandler::finish(Data& data) {
 }
 
 int to_utc(const std::string& local_time, int utc_offset) {
-    return time_to_int(local_time) - utc_offset * 60;
+    return time_to_int(local_time) - utc_offset;
 }
 
 std::vector<nm::StopTime*> StopTimeGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -212,7 +212,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     std::string odt_message;
     std::string meta_vj_name; //link to it's meta vj
     std::string shape_id;
-    int16_t utc_to_local_offset = 0; // shift used to convert the local time from the data to utc, in minute
+    int16_t utc_to_local_offset = 0; // shift used to convert the local time from the data to utc, in seconds
 
     int start_time = std::numeric_limits<int>::max(); /// First departure of vehicle
     int end_time = std::numeric_limits<int>::max(); /// Last departure of vehicle journey

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -105,8 +105,12 @@ class Schedules(ResourceUri, ResourceUtc):
         # we save the original datetime for debuging purpose
         args['original_datetime'] = args['from_datetime']
 
-        new_datetime = self.convert_to_utc(args['from_datetime'])
-        args['from_datetime'] = utils.date_to_timestamp(new_datetime)
+        if not args.get('calendar'):
+            #if a calendar is given all times will be given in local (because it might span over dst)
+            new_datetime = self.convert_to_utc(args['from_datetime'])
+            args['from_datetime'] = utils.date_to_timestamp(new_datetime)
+        else:
+            args['from_datetime'] = utils.date_to_timestamp(args['from_datetime'])
 
         return i_manager.dispatch(args, self.endpoint,
                                   instance_name=self.region)

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -199,12 +199,10 @@ get_all_stop_times(const type::JourneyPatternPoint* jpp,
                 //we need to convert this to local there since we do not have a precise date (just a period)
                 res.push_back({time + vj->utc_to_local_offset, st});
             }
-
         } else {
             //same utc tranformation
             res.push_back({st->departure_time + vj->utc_to_local_offset, st});
         }
-
     }
 
     return res;

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -68,53 +68,6 @@ std::vector<vector_datetime> make_columuns(const vector_dt_st &stop_times) {
     return result;
 }
 
-
-pbnavitia::Response
-render_v0(const std::map<stop_point_line, vector_dt_st> &map_route_stop_point,
-          DateTime datetime, DateTime max_datetime,
-          const type::Data &data) {
-    pbnavitia::Response response;
-    auto current_time = pt::second_clock::local_time();
-    pt::time_period action_period(to_posix_time(datetime, data),
-                                  to_posix_time(max_datetime, data));
-
-    auto sort_predicate =
-        [&](datetime_stop_time d1, datetime_stop_time d2)->bool {
-            auto hour1 = DateTimeUtils::hour(d1.first) % DateTimeUtils::SECONDS_PER_DAY;
-            auto hour2 = DateTimeUtils::hour(d2.first) % DateTimeUtils::SECONDS_PER_DAY;
-            return std::abs(hour1 - DateTimeUtils::hour(datetime)) <
-                   std::abs(hour2 - DateTimeUtils::hour(datetime));
-        };
-
-    for(auto id_vec : map_route_stop_point) {
-
-        auto board = response.add_departure_boards();
-        fill_pb_object(data.pt_data->stop_points[id_vec.first.first], data,
-                       board->mutable_stop_point(), 1,
-                       current_time, action_period);
-        fill_pb_object(data.pt_data->routes[id_vec.first.second], data,
-                       board->mutable_route(), 2, current_time, action_period);
-
-        auto vec_st = id_vec.second;
-        std::sort(vec_st.begin(), vec_st.end(), sort_predicate);
-
-        for(auto vec : make_columuns(vec_st)) {
-            pbnavitia::BoardItem *item = board->add_board_items();
-
-            for(DateTime dt : vec) {
-                if(!item->has_hour()) {
-                    auto hours = DateTimeUtils::hour(dt)/3600;
-                    item->set_hour(boost::lexical_cast<std::string>(hours));
-                }
-                auto minutes = (DateTimeUtils::hour(dt)%3600)/60;
-                item->add_minutes(boost::lexical_cast<std::string>(minutes));
-            }
-        }
-    }
-    return response;
-}
-
-
 pbnavitia::Response
 render_v1(const std::map<uint32_t, pbnavitia::ResponseStatus>& response_status,
           const std::map<stop_point_line, vector_dt_st> &map_route_stop_point,
@@ -280,15 +233,14 @@ departure_board(const std::string& request,
         }
     }
 
-    if(interface_version == 0) {
-        handler.pb_response = render_v0(map_route_stop_point,
-                                        handler.date_time,
-                                        handler.max_datetime, data);
-    } else if(interface_version == 1) {
+    if(interface_version == 1) {
         handler.pb_response = render_v1(response_status, map_route_stop_point,
                                         handler.date_time,
                                         handler.max_datetime,
                                         calendar_id, depth, show_codes, data);
+    } else {
+        fill_pb_error(pbnavitia::Error::bad_filter, "invalid interface version", handler.pb_response.mutable_error());
+        return handler.pb_response;
     }
 
 

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -184,7 +184,7 @@ departure_board(const std::string& request,
             if(jpp->journey_pattern->route != route) {
                 continue;
             }
-            if(stop_point->idx == jpp->journey_pattern->journey_pattern_point_list.back()->stop_point->idx) { // dans le cas de terminus
+            if(stop_point->idx == jpp->journey_pattern->journey_pattern_point_list.back()->stop_point->idx) { // for terminus
                 response_status[route->idx] = pbnavitia::ResponseStatus::terminus;
                 continue;
             }
@@ -210,11 +210,12 @@ departure_board(const std::string& request,
                       [&handler](datetime_stop_time dst1, datetime_stop_time dst2) {
                 auto is_before_start1 = (DateTimeUtils::hour(dst1.first) < DateTimeUtils::hour(handler.date_time));
                 auto is_before_start2 = (DateTimeUtils::hour(dst2.first) < DateTimeUtils::hour(handler.date_time));
+
                 if (is_before_start1 != is_before_start2) {
                     //if one is before and one is after, we want the one after first
                     return ! is_before_start1;
                 }
-                return dst1.first < dst2.first;
+                return DateTimeUtils::hour(dst1.first) < DateTimeUtils::hour(dst2.first);
                 });
             if (stop_times.size() > max_date_times) {
                 stop_times.resize(max_date_times);

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -611,7 +611,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     // however, sometime we do not have a date to convert the time to a local value (in jormungandr)
     // For example for departure board over a period (calendar)
     // thus we store the shit needed to convert all stop times of the vehicle journey to local
-    int16_t utc_to_local_offset = 0; //in minutes
+    int16_t utc_to_local_offset = 0; //in seconds
 
     bool is_adapted = false; //REMOVE (change to enum ?)
     ValidityPattern* adapted_validity_pattern = nullptr; //REMOVE


### PR DESCRIPTION
fix http://jira.canaltp.fr/browse/NAVITIAII-1320

the utc offset was apply as seconds while it was stored in minutes...

we now store it in seconds, like the DateTime
