### PR TITLE
raptor: activate global bound

### DIFF
--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -276,7 +276,7 @@ class TestLongWaitingDurationFilter(AbstractTestFixture):
             .format(from_sa="A", to_sa="D", datetime="20120614T080000")
 
         response = self.query_region(query, display=False)
-        eq_(len(response['journeys']), 3)
+        eq_(len(response['journeys']), 2)
         eq_(response['journeys'][0]['arrival_date_time'], "20120614T150000")
         eq_(response['journeys'][0]['type'], "")
         eq_(response['journeys'][1]['arrival_date_time'], "20120614T160000")

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -170,10 +170,7 @@ void RAPTOR::clear(const bool clockwise, const DateTime bound) {
     const size_t journey_pattern_points_size = data.pt_data->journey_pattern_points.size();
     b_dest.reinit(journey_pattern_points_size, bound);
     this->make_queue();
-    if(clockwise)
-        boost::fill(best_labels.values(), DateTimeUtils::inf);
-    else
-        boost::fill(best_labels.values(), DateTimeUtils::min);
+    boost::fill(best_labels.values(), bound);
 }
 
 

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -652,7 +652,8 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     ));
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (8*3600+45*60)), false, true);
 
-    BOOST_REQUIRE_EQUAL(res1.size(), 2);
+    // As the bound is tight, we now only have the shortest trip.
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
                             [&](const Path& p){
         return p.items.size() == 5  &&


### PR DESCRIPTION
israel: 118.55 -> 115.38 => 3% faster
idf: 60.89 -> 51.56 => 15% faster
fr-pdl: 90.36 -> 71.74 => 21% faster
