### PR TITLE
Disruption: add missing fields

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -70,6 +70,7 @@ namespace pt = boost::posix_time;
 using navitia::type::new_disruption::Impact;
 using navitia::type::new_disruption::PtObj;
 using navitia::type::new_disruption::Disruption;
+using navitia::type::new_disruption::Severity;
 
 inline u_int64_t operator"" _dt_time_stamp(const char* str, size_t s) {
     return navitia::to_posix_timestamp(boost::posix_time::from_iso_string(std::string(str, s)));
@@ -109,6 +110,11 @@ public:
         auto impact = boost::make_shared<Impact>();
         impact->uri = disrupt.uri;
         impact->application_periods = disrupt.get_application_periods();
+
+        auto info_severity = boost::make_shared<Severity>();
+        info_severity->uri = "info";
+        info_severity->wording = "information severity";
+        impact->severity = info_severity;
 
         switch (disrupt.object_type) {
         case chaos::PtObject::Type::PtObject_Type_network:

--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -111,10 +111,10 @@ public:
         impact->uri = disrupt.uri;
         impact->application_periods = disrupt.get_application_periods();
 
-        auto info_severity = boost::make_shared<Severity>();
-        info_severity->uri = "info";
-        info_severity->wording = "information severity";
-        impact->severity = info_severity;
+        auto severity = boost::make_shared<Severity>();
+        severity->uri = "info";
+        severity->wording = "information severity";
+        impact->severity = severity;
 
         switch (disrupt.object_type) {
         case chaos::PtObject::Type::PtObject_Type_network:

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -368,6 +368,8 @@ period = {
 disruption_message = {
     "text": fields.String(),
     "content_type": fields.String(),
+    "channel_id": fields.String(),
+    "channel_name": fields.String(),
 }
 disruption = {
     "uri": fields.String(),
@@ -378,6 +380,7 @@ disruption = {
     "updated_at": DateTime(),
     "tags": NonNullList(fields.String()),
     "cause": fields.String(),
+    "severity": fields.String(),
     "messages": NonNullList(NonNullNested(disruption_message)),
 }
 

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -381,6 +381,7 @@ disruption = {
     "tags": NonNullList(fields.String()),
     "cause": fields.String(),
     "severity": fields.String(),
+    "severity_color": fields.String(),
     "messages": NonNullList(NonNullNested(disruption_message)),
 }
 

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -365,12 +365,22 @@ period = {
     "end": DateTime(),
 }
 
+channel = {
+    "content_type": fields.String(),
+    "id": fields.String(),
+    "name": fields.String(),
+}
 disruption_message = {
     "text": fields.String(),
-    "content_type": fields.String(),
-    "channel_id": fields.String(),
-    "channel_name": fields.String(),
+    "channel": NonNullNested(channel)
 }
+
+disruption_severity = {
+    "name": fields.String(),
+    "effect": fields.String(),
+    "color": fields.String()
+}
+
 disruption = {
     "uri": fields.String(),
     "impact_uri": fields.String(),
@@ -380,8 +390,7 @@ disruption = {
     "updated_at": DateTime(),
     "tags": NonNullList(fields.String()),
     "cause": fields.String(),
-    "severity": fields.String(),
-    "severity_color": fields.String(),
+    "severity": NonNullNested(disruption_severity),
     "messages": NonNullList(NonNullNested(disruption_message)),
 }
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -799,15 +799,18 @@ def is_valid_label(label):
 def is_valid_disruption(disruption):
     get_not_null(disruption, 'uri')
     get_not_null(disruption, 'impact_uri')
-    get_not_null(disruption, 'severity')
-    get_not_null(disruption, 'severity_color')
+    s = get_not_null(disruption, 'severity')
+    get_not_null(s, 'name')
+    get_not_null(s, 'color')
+    get_not_null(s, 'effect')
     msg = get_not_null(disruption, 'messages')
     assert len(msg) > 0
     for m in msg:
         get_not_null(m, "text")
-        get_not_null(m, "content_type")
-        get_not_null(m, "channel_id")
-        get_not_null(m, "channel_name")
+        channel = get_not_null(m, 'channel')
+        get_not_null(channel, "content_type")
+        get_not_null(channel, "id")
+        get_not_null(channel, "name")
 
 s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
 r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -800,6 +800,7 @@ def is_valid_disruption(disruption):
     get_not_null(disruption, 'uri')
     get_not_null(disruption, 'impact_uri')
     get_not_null(disruption, 'severity')
+    get_not_null(disruption, 'severity_color')
     msg = get_not_null(disruption, 'messages')
     assert len(msg) > 0
     for m in msg:

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -796,6 +796,18 @@ def is_valid_label(label):
     return m is not None
 
 
+def is_valid_disruption(disruption):
+    get_not_null(disruption, 'uri')
+    get_not_null(disruption, 'impact_uri')
+    get_not_null(disruption, 'severity')
+    msg = get_not_null(disruption, 'messages')
+    assert len(msg) > 0
+    for m in msg:
+        get_not_null(m, "text")
+        get_not_null(m, "content_type")
+        get_not_null(m, "channel_id")
+        get_not_null(m, "channel_name")
+
 s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
 r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset
 

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -74,14 +74,19 @@ class TestDisruptions(AbstractTestFixture):
 
         lines_disrupt = get_not_null(impacted_lines[0], 'disruptions')
         assert len(lines_disrupt) == 1
+        for d in lines_disrupt:
+            is_valid_disruption(d)
         assert lines_disrupt[0]['uri'] == 'disruption_on_line_A'
         assert lines_disrupt[0]['impact_uri'] == 'too_bad_again'
+        assert lines_disrupt[0]['severity'] == 'bad severity'
 
         impacted_network = get_not_null(disruptions[0], 'network')
         is_valid_network(impacted_network, depth_check=0)
         assert impacted_network['id'] == 'base_network'
         network_disrupt = get_not_null(impacted_network, 'disruptions')
         assert len(network_disrupt) == 1
+        for d in network_disrupt:
+            is_valid_disruption(d)
         assert network_disrupt[0]['uri'] == 'disruption_on_line_A'
         assert network_disrupt[0]['impact_uri'] == 'too_bad_again'
 
@@ -91,6 +96,8 @@ class TestDisruptions(AbstractTestFixture):
         assert impacted_stop_areas[0]['id'] == 'stopA'
         stop_disrupt = get_not_null(impacted_stop_areas[0], 'disruptions')
         assert len(stop_disrupt) == 1
+        for d in stop_disrupt:
+            is_valid_disruption(d)
         assert stop_disrupt[0]['uri'] == 'disruption_on_stop_A'
         assert stop_disrupt[0]['impact_uri'] == 'too_bad'
 

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -78,7 +78,7 @@ class TestDisruptions(AbstractTestFixture):
             is_valid_disruption(d)
         assert lines_disrupt[0]['uri'] == 'disruption_on_line_A'
         assert lines_disrupt[0]['impact_uri'] == 'too_bad_again'
-        assert lines_disrupt[0]['severity'] == 'bad severity'
+        assert lines_disrupt[0]['severity']['name'] == 'bad severity'
 
         impacted_network = get_not_null(disruptions[0], 'network')
         is_valid_network(impacted_network, depth_check=0)

--- a/source/kraken/fill_disruption_from_chaos.cpp
+++ b/source/kraken/fill_disruption_from_chaos.cpp
@@ -197,8 +197,12 @@ make_impact(const chaos::Impact& chaos_impact, nt::PT_Data& pt_data) {
     impact->severity = make_severity(chaos_impact.severity(), holder);
     impact->informed_entities = make_pt_objects(chaos_impact.informed_entities(), pt_data, impact);
     for (const auto& chaos_message: chaos_impact.messages()) {
+        const auto& channel = chaos_message.channel();
         impact->messages.push_back({
             chaos_message.text(),
+            channel.id(),
+            channel.name(),
+            channel.content_type(),
             from_posix(chaos_message.created_at()),
             from_posix(chaos_message.updated_at()),
         });

--- a/source/kraken/fill_disruption_from_database.h
+++ b/source/kraken/fill_disruption_from_database.h
@@ -224,6 +224,7 @@ namespace navitia {
         template<typename T>
         void fill_channel(T const_it, chaos::Channel* channel) {
             FILL_TIMESTAMPMIXIN(channel)
+            FILL_REQUIRED(channel, id, std::string)
             FILL_REQUIRED(channel, name, std::string)
             FILL_NULLABLE(channel, content_type, std::string)
             FILL_NULLABLE(channel, max_size, uint32_t)

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -486,11 +486,13 @@ struct routing_api_data {
         auto info_severity = boost::make_shared<Severity>();
         info_severity->uri = "info";
         info_severity->wording = "information severity";
+        info_severity->color = "#FFFF00";
         holder.severities[info_severity->uri] = info_severity;
 
         auto bad_severity = boost::make_shared<Severity>();
         bad_severity->uri = "disruption";
         bad_severity->wording = "bad severity";
+        bad_severity->color = "#FFFFF0";
         holder.severities[bad_severity->uri] = bad_severity;
 
         {

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -42,6 +42,7 @@ namespace ng = navitia::georef;
 using navitia::type::new_disruption::Disruption;
 using navitia::type::new_disruption::Impact;
 using navitia::type::new_disruption::Tag;
+using navitia::type::new_disruption::Severity;
 
 struct test_speed_provider {
     const navitia::flat_enum_map<nt::Mode_e, float> get_default_speed() const { return test_default_speed; }
@@ -481,7 +482,17 @@ struct routing_api_data {
         nt::new_disruption::DisruptionHolder& holder = b.data->pt_data->disruption_holder;
         auto default_date = "20140101T000000"_dt;
         auto default_period = boost::posix_time::time_period(default_date, "20140201T120000"_dt);
-        std::cout << "disruption now " << default_date << std::endl;
+
+        auto info_severity = boost::make_shared<Severity>();
+        info_severity->uri = "info";
+        info_severity->wording = "information severity";
+        holder.severities[info_severity->uri] = info_severity;
+
+        auto bad_severity = boost::make_shared<Severity>();
+        bad_severity->uri = "disruption";
+        bad_severity->wording = "bad severity";
+        holder.severities[bad_severity->uri] = bad_severity;
+
         {
             //we create one disruption on stop A
             auto disruption = std::make_unique<Disruption>();
@@ -498,10 +509,12 @@ struct routing_api_data {
             impact->uri = "too_bad";
             impact->application_periods = {default_period};
 
+            impact->severity = info_severity;
+
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::StopArea, "stopA", *b.data->pt_data, impact));
 
-            impact->messages.push_back({"no luck", default_date, default_date});
-            impact->messages.push_back({"try again", default_date, default_date});
+            impact->messages.push_back({"no luck", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});
 
             disruption->add_impact(impact);
 
@@ -517,13 +530,14 @@ struct routing_api_data {
             auto impact = boost::make_shared<Impact>();
             impact->uri = "too_bad_again";
             impact->application_periods = {default_period};
+            impact->severity = bad_severity;
 
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "A", *b.data->pt_data, impact));
             //add another pt impacted object just to test with several
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Network, "base_network", *b.data->pt_data, impact));
 
-            impact->messages.push_back({"sad message", default_date, default_date});
-            impact->messages.push_back({"too sad message", default_date, default_date});
+            impact->messages.push_back({"sad message", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"too sad message", "sms", "sms", "content type", default_date, default_date});
 
             disruption->add_impact(impact);
 
@@ -543,12 +557,14 @@ struct routing_api_data {
             impact->application_periods = {boost::posix_time::time_period("20150601T000000"_dt, "20150615T120000"_dt),
                                           boost::posix_time::time_period("20150801T000000"_dt, "20150815T120000"_dt)};
 
+            impact->severity = info_severity;
+
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "A", *b.data->pt_data, impact));
             //add another pt impacted object just to test with several
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Network, "base_network", *b.data->pt_data, impact));
 
-            impact->messages.push_back({"sad message", default_date, default_date});
-            impact->messages.push_back({"too sad message", default_date, default_date});
+            impact->messages.push_back({"sad message", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"too sad message", "sms", "sms", "content type", default_date, default_date});
 
             disruption->add_impact(impact);
 
@@ -564,13 +580,14 @@ struct routing_api_data {
             auto impact = boost::make_shared<Impact>();
             impact->uri = "impact_published_later";
             impact->application_periods = {default_period};
+            impact->severity = info_severity;
 
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "A", *b.data->pt_data, impact));
             //add another pt impacted object just to test with several
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Network, "base_network", *b.data->pt_data, impact));
 
-            impact->messages.push_back({"sad message", default_date, default_date});
-            impact->messages.push_back({"too sad message", default_date, default_date});
+            impact->messages.push_back({"sad message", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"too sad message", "sms", "sms", "content type", default_date, default_date});
 
             disruption->add_impact(impact);
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -68,6 +68,22 @@ enum class Effect {
   STOP_MOVED
 };
 
+inline std::string to_string(Effect effect) {
+    switch (effect) {
+    case Effect::NO_SERVICE: return "NO_SERVICE";
+    case Effect::REDUCED_SERVICE: return "REDUCED_SERVICE";
+    case Effect::SIGNIFICANT_DELAYS: return "SIGNIFICANT_DELAYS";
+    case Effect::DETOUR: return "DETOUR";
+    case Effect::ADDITIONAL_SERVICE: return "ADDITIONAL_SERVICE";
+    case Effect::MODIFIED_SERVICE: return "MODIFIED_SERVICE";
+    case Effect::OTHER_EFFECT: return "OTHER_EFFECT";
+    case Effect::UNKNOWN_EFFECT: return "UNKNOWN_EFFECT";
+    case Effect::STOP_MOVED: return "STOP_MOVED";
+    default:
+        throw navitia::exception("unhandled effect case");
+    }
+}
+
 
 struct Cause {
     std::string uri;

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -129,6 +129,9 @@ struct Disruption;
 
 struct Message {
     std::string text;
+    std::string channel_id;
+    std::string channel_name;
+    std::string channel_content_type;
 
     boost::posix_time::ptime created_at;
     boost::posix_time::ptime updated_at;

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -116,6 +116,9 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     //TODO: updated at must be computed with the max of all computed values (from disruption, impact, ...)
     pb_disrution->set_updated_at(navitia::to_posix_timestamp(impact->updated_at));
 
+    pb_disrution->set_severity(impact->severity->wording);
+    pb_disrution->set_severity_color(impact->severity->color);
+
     for (const auto& t: impact->disruption->tags) {
         pb_disrution->add_tags(t->name);
     }
@@ -126,7 +129,9 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     for (const auto& m: impact->messages) {
         auto pb_m = pb_disrution->add_messages();
         pb_m->set_text(m.text);
-        pb_m->set_content_type(""); //what do we want ?
+        pb_m->set_content_type(m.channel_content_type);
+        pb_m->set_channel_id(m.channel_id);
+        pb_m->set_channel_name(m.channel_name);
     }
 
     //we need to compute the active status

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -116,8 +116,10 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     //TODO: updated at must be computed with the max of all computed values (from disruption, impact, ...)
     pb_disrution->set_updated_at(navitia::to_posix_timestamp(impact->updated_at));
 
-    pb_disrution->set_severity(impact->severity->wording);
-    pb_disrution->set_severity_color(impact->severity->color);
+    auto pb_severity = pb_disrution->mutable_severity();
+    pb_severity->set_name(impact->severity->wording);
+    pb_severity->set_color(impact->severity->color);
+    pb_severity->set_effect(to_string(impact->severity->effect));
 
     for (const auto& t: impact->disruption->tags) {
         pb_disrution->add_tags(t->name);
@@ -129,9 +131,10 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     for (const auto& m: impact->messages) {
         auto pb_m = pb_disrution->add_messages();
         pb_m->set_text(m.text);
-        pb_m->set_content_type(m.channel_content_type);
-        pb_m->set_channel_id(m.channel_id);
-        pb_m->set_channel_name(m.channel_name);
+        auto pb_channel = pb_m->mutable_channel();
+        pb_channel->set_content_type(m.channel_content_type);
+        pb_channel->set_id(m.channel_id);
+        pb_channel->set_name(m.channel_name);
     }
 
     //we need to compute the active status

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -86,11 +86,15 @@ enum ActiveStatus {
     future = 2;
 }
 
+message Channel {
+    optional string id = 1;
+    optional string name = 2;
+    optional string content_type = 3;
+}
+
 message MessageContent {
     optional string text = 1;
-    optional string content_type = 2;
-    optional string channel_id = 3;
-    optional string channel_name = 4;
+    optional Channel channel = 4;
 }
 
 //message are the old disruption, remove as soon as possible
@@ -99,6 +103,7 @@ enum MessageStatus {
     warning = 1;
     disrupt = 2;
 }
+
 message Message {
     optional string uri = 1;
     optional string message = 2;
@@ -108,6 +113,12 @@ message Message {
     optional string start_application_daily_hour = 6;
     optional string end_application_daily_hour = 7;
     optional MessageStatus message_status = 8;
+}
+
+message Severity {
+    optional string name                           = 1;
+    optional string color                          = 2;
+    optional string effect                         = 3;
 }
 
 message Disruption {
@@ -120,8 +131,7 @@ message Disruption {
     repeated string tags                            = 13;
     optional string cause                           = 14;
     repeated MessageContent messages                = 15;
-    optional string severity                        = 16;
-    optional string severity_color                  = 17;
+    optional Severity severity                      = 16;
 }
 
 message GeographicalCoord {

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -89,6 +89,8 @@ enum ActiveStatus {
 message MessageContent {
     optional string text = 1;
     optional string content_type = 2;
+    optional string channel_id = 3;
+    optional string channel_name = 4;
 }
 
 //message are the old disruption, remove as soon as possible
@@ -117,7 +119,9 @@ message Disruption {
     optional uint64 updated_at                      = 12;
     repeated string tags                            = 13;
     optional string cause                           = 14;
-    repeated MessageContent messages                = 15; 
+    repeated MessageContent messages                = 15;
+    optional string severity                        = 16;
+    optional string severity_color                  = 17;
 }
 
 message GeographicalCoord {


### PR DESCRIPTION
add output for:
- severity
- color

read more informations on channel, so add:
- content_type
- channel_id
- channel_name

on a disruption message
