### PR TITLE
stat: interpreted parameters

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Calendars.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Calendars.py
@@ -130,6 +130,8 @@ class Calendars(ResourceUri):
             args["filter"] = self.get_filter(uris)
         else:
             args["filter"] = ""
+
+        self._register_interpreted_parameters(args)
         response = i_manager.dispatch(args, "calendars",
                                       instance_name=self.region)
         return response

--- a/source/jormungandr/jormungandr/interfaces/v1/Coord.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Coord.py
@@ -64,6 +64,7 @@ class Coord(ResourceUri):
                 "start_page": 0,
                 "filter": ""
             }
+            self._register_interpreted_parameters(args)
             pb_result = i_manager.dispatch(args, "places_nearby",
                                            instance_name=self.region)
             if len(pb_result.places_nearby) > 0:

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -120,6 +120,7 @@ class Disruptions(ResourceUri):
             period_end = args['datetime'] + timedelta(days=args.get('period'))
 
         args['period_end'] = period_end
+        self._register_interpreted_parameters(args)
 
         response = i_manager.dispatch(args, "disruptions",
                                       instance_name=self.region)

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -666,6 +666,8 @@ class Journeys(ResourceUri, ResourceUtc):
 
         # we save the original datetime for debuging purpose
         args['original_datetime'] = args['datetime']
+        #we add the interpreted parameters to the stats
+        self._register_interpreted_parameters(args)
 
         #we want to store the different errors
         responses = {}
@@ -783,6 +785,10 @@ class Journeys(ResourceUri, ResourceUtc):
         # we save the original datetime for debuging purpose
         args['original_datetime'] = args['datetime']
         original_datetime = args['original_datetime']
+
+        #we add the interpreted parameters to the stats
+        self._register_interpreted_parameters(args)
+
         new_datetime = self.convert_to_utc(original_datetime)
         args['datetime'] = date_to_timestamp(new_datetime)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -91,6 +91,7 @@ class Places(ResourceUri):
         self.region = i_manager.get_region(region, lon, lat)
         args = self.parsers["get"].parse_args()
         g.use_old_disruptions = args['_use_old_disruptions']
+        self._register_interpreted_parameters(args)
 
         if len(args['q']) == 0:
             abort(400, message="Search word absent")
@@ -171,6 +172,7 @@ class PlacesNearby(ResourceUri):
         else:
             abort(404)
         args["filter"] = args["filter"].replace(".id", ".uri")
+        self._register_interpreted_parameters(args)
         response = i_manager.dispatch(args, "places_nearby",
                                       instance_name=self.region)
         return response, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
@@ -91,7 +91,7 @@ class Ptobjects(ResourceUri):
         timezone.set_request_timezone(self.region)
         args = self.parsers["get"].parse_args()
         g.use_old_disruptions = args['_use_old_disruptions']
-
+        self._register_interpreted_parameters(args)
         if len(args['q']) == 0:
             abort(400, message="Search word absent")
         response = i_manager.dispatch(args, "pt_objects",

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -128,7 +128,7 @@ class Schedules(ResourceUri, ResourceUtc):
             args['from_datetime'] = utils.date_to_timestamp(new_datetime)
         else:
             args['from_datetime'] = utils.date_to_timestamp(args['from_datetime'])
-
+        self._register_interpreted_parameters(args)
         return i_manager.dispatch(args, self.endpoint,
                                   instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/StatedResource.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/StatedResource.py
@@ -40,3 +40,6 @@ class StatedResource(Resource):
 
         if stat_manager.save_stat:
             self.method_decorators.append(manage_stat_caller(stat_manager))
+
+    def _register_interpreted_parameters(self, args):
+        stat_manager.register_interpreted_parameters(args)

--- a/source/stat_persistor/Procfile
+++ b/source/stat_persistor/Procfile
@@ -1,0 +1,1 @@
+web: ./stat_persist.py stat_persistor.json

--- a/source/stat_persistor/migrations/alembic/versions/75910df5976_add_intrepreted_paramaters.py
+++ b/source/stat_persistor/migrations/alembic/versions/75910df5976_add_intrepreted_paramaters.py
@@ -1,0 +1,29 @@
+"""add intrepreted_parameters
+
+Revision ID: 75910df5976
+Revises: 236b716d0c88
+Create Date: 2015-02-02 11:21:37.028090
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '75910df5976'
+down_revision = '236b716d0c88'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table(
+        'interpreted_parameters',
+        sa.Column('param_key', sa.Text()),
+        sa.Column('param_value', sa.Text()),
+        sa.Column('request_id', sa.BigInteger(), nullable=False),
+        sa.ForeignKeyConstraint(['request_id'], ['stat.requests.id'],),
+        schema='stat'
+    )
+
+
+def downgrade():
+    op.drop_table('interpreted_parameters', schema='stat')

--- a/source/stat_persistor/stat_persistor/saver/stat_request.py
+++ b/source/stat_persistor/stat_persistor/saver/stat_request.py
@@ -47,37 +47,44 @@ def persist_stat_request(meta, conn, stat):
     error_table = meta.tables['stat.errors']
     journey_table = meta.tables['stat.journeys']
     journey_section_table = meta.tables['stat.journey_sections']
+    interpreted_parameters_table = meta.tables['stat.interpreted_parameters']
 
-    #Inserer dans la table stat.requests
+    #stat.requests
     query = request_table.insert()
     request_id = conn.execute(query.values(build_stat_request_dict(stat)))
 
-    #Inserer dans la tables stat.coverages
+    #stat.coverages
     query = coverage_table.insert()
     for coverage in stat.coverages:
         conn.execute(query.values(
             build_stat_coverage_dict(coverage, request_id.inserted_primary_key[0])))
 
-    #Inserer dans la table stat.parameters
+    #stat.parameters
     query = parameter_table.insert()
     for param in stat.parameters:
         conn.execute(query.values(
             build_stat_parameter_dict(param, request_id.inserted_primary_key[0])))
 
-    #Inserer dans la table stat.parameters
+    #stat.interpreted_parameters
+    query = interpreted_parameters_table.insert()
+    for param in stat.interpreted_parameters:
+        conn.execute(query.values(
+            build_stat_parameter_dict(param, request_id.inserted_primary_key[0])))
+
+    #stat.errors
     query = error_table.insert()
     if stat.error.id:
         conn.execute(query.values(
             build_stat_error_dict(stat.error, request_id.inserted_primary_key[0])))
 
-    #Inserer les journeys dans la table stat.journeys
+    #stat.journeys
     for journey in stat.journeys:
         query = journey_table.insert()
         journey_id = conn.execute(
             query.values(build_stat_journey_dict(journey,
                                                  request_id.inserted_primary_key[0])))
 
-        #Inserer les sections de la journey dans la table stat.journey_sections:
+        #stat.journey_sections:
         query = journey_section_table.insert()
         for section in journey.sections:
             conn.execute(query.values(build_stat_section_dict(section,

--- a/source/stat_persistor/stat_persistor/saver/statsaver.py
+++ b/source/stat_persistor/stat_persistor/saver/statsaver.py
@@ -71,6 +71,10 @@ class StatSaver(object):
                                            autoload=True,
                                            schema='stat')
 
+        self.interpreted_parameters_table = Table('interpreted_parameters', self.meta,
+                                     autoload=True,
+                                     schema='stat')
+
     def persist_stat(self, config, stat_request):
         self.__persist(config, stat_request, persist_stat_request)
 

--- a/source/type/stat.proto
+++ b/source/type/stat.proto
@@ -16,62 +16,63 @@ message StatCoverage{
 }
 
 message StatRequest {
-    //POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)    
-    optional uint64	request_date = 1;
-    optional int32	user_id = 2;
-    optional string	user_name = 3;
-    optional int32	application_id = 4;
-    optional string	application_name = 5;
-    optional int32	request_duration = 6;
-    optional string	api = 7;
+    //POSIX time (i.e., number of seconds since January 1st 1970 00:00:00 UTC)
+    optional uint64 request_date = 1;
+    optional int32  user_id = 2;
+    optional string user_name = 3;
+    optional int32  application_id = 4;
+    optional string application_name = 5;
+    optional int32  request_duration = 6;
+    optional string api = 7;
     optional string   path = 8;
-    optional string	host = 10;
-    optional int32	response_size = 11;
-    optional string	client = 12;
+    optional string host = 10;
+    optional int32  response_size = 11;
+    optional string client = 12;
     repeated StatCoverage coverages = 13;
     repeated StatParameter parameters = 14;
     optional StatError error = 15;
     repeated StatJourneyResponse journeys = 16;
+    repeated StatParameter interpreted_parameters = 17;
 }
 
 message StatJourneyResponse {
-    optional uint64 	requested_date_time = 1;
-    optional uint64 	departure_date_time = 2;
-    optional uint64 	arrival_date_time = 3;
-    optional int32 	duration = 4;
-    optional int32 	nb_transfers = 5;
-    optional string 	type = 6;
+    optional uint64     requested_date_time = 1;
+    optional uint64     departure_date_time = 2;
+    optional uint64     arrival_date_time = 3;
+    optional int32      duration = 4;
+    optional int32      nb_transfers = 5;
+    optional string     type = 6;
     repeated StatJourneySection sections = 7;
 }
 
 message StatJourneySection {
-    optional uint64 	departure_date_time = 1;
-    optional uint64 	arrival_date_time = 2;
-    optional int32 	duration = 3;
-    optional string 	type = 4;
+    optional uint64     departure_date_time = 1;
+    optional uint64     arrival_date_time = 2;
+    optional int32  duration = 3;
+    optional string     type = 4;
     optional string   mode = 5;
-    optional string 	from_embedded_type = 6;
-    optional string 	from_id = 7;
-    optional string 	from_name = 8;
+    optional string     from_embedded_type = 6;
+    optional string     from_id = 7;
+    optional string     from_name = 8;
     optional GeographicalCoord from_coord = 9;
-    optional string 	from_admin_id = 10;
-    optional string 	from_admin_name = 11;
-    optional string 	to_embedded_type = 12;
-    optional string 	to_id = 13;
-    optional string 	to_name = 14;
+    optional string     from_admin_id = 10;
+    optional string     from_admin_name = 11;
+    optional string     to_embedded_type = 12;
+    optional string     to_id = 13;
+    optional string     to_name = 14;
     optional GeographicalCoord to_coord = 15;
-    optional string 	to_admin_id = 16;
-    optional string 	to_admin_name = 17;
-    optional string 	vehicle_journey_id = 18;
-    optional string 	line_id = 19;
-    optional string 	line_code = 20;
-    optional string 	route_id = 21;
-    optional string 	network_id = 22;
-    optional string 	network_name = 23;
-    optional string 	physical_mode_id = 24;
-    optional string 	physical_mode_name = 25;
-    optional string 	commercial_mode_id = 26;
-    optional string 	commercial_mode_name = 27;
+    optional string     to_admin_id = 16;
+    optional string     to_admin_name = 17;
+    optional string     vehicle_journey_id = 18;
+    optional string     line_id = 19;
+    optional string     line_code = 20;
+    optional string     route_id = 21;
+    optional string     network_id = 22;
+    optional string     network_name = 23;
+    optional string     physical_mode_id = 24;
+    optional string     physical_mode_name = 25;
+    optional string     commercial_mode_id = 26;
+    optional string     commercial_mode_name = 27;
 }
 
 


### PR DESCRIPTION
In stat we keep the parameter set by the client and log in another table the parameters used by jormungandr with default values and eventually modification done by the internal logic of each api.

Currently ptref filter are stored as is, the parsing of the query is not done, so for a departure query on one stop_area for a specific line, we will store something like this:

```
line.uri=line:NAN:NA-0 and stop_point.uri=stop_point:NAN:SP:COMD3
```
