### PR TITLE
Kraken: fix overlapping of two stop_times of a vehicle_journey

### DIFF
--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -68,7 +68,6 @@ struct RAPTOR
     boost::dynamic_bitset<> valid_journey_pattern_points;
     ///L'ordre du premier j: public AbstractRouterourney_pattern point de la journey_pattern
     queue_t Q;
-    bool end_algorithm = false;
 
     //Constructeur
     RAPTOR(const navitia::type::Data &data) :
@@ -159,12 +158,13 @@ struct RAPTOR
                       bool global_pruning = true,
                       const uint32_t max_transfers=std::numeric_limits<uint32_t>::max());
 
-    /// Fonction générique pour la marche à pied
-    /// Il faut spécifier le visiteur selon le sens souhaité
-    template<typename Visitor> void foot_path(const Visitor & v);
+    /// Apply foot pathes to labels
+    /// Return true if it improves at least one label, false otherwise
+    template<typename Visitor> bool foot_path(const Visitor & v);
 
+    /// Returns true if we improve at least one label, false otherwise
     template<typename Visitor>
-    void apply_vj_extension(const Visitor& v, const bool global_pruning,
+    bool apply_vj_extension(const Visitor& v, const bool global_pruning,
                             const type::VehicleJourney* prev_vj, type::idx_t boarding_jpp_idx,
                             DateTime workingDt, const uint16_t l_zone,
                             const bool disruption_active);

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -68,6 +68,7 @@ struct RAPTOR
     boost::dynamic_bitset<> valid_journey_pattern_points;
     ///L'ordre du premier j: public AbstractRouterourney_pattern point de la journey_pattern
     queue_t Q;
+    bool end_algorithm = false;
 
     //Constructeur
     RAPTOR(const navitia::type::Data &data) :
@@ -178,23 +179,6 @@ struct RAPTOR
     /// Retourne à quel tour on a trouvé la meilleure solution pour ce journey_patternpoint
     /// Retourne -1 s'il n'existe pas de meilleure solution
     int best_round(type::idx_t journey_pattern_point_idx);
-
-    template<typename Visitor>
-    inline
-    void mark_all_jpp_of_sp(const type::StopPoint* stop_point, const DateTime dt, const type::idx_t boarding_jpp,
-                            label_vector_t& working_labels, Visitor visitor) {
-        for(auto jpp : stop_point->journey_pattern_point_list) {
-            type::idx_t jpp_idx = jpp->idx;
-            if(jpp_idx != boarding_jpp && visitor.comp(dt, best_labels[jpp_idx])) {
-               working_labels[jpp_idx].dt_transfer = dt;
-               working_labels[jpp_idx].boarding_jpp_transfer = boarding_jpp;
-               best_labels[jpp_idx] = dt;
-               if(visitor.comp(jpp->order, Q[jpp->journey_pattern->idx])) {
-                   Q[jpp->journey_pattern->idx] = jpp->order;
-               }
-            }
-        }
-    }
 
     ~RAPTOR() {}
 };

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -69,6 +69,20 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
             } else {
                 auto start_time = st.start_time(!clockwise),
                      end_time = st.end_time(!clockwise) % DateTimeUtils::SECONDS_PER_DAY;
+                // Here we check if hour is out of the period of the frequency.
+                // In normal case we have something like:
+                // 0-------------------------------------86400(midnight)
+                //     start_time-------end_time
+                // So hour is out of the period if (hour < start_time || hour > end_time)
+                // If end_time, is after midnight, so end_time%86400 will be < start_time
+                // So we will have something like:
+                // 0-------------------------------------86400(midnight)
+                //     end_time-------start_time
+                // So hour will be out of the period if (hour <= start_time && hour >= end_time)
+                // We can think of a case where even with the modulo, end_time is superior
+                // to start_time, so the vehicle always runs, therefore the dataset should have
+                // start_time=0, end_time=86400, if this happens, we should handle it in
+                // the ed part
                 if ((start_time < end_time && (hour < start_time || hour > end_time)) ||
                     (start_time > end_time && (hour <= start_time && hour >= end_time)) ||
                     start_time == end_time) {

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -63,12 +63,12 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
             const type::StopTime& st = vj->stop_time_list[jpp->order];
             auto st_hour = clockwise ? st.arrival_time : st.departure_time;
             if (!st.is_frequency()) {
-                if ((st_hour%86400) != hour) {
+                if ((st_hour%DateTimeUtils::SECONDS_PER_DAY) != hour) {
                     continue;
                 }
             } else {
                 auto start_time = st.start_time(!clockwise),
-                     end_time = st.end_time(!clockwise) % 86400;
+                     end_time = st.end_time(!clockwise) % DateTimeUtils::SECONDS_PER_DAY;
                 if ((start_time < end_time && (hour < start_time || hour > end_time)) ||
                     (start_time > end_time && (hour <= start_time && hour >= end_time)) ||
                     start_time == end_time) {

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -155,9 +155,8 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
                 const type::StopTime* st = nullptr;
                 DateTime dt = 0;
 
-                std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt_pt,
-                        accessibilite_params.vehicle_properties,
-                        !clockwise, disruption_active, raptor.data, true);
+                std::tie(st, dt) = get_current_stidx_gap(round, jppidx, raptor.labels, accessibilite_params,
+                                                                      !clockwise, raptor.data, disruption_active);
                 if(st != nullptr) {
                     if(clockwise) {
                         auto arrival_time = !st->is_frequency() ? 
@@ -170,11 +169,11 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
                             st->f_departure_time(DateTimeUtils::hour(dt));
                         DateTimeUtils::update(best_dt_jpp, departure_time, true);
                     }
+                    if(clockwise)
+                        best_dt = l.dt_pt - spid_dist.second.total_seconds();
+                    else
+                        best_dt = l.dt_pt + spid_dist.second.total_seconds();
                 }
-                if(clockwise)
-                    best_dt = l.dt_pt - spid_dist.second.total_seconds();
-                else
-                    best_dt = l.dt_pt + spid_dist.second.total_seconds();
             }
         }
         if(best_jpp != type::invalid_idx) {

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -1360,6 +1360,26 @@ BOOST_AUTO_TEST_CASE(pareto_front) {
                 }));
 }
 
+ BOOST_AUTO_TEST_CASE(overlapping_on_first_st) {
+     ed::builder b("20120614");
+     b.vj("A")("stop1", 8000, 8200)("stop2", 8500);
+     b.vj("A")("stop1", 8100, 8300)("stop2", 8600);
+     b.data->pt_data->index();
+     b.data->build_raptor();
+     RAPTOR raptor(*b.data);
+     auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, false, true);
+
+     BOOST_REQUIRE_EQUAL(res1.size(), 1);
+
+     auto res = res1.back();
+     BOOST_CHECK_EQUAL(res.items[0].stop_points[0]->idx, 0);
+     BOOST_CHECK_EQUAL(res.items[0].stop_points[1]->idx, 1);
+     BOOST_CHECK_EQUAL(res.items[0].departure.time_of_day().total_seconds(), 8200);
+     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 8500);
+     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
+     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
+
+ }
 
 BOOST_AUTO_TEST_CASE(stay_in_unnecessary) {
     ed::builder b("20120614");


### PR DESCRIPTION
It could happen that we have 2 stop_time at vj looking alike:
ST1: arrival_time:   8h00
     departure_time: 8h10
ST2: arrival_time: 8h05
     departure_time: 8h15
It can happen at the first vj.

With the previous method, when we marked ST1, we were retrieving ST2.
AND THAT'S NO GOOD!
