### PR TITLE
Kraken: add partial_terminus in stop_schedules

### DIFF
--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -160,8 +160,15 @@ departure_board(const std::string& request,
                 continue;
             }
             if(stop_point->idx == jpp->journey_pattern->journey_pattern_point_list.back()->stop_point->idx) { // for terminus
-                response_status[route->idx] = pbnavitia::ResponseStatus::terminus;
-                continue;
+                auto it = response_status.find(route->idx);
+                if (it == response_status.end()) {
+                    response_status[route->idx] = pbnavitia::ResponseStatus::terminus;
+                }
+            } else {
+                auto it = response_status.find(route->idx);
+                if (it != response_status.end() && it->second == pbnavitia::ResponseStatus::terminus) {
+                    response_status[route->idx] = pbnavitia::ResponseStatus::partial_terminus;
+                }
             }
             std::vector<datetime_stop_time> tmp;
             if (! calendar_id) {

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -63,10 +63,10 @@ enum ResponseStatus{
 	no_departure_this_day = 1;
 	no_active_mode_this_day = 2;
 	no_active_circulation_this_day = 3;
-	no_direct_route_this_day = 4;
-	no_departure_stoppoint = 5;
 	terminus = 6;
 	date_out_of_bound = 7;
+	partial_terminus = 8;
+    ok = 9;
 }
 
 


### PR DESCRIPTION
We were not displaying stop_times when a stop_point was a partial_terminus
