### PR TITLE
Add notes on lines and routes for journeys and schedules API

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -80,6 +80,10 @@ class SectionLinks(fields.Raw):
         if links:
             for type_, value in links:
                 response.append({"type": type_.name, "id": value})
+
+        if obj.HasField('pt_display_informations'):
+            for value in obj.pt_display_informations.notes:
+                response.append({"type": 'notes', "id": value.uri, 'value': value.note})
         return response
 
 
@@ -211,7 +215,7 @@ ticket = {
 journeys = {
     "journeys": NonNullList(NonNullNested(journey)),
     "error": PbField(error, attribute='error'),
-    "tickets": NonNullList(NonNullNested(ticket))
+    "tickets": NonNullList(NonNullNested(ticket)),
 }
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -44,6 +44,14 @@ from errors import ManageError
 from flask.ext.restful.types import natural, boolean
 from jormungandr.utils import ResourceUtc
 
+class RouteSchedulesLinkField(fields.Raw):
+
+    def output(self, key, obj):
+        response = []
+        if obj.HasField('pt_display_informations'):
+            for value in obj.pt_display_informations.notes:
+                response.append({"type": 'notes', "id": value.uri, 'value': value.note})
+        return response
 
 class Schedules(ResourceUri, ResourceUtc):
     parsers = {}
@@ -142,6 +150,7 @@ route_schedule_fields = {
     "table": PbField(table_field),
     "display_informations": PbField(display_informations_route,
                                     attribute='pt_display_informations'),
+    "links": RouteSchedulesLinkField(attribute='pt_display_informations'),
     "geojson": MultiLineString()
 }
 

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -601,6 +601,9 @@ class UrisToLinks():
             response.append({"type": "network", "id": uris.network})
         if uris.note != '':
             response.append({"type": "note", "id": uris.note})
+
+        for value in display_info.notes:
+            response.append({"type": 'notes', "id": value.uri, 'value': value.note})
         return response
 
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -74,7 +74,7 @@ struct wrong_version : public navitia::exception {
 class Data : boost::noncopyable{
 public:
 
-    static const unsigned int data_version = 31; //< Data version number. *INCREMENT* every time serialized data are modified
+    static const unsigned int data_version = 32; //< Data version number. *INCREMENT* every time serialized data are modified
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1202,6 +1202,9 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
         return ;
     pbnavitia::Uris* uris = pt_display_info->mutable_uris();
     uris->set_route(r->uri);
+    if(!r->comment.empty()){
+        fill_pb_object(r->comment, data, pt_display_info->add_notes(), max_depth, now, action_period);
+    }
     for(auto message : r->get_applicable_messages(now, action_period)){
         fill_message(message, data, pt_display_info, max_depth-1, now, action_period);
     }
@@ -1228,6 +1231,9 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
         pt_display_info->set_color(r->line->color);
         pt_display_info->set_code(r->line->code);
         pt_display_info->set_name(r->line->name);
+        if(!r->line->comment.empty()){
+            fill_pb_object(r->line->comment, data, pt_display_info->add_notes(), max_depth, now, action_period);
+        }
         for(auto message : r->line->get_applicable_messages(now, action_period)){
             fill_message(message, data, pt_display_info, max_depth-1, now, action_period);
         }
@@ -1277,6 +1283,9 @@ void fill_pb_object(const nt::VehicleJourney* vj, const nt::Data& data,
         fill_pb_object(vj, data, has_equipments, origin, destination,  max_depth-1, now, action_period);
     }else{
         fill_pb_object(vj, data, has_equipments, max_depth-1, now, action_period);
+    }
+    if(!vj->comment.empty()){
+        fill_pb_object(vj->comment, data, pt_display_info->add_notes(), max_depth, now, action_period);
     }
 }
 

--- a/source/type/response.proto
+++ b/source/type/response.proto
@@ -77,6 +77,7 @@ message PtDisplayInfo {
     optional string name = 12;
     repeated Message messages = 13;
     repeated Disruption disruptions = 14;
+    repeated Note notes = 15;
 }
 
 message Uris {
@@ -363,7 +364,7 @@ message Response{
     optional Load load = 46;
     optional Metadatas metadatas = 48;
     optional Pagination pagination = 49;
-    
+
     //Disruptions
     repeated Disruptions disruptions = 60;
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -575,7 +575,7 @@ struct Line : public Header, Nameable, HasMessages, Codes{
         ar & idx & name & uri & code & forward_name & backward_name
                 & additional_data & color & sort & commercial_mode
                 & company_list & network & route_list & physical_mode_list
-                & impacts & calendar_list & codes & shape;
+                & impacts & calendar_list & codes & shape & comment;
     }
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
 
@@ -607,7 +607,7 @@ struct Route : public Header, Nameable, HasMessages, Codes{
     type::hasOdtProperties get_odt_properties() const;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-        ar & idx & name & uri & line & journey_pattern_list & impacts & codes & shape;
+        ar & idx & name & uri & line & journey_pattern_list & impacts & codes & shape & comment;
     }
 
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;


### PR DESCRIPTION
A field "notes" has been added to the PtDisplayInfo protobuf message, it's
contain notes for the route, the line and the vehicle journey.

In the journey API the notes are referenced in the item "links" of a
section.

In the route schedules API the notes are in `route_schedules.table.headers.links`
and in `route_schedules.links`. Notes on lines and routes are duplicated, one time on the global links
and on each headers.

And finally for Stop Schedules the notes are in the links of each items: `stop_chedules[].links`
