### PR TITLE
Cmake: remove worker dependency to fill_disruption_from_database

### DIFF
--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -1,9 +1,11 @@
+add_library(fill_disruption_from_chaos fill_disruption_from_chaos.cpp)
+target_link_libraries(fill_disruption_from_chaos data pb_lib protobuf)
 
-add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp fill_disruption_from_chaos.cpp)
-target_link_libraries(workers pq pqxx SimpleAmqpClient disruption_api calendar_api ptreferential autocomplete georef
+add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp)
+target_link_libraries(workers fill_disruption_from_chaos pq pqxx SimpleAmqpClient disruption_api calendar_api ptreferential autocomplete georef
   routing time_tables tcmalloc)
 add_library(fill_disruption_from_database fill_disruption_from_database.cpp)
-target_link_libraries(fill_disruption_from_database workers data pb_lib pq pqxx ${Boost_FORMAT_LIBRARY} protobuf)
+target_link_libraries(fill_disruption_from_database fill_disruption_from_chaos data pb_lib pq pqxx ${Boost_FORMAT_LIBRARY} protobuf)
 
 add_executable(kraken kraken_zmq.cpp)
 target_link_libraries(kraken workers zmq types proximitylist


### PR DESCRIPTION
because fill_disruption_from_database is used by ed, so we had a
tcmalloc dependency to ed
