### PR TITLE
better reverve geocoding in journey 

### DIFF
--- a/source/jormungandr/tests/stats_tests.py
+++ b/source/jormungandr/tests/stats_tests.py
@@ -121,7 +121,7 @@ class MockWrapper:
         assert stat.journeys[1].sections[0].mode == "walking"
         assert stat.journeys[1].sections[0].to_embedded_type == "address"
         assert stat.journeys[1].sections[0].to_id == ""
-        assert stat.journeys[1].sections[0].to_name == "rue ar"
+        assert stat.journeys[1].sections[0].to_name == "rue ag"
         assert stat.journeys[1].sections[0].type == "street_network"
 
     def check_stat_places_to_publish(self, stat):

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -390,17 +390,13 @@ void add_pathes(EnhancedResponse &enhanced_response, const std::vector<navitia::
             pb_journey->set_departure_date_time(str_departure);
             pb_journey->set_arrival_date_time(str_arrival);
             // We add coherence with the origin of the request
-            if (origin.type != nt::Type_e::Address && origin.type != nt::Type_e::Coord && origin.type != nt::Type_e::Way) {
-                auto origin_pb = pb_journey->mutable_sections(0)->mutable_origin();
-                origin_pb->Clear();
-                fill_pb_placemark(origin, d, origin_pb, 2);
-            }
+            auto origin_pb = pb_journey->mutable_sections(0)->mutable_origin();
+            origin_pb->Clear();
+            fill_pb_placemark(origin, d, origin_pb, 2);
             //We add coherence with the destination object of the request
-            if (destination.type != nt::Type_e::Address && destination.type != nt::Type_e::Coord && destination.type != nt::Type_e::Way) {
-                auto destination_pb = pb_journey->mutable_sections(pb_journey->sections_size()-1)->mutable_destination();
-                destination_pb->Clear();
-                fill_pb_placemark(destination, d, destination_pb, 2);
-            }
+            auto destination_pb = pb_journey->mutable_sections(pb_journey->sections_size()-1)->mutable_destination();
+            destination_pb->Clear();
+            fill_pb_placemark(destination, d, destination_pb, 2);
         }
     }
 }

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -962,7 +962,7 @@ BOOST_FIXTURE_TEST_CASE(car_direct, streetnetworkmode_fixture<test_speed_provide
 
     BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::STREET_NETWORK);
     BOOST_CHECK_EQUAL(section.origin().address().name(), "rue bs");
-    BOOST_CHECK_EQUAL(section.destination().address().name(), "rue ef");
+    BOOST_CHECK_EQUAL(section.destination().address().name(), "rue ag");
     BOOST_REQUIRE_EQUAL(section.street_network().coordinates_size(), 5);
     BOOST_CHECK_EQUAL(section.street_network().mode(), pbnavitia::StreetNetworkMode::Car);
     BOOST_CHECK_EQUAL(section.street_network().duration(), 18); // (20+50+20)/5
@@ -1041,7 +1041,7 @@ BOOST_FIXTURE_TEST_CASE(car_parking_bus, streetnetworkmode_fixture<test_speed_pr
 
     // section 2: goto B
     BOOST_CHECK_EQUAL(sections.Get(2).type(), pbnavitia::SectionType::STREET_NETWORK);
-    BOOST_CHECK_EQUAL(sections.Get(2).origin().address().name(), "rue bd");
+    BOOST_CHECK_EQUAL(sections.Get(2).origin().address().name(), "rue bs");
     BOOST_CHECK_EQUAL(sections.Get(2).destination().name(), "stop_point:stopB");
     BOOST_CHECK_EQUAL(sections.Get(2).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
     BOOST_CHECK_EQUAL(sections.Get(2).street_network().duration(), 10);
@@ -1059,7 +1059,7 @@ BOOST_FIXTURE_TEST_CASE(car_parking_bus, streetnetworkmode_fixture<test_speed_pr
     BOOST_CHECK_EQUAL(sections.Get(4).type(), pbnavitia::SectionType::STREET_NETWORK);
     BOOST_CHECK_EQUAL(sections.Get(4).origin().name(), "stop_point:stopA");
     //BOOST_CHECK_EQUAL(sections.Get(4).origin().address().name(), "rue bd");
-    BOOST_CHECK_EQUAL(sections.Get(4).destination().address().name(), "rue ar");
+    BOOST_CHECK_EQUAL(sections.Get(4).destination().address().name(), "rue ag");
     BOOST_CHECK_EQUAL(sections.Get(4).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
     BOOST_CHECK_EQUAL(sections.Get(4).street_network().duration(), 90);
     const auto pathitems4 = sections.Get(4).street_network().path_items();
@@ -1110,7 +1110,7 @@ BOOST_FIXTURE_TEST_CASE(bus_car_parking, streetnetworkmode_fixture<test_speed_pr
 
     // section 0: goto to the station
     BOOST_CHECK_EQUAL(sections.Get(0).type(), pbnavitia::SectionType::STREET_NETWORK);
-    BOOST_CHECK_EQUAL(sections.Get(0).origin().address().name(), "rue ar");
+    BOOST_CHECK_EQUAL(sections.Get(0).origin().address().name(), "rue ag");
     BOOST_CHECK_EQUAL(sections.Get(0).destination().stop_point().name(), "stop_point:stopA");
     BOOST_CHECK_EQUAL(sections.Get(0).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
     BOOST_CHECK_EQUAL(sections.Get(0).street_network().duration(), 90);
@@ -1261,7 +1261,7 @@ BOOST_FIXTURE_TEST_CASE(bss_test, streetnetworkmode_fixture<test_speed_provider>
     BOOST_CHECK_EQUAL(prev_section.destination().uri(), section.origin().uri());
     BOOST_REQUIRE_EQUAL(section.type(), pbnavitia::SectionType::STREET_NETWORK);
     BOOST_CHECK_EQUAL(section.origin().address().name(), "rue ag");
-    BOOST_CHECK_EQUAL(section.destination().address().name(), "rue ar");
+    BOOST_CHECK_EQUAL(section.destination().address().name(), "rue ag");
     BOOST_CHECK_EQUAL(section.street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
 
     BOOST_REQUIRE_EQUAL(section.street_network().path_items_size(), 2);

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -179,6 +179,8 @@ struct routing_api_data {
         way->idx = 2;
         way->way_type = "rue";
         way->admin_list.push_back(admin);
+        way->add_house_number(navitia::georef::HouseNumber(E.lon(), E.lat(), 2));
+        way->add_house_number(navitia::georef::HouseNumber(F.lon(), F.lat(), 5));
         b.data->geo_ref->ways.push_back(way);
 
         way = new navitia::georef::Way();
@@ -200,6 +202,7 @@ struct routing_api_data {
         way->idx = 5;
         way->way_type = "rue";
         way->admin_list.push_back(admin);
+        way->add_house_number(navitia::georef::HouseNumber(R.lon(), R.lat(), 1));
         b.data->geo_ref->ways.push_back(way);
 
         way = new navitia::georef::Way();
@@ -257,6 +260,7 @@ struct routing_api_data {
         way->idx = 13;
         way->way_type = "rue";
         way->admin_list.push_back(admin);
+        way->add_house_number(navitia::georef::HouseNumber(D.lon(), D.lat(), 1));
         b.data->geo_ref->ways.push_back(way);
 
         // A->B

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -72,7 +72,7 @@ void fill_address(const T* obj, const nt::Data& data,
     int depth = (max_depth <= 3) ? max_depth : 3;
     address->set_name(address_name);
     std::string label;
-    if(house_number >= 0){
+    if(house_number >= 1){
         address->set_house_number(house_number);
         label += std::to_string(house_number) + " ";
     }
@@ -725,7 +725,7 @@ void fill_pb_placemark(const navitia::georef::Admin* admin, const type::Data &da
 void fill_pb_placemark(const navitia::georef::Way* way,
                        const type::Data &data, pbnavitia::PtObject* place,
                        int house_number,
-                       type::GeographicalCoord& coord,
+                       const type::GeographicalCoord& coord,
                        int max_depth, const pt::ptime& now,
                        const pt::time_period& action_period,
                        const bool){
@@ -963,6 +963,13 @@ void fill_pb_placemark(const type::EntryPoint& point, const type::Data &data,
         if (it != data.geo_ref->admin_map.end()) {
             fill_pb_placemark(data.geo_ref->admins[it->second], data, place, max_depth, now, action_period);
         }
+    } else if (point.type == type::Type_e::Coord){
+        try{
+            auto address = data.geo_ref->nearest_addr(point.coordinates);
+            fill_pb_placemark(address.second, data, place, address.first, point.coordinates, max_depth, now,
+                    action_period);
+        }catch(proximitylist::NotFound){}
+
     }
 }
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -113,7 +113,7 @@ void fill_pb_object(const navitia::type::StopTime* st, const type::Data &data, p
 
 void fill_codes(const std::string& type, const std::string& value, pbnavitia::Code* code);
 
-void fill_pb_placemark(const navitia::georef::Way* way, const type::Data &data, pbnavitia::PtObject* place, int house_number, type::GeographicalCoord& coord, int max_depth = 0,
+void fill_pb_placemark(const navitia::georef::Way* way, const type::Data &data, pbnavitia::PtObject* place, int house_number, const type::GeographicalCoord& coord, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period,
         const bool show_codes = false);


### PR DESCRIPTION
When we have a journey with coordinate as departure or arrival we try to
set the departure or arrival at the address for this coordinate. It's
only change the displayed result, but this coordinate is projected on the
nearest edge, and this one can be on another way.
