### PR TITLE
jormungandr: remove the error when another call give results

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -371,6 +371,10 @@ class Scenario(simple.Scenario):
         if len(new_response.journeys) == 0:
             return
 
+        #if the initial response was an error we remove the error since we have result now
+        if initial_response.HasField('error'):
+            initial_response.ClearField('error')
+
         #we don't want to add a journey already there
         tickets_to_add = set()
         for new_j in new_response.journeys:


### PR DESCRIPTION
If the first call to kraken returned an error then another call return a
result the error code was kept even if we had a valid response
