### PR TITLE
Fix sorting of vj in route schedules

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -70,7 +70,7 @@ nt::MetaVehicleJourney* get_or_create_metavj(builder& b, const std::string name)
     return it->second;
 }
 
-nt::JourneyPattern* get_or_create_journey_pattern(builder&b, std::string uri) {
+nt::JourneyPattern* get_or_create_journey_pattern(builder& b, const std::string& uri) {
     auto it = std::find_if(b.data->pt_data->journey_patterns.begin(),
                         b.data->pt_data->journey_patterns.end(),
                         [uri](nt::JourneyPattern* jp) {

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -51,7 +51,9 @@ struct VJ {
     navitia::type::VehicleJourney * vj;
 
     /// Construit un nouveau vehicle journey
-    VJ(builder & b, const std::string &line_name, const std::string &validity_pattern, const std::string & block_id, bool is_adapted = true, const std::string& uri="", std::string meta_vj_name = "");
+    VJ(builder & b, const std::string &line_name, const std::string &validity_pattern,
+       const std::string & block_id, bool is_adapted = true, const std::string& uri="",
+       std::string meta_vj_name = "", std::string jp_uri = "");
 
     /// Ajout un nouveau stopTime
     /// Lorsque le depart n'est pas specifié, on suppose que c'est le même qu'à l'arrivée
@@ -107,14 +109,16 @@ struct builder{
           const std::string& block_id="",
           const bool wheelchair_boarding = true,
           const std::string& uri="",
-          const std::string& meta_vj="");
+          const std::string& meta_vj="",
+          const std::string &jp_uri = "");
     VJ vj(const std::string& network_name,
           const std::string& line_name,
           const std::string& validity_pattern = "11111111",
           const std::string& block_id="",
           const bool wheelchair_boarding = true,
           const std::string& uri="",
-          const std::string& meta_vj="");
+          const std::string& meta_vj="",
+          const std::string &jp_uri="");
 
     /// Crée un nouveau stop area
     SA sa(const std::string & name, double x = 0, double y = 0, const bool is_adapted = true);

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -144,12 +144,10 @@ std::vector<std::vector<datetime_stop_time> >
 make_matrice(const std::vector<std::vector<datetime_stop_time> >& stop_times,
              const Thermometer &thermometer, const type::Data &) {
     // result group stop_times by stop_point, tmp by vj.
-    std::vector<std::vector<datetime_stop_time> > result, tmp;
     const size_t thermometer_size = thermometer.get_thermometer().size();
-    for (size_t i=0; i < stop_times.size(); ++i) {
-        tmp.push_back(std::vector<datetime_stop_time>(thermometer_size));
-    }
-
+    std::vector<std::vector<datetime_stop_time> > 
+        result(thermometer_size, std::vector<datetime_stop_time>(stop_times.size())),
+        tmp(stop_times.size(), std::vector<datetime_stop_time>(thermometer_size));
     // We match every stop_time with the journey pattern
     int y=0;
     for(const std::vector<datetime_stop_time>& vec : stop_times) {
@@ -164,11 +162,6 @@ make_matrice(const std::vector<std::vector<datetime_stop_time> >& stop_times,
     }
 
     std::sort(tmp.begin(), tmp.end(), compare);
-
-    for(unsigned int i=0; i<thermometer_size; ++i) {
-        result.push_back(std::vector<datetime_stop_time>());
-        result.back().resize(stop_times.size());
-    }
     // We rotate the matrice, so it can be handle more easily in route_schedule
     for (size_t i=0; i<tmp.size(); ++i) {
         for (size_t j=0; j<tmp[i].size(); ++j) {

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -152,7 +152,7 @@ make_matrice(const std::vector<std::vector<datetime_stop_time> >& stop_times,
 
     // We match every stop_time with the journey pattern
     int y=0;
-    for(std::vector<datetime_stop_time> vec : stop_times) {
+    for(const std::vector<datetime_stop_time>& vec : stop_times) {
         auto jpp = *vec.front().second->vehicle_journey->journey_pattern;
         std::vector<uint32_t> orders = thermometer.match_journey_pattern(jpp);
         int order = 0;

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -153,8 +153,8 @@ make_matrice(const std::vector<std::vector<datetime_stop_time> >& stop_times,
     // We match every stop_time with the journey pattern
     int y=0;
     for(const std::vector<datetime_stop_time>& vec : stop_times) {
-        auto jpp = *vec.front().second->vehicle_journey->journey_pattern;
-        std::vector<uint32_t> orders = thermometer.match_journey_pattern(jpp);
+        auto journey_pattern = vec.front().second->vehicle_journey->journey_pattern;
+        std::vector<uint32_t> orders = thermometer.match_journey_pattern(*journey_pattern);
         int order = 0;
         for(datetime_stop_time dt_stop_time : vec) {
             tmp[y][orders[order]] = dt_stop_time;

--- a/source/time_tables/tests/CMakeLists.txt
+++ b/source/time_tables/tests/CMakeLists.txt
@@ -16,3 +16,9 @@ ADD_BOOST_TEST(thermometer_test)
 add_executable(departure_boards_test departure_boards_test.cpp)
 target_link_libraries(departure_boards_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
 ADD_BOOST_TEST(departure_boards_test)
+
+
+
+add_executable(route_schedules_test route_schedules_test.cpp)
+target_link_libraries(route_schedules_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
+ADD_BOOST_TEST(route_schedules_test)

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -1,0 +1,97 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+  
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+ 
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+  
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+   
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+   
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+  
+Stay tuned using
+twitter @navitia 
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_ed
+#include <boost/test/unit_test.hpp>
+#include "ed/build_helper.h"
+#include "type/type.h"
+#include "tests/utils_test.h"
+#include "time_tables/route_schedules.h"
+//for more concice test
+pt::ptime d(std::string str) {
+    return boost::posix_time::from_iso_string(str);
+}
+/*
+    Wanted schedules:
+            VJ1    VJ2    VJ3    VJ4
+        A          8h00   8h05
+        B          8h10   8h20   8h25
+        C   8h05
+        D   9h30                 9h35
+
+        But the thermometer algorithm is buggy, is doesn't give the shorest common superstring..
+        So, actually we have this schedule
+            VJ1
+        C
+        D
+        A   8h
+        B   8h10
+        D
+
+With VJ1, and VJ2, we ensure that we are no more comparing the two first jpp of
+each VJ, but we have a more human order.
+VJ2 and VJ3, is a basic test.
+The difficulty with VJ4 comes when we have to compare it to VJ1.
+When comparing VJ1 and VJ4, we compare VJ1(stopC) with VJ4(stopD)
+and when we compare VJ4 and VJ1, we compare VJ4(stopB) with VJ1(stopC).
+*/
+BOOST_AUTO_TEST_CASE(test1) {
+    ed::builder b("20120614");
+    const std::string a_name = "stopA",
+                      b_name = "stopB",
+                      c_name = "stopC",
+                      d_name = "stopD";
+    b.vj("A", "1111111", "", true, "1", "1", "JP1")(c_name, 8*3600 + 5*60)(d_name, 9*3600 + 30*60);
+    b.vj("A", "1111111", "", true, "2", "2", "JP2")(a_name, 8*3600)(b_name, 8*3600 + 10*60);
+    b.vj("A", "1111111", "", true, "3", "3", "JP2")(a_name, 8*3600 + 5*60)(b_name, 8*3600 + 20*60);
+    b.vj("A", "1111111", "", true, "4", "4", "JP3")(b_name, 8*3600+25*60)(d_name, 9*3600 + 35*60);
+    b.data->pt_data->index();
+    b.data->build_raptor();
+
+    boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20120613");
+    boost::gregorian::date end = boost::gregorian::date_from_iso_string("20120630");
+
+    b.data->meta->production_date = boost::gregorian::date_period(begin, end);
+
+    pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=A", {}, d("20120615T070000"), 86400, 1, 3,
+    10, 0, *(b.data), false, false);
+    BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
+    pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
+    auto get_vj = [](pbnavitia::RouteSchedule r, int i) {
+        return r.table().headers(i).pt_display_informations().uris().vehicle_journey();
+    };
+    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 0), "1");
+    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 1), "2");
+    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 2), "3");
+    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 3), "4");
+}
+
+


### PR DESCRIPTION
We were only comparing vj with their first stop_time defined. So with this case:

```
A    7h00
B    8h00   7h30      
C           8h00
```

And we actually want: 

```
A         7h00
B   7h30  8h00
C   8h00
```
