### PR TITLE
kraken: handling crowfly for main_stop_area

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -132,7 +132,7 @@ void add_pathes(EnhancedResponse &enhanced_response, const std::vector<navitia::
          *    to the origin stop point of the first section only if the stop point belongs to this area.
          *
          * 2) we start from an area but the chosen stop point don't belongs to this area, for example we want to start
-         * from an city, but the pt part of the journey start in another city, in this case 
+         * from an city, but the pt part of the journey start in another city, in this case
          * we add a street network section from the centroid of this area to the departure of the first pt_section
          *
          * 3) We start from a ponctual place (everything but stop_area or admin)
@@ -142,7 +142,8 @@ void add_pathes(EnhancedResponse &enhanced_response, const std::vector<navitia::
          * same we do nothing
          **/
 
-        if (!path.items.front().stop_points.empty() && use_crow_fly(origin, path.items.front().stop_points.front())){
+        if (!path.items.front().stop_points.empty()
+                && use_crow_fly(origin, path.items.front().stop_points.front(), d)){
             const auto sp_dest = path.items.front().stop_points.front();
             type::EntryPoint destination_tmp(type::Type_e::StopPoint, sp_dest->uri);
             bt::time_period action_period(path.items.front().departures.front(),
@@ -283,7 +284,8 @@ void add_pathes(EnhancedResponse &enhanced_response, const std::vector<navitia::
             pb_section->set_duration(arr_time - dep_time);
         }
 
-        if (!path.items.back().stop_points.empty() && use_crow_fly(destination, path.items.back().stop_points.back())){
+        if (!path.items.back().stop_points.empty()
+                && use_crow_fly(destination, path.items.back().stop_points.back(), d)){
             const auto sp_orig = path.items.back().stop_points.back();
             type::EntryPoint origin_tmp(type::Type_e::StopPoint, sp_orig->uri);
             bt::time_period action_period(path.items.back().departures.back(),

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -29,6 +29,7 @@ www.navitia.io
 */
 
 #include "routing.h"
+#include "type/data.h"
 
 namespace navitia { namespace routing {
 
@@ -74,15 +75,23 @@ std::string PathItem::print() const {
 }
 
 
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point){
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point, const type::Data& data){
     if(point.type == type::Type_e::StopArea){
         //if we have a stop area in the request, we only do a crowfly section if the used stop point belongs to this stop area
         return point.uri == stop_point->stop_area->uri;
     }else if(point.type == type::Type_e::Admin){
         //if we have a admin in the request, we only do a crowfly section if the used stop point belongs to this admin
         auto admin_it = find_if(begin(stop_point->stop_area->admin_list), end(stop_point->stop_area->admin_list),
-                [point](const navitia::georef::Admin* admin){return admin->uri == point.uri;});
-        return admin_it != end(stop_point->stop_area->admin_list);
+                [point](const navitia::georef::Admin* admin){return (admin->uri == point.uri);});
+        if(admin_it != end(stop_point->stop_area->admin_list)){
+            return true;
+        }else{//we handle the main_stop_area of an admin here
+            //we want a crowfly for all main_stop_areas of a admin, even if the stop_area is not in the admin
+            auto admin = data.geo_ref->admins[data.geo_ref->admin_map[point.uri]];
+            auto it = find_if(begin(admin->main_stop_areas), end(admin->main_stop_areas),
+                    [stop_point](const type::StopArea* stop_area){return stop_area == stop_point->stop_area;});
+            return it != end(admin->main_stop_areas);
+        }
     }else{
         //if the request is on any other type we don't want a crowfly section
         return false;

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -124,7 +124,7 @@ bool operator==(const PathItem & a, const PathItem & b);
  * @param point: the object where we are going/coming: the requested origin for the first section or the destination for the last section
  * @param stop_point: for the first section, the stop point where we are going, or for the last section the stop point from where we come
  */
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point);
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point, const type::Data& data);
 
 
 }}

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1476,34 +1476,47 @@ BOOST_AUTO_TEST_CASE(use_crow_fly){
     navitia::type::EntryPoint ep;
     navitia::type::StopPoint sp;
     navitia::type::StopArea sa;
-    ng::Admin admin;
+    ng::Admin* admin = new ng::Admin();
     sp.stop_area = &sa;
-    sa.admin_list.push_back(&admin);
+    sa.admin_list.push_back(admin);
 
     sa.uri = "sa:foo";
-    admin.uri = "admin";
+    admin->uri = "admin";
     ep.uri = "foo";
     ep.type = navitia::type::Type_e::Address;
+    navitia::type::Data data;
+    data.geo_ref->admins.push_back(admin);
+    data.geo_ref->admin_map[admin->uri] = 0;
 
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, data));
 
     ep.type = navitia::type::Type_e::POI;
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, data));
 
     ep.type = navitia::type::Type_e::Coord;
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, data));
 
     ep.type = navitia::type::Type_e::StopArea;
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, data));
 
     ep.type = navitia::type::Type_e::Admin;
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, data));
 
     ep.type = navitia::type::Type_e::Admin;
     ep.uri = "admin";
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(nr::use_crow_fly(ep, &sp, data));
 
     ep.type = navitia::type::Type_e::StopArea;
     ep.uri = "sa:foo";
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp));
+    BOOST_CHECK(nr::use_crow_fly(ep, &sp, data));
+
+    ep.type = navitia::type::Type_e::Admin;
+    ep.uri = "admin";
+    navitia::type::StopPoint sp2;
+    navitia::type::StopArea sa2;
+    sp2.stop_area = &sa2;
+    BOOST_CHECK(! nr::use_crow_fly(ep, &sp2, data));
+
+    admin->main_stop_areas.push_back(&sa2);
+    BOOST_CHECK(nr::use_crow_fly(ep, &sp2, data));
 }


### PR DESCRIPTION
If a stop_area is defined as a main_stop_area of a admin we want a
crowfly, even if this stop_area is not in the admin.
