### PR TITLE
Kraken: introduce previous passages

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -69,6 +69,9 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument("from_datetime", type=date_time_format,
                                 description="The datetime from which you want\
                                 the schedules")
+        parser_get.add_argument("until_datetime", type=date_time_format,
+                                description="The datetime until which you want\
+                                the schedules")
         parser_get.add_argument("duration", type=int, default=3600 * 24,
                                 description="Maximum duration between datetime\
                                 and the retrieved stop time")
@@ -128,7 +131,8 @@ class Schedules(ResourceUri, ResourceUtc):
             args['from_datetime'] = utils.date_to_timestamp(new_datetime)
         else:
             args['from_datetime'] = utils.date_to_timestamp(args['from_datetime'])
-        self._register_interpreted_parameters(args)
+            args['until_datetime'] = utils.date_to_timestamp(args['until_datetime'])
+		self._register_interpreted_parameters(args)
         return i_manager.dispatch(args, self.endpoint,
                                   instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -145,7 +145,7 @@ class Schedules(ResourceUri, ResourceUtc):
                 and self.endpoint[:4] == "next":
             self.endpoint = "previous" + self.endpoint[4:]
         
-        self._register_interpreted_parameters(args) 
+        self._register_interpreted_parameters(args)
         return i_manager.dispatch(args, self.endpoint,
                                   instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -127,17 +127,20 @@ class Schedules(ResourceUri, ResourceUtc):
 
         if not args.get('calendar'):
             #if a calendar is given all times will be given in local (because it might span over dst)
-            new_datetime = self.convert_to_utc(args['from_datetime'])
-            args['from_datetime'] = utils.date_to_timestamp(new_datetime)
+            if args['from_datetime']:
+                new_datetime = self.convert_to_utc(args['from_datetime'])
+                args['from_datetime'] = utils.date_to_timestamp(new_datetime)
+            if args['until_datetime']:
+                new_datetime = self.convert_to_utc(args['until_datetime'])
+                args['until_datetime'] = utils.date_to_timestamp(new_datetime)
         else:
             args['from_datetime'] = utils.date_to_timestamp(args['from_datetime'])
-            args['until_datetime'] = utils.date_to_timestamp(args['until_datetime'])
 
         if not args["from_datetime"] and args["until_datetime"]\
-                and self.endpoint[4:] == "next":
-            self.endpoint = "prev" + self.endpoint[4:]
-		
-		self._register_interpreted_parameters(args)
+                and self.endpoint[:4] == "next":
+            self.endpoint = "previous" + self.endpoint[4:]
+        
+        self._register_interpreted_parameters(args) 
         return i_manager.dispatch(args, self.endpoint,
                                   instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -68,10 +68,10 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument("filter", type=str)
         parser_get.add_argument("from_datetime", type=date_time_format,
                                 description="The datetime from which you want\
-                                the schedules")
+                                the schedules", default=None)
         parser_get.add_argument("until_datetime", type=date_time_format,
                                 description="The datetime until which you want\
-                                the schedules")
+                                the schedules", default=None)
         parser_get.add_argument("duration", type=int, default=3600 * 24,
                                 description="Maximum duration between datetime\
                                 and the retrieved stop time")
@@ -118,7 +118,7 @@ class Schedules(ResourceUri, ResourceUtc):
             self.region = i_manager.get_region(region, lon, lat)
         timezone.set_request_timezone(self.region)
 
-        if not args["from_datetime"]:
+        if not args["from_datetime"] and not args["until_datetime"]:
             args['from_datetime'] = datetime.now()
             args['from_datetime'] = args['from_datetime'].replace(hour=13, minute=37)
 
@@ -132,6 +132,11 @@ class Schedules(ResourceUri, ResourceUtc):
         else:
             args['from_datetime'] = utils.date_to_timestamp(args['from_datetime'])
             args['until_datetime'] = utils.date_to_timestamp(args['until_datetime'])
+
+        if not args["from_datetime"] and args["until_datetime"]\
+                and self.endpoint[4:] == "next":
+            self.endpoint = "prev" + self.endpoint[4:]
+		
 		self._register_interpreted_parameters(args)
         return i_manager.dispatch(args, self.endpoint,
                                   instance_name=self.region)

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -192,13 +192,15 @@ class V1Routing(AModule):
         self.add_resource(Schedules.NextArrivals,
                           region + '<uri:uri>/arrivals',
                           coord + '<uri:uri>/arrivals',
-                          '/arrivals',
+                          region + 'arrivals',
+                          coord + 'arrivals',
                           endpoint='arrivals')
 
         self.add_resource(Schedules.NextDepartures,
                           region + '<uri:uri>/departures',
                           coord + '<uri:uri>/departures',
-                          '/departures',
+                          region + 'departures',
+                          coord + 'departures',
                           endpoint='departures')
 
         self.add_resource(Schedules.StopSchedules,

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -152,8 +152,10 @@ class Scenario(object):
         st = req.next_stop_times
         st.departure_filter = departure_filter
         st.arrival_filter = arrival_filter
-        st.from_datetime = request["from_datetime"]
-        st.until_datetime = request["until_datetime"]
+        if request["from_datetime"]:
+            st.from_datetime = request["from_datetime"]
+        if request["until_datetime"]:
+            st.until_datetime = request["until_datetime"]
         st.duration = request["duration"]
         st.depth = request["depth"]
         st.show_codes = request["show_codes"]
@@ -188,6 +190,12 @@ class Scenario(object):
 
     def next_departures(self, request, instance):
         return self.__stop_times(request, instance, request["filter"], "", type_pb2.NEXT_DEPARTURES)
+
+    def previous_arrivals(self, request, instance):
+        return self.__stop_times(request, instance, "", request["filter"], type_pb2.PREVIOUS_ARRIVALS)
+
+    def previous_departures(self, request, instance):
+        return self.__stop_times(request, instance, request["filter"], "", type_pb2.PREVIOUS_DEPARTURES)
 
     def stops_schedules(self, request, instance):
         return self.__stop_times(request, instance, request["departure_filter"], request["arrival_filter"],

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -153,6 +153,7 @@ class Scenario(object):
         st.departure_filter = departure_filter
         st.arrival_filter = arrival_filter
         st.from_datetime = request["from_datetime"]
+        st.until_datetime = request["until_datetime"]
         st.duration = request["duration"]
         st.depth = request["depth"]
         st.show_codes = request["show_codes"]

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "ptreferential/ptreferential_api.h"
 #include "time_tables/route_schedules.h"
 #include "time_tables/next_passages.h"
+#include "time_tables/previous_passages.h"
 #include "time_tables/2stops_schedules.h"
 #include "time_tables/departure_boards.h"
 #include "disruption/disruption_api.h"
@@ -230,6 +231,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
     this->init_worker_data(data);
 
     bt::ptime from_datetime = bt::from_time_t(request.from_datetime());
+    bt::ptime until_datetime = bt::from_time_t(request.until_datetime());
     try {
         switch(api) {
         case pbnavitia::NEXT_DEPARTURES:
@@ -239,7 +241,19 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     type::AccessibiliteParams(), *data, false, request.count(),
                     request.start_page(), request.show_codes());
         case pbnavitia::NEXT_ARRIVALS:
-            return timetables::next_arrivals(request.arrival_filter(),
+            return timetables::previous_arrivals(request.arrival_filter(),
+                    forbidden_uri, until_datetime,
+                    request.duration(), request.nb_stoptimes(), request.depth(),
+                    type::AccessibiliteParams(),
+                    *data, false, request.count(), request.start_page(), request.show_codes());
+        case pbnavitia::PREVIOUS_DEPARTURES:
+            return timetables::previous_departures(request.departure_filter(),
+                    forbidden_uri, until_datetime,
+                    request.duration(), request.nb_stoptimes(), request.depth(),
+                    type::AccessibiliteParams(), *data, false, request.count(),
+                    request.start_page(), request.show_codes());
+        case pbnavitia::PREVIOUS_ARRIVALS:
+            return timetables::previous_arrivals(request.arrival_filter(),
                     forbidden_uri, from_datetime,
                     request.duration(), request.nb_stoptimes(), request.depth(),
                     type::AccessibiliteParams(),
@@ -591,6 +605,8 @@ pbnavitia::Response Worker::dispatch(const pbnavitia::Request& request) {
         case pbnavitia::ROUTE_SCHEDULES:
         case pbnavitia::NEXT_DEPARTURES:
         case pbnavitia::NEXT_ARRIVALS:
+        case pbnavitia::PREVIOUS_DEPARTURES:
+        case pbnavitia::PREVIOUS_ARRIVALS:
         case pbnavitia::STOPS_SCHEDULES:
         case pbnavitia::DEPARTURE_BOARDS:
             response = next_stop_times(request.next_stop_times(), request.requested_api()); break;

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -241,7 +241,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     type::AccessibiliteParams(), *data, false, request.count(),
                     request.start_page(), request.show_codes());
         case pbnavitia::NEXT_ARRIVALS:
-            return timetables::previous_arrivals(request.arrival_filter(),
+            return timetables::next_arrivals(request.arrival_filter(),
                     forbidden_uri, until_datetime,
                     request.duration(), request.nb_stoptimes(), request.depth(),
                     type::AccessibiliteParams(),

--- a/source/time_tables/CMakeLists.txt
+++ b/source/time_tables/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(thermometer thermometer.cpp)
 target_link_libraries(thermometer types)    
 
-SET(TIME_TABLES_SRC get_stop_times.cpp next_passages.cpp 2stops_schedules.cpp route_schedules.cpp departure_boards.cpp request_handle.cpp)
+SET(TIME_TABLES_SRC get_stop_times.cpp next_passages.cpp 2stops_schedules.cpp route_schedules.cpp departure_boards.cpp request_handle.cpp previous_passages.cpp)
 add_library(time_tables ${TIME_TABLES_SRC})
 #TODO: a static lib doesn't need to be linked with is dependency
 target_link_libraries(time_tables utils types routing autocomplete proximitylist ptreferential georef thermometer)

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -105,7 +105,7 @@ departure_board(const std::string& request,
                 int count, int start_page, const type::Data &data, bool disruption_active,
                 bool show_codes) {
 
-    RequestHandle handler("DEPARTURE_BOARD", request, forbidden_uris, date,  duration, data, calendar_id);
+    RequestHandle handler(request, forbidden_uris, date,  duration, data, calendar_id);
 
     if(handler.pb_response.has_error())
         return handler.pb_response;

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -73,14 +73,17 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
                     result.push_back(std::make_pair(dt_temp, st.first));
                     test_add = true;
                     // The next stop time must be at least one second after
-                    next_requested_datetime[jpp_idx] = clockwise ? dt_temp + 1 : dt_temp - 1;
+                    next_requested_datetime[jpp_idx] = dt_temp + (clockwise? 1 : -1);
                 }
             }
         }
     }
     std::sort(result.begin(), result.end(),
             [&clockwise](datetime_stop_time dst1, datetime_stop_time dst2) {
-            return (clockwise && dst1.first < dst2.first) || (!clockwise && dst1.first > dst2.first);
+            if (clockwise) {
+                return dst1.first < dst2.first;
+            }
+            return dst1.first > dst2.first;
     });
     if (result.size() > max_departures) {
         result.resize(max_departures);
@@ -104,6 +107,7 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
             continue;
         }
         auto st = get_all_stop_times(jpp, calendar_id, accessibilite_params.vehicle_properties);
+
         //afterward we filter the datetime not in [dt, max_dt]
         //the difficult part comes from the fact that for calendar dt are max_dt are not really datetime,
         //there are time but max_dt can be the day after like [today 4:00, tomorow 3:00]

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -53,10 +53,6 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
     for(auto jpp_idx : journey_pattern_points){
         next_requested_datetime[jpp_idx] = dt;
     }
-    auto next_stop_times = std::bind(
-            clockwise ? &routing::NextStopTime::earliest_stop_time : &routing::NextStopTime::tardiest_stop_time,
-            &next_st, std::placeholders::_1, std::placeholders::_2, disruption_active,
-            accessibilite_params.vehicle_properties, true);
 
     while(test_add && result.size() < max_departures) {
         test_add = false;
@@ -65,7 +61,9 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
             if(!jpp->stop_point->accessible(accessibilite_params.properties)) {
                 continue;
             }
-            auto st = next_stop_times(routing::JppIdx(*jpp), next_requested_datetime[jpp_idx]);
+            auto st = next_st.next_stop_time(routing::JppIdx(*jpp), next_requested_datetime[jpp_idx],
+                                             clockwise, disruption_active,
+                                             accessibilite_params.vehicle_properties, true);
 
             if (st.first != nullptr) {
                 DateTime dt_temp = st.second;

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -31,6 +31,7 @@ www.navitia.io
 #include "get_stop_times.h"
 #include "routing/next_stop_time.h"
 #include "type/pb_converter.h"
+#include <functional>
 
 namespace navitia { namespace timetables {
 
@@ -40,7 +41,8 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
                                                const size_t max_departures,
                                                const type::Data& data, 
                                                bool disruption_active,
-                                               const type::AccessibiliteParams& accessibilite_params) {
+                                               const type::AccessibiliteParams& accessibilite_params,
+                                               const bool clockwise) {
     std::vector<datetime_stop_time> result;
     auto test_add = true;
     routing::NextStopTime next_st = routing::NextStopTime(data);
@@ -51,6 +53,10 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
     for(auto jpp_idx : journey_pattern_points){
         next_requested_datetime[jpp_idx] = dt;
     }
+    auto next_stop_times = std::bind(
+            clockwise ? &routing::NextStopTime::earliest_stop_time : &routing::NextStopTime::tardiest_stop_time,
+            &next_st, std::placeholders::_1, std::placeholders::_2, disruption_active,
+            accessibilite_params.vehicle_properties, true);
 
     while(test_add && result.size() < max_departures) {
         test_add = false;
@@ -59,23 +65,23 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
             if(!jpp->stop_point->accessible(accessibilite_params.properties)) {
                 continue;
             }
-            auto st = next_st.earliest_stop_time(routing::JppIdx(*jpp),
-                                                 next_requested_datetime[jpp_idx],
-                                                 disruption_active,
-                                                 accessibilite_params.vehicle_properties);
+            auto st = next_stop_times(routing::JppIdx(*jpp), next_requested_datetime[jpp_idx]);
 
             if (st.first != nullptr) {
                 DateTime dt_temp = st.second;
-                if (dt_temp <= max_dt) {
+                if ( (clockwise && dt_temp <= max_dt) || (!clockwise && dt_temp >= max_dt)) {
                     result.push_back(std::make_pair(dt_temp, st.first));
                     test_add = true;
                     // The next stop time must be at least one second after
-                    next_requested_datetime[jpp_idx] = dt_temp + 1;
+                    next_requested_datetime[jpp_idx] = clockwise ? dt_temp + 1 : dt_temp - 1;
                 }
             }
         }
-     }
-    std::sort(result.begin(), result.end(),[](datetime_stop_time dst1, datetime_stop_time dst2) {return dst1.first < dst2.first;});
+    }
+    std::sort(result.begin(), result.end(),
+            [&clockwise](datetime_stop_time dst1, datetime_stop_time dst2) {
+            return (clockwise && dst1.first < dst2.first) || (!clockwise && dst1.first > dst2.first);
+    });
     if (result.size() > max_departures) {
         result.resize(max_departures);
     }
@@ -98,7 +104,6 @@ std::vector<datetime_stop_time> get_stop_times(const std::vector<type::idx_t>& j
             continue;
         }
         auto st = get_all_stop_times(jpp, calendar_id, accessibilite_params.vehicle_properties);
-
         //afterward we filter the datetime not in [dt, max_dt]
         //the difficult part comes from the fact that for calendar dt are max_dt are not really datetime,
         //there are time but max_dt can be the day after like [today 4:00, tomorow 3:00]

--- a/source/time_tables/get_stop_times.h
+++ b/source/time_tables/get_stop_times.h
@@ -54,7 +54,8 @@ get_stop_times(const std::vector<type::idx_t>& journey_pattern_points,
                const size_t max_departures,
                const type::Data& data,
                bool disruption_active,
-               const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams());
+               const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
+               const bool clockwise = true);
 
 
 std::vector<datetime_stop_time>

--- a/source/time_tables/next_passages.cpp
+++ b/source/time_tables/next_passages.cpp
@@ -50,7 +50,7 @@ next_passages(const std::string &request,
               const type::AccessibiliteParams & accessibilite_params,
               const type::Data & data, bool disruption_active, Visitor vis, uint32_t count,
               uint32_t start_page, const bool show_codes) {
-    RequestHandle handler(vis.api_str, request, forbidden_uris, datetime, duration, data, {});
+    RequestHandle handler(request, forbidden_uris, datetime, duration, data, {});
 
     if(handler.pb_response.has_error()) {
         return handler.pb_response;
@@ -70,10 +70,11 @@ next_passages(const std::string &request,
 
     for(auto dt_stop_time : passages_dt_st) {
         pbnavitia::Passage * passage;
-        if(vis.api_str == "NEXT_ARRIVALS")
+        if(vis.api_pb == pbnavitia::NEXT_ARRIVALS) {
             passage = handler.pb_response.add_next_arrivals();
-        else
+        } else {
             passage = handler.pb_response.add_next_departures();
+        }
         auto departure_date = navitia::to_posix_timestamp(dt_stop_time.first, data);
         auto arrival_date = navitia::to_posix_timestamp(dt_stop_time.first, data);
         passage->mutable_stop_date_time()->set_departure_date_time(departure_date);
@@ -120,11 +121,10 @@ pbnavitia::Response next_departures(const std::string &request,
                 return jpp == last_jpp;
             }
         };
-        std::string api_str;
         pbnavitia::API api_pb;
         predicate_t predicate;
         vis_next_departures(const type::Data& data) :
-            api_str("NEXT_DEPARTURES"), api_pb(pbnavitia::NEXT_DEPARTURES), predicate(data) {}
+            api_pb(pbnavitia::NEXT_DEPARTURES), predicate(data) {}
     };
     vis_next_departures vis(data);
     return next_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
@@ -147,11 +147,10 @@ pbnavitia::Response next_arrivals(const std::string &request,
                 return data.pt_data->journey_pattern_points[jppidx]->order == 0;
             }
         };
-        std::string api_str;
         pbnavitia::API api_pb;
         predicate_t predicate;
         vis_next_arrivals(const type::Data& data) :
-            api_str("NEXT_ARRIVALS"), api_pb(pbnavitia::NEXT_ARRIVALS), predicate(data) {}
+            api_pb(pbnavitia::NEXT_ARRIVALS), predicate(data) {}
     };
     vis_next_arrivals vis(data);
     return next_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -50,7 +50,7 @@ previous_passages(const std::string &request,
               const type::AccessibiliteParams & accessibilite_params,
               const type::Data & data, bool disruption_active, Visitor vis, uint32_t count,
               uint32_t start_page, const bool show_codes) {
-    RequestHandle handler(vis.api_str, request, forbidden_uris, datetime, duration, data, {}, false);
+    RequestHandle handler(request, forbidden_uris, datetime, duration, data, {}, false);
 
     if(handler.pb_response.has_error()) {
         return handler.pb_response;
@@ -71,10 +71,11 @@ previous_passages(const std::string &request,
 
     for(auto dt_stop_time : passages_dt_st) {
         pbnavitia::Passage * passage;
-        if(vis.api_str == "NEXT_ARRIVALS")
+        if(vis.api_pb == pbnavitia::PREVIOUS_ARRIVALS) {
             passage = handler.pb_response.add_next_arrivals();
-        else
+        } else {
             passage = handler.pb_response.add_next_departures();
+        }
         auto departure_date = navitia::to_posix_timestamp(dt_stop_time.first, data);
         auto arrival_date = navitia::to_posix_timestamp(dt_stop_time.first, data);
         passage->mutable_stop_date_time()->set_departure_date_time(departure_date);
@@ -121,11 +122,10 @@ pbnavitia::Response previous_departures(const std::string &request,
                 return jpp == last_jpp;
             }
         };
-        std::string api_str;
         pbnavitia::API api_pb;
         predicate_t predicate;
         vis_previous_departures(const type::Data& data) :
-            api_str("NEXT_DEPARTURES"), api_pb(pbnavitia::NEXT_DEPARTURES), predicate(data) {}
+            api_pb(pbnavitia::PREVIOUS_DEPARTURES), predicate(data) {}
     };
     vis_previous_departures vis(data);
     return previous_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
@@ -148,11 +148,10 @@ pbnavitia::Response previous_arrivals(const std::string &request,
                 return data.pt_data->journey_pattern_points[jppidx]->order == 0;
             }
         };
-        std::string api_str;
         pbnavitia::API api_pb;
         predicate_t predicate;
         vis_previous_arrivals(const type::Data& data) :
-            api_str("PREVIOUS_ARRIVALS"), api_pb(pbnavitia::PREVIOUS_ARRIVALS), predicate(data) {}
+            api_pb(pbnavitia::PREVIOUS_ARRIVALS), predicate(data) {}
     };
     vis_previous_arrivals vis(data);
     return previous_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -1,0 +1,163 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+  
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+ 
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+  
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+   
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+   
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+  
+Stay tuned using
+twitter @navitia 
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "previous_passages.h"
+#include "get_stop_times.h"
+#include "request_handle.h"
+#include "boost/date_time/posix_time/posix_time.hpp"
+#include "type/datetime.h"
+#include "ptreferential/ptreferential.h"
+#include "utils/paginate.h"
+
+
+namespace pt = boost::posix_time;
+
+namespace navitia { namespace timetables {
+
+template<typename Visitor>
+pbnavitia::Response
+previous_passages(const std::string &request,
+              const std::vector<std::string>& forbidden_uris,
+              const pt::ptime datetime,
+              uint32_t duration, uint32_t nb_stoptimes, const int depth,
+              const type::AccessibiliteParams & accessibilite_params,
+              const type::Data & data, bool disruption_active, Visitor vis, uint32_t count,
+              uint32_t start_page, const bool show_codes) {
+    RequestHandle handler(vis.api_str, request, forbidden_uris, datetime, duration, data, {}, false);
+
+    if(handler.pb_response.has_error()) {
+        return handler.pb_response;
+    }
+
+    std::remove_if(handler.journey_pattern_points.begin(),
+                   handler.journey_pattern_points.end(), vis.predicate);
+
+    auto passages_dt_st = get_stop_times(handler.journey_pattern_points,
+                            handler.date_time, handler.max_datetime,
+                            nb_stoptimes, data, disruption_active, accessibilite_params,
+                            false);
+    size_t total_result = passages_dt_st.size();
+    passages_dt_st = paginate(passages_dt_st, count, start_page);
+    auto now = pt::second_clock::local_time();
+    pt::time_period action_period(navitia::to_posix_time(handler.date_time, data),
+                                  navitia::to_posix_time(handler.max_datetime, data));
+
+    for(auto dt_stop_time : passages_dt_st) {
+        pbnavitia::Passage * passage;
+        if(vis.api_str == "NEXT_ARRIVALS")
+            passage = handler.pb_response.add_next_arrivals();
+        else
+            passage = handler.pb_response.add_next_departures();
+        auto departure_date = navitia::to_posix_timestamp(dt_stop_time.first, data);
+        auto arrival_date = navitia::to_posix_timestamp(dt_stop_time.first, data);
+        passage->mutable_stop_date_time()->set_departure_date_time(departure_date);
+        passage->mutable_stop_date_time()->set_arrival_date_time(arrival_date);
+        const type::JourneyPatternPoint* jpp = dt_stop_time.second->journey_pattern_point;
+        fill_pb_object(jpp->stop_point, data, passage->mutable_stop_point(),
+                depth, now, action_period);
+        const type::VehicleJourney* vj = dt_stop_time.second->vehicle_journey;
+        const type::JourneyPattern* jp = vj->journey_pattern;
+        const type::Route* route = jp->route;
+        const type::Line* line = route->line;
+        const type::PhysicalMode* physical_mode = jp->physical_mode;
+        auto m_vj = passage->mutable_vehicle_journey();
+        auto m_route = m_vj->mutable_route();
+        auto m_physical_mode = m_vj->mutable_journey_pattern()->mutable_physical_mode();
+        fill_pb_object(vj, data, m_vj, 0, now, action_period, show_codes);
+        fill_pb_object(route, data, m_route, 0, now, action_period, show_codes);
+        fill_pb_object(line, data, m_route->mutable_line(), 0, now, action_period, show_codes);
+        fill_pb_object(physical_mode, data, m_physical_mode, 0, now, action_period);
+    }
+    auto pagination = handler.pb_response.mutable_pagination();
+    pagination->set_totalresult(total_result);
+    pagination->set_startpage(start_page);
+    pagination->set_itemsperpage(count);
+    pagination->set_itemsonpage(passages_dt_st.size());
+    return handler.pb_response;
+}
+
+
+pbnavitia::Response previous_departures(const std::string &request,
+        const std::vector<std::string>& forbidden_uris,
+        const pt::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
+        const int depth, const type::AccessibiliteParams & accessibilite_params,
+        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const bool show_codes) {
+
+    struct vis_previous_departures {
+        struct predicate_t {
+            const type::Data &data;
+            predicate_t(const type::Data& data) : data(data){}
+            bool operator()(const type::idx_t jppidx) const {
+                auto jpp = data.pt_data->journey_pattern_points[jppidx];
+                auto last_jpp = jpp->journey_pattern->journey_pattern_point_list.back();
+                return jpp == last_jpp;
+            }
+        };
+        std::string api_str;
+        pbnavitia::API api_pb;
+        predicate_t predicate;
+        vis_previous_departures(const type::Data& data) :
+            api_str("NEXT_DEPARTURES"), api_pb(pbnavitia::NEXT_DEPARTURES), predicate(data) {}
+    };
+    vis_previous_departures vis(data);
+    return previous_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
+                         accessibilite_params, data, disruption_active, vis, count, start_page, show_codes);
+}
+
+
+pbnavitia::Response previous_arrivals(const std::string &request,
+        const std::vector<std::string>& forbidden_uris,
+        const pt::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
+        const int depth, const type::AccessibiliteParams & accessibilite_params,
+        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const bool show_codes) {
+
+    struct vis_previous_arrivals {
+        struct predicate_t {
+            const type::Data &data;
+            predicate_t(const type::Data& data) : data(data){}
+            bool operator()(const type::idx_t jppidx) const{
+                return data.pt_data->journey_pattern_points[jppidx]->order == 0;
+            }
+        };
+        std::string api_str;
+        pbnavitia::API api_pb;
+        predicate_t predicate;
+        vis_previous_arrivals(const type::Data& data) :
+            api_str("PREVIOUS_ARRIVALS"), api_pb(pbnavitia::PREVIOUS_ARRIVALS), predicate(data) {}
+    };
+    vis_previous_arrivals vis(data);
+    return previous_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
+            accessibilite_params, data, disruption_active, vis,count , start_page, show_codes);
+}
+
+
+} }

--- a/source/time_tables/previous_passages.h
+++ b/source/time_tables/previous_passages.h
@@ -1,0 +1,49 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+  
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+ 
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+  
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+   
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+   
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+  
+Stay tuned using
+twitter @navitia 
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include "type/pb_converter.h"
+namespace navitia { namespace timetables {
+
+
+pbnavitia::Response previous_departures(const std::string &request,
+        const std::vector<std::string>& forbidden_uris,
+        const boost::posix_time::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
+        const int depth, const type::AccessibiliteParams & accessibilite_params,
+        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const bool show_codes);
+pbnavitia::Response previous_arrivals(const std::string &request,
+        const std::vector<std::string>& forbidden_uris,
+        const boost::posix_time::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
+        const int depth, const type::AccessibiliteParams & accessibilite_params,
+        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const bool show_codes);
+
+}}

--- a/source/time_tables/request_handle.cpp
+++ b/source/time_tables/request_handle.cpp
@@ -55,7 +55,7 @@ RequestHandle::RequestHandle(const std::string &request,
 
     if(! pb_response.has_error()){
         date_time = DateTimeUtils::set((datetime.date() - data.meta->production_date.begin()).days(), datetime.time_of_day().total_seconds());
-        max_datetime = clockwise ? (date_time + duration) : (date_time - duration);
+        max_datetime = date_time + duration * (clockwise ? 1 : -1);
         const auto jpp_t = type::Type_e::JourneyPatternPoint;
 
         try {

--- a/source/time_tables/request_handle.cpp
+++ b/source/time_tables/request_handle.cpp
@@ -38,7 +38,8 @@ RequestHandle::RequestHandle(const std::string& /*api*/, const std::string &requ
                              const std::vector<std::string>& forbidden_uris,
                              const pt::ptime datetime, uint32_t duration,
                              const type::Data &data,
-                             boost::optional<const std::string> calendar_id) :
+                             boost::optional<const std::string> calendar_id,
+                             const bool clockwise) :
     date_time(DateTimeUtils::inf), max_datetime(DateTimeUtils::inf){
 
     if (! calendar_id) {
@@ -54,7 +55,7 @@ RequestHandle::RequestHandle(const std::string& /*api*/, const std::string &requ
 
     if(! pb_response.has_error()){
         date_time = DateTimeUtils::set((datetime.date() - data.meta->production_date.begin()).days(), datetime.time_of_day().total_seconds());
-        max_datetime = date_time + duration;
+        max_datetime = clockwise ? (date_time + duration) : (date_time - duration);
         const auto jpp_t = type::Type_e::JourneyPatternPoint;
 
         try {

--- a/source/time_tables/request_handle.cpp
+++ b/source/time_tables/request_handle.cpp
@@ -34,7 +34,7 @@ www.navitia.io
 
 namespace navitia { namespace timetables {
 
-RequestHandle::RequestHandle(const std::string& /*api*/, const std::string &request,
+RequestHandle::RequestHandle(const std::string &request,
                              const std::vector<std::string>& forbidden_uris,
                              const pt::ptime datetime, uint32_t duration,
                              const type::Data &data,

--- a/source/time_tables/request_handle.h
+++ b/source/time_tables/request_handle.h
@@ -44,7 +44,7 @@ struct RequestHandle {
     std::vector<type::idx_t> journey_pattern_points;
     int total_result;
 
-    RequestHandle(const std::string& api, const std::string& request,
+    RequestHandle(const std::string& request,
                   const std::vector<std::string>& forbidden_uris,
                   const boost::posix_time::ptime datetime, uint32_t duration,
                   const type::Data& data,

--- a/source/time_tables/request_handle.h
+++ b/source/time_tables/request_handle.h
@@ -48,7 +48,7 @@ struct RequestHandle {
                   const std::vector<std::string>& forbidden_uris,
                   const boost::posix_time::ptime datetime, uint32_t duration,
                   const type::Data& data,
-                  boost::optional<const std::string> calendar_id);
+                  boost::optional<const std::string> calendar_id, const bool clockwise = true);
 };
 }
 

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -181,7 +181,7 @@ route_schedule(const std::string& filter,
                uint32_t duration, uint32_t interface_version,
                const uint32_t max_depth, int count, int start_page,
                const type::Data &d, bool disruption_active, const bool show_codes) {
-    RequestHandle handler("ROUTE_SCHEDULE", filter, forbidden_uris, datetime, duration, d, {});
+    RequestHandle handler(filter, forbidden_uris, datetime, duration, d, {});
 
     if(handler.pb_response.has_error()) {
         return handler.pb_response;

--- a/source/time_tables/tests/get_stop_times.cpp
+++ b/source/time_tables/tests/get_stop_times.cpp
@@ -50,6 +50,8 @@ BOOST_AUTO_TEST_CASE(test1){
     auto result = get_stop_times(jpps, navitia::DateTimeUtils::min, navitia::DateTimeUtils::inf, 1, *b.data, false);
     BOOST_REQUIRE_EQUAL(result.size(), 1);
 
+    result = get_stop_times(jpps, navitia::DateTimeUtils::set(0, 86399), navitia::DateTimeUtils::min, 1, *b.data, false, {}, false);
+    BOOST_REQUIRE_EQUAL(result.size(), 1);
 }
 
 /**

--- a/source/time_tables/tests/get_stop_times.cpp
+++ b/source/time_tables/tests/get_stop_times.cpp
@@ -39,7 +39,7 @@ using namespace navitia;
 
 BOOST_AUTO_TEST_CASE(test1){
     ed::builder b("20120614");
-    b.vj("A")("stop1", 8000, 8050)("stop2", 8100,8150);
+    b.vj("A")("stop1", 8000, 8050)("stop2", 8100,8150)("stop3", 8200, 8250);
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
@@ -47,11 +47,22 @@ BOOST_AUTO_TEST_CASE(test1){
     std::vector<navitia::type::idx_t> jpps;
     for(auto jpp : b.data->pt_data->journey_pattern_points)
         jpps.push_back(jpp->idx);
-    auto result = get_stop_times(jpps, navitia::DateTimeUtils::min, navitia::DateTimeUtils::inf, 1, *b.data, false);
-    BOOST_REQUIRE_EQUAL(result.size(), 1);
 
-    result = get_stop_times(jpps, navitia::DateTimeUtils::set(0, 86399), navitia::DateTimeUtils::min, 1, *b.data, false, {}, false);
-    BOOST_REQUIRE_EQUAL(result.size(), 1);
+    auto result = get_stop_times(jpps, navitia::DateTimeUtils::min, navitia::DateTimeUtils::set(1, 0), 100, *b.data, false);
+    BOOST_REQUIRE_EQUAL(result.size(), 2);
+    BOOST_CHECK(std::any_of(result.begin(), result.end(),
+                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 0;}));
+    BOOST_CHECK(std::any_of(result.begin(), result.end(),
+                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 1;}));
+
+    result = get_stop_times(jpps, navitia::DateTimeUtils::set(0, 86399), navitia::DateTimeUtils::min, 100, *b.data, false, {}, false);
+    BOOST_REQUIRE_EQUAL(result.size(), 2);
+    BOOST_CHECK(std::any_of(result.begin(), result.end(),
+                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 1;}));
+    BOOST_CHECK(std::any_of(result.begin(), result.end(),
+                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 2;}));
+
+
 }
 
 /**

--- a/source/type/request.proto
+++ b/source/type/request.proto
@@ -45,6 +45,7 @@ message NextStopTimeRequest {
     repeated string forbidden_uri       = 12;
     optional string calendar            = 13;
     optional bool show_codes            = 14;
+    required uint64 until_datetime      = 15;
 }
 
 message StreetNetworkParams{

--- a/source/type/request.proto
+++ b/source/type/request.proto
@@ -34,7 +34,7 @@ message PlacesRequest {
 message NextStopTimeRequest {
     required string departure_filter    = 1;
     required string arrival_filter      = 2;
-    required uint64 from_datetime       = 3;
+    optional uint64 from_datetime       = 3;
     required int32 duration             = 4;
     required int32 depth                = 5;
     required int32 nb_stoptimes         = 7;
@@ -45,7 +45,7 @@ message NextStopTimeRequest {
     repeated string forbidden_uri       = 12;
     optional string calendar            = 13;
     optional bool show_codes            = 14;
-    required uint64 until_datetime      = 15;
+    optional uint64 until_datetime      = 15;
 }
 
 message StreetNetworkParams{

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -42,6 +42,8 @@ enum API {
     NMPLANNER = 19;
     pt_objects = 20;
     place_code = 21;
+    PREVIOUS_DEPARTURES = 23;
+    PREVIOUS_ARRIVALS = 24;
 }
 
 enum VehicleJourneyType{


### PR DESCRIPTION
You can ask for previous passages with the parameter until_datetime in departures and arrivals.

I have a problem of exclusive parameters because we have a duration parameter so you can't have both from_datetime and until_datetime filled with the duration parameter.
