### PR TITLE
Raptor: Freq vj

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -147,6 +147,7 @@ public:
         b.vj("network:Test","line:test","11111111","",true, "")("stop_area:stop22", 8*3600 +10*60, 8*3600 + 11 * 60)
                 ("stop_area:stop22", 8*3600 + 20 * 60 ,8*3600 + 21*60);
         b.generate_dummy_basis();
+        b.finish();
         b.data->pt_data->index();
         b.data->build_uri();
         for(navitia::type::Line *line : b.data->pt_data->lines){

--- a/source/ed/adapted.cpp
+++ b/source/ed/adapted.cpp
@@ -123,59 +123,60 @@ static nt::VehicleJourney* create_adapted_vj(
         const std::vector<nt::StopTime>& impacted_st,
         nt::PT_Data& data){
     //on duplique le VJ
-    nt::VehicleJourney* vj_adapted = new nt::VehicleJourney(*current_vj);
-    vj_adapted->uri = make_adapted_uri(theorical_vj, data);
-    data.vehicle_journeys.push_back(vj_adapted);
-    data.vehicle_journeys_map[vj_adapted->uri] = vj_adapted;
-    //le nouveau VJ garde bien une référence vers le théorique, et non pas sur le VJ adapté dont il est issu.
-    vj_adapted->theoric_vehicle_journey = theorical_vj;
-    theorical_vj->adapted_vehicle_journey_list.push_back(vj_adapted);
+    throw "TODO!"; //check how to refacto this part
+//    nt::VehicleJourney* vj_adapted = new nt::VehicleJourney(*current_vj);
+//    vj_adapted->uri = make_adapted_uri(theorical_vj, data);
+//    data.vehicle_journeys.push_back(vj_adapted);
+//    data.vehicle_journeys_map[vj_adapted->uri] = vj_adapted;
+//    //le nouveau VJ garde bien une référence vers le théorique, et non pas sur le VJ adapté dont il est issu.
+//    vj_adapted->theoric_vehicle_journey = theorical_vj;
+//    theorical_vj->adapted_vehicle_journey_list.push_back(vj_adapted);
 
-    //si on pointe vers le meme validity pattern pour l'adapté et le théorique, on duplique
-    if(theorical_vj->adapted_validity_pattern == theorical_vj->validity_pattern){
-        theorical_vj->adapted_validity_pattern = new nt::ValidityPattern(*theorical_vj->validity_pattern);
-        data.validity_patterns.push_back(theorical_vj->adapted_validity_pattern);
-    }
+//    //si on pointe vers le meme validity pattern pour l'adapté et le théorique, on duplique
+//    if(theorical_vj->adapted_validity_pattern == theorical_vj->validity_pattern){
+//        theorical_vj->adapted_validity_pattern = new nt::ValidityPattern(*theorical_vj->validity_pattern);
+//        data.validity_patterns.push_back(theorical_vj->adapted_validity_pattern);
+//    }
 
-    vj_adapted->is_adapted = true;
-    vj_adapted->validity_pattern = new nt::ValidityPattern(current_vj->validity_pattern->beginning_date);
-    data.validity_patterns.push_back(vj_adapted->validity_pattern);
+//    vj_adapted->is_adapted = true;
+//    vj_adapted->validity_pattern = new nt::ValidityPattern(current_vj->validity_pattern->beginning_date);
+//    data.validity_patterns.push_back(vj_adapted->validity_pattern);
 
-    vj_adapted->adapted_validity_pattern = new nt::ValidityPattern(vj_adapted->validity_pattern->beginning_date);
-    data.validity_patterns.push_back(vj_adapted->adapted_validity_pattern);
+//    vj_adapted->adapted_validity_pattern = new nt::ValidityPattern(vj_adapted->validity_pattern->beginning_date);
+//    data.validity_patterns.push_back(vj_adapted->adapted_validity_pattern);
 
-    //On duplique le journey pattern
-    nt::JourneyPattern* jp = new nt::JourneyPattern(*vj_adapted->journey_pattern);
-    data.journey_patterns.push_back(jp);
-    vj_adapted->journey_pattern = jp;
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(vj_adapted);
-    jp->uri = vj_adapted->journey_pattern->uri + ":adapted:"+boost::lexical_cast<std::string>(data.journey_patterns.size());
-    //@TODO changer l'uri
+//    //On duplique le journey pattern
+//    nt::JourneyPattern* jp = new nt::JourneyPattern(*vj_adapted->journey_pattern);
+//    data.journey_patterns.push_back(jp);
+//    vj_adapted->journey_pattern = jp;
+//    jp->vehicle_journey_list.clear();
+//    jp->vehicle_journey_list.push_back(vj_adapted);
+//    jp->uri = vj_adapted->journey_pattern->uri + ":adapted:"+boost::lexical_cast<std::string>(data.journey_patterns.size());
+//    //@TODO changer l'uri
 
-    //on duplique les journey pattern point
-    jp->journey_pattern_point_list = std::vector<nt::JourneyPatternPoint*>();
-    //On duplique les StopTime
-    vj_adapted->stop_time_list.clear();
-    for(auto jpp : current_vj->journey_pattern->journey_pattern_point_list) {
-        auto it = std::find_if(impacted_st.begin(), impacted_st.end(),
-                               [&](const nt::StopTime& st) {return st.journey_pattern_point == jpp;});
-        if (it != impacted_st.end()) {
-            continue;
-        }
-        auto new_jpp = new nt::JourneyPatternPoint(*jpp);
-        new_jpp->order = jp->journey_pattern_point_list.size();
-        data.journey_pattern_points.push_back(new_jpp);
-        jp->journey_pattern_point_list.push_back(new_jpp);
-        new_jpp->journey_pattern = jp;
-        //@TODO changer l'uri
-        new_jpp->uri = jpp->uri + ":adapted:"+boost::lexical_cast<std::string>(data.journey_pattern_points.size());
-        vj_adapted->stop_time_list.push_back(current_vj->stop_time_list[jpp->order]);
-        nt::StopTime& new_stop = vj_adapted->stop_time_list.back();
-        new_stop.vehicle_journey = vj_adapted;
-        new_stop.journey_pattern_point = new_jpp;
-    }
-    return vj_adapted;
+//    //on duplique les journey pattern point
+//    jp->journey_pattern_point_list = std::vector<nt::JourneyPatternPoint*>();
+//    //On duplique les StopTime
+//    vj_adapted->stop_time_list.clear();
+//    for(auto jpp : current_vj->journey_pattern->journey_pattern_point_list) {
+//        auto it = std::find_if(impacted_st.begin(), impacted_st.end(),
+//                               [&](const nt::StopTime& st) {return st.journey_pattern_point == jpp;});
+//        if (it != impacted_st.end()) {
+//            continue;
+//        }
+//        auto new_jpp = new nt::JourneyPatternPoint(*jpp);
+//        new_jpp->order = jp->journey_pattern_point_list.size();
+//        data.journey_pattern_points.push_back(new_jpp);
+//        jp->journey_pattern_point_list.push_back(new_jpp);
+//        new_jpp->journey_pattern = jp;
+//        //@TODO changer l'uri
+//        new_jpp->uri = jpp->uri + ":adapted:"+boost::lexical_cast<std::string>(data.journey_pattern_points.size());
+//        vj_adapted->stop_time_list.push_back(current_vj->stop_time_list[jpp->order]);
+//        nt::StopTime& new_stop = vj_adapted->stop_time_list.back();
+//        new_stop.vehicle_journey = vj_adapted;
+//        new_stop.journey_pattern_point = new_jpp;
+//    }
+//    return vj_adapted;
 }
 
 static std::pair<bool, nt::VehicleJourney*> find_reference_vj(

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -36,29 +36,6 @@ namespace pt = boost::posix_time;
 
 namespace ed {
 
-/*
- * Make the vj a frequency VJ
- * Note: it does note return a VJ& because it's clearer that way that all 
- * the vj stop times need to be filled before calling the method
- */
-void VJ::frequency(uint32_t start_time, uint32_t end_time, uint32_t headway_secs) {
-    vj->start_time = start_time;
-
-    size_t nb_trips = std::ceil((end_time - start_time)/headway_secs);
-    vj->end_time = start_time + ( nb_trips * headway_secs );
-    vj->headway_secs = headway_secs;
-
-    uint32_t begin = vj->stop_time_list.front().arrival_time;
-    for(navitia::type::StopTime& st : vj->stop_time_list) {
-        st.set_is_frequency(true);
-        //For frequency based trips, make arrival and departure time relative from the first stop.
-        if (begin > 0){
-            st.arrival_time -= begin;
-            st.departure_time -= begin;
-        }
-    }
-}
-
 nt::MetaVehicleJourney* builder::get_or_create_metavj(const std::string name) {
     auto it = data->pt_data->meta_vj.find(name);
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -522,9 +522,9 @@ void builder::connection(const std::string & name1, const std::string & name2, f
         vj->idx = data->pt_data->vehicle_journeys.size();
         vj->name = "vehicle_journey " + std::to_string(vj->idx);
         data->pt_data->vehicle_journeys.push_back(vj);
-
      }
 
+     build_blocks();
      for(navitia::type::VehicleJourney* vj : this->data->pt_data->vehicle_journeys) {
          //we need to put the vj ptr on each stop time
          for (auto& st: vj->stop_time_list) {
@@ -550,7 +550,6 @@ void builder::connection(const std::string & name1, const std::string & name2, f
              }
          }
      }
-     build_blocks();
  }
 
 /*

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -45,13 +45,21 @@ namespace ed {
 
 struct builder;
 
+struct VJKey {
+    navitia::type::JourneyPattern* jp;
+    size_t vj_idx;
+    bool is_frequency;
+    navitia::type::VehicleJourney* get_vj() const;
+};
+
 /// Structure retournée à la construction d'un VehicleJourney
 struct VJ {
     builder & b;
-    navitia::type::VehicleJourney * vj;
+    VJKey vj_key;
 
     /// Construit un nouveau vehicle journey
     VJ(builder & b, const std::string &line_name, const std::string &validity_pattern,
+       bool is_frequency,
        const std::string & block_id, bool is_adapted = true, const std::string& uri="",
        std::string meta_vj_name = "", std::string jp_uri = "");
 
@@ -64,16 +72,13 @@ struct VJ {
     VJ& operator()(const std::string &stopPoint, const std::string& arrivee, const std::string& depart,
             uint16_t local_traffic_zone = std::numeric_limits<uint16_t>::max(), bool drop_off_allowed = true, bool pick_up_allowed = true);
 
-    /// Transforme les horaires en horaire entre start_time et end_time, toutes les headways secs
-    void frequency(uint32_t start_time, uint32_t end_time, uint32_t headway_secs);
-
     // set the shape to the last stop point
     VJ& st_shape(const navitia::type::LineString& shape);
 };
 
 struct SA {
-    builder & b;
-    navitia::type::StopArea * sa;
+    builder& b;
+    navitia::type::StopArea* sa;
 
     /// Construit un nouveau stopArea
     SA(builder & b, const std::string & sa_name, double x, double y, bool is_adapted = true);
@@ -95,6 +100,9 @@ struct builder{
     std::unique_ptr<navitia::type::Data> data = std::make_unique<navitia::type::Data>();
     navitia::georef::GeoRef street_network;
 
+    //we need to store all meta vj key, because they can be created only at the end (by the finish())
+    std::vector<std::pair<std::string, VJKey>> meta_vj_keys;
+
 
     /// Il faut préciser là date de début des différents validity patterns
     builder(const std::string & date) : begin(boost::gregorian::date_from_iso_string(date)) {
@@ -103,14 +111,15 @@ struct builder{
 		data->loaded = true;
     }
 
-    /// Crée un vehicle journey
+    /// Create a discrete vehicle journey (no frequency, explicit stop times)
     VJ vj(const std::string& line_name,
           const std::string& validity_pattern = "11111111",
           const std::string& block_id="",
           const bool wheelchair_boarding = true,
           const std::string& uri="",
           const std::string& meta_vj="",
-          const std::string &jp_uri = "");
+          const std::string& jp_uri = "");
+
     VJ vj(const std::string& network_name,
           const std::string& line_name,
           const std::string& validity_pattern = "11111111",
@@ -118,7 +127,20 @@ struct builder{
           const bool wheelchair_boarding = true,
           const std::string& uri="",
           const std::string& meta_vj="",
-          const std::string &jp_uri="");
+          const std::string &jp_uri="",
+          bool is_frequency=false);
+
+    VJ frequency_vj(const std::string& line_name,
+                    uint32_t start_time,
+                    uint32_t end_time,
+                    uint32_t headway_secs,
+                    const std::string& network_name = "default_network",
+                    const std::string& validity_pattern = "11111111",
+                    const std::string& block_id="",
+                    const bool wheelchair_boarding = true,
+                    const std::string& uri="",
+                    const std::string& meta_vj="",
+                    const std::string &jp_uri="");
 
     /// Crée un nouveau stop area
     SA sa(const std::string & name, double x = 0, double y = 0, const bool is_adapted = true);
@@ -133,6 +155,9 @@ struct builder{
     void generate_dummy_basis();
     void manage_admin();
     void build_autocomplete();
+
+private:
+    nt::MetaVehicleJourney* get_or_create_metavj(const std::string name);
 };
 
 }

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -45,17 +45,11 @@ namespace ed {
 
 struct builder;
 
-struct VJKey {
-    navitia::type::JourneyPattern* jp;
-    size_t vj_idx;
-    bool is_frequency;
-    navitia::type::VehicleJourney* get_vj() const;
-};
 
 /// Structure retournée à la construction d'un VehicleJourney
 struct VJ {
     builder & b;
-    VJKey vj_key;
+    nt::VehicleJourney* vj;
 
     /// Construit un nouveau vehicle journey
     VJ(builder & b, const std::string &line_name, const std::string &validity_pattern,
@@ -99,10 +93,6 @@ struct builder{
 
     std::unique_ptr<navitia::type::Data> data = std::make_unique<navitia::type::Data>();
     navitia::georef::GeoRef street_network;
-
-    //we need to store all meta vj key, because they can be created only at the end (by the finish())
-    std::vector<std::pair<std::string, VJKey>> meta_vj_keys;
-
 
     /// Il faut préciser là date de début des différents validity patterns
     builder(const std::string & date) : begin(boost::gregorian::date_from_iso_string(date)) {
@@ -156,7 +146,6 @@ struct builder{
     void manage_admin();
     void build_autocomplete();
 
-private:
     nt::MetaVehicleJourney* get_or_create_metavj(const std::string name);
 };
 

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -920,7 +920,7 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(vj->odt_message);
         values.push_back(std::to_string(vj->utc_to_local_offset));
 
-        bool is_frequency = (vj->start_time != std::numeric_limits<int>::max() ? true : false);
+        bool is_frequency = vj->start_time != std::numeric_limits<int>::max();
         values.push_back(std::to_string(is_frequency));
 
         this->lotus.insert(values);

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -874,7 +874,7 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
              "start_time", "end_time", "headway_sec",
              "adapted_validity_pattern_id", "company_id", "journey_pattern_id",
              "theoric_vehicle_journey_id", "vehicle_properties_id",
-             "odt_type_id", "odt_message", "utc_to_local_offset"});
+             "odt_type_id", "odt_message", "utc_to_local_offset", "is_frequency"});
 
     for(types::VehicleJourney* vj : vehicle_journeys){
         std::vector<std::string> values;
@@ -919,6 +919,10 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(std::to_string(static_cast<int>(vj->vehicle_journey_type)));
         values.push_back(vj->odt_message);
         values.push_back(std::to_string(vj->utc_to_local_offset));
+
+        bool is_frequency = (vj->start_time != std::numeric_limits<int>::max() ? true : false);
+        values.push_back(std::to_string(is_frequency));
+
         this->lotus.insert(values);
     }
     this->lotus.finish_bulk_insert();

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -712,30 +712,30 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
 
         auto journey_pattern = journey_pattern_map[const_it["journey_pattern_id"].as<idx_t>()];
         if (const_it["is_frequency"].as<bool>()) {
-            journey_pattern->frequency_vehicle_journey_list.emplace_back();
+            journey_pattern->frequency_vehicle_journey_list.emplace_back(new nt::FrequencyVehicleJourney());
             auto& vj = journey_pattern->frequency_vehicle_journey_list.back();
 
-            fill_vj(const_it, vj, prev_vjs, next_vjs);
+            fill_vj(const_it, *vj, prev_vjs, next_vjs);
 
-            const_it["start_time"].to(vj.start_time);
-            const_it["end_time"].to(vj.end_time);
-            const_it["headway_sec"].to(vj.headway_secs);
+            const_it["start_time"].to(vj->start_time);
+            const_it["end_time"].to(vj->end_time);
+            const_it["headway_sec"].to(vj->headway_secs);
         } else {
-            journey_pattern->discrete_vehicle_journey_list.emplace_back();
+            journey_pattern->discrete_vehicle_journey_list.emplace_back(new nt::DiscreteVehicleJourney());
             auto& vj = journey_pattern->discrete_vehicle_journey_list.back();
-            fill_vj(const_it, vj, prev_vjs, next_vjs);
+            fill_vj(const_it, *vj, prev_vjs, next_vjs);
         }
     }
 
     //we need to wait for every jp to be filled to store the vj pointers is the global map
     for (auto* jp: data.pt_data->journey_patterns) {
         for (auto& vj: jp->discrete_vehicle_journey_list) {
-            data.pt_data->vehicle_journeys.push_back(&vj);
-            this->vehicle_journey_map[vj_id_map[vj.uri]] = &vj;
+            data.pt_data->vehicle_journeys.push_back(vj.get());
+            this->vehicle_journey_map[vj_id_map[vj->uri]] = vj.get();
         }
         for (auto & vj: jp->frequency_vehicle_journey_list) {
-            data.pt_data->vehicle_journeys.push_back(&vj);
-            this->vehicle_journey_map[vj_id_map[vj.uri]] = &vj;
+            data.pt_data->vehicle_journeys.push_back(vj.get());
+            this->vehicle_journey_map[vj_id_map[vj->uri]] = vj.get();
         }
     }
     for(const auto& vjid_vj: prev_vjs) {

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -638,7 +638,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "vj.end_time as end_time,"
         "vj.headway_sec as headway_sec,"
         "vj.utc_to_local_offset as utc_to_local_offset, "
-        "vj.is_frequency as is_frequency, " // TODO!!
+        "vj.is_frequency as is_frequency, "
         "vp.wheelchair_accessible as wheelchair_accessible,"
         "vp.bike_accepted as bike_accepted,"
         "vp.air_conditioned as air_conditioned,"

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -623,6 +623,61 @@ void EdReader::fill_stop_point_connections(nt::Data& data, pqxx::work& work){
 }
 
 
+void EdReader::fill_vj(const pqxx::result::const_iterator& const_it, nt::VehicleJourney& vj,
+                       std::multimap<idx_t, std::string>& prev_vjs,
+                       std::multimap<idx_t, std::string>& next_vjs) {
+    const_it["uri"].to(vj.uri);
+    const_it["name"].to(vj.name);
+    const_it["comment"].to(vj.comment);
+    const_it["odt_message"].to(vj.odt_message);
+    const_it["utc_to_local_offset"].to(vj.utc_to_local_offset);
+    const_it["external_code"].to(vj.codes["external_code"]);
+    vj.vehicle_journey_type = static_cast<nt::VehicleJourneyType>(const_it["odt_type_id"].as<int>());
+
+    vj.company = company_map[const_it["company_id"].as<idx_t>()];
+
+    vj.adapted_validity_pattern = validity_pattern_map[const_it["adapted_validity_pattern_id"].as<idx_t>()];
+
+    if(!const_it["validity_pattern_id"].is_null()){
+        vj.validity_pattern = validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
+    }
+
+    if(!const_it["theoric_vehicle_journey_id"].is_null()){
+        vj.theoric_vehicle_journey = vehicle_journey_map[const_it["theoric_vehicle_journey_id"].as<idx_t>()];
+    }
+
+    if (const_it["wheelchair_accessible"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::WHEELCHAIR_ACCESSIBLE);
+    }
+    if (const_it["bike_accepted"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::BIKE_ACCEPTED);
+    }
+    if (const_it["air_conditioned"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::AIR_CONDITIONED);
+    }
+    if (const_it["visual_announcement"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::VISUAL_ANNOUNCEMENT);
+    }
+    if (const_it["audible_announcement"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::AUDIBLE_ANNOUNCEMENT);
+    }
+    if (const_it["appropriate_escort"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::APPOPRIATE_ESCORT);
+    }
+    if (const_it["appropriate_signage"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::APPOPRIATE_SIGNAGE);
+    }
+    if (const_it["school_vehicle"].as<bool>()){
+        vj.set_vehicle(navitia::type::hasVehicleProperties::SCHOOL_VEHICLE);
+    }
+    if (!const_it["prev_vj_id"].is_null()) {
+        prev_vjs.insert(std::make_pair(const_it["prev_vj_id"].as<idx_t>(), vj.uri));
+    }
+    if (!const_it["next_vj_id"].is_null()) {
+        next_vjs.insert(std::make_pair(const_it["next_vj_id"].as<idx_t>(), vj.uri));
+    }
+}
+
 void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
     std::string request = "SELECT vj.id as id, vj.name as name, vj.uri as uri,"
         "vj.comment as comment, vj.company_id as company_id, "
@@ -638,6 +693,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "vj.end_time as end_time,"
         "vj.headway_sec as headway_sec,"
         "vj.utc_to_local_offset as utc_to_local_offset, "
+        "vj.is_frequency as is_frequency, " // TODO!!
         "vp.wheelchair_accessible as wheelchair_accessible,"
         "vp.bike_accepted as bike_accepted,"
         "vp.air_conditioned as air_conditioned,"
@@ -650,75 +706,45 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         "where vj.vehicle_properties_id = vp.id ";
 
     pqxx::result result = work.exec(request);
-    std::multimap<idx_t, nt::VehicleJourney*> prev_vjs, next_vjs;
-    for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
-        nt::VehicleJourney* vj = new nt::VehicleJourney();
+    std::multimap<idx_t, std::string> prev_vjs, next_vjs;
+    std::map<std::string, size_t> vj_id_map; //we need to store the vj db id, to fill vehicle_journey_map
+    for (auto const_it = result.begin(); const_it != result.end(); ++const_it) {
 
-        const_it["uri"].to(vj->uri);
-        const_it["name"].to(vj->name);
-        const_it["comment"].to(vj->comment);
-        const_it["odt_message"].to(vj->odt_message);
-        const_it["utc_to_local_offset"].to(vj->utc_to_local_offset);
-        const_it["external_code"].to(vj->codes["external_code"]);
-        vj->vehicle_journey_type = static_cast<nt::VehicleJourneyType>(const_it["odt_type_id"].as<int>());
+        auto journey_pattern = journey_pattern_map[const_it["journey_pattern_id"].as<idx_t>()];
+        if (const_it["is_frequency"].as<bool>()) {
+            journey_pattern->frequency_vehicle_journey_list.emplace_back();
+            auto& vj = journey_pattern->frequency_vehicle_journey_list.back();
 
-        vj->journey_pattern = journey_pattern_map[const_it["journey_pattern_id"].as<idx_t>()];
-        vj->journey_pattern->vehicle_journey_list.push_back(vj);
+            fill_vj(const_it, vj, prev_vjs, next_vjs);
 
-        vj->company = company_map[const_it["company_id"].as<idx_t>()];
-
-        vj->adapted_validity_pattern = validity_pattern_map[const_it["adapted_validity_pattern_id"].as<idx_t>()];
-
-        const_it["start_time"].to(vj->start_time);
-        const_it["end_time"].to(vj->end_time);
-        const_it["headway_sec"].to(vj->headway_secs);
-
-        if(!const_it["validity_pattern_id"].is_null()){
-            vj->validity_pattern = validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
+            const_it["start_time"].to(vj.start_time);
+            const_it["end_time"].to(vj.end_time);
+            const_it["headway_sec"].to(vj.headway_secs);
+        } else {
+            journey_pattern->discrete_vehicle_journey_list.emplace_back();
+            auto& vj = journey_pattern->discrete_vehicle_journey_list.back();
+            fill_vj(const_it, vj, prev_vjs, next_vjs);
         }
-
-        if(!const_it["theoric_vehicle_journey_id"].is_null()){
-            vj->theoric_vehicle_journey = vehicle_journey_map[const_it["theoric_vehicle_journey_id"].as<idx_t>()];
-        }
-
-        if (const_it["wheelchair_accessible"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::WHEELCHAIR_ACCESSIBLE);
-        }
-        if (const_it["bike_accepted"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::BIKE_ACCEPTED);
-        }
-        if (const_it["air_conditioned"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::AIR_CONDITIONED);
-        }
-        if (const_it["visual_announcement"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::VISUAL_ANNOUNCEMENT);
-        }
-        if (const_it["audible_announcement"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::AUDIBLE_ANNOUNCEMENT);
-        }
-        if (const_it["appropriate_escort"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::APPOPRIATE_ESCORT);
-        }
-        if (const_it["appropriate_signage"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::APPOPRIATE_SIGNAGE);
-        }
-        if (const_it["school_vehicle"].as<bool>()){
-            vj->set_vehicle(navitia::type::hasVehicleProperties::SCHOOL_VEHICLE);
-        }
-        if (!const_it["prev_vj_id"].is_null()) {
-            prev_vjs.insert(std::make_pair(const_it["prev_vj_id"].as<idx_t>(), vj));
-        }
-        if (!const_it["next_vj_id"].is_null()) {
-            next_vjs.insert(std::make_pair(const_it["next_vj_id"].as<idx_t>(), vj));
-        }
-        data.pt_data->vehicle_journeys.push_back(vj);
-        this->vehicle_journey_map[const_it["id"].as<idx_t>()] = vj;
     }
-    for(auto vjid_vj: prev_vjs) {
-       vjid_vj.second->prev_vj = vehicle_journey_map[vjid_vj.first];
+
+    //we need to wait for every jp to be filled to store the vj pointers is the global map
+    for (auto* jp: data.pt_data->journey_patterns) {
+        for (auto& vj: jp->discrete_vehicle_journey_list) {
+            data.pt_data->vehicle_journeys.push_back(&vj);
+            this->vehicle_journey_map[vj_id_map[vj.uri]] = &vj;
+        }
+        for (auto & vj: jp->frequency_vehicle_journey_list) {
+            data.pt_data->vehicle_journeys.push_back(&vj);
+            this->vehicle_journey_map[vj_id_map[vj.uri]] = &vj;
+        }
     }
-    for(auto vjid_vj: next_vjs) {
-       vjid_vj.second->next_vj = vehicle_journey_map[vjid_vj.first];
+    for(const auto& vjid_vj: prev_vjs) {
+        auto* vj = vehicle_journey_map[vj_id_map[vjid_vj.second]];
+        vj->prev_vj = vehicle_journey_map[vjid_vj.first];
+    }
+    for(const auto& vjid_vj: next_vjs) {
+        auto* vj = vehicle_journey_map[vj_id_map[vjid_vj.second]];
+        vj->next_vj = vehicle_journey_map[vjid_vj.first];
     }
 }
 

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -147,9 +147,6 @@ private:
 
     /// coherence check for logging purpose
     void check_coherence(navitia::type::Data& data) const;
-    void fill_vj(const pqxx::result::const_iterator& const_it, nt::VehicleJourney& vj,
-                 std::multimap<idx_t, std::string>& prev_vjs,
-                 std::multimap<idx_t, std::string>& next_vjs);
     log4cplus::Logger log = log4cplus::Logger::getInstance("log");
 };
 

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -147,7 +147,9 @@ private:
 
     /// coherence check for logging purpose
     void check_coherence(navitia::type::Data& data) const;
-
+    void fill_vj(const pqxx::result::const_iterator& const_it, nt::VehicleJourney& vj,
+                 std::multimap<idx_t, std::string>& prev_vjs,
+                 std::multimap<idx_t, std::string>& next_vjs);
     log4cplus::Logger log = log4cplus::Logger::getInstance("log");
 };
 

--- a/source/ed/tests/adapted_test.cpp
+++ b/source/ed/tests/adapted_test.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_0){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj;
+    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011 (1er mars est un vendredi)
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_1){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj;
+    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011 (1er mars est un vendredi)
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_2){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_2){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011 (1er mars est un vendredi)
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(impact_line_0){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -500,7 +500,7 @@ BOOST_AUTO_TEST_CASE(impact_line_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(impact_line_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(impact_line_1){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE(impact_line_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(impact_line_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(impact_network_0){
     ed::builder b("201303011T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -838,7 +838,7 @@ BOOST_AUTO_TEST_CASE(impact_network_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -850,7 +850,7 @@ BOOST_AUTO_TEST_CASE(impact_network_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1007,7 +1007,7 @@ BOOST_AUTO_TEST_CASE(impact_network_1){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1020,7 +1020,7 @@ BOOST_AUTO_TEST_CASE(impact_network_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:A", "line:A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -1032,7 +1032,7 @@ BOOST_AUTO_TEST_CASE(impact_network_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1189,7 +1189,7 @@ BOOST_AUTO_TEST_CASE(impact_network_2){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1202,7 +1202,7 @@ BOOST_AUTO_TEST_CASE(impact_network_2){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -1214,7 +1214,7 @@ BOOST_AUTO_TEST_CASE(impact_network_2){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1381,7 +1381,7 @@ BOOST_AUTO_TEST_CASE(impact_network_3){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("network:A", "lineA", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
+    VehicleJourney* vj = b.vj("network:A", "lineA", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1394,7 +1394,7 @@ BOOST_AUTO_TEST_CASE(impact_network_3){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -1406,7 +1406,7 @@ BOOST_AUTO_TEST_CASE(impact_network_3){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1572,7 +1572,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_0){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", -1,8050)("stop_point:stop2", 8200)("stop_point:stop3", 8200,8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", -1,8050)("stop_point:stop2", 8200)("stop_point:stop3", 8200,8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1693,7 +1693,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_1){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1791,7 +1791,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_2){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200, 8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200, 8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1925,7 +1925,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_passe_minuit){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", "23:30", "23:40")("stop_point:stop2", "25:00", "25:00")("stop_point:stop3", "26:00", "26:10").vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", "23:30", "23:40")("stop_point:stop2", "25:00", "25:00")("stop_point:stop3", "26:00", "26:10").vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -2038,7 +2038,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_3){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -2222,7 +2222,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_4){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130312T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj;
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj_key.get_vj();
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;

--- a/source/ed/tests/adapted_test.cpp
+++ b/source/ed/tests/adapted_test.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_0){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj_key.get_vj();
+    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj;
     //construction du validityPattern du vj2: 1110011 (1er mars est un vendredi)
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_1){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", 8000,8050)("stop2", 8200,8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj_key.get_vj();
+    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", 9000,9050)("stop2", 9200,9250).vj;
     //construction du validityPattern du vj2: 1110011 (1er mars est un vendredi)
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_2){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(impact_vj_2){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011 (1er mars est un vendredi)
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(impact_line_0){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -500,7 +500,7 @@ BOOST_AUTO_TEST_CASE(impact_line_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -512,7 +512,7 @@ BOOST_AUTO_TEST_CASE(impact_line_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(impact_line_1){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -679,7 +679,7 @@ BOOST_AUTO_TEST_CASE(impact_line_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(impact_line_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -825,7 +825,7 @@ BOOST_AUTO_TEST_CASE(impact_network_0){
     ed::builder b("201303011T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -838,7 +838,7 @@ BOOST_AUTO_TEST_CASE(impact_network_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -850,7 +850,7 @@ BOOST_AUTO_TEST_CASE(impact_network_0){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1007,7 +1007,7 @@ BOOST_AUTO_TEST_CASE(impact_network_1){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1020,7 +1020,7 @@ BOOST_AUTO_TEST_CASE(impact_network_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:A", "line:A", "", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -1032,7 +1032,7 @@ BOOST_AUTO_TEST_CASE(impact_network_1){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1189,7 +1189,7 @@ BOOST_AUTO_TEST_CASE(impact_network_2){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("network:A", "line:A", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1202,7 +1202,7 @@ BOOST_AUTO_TEST_CASE(impact_network_2){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -1214,7 +1214,7 @@ BOOST_AUTO_TEST_CASE(impact_network_2){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1381,7 +1381,7 @@ BOOST_AUTO_TEST_CASE(impact_network_3){
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
 
-    VehicleJourney* vj = b.vj("network:A", "lineA", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("network:A", "lineA", "1111111", "", true, "vehicle_journey:vj1")("stop1", "8:50","9:00")("stop2", "11:00", "11:02").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1394,7 +1394,7 @@ BOOST_AUTO_TEST_CASE(impact_network_3){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:A", "line:A", "1110011", "", true, "vehicle_journey:vj2")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj2: 1110011
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = false;
@@ -1406,7 +1406,7 @@ BOOST_AUTO_TEST_CASE(impact_network_3){
     vj->validity_pattern->add(vj->validity_pattern->beginning_date, end_date, validedays);
     vj->adapted_validity_pattern->add(vj->adapted_validity_pattern->beginning_date, end_date, validedays);
 
-    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj_key.get_vj();
+    vj = b.vj("network:B", "line:B", "1111111", "", true, "vehicle_journey:vj3")("stop1", "10:50","11:00")("stop2","13:00","13:02").vj;
     //construction du validityPattern du vj3: 1111111
     validedays[navitia::Sunday] = true;
     validedays[navitia::Monday] = true;
@@ -1572,7 +1572,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_0){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", -1,8050)("stop_point:stop2", 8200)("stop_point:stop3", 8200,8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", -1,8050)("stop_point:stop2", 8200)("stop_point:stop3", 8200,8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1693,7 +1693,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_1){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1791,7 +1791,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_2){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200, 8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200, 8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -1925,7 +1925,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_passe_minuit){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", "23:30", "23:40")("stop_point:stop2", "25:00", "25:00")("stop_point:stop3", "26:00", "26:10").vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", "23:30", "23:40")("stop_point:stop2", "25:00", "25:00")("stop_point:stop3", "26:00", "26:10").vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -2038,7 +2038,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_3){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130308T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;
@@ -2222,7 +2222,7 @@ BOOST_AUTO_TEST_CASE(impact_stoppoint_4){
     ed::builder b("20130301T1739");
     bg::date end_date = bg::date_from_iso_string("20130312T1739");
     b.generate_dummy_basis();
-    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj_key.get_vj();
+    VehicleJourney* vj = b.vj("A", "", "", true, "vehicle_journey:vj1")("stop_point:stop1", 8000,8050)("stop_point:stop2", 8200,8250).vj;
     //construction du validityPattern du vj1: 1111111
     std::bitset<7> validedays;
     validedays[navitia::Sunday] = true;

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -56,6 +56,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
+    b.finish();
     b.generate_dummy_basis();
     b.data->pt_data->index();
     b.data->build_raptor();
@@ -145,6 +146,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff_no_data) {
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
     b.generate_dummy_basis();
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();

--- a/source/fare/tests/fare_test.cpp
+++ b/source/fare/tests/fare_test.cpp
@@ -109,7 +109,7 @@ static navitia::routing::Path string_to_path(const std::vector<std::string>& key
         last_sp->stop_area->uri = dest_stop_area;
 
         nt::StopTime* first_st = new nt::StopTime();
-        first_st->vehicle_journey = new nt::VehicleJourney();
+        first_st->vehicle_journey = new nt::DiscreteVehicleJourney();
         first_st->vehicle_journey->journey_pattern = new nt::JourneyPattern();
         first_st->vehicle_journey->journey_pattern->route = new nt::Route();
         first_st->vehicle_journey->journey_pattern->route->line = new nt::Line();

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp)
 target_link_libraries(workers fill_disruption_from_chaos pq pqxx SimpleAmqpClient disruption_api calendar_api ptreferential autocomplete georef
   routing time_tables tcmalloc)
 add_library(fill_disruption_from_database fill_disruption_from_database.cpp)
-target_link_libraries(fill_disruption_from_database fill_disruption_from_chaos data pb_lib pq pqxx ${Boost_FORMAT_LIBRARY} protobuf)
+target_link_libraries(fill_disruption_from_database fill_disruption_from_chaos data types pb_lib pq pqxx ${Boost_SERIALIZATION_LIBRARY} ${Boost_FORMAT_LIBRARY} protobuf)
 
 add_executable(kraken kraken_zmq.cpp)
 target_link_libraries(kraken workers zmq types proximitylist

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -5,5 +5,5 @@ target_link_libraries(data_manager_test workers utils log4cplus tcmalloc ${Boost
 ADD_BOOST_TEST(data_manager_test)
 
 add_executable(disruption_reader_test disruption_reader_test.cpp)
-target_link_libraries(disruption_reader_test workers data pb_lib utils log4cplus tcmalloc ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(disruption_reader_test workers data types pb_lib utils log4cplus tcmalloc ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
 ADD_BOOST_TEST(disruption_reader_test)

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -155,6 +155,7 @@ BOOST_AUTO_TEST_CASE(sans_filtre) {
     b.vj("B")("stop3", 9000,9050)("stop4", 9200,9250);
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
+    b.finish();
 
     auto indexes = make_query(navitia::type::Type_e::Line, "", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 2);
@@ -198,6 +199,7 @@ BOOST_AUTO_TEST_CASE(get_indexes_test){
     b.vj("B")("stop3", 9000,9050)("stop4", 9200,9250);
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
+    b.finish();
     b.data->pt_data->index();
 
     // On cherche à retrouver la ligne 1, en passant le stoparea en filtre
@@ -228,6 +230,7 @@ BOOST_AUTO_TEST_CASE(make_query_filtre_direct) {
     b.vj("B")("stop3", 9000,9050)("stop4", 9200,9250);
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
+    b.finish();
 
     auto indexes = make_query(navitia::type::Type_e::Line, "line.uri=A", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 1);
@@ -268,6 +271,7 @@ BOOST_AUTO_TEST_CASE(forbidden_uri) {
     b.vj("B")("stop3", 9000,9050)("stop4", 9200,9250);
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
+    b.finish();
     b.data->pt_data->build_uri();
 
     BOOST_CHECK_THROW(make_query(navitia::type::Type_e::Line, "stop_point.uri=stop1", {"A"}, *(b.data)), ptref_error);

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -46,7 +46,7 @@ best_stop_time(const type::JourneyPatternPoint* jpp,
 /** Which is the first valid stop_time in this range ?
  *  Returns invalid_idx is none is
  */
-static std::pair<const type::StopTime*, DateTime>
+std::pair<const type::StopTime*, DateTime>
 next_valid_discrete_pick_up(const type::JourneyPatternPoint* jpp, const DateTime dt,
         const type::Data &data, bool reconstructing_path,
         const type::VehicleProperties &required_vehicle_properties,
@@ -242,7 +242,7 @@ previous_valid_discrete_drop_off(const type::JourneyPatternPoint* jpp, const Dat
  *
  *      Note: if nothing found, we do the same lookup the day after
  */
-static std::pair<const type::StopTime*, uint32_t>
+std::pair<const type::StopTime*, uint32_t>
 earliest_stop_time(const type::JourneyPatternPoint* jpp,
                    const DateTime dt, const type::Data &data,
                    bool disruption_active,

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -142,7 +142,7 @@ previous_valid_frequency_drop_off(const type::JourneyPatternPoint* jpp, const Da
                              bool reconstructing_path,
                              const type::VehicleProperties &vehicle_properties,
                              bool disruption_active) {
-    std::pair<const type::StopTime*, DateTime> best = {nullptr, DateTimeUtils::inf};
+    std::pair<const type::StopTime*, DateTime> best = {nullptr, DateTimeUtils::not_valid};
     for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
         //we get stop time corresponding to the jpp
         const auto& st = freq_vj->stop_time_list[jpp->order];

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -70,6 +70,7 @@ next_valid_discrete_pick_up(const type::JourneyPatternPoint* jpp, const DateTime
     auto date = DateTimeUtils::date(dt);
     for(; idx < end; ++idx) {
         const type::StopTime* st = data.dataRaptor->st_forward[idx];
+        BOOST_ASSERT(st->journey_pattern_point == jpp);
         if (st->valid_end(reconstructing_path) &&
             st->is_valid_day(date, false, disruption_active)
             && st->vehicle_journey->accessible(required_vehicle_properties) ){

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -46,55 +46,116 @@ best_stop_time(const type::JourneyPatternPoint* jpp,
 /** Which is the first valid stop_time in this range ?
  *  Returns invalid_idx is none is
  */
-static const type::StopTime*
-next_valid_pick_up(type::idx_t idx,
-                   const type::idx_t end,
-                   const DateTime dt,
-                   const type::Data& data,
-                   bool reconstructing_path,
-                   const type::VehicleProperties& required_vehicle_properties,
-                   bool disruption_active){
+static std::pair<const type::StopTime*, DateTime> 
+next_valid_discrete_pick_up(type::idx_t idx, 
+			const type::idx_t end, 
+			const DateTime dt,
+        const type::Data &data, 
+	bool reconstructing_path,
+        const type::VehicleProperties &required_vehicle_properties,
+        bool disruption_active){
     const auto date = DateTimeUtils::date(dt);
-    const auto hour = DateTimeUtils::hour(dt);
     for(; idx < end; ++idx) {
         const type::StopTime* st = data.dataRaptor->st_forward[idx];
-        if (st->valid_end(reconstructing_path) && st->valid_hour(hour, true) &&
+        if (st->valid_end(reconstructing_path) &&
             st->is_valid_day(date, false, disruption_active)
             && st->vehicle_journey->accessible(required_vehicle_properties) ){
-                return st;
+                return {st, DateTimeUtils::set(date, st->departure_time)};
         }
     }
-    return nullptr;
+    return {nullptr, std::numeric_limits<DateTime>::max()};
+}
+
+std::pair<const type::StopTime*, DateTime>
+next_valid_frequency_pick_up(const type::JourneyPatternPoint* jpp, const DateTime dt,
+                             bool reconstructing_path,
+                             const type::VehicleProperties &vehicle_properties,
+                             bool disruption_active) {
+    // to find the next frequency VJ, for the moment we loop through all frequency VJ of the JP
+    // and for each jp, get compute the datetime on the jpp
+    std::pair<const type::StopTime*, DateTime> best = {nullptr, std::numeric_limits<DateTime>::max()};
+    for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
+        //we get stop time corresponding to the jpp
+
+        const auto& st = freq_vj.stop_time_list[jpp->order];
+
+        if (! st.valid_end(reconstructing_path) ||
+            freq_vj.accessible(vehicle_properties)) {
+            continue;
+        }
+
+        const auto next_dt = get_next_departure(dt, freq_vj, st, disruption_active);
+
+        if (next_dt < best.second) {
+            best = {&st, next_dt};
+        }
+    }
+    return best;
 }
 
 
 /**
- * the valid_pick_up funciton can be called 2 differents ways:
- * - with a date time => we look for the new valid stop time valid the the day of the date time and after the hour of the date time.
+ * valid_pick_up function:
+ * we look for the new valid stop time valid the the day of the date time and after the hour of the date time.
+ *
+ * 2 lookup are done,
+ *  one on the ordered vector of departures (for the non frequency VJ),
+ *  and one on the frenquency VJ (for the moment we loop through all frequency VJ, no clever data structure, we'll see if it is worth adding it)
+ *
  *      Note: if nothing found, we also look for a stop time the day after
- * - with a calendar and a hour => we look for the next valid stop time valid for the calendar and after the hour of the date time.
  */
 static std::pair<const type::StopTime*, DateTime>
-valid_pick_up(const std::vector<uint32_t>::const_iterator begin,
-              type::idx_t idx,
-              const type::idx_t end,
-              const DateTime dt,
-              const type::Data& data,
-              bool reconstructing_path,
-              const type::VehicleProperties &vehicle_properties,
-              bool disruption_active) {
-    const type::StopTime* first_st = next_valid_pick_up(idx, end,
-            dt, data, reconstructing_path, vehicle_properties, disruption_active);
-    // If no trip was found, we look for one the day after
-    if(first_st != nullptr) {
-        return {first_st, dt};
-    }
-    idx = begin - data.dataRaptor->departure_times.begin();
-    auto working_dt = DateTimeUtils::set(DateTimeUtils::date(dt)+1, 0);
-    first_st = next_valid_pick_up(idx, end, working_dt,
-        data, reconstructing_path, vehicle_properties,disruption_active);
+valid_pick_up(const type::JourneyPatternPoint* jpp, 
+	const DateTime dt,
+        const type::Data& data, 
+	bool reconstructing_path,
+        const type::VehicleProperties &vehicle_properties,
+        bool disruption_active) {
 
-    return {first_st, working_dt};
+    auto begin = data.dataRaptor->departure_times.begin() +
+            data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
+            jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    auto end = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    auto it = std::lower_bound(begin, end, DateTimeUtils::hour(dt),
+                               bound_predicate_earliest);
+
+    type::idx_t idx = it - data.dataRaptor->departure_times.begin();
+    type::idx_t end_idx = (begin - data.dataRaptor->departure_times.begin()) +
+                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+
+    const auto first_discrete_st_pair =
+            next_valid_discrete_pick_up(idx, end_idx, dt, data, reconstructing_path, vehicle_properties, disruption_active);
+
+    //TODO use first_discrete as a LB ?
+    const auto first_frequency_st_pair =
+            next_valid_frequency_pick_up(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
+
+    auto date = DateTimeUtils::date(dt);
+
+    // If no trip was found, we look for one the day after
+    if (first_discrete_st_pair.first || first_frequency_st_pair.first) {
+        //we need to find the best between the frequency one and the 'normal' one
+        if (first_discrete_st_pair.second <= first_frequency_st_pair.second) {
+            //discrete's better
+            return first_discrete_st_pair;
+        }
+        return first_frequency_st_pair;
+    }
+
+    idx = begin - data.dataRaptor->departure_times.begin();
+    auto working_dt = DateTimeUtils::set(date + 1, 0);
+    const auto tomorow_first_discrete =
+            next_valid_discrete_pick_up(idx, end_idx, working_dt, data, reconstructing_path, vehicle_properties,disruption_active);
+
+    //TODO use first_discrete as a LB ?
+    const auto tomorow_first_frequency =
+            next_valid_frequency_pick_up(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
+
+    if (tomorow_first_discrete.second <= tomorow_first_frequency.second) {
+        //discrete's better
+        return tomorow_first_discrete;
+    }
+    return tomorow_first_frequency;
 }
 
 static const type::StopTime*
@@ -126,33 +187,9 @@ earliest_stop_time(const type::JourneyPatternPoint* jpp,
                    bool reconstructing_path,
                    const type::VehicleProperties& vehicle_properties) {
     //We look for the earliest stop time of the journey_pattern >= dt.hour()
-    auto begin = data.dataRaptor->departure_times.begin() +
-            data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
-            jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-    auto end = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-    auto it = std::lower_bound(begin, end, DateTimeUtils::hour(dt),
-                               bound_predicate_earliest);
-
-    type::idx_t idx = it - data.dataRaptor->departure_times.begin();
-    type::idx_t end_idx = (begin - data.dataRaptor->departure_times.begin()) +
-                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
 
     //Return the first valid trip
-    std::pair<const type::StopTime*, DateTime> first_st =
-            valid_pick_up(begin, idx, end_idx, dt, data, reconstructing_path, vehicle_properties, disruption_active);
-
-    if(first_st.first != nullptr) {
-        if(!first_st.first->is_frequency()) {
-            DateTimeUtils::update(first_st.second, first_st.first->departure_time);
-        } else {
-            first_st.second = dt;
-            const DateTime tmp_dt = f_departure_time(DateTimeUtils::hour(first_st.second), *first_st.first);
-            DateTimeUtils::update(first_st.second, DateTimeUtils::hour(tmp_dt));
-        }
-        assert(first_st.first->journey_pattern_point == jpp);
-        return first_st;
-    }
-    return {nullptr, 0};
+    return valid_pick_up(jpp, dt, data, reconstructing_path, vehicle_properties, disruption_active);
 }
 
 // get all stop times for a given jpp and a given calendar
@@ -167,101 +204,181 @@ get_all_stop_times(const type::JourneyPatternPoint* jpp,
                    const type::VehicleProperties& vehicle_properties) {
 
     std::set<const type::MetaVehicleJourney*> meta_vjs;
-    for (auto vj: jpp->journey_pattern->vehicle_journey_list) {
-        if (! vj->meta_vj) {
-            throw navitia::exception("vj " + vj->uri + " has been ill constructed, it has no meta vj");
-        }
-        meta_vjs.insert(vj->meta_vj);
-    }
-    std::vector<const type::VehicleJourney*> vjs;
-    for (const auto meta_vj: meta_vjs) {
-        if (meta_vj->associated_calendars.find(calendar_id) == meta_vj->associated_calendars.end()) {
-            //meta vj not associated with the calender, we skip
-            continue;
-        }
-        //we can get only the first theoric one, because BY CONSTRUCTION all theoric vj have the same local times
-        vjs.push_back(meta_vj->theoric_vj.front());
-    }
-    if (vjs.empty()) {
-        return {};
-    }
+    throw "todo pas trop chiant";
+//    for (auto vj: jpp->journey_pattern->vehicle_journey_list()) {
+//        if (! vj->meta_vj) {
+//            throw navitia::exception("vj " + vj->uri + " has been ill constructed, it has no meta vj");
+//        }
+//        meta_vjs.insert(vj->meta_vj);
+//    }
+//    std::vector<const type::VehicleJourney*> vjs;
+//    for (const auto meta_vj: meta_vjs) {
+//        if (meta_vj->associated_calendars.find(calendar_id) == meta_vj->associated_calendars.end()) {
+//            //meta vj not associated with the calender, we skip
+//            continue;
+//        }
+//        //we can get only the first theoric one, because BY CONSTRUCTION all theoric vj have the same local times
+//        vjs.push_back(meta_vj->theoric_vj.front());
+//    }
+//    if (vjs.empty()) {
+//        return {};
+//    }
 
-    std::vector<std::pair<DateTime, const type::StopTime*>> res;
-    for (const auto vj: vjs) {
-        //loop through stop times for stop jpp->stop_point
-        const auto& st = *(vj->stop_time_list.begin() + jpp->order);
-        if (! st.vehicle_journey->accessible(vehicle_properties)) {
-            continue; //the stop time must be accessible
-        }
-        if (st.is_frequency()) {
-            //if it is a frequency, we got to expand the timetable
+//    std::vector<std::pair<DateTime, const type::StopTime*>> res;
+//    for (const auto vj: vjs) {
+//        //loop through stop times for stop jpp->stop_point
+//        const auto& st = *(vj->stop_time_list.begin() + jpp->order);
+//        if (! st.vehicle_journey->accessible(vehicle_properties)) {
+//            continue; //the stop time must be accessible
+//        }
+//        if (st.is_frequency()) {
+//            //if it is a frequency, we got to expand the timetable
 
-            //Note: end can be lower than start, so we have to cycle through the day
-            bool is_looping = (vj->start_time > vj->end_time);
-            auto stop_loop = [vj, is_looping](u_int32_t t) {
-                if (! is_looping)
-                    return t <= vj->end_time;
-                return t > vj->end_time;
-            };
-            for (auto time = vj->start_time; stop_loop(time); time += vj->headway_secs) {
-                if (is_looping && time > DateTimeUtils::SECONDS_PER_DAY) {
-                    time -= DateTimeUtils::SECONDS_PER_DAY;
-                }
+//            //Note: end can be lower than start, so we have to cycle through the day
+//            bool is_looping = (vj->start_time > vj->end_time);
+//            auto stop_loop = [vj, is_looping](u_int32_t t) {
+//                if (! is_looping)
+//                    return t <= vj->end_time;
+//                return t > vj->end_time;
+//            };
+//            for (auto time = vj->start_time; stop_loop(time); time += vj->headway_secs) {
+//                if (is_looping && time > DateTimeUtils::SECONDS_PER_DAY) {
+//                    time -= DateTimeUtils::SECONDS_PER_DAY;
+//                }
 
-                //we need to convert this to local there since we do not have a precise date (just a period)
-                res.push_back({time + vj->utc_to_local_offset, &st});
-            }
-        } else {
-            //same utc tranformation
-            res.push_back({st.departure_time + vj->utc_to_local_offset, &st});
-        }
-    }
+//                //we need to convert this to local there since we do not have a precise date (just a period)
+//                res.push_back({time + vj->utc_to_local_offset, &st});
+//            }
+//        } else {
+//            //same utc tranformation
+//            res.push_back({st.departure_time + vj->utc_to_local_offset, &st});
+//        }
+//    }
 
-    return res;
+//    return res;
 }
 
+/**
+* Here we want the next dt in the period of the frequency.
+* If none is found, we return std::numeric_limits<DateTime>::max()
+*
+*  In normal case we have something like:
+* 0-------------------------------------86400(midnight)
+*     start-------end
+*
+* in this case, it's easy, hour should be in [start; end]
+* if before, next departure is start, if after, no next departure
+*
+*
+* If end_time, is after midnight, so end_time%86400 will be < start_time
+*
+* So we will have something like:
+* 0-------------------------------------86400----------------------------86400*2
+*                             start----------------end
+*
+* by check that on only one day (modulating by 86400), we have:
+* 0-------------------------------------86400(midnight)
+*  -------end                 start--------
+*
+* Note: If hour in [0, end] we have to check the previous day validity pattern
+**/
+DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted) {
+    const u_int32_t lower_bound = (freq_vj.start_time + st.departure_time) % DateTimeUtils::SECONDS_PER_DAY;
+    const u_int32_t higher_bound = (freq_vj.end_time + st.departure_time) % DateTimeUtils::SECONDS_PER_DAY;
+
+    auto hour = DateTimeUtils::hour(dt);
+    auto date = DateTimeUtils::date(dt);
+
+    const bool classic_case = lower_bound <= higher_bound;
+
+    //in the 'classic' case, hour should be in [lower, higher]
+    // but in case of midnight overrun, hour should be in [higher, lower]
+    if (classic_case) {
+        if (hour <= lower_bound) {
+            if (freq_vj.is_valid(date, adapted)) {
+                return DateTimeUtils::set(date, lower_bound);
+            }
+            return std::numeric_limits<DateTime>::max();
+        }
+        if (hour > higher_bound) {
+            //no solution on the day
+            return std::numeric_limits<DateTime>::max();
+        }
+    }
+
+
+    double diff;
+    if (classic_case || //in classic case, we must be in [start, end]
+            (! classic_case && within(hour, {lower_bound, DateTimeUtils::SECONDS_PER_DAY}))) {
+        //we need to check if the vj is valid for our day
+        if (! freq_vj.is_valid(date, adapted)) {
+            return std::numeric_limits<DateTime>::max();
+        }
+
+         diff = hour - lower_bound;
+    } else {
+        // overnight case and hour > midnight
+        if (hour > higher_bound) {
+            if (freq_vj.is_valid(date, adapted)) {
+                return DateTimeUtils::set(date, lower_bound);
+            }
+            return std::numeric_limits<DateTime>::max();
+        }
+        //we need to see if the vj was valid the day before
+        if (! freq_vj.is_valid(date - 1, adapted)) {
+            //the vj was not valid, next departure is lower
+            return DateTimeUtils::set(date, lower_bound);
+        }
+
+        diff = higher_bound - hour;
+    }
+    const uint32_t x = std::ceil(diff / double(freq_vj.headway_secs));
+
+    return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
+}
 
 std::pair<const type::StopTime*, uint32_t>
 tardiest_stop_time(const type::JourneyPatternPoint* jpp,
                    const DateTime dt, const type::Data &data, bool disruption_active,
                    bool reconstructing_path,
                    const type::VehicleProperties& vehicle_properties) {
+    throw "TODO";
     //On cherche le plus grand stop time de la journey_pattern <= dt.hour()
-    const auto begin = data.dataRaptor->arrival_times.begin() +
-                       data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
-                       jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-    const auto end = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-    auto it = std::lower_bound(begin, end, DateTimeUtils::hour(dt), bound_predicate_tardiest);
+//    const auto begin = data.dataRaptor->arrival_times.begin() +
+//                       data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
+//                       jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+//    const auto end = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+//    auto it = std::lower_bound(begin, end, DateTimeUtils::hour(dt), bound_predicate_tardiest);
 
-    type::idx_t idx = it - data.dataRaptor->arrival_times.begin();
-    type::idx_t end_idx = (begin - data.dataRaptor->arrival_times.begin()) +
-                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+//    type::idx_t idx = it - data.dataRaptor->arrival_times.begin();
+//    type::idx_t end_idx = (begin - data.dataRaptor->arrival_times.begin()) +
+//                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
 
-    const type::StopTime* first_st = valid_drop_off(idx, end_idx,
-            dt, data,
-            reconstructing_path, vehicle_properties, disruption_active);
+//    const type::StopTime* first_st = valid_drop_off(idx, end_idx,
+//            dt, data,
+//            reconstructing_path, vehicle_properties, disruption_active);
 
-    auto working_dt = dt;
-    // If no trip was found, we look for one the day before
-    if(first_st == nullptr && DateTimeUtils::date(dt) > 0){
-        idx = begin - data.dataRaptor->arrival_times.begin();
-        working_dt = DateTimeUtils::set(DateTimeUtils::date(working_dt) - 1,
-                                        DateTimeUtils::SECONDS_PER_DAY - 1);
-        first_st = valid_drop_off(idx, end_idx, working_dt, data, reconstructing_path,
-                vehicle_properties, disruption_active);
-    }
+//    auto working_dt = dt;
+//    // If no trip was found, we look for one the day before
+//    if(first_st == nullptr && DateTimeUtils::date(dt) > 0){
+//        idx = begin - data.dataRaptor->arrival_times.begin();
+//        working_dt = DateTimeUtils::set(DateTimeUtils::date(working_dt) - 1,
+//                                        DateTimeUtils::SECONDS_PER_DAY - 1);
+//        first_st = valid_drop_off(idx, end_idx, working_dt, data, reconstructing_path,
+//                vehicle_properties, disruption_active);
+//    }
 
-    if(first_st != nullptr){
-        if(!first_st->is_frequency()) {
-            DateTimeUtils::update(working_dt, DateTimeUtils::hour(first_st->arrival_time), false);
-        } else {
-            working_dt = dt;
-            const DateTime tmp_dt = f_arrival_time(DateTimeUtils::hour(working_dt), *first_st);
-            DateTimeUtils::update(working_dt, DateTimeUtils::hour(tmp_dt), false);
-        }
-        assert(first_st->journey_pattern_point == jpp);
-        return std::make_pair(first_st, working_dt);
-    }
+//    if(first_st != nullptr){
+//        if(!first_st->is_frequency()) {
+//            DateTimeUtils::update(working_dt, DateTimeUtils::hour(first_st->arrival_time), false);
+//        } else {
+//            working_dt = dt;
+//            const DateTime tmp_dt = f_arrival_time(DateTimeUtils::hour(working_dt), *first_st);
+//            DateTimeUtils::update(working_dt, DateTimeUtils::hour(tmp_dt), false);
+//        }
+//        assert(first_st->journey_pattern_point == jpp);
+//        return std::make_pair(first_st, working_dt);
+//    }
 
     //Cette journey_pattern ne comporte aucun trip compatible
     return std::make_pair(nullptr, 0);

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -302,12 +302,13 @@ get_all_stop_times(const type::JourneyPatternPoint* jpp,
                    const type::VehicleProperties& vehicle_properties) {
 
     std::set<const type::MetaVehicleJourney*> meta_vjs;
-    for (auto vj: jpp->journey_pattern->get_vehicle_journey_list()) {
-        if (! vj->meta_vj) {
-            throw navitia::exception("vj " + vj->uri + " has been ill constructed, it has no meta vj");
+    jpp->journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj ) {
+        if (! vj.meta_vj) {
+            throw navitia::exception("vj " + vj.uri + " has been ill constructed, it has no meta vj");
         }
-        meta_vjs.insert(vj->meta_vj);
-    }
+        meta_vjs.insert(vj.meta_vj);
+        return true;
+    });
     std::vector<const type::VehicleJourney*> vjs;
     for (const auto meta_vj: meta_vjs) {
         if (meta_vj->associated_calendars.find(calendar_id) == meta_vj->associated_calendars.end()) {

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -104,14 +104,14 @@ next_valid_frequency_pick_up(const type::JourneyPatternPoint* jpp, const DateTim
     for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
         //we get stop time corresponding to the jpp
 
-        const auto& st = freq_vj.stop_time_list[jpp->order];
+        const auto& st = freq_vj->stop_time_list[jpp->order];
 
         if (! st.valid_end(reconstructing_path) ||
-            ! freq_vj.accessible(vehicle_properties)) {
+            ! freq_vj->accessible(vehicle_properties)) {
             continue;
         }
 
-        const auto next_dt = get_next_departure(dt, freq_vj, st, disruption_active);
+        const auto next_dt = get_next_departure(dt, *freq_vj, st, disruption_active);
 
         if (next_dt < best.second) {
             best = {&st, next_dt};
@@ -123,14 +123,14 @@ next_valid_frequency_pick_up(const type::JourneyPatternPoint* jpp, const DateTim
         for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
             //we get stop time corresponding to the jpp
 
-            const auto& st = freq_vj.stop_time_list[jpp->order];
+            const auto& st = freq_vj->stop_time_list[jpp->order];
 
             if (! st.valid_end(reconstructing_path) ||
-                ! freq_vj.accessible(vehicle_properties)) {
+                ! freq_vj->accessible(vehicle_properties)) {
                 continue;
             }
 
-            const auto next_dt = get_next_departure(next_date, freq_vj, st, disruption_active);
+            const auto next_dt = get_next_departure(next_date, *freq_vj, st, disruption_active);
 
             if (next_dt < best.second) {
                 best = {&st, next_dt};
@@ -148,14 +148,14 @@ previous_valid_frequency_drop_off(const type::JourneyPatternPoint* jpp, const Da
     std::pair<const type::StopTime*, DateTime> best = {nullptr, std::numeric_limits<DateTime>::max()};
     for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
         //we get stop time corresponding to the jpp
-        const auto& st = freq_vj.stop_time_list[jpp->order];
+        const auto& st = freq_vj->stop_time_list[jpp->order];
 
         if (! st.valid_end(!reconstructing_path) ||
-            ! freq_vj.accessible(vehicle_properties)) {
+            ! freq_vj->accessible(vehicle_properties)) {
             continue;
         }
 
-        const auto previous_dt = get_previous_arrival(dt, freq_vj, st, disruption_active);
+        const auto previous_dt = get_previous_arrival(dt, *freq_vj, st, disruption_active);
 
         if (best.second == DateTimeUtils::inf || previous_dt > best.second) {
             best = {&st, previous_dt};
@@ -166,14 +166,14 @@ previous_valid_frequency_drop_off(const type::JourneyPatternPoint* jpp, const Da
         const auto previous_date = DateTimeUtils::set(DateTimeUtils::date(dt) - 1, DateTimeUtils::SECONDS_PER_DAY - 1);
         for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
             //we get stop time corresponding to the jpp
-            const auto& st = freq_vj.stop_time_list[jpp->order];
+            const auto& st = freq_vj->stop_time_list[jpp->order];
 
             if (! st.valid_end(!reconstructing_path) ||
-                ! freq_vj.accessible(vehicle_properties)) {
+                ! freq_vj->accessible(vehicle_properties)) {
                 continue;
             }
 
-            const auto previous_dt = get_previous_arrival(previous_date, freq_vj, st, disruption_active);
+            const auto previous_dt = get_previous_arrival(previous_date, *freq_vj, st, disruption_active);
 
             if (best.second == DateTimeUtils::inf || previous_dt > best.second) {
                 best = {&st, previous_dt};

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -46,23 +46,50 @@ best_stop_time(const type::JourneyPatternPoint* jpp,
 /** Which is the first valid stop_time in this range ?
  *  Returns invalid_idx is none is
  */
-static std::pair<const type::StopTime*, DateTime> 
-next_valid_discrete_pick_up(type::idx_t idx, 
-			const type::idx_t end, 
-			const DateTime dt,
-        const type::Data &data, 
-	bool reconstructing_path,
+static std::pair<const type::StopTime*, DateTime>
+next_valid_discrete_pick_up(const type::JourneyPatternPoint* jpp, const DateTime dt,
+        const type::Data &data, bool reconstructing_path,
         const type::VehicleProperties &required_vehicle_properties,
         bool disruption_active){
-    const auto date = DateTimeUtils::date(dt);
+
+    if (data.dataRaptor->departure_times.empty()) {
+        return {nullptr, DateTimeUtils::max};
+    }
+    const auto begin = data.dataRaptor->departure_times.begin() +
+            data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
+            jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    const auto end_it = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    const auto it = std::lower_bound(begin, end_it, DateTimeUtils::hour(dt),
+                               bound_predicate_earliest);
+
+    type::idx_t idx = it - data.dataRaptor->departure_times.begin();
+    const type::idx_t end = (begin - data.dataRaptor->departure_times.begin()) +
+                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+
+
+    auto date = DateTimeUtils::date(dt);
     for(; idx < end; ++idx) {
         const type::StopTime* st = data.dataRaptor->st_forward[idx];
         if (st->valid_end(reconstructing_path) &&
             st->is_valid_day(date, false, disruption_active)
             && st->vehicle_journey->accessible(required_vehicle_properties) ){
-                return {st, DateTimeUtils::set(date, st->departure_time)};
+                return {st, DateTimeUtils::set(date, st->departure_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
     }
+
+    //if non was found, we try again the next day
+    idx = begin - data.dataRaptor->departure_times.begin();
+    date++;
+    for(; idx < end; ++idx) {
+        const type::StopTime* st = data.dataRaptor->st_forward[idx];
+        if (st->valid_end(reconstructing_path) &&
+            st->is_valid_day(date, false, disruption_active)
+            && st->vehicle_journey->accessible(required_vehicle_properties) ){
+                return {st, DateTimeUtils::set(date, st->departure_time % DateTimeUtils::SECONDS_PER_DAY)};
+        }
+    }
+
+    // if nothing found, return max
     return {nullptr, std::numeric_limits<DateTime>::max()};
 }
 
@@ -80,7 +107,7 @@ next_valid_frequency_pick_up(const type::JourneyPatternPoint* jpp, const DateTim
         const auto& st = freq_vj.stop_time_list[jpp->order];
 
         if (! st.valid_end(reconstructing_path) ||
-            freq_vj.accessible(vehicle_properties)) {
+            ! freq_vj.accessible(vehicle_properties)) {
             continue;
         }
 
@@ -90,47 +117,146 @@ next_valid_frequency_pick_up(const type::JourneyPatternPoint* jpp, const DateTim
             best = {&st, next_dt};
         }
     }
+    //TODO look for the next day
+    if (best.first == nullptr) {
+        const auto next_date = DateTimeUtils::set(DateTimeUtils::date(dt) + 1, 0);
+        for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
+            //we get stop time corresponding to the jpp
+
+            const auto& st = freq_vj.stop_time_list[jpp->order];
+
+            if (! st.valid_end(reconstructing_path) ||
+                ! freq_vj.accessible(vehicle_properties)) {
+                continue;
+            }
+
+            const auto next_dt = get_next_departure(next_date, freq_vj, st, disruption_active);
+
+            if (next_dt < best.second) {
+                best = {&st, next_dt};
+            }
+        }
+    }
     return best;
+}
+
+std::pair<const type::StopTime*, DateTime>
+previous_valid_frequency_drop_off(const type::JourneyPatternPoint* jpp, const DateTime dt,
+                             bool reconstructing_path,
+                             const type::VehicleProperties &vehicle_properties,
+                             bool disruption_active) {
+    std::pair<const type::StopTime*, DateTime> best = {nullptr, std::numeric_limits<DateTime>::max()};
+    for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
+        //we get stop time corresponding to the jpp
+        const auto& st = freq_vj.stop_time_list[jpp->order];
+
+        if (! st.valid_end(!reconstructing_path) ||
+            ! freq_vj.accessible(vehicle_properties)) {
+            continue;
+        }
+
+        const auto previous_dt = get_previous_arrival(dt, freq_vj, st, disruption_active);
+
+        if (best.second == DateTimeUtils::inf || previous_dt > best.second) {
+            best = {&st, previous_dt};
+        }
+    }
+
+    if (best.first == nullptr) {
+        const auto previous_date = DateTimeUtils::set(DateTimeUtils::date(dt) - 1, DateTimeUtils::SECONDS_PER_DAY - 1);
+        for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
+            //we get stop time corresponding to the jpp
+            const auto& st = freq_vj.stop_time_list[jpp->order];
+
+            if (! st.valid_end(!reconstructing_path) ||
+                ! freq_vj.accessible(vehicle_properties)) {
+                continue;
+            }
+
+            const auto previous_dt = get_previous_arrival(previous_date, freq_vj, st, disruption_active);
+
+            if (best.second == DateTimeUtils::inf || previous_dt > best.second) {
+                best = {&st, previous_dt};
+            }
+        }
+    }
+    return best;
+}
+
+std::pair<const type::StopTime*, DateTime>
+previous_valid_discrete_drop_off(const type::JourneyPatternPoint* jpp, const DateTime dt,
+               const type::Data &data, bool reconstructing_path,
+               const type::VehicleProperties &required_vehicle_properties,
+               bool disruption_active){
+    //On cherche le plus grand stop time de la journey_pattern <= dt.hour()
+    if (data.dataRaptor->arrival_times.empty()) {
+        return {nullptr, DateTimeUtils::inf};
+    }
+    const auto begin = data.dataRaptor->arrival_times.begin() +
+                       data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
+                       jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    const auto end_it = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    const auto it = std::lower_bound(begin, end_it, DateTimeUtils::hour(dt), bound_predicate_tardiest);
+
+    type::idx_t idx = it - data.dataRaptor->arrival_times.begin();
+    const type::idx_t end = (begin - data.dataRaptor->arrival_times.begin()) +
+                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+
+    auto date = DateTimeUtils::date(dt);
+    for(; idx < end; ++idx) {
+        const type::StopTime* st = data.dataRaptor->st_backward[idx];
+        if (st->valid_end(!reconstructing_path) &&
+            st->is_valid_day(date, true, disruption_active)
+            && st->vehicle_journey->accessible(required_vehicle_properties) ){
+                return {st, DateTimeUtils::set(date, st->arrival_time % DateTimeUtils::SECONDS_PER_DAY)};
+        }
+    }
+
+    if (date == 0) {
+        return {nullptr, std::numeric_limits<DateTime>::max()};
+    }
+    idx = begin - data.dataRaptor->arrival_times.begin();
+
+    --date;
+    for(; idx < end; ++idx) {
+        const type::StopTime* st = data.dataRaptor->st_backward[idx];
+        if (st->valid_end(!reconstructing_path) &&
+            st->is_valid_day(date, true, disruption_active)
+            && st->vehicle_journey->accessible(required_vehicle_properties) ){
+            return {st, DateTimeUtils::set(date, st->arrival_time % DateTimeUtils::SECONDS_PER_DAY)};
+        }
+    }
+
+    return {nullptr, std::numeric_limits<DateTime>::max()};
 }
 
 
 /**
- * valid_pick_up function:
- * we look for the new valid stop time valid the the day of the date time and after the hour of the date time.
+ * earliest_stop_time function:
+ * we look for the next valid stop time valid the day of the date time and after the hour of the date time.
  *
  * 2 lookup are done,
  *  one on the ordered vector of departures (for the non frequency VJ),
  *  and one on the frenquency VJ (for the moment we loop through all frequency VJ, no clever data structure, we'll see if it is worth adding it)
  *
- *      Note: if nothing found, we also look for a stop time the day after
+ *      Note: if nothing found, we do the same lookup the day after
  */
-static std::pair<const type::StopTime*, DateTime>
-valid_pick_up(const type::JourneyPatternPoint* jpp, 
-	const DateTime dt,
-        const type::Data& data, 
-	bool reconstructing_path,
-        const type::VehicleProperties &vehicle_properties,
-        bool disruption_active) {
+static std::pair<const type::StopTime*, uint32_t>
+earliest_stop_time(const type::JourneyPatternPoint* jpp,
+                   const DateTime dt, const type::Data &data,
+                   bool disruption_active,
+                   bool reconstructing_path,
+                   const type::VehicleProperties& vehicle_properties) {
+    //We look for the earliest stop time of the journey_pattern >= dt.hour()
 
-    auto begin = data.dataRaptor->departure_times.begin() +
-            data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
-            jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-    auto end = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-    auto it = std::lower_bound(begin, end, DateTimeUtils::hour(dt),
-                               bound_predicate_earliest);
-
-    type::idx_t idx = it - data.dataRaptor->departure_times.begin();
-    type::idx_t end_idx = (begin - data.dataRaptor->departure_times.begin()) +
-                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    //Return the first valid trip
 
     const auto first_discrete_st_pair =
-            next_valid_discrete_pick_up(idx, end_idx, dt, data, reconstructing_path, vehicle_properties, disruption_active);
+            next_valid_discrete_pick_up(jpp, dt, data, reconstructing_path, vehicle_properties, disruption_active);
 
     //TODO use first_discrete as a LB ?
     const auto first_frequency_st_pair =
             next_valid_frequency_pick_up(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
-
-    auto date = DateTimeUtils::date(dt);
 
     // If no trip was found, we look for one the day after
     if (first_discrete_st_pair.first || first_frequency_st_pair.first) {
@@ -142,121 +268,101 @@ valid_pick_up(const type::JourneyPatternPoint* jpp,
         return first_frequency_st_pair;
     }
 
-    idx = begin - data.dataRaptor->departure_times.begin();
-    auto working_dt = DateTimeUtils::set(date + 1, 0);
-    const auto tomorow_first_discrete =
-            next_valid_discrete_pick_up(idx, end_idx, working_dt, data, reconstructing_path, vehicle_properties,disruption_active);
-
-    //TODO use first_discrete as a LB ?
-    const auto tomorow_first_frequency =
-            next_valid_frequency_pick_up(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
-
-    if (tomorow_first_discrete.second <= tomorow_first_frequency.second) {
-        //discrete's better
-        return tomorow_first_discrete;
-    }
-    return tomorow_first_frequency;
-}
-
-static const type::StopTime*
-valid_drop_off(type::idx_t idx,
-               const type::idx_t end,
-               const DateTime dt,
-               const type::Data& data,
-               bool reconstructing_path,
-               const type::VehicleProperties& required_vehicle_properties,
-               bool disruption_active){
-    const auto date = DateTimeUtils::date(dt);
-    const auto hour = DateTimeUtils::hour(dt);
-    for(; idx < end; ++idx) {
-        const type::StopTime* st = data.dataRaptor->st_backward[idx];
-        if (st->valid_end(!reconstructing_path) && st->valid_hour(hour, false) &&
-            st->is_valid_day(date, true, disruption_active)
-            && st->vehicle_journey->accessible(required_vehicle_properties) ){
-                return st;
-        }
-    }
-    return nullptr;
+    return {nullptr, std::numeric_limits<DateTime>::max()};
 }
 
 
 std::pair<const type::StopTime*, uint32_t>
-earliest_stop_time(const type::JourneyPatternPoint* jpp,
-                   const DateTime dt, const type::Data &data,
-                   bool disruption_active,
+tardiest_stop_time(const type::JourneyPatternPoint* jpp,
+                   const DateTime dt, const type::Data &data, bool disruption_active,
                    bool reconstructing_path,
                    const type::VehicleProperties& vehicle_properties) {
-    //We look for the earliest stop time of the journey_pattern >= dt.hour()
 
-    //Return the first valid trip
-    return valid_pick_up(jpp, dt, data, reconstructing_path, vehicle_properties, disruption_active);
+    const auto first_discrete_st_pair =
+            previous_valid_discrete_drop_off(jpp, dt, data, reconstructing_path, vehicle_properties, disruption_active);
+
+    //TODO use first_discrete as a LB ?
+    const auto first_frequency_st_pair =
+            previous_valid_frequency_drop_off(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
+
+    if (first_discrete_st_pair.first || first_frequency_st_pair.first) {
+        //we need to find the best between the frequency one and the 'normal' one
+        if (first_discrete_st_pair.second <= first_frequency_st_pair.second) {
+            //discrete's better
+            return first_discrete_st_pair;
+        }
+        return first_frequency_st_pair;
+    }
+    return {nullptr, std::numeric_limits<DateTime>::max()};
 }
 
-// get all stop times for a given jpp and a given calendar
-//
-// earliest stop time for calendar is different than for a datetime
-// we have to consider only the first theoric vj of all meta vj for the given jpp
-// for all those vj, we select the one associated to the calendar,
-// and we loop through all stop times for the jpp 
+/** get all stop times for a given jpp and a given calendar
+ *
+ * earliest stop time for calendar is different than for a datetime
+ * we have to consider only the first theoric vj of all meta vj for the given jpp
+ * for all those vj, we select the one associated to the calendar,
+ * and we loop through all stop times for the jpp
+*/
 std::vector<std::pair<uint32_t, const type::StopTime*>>
 get_all_stop_times(const type::JourneyPatternPoint* jpp,
                    const std::string calendar_id,
                    const type::VehicleProperties& vehicle_properties) {
 
     std::set<const type::MetaVehicleJourney*> meta_vjs;
-    throw "todo pas trop chiant";
-//    for (auto vj: jpp->journey_pattern->vehicle_journey_list()) {
-//        if (! vj->meta_vj) {
-//            throw navitia::exception("vj " + vj->uri + " has been ill constructed, it has no meta vj");
-//        }
-//        meta_vjs.insert(vj->meta_vj);
-//    }
-//    std::vector<const type::VehicleJourney*> vjs;
-//    for (const auto meta_vj: meta_vjs) {
-//        if (meta_vj->associated_calendars.find(calendar_id) == meta_vj->associated_calendars.end()) {
-//            //meta vj not associated with the calender, we skip
-//            continue;
-//        }
-//        //we can get only the first theoric one, because BY CONSTRUCTION all theoric vj have the same local times
-//        vjs.push_back(meta_vj->theoric_vj.front());
-//    }
-//    if (vjs.empty()) {
-//        return {};
-//    }
+    for (auto vj: jpp->journey_pattern->get_vehicle_journey_list()) {
+        if (! vj->meta_vj) {
+            throw navitia::exception("vj " + vj->uri + " has been ill constructed, it has no meta vj");
+        }
+        meta_vjs.insert(vj->meta_vj);
+    }
+    std::vector<const type::VehicleJourney*> vjs;
+    for (const auto meta_vj: meta_vjs) {
+        if (meta_vj->associated_calendars.find(calendar_id) == meta_vj->associated_calendars.end()) {
+            //meta vj not associated with the calender, we skip
+            continue;
+        }
+        //we can get only the first theoric one, because BY CONSTRUCTION all theoric vj have the same local times
+        vjs.push_back(meta_vj->theoric_vj.front());
+    }
+    if (vjs.empty()) {
+        return {};
+    }
 
-//    std::vector<std::pair<DateTime, const type::StopTime*>> res;
-//    for (const auto vj: vjs) {
-//        //loop through stop times for stop jpp->stop_point
-//        const auto& st = *(vj->stop_time_list.begin() + jpp->order);
-//        if (! st.vehicle_journey->accessible(vehicle_properties)) {
-//            continue; //the stop time must be accessible
-//        }
-//        if (st.is_frequency()) {
-//            //if it is a frequency, we got to expand the timetable
+    std::vector<std::pair<DateTime, const type::StopTime*>> res;
+    for (const auto vj: vjs) {
+        //loop through stop times for stop jpp->stop_point
+        const auto& st = *(vj->stop_time_list.begin() + jpp->order);
+        if (! st.vehicle_journey->accessible(vehicle_properties)) {
+            continue; //the stop time must be accessible
+        }
+        if (st.is_frequency()) {
+            //if it is a frequency, we got to expand the timetable
 
-//            //Note: end can be lower than start, so we have to cycle through the day
-//            bool is_looping = (vj->start_time > vj->end_time);
-//            auto stop_loop = [vj, is_looping](u_int32_t t) {
-//                if (! is_looping)
-//                    return t <= vj->end_time;
-//                return t > vj->end_time;
-//            };
-//            for (auto time = vj->start_time; stop_loop(time); time += vj->headway_secs) {
-//                if (is_looping && time > DateTimeUtils::SECONDS_PER_DAY) {
-//                    time -= DateTimeUtils::SECONDS_PER_DAY;
-//                }
+            //Note: end can be lower than start, so we have to cycle through the day
+            const auto freq_vj = static_cast<const type::FrequencyVehicleJourney*>(vj);
+            bool is_looping = (freq_vj->start_time > freq_vj->end_time);
+            auto stop_loop = [freq_vj, is_looping](u_int32_t t) {
+                if (! is_looping)
+                    return t <= freq_vj->end_time;
+                return t > freq_vj->end_time;
+            };
+            for (auto time = freq_vj->start_time; stop_loop(time); time += freq_vj->headway_secs) {
+                if (is_looping && time > DateTimeUtils::SECONDS_PER_DAY) {
+                    time -= DateTimeUtils::SECONDS_PER_DAY;
+                }
 
-//                //we need to convert this to local there since we do not have a precise date (just a period)
-//                res.push_back({time + vj->utc_to_local_offset, &st});
-//            }
-//        } else {
-//            //same utc tranformation
-//            res.push_back({st.departure_time + vj->utc_to_local_offset, &st});
-//        }
-//    }
+                //we need to convert this to local there since we do not have a precise date (just a period)
+                res.push_back({time + freq_vj->utc_to_local_offset, &st});
+            }
+        } else {
+            //same utc tranformation
+            res.push_back({st.departure_time + vj->utc_to_local_offset, &st});
+        }
+    }
 
-//    return res;
+    return res;
 }
+
 
 /**
 * Here we want the next dt in the period of the frequency.
@@ -280,16 +386,16 @@ get_all_stop_times(const type::JourneyPatternPoint* jpp,
 * 0-------------------------------------86400(midnight)
 *  -------end                 start--------
 *
-* Note: If hour in [0, end] we have to check the previous day validity pattern
+* Note: If hour in [0, end] we have to check the previous day's validity pattern
 **/
 DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted) {
     const u_int32_t lower_bound = (freq_vj.start_time + st.departure_time) % DateTimeUtils::SECONDS_PER_DAY;
-    const u_int32_t higher_bound = (freq_vj.end_time + st.departure_time) % DateTimeUtils::SECONDS_PER_DAY;
+    const u_int32_t upper_bound = (freq_vj.end_time + st.departure_time) % DateTimeUtils::SECONDS_PER_DAY;
 
     auto hour = DateTimeUtils::hour(dt);
     auto date = DateTimeUtils::date(dt);
 
-    const bool classic_case = lower_bound <= higher_bound;
+    const bool classic_case = lower_bound <= upper_bound;
 
     //in the 'classic' case, hour should be in [lower, higher]
     // but in case of midnight overrun, hour should be in [higher, lower]
@@ -300,14 +406,12 @@ DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& fr
             }
             return std::numeric_limits<DateTime>::max();
         }
-        if (hour > higher_bound) {
+        if (hour > upper_bound) {
             //no solution on the day
             return std::numeric_limits<DateTime>::max();
         }
     }
 
-
-    double diff;
     if (classic_case || //in classic case, we must be in [start, end]
             (! classic_case && within(hour, {lower_bound, DateTimeUtils::SECONDS_PER_DAY}))) {
         //we need to check if the vj is valid for our day
@@ -315,73 +419,88 @@ DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& fr
             return std::numeric_limits<DateTime>::max();
         }
 
-         diff = hour - lower_bound;
-    } else {
-        // overnight case and hour > midnight
-        if (hour > higher_bound) {
+         double diff = hour - lower_bound;
+         const uint32_t x = std::ceil(diff / double(freq_vj.headway_secs));
+         return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
+    }
+
+    // overnight case and hour > midnight
+    if (hour > upper_bound) {
+        if (freq_vj.is_valid(date, adapted)) {
+            return DateTimeUtils::set(date, lower_bound);
+        }
+        return std::numeric_limits<DateTime>::max();
+    }
+    //we need to see if the vj was valid the day before
+    if (! freq_vj.is_valid(date - 1, adapted)) {
+        //the vj was not valid, next departure is lower
+        return DateTimeUtils::set(date, lower_bound);
+    }
+
+    double diff = hour - lower_bound + DateTimeUtils::SECONDS_PER_DAY;
+    const int32_t x = std::ceil(diff / double(freq_vj.headway_secs));
+
+    std::cout << " next : " << str(lower_bound) << "," << str(upper_bound) << " diff= " << str(diff)
+              << " x = " << x << " res == " << DateTimeUtils::set(date, (lower_bound + x * freq_vj.headway_secs) % DateTimeUtils::SECONDS_PER_DAY) << std::endl;
+
+    return DateTimeUtils::set(date, (lower_bound + x * freq_vj.headway_secs) % DateTimeUtils::SECONDS_PER_DAY);
+}
+
+DateTime get_previous_arrival(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted) {
+    const u_int32_t lower_bound = (freq_vj.start_time + st.arrival_time) % DateTimeUtils::SECONDS_PER_DAY;
+    const u_int32_t upper_bound = (freq_vj.end_time + st.arrival_time) % DateTimeUtils::SECONDS_PER_DAY;
+
+    auto hour = DateTimeUtils::hour(dt);
+    auto date = DateTimeUtils::date(dt);
+
+    const bool classic_case = lower_bound <= upper_bound;
+
+    //in the 'classic' case, hour should be in [lower, higher]
+    // but in case of midnight overrun, hour should be in [higher, lower]
+    if (classic_case) {
+        if (hour >= upper_bound) {
             if (freq_vj.is_valid(date, adapted)) {
-                return DateTimeUtils::set(date, lower_bound);
+                return DateTimeUtils::set(date, upper_bound);
             }
             return std::numeric_limits<DateTime>::max();
         }
-        //we need to see if the vj was valid the day before
-        if (! freq_vj.is_valid(date - 1, adapted)) {
-            //the vj was not valid, next departure is lower
-            return DateTimeUtils::set(date, lower_bound);
+        if (hour < lower_bound) {
+            //no solution on the day
+            return std::numeric_limits<DateTime>::max();
+        }
+    }
+
+    if (classic_case || //in classic case, we must be in [start, end]
+            (! classic_case && within(hour, {lower_bound, DateTimeUtils::SECONDS_PER_DAY}))) {
+        //we need to check if the vj is valid for our day
+        if (! freq_vj.is_valid(date, adapted)) {
+            return std::numeric_limits<DateTime>::max();
         }
 
-        diff = higher_bound - hour;
+         double diff = hour - lower_bound;
+         const uint32_t x = std::floor(diff / double(freq_vj.headway_secs));
+         return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
     }
-    const uint32_t x = std::ceil(diff / double(freq_vj.headway_secs));
 
-    return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
-}
+    // overnight case and hour > midnight
+    if (hour > upper_bound) {
+        //case with hour in [upper_bound, lower_boud]
+        if (freq_vj.is_valid(date, adapted)) {
+            return DateTimeUtils::set(date, upper_bound);
+        }
+        return std::numeric_limits<DateTime>::max();
+    }
+    //we need to see if the vj was valid the day before
+    if (! freq_vj.is_valid(date - 1, adapted)) {
+        //the vj was not valid, next departure is lower
+        return std::numeric_limits<DateTime>::max();
+    }
 
-std::pair<const type::StopTime*, uint32_t>
-tardiest_stop_time(const type::JourneyPatternPoint* jpp,
-                   const DateTime dt, const type::Data &data, bool disruption_active,
-                   bool reconstructing_path,
-                   const type::VehicleProperties& vehicle_properties) {
-    throw "TODO";
-    //On cherche le plus grand stop time de la journey_pattern <= dt.hour()
-//    const auto begin = data.dataRaptor->arrival_times.begin() +
-//                       data.dataRaptor->first_stop_time[jpp->journey_pattern->idx] +
-//                       jpp->order * data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-//    const auto end = begin + data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
-//    auto it = std::lower_bound(begin, end, DateTimeUtils::hour(dt), bound_predicate_tardiest);
+    const double diff = hour - lower_bound + DateTimeUtils::SECONDS_PER_DAY;
+    const int32_t x = std::floor(diff / double(freq_vj.headway_secs));
 
-//    type::idx_t idx = it - data.dataRaptor->arrival_times.begin();
-//    type::idx_t end_idx = (begin - data.dataRaptor->arrival_times.begin()) +
-//                           data.dataRaptor->nb_trips[jpp->journey_pattern->idx];
+    return DateTimeUtils::set(date - 1, lower_bound + x * freq_vj.headway_secs);
 
-//    const type::StopTime* first_st = valid_drop_off(idx, end_idx,
-//            dt, data,
-//            reconstructing_path, vehicle_properties, disruption_active);
-
-//    auto working_dt = dt;
-//    // If no trip was found, we look for one the day before
-//    if(first_st == nullptr && DateTimeUtils::date(dt) > 0){
-//        idx = begin - data.dataRaptor->arrival_times.begin();
-//        working_dt = DateTimeUtils::set(DateTimeUtils::date(working_dt) - 1,
-//                                        DateTimeUtils::SECONDS_PER_DAY - 1);
-//        first_st = valid_drop_off(idx, end_idx, working_dt, data, reconstructing_path,
-//                vehicle_properties, disruption_active);
-//    }
-
-//    if(first_st != nullptr){
-//        if(!first_st->is_frequency()) {
-//            DateTimeUtils::update(working_dt, DateTimeUtils::hour(first_st->arrival_time), false);
-//        } else {
-//            working_dt = dt;
-//            const DateTime tmp_dt = f_arrival_time(DateTimeUtils::hour(working_dt), *first_st);
-//            DateTimeUtils::update(working_dt, DateTimeUtils::hour(tmp_dt), false);
-//        }
-//        assert(first_st->journey_pattern_point == jpp);
-//        return std::make_pair(first_st, working_dt);
-//    }
-
-    //Cette journey_pattern ne comporte aucun trip compatible
-    return std::make_pair(nullptr, 0);
 }
 }}
 

--- a/source/routing/best_stoptime.h
+++ b/source/routing/best_stoptime.h
@@ -67,61 +67,48 @@ best_stop_time(const type::JourneyPatternPoint* jpp,
           const bool clockwise, bool disruption_active, const type::Data &data, bool reconstructing_path = false);
 
 /// For timetables in frequency-model
-inline u_int32_t f_arrival_time(uint32_t hour, const type::StopTime& st) {
-    const u_int32_t lower_bound = st.start_time(false);
-    const u_int32_t higher_bound = st.end_time(false);
-    // If higher bound is overmidnight the hour can be either in [lower_bound;midnight] or in
-    // [midnight;higher_bound]
-    if((higher_bound < DateTimeUtils::SECONDS_PER_DAY && hour>=lower_bound && hour<=higher_bound) ||
-            (higher_bound > DateTimeUtils::SECONDS_PER_DAY && (
-                (hour>=lower_bound && hour <= DateTimeUtils::SECONDS_PER_DAY)
-                 || (hour + DateTimeUtils::SECONDS_PER_DAY) <= higher_bound) )) {
-        if(hour < lower_bound)
-            hour += DateTimeUtils::SECONDS_PER_DAY;
-        const uint32_t x = std::floor(double(hour - lower_bound) / double(st.vehicle_journey->headway_secs));
-        BOOST_ASSERT(x*st.vehicle_journey->headway_secs+lower_bound <= hour);
-        BOOST_ASSERT(((hour - (x*st.vehicle_journey->headway_secs+lower_bound))%DateTimeUtils::SECONDS_PER_DAY) <= st.vehicle_journey->headway_secs);
-        return lower_bound + x * st.vehicle_journey->headway_secs;
-    } else {
-        return higher_bound;
-    }
+inline bool within(u_int32_t val, std::pair<u_int32_t, u_int32_t> bound) {
+    return val >= bound.first && val <= bound.second;
 }
 
+DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted = false);
 
 inline u_int32_t f_departure_time(uint32_t hour, const type::StopTime& st) {
-    const u_int32_t lower_bound = st.start_time(true);
-    const u_int32_t higher_bound = st.end_time(true);
-    // If higher bound is overmidnight the hour can be either in [lower_bound;midnight] or in
-    // [midnight;higher_bound]
-    if((higher_bound < DateTimeUtils::SECONDS_PER_DAY && hour>=lower_bound && hour<=higher_bound) ||
-            (higher_bound > DateTimeUtils::SECONDS_PER_DAY && (
-                (hour>=lower_bound && hour <= DateTimeUtils::SECONDS_PER_DAY)
-                 || (hour + DateTimeUtils::SECONDS_PER_DAY) <= higher_bound) )) {
-        if(hour < lower_bound)
-            hour += DateTimeUtils::SECONDS_PER_DAY;
-        const uint32_t x = std::ceil(double(hour - lower_bound) / double(st.vehicle_journey->headway_secs));
-        BOOST_ASSERT((x*st.vehicle_journey->headway_secs+lower_bound) >= hour);
-        BOOST_ASSERT((((x*st.vehicle_journey->headway_secs+lower_bound) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= st.vehicle_journey->headway_secs);
-        return lower_bound + x * st.vehicle_journey->headway_secs;
-    } else {
-        return lower_bound;
-    }
+//    const u_int32_t lower_bound = st.start_time(true);
+//    const u_int32_t higher_bound = st.end_time(true);
+//    // If higher bound is overmidnight the hour can be either in [lower_bound;midnight] or in
+//    // [midnight;higher_bound]
+//    if((higher_bound < DateTimeUtils::SECONDS_PER_DAY && hour>=lower_bound && hour<=higher_bound) ||
+//            (higher_bound > DateTimeUtils::SECONDS_PER_DAY && (
+//                (hour>=lower_bound && hour <= DateTimeUtils::SECONDS_PER_DAY)
+//                 || (hour + DateTimeUtils::SECONDS_PER_DAY) <= higher_bound) )) {
+//        if(hour < lower_bound)
+//            hour += DateTimeUtils::SECONDS_PER_DAY;
+//        const uint32_t x = std::ceil(double(hour - lower_bound) / double(st.vehicle_journey->headway_secs));
+//        BOOST_ASSERT((x*st.vehicle_journey->headway_secs+lower_bound) >= hour);
+//        BOOST_ASSERT((((x*st.vehicle_journey->headway_secs+lower_bound) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= st.vehicle_journey->headway_secs);
+//        return lower_bound + x * st.vehicle_journey->headway_secs;
+//    } else {
+//        return lower_bound;
+//    }
+    throw "TODO!";
 }
 
 inline uint32_t compute_gap(const uint32_t hour, const uint32_t start_time,
         const uint32_t end_time, const  uint32_t headway_secs, const bool clockwise) {
-    if((hour>=start_time && hour <= end_time)
-            || (end_time>DateTimeUtils::SECONDS_PER_DAY && ((end_time-DateTimeUtils::SECONDS_PER_DAY)>=hour))) {
-        const double tmp = double(hour - start_time) / double(headway_secs);
-        const uint32_t x = (clockwise ? std::ceil(tmp) : std::floor(tmp));
-        BOOST_ASSERT((clockwise && (x*headway_secs+start_time >= hour)) ||
-                     (!clockwise && (x*headway_secs+start_time <= hour)));
-        BOOST_ASSERT((clockwise && (((x*headway_secs+start_time) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= headway_secs) ||
-                     (!clockwise && ((hour - (x*headway_secs+start_time))%DateTimeUtils::SECONDS_PER_DAY) <= headway_secs));
-        return x * headway_secs;
-    } else {
-        return 0;
-    }
+//    if((hour>=start_time && hour <= end_time)
+//            || (end_time>DateTimeUtils::SECONDS_PER_DAY && ((end_time-DateTimeUtils::SECONDS_PER_DAY)>=hour))) {
+//        const double tmp = double(hour - start_time) / double(headway_secs);
+//        const uint32_t x = (clockwise ? std::ceil(tmp) : std::floor(tmp));
+//        BOOST_ASSERT((clockwise && (x*headway_secs+start_time >= hour)) ||
+//                     (!clockwise && (x*headway_secs+start_time <= hour)));
+//        BOOST_ASSERT((clockwise && (((x*headway_secs+start_time) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= headway_secs) ||
+//                     (!clockwise && ((hour - (x*headway_secs+start_time))%DateTimeUtils::SECONDS_PER_DAY) <= headway_secs));
+//        return x * headway_secs;
+//    } else {
+//        return 0;
+//    }
+    throw "TODO!";
 }
 inline bool bound_predicate_earliest(const uint32_t departure_time, const uint32_t hour) {
     return departure_time < hour;

--- a/source/routing/best_stoptime.h
+++ b/source/routing/best_stoptime.h
@@ -72,44 +72,8 @@ inline bool within(u_int32_t val, std::pair<u_int32_t, u_int32_t> bound) {
 }
 
 DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted = false);
+DateTime get_previous_arrival(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted = false);
 
-inline u_int32_t f_departure_time(uint32_t hour, const type::StopTime& st) {
-//    const u_int32_t lower_bound = st.start_time(true);
-//    const u_int32_t higher_bound = st.end_time(true);
-//    // If higher bound is overmidnight the hour can be either in [lower_bound;midnight] or in
-//    // [midnight;higher_bound]
-//    if((higher_bound < DateTimeUtils::SECONDS_PER_DAY && hour>=lower_bound && hour<=higher_bound) ||
-//            (higher_bound > DateTimeUtils::SECONDS_PER_DAY && (
-//                (hour>=lower_bound && hour <= DateTimeUtils::SECONDS_PER_DAY)
-//                 || (hour + DateTimeUtils::SECONDS_PER_DAY) <= higher_bound) )) {
-//        if(hour < lower_bound)
-//            hour += DateTimeUtils::SECONDS_PER_DAY;
-//        const uint32_t x = std::ceil(double(hour - lower_bound) / double(st.vehicle_journey->headway_secs));
-//        BOOST_ASSERT((x*st.vehicle_journey->headway_secs+lower_bound) >= hour);
-//        BOOST_ASSERT((((x*st.vehicle_journey->headway_secs+lower_bound) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= st.vehicle_journey->headway_secs);
-//        return lower_bound + x * st.vehicle_journey->headway_secs;
-//    } else {
-//        return lower_bound;
-//    }
-    throw "TODO!";
-}
-
-inline uint32_t compute_gap(const uint32_t hour, const uint32_t start_time,
-        const uint32_t end_time, const  uint32_t headway_secs, const bool clockwise) {
-//    if((hour>=start_time && hour <= end_time)
-//            || (end_time>DateTimeUtils::SECONDS_PER_DAY && ((end_time-DateTimeUtils::SECONDS_PER_DAY)>=hour))) {
-//        const double tmp = double(hour - start_time) / double(headway_secs);
-//        const uint32_t x = (clockwise ? std::ceil(tmp) : std::floor(tmp));
-//        BOOST_ASSERT((clockwise && (x*headway_secs+start_time >= hour)) ||
-//                     (!clockwise && (x*headway_secs+start_time <= hour)));
-//        BOOST_ASSERT((clockwise && (((x*headway_secs+start_time) - hour)%DateTimeUtils::SECONDS_PER_DAY) <= headway_secs) ||
-//                     (!clockwise && ((hour - (x*headway_secs+start_time))%DateTimeUtils::SECONDS_PER_DAY) <= headway_secs));
-//        return x * headway_secs;
-//    } else {
-//        return 0;
-//    }
-    throw "TODO!";
-}
 inline bool bound_predicate_earliest(const uint32_t departure_time, const uint32_t hour) {
     return departure_time < hour;
 }

--- a/source/routing/best_stoptime.h
+++ b/source/routing/best_stoptime.h
@@ -71,6 +71,12 @@ inline bool within(u_int32_t val, std::pair<u_int32_t, u_int32_t> bound) {
     return val >= bound.first && val <= bound.second;
 }
 
+inline bool is_valid(const nt::StopTime* st, uint32_t date, bool is_arrival, bool disruption_active, bool reconstructing_path, const type::VehicleProperties & vehicle_properties) {
+    return st->valid_end(reconstructing_path) &&
+        st->is_valid_day(date, is_arrival, disruption_active)
+        && st->vehicle_journey->accessible(vehicle_properties);
+}
+
 DateTime get_next_departure(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted = false);
 DateTime get_previous_arrival(DateTime dt, const type::FrequencyVehicleJourney& freq_vj, const type::StopTime& st, const bool adapted = false);
 

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -96,12 +96,12 @@ void dataRAPTOR::load(const type::PT_Data &data)
 
     for(const type::JourneyPattern* journey_pattern : data.journey_patterns) {
         first_stop_time.push_back(arrival_times.size());
-        nb_trips.push_back(journey_pattern->vehicle_journey_list.size());
+        nb_trips.push_back(journey_pattern->get_vehicle_journey_list().size());
 
         // On regroupe ensemble tous les horaires de tous les journey_pattern_point
         for(unsigned int i=0; i < journey_pattern->journey_pattern_point_list.size(); ++i) {
             std::vector<const type::StopTime*> vec_st;
-            for(const type::VehicleJourney* vj : journey_pattern->vehicle_journey_list) {
+            for(const type::VehicleJourney* vj : journey_pattern->get_vehicle_journey_list()) {
                 assert(vj->stop_time_list[i].journey_pattern_point == journey_pattern->journey_pattern_point_list[i]);
                 vec_st.push_back(&vj->stop_time_list[i]);
             }
@@ -129,12 +129,10 @@ void dataRAPTOR::load(const type::PT_Data &data)
             st_forward.insert(st_forward.end(), vec_st.begin(), vec_st.end());
 
             for(auto st : vec_st) {
-                uint32_t time;
-                if(!st->is_frequency())
-                    time = DateTimeUtils::hour(st->departure_time);
-                else
-                    time = DateTimeUtils::hour(st->vehicle_journey->end_time+st->departure_time);
-                departure_times.push_back(time);
+                //we only add the non frequency stop time, the rest are not search for in this structure
+                if (! st->is_frequency()) {
+                    departure_times.push_back(DateTimeUtils::hour(st->departure_time));
+                }
             }
 
             std::sort(vec_st.begin(), vec_st.end(),
@@ -160,18 +158,16 @@ void dataRAPTOR::load(const type::PT_Data &data)
 
             st_backward.insert(st_backward.end(), vec_st.begin(), vec_st.end());
             for(auto st : vec_st) {
-                uint32_t time;
-                if(!st->is_frequency())
-                    time = DateTimeUtils::hour(st->arrival_time);
-                else
-                    time = DateTimeUtils::hour(st->start_time(false));
-                arrival_times.push_back(time);
+                //we add only the non frequency stop time, the frequency one are search for a different way in best stop time
+                if (! st->is_frequency()) {
+                    arrival_times.push_back(DateTimeUtils::hour(st->arrival_time));
+                }
             }
         }
 
         // On dit que le journey pattern est valide en date j s'il y a au moins une circulation à j-1/j+1
         for(int i=0; i<=365; ++i) {
-            for(auto vj : journey_pattern->vehicle_journey_list) {
+            for(auto vj : journey_pattern->get_vehicle_journey_list()) {
                 if(vj->validity_pattern->check2(i)) {
                     jp_validity_patterns[i].set(journey_pattern->idx);
                     break;
@@ -181,7 +177,7 @@ void dataRAPTOR::load(const type::PT_Data &data)
 
         // On dit que le journey pattern est valide en date j s'il y a au moins une circulation à j-1/j+1
         for(int i=0; i<=365; ++i) {
-            for(auto vj : journey_pattern->vehicle_journey_list) {
+            for(auto vj : journey_pattern->get_vehicle_journey_list()) {
                 if(vj->adapted_validity_pattern->check2(i)) {
                     jp_adapted_validity_pattern[i].set(journey_pattern->idx);
                     break;

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -148,22 +148,25 @@ void dataRAPTOR::load(const type::PT_Data &data)
 
         // On dit que le journey pattern est valide en date j s'il y a au moins une circulation à j-1/j+1
         for(int i=0; i<=365; ++i) {
-            for(auto vj : journey_pattern->get_vehicle_journey_list()) {
-                if(vj->validity_pattern->check2(i)) {
+
+            journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
+                if(vj.validity_pattern->check2(i)) {
                     jp_validity_patterns[i].set(journey_pattern->idx);
-                    break;
+                    return false;
                 }
-            }
+                return true;
+            });
         }
 
         // On dit que le journey pattern est valide en date j s'il y a au moins une circulation à j-1/j+1
         for(int i=0; i<=365; ++i) {
-            for(auto vj : journey_pattern->get_vehicle_journey_list()) {
-                if(vj->adapted_validity_pattern->check2(i)) {
+            journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
+                if(vj.adapted_validity_pattern->check2(i)) {
                     jp_adapted_validity_pattern[i].set(journey_pattern->idx);
-                    break;
+                    return false;
                 }
-            }
+                return true;
+            });
         }
     }
 

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -96,7 +96,7 @@ void dataRAPTOR::load(const type::PT_Data &data)
 
     for(const type::JourneyPattern* journey_pattern : data.journey_patterns) {
         first_stop_time.push_back(arrival_times.size());
-        nb_trips.push_back(journey_pattern->get_vehicle_journey_list().size());
+        nb_trips.push_back(journey_pattern->discrete_vehicle_journey_list.size());
 
         //we group all descrete stop times from all journey_pattern_point
         //the frequency stop times are not considered here, they are search for a different way in best_stop_time

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -99,12 +99,12 @@ void dataRAPTOR::load(const type::PT_Data &data)
         nb_trips.push_back(journey_pattern->get_vehicle_journey_list().size());
 
         //we group all descrete stop times from all journey_pattern_point
-        //we frequency stop times are not considered here, they are search for a different way in best stop time
+        //the frequency stop times are not considered here, they are search for a different way in best_stop_time
         for(unsigned int i=0; i < journey_pattern->journey_pattern_point_list.size(); ++i) {
             std::vector<const type::StopTime*> vec_st;
             for(const auto& vj : journey_pattern->discrete_vehicle_journey_list) {
-                assert(vj.stop_time_list[i].journey_pattern_point == journey_pattern->journey_pattern_point_list[i]);
-                vec_st.push_back(&vj.stop_time_list[i]);
+                assert(vj->stop_time_list[i].journey_pattern_point == journey_pattern->journey_pattern_point_list[i]);
+                vec_st.push_back(&vj->stop_time_list[i]);
             }
             std::sort(vec_st.begin(), vec_st.end(),
                       [&](const type::StopTime* st1, const type::StopTime* st2)->bool{

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -74,7 +74,7 @@ struct dataRAPTOR {
     std::vector<boost::dynamic_bitset<> > jp_adapted_validity_pattern;
 
 
-    dataRAPTOR()  {}
+    dataRAPTOR() {}
     void load(const navitia::type::PT_Data &data);
 
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -494,9 +494,7 @@ void RAPTOR::set_valid_jp_and_jpp(uint32_t date, const std::vector<std::string> 
             }
             valid_journey_patterns.set(journey_pattern->idx, allowed_jp.count(journey_pattern) > 0);
         }
-        LOG4CPLUS_INFO(logger, "Number of allowed journey patterns: " << allowed_jp.size());
     }
-    LOG4CPLUS_INFO(logger, "Odt allowed? " << (allow_odt));
 
 }
 

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -59,7 +59,7 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
         const auto date = DateTimeUtils::date(label.dt_pt);
         const auto hour = DateTimeUtils::hour(label.dt_pt);
         const type::JourneyPatternPoint* jpp = data.pt_data->journey_pattern_points[journey_pattern_point];
-        for (type::VehicleJourney* vj : jpp->journey_pattern->vehicle_journey_list) {
+        for (const type::VehicleJourney* vj : jpp->journey_pattern->get_vehicle_journey_list()) {
             const type::StopTime& st = vj->stop_time_list[jpp->order];
             auto st_hour = clockwise ? st.arrival_time : st.departure_time;
             if (!st.is_frequency()) {

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -59,8 +59,8 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
         const auto date = DateTimeUtils::date(label.dt_pt);
         const auto hour = DateTimeUtils::hour(label.dt_pt);
         const type::JourneyPatternPoint* jpp = data.pt_data->journey_pattern_points[journey_pattern_point];
-        for (const type::DiscreteVehicleJourney& vj : jpp->journey_pattern->discrete_vehicle_journey_list) {
-            const type::StopTime& st = vj.stop_time_list[jpp->order];
+        for (const auto& vj : jpp->journey_pattern->discrete_vehicle_journey_list) {
+            const type::StopTime& st = vj->stop_time_list[jpp->order];
             auto st_hour = clockwise ? st.arrival_time : st.departure_time;
             if ((st_hour % DateTimeUtils::SECONDS_PER_DAY) != hour) {
                 continue;
@@ -76,11 +76,11 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
             }
         }
         // if we haven't found it in the discrete vj, we look into the frequency ones
-        for (const type::FrequencyVehicleJourney& vj : jpp->journey_pattern->frequency_vehicle_journey_list) {
-            const type::StopTime& st = vj.stop_time_list[jpp->order];
-            auto start_time = (vj.start_time + (clockwise? st.departure_time : st.arrival_time)) % DateTimeUtils::SECONDS_PER_DAY;
+        for (const auto& vj : jpp->journey_pattern->frequency_vehicle_journey_list) {
+            const type::StopTime& st = vj->stop_time_list[jpp->order];
+            auto start_time = (vj->start_time + (clockwise? st.departure_time : st.arrival_time)) % DateTimeUtils::SECONDS_PER_DAY;
 
-            auto end_time = (vj.end_time + (clockwise? st.departure_time : st.arrival_time)) % DateTimeUtils::SECONDS_PER_DAY;
+            auto end_time = (vj->end_time + (clockwise? st.departure_time : st.arrival_time)) % DateTimeUtils::SECONDS_PER_DAY;
             // Here we check if hour is out of the period of the frequency.
             // In normal case we have something like:
             // 0-------------------------------------86400(midnight)

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -78,9 +78,9 @@ get_current_stidx_gap(size_t count, type::idx_t journey_pattern_point, const std
         // if we haven't found it in the discrete vj, we look into the frequency ones
         for (const type::FrequencyVehicleJourney& vj : jpp->journey_pattern->frequency_vehicle_journey_list) {
             const type::StopTime& st = vj.stop_time_list[jpp->order];
-            auto start_time = vj.start_time + (clockwise? st.departure_time : st.arrival_time) % DateTimeUtils::SECONDS_PER_DAY;
+            auto start_time = (vj.start_time + (clockwise? st.departure_time : st.arrival_time)) % DateTimeUtils::SECONDS_PER_DAY;
 
-            auto end_time = vj.end_time + (clockwise? st.departure_time : st.arrival_time) % DateTimeUtils::SECONDS_PER_DAY;
+            auto end_time = (vj.end_time + (clockwise? st.departure_time : st.arrival_time)) % DateTimeUtils::SECONDS_PER_DAY;
             // Here we check if hour is out of the period of the frequency.
             // In normal case we have something like:
             // 0-------------------------------------86400(midnight)

--- a/source/routing/tests/best_stoptime.cpp
+++ b/source/routing/tests/best_stoptime.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, sp1_departure - 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, sp1_departure - 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, sp1_departure, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, sp1_departure, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, sp1_departure + 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, sp1_departure + 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp2, sp2_departure - 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, sp2_departure - 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp2, sp2_departure, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, sp2_departure, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp2, sp2_arrival + 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, sp2_arrival + 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
@@ -2152,7 +2152,7 @@ BOOST_FIXTURE_TEST_CASE(test_get_next_dep_classic_case_after_period, classic_fre
 
     auto next_dt = get_next_departure(dt, vj, st);
 
-    BOOST_REQUIRE_EQUAL(next_dt, std::numeric_limits<DateTime>::max());
+    BOOST_REQUIRE_EQUAL(next_dt, DateTimeUtils::inf);
 }
 
 BOOST_FIXTURE_TEST_CASE(test_get_next_dep_classic_case_in_period, classic_freq_dataset) {

--- a/source/routing/tests/best_stoptime.cpp
+++ b/source/routing/tests/best_stoptime.cpp
@@ -62,6 +62,7 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     DateTime sp2_departure = 8150;
     std::string spa1 = "stop1";
     std::string spa2 = "stop2";
+    // no pickup nor drop off allowed
     b.vj("A")(spa1, sp1_departure, sp1_departure, 0, false, false)
              (spa2, sp2_arrival, sp2_arrival, 0, false, false);
     b.finish();
@@ -82,24 +83,24 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, sp1_departure - 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, sp1_departure - 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, sp1_departure, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, sp1_departure, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, sp1_departure + 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, sp1_departure + 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -107,24 +108,24 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp2, sp2_departure - 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, sp2_departure - 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp2, sp2_departure, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, sp2_departure, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
     {
         std::tie(st1, dt1) = earliest_stop_time(jpp2, sp2_arrival + 1, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, sp2_arrival + 1, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::max);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -178,7 +179,7 @@ BOOST_AUTO_TEST_CASE(base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(DateTimeUtils::date(dt_test), sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, DateTimeUtils::hour(sp1_departure));
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -189,7 +190,7 @@ BOOST_AUTO_TEST_CASE(base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(DateTimeUtils::date(dt_test), sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -200,7 +201,7 @@ BOOST_AUTO_TEST_CASE(base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -267,7 +268,7 @@ BOOST_AUTO_TEST_CASE(base) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -279,7 +280,7 @@ BOOST_AUTO_TEST_CASE(base) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, dt_test);
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -291,7 +292,7 @@ BOOST_AUTO_TEST_CASE(base) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -342,7 +343,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -353,7 +354,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -364,7 +365,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -375,7 +376,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        // we ask for the previous departure from 23:59 the day 1
+        // the previous departure is the day 1, at 100 (same as the day 0 at 86400 + 100)
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -386,7 +389,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -397,7 +400,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -408,7 +411,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -465,7 +468,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -476,7 +479,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -487,7 +490,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -571,7 +574,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -582,7 +585,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -593,7 +596,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -963,7 +966,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -974,7 +977,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -984,8 +987,8 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -993,7 +996,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st2 == nullptr);
     }
     {
@@ -1037,13 +1040,13 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr); // No departure because this is a terminus
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st2 == nullptr);
         // There are no trip leaving before
     }
@@ -1051,7 +1054,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1062,7 +1065,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1118,7 +1121,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1129,7 +1132,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1139,8 +1142,8 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -1148,7 +1151,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st2 == nullptr);
     }
     {
@@ -1190,8 +1193,8 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         DateTime dt_test = DateTimeUtils::set(0, sp3_arrival);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 == nullptr);
     }
@@ -1199,8 +1202,8 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 == nullptr);
     }
@@ -1208,7 +1211,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1219,7 +1222,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1251,10 +1254,10 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
  */
 BOOST_AUTO_TEST_CASE(freq_base) {
     ed::builder b("20120614");
-    DateTime sp1_departure = 8000;
-    DateTime sp2_arrival = 8100;
-    DateTime sp2_departure = 8150;
-    DateTime sp3_arrival = 8200;
+    DateTime sp1_departure = 000;
+    DateTime sp2_arrival = 100;
+    DateTime sp2_departure = 150;
+    DateTime sp3_arrival = 200;
     DateTime start_time = 6000;
     DateTime end_time = 7000;
     uint32_t headway_sec = 300;
@@ -1289,7 +1292,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1299,7 +1302,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1309,7 +1312,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time + headway_sec));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1319,7 +1322,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1329,7 +1332,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1339,7 +1342,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1424,8 +1427,8 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         DateTime dt_test = DateTimeUtils::set(0, hour - 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -1434,8 +1437,8 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -1444,7 +1447,7 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = earliest_stop_time(jpp3, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp3, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, hour));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1486,7 +1489,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1498,7 +1501,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1509,7 +1512,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time + headway_sec));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1520,7 +1523,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time - headway_sec));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1531,7 +1534,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         std::tie(st1, dt1) = earliest_stop_time(jpp1, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp1, dt_test, *(b.data), false, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
-        BOOST_CHECK_EQUAL(dt2, 0);
+        BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
         BOOST_CHECK(st2 == nullptr);
@@ -1542,7 +1545,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         DateTime dt_test = DateTimeUtils::set(0, end_time + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time + sp2_arrival - sp1_departure));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1553,7 +1556,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         DateTime dt_test = DateTimeUtils::set(0, start_time + sp2_arrival - sp1_departure + 1);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time + sp2_arrival - sp1_departure));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1564,7 +1567,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         DateTime dt_test = DateTimeUtils::set(0, last_time - headway_sec - 10);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time - 2 * headway_sec + sp2_arrival - sp1_departure ));
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1575,7 +1578,7 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         DateTime dt_test = DateTimeUtils::set(1, 0);
         std::tie(st1, dt1) = earliest_stop_time(jpp2, dt_test, *(b.data), false, false);
         std::tie(st2, dt2) = tardiest_stop_time(jpp2, dt_test, *(b.data), false, false);
-        BOOST_CHECK_EQUAL(dt1, 0);
+        BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_CHECK(st1 == nullptr);
         BOOST_REQUIRE(st2 != nullptr);
@@ -1860,13 +1863,15 @@ BOOST_AUTO_TEST_CASE(test_calendar) {
     auto cal(new type::Calendar(b.data->meta->production_date.begin()));
     cal->uri="cal1";
 
+
+    b.finish();
+
     for (auto vj_name: {"vj1", "vj2"}) {
         auto associated_cal = new type::AssociatedCalendar();
         associated_cal->calendar = cal;
         b.data->pt_data->meta_vj[vj_name]->associated_calendars.insert({cal->uri, associated_cal});
     }
 
-    b.finish();
     b.data->pt_data->index();
     b.data->build_uri();
     b.data->build_raptor();
@@ -1969,13 +1974,15 @@ BOOST_AUTO_TEST_CASE(test_frequency_for_calendar) {
     auto cal(new type::Calendar(b.data->meta->production_date.begin()));
     cal->uri="cal1";
 
+
+    b.finish();
+
     for (auto vj_name: {"vj1", "vj2"}) {
         auto associated_cal = new type::AssociatedCalendar();
         associated_cal->calendar = cal;
         b.data->pt_data->meta_vj[vj_name]->associated_calendars.insert({cal->uri, associated_cal});
     }
 
-    b.finish();
     b.data->pt_data->index();
     b.data->build_uri();
     b.data->build_raptor();
@@ -2039,11 +2046,12 @@ BOOST_AUTO_TEST_CASE(test_looping_frequency_for_calendar) {
     auto cal(new type::Calendar(b.data->meta->production_date.begin()));
     cal->uri="cal1";
 
+    b.finish();
+
     auto associated_cal = new type::AssociatedCalendar();
     associated_cal->calendar = cal;
     b.data->pt_data->meta_vj["vj1"]->associated_calendars.insert({cal->uri, associated_cal});
 
-    b.finish();
     b.data->pt_data->index();
     b.data->build_uri();
     b.data->build_raptor();
@@ -2086,11 +2094,12 @@ BOOST_AUTO_TEST_CASE(test_frequency_over_midnight_for_calendar) {
     auto cal(new type::Calendar(b.data->meta->production_date.begin()));
     cal->uri="cal1";
 
+    b.finish();
+
     auto associated_cal = new type::AssociatedCalendar();
     associated_cal->calendar = cal;
     b.data->pt_data->meta_vj["vj1"]->associated_calendars.insert({cal->uri, associated_cal});
 
-    b.finish();
     b.data->pt_data->index();
     b.data->build_uri();
     b.data->build_raptor();
@@ -2202,10 +2211,11 @@ BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_before_midnight, midnight_fr
 }
 
 BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_before_end, midnight_freq_dataset) {
-    //the 5:08:30, the next one is 5:20:30, but we have to check the day before (which is ok is this case)
-    DateTime dt = DateTimeUtils::set(1, 5 * 60 * 60 + 30);
+    //it's 5:08:30, the next one is 5:20:30, but we have to check the day before (which is ok is this case)
+    DateTime dt = DateTimeUtils::set(1, 5 * 60 * 60 + 8 * 60 + 30);
 
     auto next_dt = get_next_departure(dt, vj, st);
+    std::cout << "rs:" << str(next_dt) << std::endl;
 
     BOOST_REQUIRE_EQUAL(next_dt, DateTimeUtils::set(1, 5 * 60 * 60 + 20 * 60 + 30));
 }
@@ -2229,9 +2239,37 @@ struct midnight_freq_dataset_no_valid_first_day {
 };
 
 BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_before_end_no_valid, midnight_freq_dataset_no_valid_first_day) {
-    //the 5:08, the next one is 5:20, but we have to check the day before
+    //it's 5:08, the next one is 5:20, but we have to check the day before
     //since the day before was not valid, we have to wait for the begining of the service
-    DateTime dt = DateTimeUtils::set(1, 5 * 60 * 60);
+    DateTime dt = DateTimeUtils::set(1, 5 * 60 * 60 + 8 * 60 + 30);
+
+    auto next_dt = get_next_departure(dt, vj, st);
+
+    BOOST_REQUIRE_EQUAL(next_dt, DateTimeUtils::set(1, 17 * 60 * 60 + 30));
+}
+
+BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_after_end_no_valid, midnight_freq_dataset_no_valid_first_day) {
+    //it's 10:08, the next one is 17:20, and we don't have to check the day before
+    DateTime dt = DateTimeUtils::set(1, 10 * 60 * 60 + 8 * 60 + 30);
+
+    auto next_dt = get_next_departure(dt, vj, st);
+
+    BOOST_REQUIRE_EQUAL(next_dt, DateTimeUtils::set(1, 17 * 60 * 60 + 30));
+}
+
+BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_begin_service, midnight_freq_dataset_no_valid_first_day) {
+    //it's 17:00:30, the next one is 17:00:30, same time, and we don't have to check the day before
+    DateTime dt = DateTimeUtils::set(1, 17 * 60 * 60 + 30);
+
+    auto next_dt = get_next_departure(dt, vj, st);
+
+    BOOST_REQUIRE_EQUAL(next_dt, DateTimeUtils::set(1, 17 * 60 * 60 + 30));
+}
+
+BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_midnight_case, midnight_freq_dataset_no_valid_first_day) {
+    //it's midnight, the next one is 00:00:30, so we have to check the day before
+    //since the day before is not valid, we have to wait for the begining of the service
+    DateTime dt = DateTimeUtils::set(1, 0);
 
     auto next_dt = get_next_departure(dt, vj, st);
 

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -1044,7 +1044,7 @@ BOOST_AUTO_TEST_CASE(multiples_vj) {
 
 BOOST_AUTO_TEST_CASE(freq_vj) {
     ed::builder b("20120614");
-    b.vj("A1")("stop1", 8*3600)("stop2", 8*3600+10*60).frequency(8*3600,18*3600,5*60);
+    b.frequency_vj("A1", 8*3600,18*3600,5*60)("stop1", 8*3600)("stop2", 8*3600+10*60);
 
     b.data->pt_data->index();
     b.data->build_raptor();
@@ -1066,7 +1066,7 @@ BOOST_AUTO_TEST_CASE(freq_vj) {
 
 BOOST_AUTO_TEST_CASE(freq_vj_pam) {
     ed::builder b("20120614");
-    b.vj("A1")("stop1", 8*3600)("stop2", 8*3600+10*60).frequency(8*3600,26*3600,5*60);
+    b.frequency_vj("A1", 8*3600,26*3600,5*60)("stop1", 8*3600)("stop2", 8*3600+10*60);
 
     b.data->pt_data->index();
     b.data->build_raptor();

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2,25 +2,25 @@
   
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
 twitter @navitia 
 IRC #navitia on freenode
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(direct){
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050)("stop2", 8100,8150);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     RAPTOR raptor(*b.data);
 
@@ -101,6 +102,7 @@ BOOST_AUTO_TEST_CASE(change){
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
@@ -212,6 +214,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     b.connection("C", "C", 120);
     b.connection("D", "D", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -245,6 +248,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
@@ -303,6 +307,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -360,6 +365,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     ed::builder b("20120614");
     b.vj("A")("stop1", 23*3600)("stop2", 23*3600 + 30*60, 24*3600 + 30*60)("stop3", 24*3600 + 40 * 60);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -411,7 +417,8 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     ed::builder b("20120614");
     b.vj("D", "10", "", true)("stop1", 8000)("stop2", 8200);
     b.vj("D", "1", "", true)("stop1", 9000)("stop2", 9200);
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -447,7 +454,8 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
 /*BOOST_AUTO_TEST_CASE(validit_pattern_2) {
     ed::builder b("20120614");
     b.vj("D", "10", "", true)("stop1", 8000)("stop2", 8200);
-    b.data->pt_data->index();
+
+   b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -468,7 +476,8 @@ BOOST_AUTO_TEST_CASE(forbidden_uri){
     b.vj("A")("stop1", 8000)("stop2", 8100,8150);
     b.vj("B")("stop3", 9500)("stop4", 10000);
     b.vj("C")("stop1", 8000, 8050)("stop4", 18000);
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     RAPTOR raptor(*b.data);
 
@@ -491,7 +500,8 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -536,7 +546,8 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
 
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -584,7 +595,8 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -598,21 +610,21 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
                             [&](const Path& p){
         return   p.items.size() == 5 &&
-                 p.items[0].stop_points.size() == 2 &&
-                 p.items[1].stop_points.size() == 1 &&
-                 p.items[2].stop_points.size() == 3 &&
-                 p.items[3].stop_points.size() == 1 &&
-                 p.items[4].stop_points.size() == 2 &&
-                 p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx &&
-                 p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx &&
-                 p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
-                 p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
-                 p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx &&
-                 p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
-                 p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
-                 p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx &&
-                 p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60 &&
-                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
+                p.items[0].stop_points.size() == 2 &&
+                p.items[1].stop_points.size() == 1 &&
+                p.items[2].stop_points.size() == 3 &&
+                p.items[3].stop_points.size() == 1 &&
+                p.items[4].stop_points.size() == 2 &&
+                p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx &&
+                p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx &&
+                p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
+                p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx &&
+                p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx &&
+                p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
+                p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx &&
+                p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx &&
+                p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60 &&
+                p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }));
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false, true);
@@ -636,29 +648,29 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx &&
                 p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60 &&
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
-        }
+    }
     ));
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
                             [&](const Path& p){
-           return p.items.size() == 5  &&
-                  p.items[0].stop_points.size() == 2  &&
-                  p.items[1].stop_points.size() == 1  &&
-                  p.items[2].stop_points.size() == 3  &&
-                  p.items[3].stop_points.size() == 1  &&
-                  p.items[4].stop_points.size() == 2  &&
-                  p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx  &&
-                  p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx  &&
-                  p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx  &&
-                  p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx  &&
-                  p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx  &&
-                  p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx  &&
-                  p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx  &&
-                  p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx  &&
-                  p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60  &&
-                  p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
+        return p.items.size() == 5  &&
+                p.items[0].stop_points.size() == 2  &&
+                p.items[1].stop_points.size() == 1  &&
+                p.items[2].stop_points.size() == 3  &&
+                p.items[3].stop_points.size() == 1  &&
+                p.items[4].stop_points.size() == 2  &&
+                p.items[0].stop_points[0]->idx == d.stop_points_map["stop1"]->idx  &&
+                p.items[0].stop_points[1]->idx == d.stop_points_map["stop2"]->idx  &&
+                p.items[1].stop_points[0]->idx == d.stop_points_map["stop2"]->idx  &&
+                p.items[2].stop_points[0]->idx == d.stop_points_map["stop2"]->idx  &&
+                p.items[2].stop_points[2]->idx == d.stop_points_map["stop3"]->idx  &&
+                p.items[3].stop_points[0]->idx == d.stop_points_map["stop3"]->idx  &&
+                p.items[4].stop_points[0]->idx == d.stop_points_map["stop3"]->idx  &&
+                p.items[4].stop_points[1]->idx == d.stop_points_map["stop4"]->idx  &&
+                p.items[0].departure.time_of_day().total_seconds() == 8*3600+20*60  &&
+                p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }));
 
 
@@ -673,7 +685,8 @@ BOOST_AUTO_TEST_CASE(pam_veille) {
     ed::builder b("20120614");
     b.vj("A", "11111111", "", true)("stop1", 3*60)("stop2", 20*60);
     b.vj("B", "01", "", true)("stop0", 23*3600)("stop2", 24*3600 + 30*60)("stop3", 24*3600 + 40*60);
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -695,7 +708,8 @@ BOOST_AUTO_TEST_CASE(pam_3) {
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
-    b.data->pt_data->index();
+
+    b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -718,6 +732,7 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     destinations.push_back(std::make_pair(1,navitia::seconds(0)));
 
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -732,8 +747,9 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop2", 8*3600+15*60)("stop3", 8*3600 + 20*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -749,8 +765,9 @@ BOOST_AUTO_TEST_CASE(stay_in_short) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop2", 8*3600+10*60)("stop3", 8*3600 + 20*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -765,16 +782,17 @@ BOOST_AUTO_TEST_CASE(stay_in_short) {
 BOOST_AUTO_TEST_CASE(stay_in_nl) {
     ed::builder b("20120614");
     b.vj("9658", "1111111", "block1", true) ("ehv", 60300,60600)
-                                            ("ehb", 60780,60780)
-                                            ("bet", 61080,61080)
-                                            ("btl", 61560,61560)
-                                            ("vg",  61920,61920)
-                                            ("ht",  62340,62340);
+            ("ehb", 60780,60780)
+            ("bet", 61080,61080)
+            ("btl", 61560,61560)
+            ("vg",  61920,61920)
+            ("ht",  62340,62340);
     b.vj("4462", "1111111", "block1", true) ("ht",  62760,62760)
-                                            ("hto", 62940,62940)
-                                            ("rs",  63180,63180);
-    b.finish();
+            ("hto", 62940,62940)
+            ("rs",  63180,63180);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -789,16 +807,17 @@ BOOST_AUTO_TEST_CASE(stay_in_nl) {
 BOOST_AUTO_TEST_CASE(stay_in_nl_counterclock) {
     ed::builder b("20120614");
     b.vj("9658", "1111111", "block1", true) ("ehv", 60300,60600)
-                                            ("ehb", 60780,60780)
-                                            ("bet", 61080,61080)
-                                            ("btl", 61560,61560)
-                                            ("vg",  61920,61920)
-                                            ("ht",  62340,62340);
+            ("ehb", 60780,60780)
+            ("bet", 61080,61080)
+            ("btl", 61560,61560)
+            ("vg",  61920,61920)
+            ("ht",  62340,62340);
     b.vj("4462", "1111111", "block1", true) ("ht",  62760,62760)
-                                            ("hto", 62940,62940)
-                                            ("rs",  63180,63180);
-    b.finish();
+            ("hto", 62940,62940)
+            ("rs",  63180,63180);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -815,8 +834,9 @@ BOOST_AUTO_TEST_CASE(stay_in_teleport) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -833,8 +853,9 @@ BOOST_AUTO_TEST_CASE(stay_in_departure_last_of_first_vj) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -855,8 +876,9 @@ BOOST_AUTO_TEST_CASE(stay_in_complex) {
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -878,8 +900,9 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -888,9 +911,9 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
-                          return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 15*60;}));
+                    return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 15*60;}));
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
-                          return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 20*60;}));
+                    return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 20*60;}));
 }
 
 
@@ -900,8 +923,9 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop5", 8*3600 + 20*60);
     b.vj("C", "1111111", "block1", true)("stop6", 8*3600+25*60)("stop3", 8*3600 + 30*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -919,8 +943,9 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     b.vj("B", "1111111", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
     b.vj("C", "1111111", "block1", true)("stop5", 8*3600+25*60)("stop1", 8*3600 + 30*60);
     b.vj("D", "1111111", "block1", true)("stop4", 8*3600+35*60)("stop3", 8*3600 + 40*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -935,8 +960,9 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "0000", "block1", true)("stop4", 8*3600+15*60)("stop3", 8*3600 + 20*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -956,8 +982,8 @@ BOOST_AUTO_TEST_CASE(first_vj_stay_in) {
     b.vj("C")("stop2", 8*3600)("stop3", 8*3600+10*60)("stop4", 8*3600+15*60);
     b.vj("C", "111111", "block1")("stop2", 8*3600+25*60)("stop3", 8*3600+30*60)("stop4", 8*3600+45*60);
     b.vj("D", "111111", "block1")("stop5", 8*3600+50*60);
-    b.finish();
-    b.data->pt_data->index();
+
+   b.data->pt_data->index(); b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -973,7 +999,9 @@ BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");
     b.vj("A")("stop1",8*3600+10*60, 8*3600 + 10*60,1)("stop2",8*3600+15*60,8*3600+15*60,1)("stop3", 8*3600+20*60);
     b.vj("B")("stop1",9*3600)("stop2",10*3600);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -996,7 +1024,9 @@ BOOST_AUTO_TEST_CASE(mdi) {
 
     b.vj("B")("stop1",17*3600, 17*3600,std::numeric_limits<uint16_t>::max(), true, false)("stop2", 17*3600+15*60)("stop3",17*3600+30*60, 17*3600+30*60,std::numeric_limits<uint16_t>::max(), true, false);
     b.vj("C")("stop4",16*3600, 16*3600,std::numeric_limits<uint16_t>::max(), true, true)("stop5", 16*3600+15*60)("stop6",16*3600+30*60, 16*3600+30*60,std::numeric_limits<uint16_t>::max(), false, true);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1029,7 +1059,9 @@ BOOST_AUTO_TEST_CASE(multiples_vj) {
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
 
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1046,7 +1078,9 @@ BOOST_AUTO_TEST_CASE(freq_vj) {
     ed::builder b("20120614");
     b.frequency_vj("A1", 8*3600,18*3600,5*60)("stop1", 8*3600)("stop2", 8*3600+10*60);
 
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1068,7 +1102,9 @@ BOOST_AUTO_TEST_CASE(freq_vj_pam) {
     ed::builder b("20120614");
     b.frequency_vj("A1", 8*3600,26*3600,5*60)("stop1", 8*3600)("stop2", 8*3600+10*60);
 
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1098,7 +1134,9 @@ BOOST_AUTO_TEST_CASE(freq_vj_pam) {
 BOOST_AUTO_TEST_CASE(max_duration){
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050)("stop2", 8100,8150);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1122,14 +1160,16 @@ BOOST_AUTO_TEST_CASE(max_transfers){
     b.vj("C")("stop3",9000)("stop2",11000);
     b.vj("D")("stop3",9000)("stop4",9500);
     b.vj("E")("stop4",10000)("stop2",10500);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
     for(uint32_t nb_transfers=0; nb_transfers<=2; ++nb_transfers) {
-//        type::Properties p;
+        //        type::Properties p;
         auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, false, true, true, type::AccessibiliteParams(), nb_transfers);
         BOOST_REQUIRE(res1.size()>=1);
         for(auto r : res1) {
@@ -1152,7 +1192,9 @@ BOOST_AUTO_TEST_CASE(destination_over_writing) {
     b.connection("stop1", "stop1", 120);
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1178,7 +1220,9 @@ BOOST_AUTO_TEST_CASE(over_midnight_special) {
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
 
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1200,14 +1244,15 @@ BOOST_AUTO_TEST_CASE(invalid_stay_in_overmidnight) {
     ed::builder b("20120614");
     b.vj("A", "111", "block1", true)("stop1", 8*3600)("stop2", 8*3600+10*60);
     b.vj("B", "010", "block1", true)("stop2", 8*3600+15*60)("stop3", 24*3600 + 20*60, 24*3600+25*60)("stop4", 24*3600+30*60, 24*3600+35*60);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    // Here we want to check if the second vehicle_journey is not taken on the 
+    // Here we want to check if the second vehicle_journey is not taken on the
     // first day
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, false, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
@@ -1241,15 +1286,17 @@ BOOST_AUTO_TEST_CASE(no_departure_before_given_date) {
     b.connection("stop4", "stop4", 100);
     b.connection("stop5", "stop5", 100);
 
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
 
     std::vector<std::pair<type::idx_t, navitia::time_duration>> departures =
-        {{b.sps["stop1"]->idx, navitia::seconds(1500)}};
+    {{b.sps["stop1"]->idx, navitia::seconds(1500)}};
     std::vector<std::pair<type::idx_t, navitia::time_duration>> arrivals =
-        {{b.sps["stop5"]->idx, navitia::seconds(0)}};
+    {{b.sps["stop5"]->idx, navitia::seconds(0)}};
 
     auto results = raptor.compute_all(departures, arrivals, 6000, false, true);
 
@@ -1278,7 +1325,9 @@ BOOST_AUTO_TEST_CASE(no_departure_before_given_date) {
 BOOST_AUTO_TEST_CASE(less_fallback) {
     ed::builder b("20120614");
     b.vj("A")("stop1", 8*3600)("stop2", 8*3600 + 1*60)("stop3", 8*3600 + 12*60);
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1288,21 +1337,21 @@ BOOST_AUTO_TEST_CASE(less_fallback) {
         {d.stop_areas_map["stop1"]->stop_point_list.front()->journey_pattern_point_list.front()->idx, navitia::seconds(0)}
     };
     std::vector<std::pair<type::idx_t, navitia::time_duration>> destinations =
-        {{d.stop_areas_map["stop1"]->stop_point_list.front()->idx, navitia::seconds(560)},
-         {d.stop_areas_map["stop2"]->stop_point_list.front()->idx, navitia::seconds(320)},
-         {d.stop_areas_map["stop3"]->stop_point_list.front()->idx, navitia::seconds(0)}};
+    {{d.stop_areas_map["stop1"]->stop_point_list.front()->idx, navitia::seconds(560)},
+     {d.stop_areas_map["stop2"]->stop_point_list.front()->idx, navitia::seconds(320)},
+     {d.stop_areas_map["stop3"]->stop_point_list.front()->idx, navitia::seconds(0)}};
     auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
-                [](const routing::Path& path) {
-                    return path.items.back().arrival.time_of_day().total_seconds() == 8*3600 + 12*60;
-                }));
+                            [](const routing::Path& path) {
+        return path.items.back().arrival.time_of_day().total_seconds() == 8*3600 + 12*60;
+    }));
 
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
-                [](const routing::Path& path) {
-                    return path.items.back().arrival.time_of_day().total_seconds() == 8*3600 + 60;
-                }));
+                            [](const routing::Path& path) {
+        return path.items.back().arrival.time_of_day().total_seconds() == 8*3600 + 60;
+    }));
 }
 
 
@@ -1331,7 +1380,9 @@ BOOST_AUTO_TEST_CASE(pareto_front) {
     b.vj("line2")("stop2", 9*3600 + 55*60)("stop3", 10*3600);
     b.connection("stop2", "stop2", 120);
 
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1342,51 +1393,54 @@ BOOST_AUTO_TEST_CASE(pareto_front) {
     };
     // We are going to J point, so we add the walking times
     std::vector<std::pair<type::idx_t, navitia::time_duration>> destinations =
-        {{d.stop_areas_map["stop2"]->stop_point_list.front()->idx, navitia::seconds(15*60)},
-         {d.stop_areas_map["stop3"]->stop_point_list.front()->idx, navitia::seconds(0)}};
+    {{d.stop_areas_map["stop2"]->stop_point_list.front()->idx, navitia::seconds(15*60)},
+     {d.stop_areas_map["stop3"]->stop_point_list.front()->idx, navitia::seconds(0)}};
     auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
-                [](const routing::Path& path) {
-                    return path.items.size() == 1 &&
-                           path.items.back().arrival.time_of_day().total_seconds() == 9*3600 + 50*60;
-                }));
+                            [](const routing::Path& path) {
+        return path.items.size() == 1 &&
+                path.items.back().arrival.time_of_day().total_seconds() == 9*3600 + 50*60;
+    }));
 
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
-                [](const routing::Path& path) {
-                return path.items.size() == 3 &&
-                    path.items.back().arrival.time_of_day().total_seconds() == 10*3600;
-                }));
+                            [](const routing::Path& path) {
+        return path.items.size() == 3 &&
+                path.items.back().arrival.time_of_day().total_seconds() == 10*3600;
+    }));
 }
 
- BOOST_AUTO_TEST_CASE(overlapping_on_first_st) {
-     ed::builder b("20120614");
-     b.vj("A")("stop1", 8000, 8200)("stop2", 8500);
-     b.vj("A")("stop1", 8100, 8300)("stop2", 8600);
-     b.data->pt_data->index();
-     b.data->build_raptor();
-     RAPTOR raptor(*b.data);
-     auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, false, true);
+BOOST_AUTO_TEST_CASE(overlapping_on_first_st) {
+    ed::builder b("20120614");
+    b.vj("A")("stop1", 8000, 8200)("stop2", 8500);
+    b.vj("A")("stop1", 8100, 8300)("stop2", 8600);
 
-     BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    b.data->pt_data->index();
+    b.finish();
+    b.data->build_raptor();
+    RAPTOR raptor(*b.data);
+    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, false, true);
 
-     auto res = res1.back();
-     BOOST_CHECK_EQUAL(res.items[0].stop_points[0]->idx, 0);
-     BOOST_CHECK_EQUAL(res.items[0].stop_points[1]->idx, 1);
-     BOOST_CHECK_EQUAL(res.items[0].departure.time_of_day().total_seconds(), 8200);
-     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 8500);
-     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
-     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
- }
+    auto res = res1.back();
+    BOOST_CHECK_EQUAL(res.items[0].stop_points[0]->idx, 0);
+    BOOST_CHECK_EQUAL(res.items[0].stop_points[1]->idx, 1);
+    BOOST_CHECK_EQUAL(res.items[0].departure.time_of_day().total_seconds(), 8200);
+    BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 8500);
+    BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
+    BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
+
+}
 
 BOOST_AUTO_TEST_CASE(stay_in_unnecessary) {
     ed::builder b("20120614");
     b.vj("A", "1111111", "block1", true)("stop2", 8*3600)("stop3", 8*3600+10*60);
     b.vj("B", "1111111", "block1", true)("stop1", 7*3600)("stop2", 8*3600);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -1404,8 +1458,9 @@ BOOST_AUTO_TEST_CASE(stay_in_unnecessary2) {
     b.vj("A", "1111111", "block1", true)("stop1", 7*3600)("stop2", 8*3600);
     b.vj("line2")("stop2", 9*3600 + 55*60)("stop4", 10*3600);
     b.connection("stop2", "stop2", 120);
-    b.finish();
+
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(direct){
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050)("stop2", 9100, 9150);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -106,6 +107,7 @@ BOOST_AUTO_TEST_CASE(change){
     b.connection("stop4", "stop4", 120);
     b.connection("stop5", "stop5", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -180,6 +182,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -239,6 +242,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     b.connection("stop3", "stop3", 120);
     b.connection("stop4", "stop4", 120);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -298,6 +302,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     ed::builder b("20120614");
     b.vj("A")("stop1", 23*3600)("stop2", 23*3600 + 30*60, 24*3600 + 30*60)("stop3", 24*3600 + 40*60);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -349,6 +354,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit4){
     ed::builder b("20120614");
     b.vj("A", "0001000", "", true)("stop1", 23*3600+55*60, 24*3600)("stop2", 24*3600 + 15*60);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -375,6 +381,7 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     b.vj("D", "00", "", true)("stop1", 8000)("stop2", 8200);
     b.vj("C", "10", "", true)("stop1", 9000)("stop2", 9200);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -392,6 +399,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -435,6 +443,7 @@ BOOST_AUTO_TEST_CASE(sn_fin) {
     departs.push_back(std::make_pair(0, navitia::seconds(0)));
     destinations.push_back(std::make_pair(1, navitia::seconds(10 * 60)));
     b.data->pt_data->index();
+    b.finish();
     b.data->build_raptor();
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
@@ -550,6 +559,7 @@ BOOST_AUTO_TEST_CASE(itl) {
     ed::builder b("20120614");
     b.vj("A")("stop1",8*3600+10*60, 8*3600 + 10*60,1)("stop2",8*3600+15*60,8*3600+15*60,1)("stop3", 8*3600+20*60);
     b.vj("B")("stop1",9*3600)("stop2",10*3600);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
@@ -573,6 +583,7 @@ BOOST_AUTO_TEST_CASE(mdi) {
 
     b.vj("B")("stop1",17*3600, 17*3600,std::numeric_limits<uint16_t>::max(), true, false)("stop2", 17*3600+15*60)("stop3",17*3600+30*60, 17*3600+30*60,std::numeric_limits<uint16_t>::max(), true, true);
     b.vj("C")("stop4",16*3600, 16*3600,std::numeric_limits<uint16_t>::max(), true, true)("stop5", 16*3600+15*60)("stop6",16*3600+30*60, 16*3600+30*60,std::numeric_limits<uint16_t>::max(), false, true);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
@@ -593,6 +604,7 @@ BOOST_AUTO_TEST_CASE(mdi) {
 BOOST_AUTO_TEST_CASE(max_duration){
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050)("stop2", 8100,8150);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
@@ -616,6 +628,7 @@ BOOST_AUTO_TEST_CASE(max_transfers){
     b.vj("C")("stop3",9000)("stop2",11000);
     b.vj("D")("stop3",9000)("stop4",9500);
     b.vj("E")("stop4",10000)("stop2",10500);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -89,6 +89,7 @@ BOOST_AUTO_TEST_CASE(simple_journey) {
     b.vj("A")("stop_area:stop1", 8*3600 +10*60, 8*3600 + 11 * 60)("stop_area:stop2", 8*3600 + 20 * 60 ,8*3600 + 21*60);
     navitia::type::Data data;
     b.generate_dummy_basis();
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
@@ -605,6 +606,7 @@ BOOST_AUTO_TEST_CASE(journey_array){
     b.vj("A")("stop_area:stop1", 8*3600 +10*60, 8*3600 + 11 * 60)("stop_area:stop2", 8*3600 + 20 * 60 ,8*3600 + 21*60);
     b.vj("A")("stop_area:stop1", 9*3600 +10*60, 9*3600 + 11 * 60)("stop_area:stop2",  9*3600 + 20 * 60 ,9*3600 + 21*60);
     navitia::type::Data data;
+    b.finish();
     b.generate_dummy_basis();
     b.data->pt_data->index();
     b.data->build_raptor();

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -410,6 +410,8 @@ struct routing_api_data {
             ("stop_point:stopA", 8*3600 + 1*60, 8*3600 + 1 * 60)
             ("stop_point:stopB", 8*3600 + 1 * 60 + 2, 8*3600 + 1*60 + 2)
             .st_shape({A, I, B});
+
+        b.finish();
         b.data->build_uri();
         b.data->pt_data->index();
         b.data->build_raptor();

--- a/source/sql/alembic/versions/82749d34a18_frequency_vj.py
+++ b/source/sql/alembic/versions/82749d34a18_frequency_vj.py
@@ -1,0 +1,23 @@
+"""add field to know if a vj is a frequency vj
+
+Revision ID: 82749d34a18
+Revises: 43822e80c45a
+Create Date: 2014-12-22 14:56:37.358868
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '82749d34a18'
+down_revision = '43822e80c45a'
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2 as ga
+
+
+def upgrade():
+    op.add_column('vehicle_journey', sa.Column('is_frequency', sa.BOOLEAN(), nullable=True, default=False), schema='navitia')
+
+
+def downgrade():
+    op.drop_column('vehicle_journey', 'is_frequency', schema='navitia')

--- a/source/sql/models/navitia.py
+++ b/source/sql/models/navitia.py
@@ -233,6 +233,7 @@ vehicle_journey = Table('vehicle_journey', metadata,*[
     Column('end_time', INTEGER(), primary_key=False),
     Column('headway_sec', INTEGER(), primary_key=False),
     Column('utc_to_local_offset', INTEGER(), primary_key=False),
+    Column('is_frequency', BOOLEAN(), primary_key=False),
     ForeignKeyConstraint(['vehicle_properties_id'], [u'navitia.vehicle_properties.id'], name=u'vehicle_journey_vehicle_properties_id_fkey'),
     ForeignKeyConstraint(['validity_pattern_id'], [u'navitia.validity_pattern.id'], name=u'vehicle_journey_validity_pattern_id_fkey'),
     ForeignKeyConstraint(['previous_vehicle_journey_id'], [u'navitia.vehicle_journey.id'], name=u'vehicle_journey_previous_vehicle_journey_id_fkey'),

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -64,15 +64,12 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
                                                   false,
                                                   accessibilite_params.vehicle_properties);
 
-            if(st.first != nullptr) {
+            if (st.first != nullptr) {
                 DateTime dt_temp = st.second;
-                if(dt_temp <= max_dt) {
+                if (dt_temp <= max_dt) {
                     result.push_back(std::make_pair(dt_temp, st.first));
                     test_add = true;
                     // The next stop time must be at least one second after
-                    if(st.first->is_frequency()) {
-                        DateTimeUtils::update(dt_temp, st.first->vehicle_journey->end_time+st.first->departure_time);
-                    }
                     next_requested_datetime[jpp_idx] = dt_temp + 1;
                 }
             }

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -72,7 +72,8 @@ get_all_stop_times(const vector_idx& journey_patterns,
             if(!stop_time.is_frequency()) {
                 DateTimeUtils::update(dt, stop_time.departure_time);
             } else {
-                DateTimeUtils::update(dt, routing::f_departure_time(dt, stop_time));
+                // for frequencies, we only need to add the stoptime offset to the first stoptime
+                dt = ho.first + stop_time.departure_time;
             }
             result.back().push_back(std::make_pair(dt, &stop_time));
         }

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -31,6 +31,7 @@ struct calendar_fixture {
         // and wednesday that will not be matched to any cal
         b.vj("network:R", "line:A", "110010011", "", true, "wednesday")("stop1", 17 * 3600, 17 * 3600 + 10 * 60)("stop2", 18 * 3600, 18 * 3600 + 10 * 60);
 
+        b.finish();
         b.data->build_uri();
         beg = b.data->meta->production_date.begin();
         end_of_year = beg + boost::gregorian::years(1) + boost::gregorian::days(1);

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -243,10 +243,9 @@ struct small_cal_fixture {
     ed::builder b;
     small_cal_fixture(): b("20120614") {
         //vj1 has stoptimes all day from 00:10 every hour
-        b.vj("network:R", "line:A", "1111111", "", true, "vj1")
+        b.frequency_vj("line:A", 60*10, 24*60*60 + 60*10 - 1, 60*60, "network:R", "1111111", "", true, "vj1")
                 ("stop1", 0, 0)
-                ("stop2", 10, 20) //we need stop1 not to be the terminus
-                .frequency(60*10, 24*60*60 + 60*10 - 1, 60*60);
+                ("stop2", 10, 20); //we need stop1 not to be the terminus
 
         //we add a calendar that match the vj
         auto cal = new navitia::type::Calendar(b.data->meta->production_date.begin());

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -61,6 +61,7 @@ BOOST_AUTO_TEST_CASE(test1) {
     ed::builder b("20120614");
     b.vj("A")("stop1", 36000, 36100)("stop2", 36150,362000);
     b.vj("B")("stop1", 36000, 36100)("stop2", 36150,36200)("stop3", 36250,36300);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
 
@@ -206,6 +207,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
     b.lines["line:A"]->calendar_list.push_back(nearly_cal);
 
     //call all the init again
+    b.finish();
     b.data->build_uri();
     b.data->pt_data->index();
     b.data->build_raptor();
@@ -268,6 +270,7 @@ struct small_cal_fixture {
         b.lines["line:A"]->calendar_list.push_back(empty_cal);
 
         //call all the init again
+        b.finish();
         b.data->build_uri();
         b.data->pt_data->index();
         b.data->build_raptor();

--- a/source/time_tables/tests/get_stop_times.cpp
+++ b/source/time_tables/tests/get_stop_times.cpp
@@ -38,6 +38,7 @@ using namespace navitia::timetables;
 BOOST_AUTO_TEST_CASE(test1){
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050)("stop2", 8100,8150);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
 

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -73,6 +73,7 @@ BOOST_AUTO_TEST_CASE(test1) {
     b.vj("A", "1111111", "", true, "2", "2", "JP2")(a_name, 8*3600)(b_name, 8*3600 + 10*60);
     b.vj("A", "1111111", "", true, "3", "3", "JP2")(a_name, 8*3600 + 5*60)(b_name, 8*3600 + 20*60);
     b.vj("A", "1111111", "", true, "4", "4", "JP3")(b_name, 8*3600+25*60)(d_name, 9*3600 + 35*60);
+    b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
 

--- a/source/type/datetime.h
+++ b/source/type/datetime.h
@@ -51,6 +51,9 @@ namespace DateTimeUtils{
 
     constexpr navitia::DateTime inf = std::numeric_limits<uint32_t>::max();
 
+    // sometimes we need a not valid datetime which is not semanticaly the max, so we use a different name
+    constexpr navitia::DateTime not_valid = std::numeric_limits<uint32_t>::max();
+
     constexpr navitia::DateTime min = 0;
 
     inline navitia::DateTime set(int date, int time_of_day) {

--- a/source/type/datetime.h
+++ b/source/type/datetime.h
@@ -49,8 +49,11 @@ namespace DateTimeUtils{
 
     const uint32_t SECONDS_PER_DAY = 86400;
 
-    const navitia::DateTime inf = std::numeric_limits<uint32_t>::max();
-    const navitia::DateTime min = 0;
+    //even if inf and max have the same values, it's better to have 2 different names
+    constexpr navitia::DateTime inf = std::numeric_limits<uint32_t>::max();
+    constexpr navitia::DateTime max = std::numeric_limits<uint32_t>::max();
+
+    constexpr navitia::DateTime min = 0;
 
     inline navitia::DateTime set(int date, int time_of_day) {
         return date * SECONDS_PER_DAY + time_of_day;

--- a/source/type/datetime.h
+++ b/source/type/datetime.h
@@ -49,9 +49,7 @@ namespace DateTimeUtils{
 
     const uint32_t SECONDS_PER_DAY = 86400;
 
-    //even if inf and max have the same values, it's better to have 2 different names
     constexpr navitia::DateTime inf = std::numeric_limits<uint32_t>::max();
-    constexpr navitia::DateTime max = std::numeric_limits<uint32_t>::max();
 
     constexpr navitia::DateTime min = 0;
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -33,6 +33,7 @@ www.navitia.io
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 
+#include <boost/serialization/weak_ptr.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/date_time/gregorian/greg_serialize.hpp>
 #include <boost/date_time/posix_time/time_serialize.hpp>
@@ -40,6 +41,7 @@ www.navitia.io
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/variant.hpp>
+#include <boost/serialization/variant.hpp>
 
 #include <atomic>
 #include <map>

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -205,6 +205,12 @@ void PT_Data::index(){
 }
 
 PT_Data::~PT_Data() {
+    //big uggly hack :(
+    // the vj are objects owned by the jp,
+    // change all pt object (but vj and st) to unique ptr!
+    vehicle_journeys.clear();
+
+
 #define DELETE_PTDATA(type_name, collection_name) \
         std::for_each(collection_name.begin(), collection_name.end(),\
                 [](type_name* obj){delete obj;});

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -207,7 +207,7 @@ void PT_Data::index(){
 PT_Data::~PT_Data() {
     //big uggly hack :(
     // the vj are objects owned by the jp,
-    // change all pt object (but vj and st) to unique ptr!
+    // TODO change all pt object (but vj and st) to unique ptr!
     vehicle_journeys.clear();
 
 

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -98,16 +98,11 @@ struct PT_Data : boost::noncopyable{
         }
     }
 
-    /** Fonction qui permet de sérialiser (aka binariser la structure de données
-      *
-      * Elle est appelée par boost et pas directement
-      */
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
         ar
         #define SERIALIZE_ELEMENTS(type_name, collection_name) & collection_name & collection_name##_map
                 ITERATE_NAVITIA_PT_TYPES(SERIALIZE_ELEMENTS)
-                & ext_codes_map
-                & stop_area_autocomplete & stop_point_autocomplete & line_autocomplete
+                & ext_codes_map & stop_area_autocomplete & stop_point_autocomplete & line_autocomplete
                 & network_autocomplete & mode_autocomplete & route_autocomplete
                 & stop_area_proximity_list & stop_point_proximity_list
                 & stop_point_connections
@@ -139,7 +134,11 @@ struct PT_Data : boost::noncopyable{
 
     size_t nb_stop_times() const {
         size_t nb = 0;
-        for (const auto* vj: vehicle_journeys) { nb += vj->stop_time_list.size(); }
+        for (const auto jp:journey_patterns) {
+            for (const auto* vj: jp->get_vehicle_journey_list()) {
+                nb += vj->stop_time_list.size();
+            }
+        }
         return nb;
     }
 

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -135,10 +135,11 @@ struct PT_Data : boost::noncopyable{
     size_t nb_stop_times() const {
         size_t nb = 0;
         for (const auto jp:journey_patterns) {
-            for (const auto* vj: jp->get_vehicle_journey_list()) {
-                nb += vj->stop_time_list.size();
-            }
-        }
+            jp->for_each_vehicle_journey([&](const nt::VehicleJourney& vj){
+                nb += vj.stop_time_list.size();
+                return true;
+            });
+        };
         return nb;
     }
 

--- a/source/type/tests/aggregation_odt_test.cpp
+++ b/source/type/tests/aggregation_odt_test.cpp
@@ -39,7 +39,6 @@ www.navitia.io
 struct aggregate_odt_fixture {
     ed::builder b;
     navitia::type::JourneyPattern* jp ;
-    navitia::type::VehicleJourney* vj;
     navitia::type::Route* route;
     navitia::type::Line* line;
     aggregate_odt_fixture() : b("20140210"){
@@ -65,83 +64,69 @@ struct aggregate_odt_fixture {
         b.data->pt_data->journey_patterns.push_back(jp);
         b.data->pt_data->journey_patterns_map["zonal_odt"] = jp;
 
+        regular_vj = std::make_unique<navitia::type::DiscreteVehicleJourney>();
+        regular_vj->vehicle_journey_type = navitia::type::VehicleJourneyType::regular;
 
-        vj = new navitia::type::VehicleJourney();
-        vj->vehicle_journey_type = navitia::type::VehicleJourneyType::regular;
-        b.data->pt_data->vehicle_journeys_map["regular"] = vj;
-        b.data->pt_data->vehicle_journeys.push_back(vj);
+        virtual_with_stop_time_vj = std::make_unique<navitia::type::DiscreteVehicleJourney>();
+        virtual_with_stop_time_vj->vehicle_journey_type = navitia::type::VehicleJourneyType::virtual_with_stop_time;
 
-        vj = new navitia::type::VehicleJourney();
-        vj->vehicle_journey_type = navitia::type::VehicleJourneyType::virtual_with_stop_time;
-        b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"] = vj;
-        b.data->pt_data->vehicle_journeys.push_back(vj);
+        virtual_without_stop_time_vj = std::make_unique<navitia::type::DiscreteVehicleJourney>();
+        virtual_without_stop_time_vj->vehicle_journey_type = navitia::type::VehicleJourneyType::virtual_without_stop_time;
 
-        vj = new navitia::type::VehicleJourney();
-        vj->vehicle_journey_type = navitia::type::VehicleJourneyType::virtual_without_stop_time;
-        b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"] = vj;
-        b.data->pt_data->vehicle_journeys.push_back(vj);
+        stop_point_to_stop_point_vj = std::make_unique<navitia::type::DiscreteVehicleJourney>();
+        stop_point_to_stop_point_vj->vehicle_journey_type = navitia::type::VehicleJourneyType::stop_point_to_stop_point;
 
-        vj = new navitia::type::VehicleJourney();
-        vj->vehicle_journey_type = navitia::type::VehicleJourneyType::stop_point_to_stop_point;
-        b.data->pt_data->vehicle_journeys_map["stop_point_to_stop_point"] = vj;
-        b.data->pt_data->vehicle_journeys.push_back(vj);
+        address_to_stop_point_vj = std::make_unique<navitia::type::DiscreteVehicleJourney>();
+        address_to_stop_point_vj->vehicle_journey_type = navitia::type::VehicleJourneyType::adress_to_stop_point;
 
-        vj = new navitia::type::VehicleJourney();
-        vj->vehicle_journey_type = navitia::type::VehicleJourneyType::adress_to_stop_point;
-        b.data->pt_data->vehicle_journeys_map["address_to_stop_point"] = vj;
-        b.data->pt_data->vehicle_journeys.push_back(vj);
-
-        vj = new navitia::type::VehicleJourney();
-        vj->vehicle_journey_type = navitia::type::VehicleJourneyType::odt_point_to_point;
-        b.data->pt_data->vehicle_journeys_map["odt_point_to_point"] = vj;
-        b.data->pt_data->vehicle_journeys.push_back(vj);
-
+        odt_point_to_point_vj = std::make_unique<navitia::type::DiscreteVehicleJourney>();
+        odt_point_to_point_vj->vehicle_journey_type = navitia::type::VehicleJourneyType::odt_point_to_point;
     }
 
+    std::unique_ptr<navitia::type::DiscreteVehicleJourney> regular_vj;
+    std::unique_ptr<navitia::type::DiscreteVehicleJourney> virtual_with_stop_time_vj;
+    std::unique_ptr<navitia::type::DiscreteVehicleJourney> virtual_without_stop_time_vj;
+    std::unique_ptr<navitia::type::DiscreteVehicleJourney> stop_point_to_stop_point_vj;
+    std::unique_ptr<navitia::type::DiscreteVehicleJourney> address_to_stop_point_vj;
+    std::unique_ptr<navitia::type::DiscreteVehicleJourney> odt_point_to_point_vj;
 
 };
 
 // Tests for VehicleJourney Object
 BOOST_FIXTURE_TEST_CASE(vj_none_odt_test, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["regular"];
-    BOOST_CHECK_EQUAL(vj->is_none_odt(), true);
-    BOOST_CHECK_EQUAL(vj->is_virtual_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_zonal_odt(), false);
+    BOOST_CHECK_EQUAL(regular_vj->is_none_odt(), true);
+    BOOST_CHECK_EQUAL(regular_vj->is_virtual_odt(), false);
+    BOOST_CHECK_EQUAL(regular_vj->is_zonal_odt(), false);
 }
 
 BOOST_FIXTURE_TEST_CASE(vj_virtual_odt_test, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"];
-    BOOST_CHECK_EQUAL(vj->is_none_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_virtual_odt(), true);
-    BOOST_CHECK_EQUAL(vj->is_zonal_odt(), false);
+    BOOST_CHECK_EQUAL(virtual_with_stop_time_vj->is_none_odt(), false);
+    BOOST_CHECK_EQUAL(virtual_with_stop_time_vj->is_virtual_odt(), true);
+    BOOST_CHECK_EQUAL(virtual_with_stop_time_vj->is_zonal_odt(), false);
 }
 
 BOOST_FIXTURE_TEST_CASE(vj_zonal_odt_test1, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"];
-    BOOST_CHECK_EQUAL(vj->is_none_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_virtual_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_zonal_odt(), true);
+    BOOST_CHECK_EQUAL(virtual_without_stop_time_vj->is_none_odt(), false);
+    BOOST_CHECK_EQUAL(virtual_without_stop_time_vj->is_virtual_odt(), false);
+    BOOST_CHECK_EQUAL(virtual_without_stop_time_vj->is_zonal_odt(), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(vj_zonal_odt_test2, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["stop_point_to_stop_point"];
-    BOOST_CHECK_EQUAL(vj->is_none_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_virtual_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_zonal_odt(), true);
+    BOOST_CHECK_EQUAL(stop_point_to_stop_point_vj->is_none_odt(), false);
+    BOOST_CHECK_EQUAL(stop_point_to_stop_point_vj->is_virtual_odt(), false);
+    BOOST_CHECK_EQUAL(stop_point_to_stop_point_vj->is_zonal_odt(), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(vj_zonal_odt_test3, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["address_to_stop_point"];
-    BOOST_CHECK_EQUAL(vj->is_none_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_virtual_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_zonal_odt(), true);
+    BOOST_CHECK_EQUAL(address_to_stop_point_vj->is_none_odt(), false);
+    BOOST_CHECK_EQUAL(address_to_stop_point_vj->is_virtual_odt(), false);
+    BOOST_CHECK_EQUAL(address_to_stop_point_vj->is_zonal_odt(), true);
 }
 
 BOOST_FIXTURE_TEST_CASE(vj_zonal_odt_test4, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["odt_point_to_point"];
-    BOOST_CHECK_EQUAL(vj->is_none_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_virtual_odt(), false);
-    BOOST_CHECK_EQUAL(vj->is_zonal_odt(), true);
+    BOOST_CHECK_EQUAL(odt_point_to_point_vj->is_none_odt(), false);
+    BOOST_CHECK_EQUAL(odt_point_to_point_vj->is_virtual_odt(), false);
+    BOOST_CHECK_EQUAL(odt_point_to_point_vj->is_zonal_odt(), true);
 }
 
 // Tests for JourneyPattern Object
@@ -155,9 +140,8 @@ BOOST_FIXTURE_TEST_CASE(jp_without_vj, aggregate_odt_fixture) {
 }
 
 BOOST_FIXTURE_TEST_CASE(jp_none_odt_test, aggregate_odt_fixture) {
-    vj = b.data->pt_data->vehicle_journeys_map["regular"];
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.push_back(vj);
+    jp->discrete_vehicle_journey_list.push_back(std::move(regular_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), true);
@@ -167,9 +151,9 @@ BOOST_FIXTURE_TEST_CASE(jp_none_odt_test, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_virtual_odt_test, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["regular"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(regular_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_with_stop_time_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -179,10 +163,10 @@ BOOST_FIXTURE_TEST_CASE(jp_virtual_odt_test, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test1, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["regular"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(regular_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_with_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_without_stop_time_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -192,11 +176,11 @@ BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test1, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test2, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["regular"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["stop_point_to_stop_point"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(regular_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_with_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_without_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(stop_point_to_stop_point_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -206,12 +190,12 @@ BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test2, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test3, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["regular"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["stop_point_to_stop_point"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["address_to_stop_point"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(regular_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_with_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_without_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(stop_point_to_stop_point_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(address_to_stop_point_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -221,13 +205,13 @@ BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test3, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test4, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["regular"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_with_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["stop_point_to_stop_point"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["address_to_stop_point"]);
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["odt_point_to_point"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(regular_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_with_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_without_stop_time_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(stop_point_to_stop_point_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(address_to_stop_point_vj));
+    jp->discrete_vehicle_journey_list.push_back(std::move(odt_point_to_point_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -238,8 +222,8 @@ BOOST_FIXTURE_TEST_CASE(jp_virtual_and_zonal_odt_test4, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test1, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["virtual_without_stop_time"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(virtual_without_stop_time_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -249,8 +233,8 @@ BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test1, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test2, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["stop_point_to_stop_point"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(stop_point_to_stop_point_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -260,8 +244,8 @@ BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test2, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test3, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["address_to_stop_point"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(address_to_stop_point_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -271,8 +255,8 @@ BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test3, aggregate_odt_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(jp_zonal_odt_test4, aggregate_odt_fixture) {
     jp = b.data->pt_data->journey_patterns_map["jp1"];
-    jp->vehicle_journey_list.clear();
-    jp->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys_map["odt_point_to_point"]);
+    jp->discrete_vehicle_journey_list.clear();
+    jp->discrete_vehicle_journey_list.push_back(std::move(odt_point_to_point_vj));
     jp->build_odt_properties();
 
     BOOST_CHECK_EQUAL(jp->odt_properties.is_regular(), false);
@@ -311,7 +295,6 @@ BOOST_FIXTURE_TEST_CASE(route_virtual_odt, aggregate_odt_fixture) {
     BOOST_CHECK_EQUAL(odt.is_virtual_odt(), true);
     BOOST_CHECK_EQUAL(odt.is_zonal_odt(), false);
 }
-
 
 BOOST_FIXTURE_TEST_CASE(route_virtual_and_zonal_odt, aggregate_odt_fixture) {
     route = b.data->pt_data->routes_map["route1"];

--- a/source/type/tests/associated_calendar_test.cpp
+++ b/source/type/tests/associated_calendar_test.cpp
@@ -60,6 +60,7 @@ struct calendar_fixture {
         cal->active_periods.push_back({start, end});
         cal->week_pattern = std::bitset<7>("1111111");
         b.data->pt_data->calendars.push_back(cal);
+        b.finish();
     }
     ed::builder b;
     navitia::type::Calendar* cal;
@@ -195,6 +196,7 @@ struct associated_cal_fixture {
                 ("stop_area:stop1", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)
                 ("stop_area:stop2", 11 * 3600 + 10 * 60 ,11 * 3600 + 10 * 60);
 
+        b.finish();
         b.lines["line:A"]->calendar_list.push_back(always_on_cal);
         b.lines["line:A"]->calendar_list.push_back(wednesday_cal);
         b.lines["line:A"]->calendar_list.push_back(monday_cal);

--- a/source/type/tests/datetime.cpp
+++ b/source/type/tests/datetime.cpp
@@ -109,42 +109,6 @@ BOOST_AUTO_TEST_CASE(moins) {
     BOOST_CHECK_EQUAL(t2, 86400 - 3 * 3600);
 }
 
-BOOST_AUTO_TEST_CASE(freq_stop_time_validation){
-    type::StopTime st;
-    throw "think about the need for valid_hour now";
-//    st.vehicle_journey = new type::FrequencyVehicleJourney();
-//    st.vehicle_journey->start_time = 8000;
-//    st.vehicle_journey->end_time = 9000;
-//    st.properties.set(type::StopTime::IS_FREQUENCY);
-//    BOOST_CHECK(st.valid_hour(7999, true));
-//    BOOST_CHECK(st.valid_hour(8000, true));
-//    BOOST_CHECK(st.valid_hour(8500, true));
-//    BOOST_CHECK(st.valid_hour(9000, true));
-//    BOOST_CHECK(!st.valid_hour(9001, true));
-//    BOOST_CHECK(!st.valid_hour(7999, false));
-//    BOOST_CHECK(st.valid_hour(8000, false));
-//    BOOST_CHECK(st.valid_hour(8500, false));
-//    BOOST_CHECK(st.valid_hour(9000, false));
-//    BOOST_CHECK(st.valid_hour(9001, false));
-
-//    st.vehicle_journey->start_time = 23 * 3600;
-//    st.vehicle_journey->end_time = 26 * 3600;
-//    BOOST_CHECK(st.valid_hour(3600, true));
-//    BOOST_CHECK(st.valid_hour(22*3600, true));
-//    BOOST_CHECK(!st.valid_hour(22*3600 + 24*3600, true));
-//    BOOST_CHECK(st.valid_hour(23*3600, true));
-//    BOOST_CHECK(st.valid_hour(25*3600, true));
-//    BOOST_CHECK(!st.valid_hour(27*3600, true));
-
-//    BOOST_CHECK(!st.valid_hour(3600, false));
-//    BOOST_CHECK(!st.valid_hour(22*3600, false));
-//    BOOST_CHECK(st.valid_hour(22*3600 + 24*3600, false));
-//    BOOST_CHECK(st.valid_hour(23*3600, false));
-//    BOOST_CHECK(st.valid_hour(25*3600, false));
-//    BOOST_CHECK(st.valid_hour(27*3600, false));
-}
-
-
 BOOST_AUTO_TEST_CASE(weekday_conversion) {
     boost::gregorian::date today(2014, 03, 5);
     BOOST_CHECK_EQUAL(navitia::get_weekday(today), navitia::Wednesday);

--- a/source/type/tests/datetime.cpp
+++ b/source/type/tests/datetime.cpp
@@ -111,36 +111,37 @@ BOOST_AUTO_TEST_CASE(moins) {
 
 BOOST_AUTO_TEST_CASE(freq_stop_time_validation){
     type::StopTime st;
-    st.vehicle_journey = new type::VehicleJourney();
-    st.vehicle_journey->start_time = 8000;
-    st.vehicle_journey->end_time = 9000;
-    st.properties.set(type::StopTime::IS_FREQUENCY);
-    BOOST_CHECK(st.valid_hour(7999, true));
-    BOOST_CHECK(st.valid_hour(8000, true));
-    BOOST_CHECK(st.valid_hour(8500, true));
-    BOOST_CHECK(st.valid_hour(9000, true));
-    BOOST_CHECK(!st.valid_hour(9001, true));
-    BOOST_CHECK(!st.valid_hour(7999, false));
-    BOOST_CHECK(st.valid_hour(8000, false));
-    BOOST_CHECK(st.valid_hour(8500, false));
-    BOOST_CHECK(st.valid_hour(9000, false));
-    BOOST_CHECK(st.valid_hour(9001, false));
+    throw "think about the need for valid_hour now";
+//    st.vehicle_journey = new type::FrequencyVehicleJourney();
+//    st.vehicle_journey->start_time = 8000;
+//    st.vehicle_journey->end_time = 9000;
+//    st.properties.set(type::StopTime::IS_FREQUENCY);
+//    BOOST_CHECK(st.valid_hour(7999, true));
+//    BOOST_CHECK(st.valid_hour(8000, true));
+//    BOOST_CHECK(st.valid_hour(8500, true));
+//    BOOST_CHECK(st.valid_hour(9000, true));
+//    BOOST_CHECK(!st.valid_hour(9001, true));
+//    BOOST_CHECK(!st.valid_hour(7999, false));
+//    BOOST_CHECK(st.valid_hour(8000, false));
+//    BOOST_CHECK(st.valid_hour(8500, false));
+//    BOOST_CHECK(st.valid_hour(9000, false));
+//    BOOST_CHECK(st.valid_hour(9001, false));
 
-    st.vehicle_journey->start_time = 23 * 3600;
-    st.vehicle_journey->end_time = 26 * 3600;
-    BOOST_CHECK(st.valid_hour(3600, true));
-    BOOST_CHECK(st.valid_hour(22*3600, true));
-    BOOST_CHECK(!st.valid_hour(22*3600 + 24*3600, true));
-    BOOST_CHECK(st.valid_hour(23*3600, true));
-    BOOST_CHECK(st.valid_hour(25*3600, true));
-    BOOST_CHECK(!st.valid_hour(27*3600, true));
+//    st.vehicle_journey->start_time = 23 * 3600;
+//    st.vehicle_journey->end_time = 26 * 3600;
+//    BOOST_CHECK(st.valid_hour(3600, true));
+//    BOOST_CHECK(st.valid_hour(22*3600, true));
+//    BOOST_CHECK(!st.valid_hour(22*3600 + 24*3600, true));
+//    BOOST_CHECK(st.valid_hour(23*3600, true));
+//    BOOST_CHECK(st.valid_hour(25*3600, true));
+//    BOOST_CHECK(!st.valid_hour(27*3600, true));
 
-    BOOST_CHECK(!st.valid_hour(3600, false));
-    BOOST_CHECK(!st.valid_hour(22*3600, false));
-    BOOST_CHECK(st.valid_hour(22*3600 + 24*3600, false));
-    BOOST_CHECK(st.valid_hour(23*3600, false));
-    BOOST_CHECK(st.valid_hour(25*3600, false));
-    BOOST_CHECK(st.valid_hour(27*3600, false));
+//    BOOST_CHECK(!st.valid_hour(3600, false));
+//    BOOST_CHECK(!st.valid_hour(22*3600, false));
+//    BOOST_CHECK(st.valid_hour(22*3600 + 24*3600, false));
+//    BOOST_CHECK(st.valid_hour(23*3600, false));
+//    BOOST_CHECK(st.valid_hour(25*3600, false));
+//    BOOST_CHECK(st.valid_hour(27*3600, false));
 }
 
 

--- a/source/type/tests/fill_pb_object_tests.cpp
+++ b/source/type/tests/fill_pb_object_tests.cpp
@@ -44,6 +44,7 @@ BOOST_AUTO_TEST_CASE(test_pt_displayinfo_destination) {
     b.vj("A")("stop1", 8000, 8050);
     b.vj("A")("stop1", 8000, 8050);
     b.vj("V")("stop2", 8000, 8050);
+    b.finish();
     b.data->build_uri();
     b.data->pt_data->index();
     b.data->build_raptor();

--- a/source/type/tests/test.cpp
+++ b/source/type/tests/test.cpp
@@ -182,7 +182,7 @@ BOOST_FIXTURE_TEST_CASE(message_is_applicable_simple, disruption_fixture) {
 
 
 BOOST_AUTO_TEST_CASE(vj_is_odt) {
-    navitia::type::VehicleJourney vj_odt, vj_regular;
+    navitia::type::DiscreteVehicleJourney vj_odt, vj_regular;
 
     vj_regular.vehicle_journey_type = VehicleJourneyType::regular;
     vj_regular.has_landing();

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -651,3 +651,6 @@ void StreetNetworkParams::set_filter(const std::string &param_uri){
 }
 
 }} //namespace navitia::type
+
+BOOST_CLASS_EXPORT_GUID(navitia::type::DiscreteVehicleJourney, "DiscreteVehicleJourney")
+BOOST_CLASS_EXPORT_GUID(navitia::type::FrequencyVehicleJourney, "FrequencyVehicleJourney")

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -532,14 +532,12 @@ type::hasOdtProperties Route::get_odt_properties() const{
 }
 
 void JourneyPattern::build_odt_properties(){
-    if (!this->vehicle_journey_list.empty()){
-        for (const auto vj : vehicle_journey_list) {
-            if (vj->is_virtual_odt()) {
-                this->odt_properties.set_virtual_odt();
-            }
-            if (vj->is_zonal_odt()) {
-                this->odt_properties.set_zonal_odt();
-            }
+    for (const auto vj : get_vehicle_journey_list()) {
+        if (vj->is_virtual_odt()) {
+            this->odt_properties.set_virtual_odt();
+        }
+        if (vj->is_zonal_odt()) {
+            this->odt_properties.set_zonal_odt();
         }
     }
 }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -575,6 +575,25 @@ std::vector<idx_t> VehicleJourney::get(Type_e type, const PT_Data &) const {
 }
 
 VehicleJourney::~VehicleJourney() { }
+FrequencyVehicleJourney::~FrequencyVehicleJourney() { }
+DiscreteVehicleJourney::~DiscreteVehicleJourney() { }
+
+
+JourneyPattern::~JourneyPattern(){}
+
+//we need to define the copy constructor because we don't want to copy the vjs
+//(idx can be spiped too)
+JourneyPattern::JourneyPattern(const JourneyPattern& other):
+    is_frequence(other.is_frequence),
+    route(other.route),
+    commercial_mode(other.commercial_mode),
+    physical_mode(other.physical_mode),
+    journey_pattern_point_list(other.journey_pattern_point_list),
+    odt_properties(other.odt_properties)
+{
+    name = other.name;
+    uri = other.uri;
+}
 
 std::vector<idx_t> JourneyPatternPoint::get(Type_e type, const PT_Data &) const {
     std::vector<idx_t> result;

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -504,18 +504,20 @@ idx_t Route::main_destination() const {
     std::map<idx_t, size_t> stop_point_map;
     std::pair<idx_t, size_t> best{invalid_idx, 0};
     for(const JourneyPattern* jp : this->journey_pattern_list) {
-        for(const VehicleJourney* vj : jp->get_vehicle_journey_list()) {
-            if((!vj->stop_time_list.empty())
-                && (vj->stop_time_list.back().journey_pattern_point != nullptr)
-                    && (vj->stop_time_list.back().journey_pattern_point->stop_point != nullptr)){
-                const StopPoint* sp = vj->stop_time_list.back().journey_pattern_point->stop_point;
+
+        jp->for_each_vehicle_journey([&](const VehicleJourney& vj) {
+            if((!vj.stop_time_list.empty())
+                && (vj.stop_time_list.back().journey_pattern_point != nullptr)
+                    && (vj.stop_time_list.back().journey_pattern_point->stop_point != nullptr)){
+                const StopPoint* sp = vj.stop_time_list.back().journey_pattern_point->stop_point;
                 stop_point_map[sp->idx] += 1;
                 size_t val = stop_point_map[sp->idx];
                 if (( best.first == invalid_idx) || (best.second < val)){
                     best = {sp->idx, val};
                 }
             }
-        }
+            return true;
+        });
     }
     return best.first;
 }
@@ -532,14 +534,15 @@ type::hasOdtProperties Route::get_odt_properties() const{
 }
 
 void JourneyPattern::build_odt_properties(){
-    for (const auto vj : get_vehicle_journey_list()) {
-        if (vj->is_virtual_odt()) {
+    for_each_vehicle_journey([&](const VehicleJourney& vj) {
+        if (vj.is_virtual_odt()) {
             this->odt_properties.set_virtual_odt();
         }
-        if (vj->is_zonal_odt()) {
+        if (vj.is_zonal_odt()) {
             this->odt_properties.set_zonal_odt();
         }
-    }
+        return true;
+    });
 }
 
 std::vector<idx_t> JourneyPattern::get(Type_e type, const PT_Data &) const {

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -383,7 +383,6 @@ bool VehicleJourney::operator<(const VehicleJourney& other) const {
 
     if (this == &other) return false;
     if(this->journey_pattern == other.journey_pattern){
-        // On compare les pointeurs pour avoir un ordre total (fonctionnellement osef du tri, mais techniquement c'est important)
         return this->stop_time_list.front() < other.stop_time_list.front();
     }else{
         return this->journey_pattern->uri < other.journey_pattern->uri;
@@ -584,7 +583,7 @@ DiscreteVehicleJourney::~DiscreteVehicleJourney() {}
 JourneyPattern::~JourneyPattern() {}
 
 //we need to define the copy constructor because we don't want to copy the vjs
-//(idx can be spiped too)
+//(idx can be skiped too)
 JourneyPattern::JourneyPattern(const JourneyPattern& other):
     is_frequence(other.is_frequence),
     route(other.route),

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -574,12 +574,11 @@ std::vector<idx_t> VehicleJourney::get(Type_e type, const PT_Data &) const {
     return result;
 }
 
-VehicleJourney::~VehicleJourney() { }
-FrequencyVehicleJourney::~FrequencyVehicleJourney() { }
-DiscreteVehicleJourney::~DiscreteVehicleJourney() { }
+VehicleJourney::~VehicleJourney() {}
+FrequencyVehicleJourney::~FrequencyVehicleJourney() {}
+DiscreteVehicleJourney::~DiscreteVehicleJourney() {}
 
-
-JourneyPattern::~JourneyPattern(){}
+JourneyPattern::~JourneyPattern() {}
 
 //we need to define the copy constructor because we don't want to copy the vjs
 //(idx can be spiped too)

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -106,25 +106,6 @@ uint32_t StopTime::f_arrival_time(const u_int32_t hour, bool clockwise) const {
     }
 }
 
-uint32_t StopTime::end_time(const bool is_departure) const {
-    throw "stop time end to do";
-//    return vehicle_journey->end_time + (is_departure? departure_time : arrival_time);
-}
-
-uint32_t StopTime::start_time(const bool is_departure) const {
-    throw "stop time start to do";
-//    return vehicle_journey->start_time + (is_departure? departure_time : arrival_time);
-}
-
-bool StopTime::valid_hour(uint hour, bool clockwise) const {
-    throw "valid hour to do";
-//    if(!this->is_frequency())
-//        return true;
-//    else
-//        return clockwise ? hour <= (this->end_time(true)) :
-//            (this->vehicle_journey->start_time+arrival_time) <= hour;
-}
-
 bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const bool is_adapted) const{
     if((is_arrival && arrival_time >= DateTimeUtils::SECONDS_PER_DAY)
        || (!is_arrival && departure_time >= DateTimeUtils::SECONDS_PER_DAY)) {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -708,7 +708,7 @@ struct FrequencyVehicleJourney: public VehicleJourney {
     uint32_t headway_secs = std::numeric_limits<uint32_t>::max(); // Seconds between each departure.
 
     bool is_valid(int day, const bool is_adapted) const;
-    template<class Archive> void serialize(Archive & ar, const unsigned int ) {
+    template<class Archive> void serialize(Archive & ar, const unsigned int) {
         ar & name & uri & journey_pattern & company & validity_pattern
             & idx & stop_time_list & is_adapted
             & adapted_validity_pattern & adapted_vehicle_journey_list
@@ -821,13 +821,6 @@ struct StopTime {
     DateTime section_end_date(int date, bool clockwise) const {
         return DateTimeUtils::set(date, this->section_end_time(clockwise) % DateTimeUtils::SECONDS_PER_DAY);
     }
-
-
-    /** Is this hour valid : only concerns frequency data
-     * Does the hour falls inside of the validity period of the frequency
-     * The difficult part is when the validity period goes over midnight
-     */
-    bool valid_hour(uint hour, bool clockwise) const;
 
     bool is_valid_day(u_int32_t day, const bool is_arrival, const bool is_adapted) const;
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -634,8 +634,18 @@ struct Route : public Header, Nameable, HasMessages, Codes{
 struct JourneyPattern;
 struct MetaVehicleJourney;
 
+/**
+ * A VehicleJourney is an abstract class with 2 subclasses
+ *
+ *  - DiscreteVehicleJourney
+ * The 'classic' VJ, with expanded stop times
+ *
+ *  - FrequencyVehicleJourney
+ * A frequency VJ, with a start, an end and frequency (headway)
+ *
+ * The JourneyPattern owns 2 differents list for the VJs, and both are treated differently in the algorithm (in best_stop_times)
+ */
 struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessages, Codes {
-    //TODO! remove Nameable, and put only a name
     const static Type_e type = Type_e::VehicleJourney;
     JourneyPattern* journey_pattern = nullptr;
     Company* company = nullptr;
@@ -650,7 +660,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     VehicleJourney* prev_vj = nullptr;
     //associated meta vj
     const MetaVehicleJourney* meta_vj = nullptr;
-    std::string odt_message; //TODO! remove comment or put it in outside map
+    std::string odt_message; //TODO It seems a VJ can have either a comment or an odt_message but never both, so we could use only the 'comment' to store the odt_message
 
     VehicleJourneyType vehicle_journey_type = VehicleJourneyType::regular;
 
@@ -697,17 +707,18 @@ struct DiscreteVehicleJourney: public VehicleJourney {
     DiscreteVehicleJourney() {}
     DiscreteVehicleJourney(const DiscreteVehicleJourney&) = default;
     virtual ~DiscreteVehicleJourney();
-    //TODO lots of comment
+
     template<class Archive> void serialize(Archive& ar, const unsigned int ) {
         ar & boost::serialization::base_object<VehicleJourney>(*this);
     }
 };
 
+
 struct FrequencyVehicleJourney: public VehicleJourney {
     FrequencyVehicleJourney() {}
     FrequencyVehicleJourney(const FrequencyVehicleJourney&) = default;
     virtual ~FrequencyVehicleJourney();
-    //TODO lots of comment
+
     uint32_t start_time = std::numeric_limits<uint32_t>::max(); // first departure hour
     uint32_t end_time = std::numeric_limits<uint32_t>::max(); // last departure hour
     uint32_t headway_secs = std::numeric_limits<uint32_t>::max(); // Seconds between each departure.

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -748,12 +748,12 @@ struct JourneyPattern : public Header, Nameable {
     ~JourneyPattern();
     JourneyPattern(const JourneyPattern&);
 
-    std::vector<const VehicleJourney*> get_vehicle_journey_list() const {
-        //TODO, make this an iterator
-        std::vector<const VehicleJourney*> res;
-        for (const auto& vj: discrete_vehicle_journey_list) { res.push_back(vj.get()); }
-        for (const auto& vj: frequency_vehicle_journey_list) { res.push_back(vj.get()); }
-        return res;
+    template <typename T>
+    void for_each_vehicle_journey(const T func) const {
+        //call the functor for each vj.
+        // if func return false, we stop
+        for (const auto& vj: discrete_vehicle_journey_list) { if (! func(*vj)) {return;} }
+        for (const auto& vj: frequency_vehicle_journey_list) { if (! func(*vj)) {return;} }
     }
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -668,11 +668,6 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     std::string get_direction() const;
     bool has_date_time_estimated() const;
 
-    template<typename Archive>
-    void serialize(Archive &, unsigned int const) {
-        // nothing to do
-    }
-
     bool is_odt()  const{
         return vehicle_journey_type != VehicleJourneyType::regular;
     }
@@ -691,7 +686,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
             & adapted_validity_pattern & adapted_vehicle_journey_list
             & theoric_vehicle_journey & comment & vehicle_journey_type
             & odt_message & _vehicle_properties & impacts
-            & codes //& next_vj & prev_vj
+            & codes & next_vj & prev_vj
             & meta_vj & utc_to_local_offset;
     }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -694,6 +694,9 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
 };
 
 struct DiscreteVehicleJourney: public VehicleJourney {
+    DiscreteVehicleJourney() {}
+    DiscreteVehicleJourney(const DiscreteVehicleJourney&) = default;
+    virtual ~DiscreteVehicleJourney();
     //TODO lots of comment
     template<class Archive> void serialize(Archive& ar, const unsigned int ) {
         ar & boost::serialization::base_object<VehicleJourney>(*this);
@@ -701,6 +704,9 @@ struct DiscreteVehicleJourney: public VehicleJourney {
 };
 
 struct FrequencyVehicleJourney: public VehicleJourney {
+    FrequencyVehicleJourney() {}
+    FrequencyVehicleJourney(const FrequencyVehicleJourney&) = default;
+    virtual ~FrequencyVehicleJourney();
     //TODO lots of comment
     uint32_t start_time = std::numeric_limits<uint32_t>::max(); // first departure hour
     uint32_t end_time = std::numeric_limits<uint32_t>::max(); // last departure hour
@@ -726,6 +732,10 @@ struct JourneyPattern : public Header, Nameable {
 
     std::vector<std::unique_ptr<DiscreteVehicleJourney>> discrete_vehicle_journey_list;
     std::vector<std::unique_ptr<FrequencyVehicleJourney>> frequency_vehicle_journey_list;
+
+    JourneyPattern() {}
+    ~JourneyPattern();
+    JourneyPattern(const JourneyPattern&);
 
     std::vector<const VehicleJourney*> get_vehicle_journey_list() const {
         //TODO, make this an iterator

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -49,6 +49,7 @@ www.navitia.io
 #include <boost/serialization/export.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/bimap.hpp>
+#include <boost/serialization/export.hpp>
 
 namespace navitia { namespace georef {
  struct Admin;
@@ -672,7 +673,6 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
 
     bool operator<(const VehicleJourney& other) const;
 
-    type::OdtLevel_e get_odt_level() const;
     template<typename Archive>
     void serialize(Archive &, unsigned int const) {
         // nothing to do
@@ -1083,3 +1083,4 @@ struct enum_size_trait<type::Mode_e> {
 };
 
 } //namespace navitia
+

--- a/source/validator/validator.cpp
+++ b/source/validator/validator.cpp
@@ -114,6 +114,22 @@ template<typename A, typename B> int check_relations(const std::vector<A*> &as, 
     std::cout << "    Nombre d'erreurs : " << error_count << std::endl;
     return error_count;
 }
+
+template<typename A, typename B, typename C> int check_relations(const std::vector<A*> &as, std::vector<std::unique_ptr<B>> A::*b_list, const std::vector<C*> &, A* C::*to_a_ptr){
+    static_data * s = static_data::get();
+    int error_count = 0;
+    std::cout << "Vérification des relations de " << s->captionByType(A::type) << " vers N-" << s->captionByType(B::type) << " et retour" << std::endl;
+    for(const A* a : as){
+        for(const auto& b : a->*b_list){
+            if(b.get()->*to_a_ptr != a) {
+                std::cout << "    idx invalide : " << b->idx << " pour le " << s->captionByType(A::type) << "(" << a->idx << ")" << std::endl;
+                error_count++;
+            }
+        }
+    }
+    std::cout << "    Nombre d'erreurs : " << error_count << std::endl;
+    return error_count;
+}
 int main(int argc, char** argv) {
     navitia::init_app();
     if(argc != 2){
@@ -144,9 +160,8 @@ int main(int argc, char** argv) {
     error_count += check_relations(d.pt_data->routes, &Route::line, d.pt_data->lines);
     error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::journey_pattern_point_list, d.pt_data->journey_pattern_points);
 
-    // TODO: comment this for the moment, wait to see how to do that after the DiscreteVJ/FrequencyVJ refacto
-//    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::vehicle_journey_list, d.pt_data->vehicle_journeys);
-//    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::vehicle_journey_list, d.pt_data->vehicle_journeys, &VehicleJourney::journey_pattern);
+    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::discrete_vehicle_journey_list, d.pt_data->vehicle_journeys, &VehicleJourney::journey_pattern);
+    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::frequency_vehicle_journey_list, d.pt_data->vehicle_journeys, &VehicleJourney::journey_pattern);
 
     error_count += check_relations(d.pt_data->journey_pattern_points, &JourneyPatternPoint::stop_point, d.pt_data->stop_points);
 

--- a/source/validator/validator.cpp
+++ b/source/validator/validator.cpp
@@ -143,8 +143,10 @@ int main(int argc, char** argv) {
     error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::route, d.pt_data->routes);
     error_count += check_relations(d.pt_data->routes, &Route::line, d.pt_data->lines);
     error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::journey_pattern_point_list, d.pt_data->journey_pattern_points);
-    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::vehicle_journey_list, d.pt_data->vehicle_journeys);
-    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::vehicle_journey_list, d.pt_data->vehicle_journeys, &VehicleJourney::journey_pattern);
+
+    // TODO: comment this for the moment, wait to see how to do that after the DiscreteVJ/FrequencyVJ refacto
+//    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::vehicle_journey_list, d.pt_data->vehicle_journeys);
+//    error_count += check_relations(d.pt_data->journey_patterns, &JourneyPattern::vehicle_journey_list, d.pt_data->vehicle_journeys, &VehicleJourney::journey_pattern);
 
     error_count += check_relations(d.pt_data->journey_pattern_points, &JourneyPatternPoint::stop_point, d.pt_data->stop_points);
 

--- a/source/vptranslator/CMakeLists.txt
+++ b/source/vptranslator/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(vptranslator_src
     block_pattern_to_pb.h
     block_pattern_to_pb.cpp)
 add_library(vptranslator ${vptranslator_src})
-target_link_libraries(vptranslator types)
+target_link_libraries(vptranslator types ${Boost_DATE_TIME_LIBRARY} ${Boost_SERIALIZATION_LIBRARY})
 
 
 add_executable (vptranslator_test test.cpp)

--- a/source/vptranslator/CMakeLists.txt
+++ b/source/vptranslator/CMakeLists.txt
@@ -8,6 +8,6 @@ target_link_libraries(vptranslator types ${Boost_DATE_TIME_LIBRARY} ${Boost_SERI
 
 
 add_executable (vptranslator_test test.cpp)
-target_link_libraries(vptranslator_test ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} vptranslator)
+target_link_libraries(vptranslator_test types ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} vptranslator)
 ADD_BOOST_TEST(vptranslator_test)
 


### PR DESCRIPTION
Split vehicle journeys in 2 different subclasses:
- DiscreteVehicleJourney
  
  the 'classic' vj
- FrequencyVehicleJourney
  
  the frequency vj with start, end and headway as additional informations

This has been done:
- to reduce the size of the VJ (we removed 3 useless fields for DiscreteVJ, the most used kind of VJ)
- to reduce the size of the departure/arrival raptor structures (we now only store discreteVJ stoptime, no frequencyVJ stoptime)
- to better handle frequencies (there was some bug in the way frequencies were handled)

The 2 kind of VJ are handled 2 different way in raptor (in best_stop_time to be precise):
- DiscreteVJ are handled as usual with a departure/arrival sorted vector on which we loop through to find the best stop time (seenext_valid_discrete_pick_up /previous_valid_discrete_drop_off)
- FrequencyVJ are handled for the moment in a naive way
  
  We loop through all the jpp's vj to find the next one.
  We can use more clever data structure if needed
