### PR TITLE
raptor: improve cache in best_stoptime and raptor_loop

### DIFF
--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -32,56 +32,67 @@ www.navitia.io
 
 namespace navitia { namespace routing {
 
+static const type::JourneyPatternPoint*
+get_jpp(JpIdx jp_idx, uint16_t jpp_order, const type::Data& data) {
+    return data.pt_data->journey_patterns[jp_idx.val]->journey_pattern_point_list[jpp_order];
+}
+
 std::pair<const type::StopTime*, uint32_t>
 best_stop_time(const type::JourneyPatternPoint* jpp,
                const DateTime dt,
                const type::VehicleProperties& vehicle_properties,
-               const bool clockwise, bool disruption_active, const type::Data &data, bool reconstructing_path) {
+               const bool clockwise,
+               bool disruption_active,
+               const type::Data &data,
+               bool reconstructing_path) {
     if(clockwise)
-        return earliest_stop_time(jpp, dt, data, disruption_active, reconstructing_path, vehicle_properties);
+        return earliest_stop_time(jpp, dt, data, disruption_active,
+                                  reconstructing_path, vehicle_properties);
     else
-        return tardiest_stop_time(jpp, dt, data, disruption_active, reconstructing_path, vehicle_properties);
+        return tardiest_stop_time(jpp, dt, data, disruption_active,
+                                  reconstructing_path, vehicle_properties);
 }
 
 /** Which is the first valid stop_time in this range ?
  *  Returns invalid_idx is none is
  */
 static std::pair<const type::StopTime*, DateTime>
-next_valid_discrete_pick_up(const type::JourneyPatternPoint* jpp, const DateTime dt,
-        const type::Data &data, bool reconstructing_path,
-        const type::VehicleProperties &required_vehicle_properties,
-        bool disruption_active){
+next_valid_discrete_pick_up(const JpIdx jp_idx,
+                            uint16_t jpp_order,
+                            const DateTime dt,
+                            const dataRAPTOR& dataRaptor,
+                            bool reconstructing_path,
+                            const type::VehicleProperties& required_vehicle_properties,
+                            bool disruption_active) {
 
-    if (data.dataRaptor->departure_times.empty()) {
+    if (dataRaptor.departure_times.empty()) {
         return {nullptr, DateTimeUtils::inf};
     }
-    const JpIdx jp_idx = JpIdx(*jpp->journey_pattern);
-    const auto begin = data.dataRaptor->departure_times.begin() +
-        data.dataRaptor->first_stop_time[jp_idx] +
-        jpp->order * data.dataRaptor->nb_trips[jp_idx];
-    const auto end_it = begin + data.dataRaptor->nb_trips[jp_idx];
+    const auto begin = dataRaptor.departure_times.begin() +
+        dataRaptor.first_stop_time[jp_idx] +
+        jpp_order * dataRaptor.nb_trips[jp_idx];
+    const auto end_it = begin + dataRaptor.nb_trips[jp_idx];
     const auto it = std::lower_bound(begin, end_it, DateTimeUtils::hour(dt),
                                bound_predicate_earliest);
 
-    type::idx_t idx = it - data.dataRaptor->departure_times.begin();
-    const type::idx_t end = (begin - data.dataRaptor->departure_times.begin()) +
-                           data.dataRaptor->nb_trips[jp_idx];
+    type::idx_t idx = it - dataRaptor.departure_times.begin();
+    const type::idx_t end = (begin - dataRaptor.departure_times.begin()) +
+                           dataRaptor.nb_trips[jp_idx];
 
 
     auto date = DateTimeUtils::date(dt);
     for(; idx < end; ++idx) {
-        const type::StopTime* st = data.dataRaptor->st_forward[idx];
-        BOOST_ASSERT(st->journey_pattern_point == jpp);
+        const type::StopTime* st = dataRaptor.st_forward[idx];
         if (is_valid(st, date, false, disruption_active, reconstructing_path, required_vehicle_properties)) {
                 return {st, DateTimeUtils::set(date, st->departure_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
     }
 
     //if none was found, we try again the next day
-    idx = begin - data.dataRaptor->departure_times.begin();
+    idx = begin - dataRaptor.departure_times.begin();
     date++;
     for(; idx < end; ++idx) {
-        const type::StopTime* st = data.dataRaptor->st_forward[idx];
+        const type::StopTime* st = dataRaptor.st_forward[idx];
         if (is_valid(st, date, false, disruption_active, reconstructing_path, required_vehicle_properties)) {
                 return {st, DateTimeUtils::set(date, st->departure_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
@@ -188,28 +199,29 @@ previous_valid_frequency_drop_off(const type::JourneyPatternPoint* jpp, const Da
 }
 
 static std::pair<const type::StopTime*, DateTime>
-previous_valid_discrete_drop_off(const type::JourneyPatternPoint* jpp, const DateTime dt,
-               const type::Data &data, bool reconstructing_path,
-               const type::VehicleProperties &required_vehicle_properties,
-               bool disruption_active){
+previous_valid_discrete_drop_off(const JpIdx jp_idx,
+                                 uint16_t jpp_order,
+                                 const DateTime dt,
+                                 const dataRAPTOR& dataRaptor,
+                                 bool reconstructing_path,
+                                 const type::VehicleProperties& required_vehicle_properties,
+                                 bool disruption_active) {
     //On cherche le plus grand stop time de la journey_pattern <= dt.hour()
-    if (data.dataRaptor->arrival_times.empty()) {
+    if (dataRaptor.arrival_times.empty()) {
         return {nullptr, DateTimeUtils::inf};
     }
-    const JpIdx jp_idx = JpIdx(*jpp->journey_pattern);
-    const auto begin = data.dataRaptor->arrival_times.begin() +
-                       data.dataRaptor->first_stop_time[jp_idx] +
-                       jpp->order * data.dataRaptor->nb_trips[jp_idx];
-    const auto end_it = begin + data.dataRaptor->nb_trips[jp_idx];
+    const auto begin = dataRaptor.arrival_times.begin() +
+                       dataRaptor.first_stop_time[jp_idx] +
+                       jpp_order * dataRaptor.nb_trips[jp_idx];
+    const auto end_it = begin + dataRaptor.nb_trips[jp_idx];
     const auto it = std::lower_bound(begin, end_it, DateTimeUtils::hour(dt), bound_predicate_tardiest);
 
-    type::idx_t idx = it - data.dataRaptor->arrival_times.begin();
-    const type::idx_t end = (begin - data.dataRaptor->arrival_times.begin()) +
-                           data.dataRaptor->nb_trips[jp_idx];
+    type::idx_t idx = it - dataRaptor.arrival_times.begin();
+    const type::idx_t end = (begin - dataRaptor.arrival_times.begin()) + dataRaptor.nb_trips[jp_idx];
 
     auto date = DateTimeUtils::date(dt);
     for(; idx < end; ++idx) {
-        const type::StopTime* st = data.dataRaptor->st_backward[idx];
+        const type::StopTime* st = dataRaptor.st_backward[idx];
         if (is_valid(st, date, true, disruption_active, !reconstructing_path, required_vehicle_properties)) {
                 return {st, DateTimeUtils::set(date, st->arrival_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
@@ -218,11 +230,11 @@ previous_valid_discrete_drop_off(const type::JourneyPatternPoint* jpp, const Dat
     if (date == 0) {
         return {nullptr, DateTimeUtils::not_valid};
     }
-    idx = begin - data.dataRaptor->arrival_times.begin();
+    idx = begin - dataRaptor.arrival_times.begin();
 
     --date;
     for(; idx < end; ++idx) {
-        const type::StopTime* st = data.dataRaptor->st_backward[idx];
+        const type::StopTime* st = dataRaptor.st_backward[idx];
         if (is_valid(st, date, true, disruption_active, !reconstructing_path, required_vehicle_properties)) {
             return {st, DateTimeUtils::set(date, st->arrival_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
@@ -230,7 +242,6 @@ previous_valid_discrete_drop_off(const type::JourneyPatternPoint* jpp, const Dat
 
     return {nullptr, DateTimeUtils::not_valid};
 }
-
 
 /**
  * earliest_stop_time function:
@@ -242,57 +253,121 @@ previous_valid_discrete_drop_off(const type::JourneyPatternPoint* jpp, const Dat
  *
  *      Note: if nothing found, we do the same lookup the day after
  */
+static std::pair<const type::StopTime*, DateTime>
+earliest_stop_time(JpIdx jp_idx,
+                   uint16_t jpp_order,
+                   const DateTime dt,
+                   const type::Data &data,
+                   bool disruption_active,
+                   bool reconstructing_path,
+                   const type::VehicleProperties& vehicle_properties,
+                   bool check_freq = true) {
+    //We look for the earliest stop time of the journey_pattern >= dt.hour()
+
+    //Return the first valid trip
+    const auto first_discrete_st_pair =
+        next_valid_discrete_pick_up(jp_idx, jpp_order, dt, *data.dataRaptor, reconstructing_path,
+                                    vehicle_properties, disruption_active);
+
+    if (check_freq) {
+        //TODO use first_discrete as a LB ?
+        const auto first_frequency_st_pair =
+            next_valid_frequency_pick_up(get_jpp(jp_idx, jpp_order, data), dt, reconstructing_path,
+                                         vehicle_properties, disruption_active);
+
+        //we need to find the earliest between the frequency one and the 'normal' one
+        if (first_frequency_st_pair.second < first_discrete_st_pair.second) {
+            return first_frequency_st_pair;
+        }
+    }
+
+    return first_discrete_st_pair;
+}
+
 std::pair<const type::StopTime*, DateTime>
 earliest_stop_time(const type::JourneyPatternPoint* jpp,
                    const DateTime dt, const type::Data &data,
                    bool disruption_active,
                    bool reconstructing_path,
                    const type::VehicleProperties& vehicle_properties) {
-    //We look for the earliest stop time of the journey_pattern >= dt.hour()
-
-    //Return the first valid trip
-    const auto first_discrete_st_pair =
-            next_valid_discrete_pick_up(jpp, dt, data, reconstructing_path, vehicle_properties, disruption_active);
-
-    //TODO use first_discrete as a LB ?
-    const auto first_frequency_st_pair =
-            next_valid_frequency_pick_up(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
-
-    //we need to find the earliest between the frequency one and the 'normal' one
-    if (first_discrete_st_pair.second <= first_frequency_st_pair.second) {
-        //discrete's better
-        return first_discrete_st_pair;
-    }
-    return first_frequency_st_pair;
+    return earliest_stop_time(JpIdx(*jpp->journey_pattern),
+                              jpp->order,
+                              dt,
+                              data,
+                              disruption_active,
+                              reconstructing_path,
+                              vehicle_properties);
 }
 
+static std::pair<const type::StopTime*, DateTime>
+tardiest_stop_time(JpIdx jp_idx,
+                   uint16_t jpp_order,
+                   const DateTime dt,
+                   const type::Data &data,
+                   bool disruption_active,
+                   bool reconstructing_path,
+                   const type::VehicleProperties& vehicle_properties,
+                   bool check_freq = true) {
+
+    const auto first_discrete_st_pair =
+        previous_valid_discrete_drop_off(jp_idx, jpp_order, dt, *data.dataRaptor, reconstructing_path,
+                                         vehicle_properties, disruption_active);
+
+    if (check_freq) {
+        //TODO use first_discrete as a LB ?
+        const auto first_frequency_st_pair =
+            previous_valid_frequency_drop_off(get_jpp(jp_idx, jpp_order, data), dt, reconstructing_path,
+                                              vehicle_properties, disruption_active);
+
+        // since the default value is DateTimeUtils::not_valid (== DateTimeUtils::max)
+        // we need to check first that they are
+        if (first_discrete_st_pair.second == DateTimeUtils::not_valid) {
+            return first_frequency_st_pair;
+        }
+        if (first_frequency_st_pair.second == DateTimeUtils::not_valid) {
+            return first_discrete_st_pair;
+        }
+        //we need to find the tardiest between the frequency one and the 'normal' one
+        if (first_frequency_st_pair.second < first_discrete_st_pair.second) {
+            return first_frequency_st_pair;
+        }
+    }
+
+    return first_discrete_st_pair;
+}
 
 std::pair<const type::StopTime*, DateTime>
 tardiest_stop_time(const type::JourneyPatternPoint* jpp,
-                   const DateTime dt, const type::Data &data, bool disruption_active,
+                   const DateTime dt,
+                   const type::Data &data,
+                   bool disruption_active,
                    bool reconstructing_path,
                    const type::VehicleProperties& vehicle_properties) {
+    return tardiest_stop_time(JpIdx(*jpp->journey_pattern),
+                              jpp->order,
+                              dt,
+                              data,
+                              disruption_active,
+                              reconstructing_path,
+                              vehicle_properties);
+}
 
-    const auto first_discrete_st_pair =
-            previous_valid_discrete_drop_off(jpp, dt, data, reconstructing_path, vehicle_properties, disruption_active);
-
-    //TODO use first_discrete as a LB ?
-    const auto first_frequency_st_pair =
-            previous_valid_frequency_drop_off(jpp, dt, reconstructing_path, vehicle_properties, disruption_active);
-
-    // since the default value is DateTimeUtils::not_valid (== DateTimeUtils::max)
-    // we need to check first that they are
-    if (first_discrete_st_pair.second == DateTimeUtils::not_valid) {
-        return first_frequency_st_pair;
-    }
-    if (first_frequency_st_pair.second == DateTimeUtils::not_valid) {
-        return first_discrete_st_pair;
-    }
-    //we need to find the tardiest between the frequency one and the 'normal' one
-    if (first_discrete_st_pair.second >= first_frequency_st_pair.second) {
-        return first_discrete_st_pair;
-    }
-    return first_frequency_st_pair;
+std::pair<const type::StopTime*, uint32_t>
+best_stop_time(const JpIdx jp_idx,
+               const uint16_t jpp_order,
+               const DateTime dt,
+               const type::VehicleProperties& vehicle_properties,
+               const bool clockwise,
+               bool disruption_active,
+               const type::Data &data,
+               bool reconstructing_path,
+               bool check_freq) {
+    if(clockwise)
+        return earliest_stop_time(jp_idx, jpp_order, dt, data, disruption_active,
+                                  reconstructing_path, vehicle_properties, check_freq);
+    else
+        return tardiest_stop_time(jp_idx, jpp_order, dt, data, disruption_active,
+                                  reconstructing_path, vehicle_properties, check_freq);
 }
 
 /** get all stop times for a given jpp and a given calendar

--- a/source/routing/best_stoptime.cpp
+++ b/source/routing/best_stoptime.cpp
@@ -83,6 +83,8 @@ next_valid_discrete_pick_up(const JpIdx jp_idx,
     auto date = DateTimeUtils::date(dt);
     for(; idx < end; ++idx) {
         const type::StopTime* st = dataRaptor.st_forward[idx];
+        BOOST_ASSERT(JpIdx(*st->journey_pattern_point->journey_pattern) == jp_idx);
+        BOOST_ASSERT(st->journey_pattern_point->order == jpp_order);
         if (is_valid(st, date, false, disruption_active, reconstructing_path, required_vehicle_properties)) {
                 return {st, DateTimeUtils::set(date, st->departure_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
@@ -93,6 +95,8 @@ next_valid_discrete_pick_up(const JpIdx jp_idx,
     date++;
     for(; idx < end; ++idx) {
         const type::StopTime* st = dataRaptor.st_forward[idx];
+        BOOST_ASSERT(JpIdx(*st->journey_pattern_point->journey_pattern) == jp_idx);
+        BOOST_ASSERT(st->journey_pattern_point->order == jpp_order);
         if (is_valid(st, date, false, disruption_active, reconstructing_path, required_vehicle_properties)) {
                 return {st, DateTimeUtils::set(date, st->departure_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
@@ -222,6 +226,8 @@ previous_valid_discrete_drop_off(const JpIdx jp_idx,
     auto date = DateTimeUtils::date(dt);
     for(; idx < end; ++idx) {
         const type::StopTime* st = dataRaptor.st_backward[idx];
+        BOOST_ASSERT(JpIdx(*st->journey_pattern_point->journey_pattern) == jp_idx);
+        BOOST_ASSERT(st->journey_pattern_point->order == jpp_order);
         if (is_valid(st, date, true, disruption_active, !reconstructing_path, required_vehicle_properties)) {
                 return {st, DateTimeUtils::set(date, st->arrival_time % DateTimeUtils::SECONDS_PER_DAY)};
         }
@@ -235,6 +241,8 @@ previous_valid_discrete_drop_off(const JpIdx jp_idx,
     --date;
     for(; idx < end; ++idx) {
         const type::StopTime* st = dataRaptor.st_backward[idx];
+        BOOST_ASSERT(JpIdx(*st->journey_pattern_point->journey_pattern) == jp_idx);
+        BOOST_ASSERT(st->journey_pattern_point->order == jpp_order);
         if (is_valid(st, date, true, disruption_active, !reconstructing_path, required_vehicle_properties)) {
             return {st, DateTimeUtils::set(date, st->arrival_time % DateTimeUtils::SECONDS_PER_DAY)};
         }

--- a/source/routing/best_stoptime.h
+++ b/source/routing/best_stoptime.h
@@ -61,10 +61,24 @@ tardiest_stop_time(const type::JourneyPatternPoint* jpp,
 /// either a vehicle that leaves or that arrives depending on clockwise
 std::pair<const type::StopTime*, uint32_t>
 best_stop_time(const type::JourneyPatternPoint* jpp,
-          const DateTime dt,
-          /*const type::Properties &required_properties*/
-          const type::VehicleProperties & vehicle_properties,
-          const bool clockwise, bool disruption_active, const type::Data &data, bool reconstructing_path = false);
+               const DateTime dt,
+               const type::VehicleProperties & vehicle_properties,
+               const bool clockwise,
+               bool disruption_active,
+               const type::Data &data,
+               bool reconstructing_path = false);
+
+std::pair<const type::StopTime*, uint32_t>
+best_stop_time(const JpIdx jp_idx,
+               const uint16_t jpp_order,
+               const DateTime dt,
+               const type::VehicleProperties& vehicle_properties,
+               const bool clockwise,
+               bool disruption_active,
+               const type::Data &data,
+               bool reconstructing_path = false,
+               bool check_freq = true);
+
 
 /// For timetables in frequency-model
 inline bool within(u_int32_t val, std::pair<u_int32_t, u_int32_t> bound) {

--- a/source/routing/best_stoptime.h
+++ b/source/routing/best_stoptime.h
@@ -68,6 +68,11 @@ best_stop_time(const type::JourneyPatternPoint* jpp,
                const type::Data &data,
                bool reconstructing_path = false);
 
+// As the other best_stop_time, but cache friendly and less
+// comfortable to use.  The last parametter, check_freq, allow to
+// forget to test frequency vehicle journey, a big improvement in
+// speed if you know your journey pattern don't have frequency vehicle
+// journeys.  This method is used by raptor.
 std::pair<const type::StopTime*, uint32_t>
 best_stop_time(const JpIdx jp_idx,
                const uint16_t jpp_order,

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -67,6 +67,18 @@ void dataRAPTOR::JppsFromSp::filter_jpps(const boost::dynamic_bitset<>& valid_jp
     }
 }
 
+void dataRAPTOR::JppsFromJp::load(const type::PT_Data &data) {
+    jpps_from_jp.assign(data.journey_patterns.size());
+    for (const auto* jp: data.journey_patterns) {
+        const bool has_freq = !jp->frequency_vehicle_journey_list.empty();
+        for (const auto* jpp: jp->journey_pattern_point_list) {
+            jpps_from_jp[JpIdx(*jp)].push_back(
+                {JppIdx(*jpp), SpIdx(*jpp->stop_point), jpp->order, has_freq});
+        }
+    }
+    for (auto& jpps: jpps_from_jp.values()) { jpps.shrink_to_fit(); }
+}
+
 void dataRAPTOR::load(const type::PT_Data &data)
 {
     labels_const.init_inf(data.journey_pattern_points.size());
@@ -74,6 +86,7 @@ void dataRAPTOR::load(const type::PT_Data &data)
 
     connections.load(data);
     jpps_from_sp.load(data);
+    jpps_from_jp.load(data);
 
     arrival_times.clear();
     departure_times.clear();

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -82,6 +82,24 @@ struct dataRAPTOR {
     };
     JppsFromSp jpps_from_sp;
 
+    // cache friendly access to in order JourneyPatternPoints from a JourneyPattern
+    struct JppsFromJp {
+        // compressed JourneyPatternPoint
+        struct Jpp {
+            JppIdx idx;
+            SpIdx sp_idx;
+            uint16_t order;
+            bool has_freq;
+        };
+        inline const std::vector<Jpp>& operator[](const JpIdx& jp) const {
+            return jpps_from_jp[jp];
+        }
+        void load(const navitia::type::PT_Data &data);
+    private:
+        IdxMap<type::JourneyPattern, std::vector<Jpp>> jpps_from_jp;
+    };
+    JppsFromJp jpps_from_jp;
+
     // arrival_times (resp. departure_times) are the different arrival
     // (resp. departure) times of each stop time sorted by
     //     lex(jp, jpp, arrival_time (resp. departure_time)).

--- a/source/routing/raptor_visitors.h
+++ b/source/routing/raptor_visitors.h
@@ -6,11 +6,10 @@ struct raptor_visitor {
         return a <= st.section_end_date(DateTimeUtils::date(current_dt), clockwise());
     }
 
-    inline
-    std::pair<std::vector<type::JourneyPatternPoint*>::const_iterator, std::vector<type::JourneyPatternPoint*>::const_iterator>
-    journey_pattern_points(const std::vector<type::JourneyPatternPoint*> &, const type::JourneyPattern* journey_pattern, size_t order) const {
-        return std::make_pair(journey_pattern->journey_pattern_point_list.begin() + order,
-                              journey_pattern->journey_pattern_point_list.end());
+    inline boost::iterator_range<std::vector<dataRAPTOR::JppsFromJp::Jpp>::const_iterator>
+    jpps_from_order(const dataRAPTOR::JppsFromJp& jpps_from_jp, JpIdx jp_idx, uint16_t jpp_order) const {
+        const auto& jpps = jpps_from_jp[jp_idx];
+        return boost::make_iterator_range(jpps.begin() + jpp_order, jpps.end());
     }
 
     typedef std::vector<type::StopTime>::const_iterator stop_time_iterator;
@@ -59,13 +58,10 @@ struct raptor_reverse_visitor {
         return a >= st.section_end_date(DateTimeUtils::date(current_dt), clockwise());
     }
 
-    inline
-    std::pair<std::vector<type::JourneyPatternPoint*>::const_reverse_iterator, std::vector<type::JourneyPatternPoint*>::const_reverse_iterator>
-    journey_pattern_points(const std::vector<type::JourneyPatternPoint*> &/*journey_pattern_points*/, const type::JourneyPattern* journey_pattern, size_t order) const {
-        size_t offset = journey_pattern->journey_pattern_point_list.size() - order - 1;
-        const auto begin = journey_pattern->journey_pattern_point_list.rbegin() + offset;
-        const auto end = journey_pattern->journey_pattern_point_list.rend();
-        return std::make_pair(begin, end);
+    inline boost::iterator_range<std::vector<dataRAPTOR::JppsFromJp::Jpp>::const_reverse_iterator>
+    jpps_from_order(const dataRAPTOR::JppsFromJp& jpps_from_jp, JpIdx jp_idx, uint16_t jpp_order) const {
+        const auto& jpps = jpps_from_jp[jp_idx];
+        return boost::make_iterator_range(jpps.rbegin() + jpps.size() - jpp_order - 1, jpps.rend());
     }
 
     typedef std::vector<type::StopTime>::const_reverse_iterator stop_time_iterator;


### PR DESCRIPTION
Only raptor, for 1000 trips in seconds:
- israel: 179.25 ->146.02  => 19% faster
- idf: 78.12 -> 60.05 => 23% faster
- fr-pdl: 122.93 ->107.64  => 12% faster

Number comparable with #829.
