### PR TITLE
fix disruption integration

### DIFF
--- a/source/kraken/fill_disruption_from_chaos.cpp
+++ b/source/kraken/fill_disruption_from_chaos.cpp
@@ -186,6 +186,15 @@ void add_disruption(nt::PT_Data& pt_data,
     auto from_posix = navitia::from_posix_timestamp;
     nt::new_disruption::DisruptionHolder &holder = pt_data.disruption_holder;
 
+    auto it = find_if(holder.disruptions.begin(), holder.disruptions.end(),
+            [&chaos_disruption](const std::unique_ptr<nt::new_disruption::Disruption>& disruption){
+                return disruption->uri == chaos_disruption.id();
+            });
+    if(it != holder.disruptions.end()){
+        //the disruption already exist we delete the previous one before
+        holder.disruptions.erase(it);
+    }
+
     auto disruption = std::make_unique<nt::new_disruption::Disruption>();
     disruption->uri = chaos_disruption.id();
     disruption->reference = chaos_disruption.reference();

--- a/source/kraken/fill_disruption_from_database.h
+++ b/source/kraken/fill_disruption_from_database.h
@@ -80,7 +80,7 @@ namespace navitia {
                 impact = nullptr;
             }
 
-            if (disruption && (!tag ||
+            if (disruption && !const_it["tag_id"].is_null() && (!tag ||
                     tag->id() != const_it["tag_id"].template as<std::string>())) {
                 fill_tag(const_it);
             }
@@ -175,7 +175,7 @@ namespace navitia {
             auto ptobject = impact->add_informed_entities();
             FILL_NULLABLE(ptobject, updated_at, uint64_t)
             FILL_REQUIRED(ptobject, created_at, uint64_t)
-            FILL_REQUIRED(ptobject, uri, std::string)
+            FILL_NULLABLE(ptobject, uri, std::string)
             if (!const_it["ptobject_type"].is_null()) {
                 const auto& type_ = const_it["ptobject_type"].template as<std::string>();
                 if (type_ == "line") {

--- a/source/kraken/fill_disruption_from_database.h
+++ b/source/kraken/fill_disruption_from_database.h
@@ -173,8 +173,8 @@ namespace navitia {
         template<typename T>
         void fill_pt_object(T const_it) {
             auto ptobject = impact->add_informed_entities();
-            FILL_REQUIRED(ptobject, updated_at, uint64_t)
-            FILL_NULLABLE(ptobject, created_at, uint64_t)
+            FILL_NULLABLE(ptobject, updated_at, uint64_t)
+            FILL_REQUIRED(ptobject, created_at, uint64_t)
             FILL_REQUIRED(ptobject, uri, std::string)
             if (!const_it["ptobject_type"].is_null()) {
                 const auto& type_ = const_it["ptobject_type"].template as<std::string>();

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -75,7 +75,9 @@ PtObj transform_pt_object(const std::string& uri,
                           const std::unordered_map<std::string, T*>& map,
                           const boost::shared_ptr<Impact>& impact) {
     if (auto o = find_or_default(uri, map)) {
-        if (impact) o->add_impact(impact);
+        if (impact){
+            o->add_impact(impact);
+        }
         return o;
     } else {
         LOG4CPLUS_INFO(log4cplus::Logger::getInstance("log"), "Impossible to find pt object " << uri);

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -213,6 +213,7 @@ struct Disruption {
     const std::vector<boost::shared_ptr<Impact>>& get_impacts() const {
         return impacts;
     }
+
 private:
     //Disruption have the ownership of the Impacts.  Impacts are
     //shared_ptr and not unique_ptr because there are weak_ptr


### PR DESCRIPTION
- Some fields nullable were defined as required
- we use a left join for the tag since it's possible for a disruption to have no tags
- when a disruption is received by rabbitmq we check if we already have it for doing an update of this one (more a delete and create but who care...)
