### PR TITLE
Raptor: split label on Stop point and not on jpp

### DIFF
--- a/source/routing/CMakeLists.txt
+++ b/source/routing/CMakeLists.txt
@@ -2,7 +2,7 @@ SET(BOOST_LIBS ${Boost_THREAD_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
     ${Boost_SERIALIZATION_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
 
-SET(ROUTING_SRC routing.cpp raptor_solutions.cpp raptor_path.cpp raptor.cpp raptor_api.cpp next_stop_time.cpp dataraptor.cpp raptor_utils.cpp)
+SET(ROUTING_SRC routing.cpp raptor_solutions.cpp raptor_path.cpp raptor.cpp raptor_api.cpp next_stop_time.cpp dataraptor.cpp raptor_utils.cpp raptor_solution_filter.cpp)
 
 add_library(routing ${ROUTING_SRC})
 

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -181,7 +181,6 @@ int main(int argc, char** argv){
     Timer t("Calcul avec l'algorithme ");
     //ProfilerStart("bench.prof");
     int nb_reponses = 0;
-    size_t nb_exceptions(0);
     for(auto demand : demands){
         ++show_progress;
         Timer t2;
@@ -194,17 +193,12 @@ int main(int argc, char** argv){
                       << ", " << demand.hour
                       << "\n";
         }
-        Path path;
-        try {
-            auto res = router.compute(data.pt_data->stop_areas[demand.start], data.pt_data->stop_areas[demand.target], demand.hour, demand.date, DateTimeUtils::set(demand.date + 1, demand.hour),false, true);
+        auto res = router.compute(data.pt_data->stop_areas[demand.start], data.pt_data->stop_areas[demand.target], demand.hour, demand.date, DateTimeUtils::set(demand.date + 1, demand.hour),false, true);
 
-            if(res.size() > 0) {
-                path = res[0];
-                ++ nb_reponses;
-            }
-        }
-        catch (const navitia::recoverable_exception&) {
-            ++nb_exceptions;
+        Path path;
+        if(res.size() > 0) {
+            path = res[0];
+            ++ nb_reponses;
         }
 
         Result result(path);
@@ -244,7 +238,6 @@ int main(int argc, char** argv){
     }
     out_file.close();
 
-    std::cout << "Number of requests : " << demands.size() << std::endl;
-    std::cout << "Number of results with solution " << nb_reponses << std::endl;
-    std::cout << "Number of recoverable excetions caught " << nb_exceptions << std::endl;
+    std::cout << "Number of requests: " << demands.size() << std::endl;
+    std::cout << "Number of results with solution: " << nb_reponses << std::endl;
 }

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -37,6 +37,9 @@ www.navitia.io
 #include <fstream>
 #include "utils/init.h"
 #include "utils/csv.h"
+#ifdef __BENCH_WITH_CALGRIND__
+#include "valgrind/callgrind.h"
+#endif
 
 using namespace navitia;
 using namespace routing;
@@ -181,6 +184,9 @@ int main(int argc, char** argv){
     Timer t("Calcul avec l'algorithme ");
     //ProfilerStart("bench.prof");
     int nb_reponses = 0;
+#ifdef __BENCH_WITH_CALGRIND__
+    CALLGRIND_START_INSTRUMENTATION;
+#endif
     for(auto demand : demands){
         ++show_progress;
         Timer t2;
@@ -206,6 +212,9 @@ int main(int argc, char** argv){
         results.push_back(result);
     }
     //ProfilerStop();
+#ifdef __BENCH_WITH_CALGRIND__
+    CALLGRIND_STOP_INSTRUMENTATION;
+#endif
 
 
     Timer ecriture("Writing results");

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -181,6 +181,7 @@ int main(int argc, char** argv){
     Timer t("Calcul avec l'algorithme ");
     //ProfilerStart("bench.prof");
     int nb_reponses = 0;
+    size_t nb_exceptions(0);
     for(auto demand : demands){
         ++show_progress;
         Timer t2;
@@ -193,12 +194,17 @@ int main(int argc, char** argv){
                       << ", " << demand.hour
                       << "\n";
         }
-        auto res = router.compute(data.pt_data->stop_areas[demand.start], data.pt_data->stop_areas[demand.target], demand.hour, demand.date, DateTimeUtils::set(demand.date + 1, demand.hour),false, true);
-
         Path path;
-        if(res.size() > 0) {
-            path = res[0];
-            ++ nb_reponses;
+        try {
+            auto res = router.compute(data.pt_data->stop_areas[demand.start], data.pt_data->stop_areas[demand.target], demand.hour, demand.date, DateTimeUtils::set(demand.date + 1, demand.hour),false, true);
+
+            if(res.size() > 0) {
+                path = res[0];
+                ++ nb_reponses;
+            }
+        }
+        catch (const navitia::recoverable_exception&) {
+            ++nb_exceptions;
         }
 
         Result result(path);
@@ -238,6 +244,7 @@ int main(int argc, char** argv){
     }
     out_file.close();
 
-    std::cout << "Number of requests :" << demands.size() << std::endl;
-    std::cout << "Number of results with solution" << nb_reponses << std::endl;
+    std::cout << "Number of requests : " << demands.size() << std::endl;
+    std::cout << "Number of results with solution " << nb_reponses << std::endl;
+    std::cout << "Number of recoverable excetions caught " << nb_exceptions << std::endl;
 }

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -37,8 +37,8 @@ www.navitia.io
 namespace navitia { namespace routing {
 
 void dataRAPTOR::Connections::load(const type::PT_Data &data) {
-    forward_connections.assign(data.stop_points.size());
-    backward_connections.assign(data.stop_points.size());
+    forward_connections.assign(data.stop_points);
+    backward_connections.assign(data.stop_points);
     for (const auto* conn: data.stop_point_connections) {
         forward_connections[SpIdx(*conn->departure)].push_back(
             {DateTime(conn->duration), SpIdx(*conn->destination)});
@@ -50,7 +50,7 @@ void dataRAPTOR::Connections::load(const type::PT_Data &data) {
 }
 
 void dataRAPTOR::JppsFromSp::load(const type::PT_Data &data) {
-    jpps_from_sp.assign(data.stop_points.size());
+    jpps_from_sp.assign(data.stop_points);
     for (const auto* sp: data.stop_points) {
         for (const auto* jpp: sp->journey_pattern_point_list) {
             jpps_from_sp[SpIdx(*sp)].push_back({JppIdx(*jpp), JpIdx(*jpp->journey_pattern), jpp->order});
@@ -68,7 +68,7 @@ void dataRAPTOR::JppsFromSp::filter_jpps(const boost::dynamic_bitset<>& valid_jp
 }
 
 void dataRAPTOR::JppsFromJp::load(const type::PT_Data &data) {
-    jpps_from_jp.assign(data.journey_patterns.size());
+    jpps_from_jp.assign(data.journey_patterns);
     for (const auto* jp: data.journey_patterns) {
         const bool has_freq = !jp->frequency_vehicle_journey_list.empty();
         for (const auto* jpp: jp->journey_pattern_point_list) {
@@ -82,8 +82,8 @@ void dataRAPTOR::JppsFromJp::load(const type::PT_Data &data) {
 
 void dataRAPTOR::load(const type::PT_Data &data)
 {
-    labels_const.init_inf(data.stop_points.size());
-    labels_const_reverse.init_min(data.stop_points.size());
+    labels_const.init_inf(data.stop_points);
+    labels_const_reverse.init_min(data.stop_points);
 
     connections.load(data);
     jpps_from_sp.load(data);

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -82,8 +82,8 @@ void dataRAPTOR::JppsFromJp::load(const type::PT_Data &data) {
 
 void dataRAPTOR::load(const type::PT_Data &data)
 {
-    labels_const.init_inf(data.journey_pattern_points.size());
-    labels_const_reverse.init_min(data.journey_pattern_points.size());
+    labels_const.init_inf(data.stop_points.size());
+    labels_const_reverse.init_min(data.stop_points.size());
 
     connections.load(data);
     jpps_from_sp.load(data);

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -71,6 +71,10 @@ struct dataRAPTOR {
         void load(const navitia::type::PT_Data &data);
         void filter_jpps(const boost::dynamic_bitset<>& valid_jpps);
 
+        inline IdxMap<type::StopPoint, std::vector<Jpp>>::const_iterator
+        begin() const { return jpps_from_sp.begin(); }
+        inline IdxMap<type::StopPoint, std::vector<Jpp>>::const_iterator
+        end() const { return jpps_from_sp.end(); }
     private:
         IdxMap<type::StopPoint, std::vector<Jpp>> jpps_from_sp;
     };

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -48,15 +48,8 @@ struct dataRAPTOR {
             DateTime duration;
             SpIdx sp_idx;
         };
-        inline const std::vector<Connection>& get_forward(const SpIdx& sp) const {
-            return forward_connections[sp];
-        }
-        inline const std::vector<Connection>& get_backward(const SpIdx& sp) const {
-            return backward_connections[sp];
-        }
         void load(const navitia::type::PT_Data &data);
 
-    private:
         // for a stop point, get the corresponding forward connections
         IdxMap<type::StopPoint, std::vector<Connection>> forward_connections;
         // for a stop point, get the corresponding backward connections

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -86,8 +86,8 @@ void NextStopTimeData::TimesStopTimes<Cmp>::init(const type::JourneyPattern* jp,
 }
 
 void NextStopTimeData::load(const type::PT_Data &data) {
-    forward.assign(data.journey_pattern_points.size());
-    backward.assign(data.journey_pattern_points.size());
+    forward.assign(data.journey_pattern_points);
+    backward.assign(data.journey_pattern_points);
 
     for(const auto* jp: data.journey_patterns) {
         for (const auto* jpp: jp->journey_pattern_point_list) {

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -675,17 +675,4 @@ int RAPTOR::best_round(SpIdx sp_idx){
     return -1;
 }
 
-const type::JourneyPatternPoint* RAPTOR::get_used_jpp(const Labels& label, SpIdx sp_idx) const {
-    //get the first jpp corresponding to the stop point, for the jp used by raptor
-    const auto jpp_idx = label.boarding_jpp_pt(sp_idx);
-    const auto boarding_jpp = get_jpp(jpp_idx);
-    for (const auto& jpp: boarding_jpp->journey_pattern->journey_pattern_point_list) {
-        if (SpIdx(*jpp->stop_point) == sp_idx) {
-            return jpp;
-        }
-    }
-    LOG4CPLUS_ERROR(log4cplus::Logger::getInstance("log"), "impossible rebuild the raptor path, cannot find stop point idx ");
-    throw navitia::exception("impossible to rebuild the raptor path");
-}
-
 }}

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/fill.hpp>
+#include "raptor_solution_filter.h"
 
 namespace bt = boost::posix_time;
 
@@ -269,7 +270,8 @@ RAPTOR::compute_all(const vec_stop_point_duration& departures_,
         }));
     }
     BOOST_ASSERT( departures.size() > 0 );    //Assert that reversal search was symetric
-    return result;
+
+    return filter_journeys(result);
 }
 
 std::vector<std::pair<type::EntryPoint, std::vector<Path>>>

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -131,6 +131,7 @@ bool RAPTOR::foot_path(const Visitor& v) {
             working_labels.mut_dt_transfer(destination_sp_idx) = next;
 
             best_labels_transfers[destination_sp_idx] = next;
+            result = true;
         }
     }
 
@@ -141,7 +142,6 @@ bool RAPTOR::foot_path(const Visitor& v) {
         for (const auto& jpp: sp_jpps.second) {
             if (v.comp(jpp.order, Q[jpp.jp_idx])) {
                 Q[jpp.jp_idx] = jpp.order;
-                result = true;
             }
         }
     }

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -90,6 +90,7 @@ bool RAPTOR::apply_vj_extension(const Visitor& v, const bool global_pruning,
             best_labels[sp_idx] = workingDt;
             this->b_dest.add_best(v, sp_idx, workingDt, this->count);
             add_vj = true;
+            result = true;
         }
         //If we never marked a vj, we don't want to continue
         //This is usefull when there is a loop
@@ -220,7 +221,7 @@ RAPTOR::compute_all(const vec_stop_point_duration& departures_,
     auto calc_dep = clockwise ? departures_ : destinations;
     auto calc_dest = clockwise ? destinations : departures_;
 
-    auto departures = get_solutions(calc_dep, departure_datetime, clockwise, *this, disruption_active);
+    auto departures = init_departures(calc_dep, departure_datetime, clockwise, disruption_active);
     clear(clockwise, bound);
     init(departures, calc_dest, bound, clockwise);
 
@@ -298,7 +299,7 @@ RAPTOR::compute_nm_all(const std::vector<std::pair<type::EntryPoint, vec_stop_po
         for (const auto& n_stop_point : n_point.second)
             calc_dep.push_back(n_stop_point);
 
-    auto calc_dep_solutions = get_solutions(calc_dep, departure_datetime, clockwise, *this, disruption_active);
+    auto calc_dep_solutions = init_departures(calc_dep, departure_datetime, clockwise, disruption_active);
     clear(clockwise, bound);
     init(calc_dep_solutions, {}, bound, clockwise); // no exit condition (should be improved)
 
@@ -368,7 +369,7 @@ RAPTOR::isochrone(const vec_stop_point_duration &departures_,
                          forbidden,
                          disruption_active,
                          allow_odt);
-    auto departures = get_solutions(departures_, departure_datetime, true, *this, disruption_active);
+    auto departures = init_departures(departures_, departure_datetime, true, disruption_active);
     clear(clockwise, bound);
     init(departures, {}, bound, true);
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -84,6 +84,7 @@ bool RAPTOR::apply_vj_extension(const Visitor& v, const bool global_pruning,
                 continue;
             }
             working_labels.mut_boarding_jpp_pt(sp_idx) = state.boarding_jpp_idx;
+            working_labels.mut_used_jpp(sp_idx) = JppIdx(*st.journey_pattern_point);
             working_labels.mut_dt_pt(sp_idx) = workingDt;
             best_labels[sp_idx] = workingDt;
             this->b_dest.add_best(v, sp_idx, workingDt, this->count);
@@ -587,6 +588,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const type::AccessibiliteParams & acce
                             if (visitor.comp(workingDt, bound) || best_add_result) {
                                 working_labels.mut_dt_pt(jpp.sp_idx) = workingDt;
                                 working_labels.mut_boarding_jpp_pt(jpp.sp_idx) = boarding_idx;
+                                working_labels.mut_used_jpp(jpp.sp_idx) = jpp.idx;
                                 best_labels[jpp.sp_idx] = working_labels.dt_pt(jpp.sp_idx);
                             }
                         }

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -151,7 +151,7 @@ bool RAPTOR::foot_path(const Visitor& v) {
 
 void RAPTOR::clear(const bool clockwise, const DateTime bound) {
     const int queue_value = clockwise ?  std::numeric_limits<int>::max() : -1;
-    Q.assign(data.pt_data->journey_patterns.size(), queue_value);
+    Q.assign(data.pt_data->journey_patterns, queue_value);
     if (labels.empty()) {
         labels.resize(5);
     }
@@ -161,7 +161,7 @@ void RAPTOR::clear(const bool clockwise, const DateTime bound) {
         lbl_list.clear(clean_labels);
     }
 
-    b_dest.reinit(data.pt_data->stop_points.size(), bound);
+    b_dest.reinit(data.pt_data->stop_points, bound);
     boost::fill(best_labels.values(), bound);
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -121,13 +121,11 @@ bool RAPTOR::foot_path(const Visitor& v) {
 
         for (const auto& conn: sp_cnx.second) {
             const SpIdx destination_sp_idx = conn.sp_idx;
-
             const DateTime next = v.combine(previous, conn.duration);
 
             if (! v.comp(next, working_labels.dt_transfer(destination_sp_idx))) { continue; }
 
             working_labels.mut_boarding_sp_transfer(destination_sp_idx) = sp_idx;
-
             working_labels.mut_dt_transfer(destination_sp_idx) = next;
 
             if (v.comp(next, best_labels[destination_sp_idx])) {
@@ -668,7 +666,6 @@ std::vector<Path> RAPTOR::compute(const type::StopArea* departure,
 
 
 int RAPTOR::best_round(SpIdx sp_idx){
-    //Q: a mon avis on peut virer cette methode
     for (size_t i = 0; i <= this->count; ++i) {
         if (labels[i].dt_pt(sp_idx) == best_labels[sp_idx]) {
             return i;

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -91,8 +91,6 @@ struct RAPTOR
             labels.assign(10, data.dataRaptor->labels_const);
     }
 
-
-
     void clear(bool clockwise, DateTime bound);
 
     ///Initialise les structure retour et b_dest
@@ -108,8 +106,6 @@ struct RAPTOR
     const type::JourneyPatternPoint* get_jpp(JppIdx jpp_idx) const {
         return data.pt_data->journey_pattern_points[jpp_idx.val];
     }
-
-    const type::JourneyPatternPoint* get_used_jpp(const Labels& label, SpIdx sp_idx) const;
 
     const type::StopPoint* get_sp(SpIdx idx) const {
         return data.pt_data->stop_points[idx.val];

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -77,7 +77,7 @@ struct RAPTOR
     ///La journey_pattern est elle valide ?
     boost::dynamic_bitset<> valid_journey_patterns;
     dataRAPTOR::JppsFromSp jpps_from_sp;
-    ///L'ordre du premier journey_pattern point de la journey_pattern
+    ///Order of the first journey_pattern point of each journey_pattern
     IdxMap<type::JourneyPattern, int> Q;
 
     //Constructeur

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -70,7 +70,9 @@ struct RAPTOR
     /// Each element of index i in this vector represents the labels with i transfers
     std::vector<Labels> labels;
     ///Contains the best arrival (or departure time) for each stoppoint
-    IdxMap<type::StopPoint, DateTime> best_labels;
+    IdxMap<type::StopPoint, DateTime> best_labels_pts;
+    IdxMap<type::StopPoint, DateTime> best_labels_transfers;
+
     /// Contains the best way to reach a destination point
     best_dest b_dest;
     /// Number of transfers done for the moment

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -84,7 +84,7 @@ struct RAPTOR
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
         next_st(data),
-        best_labels(data.pt_data->journey_pattern_points.size()),
+        best_labels(data.pt_data->stop_points.size()),
         count(0),
         valid_journey_patterns(data.pt_data->journey_patterns.size()),
         Q(data.pt_data->journey_patterns.size()) {

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -84,10 +84,10 @@ struct RAPTOR
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
         next_st(data),
-        best_labels(data.pt_data->stop_points.size()),
+        best_labels(data.pt_data->stop_points),
         count(0),
         valid_journey_patterns(data.pt_data->journey_patterns.size()),
-        Q(data.pt_data->journey_patterns.size()) {
+        Q(data.pt_data->journey_patterns) {
             labels.assign(10, data.dataRaptor->labels_const);
     }
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -66,21 +66,21 @@ struct RAPTOR
 
     NextStopTime next_st;
 
-    ///Contient les heures d'arrivées, de départ, ainsi que la façon dont on est arrivé à chaque journey_pattern point à chaque tour
+    /// Contains the different labels used by raptor.
+    /// Each element of index i in this vector represents the labels with i transfers
     std::vector<Labels> labels;
     ///Contains the best arrival (or departure time) for each stoppoint
     IdxMap<type::StopPoint, DateTime> best_labels;
-    ///Contient tous les points d'arrivée, et la meilleure façon dont on est arrivé à destination
+    /// Contains the best way to reach a destination point
     best_dest b_dest;
-    ///Nombre de correspondances effectuées jusqu'à présent
+    /// Number of transfers done for the moment
     unsigned int count;
-    ///La journey_pattern est elle valide ?
+    /// Are the journey pattern valid
     boost::dynamic_bitset<> valid_journey_patterns;
     dataRAPTOR::JppsFromSp jpps_from_sp;
-    ///Order of the first journey_pattern point of each journey_pattern
+    /// Order of the first journey_pattern point of each journey_pattern
     IdxMap<type::JourneyPattern, int> Q;
 
-    //Constructeur
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
         next_st(data),
@@ -195,13 +195,13 @@ struct RAPTOR
                             const bool disruption_active,
                             const RoutingState& state);
 
-    ///Boucle principale
+    ///Main loop
     template<typename Visitor>
     void raptor_loop(Visitor visitor, const type::AccessibiliteParams & accessibilite_params, bool disruption_active, bool global_pruning = true, uint32_t max_transfers=std::numeric_limits<uint32_t>::max());
 
 
-    /// Retourne à quel tour on a trouvé la meilleure solution pour ce journey_patternpoint
-    /// Retourne -1 s'il n'existe pas de meilleure solution
+    /// Return the round that has found the best solution for this stop point
+    /// Return -1 if no solution found
     int best_round(SpIdx sp_idx);
 
     ~RAPTOR() {}

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -114,7 +114,6 @@ struct RAPTOR
         return data.pt_data->stop_points[idx.val];
     }
 
-
     ///Lance un calcul d'itinéraire entre deux stop areas avec aussi une borne
     std::vector<Path>
     compute(const type::StopArea* departure, const type::StopArea* destination,
@@ -206,6 +205,19 @@ struct RAPTOR
     /// Return the round that has found the best solution for this stop point
     /// Return -1 if no solution found
     int best_round(SpIdx sp_idx);
+
+    /// First raptor loop
+    /// externalized for testing purposes
+    void first_raptor_loop(const vec_stop_point_duration& dep,
+                           const vec_stop_point_duration& arr,
+                           const DateTime& departure_datetime,
+                           bool disruption_active,
+                           bool allow_odt,
+                           const DateTime& bound,
+                           const uint32_t max_transfers,
+                           const type::AccessibiliteParams& accessibilite_params,
+                           const std::vector<std::string>& forbidden_uri,
+                           bool clockwise);
 
     ~RAPTOR() {}
 };

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -86,7 +86,8 @@ struct RAPTOR
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
         next_st(data),
-        best_labels(data.pt_data->stop_points),
+        best_labels_pts(data.pt_data->stop_points),
+        best_labels_transfers(data.pt_data->stop_points),
         count(0),
         valid_journey_patterns(data.pt_data->journey_patterns.size()),
         Q(data.pt_data->journey_patterns) {

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -517,11 +517,7 @@ static void add_isochrone_response(RAPTOR& raptor,
                 continue;
             }
 
-            const auto sp_and_date = get_final_spidx_and_date(round,
-                    sp_idx, !clockwise, disruption_active, accessibilite_params, raptor);
-            DateTime initial_dt = sp_and_date.second;
-
-            int duration = ::abs(best_lbl - init_dt); //Q: I don't see the point of the get_final_spidx_and_date call
+            int duration = ::abs(best_lbl - init_dt);
 
             if(duration > max_duration) {
                 continue;
@@ -534,7 +530,7 @@ static void add_isochrone_response(RAPTOR& raptor,
             pb_journey->set_departure_date_time(str_departure);
             pb_journey->set_requested_date_time(str_requested);
             pb_journey->set_duration(duration);
-            pb_journey->set_nb_transfers(round); //Q: round there ? if round = 1, there are 0 transfer no ?
+            pb_journey->set_nb_transfers(round - 1);
             bt::time_period action_period(navitia::to_posix_time(best_lbl-duration, raptor.data),
                                           navitia::to_posix_time(best_lbl, raptor.data));
             if (show_stop_area)

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -508,7 +508,7 @@ static void add_isochrone_response(RAPTOR& raptor,
     bt::ptime now = bt::second_clock::local_time();
     for(const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels[sp_idx];
+        const auto best_lbl = raptor.best_labels_pts[sp_idx];
         if ((clockwise && best_lbl < bound) ||
                 (!clockwise && best_lbl > bound)) {
             int round = raptor.best_round(sp_idx);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -539,10 +539,12 @@ static void add_isochrone_response(RAPTOR& raptor,
                                           navitia::to_posix_time(best_lbl, raptor.data));
             if (show_stop_area)
                 fill_pb_placemark(sp->stop_area,
-                                  raptor.data, pb_journey->mutable_destination(), 0, now, action_period, show_codes);
+                                  raptor.data, pb_journey->mutable_destination(),
+                                  0, now, action_period, show_codes);
             else
                 fill_pb_placemark(sp,
-                                  raptor.data, pb_journey->mutable_destination(), 0, now, action_period, show_codes);
+                                  raptor.data, pb_journey->mutable_destination(),
+                                  0, now, action_period, show_codes);
         }
     }
 }

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -52,9 +52,8 @@ makePathes(const std::vector<std::pair<SpIdx, navitia::time_duration> > &departu
 }
 
 /**
- * TODO
  * For a given round, return the (stop time, time of departure/arrival) used by raptor
- * to at a given stop point
+ * to mark a given stop point
  */
 std::pair<const type::StopTime*, uint32_t>
 get_current_stidx_gap(size_t count,

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -65,13 +65,9 @@ get_current_stidx_gap(size_t count,
                       bool disruption_active) {
     const auto jpp_idx = get_used_jpp(count, sp_idx, raptor);
 
-    if (! jpp_idx.is_valid()) {
-        throw "c'est la merde";
-        return std::make_pair(nullptr, std::numeric_limits<uint32_t>::max());
-    }
     const auto& ls = labels[count];
 
-    if(ls.pt_is_initialized(sp_idx)) { //TODO donc ca c'est a enlever,checke au dessus
+    if(ls.pt_is_initialized(sp_idx)) {
         const auto& dt_pt = ls.dt_pt(sp_idx);
         const auto date = DateTimeUtils::date(dt_pt);
         const auto hour = DateTimeUtils::hour(dt_pt);

--- a/source/routing/raptor_path.cpp
+++ b/source/routing/raptor_path.cpp
@@ -293,13 +293,4 @@ void patch_datetimes(Path &path){
     }
 }
 
-
-//Path
-//makePathreverse(SpIdx destination_idx, unsigned int countb,
-//                const type::AccessibiliteParams & accessibilite_params,
-//                const RAPTOR &raptor_, bool disruption_active) {
-//    return makePath(destination_idx, countb, disruption_active, false, accessibilite_params, raptor_);
-//}
-
-
 }}

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -86,7 +86,7 @@ namespace navitia { namespace routing {
             return ;
         }
 
-        void final_step(SpIdx /*current_sp*/, size_t /*count*/, const std::vector<Labels> &/*labels*/) {
+        void final_step(const SpIdx /*current_sp*/, size_t /*count*/, const std::vector<Labels> &/*labels*/) {
             return ;
         }
     };

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -86,7 +86,7 @@ namespace navitia { namespace routing {
             return ;
         }
 
-        void final_step(SpIdx /*current_jpp*/, size_t /*count*/, const std::vector<Labels> &/*labels*/) {
+        void final_step(SpIdx /*current_sp*/, size_t /*count*/, const std::vector<Labels> &/*labels*/) {
             return ;
         }
     };

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -36,12 +36,12 @@ www.navitia.io
 namespace navitia { namespace routing {
     struct RAPTOR;
      ///Construit un chemin, utilisé lorsque l'algorithme a été fait en sens anti-horaire
-    Path makePathreverse(JppIdx destination_idx, unsigned int countb,
-            const type::AccessibiliteParams & accessibilite_params,
-            const RAPTOR &raptor_, bool disruption_active);
+//    Path makePathreverse(SpIdx destination_idx, unsigned int countb,
+//            const type::AccessibiliteParams & accessibilite_params,
+//            const RAPTOR &raptor_, bool disruption_active);
 
     ///Construit un chemin
-    Path makePath(JppIdx destination_idx, size_t countb, bool clockwise,
+    Path makePath(SpIdx destination_idx, size_t countb, bool clockwise,
             bool disruption_active, const type::AccessibiliteParams & accessibilite_params,
             const RAPTOR &raptor_);
 
@@ -58,21 +58,21 @@ namespace navitia { namespace routing {
 
     std::pair<const type::StopTime*, uint32_t>
     get_current_stidx_gap(size_t count,
-                          JppIdx journey_pattern_point,
+                          SpIdx stop_point,
                           const std::vector<Labels> &labels,
                           const type::AccessibiliteParams & accessibilite_params,
                           bool clockwise,
                           const RAPTOR &raptor,
                           bool disruption_active);
 
-    template<typename Visitor>
-    void read_path(Visitor& v, JppIdx destination_idx, size_t countb, bool clockwise, bool disruption_active,
-              const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_);
+//    template<typename Visitor>
+//    void read_path(Visitor& v, JppIdx destination_idx, size_t countb, bool clockwise, bool disruption_active,
+//              const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_);
 
     struct BasePathVisitor {
-        void connection(type::StopPoint* /*departure*/, type::StopPoint* /*destination*/,
+        void connection(const type::StopPoint* /*departure*/, const type::StopPoint* /*destination*/,
                     boost::posix_time::ptime /*dep_time*/, boost::posix_time::ptime /*arr_time*/,
-                    type::StopPointConnection* /*stop_point_connection*/) {
+                    const type::StopPointConnection* /*stop_point_connection*/) {
             return ;
         }
 
@@ -94,7 +94,7 @@ namespace navitia { namespace routing {
             return ;
         }
 
-        void final_step(JppIdx /*current_jpp*/, size_t /*count*/, const std::vector<Labels> &/*labels*/) {
+        void final_step(SpIdx /*current_jpp*/, size_t /*count*/, const std::vector<Labels> &/*labels*/) {
             return ;
         }
     };

--- a/source/routing/raptor_path.h
+++ b/source/routing/raptor_path.h
@@ -35,10 +35,6 @@ www.navitia.io
 #include <vector>
 namespace navitia { namespace routing {
     struct RAPTOR;
-     ///Construit un chemin, utilisé lorsque l'algorithme a été fait en sens anti-horaire
-//    Path makePathreverse(SpIdx destination_idx, unsigned int countb,
-//            const type::AccessibiliteParams & accessibilite_params,
-//            const RAPTOR &raptor_, bool disruption_active);
 
     ///Construit un chemin
     Path makePath(SpIdx destination_idx, size_t countb, bool clockwise,
@@ -64,10 +60,6 @@ namespace navitia { namespace routing {
                           bool clockwise,
                           const RAPTOR &raptor,
                           bool disruption_active);
-
-//    template<typename Visitor>
-//    void read_path(Visitor& v, JppIdx destination_idx, size_t countb, bool clockwise, bool disruption_active,
-//              const type::AccessibiliteParams & accessibilite_params, const RAPTOR &raptor_);
 
     struct BasePathVisitor {
         void connection(const type::StopPoint* /*departure*/, const type::StopPoint* /*destination*/,

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -15,7 +15,6 @@ inline const JppIdx get_boarding_jpp(const size_t countb, const SpIdx current_sp
     if (! boarding_sp_idx.is_valid()) {
         return JppIdx();
     }
-    //TODO com'!
     return raptor_.labels[countb].used_jpp(boarding_sp_idx);
 }
 /**
@@ -113,7 +112,9 @@ handle_st(const type::StopTime* st, DateTime& workingDate, bool clockwise, const
 }
 
 /**
- *TODO remonte le vj + extension
+ * loop through all stop times of the vj and call the visitor call backs
+ *
+ * continues to other vjs if there are service extensions
  */
 template<typename Visitor>
 void handle_vj(const size_t countb, SpIdx current_sp_idx, Visitor& v,

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -13,12 +13,14 @@ inline const JppIdx get_boarding_jpp(const size_t countb, const SpIdx current_sp
         return JppIdx();
     }
     //TODO com'!
-    return JppIdx(*raptor_.get_used_jpp(raptor_.labels[countb], boarding_sp_idx));
+    return raptor_.labels[countb].used_jpp(boarding_sp_idx);
+//    return JppIdx(*raptor_.get_used_jpp(raptor_.labels[countb], boarding_sp_idx));
 }
 //TODO refacto cette partie
 inline const JppIdx get_used_jpp(const size_t countb, const SpIdx current_sp_idx, const RAPTOR &raptor_) {
     //TODO com'!
-    return JppIdx(*raptor_.get_used_jpp(raptor_.labels[countb], current_sp_idx));
+    return raptor_.labels[countb].used_jpp(current_sp_idx);
+//    return JppIdx(*raptor_.get_used_jpp(raptor_.labels[countb], current_sp_idx));
 }
 
 template<typename Visitor>

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -21,7 +21,8 @@ inline const JppIdx get_boarding_jpp(const size_t countb, const SpIdx current_sp
  * Returns the jpp used to mark the stop point in the label
  *
  * Note: this should not be necessary, since we should be able to recompute this used jpp
- * (by iterating on the jpp of the label.boarding_jpp's journey pattern), but because of service extension we cannot do that
+ * (by iterating on the jpp of the label.boarding_jpp's journey pattern),
+ * but because of service extension we cannot do that
  */
 inline const JppIdx get_used_jpp(const size_t countb, const SpIdx current_sp_idx, const RAPTOR &raptor_) {
     return raptor_.labels[countb].used_jpp(current_sp_idx);

--- a/source/routing/raptor_path_defs.h
+++ b/source/routing/raptor_path_defs.h
@@ -6,6 +6,9 @@
 
 namespace navitia { namespace routing {
 
+/**
+ * Returns the jpp used to board on the jp for a given stop point and label
+ */
 inline const JppIdx get_boarding_jpp(const size_t countb, const SpIdx current_sp_idx, const RAPTOR &raptor_) {
     const auto boarding_sp_idx = raptor_.labels[countb].boarding_sp_transfer(current_sp_idx);
 
@@ -14,13 +17,15 @@ inline const JppIdx get_boarding_jpp(const size_t countb, const SpIdx current_sp
     }
     //TODO com'!
     return raptor_.labels[countb].used_jpp(boarding_sp_idx);
-//    return JppIdx(*raptor_.get_used_jpp(raptor_.labels[countb], boarding_sp_idx));
 }
-//TODO refacto cette partie
+/**
+ * Returns the jpp used to mark the stop point in the label
+ *
+ * Note: this should not be necessary, since we should be able to recompute this used jpp
+ * (by iterating on the jpp of the label.boarding_jpp's journey pattern), but because of service extension we cannot do that
+ */
 inline const JppIdx get_used_jpp(const size_t countb, const SpIdx current_sp_idx, const RAPTOR &raptor_) {
-    //TODO com'!
     return raptor_.labels[countb].used_jpp(current_sp_idx);
-//    return JppIdx(*raptor_.get_used_jpp(raptor_.labels[countb], current_sp_idx));
 }
 
 template<typename Visitor>

--- a/source/routing/raptor_solution_filter.cpp
+++ b/source/routing/raptor_solution_filter.cpp
@@ -1,0 +1,64 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "raptor_solution_filter.h"
+
+namespace navitia { namespace routing {
+
+std::vector<Path> filter_journeys(const std::vector<Path>& paths) {
+    std::vector<Path> res;
+    for (const auto& p: paths) {
+        if (is_valid_journey(p)) {
+            res.push_back(p);
+        }
+    }
+    return res;
+}
+
+bool is_valid_journey(const Path& p) {
+
+    //we don't want journeys with 2 zone ODT in transfers
+    const type::VehicleJourney* previous_vj = nullptr;
+    for (const auto& item: p.items) {
+        auto vj = item.get_vj();
+
+        if (! vj) { continue; }
+
+        if (previous_vj) {
+            if (previous_vj->is_zonal_odt() && vj->is_zonal_odt()) {
+                return false;
+            }
+        }
+        previous_vj = vj;
+    }
+    return true;
+}
+
+}}

--- a/source/routing/raptor_solution_filter.cpp
+++ b/source/routing/raptor_solution_filter.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.

--- a/source/routing/raptor_solution_filter.h
+++ b/source/routing/raptor_solution_filter.h
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.

--- a/source/routing/raptor_solution_filter.h
+++ b/source/routing/raptor_solution_filter.h
@@ -1,0 +1,48 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include "routing.h"
+#include "raptor.h"
+#include <vector>
+
+namespace navitia { namespace routing {
+
+/**
+ * Filter the path found by raptor
+ *
+ * return the filtered list
+ */
+std::vector<Path> filter_journeys(const std::vector<Path>&);
+
+bool is_valid_journey(const Path&);
+
+}
+}

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -58,8 +58,8 @@ get_solutions(const std::vector<std::pair<SpIdx, navitia::time_duration> > &depa
 
 
 Solutions
-get_solutions(const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
-              const DateTime &dep, bool clockwise, const RAPTOR& raptor, bool) {
+init_departures(const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
+              const DateTime &dep, bool clockwise, bool) {
     Solutions result;
     for(auto dep_dist : departs) {
         Solution d;

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -239,7 +239,6 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<SpIdx, navitia
 
             SpIdx sp_idx = spid_dist.first;
 
-            // We only want solution ending by a vehicle journey or a stay_in
             if(! raptor.labels[i].pt_is_initialized(sp_idx)) {
                 continue;
             }
@@ -257,8 +256,7 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<SpIdx, navitia
                 lost_time = (raptor.labels[i].dt_pt(sp_idx) + spid_dist.second.total_seconds()) -
                     best.total_arrival;
 
-
-            //Si je gagne 5 minutes de marche a pied, je suis pret à perdre jusqu'à 10 minutes.
+            // We accept to have a 10mn worst solution if we can reduce the walking time by 5mn
             int walking_time_diff_in_s = (best.walking_time - walking_time).total_seconds();
             if (walking_time_diff_in_s > 0) {
                 float ratio = lost_time / walking_time_diff_in_s;

--- a/source/routing/raptor_solutions.cpp
+++ b/source/routing/raptor_solutions.cpp
@@ -62,17 +62,15 @@ get_solutions(const std::vector<std::pair<SpIdx, navitia::time_duration> > &depa
               const DateTime &dep, bool clockwise, const RAPTOR& raptor, bool) {
     Solutions result;
     for(auto dep_dist : departs) {
-        for(const auto* jpp: raptor.get_sp(dep_dist.first)->journey_pattern_point_list) {
-            Solution d;
-            d.count = 0;
-            d.jpp_idx = JppIdx(*jpp);
-            d.walking_time = dep_dist.second;
-            if(clockwise)
-                d.arrival = dep + d.walking_time.total_seconds();
-            else
-                d.arrival = dep - d.walking_time.total_seconds();
-            result.insert(d);
-        }
+        Solution d;
+        d.count = 0;
+        d.sp_idx = dep_dist.first;
+        d.walking_time = dep_dist.second;
+        if(clockwise)
+            d.arrival = dep + d.walking_time.total_seconds();
+        else
+            d.arrival = dep - d.walking_time.total_seconds();
+        result.insert(d);
     }
     return result;
 }
@@ -100,7 +98,7 @@ static bool is_equal(const DateTime& best_so_far,
 }
 
 static size_t nb_jpp_of_path(int count,
-                             JppIdx jpp_idx,
+                             SpIdx sp_idx,
                              bool clockwise,
                              bool disruption_active,
                              const type::AccessibiliteParams& accessibilite_params,
@@ -118,7 +116,7 @@ static size_t nb_jpp_of_path(int count,
         }
     };
     VisitorNbJPP v;
-    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    read_path(v, sp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
     return v.nb_jpp;
 }
 
@@ -137,75 +135,75 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<SpIdx, navitia::tim
         best_dt_jpp = DateTimeUtils::inf;
     }
     for(unsigned int round=1; round <= raptor.count; ++round) {
-        // For every round with look for the best journey pattern point that belongs to one of the destination stop points
-        // We must not forget to walking duration
-        JppIdx best_jpp = JppIdx();
+        // For every round we look for the best destination stop points
+        // We must not forget to take into account the walking duration
+        SpIdx best_sp = SpIdx();
         size_t best_nb_jpp_of_path = std::numeric_limits<size_t>::max();
         for(auto spid_dist : destinations) {
-            for(auto journey_pattern_point : raptor.get_sp(spid_dist.first)->journey_pattern_point_list) {
-                const JppIdx jppidx = JppIdx(*journey_pattern_point);
-                const auto& ls = raptor.labels[round];
-                if (!ls.pt_is_initialized(jppidx)) {
+
+            auto sp_idx = spid_dist.first;
+            const auto& ls = raptor.labels[round];
+            if (! ls.pt_is_initialized(sp_idx)) {
+                continue;
+            }
+            size_t nb_jpp = nb_jpp_of_path(round, sp_idx, clockwise, disruption_active,
+                                           accessibilite_params, raptor);
+            const auto& dt_pt = ls.dt_pt(sp_idx);
+            if(!improves(best_dt, clockwise, dt_pt, spid_dist.second.total_seconds())) {
+                if (!is_equal(best_dt, clockwise, dt_pt, spid_dist.second.total_seconds()) ||
+                        best_nb_jpp_of_path <= nb_jpp) {
                     continue;
                 }
-                size_t nb_jpp = nb_jpp_of_path(round, jppidx, clockwise, disruption_active,
-                                               accessibilite_params, raptor);
-                const auto& dt_pt = ls.dt_pt(jppidx);
-                if(!improves(best_dt, clockwise, dt_pt, spid_dist.second.total_seconds())) {
-                    if (!is_equal(best_dt, clockwise, dt_pt, spid_dist.second.total_seconds()) ||
-                             best_nb_jpp_of_path <= nb_jpp) {
-                        continue;
-                    }
-                }
-                best_jpp = jppidx;
-                best_dt_jpp = dt_pt;
-                best_nb_jpp_of_path = nb_jpp;
-                // When computing with clockwise, in the second pass we store deparutre time
-                // in labels, but we want arrival time, so we need to retrive the good stop_time
-                // with best_stop_time
-                const type::StopTime* st = nullptr;
-                DateTime dt = 0;
+            }
+            best_sp = sp_idx;
+            best_dt_jpp = dt_pt;
+            best_nb_jpp_of_path = nb_jpp;
+            // When computing with clockwise, in the second pass we store deparutre time
+            // in labels, but we want arrival time, so we need to retrive the good stop_time
+            // with best_stop_time
+            const type::StopTime* st = nullptr;
+            DateTime dt = 0;
 
-                std::tie(st, dt) = get_current_stidx_gap(round,
-                                                         jppidx,
-                                                         raptor.labels,
-                                                         accessibilite_params,
-                                                         !clockwise,
-                                                         raptor,
-                                                         disruption_active);
-                if(st != nullptr) {
-                    if(clockwise) {
-                        auto arrival_time = !st->is_frequency() ? 
+            std::tie(st, dt) = get_current_stidx_gap(round,
+                                                     sp_idx,
+                                                     raptor.labels,
+                                                     accessibilite_params,
+                                                     !clockwise,
+                                                     raptor,
+                                                     disruption_active);
+            if(st != nullptr) {
+                if(clockwise) {
+                    auto arrival_time = !st->is_frequency() ?
                                 st->arrival_time :
                                 st->f_arrival_time(DateTimeUtils::hour(dt));
-                        DateTimeUtils::update(best_dt_jpp, arrival_time, false);
-                    } else {
-                        auto departure_time = !st->is_frequency() ?
-                            st->departure_time :
-                            st->f_departure_time(DateTimeUtils::hour(dt));
-                        DateTimeUtils::update(best_dt_jpp, departure_time, true);
-                    }
-                    if(clockwise)
-                        best_dt = dt_pt - spid_dist.second.total_seconds();
-                    else
-                        best_dt = dt_pt + spid_dist.second.total_seconds();
+                    DateTimeUtils::update(best_dt_jpp, arrival_time, false);
+                } else {
+                    auto departure_time = !st->is_frequency() ?
+                                st->departure_time :
+                                st->f_departure_time(DateTimeUtils::hour(dt));
+                    DateTimeUtils::update(best_dt_jpp, departure_time, true);
                 }
+                if(clockwise)
+                    best_dt = dt_pt - spid_dist.second.total_seconds();
+                else
+                    best_dt = dt_pt + spid_dist.second.total_seconds();
             }
         }
-        if (best_jpp.is_valid()) {
+        if (best_sp.is_valid()) {
             Solution s;
-            s.jpp_idx = best_jpp;
+            s.sp_idx = best_sp;
             s.count = round;
-            s.walking_time = getWalkingTime(round, best_jpp, departs, destinations, clockwise, disruption_active,
+            s.walking_time = getWalkingTime(round, best_sp, departs, destinations, clockwise, disruption_active,
                                             accessibilite_params, raptor);
             s.arrival = best_dt_jpp;
             s.ratio = 0;
             s.total_arrival = best_dt;
-            JppIdx final_jpp_idx;
-            std::tie(final_jpp_idx, s.upper_bound) = get_final_jppidx_and_date(round, best_jpp, clockwise,
+            SpIdx final_sp_idx;
+            std::tie(final_sp_idx, s.upper_bound) = get_final_spidx_and_date(round, best_sp, clockwise,
                                                                              disruption_active, accessibilite_params, raptor);
+            //TODO l'heure de depart (upper bound) n'est pas bon pour le moment, voir is il ya moyen de mieux le calculer
             for(auto spid_dep : departs) {
-                if (SpIdx(*raptor.get_jpp(final_jpp_idx)->stop_point) == spid_dep.first) {
+                if (final_sp_idx == spid_dep.first) {
                     if(clockwise) {
                         s.upper_bound = s.upper_bound + spid_dep.second.total_seconds();
                     }else {
@@ -231,74 +229,75 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<SpIdx, navitia
                       const RAPTOR& raptor) {
     Solutions result;
 
-    std::map<JppIdx, Solution> tmp;
+    std::map<SpIdx, Solution> tmp;
     // We start at 1 because we don't want results of the first round
     for(uint32_t i=1; i <= raptor.count; ++i) {
         for(auto spid_dist : destinations) {
             Solution best_departure;
             best_departure.ratio = 2;
-            best_departure.jpp_idx = JppIdx();
-            for(auto journey_pattern_point: raptor.get_sp(spid_dist.first)->journey_pattern_point_list) {
-                JppIdx jppidx = JppIdx(*journey_pattern_point);
-                // We only want solution ending by a vehicle journey or a stay_in
-                if(raptor.labels[i].pt_is_initialized(jppidx)) {
-                    navitia::time_duration walking_time = getWalkingTime(i, jppidx, departs, destinations, clockwise,
-                                                                         disruption_active, accessibilite_params, raptor);
-                    if(best.walking_time < walking_time) {
-                        continue;
+            best_departure.sp_idx = SpIdx();
+
+            SpIdx sp_idx = spid_dist.first;
+
+            // We only want solution ending by a vehicle journey or a stay_in
+            if(! raptor.labels[i].pt_is_initialized(sp_idx)) {
+                continue;
+            }
+
+            navitia::time_duration walking_time = getWalkingTime(i, sp_idx, departs, destinations, clockwise,
+                                                                 disruption_active, accessibilite_params, raptor);
+            if(best.walking_time < walking_time) {
+                continue;
+            }
+            float lost_time;
+            if(clockwise)
+                lost_time = best.total_arrival -
+                    (raptor.labels[i].dt_pt(sp_idx) - best.walking_time.total_seconds());
+            else
+                lost_time = (raptor.labels[i].dt_pt(sp_idx) + spid_dist.second.total_seconds()) -
+                    best.total_arrival;
+
+
+            //Si je gagne 5 minutes de marche a pied, je suis pret à perdre jusqu'à 10 minutes.
+            int walking_time_diff_in_s = (best.walking_time - walking_time).total_seconds();
+            if (walking_time_diff_in_s > 0) {
+                float ratio = lost_time / walking_time_diff_in_s;
+                if( ratio >= best_departure.ratio) {
+                    continue;
+                }
+                Solution s;
+                s.sp_idx = sp_idx;
+                s.count = i;
+                s.ratio = ratio;
+                s.walking_time = walking_time;
+                s.arrival = raptor.labels[i].dt_pt(sp_idx);
+                SpIdx final_sp_idx;
+                DateTime last_time;
+                std::tie(final_sp_idx, last_time) = get_final_spidx_and_date(i, sp_idx, clockwise,
+                                    disruption_active, accessibilite_params, raptor);
+
+                if(clockwise) {
+                    s.upper_bound = last_time;
+                    for(auto spid_dep : departs) {
+                        if(final_sp_idx == spid_dep.first) {
+                            s.upper_bound = s.upper_bound + (spid_dep.second.total_seconds());
+                        }
                     }
-                    float lost_time;
-                    if(clockwise)
-                        lost_time = best.total_arrival -
-                            (raptor.labels[i].dt_pt(jppidx) - best.walking_time.total_seconds());
-                    else
-                        lost_time = (raptor.labels[i].dt_pt(jppidx) + spid_dist.second.total_seconds()) -
-                            best.total_arrival;
-
-
-                    //Si je gagne 5 minutes de marche a pied, je suis pret à perdre jusqu'à 10 minutes.
-                    int walking_time_diff_in_s = (best.walking_time - walking_time).total_seconds();
-                    if (walking_time_diff_in_s > 0) {
-                        float ratio = lost_time / walking_time_diff_in_s;
-                        if( ratio >= best_departure.ratio) {
-                            continue;
+                } else {
+                    s.upper_bound = last_time;
+                    for(auto spid_dep : departs) {
+                        if(final_sp_idx == spid_dep.first) {
+                            s.upper_bound = s.upper_bound - (spid_dep.second.total_seconds());
                         }
-                        Solution s;
-                        s.jpp_idx = jppidx;
-                        s.count = i;
-                        s.ratio = ratio;
-                        s.walking_time = walking_time;
-                        s.arrival = raptor.labels[i].dt_pt(jppidx);
-                        JppIdx final_jpp_idx;
-                        DateTime last_time;
-                        std::tie(final_jpp_idx, last_time) = get_final_jppidx_and_date(i, jppidx, clockwise,
-                                            disruption_active, accessibilite_params, raptor);
-                        const SpIdx final_sp_idx = SpIdx(*raptor.get_jpp(final_jpp_idx)->stop_point);
-
-                        if(clockwise) {
-                            s.upper_bound = last_time;
-                            for(auto spid_dep : departs) {
-                                if(final_sp_idx == spid_dep.first) {
-                                    s.upper_bound = s.upper_bound + (spid_dep.second.total_seconds());
-                                }
-                            }
-                        } else {
-                            s.upper_bound = last_time;
-                            for(auto spid_dep : departs) {
-                                if(final_sp_idx == spid_dep.first) {
-                                    s.upper_bound = s.upper_bound - (spid_dep.second.total_seconds());
-                                }
-                            }
-                        }
-                        best_departure = s;
                     }
                 }
+                best_departure = s;
             }
-            if (best_departure.jpp_idx.is_valid()) {
-                if(tmp.find(best_departure.jpp_idx) == tmp.end()) {
-                    tmp.insert(std::make_pair(best_departure.jpp_idx, best_departure));
-                } else if(tmp[best_departure.jpp_idx].ratio > best_departure.ratio) {
-                    tmp[best_departure.jpp_idx] = best_departure;
+            if (best_departure.sp_idx.is_valid()) {
+                if (tmp.find(best_departure.sp_idx) == tmp.end()) {
+                    tmp.insert(std::make_pair(best_departure.sp_idx, best_departure));
+                } else if (tmp[best_departure.sp_idx].ratio > best_departure.ratio) {
+                    tmp[best_departure.sp_idx] = best_departure;
                 }
             }
         }
@@ -320,59 +319,56 @@ get_walking_solutions(bool clockwise, const std::vector<std::pair<SpIdx, navitia
 }
 
 struct VisitorFinalJppAndDate : public BasePathVisitor {
-    JppIdx current_jpp = JppIdx();
+    SpIdx current_sp = SpIdx();
     DateTime last_time = DateTimeUtils::inf;
-    void final_step(const JppIdx current_jpp, size_t count, const std::vector<Labels> &labels) {
-        this->current_jpp = current_jpp;
-        last_time = labels[count].dt_pt(current_jpp);
+    void final_step(const SpIdx current_sp, size_t count, const std::vector<Labels> &labels) {
+        this->current_sp = current_sp;
+        last_time = labels[count].dt_pt(current_sp);
     }
 };
 
 // Reparcours l’itinéraire rapidement pour avoir le JPP et la date de départ (si on cherchait l’arrivée au plus tôt)
-std::pair<JppIdx, DateTime>
-get_final_jppidx_and_date(int count, JppIdx jpp_idx, bool clockwise, bool disruption_active,
+std::pair<SpIdx, DateTime>
+get_final_spidx_and_date(int count, SpIdx sp_idx, bool clockwise, bool disruption_active,
                           const type::AccessibiliteParams & accessibilite_params, const RAPTOR& raptor) {
     VisitorFinalJppAndDate v;
-    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
-    return std::make_pair(v.current_jpp, v.last_time);
+    read_path(v, sp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    return std::make_pair(v.current_sp, v.last_time);
 }
 
 
 struct VisitorWalkingTime : public BasePathVisitor {
-    JppIdx departure_jpp_idx = JppIdx();
+    SpIdx departure_sp_idx = SpIdx();
 
-    void final_step(JppIdx current_jpp, size_t , const std::vector<Labels> &){
-        departure_jpp_idx = current_jpp;
+    void final_step(SpIdx current_sp, size_t , const std::vector<Labels> &) {
+        departure_sp_idx = current_sp;
     }
 
 };
 
 
-navitia::time_duration getWalkingTime(int count, JppIdx jpp_idx, const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
+navitia::time_duration getWalkingTime(int count, SpIdx sp_idx, const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
                      const std::vector<std::pair<SpIdx, navitia::time_duration> > &destinations,
                      bool clockwise, bool disruption_active, const type::AccessibiliteParams & accessibilite_params,
                      const RAPTOR& raptor) {
-
-    const auto* current_jpp = raptor.get_jpp(jpp_idx);
     navitia::time_duration walking_time = {};
 
     //Marche à la fin
     for(auto dest_dist : destinations) {
-        if(dest_dist.first == SpIdx(*current_jpp->stop_point)) {
+        if(dest_dist.first == sp_idx) {
             walking_time = dest_dist.second;
             break;
         }
     }
 
     VisitorWalkingTime v;
-    read_path(v, jpp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
-    if (!v.departure_jpp_idx.is_valid()) {
+    read_path(v, sp_idx, count, !clockwise, disruption_active, accessibilite_params, raptor);
+    if (!v.departure_sp_idx.is_valid()) {
         return walking_time;
     }
-    const auto* departure_jpp = raptor.get_jpp(v.departure_jpp_idx);
     //Marche au départ
     for(auto dep_dist : departs) {
-        if (dep_dist.first == SpIdx(*departure_jpp->stop_point)) {
+        if (dep_dist.first == v.departure_sp_idx) {
             walking_time += dep_dist.second;
             break;
         }

--- a/source/routing/raptor_solutions.h
+++ b/source/routing/raptor_solutions.h
@@ -81,8 +81,8 @@ get_solutions(const std::vector<std::pair<SpIdx, navitia::time_duration> > &depa
 
 //This one is hacky, it's used to retrieve the departures.
 Solutions
-get_solutions(const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
-             const DateTime &dep, bool clockwise, const RAPTOR& raptor, bool disruption_active);
+init_departures(const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
+             const DateTime &dep, bool clockwise, bool disruption_active);
 
 Solutions
 get_walking_solutions(bool clockwise, const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,

--- a/source/routing/raptor_solutions.h
+++ b/source/routing/raptor_solutions.h
@@ -41,13 +41,13 @@ namespace navitia { namespace routing {
 struct RAPTOR;
 
 struct Solution {
-    JppIdx jpp_idx;
+    SpIdx sp_idx;  //arrival stop point of the solution
     uint32_t count;
     DateTime arrival, upper_bound, total_arrival;
     float ratio;
     navitia::time_duration walking_time = {};
 
-    Solution() : jpp_idx(), count(0),
+    Solution() : sp_idx(), count(0),
                        arrival(DateTimeUtils::inf), upper_bound(DateTimeUtils::inf),
                        ratio(std::numeric_limits<float>::min()) {}
 
@@ -58,8 +58,8 @@ struct Solution {
         if(this->count != s.count) {
             return this->count < s.count;
         }
-        if (this->jpp_idx != s.jpp_idx) {
-            return this->jpp_idx < s.jpp_idx;
+        if (this->sp_idx != s.sp_idx) {
+            return this->sp_idx < s.sp_idx;
         }
         if(this->upper_bound != s.upper_bound) {
             return this->upper_bound < s.upper_bound;
@@ -95,11 +95,11 @@ get_pareto_front(bool clockwise, const std::vector<std::pair<SpIdx, navitia::tim
                const std::vector<std::pair<SpIdx, navitia::time_duration> > &destinations,
                const type::AccessibiliteParams & accessibilite_params, bool disruption_active, const RAPTOR& raptor);
 
-std::pair<JppIdx, DateTime>
-get_final_jppidx_and_date(int count, JppIdx jpp_idx, bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params, const navitia::routing::RAPTOR &raptor);
+std::pair<SpIdx, DateTime>
+get_final_spidx_and_date(int count, SpIdx sp_idx, bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params, const navitia::routing::RAPTOR &raptor);
 
 navitia::time_duration
-getWalkingTime(int count, JppIdx jpp_idx, const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
+getWalkingTime(int count, SpIdx sp_idx, const std::vector<std::pair<SpIdx, navitia::time_duration> > &departs,
                const std::vector<std::pair<SpIdx, navitia::time_duration> > &destinations,
                bool clockwise, bool disruption_active, const type::AccessibiliteParams &accessibilite_params,
                const navitia::routing::RAPTOR &raptor);

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -64,6 +64,7 @@ struct Labels {
         dt_transfers = clean.dt_transfers;
         boarding_jpp_pts.resize(clean.boarding_jpp_pts.size());
         boarding_sp_transfers.resize(clean.boarding_sp_transfers.size());
+        used_jpps.resize(clean.used_jpps.size());
     }
     inline const SpIdx&
     boarding_sp_transfer(SpIdx sp_idx) const {
@@ -102,12 +103,19 @@ struct Labels {
         return dt_transfer(sp_idx) != DateTimeUtils::inf && dt_transfer(sp_idx) != DateTimeUtils::min;
     }
 
+    inline JppIdx& mut_used_jpp(SpIdx sp_idx) {
+        return used_jpps[sp_idx];
+    }
+    inline const JppIdx& used_jpp(SpIdx sp_idx) const {
+        return used_jpps[sp_idx];
+    }
 private:
     inline void init(size_t nb_sp, DateTime val) {
         dt_pts.assign(nb_sp, val);
         dt_transfers.assign(nb_sp, val);
         boarding_jpp_pts.resize(nb_sp);
         boarding_sp_transfers.resize(nb_sp);
+        used_jpps.resize(nb_sp);
     }
 
     // All these vectors are indexed by sp_idx
@@ -121,6 +129,10 @@ private:
     // sp used to reach this label with a transfer.
     // Note: the sp is enough here (no need for jpp), it is used only for path reconstruction
     IdxMap<type::StopPoint, SpIdx> boarding_sp_transfers;
+
+    // jpp used to mark the stop point. Used for path reconstruction, only because of the the vj extention.
+    // The service extention makes it impossible to find the used jpp withe the boarding jpp
+    IdxMap<type::StopPoint, JppIdx> used_jpps;
 };
 
 

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -202,9 +202,6 @@ struct best_dest {
         best_now = bound;
     }
 
-//    void reverse() {
-//        best_now = DateTimeUtils::min;
-//    }
 };
 
 } // namespace routing

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -50,21 +50,21 @@ typedef Idx<type::StopPoint> SpIdx;
 
 struct Labels {
     // initialize the structure according to the number of jpp
-    inline void init_inf(size_t nb_sp) {
-        init(nb_sp, DateTimeUtils::inf);
+    inline void init_inf(const std::vector<type::StopPoint*>& stops) {
+        init(stops, DateTimeUtils::inf);
     }
     // initialize the structure according to the number of jpp
-    inline void init_min(size_t nb_sp) {
-        init(nb_sp, DateTimeUtils::min);
+    inline void init_min(const std::vector<type::StopPoint*>& stops) {
+        init(stops, DateTimeUtils::min);
     }
     // clear the structure according to a given structure. Same as a
     // copy without touching the boarding_jpp fields
     inline void clear(const Labels& clean) {
         dt_pts = clean.dt_pts;
         dt_transfers = clean.dt_transfers;
-        boarding_jpp_pts.resize(clean.boarding_jpp_pts.size());
-        boarding_sp_transfers.resize(clean.boarding_sp_transfers.size());
-        used_jpps.resize(clean.used_jpps.size());
+        boarding_jpp_pts.resize(clean.boarding_jpp_pts);
+        boarding_sp_transfers.resize(clean.boarding_sp_transfers);
+        used_jpps.resize(clean.used_jpps);
     }
     inline const SpIdx&
     boarding_sp_transfer(SpIdx sp_idx) const {
@@ -110,12 +110,12 @@ struct Labels {
         return used_jpps[sp_idx];
     }
 private:
-    inline void init(size_t nb_sp, DateTime val) {
-        dt_pts.assign(nb_sp, val);
-        dt_transfers.assign(nb_sp, val);
-        boarding_jpp_pts.resize(nb_sp);
-        boarding_sp_transfers.resize(nb_sp);
-        used_jpps.resize(nb_sp);
+    inline void init(const std::vector<type::StopPoint*>& stops, DateTime val) {
+        dt_pts.assign(stops, val);
+        dt_transfers.assign(stops, val);
+        boarding_jpp_pts.resize(stops);
+        boarding_sp_transfers.resize(stops);
+        used_jpps.resize(stops);
     }
 
     // All these vectors are indexed by sp_idx
@@ -190,15 +190,15 @@ struct best_dest {
         return false;
     }
 
-    void reinit(const size_t nb_sp_idx) {
-        sp_idx_duration.assign(nb_sp_idx, boost::posix_time::pos_infin);
+    void reinit(const std::vector<type::StopPoint*>& stops) {
+        sp_idx_duration.assign(stops, boost::posix_time::pos_infin);
         best_now = DateTimeUtils::inf;
         best_now_sp_idx = SpIdx();
         count = std::numeric_limits<size_t>::max();
     }
 
-    void reinit(size_t nb_sp_idx, const DateTime& bound) {
-        reinit(nb_sp_idx);
+    void reinit(const std::vector<type::StopPoint*>& stops, const DateTime& bound) {
+        reinit(stops);
         best_now = bound;
     }
 

--- a/source/routing/raptor_visitors.h
+++ b/source/routing/raptor_visitors.h
@@ -2,7 +2,7 @@
 
 namespace navitia { namespace routing {
 struct raptor_visitor {
-    inline bool better_or_equal(const DateTime &a, const DateTime &current_dt, const type::StopTime& st) const {
+    inline bool better_or_equal(const DateTime& a, const DateTime& current_dt, const type::StopTime& st) const {
         return a <= st.section_end_date(DateTimeUtils::date(current_dt), clockwise());
     }
 

--- a/source/routing/tests/raptor_odt_test.cpp
+++ b/source/routing/tests/raptor_odt_test.cpp
@@ -60,11 +60,11 @@ public:
 
     Params():b("20140113") {
 
-        b.vj("network:R", "line:A", "1111111111111", "", true, "vj1")("stop_area:stop1", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)("stop_area:stop2", 11 * 3600 + 10 * 60 ,11 * 3600 + 10 * 60);
-        b.vj("network:R", "line:C", "1111111111111", "", true, "vj2")("stop_area:stop1", 10 * 3600 + 30 * 60, 10 * 3600 + 30 * 60)("stop_area:stop2", 11 * 3600 + 10 * 60 ,11 * 3600 + 10 * 60);
-        b.vj("network:R", "line:D", "1111111111111", "", true, "vj3")("stop_area:stop2", 11 * 3600 + 15 * 60, 11 * 3600 + 15 * 60)("stop_area:stop3", 13 * 3600 + 10 * 60 ,13 * 3600 + 10 * 60);
+        b.vj("network:R", "line:A", "1111111111111", "", true, "vj1")("stop_area:stop1", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)("stop_area:stop2", 11 * 3600 + 10 * 60, 11 * 3600 + 10 * 60);
+        b.vj("network:R", "line:C", "1111111111111", "", true, "vj2")("stop_area:stop1", 10 * 3600 + 30 * 60, 10 * 3600 + 30 * 60)("stop_area:stop2", 11 * 3600 + 25 * 60, 11 * 3600 + 25 * 60);
+        b.vj("network:R", "line:D", "1111111111111", "", true, "vj3")("stop_area:stop2", 11 * 3600 + 30 * 60, 11 * 3600 + 30 * 60)("stop_area:stop3", 13 * 3600 + 10 * 60 ,13 * 3600 + 10 * 60);
         b.vj("network:R", "line:E", "1111111111111", "", true, "vj4")("stop_area:stop4", 8 * 3600 + 30 * 60, 8* 3600 + 30 * 60)("stop_area:stop1", 9 * 3600 + 10 * 60 , 9 * 3600 + 10 * 60);
-        b.vj("network:R", "line:F", "1111111111111", "", true, "vj5")("stop_area:stop5", 11 * 3600 + 15 * 60, 11 * 3600 + 15 * 60)("stop_area:stop6", 13 * 3600 + 10 * 60 ,13 * 3600 + 10 * 60);
+        b.vj("network:R", "line:F", "1111111111111", "", true, "vj5")("stop_area:stop5", 11 * 3600 + 30 * 60, 11 * 3600 + 30 * 60)("stop_area:stop6", 13 * 3600 + 10 * 60 ,13 * 3600 + 10 * 60);
         b.vj("network:R", "line:G", "1111111111111", "", true, "vj6")("stop_area:stop7", 8 * 3600 + 30 * 60, 8* 3600 + 30 * 60)("stop_area:stop8", 9 * 3600 + 10 * 60 , 9 * 3600 + 10 * 60);
         b.connection("stop_area:stop2", "stop_area:stop2", 120);
         b.connection("stop_area:stop1", "stop_area:stop1", 120);
@@ -282,9 +282,9 @@ BOOST_AUTO_TEST_CASE(test5){
     section = journey.sections(0);
     displ = section.pt_display_informations();
     BOOST_CHECK_EQUAL(displ.uris().vehicle_journey(), "vj2");
-    BOOST_CHECK_EQUAL(journey.duration(), 2400);
+    BOOST_CHECK_EQUAL(journey.duration(), 3300);
     BOOST_CHECK_EQUAL(journey.departure_date_time(), navitia::test::to_posix_timestamp("20140114T103000"));
-    BOOST_CHECK_EQUAL(journey.arrival_date_time(), navitia::test::to_posix_timestamp("20140114T111000"));
+    BOOST_CHECK_EQUAL(journey.arrival_date_time(), navitia::test::to_posix_timestamp("20140114T112500"));
     vj1->stop_time_list.front().set_odt(false);
     vj1->stop_time_list.front().set_date_time_estimated(false);
     vj1->stop_time_list.back().set_odt(false);

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -1527,3 +1527,34 @@ BOOST_AUTO_TEST_CASE(y_line_the_ultimate_political_blocking_bug){
     BOOST_CHECK_EQUAL(res1[0].items[2].departure.time_of_day().total_seconds(), 8500);
     BOOST_CHECK_EQUAL(res1[0].items[2].arrival.time_of_day().total_seconds(), 8600);
 }
+
+/*
+ *    A --------------- B --------------- C --------------- D
+ *
+ * l1   ----------------x-----------------x----------------->
+ *
+ * l2                    -----------------
+ *                                       | service extension
+ * l3                                    ------------------->
+ *
+ * We want to test that raptor stops at the second iteration (because the service extension does not improve the solution)
+ * */
+BOOST_AUTO_TEST_CASE(finish_on_service_extension) {
+    ed::builder b("20120614");
+    b.vj("l1", "1", "", true)("A", 8000, 8000)("B", 8100, 8100)("C", 8200, 8200)("D", 8500, 8500);
+    b.vj("l2", "1", "toto", true)("B", 8400, 8400)("C", 8600, 8600);
+    b.vj("l3", "1", "toto", true)("C", 8600, 8600)("D", 10000, 10000);
+
+    b.connection("B", "B", 10);
+    b.data->pt_data->index();
+    b.data->build_uri();
+    b.data->build_raptor();
+    RAPTOR raptor(*(b.data));
+    type::PT_Data& d = *b.data->pt_data;
+
+    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7900, 0, DateTimeUtils::inf, false, false);
+    BOOST_CHECK_EQUAL(res1.size(), 1);
+
+    //and raptor has to stop on count 2
+    BOOST_CHECK_EQUAL(raptor.count, 2);
+}

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -84,9 +84,8 @@ struct calendar_fixture {
         b.data->pt_data->meta_vj["all"]->associated_calendars[weekend_cal->uri] = associated_calendar_for_week_end;
 
         b.data->build_uri();
-        b.data->pt_data->index();
+        b.data->complete();
         b.data->build_raptor();
         b.data->geo_ref->init();
-        b.data->complete();
     }
 };

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "type/type.h"
 #include "tests/utils_test.h"
 #include "departure_board_test_data.h"
+#include "routing/raptor.h"
 
 struct logger_initialized {
     logger_initialized()   { init_logger(); }
@@ -431,4 +432,17 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period_before, small_cal_fixtur
         BOOST_CHECK_EQUAL(stop_date_time.time(), time_to_int(hour, 10, 00));
         BOOST_CHECK_EQUAL(stop_date_time.date(), 0); //no date
     }
+}
+
+
+BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
+    // some jormungandr test use the calendar_fixture for simple journey computation, so we add a simple test on journey
+    navitia::routing::RAPTOR raptor(*(b.data));
+    navitia::type::PT_Data& d = *b.data->pt_data;
+
+    std::cout << "== " << d.stop_areas_map["stop1"] << std::endl;
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8*60*60, 0, navitia::DateTimeUtils::inf, false, true);
+
+    //we must have a journey
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -440,7 +440,6 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
     navitia::routing::RAPTOR raptor(*(b.data));
     navitia::type::PT_Data& d = *b.data->pt_data;
 
-    std::cout << "== " << d.stop_areas_map["stop1"] << std::endl;
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8*60*60, 0, navitia::DateTimeUtils::inf, false, true);
 
     //we must have a journey

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -36,18 +36,18 @@ namespace navitia{namespace type {
 void PT_Data::sort(){
 
 #define SORT_AND_INDEX(type_name, collection_name)\
-    std::sort(collection_name.begin(), collection_name.end(), Less());\
+    std::stable_sort(collection_name.begin(), collection_name.end(), Less());\
     std::for_each(collection_name.begin(), collection_name.end(), Indexer<nt::idx_t>());
 
     ITERATE_NAVITIA_PT_TYPES(SORT_AND_INDEX)
 
 #undef SORT_AND_INDEX
 
-    std::sort(stop_point_connections.begin(), stop_point_connections.end());
+    std::stable_sort(stop_point_connections.begin(), stop_point_connections.end());
     std::for_each(stop_point_connections.begin(), stop_point_connections.end(), Indexer<idx_t>());
 
     for(auto* vj: this->vehicle_journeys){
-        std::sort(vj->stop_time_list.begin(), vj->stop_time_list.end());
+        std::stable_sort(vj->stop_time_list.begin(), vj->stop_time_list.end());
     }
 }
 


### PR DESCRIPTION
Split Raptor's label by stop point and not journey pattern point anymore

Bench: 
**all:**
fr_pdl: 70s-> 60s ==> -16%
israel: 118s -> 100s  ==> -18%
idf: 54s -> 48s ==> 12%

**all but foot path**
fr_pdl: 70s-> 63s ==> -11%
israel: 118s -> 114s  ==> -3%
idf: 54s -> 49s ==> -10%

**all but foot path and best label on transfers**
fr_pdl: 70s-> 68s ==> -3%
israel: 118s -> 109s  ==> -8%
idf: 54s -> 53s ==> -3%
