### PR TITLE
Time representation in navitia.io documentation

### DIFF
--- a/documentation/navitia.io/source/integration.rst
+++ b/documentation/navitia.io/source/integration.rst
@@ -1203,7 +1203,7 @@ Special Parameters
 datetime
 ########
 
-A date time with the format YYYYMMDDTHHMMSS
+A date time with the format YYYYMMDDThhmmss
 
 Misc mechanisms
 ***************


### PR DESCRIPTION
Using YYYYMMDDTHHMMSS  in doc may be confusing (both months and minutes = M), ISO 8601 format is YYYYMMDDThhmmss
