### PR TITLE
Jormungandr: Change disruption interface

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -133,7 +133,7 @@ class Disruptions(ResourceUri):
 
 
 traffic = {
-    "traffic_report": NonNullList(NonNullNested(disruption), attribute='disruptions'),
+    "traffic_reports": NonNullList(NonNullNested(disruption), attribute='disruptions'),
     "error": PbField(error, attribute='error'),
     "pagination": NonNullNested(pagination),
     "disruptions": DisruptionsField,

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -30,6 +30,7 @@
 # www.navitia.io
 
 from flask.ext.restful import marshal_with, reqparse
+from flask.globals import g
 from jormungandr import i_manager, timezone
 from fields import PbField, error, network, line,\
     NonNullList, NonNullNested, pagination, stop_area
@@ -40,6 +41,7 @@ from errors import ManageError
 from datetime import datetime
 import aniso8601
 from datetime import timedelta
+from jormungandr.interfaces.v1.fields import use_old_disruptions, DisruptionsField
 
 disruption = {
     "network": PbField(network, attribute='network'),
@@ -50,7 +52,8 @@ disruption = {
 disruptions = {
     "disruptions": NonNullList(NonNullNested(disruption)),
     "error": PbField(error, attribute='error'),
-    "pagination": NonNullNested(pagination)
+    "pagination": NonNullNested(pagination),
+    "all_disruptions": DisruptionsField,
 }
 
 
@@ -90,7 +93,12 @@ class Disruptions(ResourceUri):
                                 description="forbidden ids",
                                 dest="forbidden_uris[]",
                                 action="append")
+        parser_get.add_argument("_use_old_disruptions", type=bool,
+                                description="temporary boolean to use the old disruption interface. "
+                                            "Will be deleted soon, just needed for synchronization with the front end",
+                                default=False)
 
+    @use_old_disruptions()
     @marshal_with(disruptions)
     @ManageError()
     def get(self, region=None, lon=None, lat=None, uri=None):
@@ -115,4 +123,81 @@ class Disruptions(ResourceUri):
 
         response = i_manager.dispatch(args, "disruptions",
                                       instance_name=self.region)
+
+        # we store in g if we want the disruptions in the old or in the new format
+        # It's not well designed, but it is temporary
+        # DELETE that asap
+        g.use_old_disruptions = args['_use_old_disruptions']
+
+        return response
+
+
+traffic = {
+    "traffic_report": NonNullList(NonNullNested(disruption), attribute='disruptions'),
+    "error": PbField(error, attribute='error'),
+    "pagination": NonNullNested(pagination),
+    "disruptions": DisruptionsField,
+}
+
+
+class TrafficReport(ResourceUri):
+    def __init__(self):
+        ResourceUri.__init__(self)
+        self.parsers = {}
+        self.parsers["get"] = reqparse.RequestParser(
+            argument_class=ArgumentDoc)
+        parser_get = self.parsers["get"]
+        parser_get.add_argument("depth", type=int, default=1)
+        parser_get.add_argument("count", type=int, default=10,
+                                description="Number of disruptions per page")
+        parser_get.add_argument("start_page", type=int, default=0,
+                                description="The current page")
+        parser_get.add_argument("period", type=int,
+                                description="Period in days from datetime. DEPRECATED use duration parameter")
+        parser_get.add_argument("duration", type=duration, default=timedelta(days=365),
+                                description="Duration from the period we want to display the disruption on")
+        parser_get.add_argument("datetime", type=date_time_format, default=datetime.now(), #TODO!! we have to take the local instance time
+                                description="The datetime from which you want the disruption "
+                                            "(filter on the disruption application periods)")
+        parser_get.add_argument("_current_datetime", type=date_time_format, default=datetime.now(), #TODO!! we have to take the local instance time
+                                description="The datetime we want to publish the disruptions from."
+                                            " Default is the current date and it is mainly used for debug."
+                                            " Note: it is not the same as 'datetime' which, combined with"
+                                            " duration form a period used to filter the disruption"
+                                            " application periods")
+        parser_get.add_argument("forbidden_id[]", type=unicode,
+                                description="forbidden ids",
+                                dest="forbidden_uris[]",
+                                action="append")
+
+    @use_old_disruptions()
+    @marshal_with(traffic)
+    @ManageError()
+    def get(self, region=None, lon=None, lat=None, uri=None):
+        self.region = i_manager.get_region(region, lon, lat)
+        timezone.set_request_timezone(self.region)
+        args = self.parsers["get"].parse_args()
+
+        # we store in g if we want the disruptions in the old or in the new format
+        # It's not well designed, but it is temporary
+        # DELETE that asap
+        g.use_old_disruptions = False
+
+        if uri:
+            if uri[-1] == "/":
+                uri = uri[:-1]
+            uris = uri.split("/")
+            args["filter"] = self.get_filter(uris)
+        else:
+            args["filter"] = ""
+
+        #we compute the period end with the duration (or the deprecated 'period' argument)
+        period_end = args['datetime'] + args['duration']
+        if args.get('period'):
+            period_end = args['datetime'] + timedelta(days=args.get('period'))
+
+        args['period_end'] = period_end
+
+        response = i_manager.dispatch(args, "disruptions", instance_name=self.region)
+
         return response

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -96,7 +96,7 @@ class Disruptions(ResourceUri):
         parser_get.add_argument("_use_old_disruptions", type=bool,
                                 description="temporary boolean to use the old disruption interface. "
                                             "Will be deleted soon, just needed for synchronization with the front end",
-                                default=False)
+                                default=True)
 
     @use_old_disruptions_if_needed()
     @marshal_with(disruptions)

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -41,7 +41,7 @@ from errors import ManageError
 from datetime import datetime
 import aniso8601
 from datetime import timedelta
-from jormungandr.interfaces.v1.fields import use_old_disruptions, DisruptionsField
+from jormungandr.interfaces.v1.fields import use_old_disruptions_if_needed, DisruptionsField
 
 disruption = {
     "network": PbField(network, attribute='network'),
@@ -98,7 +98,7 @@ class Disruptions(ResourceUri):
                                             "Will be deleted soon, just needed for synchronization with the front end",
                                 default=False)
 
-    @use_old_disruptions()
+    @use_old_disruptions_if_needed()
     @marshal_with(disruptions)
     @ManageError()
     def get(self, region=None, lon=None, lat=None, uri=None):
@@ -170,7 +170,7 @@ class TrafficReport(ResourceUri):
                                 dest="forbidden_uris[]",
                                 action="append")
 
-    @use_old_disruptions()
+    @use_old_disruptions_if_needed()
     @marshal_with(traffic)
     @ManageError()
     def get(self, region=None, lon=None, lat=None, uri=None):

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -36,6 +36,7 @@ from jormungandr import i_manager
 from jormungandr.exceptions import RegionNotFound
 from jormungandr.instance_manager import instances_comparator
 from jormungandr import authentication
+from jormungandr.interfaces.v1.fields import use_old_disruptions_if_needed, DisruptionsField
 from jormungandr.protobuf_to_dict import protobuf_to_dict
 from fields import stop_point, stop_area, line, physical_mode, \
     commercial_mode, company, network, pagination, place,\
@@ -219,6 +220,7 @@ journeys = {
     "journeys": NonNullList(NonNullNested(journey)),
     "error": PbField(error, attribute='error'),
     "tickets": NonNullList(NonNullNested(ticket)),
+    "disruptions": DisruptionsField,
 }
 
 
@@ -559,6 +561,10 @@ class Journeys(ResourceUri, ResourceUtc):
         parser_get.add_argument("show_codes", type=boolean, default=False,
                             description="show more identification codes")
         parser_get.add_argument("traveler_type", type=option_value(travelers_profile.keys()))
+        parser_get.add_argument("_use_old_disruptions", type=bool,
+                                description="temporary boolean to use the old disruption interface. "
+                                            "Will be deleted soon, just needed for synchronization with the front end",
+                                default=False)
 
         self.method_decorators.append(complete_links(self))
         self.method_decorators.append(update_journeys_status(self))
@@ -579,10 +585,13 @@ class Journeys(ResourceUri, ResourceUtc):
     @add_fare_links()
     @add_journey_pagination()
     @add_journey_href()
+    @use_old_disruptions_if_needed()
     @marshal_with(journeys)
     @ManageError()
     def get(self, region=None, lon=None, lat=None, uri=None):
         args = self.parsers['get'].parse_args()
+
+        g.use_old_disruptions = args['_use_old_disruptions']
 
         if args['traveler_type']:
             profile = travelers_profile[args['traveler_type']]

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -86,6 +86,11 @@ class Schedules(ResourceUri, ResourceUtc):
                                 description="Id of the calendar")
         parser_get.add_argument("show_codes", type=boolean, default=False,
                             description="show more identification codes")
+        parser_get.add_argument("_use_old_disruptions", type=bool,
+                                description="temporary boolean to use the old disruption interface. "
+                                            "Will be deleted soon, just needed for synchronization with the front end",
+                                default=False)
+
         self.method_decorators.append(complete_links(self))
 
     def get(self, uri=None, region=None, lon=None, lat=None):

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -45,7 +45,7 @@ from jormungandr.interfaces.argument import ArgumentDoc
 from jormungandr.interfaces.parsers import depth_argument
 from errors import ManageError
 from Coord import Coord
-from jormungandr.interfaces.v1.fields import DisruptionsField
+from jormungandr.interfaces.v1.fields import DisruptionsField, use_old_disruptions_if_needed
 from jormungandr.timezone import set_request_timezone
 from flask.ext.restful.types import boolean
 from jormungandr.interfaces.parsers import option_value
@@ -89,6 +89,7 @@ class Uri(ResourceUri):
                                 description="The filter parameter")
         self.collection = collection
         self.method_decorators.insert(0, ManageError())
+        self.method_decorators.append(use_old_disruptions_if_needed())
 
     def get(self, region=None, lon=None, lat=None, uri=None, id=None):
         collection = self.collection
@@ -102,10 +103,10 @@ class Uri(ResourceUri):
             if "external_code" in args and args["external_code"]:
                 type_ = collections_to_resource_type[collection]
                 for instance in i_manager.get_regions():
-		    res = i_manager.instances[instance].has_external_code(type_, args["external_code"]) 
+                    res = i_manager.instances[instance].has_external_code(type_, args["external_code"])
                     if res:
                         region = instance
-			id = res
+                        id = res
                         break
                 if not region:
                     abort(404, message="Unable to find an object for the uri %s"

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -31,6 +31,7 @@
 
 from flask import url_for, redirect
 from flask.ext.restful import fields, marshal_with, reqparse, abort
+from flask.globals import g
 from jormungandr import i_manager, authentication
 from converters_collection_type import collections_to_resource_type
 from fields import stop_point, stop_area, route, line, physical_mode, \
@@ -44,6 +45,7 @@ from jormungandr.interfaces.argument import ArgumentDoc
 from jormungandr.interfaces.parsers import depth_argument
 from errors import ManageError
 from Coord import Coord
+from jormungandr.interfaces.v1.fields import DisruptionsField
 from jormungandr.timezone import set_request_timezone
 from flask.ext.restful.types import boolean
 from jormungandr.interfaces.parsers import option_value
@@ -77,6 +79,11 @@ class Uri(ResourceUri):
         parser.add_argument("odt_level", type=option_value(odt_levels),
                                          default="all",
                                          description="odt level")
+        parser.add_argument("_use_old_disruptions", type=bool,
+                                description="temporary boolean to use the old disruption interface. "
+                                            "Will be deleted soon, just needed for synchronization with the front end",
+                                default=False)
+
         if is_collection:
             parser.add_argument("filter", type=str, default="",
                                 description="The filter parameter")
@@ -113,6 +120,8 @@ class Uri(ResourceUri):
         #we store the region in the 'g' object, which is local to a request
         set_request_timezone(self.region)
 
+        g.use_old_disruptions = args['_use_old_disruptions']
+
         if not self.region:
             return {"error": "No region"}, 404
         if collection and id:
@@ -144,7 +153,8 @@ def journey_pattern_points(is_collection):
                  NonNullList(fields.Nested(journey_pattern_point,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -164,7 +174,8 @@ def commercial_modes(is_collection):
                  NonNullList(fields.Nested(commercial_mode,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -184,7 +195,8 @@ def journey_patterns(is_collection):
                  NonNullList(fields.Nested(journey_pattern,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -204,7 +216,8 @@ def vehicle_journeys(is_collection):
                  NonNullList(fields.Nested(vehicle_journey,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -224,7 +237,8 @@ def physical_modes(is_collection):
                  NonNullList(fields.Nested(physical_mode,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -243,7 +257,8 @@ def stop_points(is_collection):
                 ("stop_points",
                  NonNullList(fields.Nested(stop_point, display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -266,7 +281,8 @@ def stop_areas(is_collection):
                  NonNullList(fields.Nested(stop_area,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -289,7 +305,8 @@ def connections(is_collection):
                  NonNullList(fields.Nested(connection,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -309,7 +326,8 @@ def companies(is_collection):
                  NonNullList(fields.Nested(company,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -329,7 +347,8 @@ def poi_types(is_collection):
                  NonNullList(fields.Nested(poi_type,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -349,7 +368,8 @@ def routes(is_collection):
                  NonNullList(fields.Nested(route,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -372,7 +392,8 @@ def lines(is_collection):
                  NonNullList(fields.Nested(line,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -395,7 +416,8 @@ def pois(is_collection):
                  NonNullList(fields.Nested(poi,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)
@@ -418,7 +440,8 @@ def networks(is_collection):
                  NonNullList(fields.Nested(network,
                                            display_null=False))),
                 ("pagination", PbField(pagination)),
-                ("error", PbField(error))
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
             ]
             collections = marshal_with(OrderedDict(self.collections),
                                        display_null=False)

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -396,7 +396,7 @@ disruption_severity = {
 
 disruption_marshaller = {
     "id": fields.String(attribute="uri"),
-    "impact_uri": fields.String(),
+    "impact_id": fields.String(attribute="impact_uri"),
     "title": fields.String(),
     "application_periods": NonNullList(NonNullNested(period)),
     "status": disruption_status,
@@ -410,6 +410,7 @@ disruption_marshaller = {
 #OLD disruption, DEPRECATED
 disruption = deepcopy(disruption_marshaller)
 disruption_marshaller["uri"] = fields.String()
+disruption_marshaller["impact_uri"] = fields.String()
 
 
 class DisruptionsField(fields.Raw):
@@ -420,13 +421,11 @@ class DisruptionsField(fields.Raw):
     def output(self, key, obj):
         all_disruptions = {}
 
-        def get_all_disruptions(name, val):
-            # print "{} = {}".format(name, val)
-            try:
-                disruptions = val.disruptions
-                if disruptions:
-                    disruptions[0].uri
-            except AttributeError:
+        def get_all_disruptions(_, val):
+            if not hasattr(val, 'disruptions'):
+                return
+            disruptions = val.disruptions
+            if not disruptions or not hasattr(disruptions[0], 'uri'):
                 return
 
             for d in disruptions:

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -391,7 +391,7 @@ disruption_severity = {
     "name": fields.String(),
     "effect": fields.String(),
     "color": fields.String(),
-    "color": fields.String()
+    "priority": fields.Integer(),
 }
 
 disruption_marshaller = {

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -390,6 +390,7 @@ disruption_message = {
 disruption_severity = {
     "name": fields.String(),
     "effect": fields.String(),
+    "color": fields.String(),
     "color": fields.String()
 }
 
@@ -443,7 +444,7 @@ display_informations_route = {
     "color": fields.String(attribute="color"),
     "code": fields.String(attribute="code"),
     "messages": NonNullList(NonNullNested(generic_message)),
-    "disruptions": NonNullList(NonNullNested(disruption)),
+    "links": DisruptionLinks(),
 }
 
 display_informations_vj = {
@@ -458,7 +459,7 @@ display_informations_vj = {
     "equipments": equipments(attribute="has_equipments"),
     "headsign": fields.String(attribute="headsign"),
     "messages": NonNullList(NonNullNested(generic_message)),
-    "disruptions": NonNullList(NonNullNested(disruption))
+    "links": DisruptionLinks(),
 }
 
 coord = {
@@ -690,7 +691,8 @@ instance_parameters = {
 instance_status_with_parameters = deepcopy(instance_status)
 instance_status_with_parameters['parameters'] = fields.Nested(instance_parameters, allow_null=True)
 
-class use_old_disruptions:
+
+class use_old_disruptions_if_needed:
     """
     delete disruption links and put the disruptions directly in the owner objets
 

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -77,6 +77,7 @@ def create_internal_link(rel, _type, id, templated=False, description=None):
     d = {
         "templated": templated,
         "rel": rel,
+        "internal": True,
         "type": _type
     }
     if description:

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -212,6 +212,11 @@ class V1Routing(AModule):
                           region + '<uri:uri>/disruptions',
                           endpoint='disruptions')
 
+        self.add_resource(Disruptions.TrafficReport,
+                          region + 'traffic_report',
+                          region + '<uri:uri>/traffic_report',
+                          endpoint='traffic_report')
+
         self.add_resource(Status.Status,
                           region + 'status',
                           endpoint='status')

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -213,9 +213,9 @@ class V1Routing(AModule):
                           endpoint='disruptions')
 
         self.add_resource(Disruptions.TrafficReport,
-                          region + 'traffic_report',
-                          region + '<uri:uri>/traffic_report',
-                          endpoint='traffic_report')
+                          region + 'traffic_reports',
+                          region + '<uri:uri>/traffic_reports',
+                          endpoint='traffic_reports')
 
         self.add_resource(Status.Status,
                           region + 'status',

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -157,7 +157,7 @@ def walk_dict(tree, visitor):
     add_elt("main", tree, first=True)
     while queue:
         elem = queue.pop()
-        #we don't want to visit the list, we'll visit each node separatly
+        #we don't want to visit the list, we'll visit each node separately
         if not isinstance(elem[1], (list, tuple)):
             visitor(elem[0], elem[1])
         #for list and tuple, the name is the parent's name
@@ -170,7 +170,6 @@ def walk_protobuf(pb_object, visitor):
     >>> journeys = response_pb2.Response()
     >>> journey_standard = journeys.journeys.add()
     >>> journey_standard.type = "none"
-    >>> journey_standard.arrival_date_time = str_to_time_stamp("20131107T150000")
     >>> journey_standard.duration = 1
     >>> journey_standard.nb_transfers = 2
     >>> s = journey_standard.sections.add()
@@ -182,12 +181,12 @@ def walk_protobuf(pb_object, visitor):
     >>> journey_rapid.nb_transfers = 6
     >>> s = journey_rapid.sections.add()
     >>> s.duration = 7
-
+    >>>
     >>> from collections import defaultdict
     >>> types_counter = defaultdict(int)
     >>> def visitor(name, val):
     ...     types_counter[type(val)] +=1
-
+    >>>
     >>> walk_protobuf(journeys, visitor)
     >>> types_counter[response_pb2.Response]
     1

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -28,11 +28,15 @@
 # www.navitia.io
 
 import calendar
+from collections import deque
 from datetime import datetime
+from google.protobuf.descriptor import FieldDescriptor
+from google.protobuf.internal.containers import RepeatedScalarFieldContainer
 from jormungandr import i_manager
 import logging
 import pytz
 from jormungandr.exceptions import RegionNotFound
+from navitiacommon import response_pb2
 
 
 def str_to_time_stamp(str):
@@ -105,3 +109,114 @@ class ResourceUtc:
             dt = dt.astimezone(self.tz())
             return dt.strftime("%Y%m%dT%H%M%S")
         return None  # for the moment I prefer not to display anything instead of something wrong
+
+
+def walk_dict(tree, visitor):
+    """
+    depth first search on a dict.
+    call the visit(elem) method on the visitor for each node
+
+    >>> bob = {'tutu': 1,
+    ... 'tata': [1, 2],
+    ... 'toto': {'bob':12, 'bobette': 13, 'nested_bob': {'bob': 3}},
+    ... 'tete': ('tuple1', ['ltuple1', 'ltuple2']),
+    ... 'titi': [{'a':1}, {'b':1}]}
+
+    >>> def my_visitor(name, val):
+    ...     print "{}={}".format(name, val)
+
+    >>> walk_dict(bob, my_visitor)
+    titi={'b': 1}
+    b=1
+    titi={'a': 1}
+    a=1
+    tete=ltuple2
+    tete=ltuple1
+    tete=tuple1
+    tutu=1
+    toto={'bobette': 13, 'bob': 12, 'nested_bob': {'bob': 3}}
+    nested_bob={'bob': 3}
+    bob=3
+    bob=12
+    bobette=13
+    tata=2
+    tata=1
+    """
+    queue = deque()
+
+    def add_elt(name, elt, first=False):
+        if isinstance(elt, (list, tuple)):
+            for val in elt:
+                queue.append((name, val))
+        elif hasattr(elt, 'iteritems'):
+            for k, v in elt.iteritems():
+                queue.append((k, v))
+        elif first:  # for the first elt, we add it even if it is no collection
+            queue.append((name, elt))
+
+    add_elt("main", tree, first=True)
+    while queue:
+        elem = queue.pop()
+        #we don't want to visit the list, we'll visit each node separatly
+        if not isinstance(elem[1], (list, tuple)):
+            visitor(elem[0], elem[1])
+        #for list and tuple, the name is the parent's name
+        add_elt(elem[0], elem[1])
+
+
+def walk_protobuf(pb_object, visitor):
+    """
+    Walk on a protobuf and call the visitor for each nodes
+    >>> journeys = response_pb2.Response()
+    >>> journey_standard = journeys.journeys.add()
+    >>> journey_standard.type = "none"
+    >>> journey_standard.arrival_date_time = str_to_time_stamp("20131107T150000")
+    >>> journey_standard.duration = 1
+    >>> journey_standard.nb_transfers = 2
+    >>> s = journey_standard.sections.add()
+    >>> s.duration = 3
+    >>> s = journey_standard.sections.add()
+    >>> s.duration = 4
+    >>> journey_rapid = journeys.journeys.add()
+    >>> journey_rapid.duration = 5
+    >>> journey_rapid.nb_transfers = 6
+    >>> s = journey_rapid.sections.add()
+    >>> s.duration = 7
+
+    >>> from collections import defaultdict
+    >>> types_counter = defaultdict(int)
+    >>> def visitor(name, val):
+    ...     types_counter[type(val)] +=1
+
+    >>> walk_protobuf(journeys, visitor)
+    >>> types_counter[response_pb2.Response]
+    1
+    >>> types_counter[response_pb2.Journey]
+    2
+    >>> types_counter[response_pb2.Section]
+    3
+    >>> types_counter[int]  # and 7 int in all
+    7
+    """
+    queue = deque()
+
+    def add_elt(name, elt):
+        try:
+            fields = elt.ListFields()
+        except AttributeError:
+            return
+        for field, value in fields:
+            if field.label == FieldDescriptor.LABEL_REPEATED:
+                for v in value:
+                    queue.append((field.name, v))
+            else:
+                queue.append((field.name, value))
+
+    # add_elt("main", pb_object)
+    queue.append(('main', pb_object))
+    while queue:
+        elem = queue.pop()
+
+        visitor(elem[0], elem[1])
+
+        add_elt(elem[0], elem[1])

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -389,10 +389,10 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         test /disruptions and check that an update of a disruption is correctly done
         """
         self.wait_for_rabbitmq_cnx()
-        query = 'traffic_report?datetime=20140101T000000&_current_datetime=20140101T000000'
+        query = 'traffic_reports?datetime=20140101T000000&_current_datetime=20140101T000000'
         response = self.query_region(query)
 
-        disrupt = get_disruptions(response['traffic_report'][0]['network'], response)
+        disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
         eq_(len(disrupt), 1)
 
@@ -407,7 +407,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         response = self.query_region(query)
 
-        disrupt = get_disruptions(response['traffic_report'][0]['network'], response)
+        disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
         eq_(len(disrupt), 2)
 
@@ -424,7 +424,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         response = self.query_region(query)
 
-        disrupt = get_disruptions(response['traffic_report'][0]['network'], response)
+        disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
         eq_(len(disrupt), 2)
         for disruption in disrupt:
@@ -440,7 +440,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         response = self.query_region(query)
 
-        disrupt = get_disruptions(response['traffic_report'][0]['network'], response)
+        disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
         eq_(len(disrupt), 1)
         for disruption in disrupt:

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -345,11 +345,13 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
 
         #we also query without disruption and obviously we should not have the network disruptions
         response = self.query_region(journey_basic_query + "&disruption_active=false")
+        assert 'journeys' in response
         disruptions = self.get_disruptions(response)
         assert disruptions
         eq_(len(disruptions), 1)
         assert 'blocking_line_disruption' in disruptions
-
+        #we also check that the journey is tagged as disrupted
+        assert any(map(lambda j: j.get('status') == 'NO_SERVICE', response['journeys']))
 
     def get_disruptions(self, response):
         """
@@ -373,9 +375,6 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
 
         utils.walk_dict(response, disruptions_filler)
 
-        print "============================="
-        print disruption_by_obj
-        print "+++++++++++++++++++++++++++++"
         return disruption_by_obj
 
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -300,59 +300,6 @@ def check_links(object, tester):
     return links
 
 
-def walk_dict(tree, visitor):
-    """
-    depth first search on a dict.
-    call the visit(elem) method on the visitor for each node
-
-    >>> bob = {'tutu': 1,
-    ... 'tata': [1, 2],
-    ... 'toto': {'bob':12, 'bobette': 13, 'nested_bob': {'bob': 3}},
-    ... 'tete': ('tuple1', ['ltuple1', 'ltuple2']),
-    ... 'titi': [{'a':1}, {'b':1}]}
-
-    >>> def my_visitor(name, val):
-    ...     print "{}={}".format(name, val)
-
-    >>> walk_dict(bob, my_visitor)
-    titi={'b': 1}
-    b=1
-    titi={'a': 1}
-    a=1
-    tete=ltuple2
-    tete=ltuple1
-    tete=tuple1
-    tutu=1
-    toto={'bobette': 13, 'bob': 12, 'nested_bob': {'bob': 3}}
-    nested_bob={'bob': 3}
-    bob=3
-    bob=12
-    bobette=13
-    tata=2
-    tata=1
-    """
-    queue = deque()
-
-    def add_elt(name, elt, first=False):
-        if isinstance(elt, (list, tuple)):
-            for val in elt:
-                queue.append((name, val))
-        elif hasattr(elt, 'iteritems'):
-            for k, v in elt.iteritems():
-                queue.append((k, v))
-        elif first:  # for the first elt, we add it even if it is no collection
-            queue.append((name, elt))
-
-    add_elt("main", tree, first=True)
-    while queue:
-        elem = queue.pop()
-        #we don't want to visit the list, we'll visit each node separatly
-        if not isinstance(elem[1], (list, tuple)):
-            visitor(elem[0], elem[1])
-        #for list and tuple, the name is the parent's name
-        add_elt(elem[0], elem[1])
-
-
 def check_internal_links(response, tester):
     """
     We want to check that all 'internal' link are correctly linked to an element in the response

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -30,6 +30,7 @@
 from collections import deque
 from nose.tools import *
 import json
+from jormungandr import utils
 from navitiacommon import request_pb2, response_pb2
 from datetime import datetime
 import logging
@@ -320,7 +321,7 @@ def check_internal_links(response, tester):
                 internal_links_id.add(val['id'])
                 internal_link_types.add(val['rel'])
 
-    walk_dict(response, add_link_visitor)
+    utils.walk_dict(response, add_link_visitor)
 
     def check_node(name, val):
 
@@ -330,7 +331,7 @@ def check_internal_links(response, tester):
                 #found one ref, we can remove the link
                 internal_links_id.remove(val['id'])
 
-    walk_dict(response, check_node)
+    utils.walk_dict(response, check_node)
 
     assert not internal_links_id, "cannot find correct ref for internal links : {}".\
         format([lid for lid in internal_links_id])
@@ -466,40 +467,6 @@ def is_valid_journey(journey, tester, query):
     assert get_valid_datetime(journey['sections'][-1]['arrival_date_time']) == last_arrival
 
 
-def can_have_disruptions(pt_obj):
-    if "disruptions" not in pt_obj:
-        #disruptions are not mandatory
-        return
-
-    disruptions = get_not_null(pt_obj, "disruptions")
-    for d in disruptions:
-        get_not_null(d, 'uri')
-        get_not_null(d, 'impact_uri')
-        get_valid_datetime(get_not_null(d, 'updated_at'))
-
-        status = get_not_null(d, 'status')
-        assert status in ['past', 'active', 'future']
-
-        periods = get_not_null(d, 'application_periods')
-        for p in periods:
-            b = get_valid_datetime(get_not_null(p, 'begin'))
-            e = get_valid_datetime(get_not_null(p, 'end'))
-
-            assert b <= e
-
-    # messages are the old school disruptions, will be refactored asap
-    msgs = get_not_null(pt_obj, "messages")
-    for m in msgs:
-        get_valid_time(get_not_null(m, 'end_application_daily_hour'))
-        get_valid_time(get_not_null(m, 'start_application_daily_hour'))
-
-        get_valid_datetime(get_not_null(m, 'start_application_date'))
-        get_valid_datetime(get_not_null(m, 'end_application_date'))
-        get_not_null(m, 'value')
-
-    eq_(len(disruptions), len(msgs))
-
-
 def is_valid_section(section, query):
     arrival = get_valid_datetime(section['arrival_date_time'])
     departure = get_valid_datetime(section['departure_date_time'])
@@ -552,8 +519,6 @@ def is_valid_stop_area(stop_area, depth_check=1):
     is_valid_label(get_not_null(stop_area, "label"))
     is_valid_coord(coord)
 
-    can_have_disruptions(stop_area)
-
 
 def is_valid_stop_point(stop_point, depth_check=1):
     """
@@ -564,8 +529,6 @@ def is_valid_stop_point(stop_point, depth_check=1):
     is_valid_label(get_not_null(stop_point, "label"))
     coord = get_not_null(stop_point, "coord")
     is_valid_coord(coord)
-
-    can_have_disruptions(stop_point)
 
     if depth_check > 0:
         is_valid_stop_area(get_not_null(stop_point, "stop_area"), depth_check-1)
@@ -583,8 +546,6 @@ def is_valid_route(route, depth_check=1):
     assert get_not_null(direction, "embedded_type") == "stop_point"
     is_valid_stop_point(get_not_null(direction, "stop_point"), depth_check - 1)
 
-    can_have_disruptions(route)
-
     if depth_check > 0:
         is_valid_line(get_not_null(route, "line"), depth_check - 1)
     else:
@@ -598,8 +559,6 @@ def is_valid_route(route, depth_check=1):
 def is_valid_line(line, depth_check=1):
     get_not_null(line, "name")
     get_not_null(line, "id")
-
-    can_have_disruptions(line)
 
     if depth_check > 0:
         is_valid_network(get_not_null(line, 'network'), depth_check - 1)
@@ -672,16 +631,12 @@ def is_valid_network(network, depth_check=1):
     get_not_null(network, "id")
     get_not_null(network, "name")
 
-    can_have_disruptions(network)
-
 
 def is_valid_vehicle_journey(vj, depth_check=1):
     if depth_check < 0:
         return
     get_not_null(vj, "id")
     get_not_null(vj, "name")
-
-    can_have_disruptions(vj)
 
     if depth_check > 0:
         is_valid_journey_pattern(get_not_null(vj, 'journey_pattern'), depth_check=depth_check-1)
@@ -743,8 +698,19 @@ def is_valid_label(label):
     return m is not None
 
 
+def get_disruptions(obj, response):
+    """
+    unref disruption links are return the list of disruptions
+    """
+    all_disruptions = {d['id']: d for d in response['disruptions']}
+
+    if 'links' not in obj:
+        return None
+    return [all_disruptions[d['id']] for d in obj['links'] if d['type'] == 'disruption']
+
+
 def is_valid_disruption(disruption):
-    get_not_null(disruption, 'uri')
+    get_not_null(disruption, 'id')
     get_not_null(disruption, 'impact_uri')
     s = get_not_null(disruption, 'severity')
     get_not_null(s, 'name')

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -711,7 +711,7 @@ def get_disruptions(obj, response):
 
 def is_valid_disruption(disruption):
     get_not_null(disruption, 'id')
-    get_not_null(disruption, 'impact_uri')
+    get_not_null(disruption, 'impact_id')
     s = get_not_null(disruption, 'severity')
     get_not_null(s, 'name')
     get_not_null(s, 'color')

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -27,18 +27,12 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from tests_mechanism import AbstractTestFixture, dataset
+from jormungandr import utils
 from check_utils import *
 
 
 def get_impacts(response):
-    impacts_by_uri = {}
-
-    def fill_dict(name, val):
-        if name == 'disruptions':
-            impacts_by_uri[val["impact_uri"]] = val
-
-    walk_dict(get_not_null(response, 'disruptions'), fill_dict)
-    return impacts_by_uri
+    return {d['impact_uri']: d for d in response['disruptions']}
 
 # for the tests we need custom datetime to display the disruptions
 default_date_filter = 'datetime=20140101T000000&_current_datetime=20140101T000000'
@@ -60,19 +54,19 @@ class TestDisruptions(AbstractTestFixture):
         one impacted stop_area
         """
 
-        response = self.query_region('disruptions?' + default_date_filter, display=True)
+        response = self.query_region('traffic_report?' + default_date_filter, display=True)
 
-        disruptions = get_not_null(response, 'disruptions')
+        traffic_report = get_not_null(response, 'traffic_report')
 
         # the disruptions are grouped by network and we have only one network
-        assert len(disruptions) == 1
+        assert len(traffic_report) == 1
 
-        impacted_lines = get_not_null(disruptions[0], 'lines')
+        impacted_lines = get_not_null(traffic_report[0], 'lines')
         assert len(impacted_lines) == 1
         is_valid_line(impacted_lines[0], depth_check=0)
         assert impacted_lines[0]['id'] == 'A'
 
-        lines_disrupt = get_not_null(impacted_lines[0], 'disruptions')
+        lines_disrupt = get_disruptions(impacted_lines[0], response)
         assert len(lines_disrupt) == 1
         for d in lines_disrupt:
             is_valid_disruption(d)
@@ -80,21 +74,21 @@ class TestDisruptions(AbstractTestFixture):
         assert lines_disrupt[0]['impact_uri'] == 'too_bad_again'
         assert lines_disrupt[0]['severity']['name'] == 'bad severity'
 
-        impacted_network = get_not_null(disruptions[0], 'network')
+        impacted_network = get_not_null(traffic_report[0], 'network')
         is_valid_network(impacted_network, depth_check=0)
         assert impacted_network['id'] == 'base_network'
-        network_disrupt = get_not_null(impacted_network, 'disruptions')
+        network_disrupt = get_disruptions(impacted_network, response)
         assert len(network_disrupt) == 1
         for d in network_disrupt:
             is_valid_disruption(d)
         assert network_disrupt[0]['uri'] == 'disruption_on_line_A'
         assert network_disrupt[0]['impact_uri'] == 'too_bad_again'
 
-        impacted_stop_areas = get_not_null(disruptions[0], 'stop_areas')
+        impacted_stop_areas = get_not_null(traffic_report[0], 'stop_areas')
         assert len(impacted_stop_areas) == 1
         is_valid_stop_area(impacted_stop_areas[0], depth_check=0)
         assert impacted_stop_areas[0]['id'] == 'stopA'
-        stop_disrupt = get_not_null(impacted_stop_areas[0], 'disruptions')
+        stop_disrupt = get_disruptions(impacted_stop_areas[0], response)
         assert len(stop_disrupt) == 1
         for d in stop_disrupt:
             is_valid_disruption(d)
@@ -202,13 +196,13 @@ class TestDisruptions(AbstractTestFixture):
 
         """
 
-        response = self.query_region('disruptions?duration=P3D&' + default_date_filter)
+        response = self.query_region('traffic_report?duration=P3D&' + default_date_filter)
 
         impacts = get_impacts(response)
         assert len(impacts) == 2
         assert 'later_impact' not in impacts
 
-        response = self.query_region('disruptions?duration=P3Y&' + default_date_filter)
+        response = self.query_region('traffic_report?duration=P3Y&' + default_date_filter)
 
         impacts = get_impacts(response)
         assert len(impacts) == 3
@@ -222,14 +216,14 @@ class TestDisruptions(AbstractTestFixture):
 
         so at 9 it is not in the list, at 11, we get it
         """
-        response = self.query_region('disruptions?datetime=20140101T000000'
+        response = self.query_region('traffic_report?datetime=20140101T000000'
                                      '&_current_datetime=20140128T090000', display=True)
 
         impacts = get_impacts(response)
         assert len(impacts) == 2
         assert 'impact_published_later' not in impacts
 
-        response = self.query_region('disruptions?datetime=20140101T000000'
+        response = self.query_region('traffic_report?datetime=20140101T000000'
                                      '&_current_datetime=20140128T130000', display=True)
 
         impacts = get_impacts(response)

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -32,7 +32,7 @@ from check_utils import *
 
 
 def get_impacts(response):
-    return {d['impact_uri']: d for d in response['disruptions']}
+    return {d['impact_id']: d for d in response['disruptions']}
 
 # for the tests we need custom datetime to display the disruptions
 default_date_filter = 'datetime=20140101T000000&_current_datetime=20140101T000000'
@@ -71,7 +71,7 @@ class TestDisruptions(AbstractTestFixture):
         for d in lines_disrupt:
             is_valid_disruption(d)
         assert lines_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert lines_disrupt[0]['impact_uri'] == 'too_bad_again'
+        assert lines_disrupt[0]['impact_id'] == 'too_bad_again'
         assert lines_disrupt[0]['severity']['name'] == 'bad severity'
 
         impacted_network = get_not_null(traffic_report[0], 'network')
@@ -82,7 +82,7 @@ class TestDisruptions(AbstractTestFixture):
         for d in network_disrupt:
             is_valid_disruption(d)
         assert network_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert network_disrupt[0]['impact_uri'] == 'too_bad_again'
+        assert network_disrupt[0]['impact_id'] == 'too_bad_again'
 
         impacted_stop_areas = get_not_null(traffic_report[0], 'stop_areas')
         assert len(impacted_stop_areas) == 1
@@ -93,7 +93,7 @@ class TestDisruptions(AbstractTestFixture):
         for d in stop_disrupt:
             is_valid_disruption(d)
         assert stop_disrupt[0]['uri'] == 'disruption_on_stop_A'
-        assert stop_disrupt[0]['impact_uri'] == 'too_bad'
+        assert stop_disrupt[0]['impact_id'] == 'too_bad'
 
         """
         by querying directly the impacted object, we find the same results
@@ -156,7 +156,7 @@ class TestDisruptions(AbstractTestFixture):
         lines_disrupt = get_not_null(impacted_lines[0], 'disruptions')
         assert len(lines_disrupt) == 1
         assert lines_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert lines_disrupt[0]['impact_uri'] == 'too_bad_again'
+        assert lines_disrupt[0]['impact_id'] == 'too_bad_again'
 
         impacted_network = get_not_null(disruptions[0], 'network')
 
@@ -165,7 +165,7 @@ class TestDisruptions(AbstractTestFixture):
         network_disrupt = get_not_null(impacted_network, 'disruptions')
         assert len(network_disrupt) == 1
         assert network_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert network_disrupt[0]['impact_uri'] == 'too_bad_again'
+        assert network_disrupt[0]['impact_id'] == 'too_bad_again'
 
         # but we should not have disruption on stop area, B is not disrupted
         assert 'stop_areas' not in disruptions[0]

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -54,9 +54,9 @@ class TestDisruptions(AbstractTestFixture):
         one impacted stop_area
         """
 
-        response = self.query_region('traffic_report?' + default_date_filter, display=True)
+        response = self.query_region('traffic_reports?' + default_date_filter, display=True)
 
-        traffic_report = get_not_null(response, 'traffic_report')
+        traffic_report = get_not_null(response, 'traffic_reports')
 
         # the disruptions are grouped by network and we have only one network
         assert len(traffic_report) == 1
@@ -196,13 +196,13 @@ class TestDisruptions(AbstractTestFixture):
 
         """
 
-        response = self.query_region('traffic_report?duration=P3D&' + default_date_filter)
+        response = self.query_region('traffic_reports?duration=P3D&' + default_date_filter)
 
         impacts = get_impacts(response)
         assert len(impacts) == 2
         assert 'later_impact' not in impacts
 
-        response = self.query_region('traffic_report?duration=P3Y&' + default_date_filter)
+        response = self.query_region('traffic_reports?duration=P3Y&' + default_date_filter)
 
         impacts = get_impacts(response)
         assert len(impacts) == 3
@@ -216,14 +216,14 @@ class TestDisruptions(AbstractTestFixture):
 
         so at 9 it is not in the list, at 11, we get it
         """
-        response = self.query_region('traffic_report?datetime=20140101T000000'
+        response = self.query_region('traffic_reports?datetime=20140101T000000'
                                      '&_current_datetime=20140128T090000', display=True)
 
         impacts = get_impacts(response)
         assert len(impacts) == 2
         assert 'impact_published_later' not in impacts
 
-        response = self.query_region('traffic_report?datetime=20140101T000000'
+        response = self.query_region('traffic_reports?datetime=20140101T000000'
                                      '&_current_datetime=20140128T130000', display=True)
 
         impacts = get_impacts(response)

--- a/source/kraken/fill_disruption_from_database.cpp
+++ b/source/kraken/fill_disruption_from_database.cpp
@@ -146,6 +146,8 @@ void fill_disruption_from_database(const std::string& connection_string,
         offset += result.size();
     }while(result.size() > 0);
     reader.finalize();
+
+    LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"),offset << " disruptions loaded");
 }
 
 void DisruptionDatabaseReader::finalize() {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -120,6 +120,7 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     pb_severity->set_name(impact->severity->wording);
     pb_severity->set_color(impact->severity->color);
     pb_severity->set_effect(to_string(impact->severity->effect));
+    pb_severity->set_priority(impact->severity->priority);
 
     for (const auto& t: impact->disruption->tags) {
         pb_disrution->add_tags(t->name);

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -119,6 +119,7 @@ message Severity {
     optional string name                           = 1;
     optional string color                          = 2;
     optional string effect                         = 3;
+    optional int32  priority                       = 4;
 }
 
 message Disruption {


### PR DESCRIPTION
Change the Disruption API.

Since the disruption is not used externally we refactor it completely before releasing it.

the v1/disruptions is now v1/traffic_reports
this impacted object can be found in the 'traffic_report' list

In all the api when a disruption needs to be dumped we only put an internal link in the impacted object

then all the disruptions informations can be found in the 'disruptions' entry.

example:

``` json
"lines": [

{
    ...
,
"id": "A",
"links": 
[
        {
            "id": "disruption_on_line_A", 
            "rel": "disruptions",
            "internal": True
            "templated": false,
            "type": "disruption"
        }
    ],
    "name": "A"
}
...
{
  "disruptions": [
    {
      "application_periods": [
        {
          "begin": "20140101T000000",
          "end": "20140201T115959"
        }
      ],
      "cause": "",
      "id": "disruption_on_stop_A",
      "impact_uri": "too_bad",
      "messages": [
        {
          "channel": {
            "content_type": "content type",
            "id": "sms",
            "name": "sms"
          },
          "text": "no luck"
        },
        {
          "channel": {
            "content_type": "content type",
            "id": "sms",
            "name": "sms"
          },
          "text": "try again"
        }
      ],
      "severity": {
        "color": "#FFFF00",
        "effect": "NO_SERVICE",
        "priority": 12,
        "name": "information severity"
      },
      "status": "active",
      "tags": [
        "tag name"
      ],
      "title": "",
      "updated_at": "20351029T063222",
      "uri": "disruption_on_stop_A"
    },
]}
```

Note: The old output can temporarily still be used by adding _use_old_disruptions=True in the API parameters
