### PR TITLE
Debian: remove tyr service files

### DIFF
--- a/debian/navitia-tyr.install
+++ b/debian/navitia-tyr.install
@@ -1,5 +1,3 @@
 usr/lib/python*/dist-packages/tyr
 /usr/share/tyr/*
-/etc/init.d/tyr_worker
-/etc/init.d/tyr_beat
 /usr/bin/manage_tyr.py


### PR DESCRIPTION
those needs to be install by fabric since there are some configuration
that needs to be done
