### PR TITLE
utc adjustement on message/disruption

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -256,16 +256,16 @@ BOOST_FIXTURE_TEST_CASE(network_filter1, Params) {
         BOOST_REQUIRE_EQUAL(line.messages_size(), 1);
         pbnavitia::Message message = line.messages(0);
         BOOST_REQUIRE_EQUAL(message.uri(), "mess1");
-        BOOST_REQUIRE_EQUAL(message.start_application_date(), "20131219T123200");
-        BOOST_REQUIRE_EQUAL(message.end_application_date(), "20131221T123200");
+        BOOST_REQUIRE_EQUAL(message.start_application_date(), navitia::test::to_posix_timestamp("20131219T123200"));
+        BOOST_REQUIRE_EQUAL(message.end_application_date(), navitia::test::to_posix_timestamp("20131221T123200"));
         BOOST_REQUIRE_EQUAL(message.start_application_daily_hour(), "000000");
         BOOST_REQUIRE_EQUAL(message.end_application_daily_hour(), "235959");
         line = disruptions.lines(1);
         BOOST_REQUIRE_EQUAL(line.messages_size(), 1);
         message = line.messages(0);
         BOOST_REQUIRE_EQUAL(message.uri(), "mess0");
-        BOOST_REQUIRE_EQUAL(message.start_application_date(), "20131219T123200");
-        BOOST_REQUIRE_EQUAL(message.end_application_date(), "20131221T123200");
+        BOOST_REQUIRE_EQUAL(message.start_application_date(), navitia::test::to_posix_timestamp("20131219T123200"));
+        BOOST_REQUIRE_EQUAL(message.end_application_date(), navitia::test::to_posix_timestamp("20131221T123200"));
         BOOST_REQUIRE_EQUAL(message.start_application_daily_hour(), "000000");
         BOOST_REQUIRE_EQUAL(message.end_application_daily_hour(), "235959");
     }

--- a/source/ed/connectors/messages_connector.cpp
+++ b/source/ed/connectors/messages_connector.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "type/data.h"
 #include "type/pt_data.h"
 #include <boost/dynamic_bitset.hpp>
+#include <boost/date_time/local_time/local_time.hpp>
 
 namespace ed{ namespace connectors{
 
@@ -78,6 +79,7 @@ void load_disruptions(
         navitia::type::PT_Data& pt_data,
         const RealtimeLoaderConfig& conf,
         const boost::posix_time::ptime& current_time){
+    using boost::local_time::local_date_time;
     //pour le moment on vire les timezone et on considére que c'est de l'heure local
     std::string request = "SELECT id, uri, start_publication_date::timestamp, "
         "end_publication_date::timestamp, start_application_date::timestamp, "
@@ -111,7 +113,7 @@ void load_disruptions(
     nt::new_disruption::DisruptionHolder& disruptions = pt_data.disruption_holder;
     boost::shared_ptr<nt::new_disruption::Impact> impact;
     std::string current_uri = "";
-
+    boost::local_time::time_zone_ptr zone(new boost::local_time::posix_time_zone("CET+1CEST,M3.5.0/2,M10.5.0/3"));
     for (auto cursor = result.begin(); cursor != result.end(); ++cursor) {
         //we can have several message for each impact, (and one impact by disruption)
         if (cursor["uri"].as<std::string>() != current_uri) {
@@ -123,15 +125,23 @@ void load_disruptions(
 
             impact = boost::make_shared<nt::new_disruption::Impact>();
             cursor["uri"].to(impact->uri);
+            auto start_pub = pt::time_from_string(cursor["start_publication_date"].as<std::string>());
+            auto end_pub = pt::time_from_string(cursor["end_publication_date"].as<std::string>());
 
             disruption->publication_period = boost::posix_time::time_period(
-                        pt::time_from_string(cursor["start_publication_date"].as<std::string>()),
-                    pt::time_from_string(cursor["end_publication_date"].as<std::string>())
+                    local_date_time(start_pub.date(), start_pub.time_of_day(), zone,
+                                    local_date_time::NOT_DATE_TIME_ON_ERROR).utc_time(),
+                    local_date_time(end_pub.date(), end_pub.time_of_day(), zone,
+                                    local_date_time::NOT_DATE_TIME_ON_ERROR).utc_time()
                     );
 
             //we need to handle the active days to split the period
-            pt::ptime start = pt::time_from_string(cursor["start_application_date"].as<std::string>());
-            pt::ptime end = pt::time_from_string(cursor["end_application_date"].as<std::string>());
+            auto start_app = pt::time_from_string(cursor["start_application_date"].as<std::string>());
+            auto end_app = pt::time_from_string(cursor["end_application_date"].as<std::string>());
+            pt::ptime start = local_date_time(start_app.date(), start_app.time_of_day(),
+                                              zone, local_date_time::NOT_DATE_TIME_ON_ERROR).utc_time();
+            pt::ptime end = local_date_time(end_app.date(), end_app.time_of_day(),
+                                              zone, local_date_time::NOT_DATE_TIME_ON_ERROR).utc_time();;
 
             auto daily_start_hour = pt::duration_from_string(
                         cursor["start_application_daily_hour"].as<std::string>());

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -354,8 +354,8 @@ Note: the 'generic_messages' are the old 'disruptions'
 generic_message = {
     "level": enum_type(attribute="message_status"),
     "value": fields.String(attribute="message"),
-    "start_application_date": fields.String(),
-    "end_application_date": fields.String(),
+    "start_application_date": DateTime(),
+    "end_application_date": DateTime(),
     "start_application_daily_hour": fields.String(),
     "end_application_daily_hour": fields.String(),
 }

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -152,10 +152,8 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     }
 
     if (! impact->application_periods.empty()) {
-        pb_message->set_start_application_date(
-                    navitia::to_iso_string_no_fractional(impact->application_periods.front().begin()));
-        pb_message->set_end_application_date(
-                    navitia::to_iso_string_no_fractional(impact->application_periods.back().last()));
+        pb_message->set_start_application_date(navitia::to_posix_timestamp(impact->application_periods.front().begin()));
+        pb_message->set_end_application_date(navitia::to_posix_timestamp(impact->application_periods.back().last()));
         //start/end daily hour are not relevent anymore
         pb_message->set_start_application_daily_hour("000000");
         pb_message->set_end_application_daily_hour("235959");

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -108,8 +108,8 @@ message Message {
     optional string uri = 1;
     optional string message = 2;
     optional string title = 3;
-    optional string start_application_date = 4;
-    optional string end_application_date = 5;
+    optional uint64 start_application_date = 4;
+    optional uint64 end_application_date = 5;
     optional string start_application_daily_hour = 6;
     optional string end_application_daily_hour = 7;
     optional MessageStatus message_status = 8;


### PR DESCRIPTION
message in ED are on localtime, we now convert them to UTC on loading (assuming a timezone at europe/paris it's ugly but we hope delete all this crap before a month).

In jormungandr messages were not shifted to localtime, it's now done like for the disruptions.
