### PR TITLE
Kraken: better handling of vehicle_journeys with stay_in

### DIFF
--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -130,20 +130,25 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
                 best_jpp = jppidx;
                 best_dt_jpp = l.dt_pt;
                 best_nb_jpp_of_path = nb_jpp;
-                // Dans le sens horaire : lors du calcul on gardé que l’heure de départ, mais on veut l’arrivée
-                // Il faut donc retrouver le stop_time qui nous intéresse avec best_stop_time
-                const type::StopTime* st;
+                // When computing with clockwise, in the second pass we store deparutre time
+                // in labels, but we want arrival time, so we need to retrive the good stop_time
+                // with best_stop_time
+                const type::StopTime* st = nullptr;
                 DateTime dt = 0;
 
-                std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt_pt, accessibilite_params.vehicle_properties,
-                                                  !clockwise, disruption_active, raptor.data, true);
-                BOOST_ASSERT(st);
+                std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt_pt,
+                        accessibilite_params.vehicle_properties,
+                        !clockwise, disruption_active, raptor.data, true);
                 if(st != nullptr) {
                     if(clockwise) {
-                        auto arrival_time = !st->is_frequency() ? st->arrival_time : st->f_arrival_time(DateTimeUtils::hour(dt));
+                        auto arrival_time = !st->is_frequency() ? 
+                                st->arrival_time :
+                                st->f_arrival_time(DateTimeUtils::hour(dt));
                         DateTimeUtils::update(best_dt_jpp, arrival_time, false);
                     } else {
-                        auto departure_time = !st->is_frequency() ? st->departure_time : st->f_departure_time(DateTimeUtils::hour(dt));
+                        auto departure_time = !st->is_frequency() ?
+                            st->departure_time :
+                            st->f_departure_time(DateTimeUtils::hour(dt));
                         DateTimeUtils::update(best_dt_jpp, departure_time, true);
                     }
                 }

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -93,6 +93,25 @@ bool is_equal(const DateTime & best_so_far, bool clockwise, const DateTime & cur
     return dt == best_so_far;
 }
 
+size_t nb_jpp_of_path(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active,
+                      const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor) {
+    struct VisitorNbJPP : public BasePathVisitor {
+        size_t nb_jpp = 0;
+        void loop_vj(const type::StopTime*, boost::posix_time::ptime, boost::posix_time::ptime) {
+            ++nb_jpp;
+        }
+
+        void change_vj(const type::StopTime*, const type::StopTime*,
+                       boost::posix_time::ptime ,boost::posix_time::ptime,
+                       bool) {
+            ++nb_jpp;
+        }
+    };
+    VisitorNbJPP v;
+    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    return v.nb_jpp;
+}
+
 Solutions
 get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, navitia::time_duration> > &departs,
                const std::vector<std::pair<type::idx_t, navitia::time_duration> > &destinations,
@@ -352,25 +371,6 @@ navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std:
     }
 
     return walking_time;
-}
-
-size_t nb_jpp_of_path(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active,
-                      const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor) {
-    struct VisitorNbJPP : public BasePathVisitor {
-        size_t nb_jpp = 0;
-        void loop_vj(const type::StopTime*, boost::posix_time::ptime, boost::posix_time::ptime) {
-            ++nb_jpp;
-        }
-
-        void change_vj(const type::StopTime*, const type::StopTime*,
-                       boost::posix_time::ptime ,boost::posix_time::ptime,
-                       bool) {
-            ++nb_jpp;
-        }
-    };
-    VisitorNbJPP v;
-    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
-    return v.nb_jpp;
 }
 
 }}

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -78,13 +78,19 @@ get_solutions(const std::vector<std::pair<type::idx_t, navitia::time_duration> >
     return result;
 }
 
+DateTime combine_dt_walking_time(bool clockwise, const DateTime & current, int walking_duration) {
+    return clockwise ? current - walking_duration : current + walking_duration;
+}
+
 // Does the current date improves compared to best_so_far – we must not forget to take the walking duration
 bool improves(const DateTime & best_so_far, bool clockwise, const DateTime & current, int walking_duration) {
-    if(clockwise) {
-        return (current - walking_duration) > best_so_far;
-    } else {
-        return (current + walking_duration) < best_so_far;
-    }
+    const auto dt = combine_dt_walking_time(clockwise, current, walking_duration);
+    return clockwise ? dt > best_so_far : dt < best_so_far;
+}
+
+bool is_equal(const DateTime & best_so_far, bool clockwise, const DateTime & current, int walking_duration) {
+    const auto dt = combine_dt_walking_time(clockwise, current, walking_duration);
+    return dt == best_so_far;
 }
 
 Solutions
@@ -105,36 +111,46 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<type::idx_t, naviti
         // For every round with look for the best journey pattern point that belongs to one of the destination stop points
         // We must not forget to walking duration
         type::idx_t best_jpp = type::invalid_idx;
+        size_t best_nb_jpp_of_path = std::numeric_limits<size_t>::max();
         for(auto spid_dist : destinations) {
             for(auto journey_pattern_point : raptor.data.pt_data->stop_points[spid_dist.first]->journey_pattern_point_list) {
                 type::idx_t jppidx = journey_pattern_point->idx;
                 auto& l = raptor.labels[round][jppidx];
-                if(l.pt_is_initialized() &&
-                   improves(best_dt, clockwise, l.dt_pt, spid_dist.second.total_seconds()) ) {
-                    best_jpp = jppidx;
-                    best_dt_jpp = l.dt_pt;
-                    // Dans le sens horaire : lors du calcul on gardé que l’heure de départ, mais on veut l’arrivée
-                    // Il faut donc retrouver le stop_time qui nous intéresse avec best_stop_time
-                    const type::StopTime* st;
-                    DateTime dt = 0;
-
-                    std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt_pt, accessibilite_params.vehicle_properties,
-                                                      !clockwise, disruption_active, raptor.data, true);
-                    BOOST_ASSERT(st);
-                    if(st != nullptr) {
-                        if(clockwise) {
-                            auto arrival_time = !st->is_frequency() ? st->arrival_time : st->f_arrival_time(DateTimeUtils::hour(dt));
-                            DateTimeUtils::update(best_dt_jpp, arrival_time, false);
-                        } else {
-                            auto departure_time = !st->is_frequency() ? st->departure_time : st->f_departure_time(DateTimeUtils::hour(dt));
-                            DateTimeUtils::update(best_dt_jpp, departure_time, true);
-                        }
-                    }
-                    if(clockwise)
-                        best_dt = l.dt_pt - spid_dist.second.total_seconds();
-                    else
-                        best_dt = l.dt_pt + spid_dist.second.total_seconds();
+                if (!l.pt_is_initialized()) {
+                    continue;
                 }
+                size_t nb_jpp = nb_jpp_of_path(round, jppidx, clockwise, disruption_active,
+                                               accessibilite_params, raptor);
+                if(!improves(best_dt, clockwise, l.dt_pt, spid_dist.second.total_seconds())) {
+                    if (!is_equal(best_dt, clockwise, l.dt_pt, spid_dist.second.total_seconds()) ||
+                             best_nb_jpp_of_path <= nb_jpp) {
+                        continue;
+                    }
+                }
+                best_jpp = jppidx;
+                best_dt_jpp = l.dt_pt;
+                best_nb_jpp_of_path = nb_jpp;
+                // Dans le sens horaire : lors du calcul on gardé que l’heure de départ, mais on veut l’arrivée
+                // Il faut donc retrouver le stop_time qui nous intéresse avec best_stop_time
+                const type::StopTime* st;
+                DateTime dt = 0;
+
+                std::tie(st, dt) = best_stop_time(journey_pattern_point, l.dt_pt, accessibilite_params.vehicle_properties,
+                                                  !clockwise, disruption_active, raptor.data, true);
+                BOOST_ASSERT(st);
+                if(st != nullptr) {
+                    if(clockwise) {
+                        auto arrival_time = !st->is_frequency() ? st->arrival_time : st->f_arrival_time(DateTimeUtils::hour(dt));
+                        DateTimeUtils::update(best_dt_jpp, arrival_time, false);
+                    } else {
+                        auto departure_time = !st->is_frequency() ? st->departure_time : st->f_departure_time(DateTimeUtils::hour(dt));
+                        DateTimeUtils::update(best_dt_jpp, departure_time, true);
+                    }
+                }
+                if(clockwise)
+                    best_dt = l.dt_pt - spid_dist.second.total_seconds();
+                else
+                    best_dt = l.dt_pt + spid_dist.second.total_seconds();
             }
         }
         if(best_jpp != type::invalid_idx) {
@@ -331,6 +347,25 @@ navitia::time_duration getWalkingTime(int count, type::idx_t jpp_idx, const std:
     }
 
     return walking_time;
+}
+
+size_t nb_jpp_of_path(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active,
+                      const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor) {
+    struct VisitorNbJPP : public BasePathVisitor {
+        size_t nb_jpp = 0;
+        void loop_vj(const type::StopTime*, boost::posix_time::ptime, boost::posix_time::ptime) {
+            ++nb_jpp;
+        }
+
+        void change_vj(const type::StopTime*, const type::StopTime*,
+                       boost::posix_time::ptime ,boost::posix_time::ptime,
+                       bool) {
+            ++nb_jpp;
+        }
+    };
+    VisitorNbJPP v;
+    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    return v.nb_jpp;
 }
 
 }}

--- a/source/routing/raptor_solutions.h
+++ b/source/routing/raptor_solutions.h
@@ -105,7 +105,4 @@ getWalkingTime(int count, type::idx_t jpp_idx, const std::vector<std::pair<type:
                bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params,
                const navitia::routing::RAPTOR &raptor);
 
-size_t nb_jpp_of_path(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active,
-                      const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor);
-
 }}

--- a/source/routing/raptor_solutions.h
+++ b/source/routing/raptor_solutions.h
@@ -105,4 +105,7 @@ getWalkingTime(int count, type::idx_t jpp_idx, const std::vector<std::pair<type:
                bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params,
                const navitia::routing::RAPTOR &raptor);
 
+size_t nb_jpp_of_path(int count, type::idx_t jpp_idx, bool clockwise, bool disruption_active,
+                      const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor);
+
 }}

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -1359,3 +1359,21 @@ BOOST_AUTO_TEST_CASE(pareto_front) {
                     path.items.back().arrival.time_of_day().total_seconds() == 10*3600;
                 }));
 }
+
+
+BOOST_AUTO_TEST_CASE(stay_in_unnecessary) {
+    ed::builder b("20120614");
+    b.vj("A", "1111111", "block1", true)("stop2", 8*3600)("stop3", 8*3600+10*60);
+    b.vj("B", "1111111", "block1", true)("stop1", 7*3600)("stop2", 8*3600);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data & d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, false, true);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_REQUIRE_EQUAL(res1.back().items.size(), 1);
+}
+


### PR DESCRIPTION
We need to be able to answer the journey with the lesser number of journey_pattern_points visited.
When we compute the pareto_front we are now taking in account this parameter.
