### PR TITLE
 kraken: recast of disruption api 

### DIFF
--- a/source/disruption/disruption.cpp
+++ b/source/disruption/disruption.cpp
@@ -55,7 +55,6 @@ void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
-                      const boost::posix_time::time_period action_period,
                       const boost::posix_time::ptime now){
 
     for(auto idx : network_idx){
@@ -77,7 +76,7 @@ void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
         }
         for(auto stop_area_idx : line_list){
             const auto* stop_area = d.pt_data->stop_areas[stop_area_idx];
-            if (stop_area->has_applicable_message(now, action_period)){
+            if (stop_area->has_publishable_message(now)){
                 disrupt& dist = this->disrupts[this->find_or_create(network)];
                 auto find_predicate = [&](type::idx_t idx ) {
                     return stop_area->idx == idx;
@@ -95,12 +94,11 @@ void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
 
 void Disruption::add_networks(const std::vector<type::idx_t>& network_idx,
                       const type::Data &d,
-                      const boost::posix_time::time_period action_period,
                       const boost::posix_time::ptime now){
 
     for(auto idx : network_idx){
         const auto* network = d.pt_data->networks[idx];
-        if (network->has_applicable_message(now, action_period)){
+        if (network->has_publishable_message(now)){
             this->disrupts[this->find_or_create(network)];
         }
     }
@@ -109,7 +107,6 @@ void Disruption::add_networks(const std::vector<type::idx_t>& network_idx,
 void Disruption::add_lines(const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
-                      const boost::posix_time::time_period action_period,
                       const boost::posix_time::ptime now){
 
     std::vector<type::idx_t> line_list;
@@ -123,7 +120,7 @@ void Disruption::add_lines(const std::string& filter,
     }
     for(auto idx : line_list){
         const auto* line = d.pt_data->lines[idx];
-        if (line->has_applicable_message(now, action_period)){
+        if (line->has_publishable_message(now)){
             disrupt& dist = this->disrupts[this->find_or_create(line->network)];
             auto find_predicate = [&](type::idx_t idx ) {
                 return line->idx == idx;
@@ -162,14 +159,13 @@ void Disruption::sort_disruptions(const type::Data &d){
 void Disruption::disruptions_list(const std::string& filter,
                         const std::vector<std::string>& forbidden_uris,
                         const type::Data &d,
-                        const boost::posix_time::time_period action_period,
                         const boost::posix_time::ptime now){
 
     std::vector<type::idx_t> network_idx = ptref::make_query(type::Type_e::Network, filter,
                                                                                       forbidden_uris, d);
-    add_networks(network_idx, d, action_period, now);
-    add_lines(filter, forbidden_uris, d, action_period, now);
-    add_stop_areas(network_idx, filter, forbidden_uris, d, action_period, now);
+    add_networks(network_idx, d, now);
+    add_lines(filter, forbidden_uris, d, now);
+    add_stop_areas(network_idx, filter, forbidden_uris, d, now);
     sort_disruptions(d);
 }
 const std::vector<disrupt>& Disruption::get_disrupts() const{

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -55,17 +55,14 @@ private:
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
-                      const boost::posix_time::time_period action_period,
                       const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
 
     void add_networks(const std::vector<type::idx_t>& network_idx,
                       const type::Data &d,
-                      const boost::posix_time::time_period action_period,
                       const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
     void add_lines(const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
-                      const boost::posix_time::time_period action_period,
                       const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
     void sort_disruptions(const type::Data &d);
 public:
@@ -74,7 +71,6 @@ public:
     void disruptions_list(const std::string& filter,
                     const std::vector<std::string>& forbidden_uris,
                     const type::Data &d,
-                    const boost::posix_time::time_period action_period,
                     const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
 
     const std::vector<disrupt>& get_disrupts() const;

--- a/source/disruption/disruption_api.h
+++ b/source/disruption/disruption_api.h
@@ -36,9 +36,7 @@ www.navitia.io
 namespace navitia { namespace disruption {
 
 pbnavitia::Response disruptions(const navitia::type::Data& d,
-                                uint64_t application_period_begin,
-                                uint64_t application_period_end,
-                                uint64_t publication_dt,
+                                uint64_t now_dt,
                                 const size_t depth,
                                 size_t count,
                                 size_t start_page, const std::string& filter,

--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -211,6 +211,7 @@ BOOST_FIXTURE_TEST_CASE(network_filter1, Params) {
     BOOST_REQUIRE_EQUAL(line.disruptions_size(), 1);
     auto disruption = line.disruptions(0);
     BOOST_CHECK_EQUAL(disruption.uri(), "mess1");
+    //we are in the publication period of the disruption but the application_period of the impact is in the future
     BOOST_CHECK_EQUAL(disruption.status(), pbnavitia::ActiveStatus::future);
 
     BOOST_REQUIRE_EQUAL(disruption.application_periods_size(), 1);

--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -165,7 +165,7 @@ public:
         disruption_wrapper.object_uri = "line:A";
         disruption_wrapper.object_type = chaos::PtObject::Type::PtObject_Type_line;
         //note we add one seconds, because the end is not is the period
-        disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2013-12-19 12:32:00"),
+        disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2013-12-20 12:32:00"),
                                                                 pt::time_from_string("2013-12-21 12:32:00") + pt::seconds(1));
         disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2013-12-19 12:32:00"),
                                                                 pt::time_from_string("2013-12-21 12:32:00") + pt::seconds(1));
@@ -175,57 +175,34 @@ public:
         disruption_wrapper.uri = "mess0";
         disruption_wrapper.object_uri = "line:S";
         disruption_wrapper.object_type = chaos::PtObject::Type::PtObject_Type_line;
-        disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2013-12-19 12:32:00"),
+        disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2013-12-21 08:32:00"),
                                                                 pt::time_from_string("2013-12-21 12:32:00") + pt::seconds(1));
-        disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2013-12-19 12:32:00"),
+        disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2013-12-21 08:32:00"),
                                                                 pt::time_from_string("2013-12-21 12:32:00") + pt::seconds(1));
         add_disruption(disruption_wrapper, *b.data->pt_data);
 
         disruption_wrapper = DisruptionCreator();
         disruption_wrapper.uri = "mess2";
-        disruption_wrapper.object_uri = "line:B";
-        disruption_wrapper.object_type = chaos::PtObject::Type::PtObject_Type_line;
-        disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2013-12-23 12:32:00"),
-                                                                pt::time_from_string("2013-12-25 12:32:00") + pt::seconds(1));
-        disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2013-12-23 12:32:00"),
-                                                                pt::time_from_string("2013-12-25 12:32:00") + pt::seconds(1));
-        add_disruption(disruption_wrapper, *b.data->pt_data);
-
-        disruption_wrapper = DisruptionCreator();
-        disruption_wrapper.uri = "mess3";
-        disruption_wrapper.object_uri = "network:M";
+        disruption_wrapper.object_uri = "network:K";
         disruption_wrapper.object_type = chaos::PtObject::Type::PtObject_Type_network;
         disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2013-12-23 12:32:00"),
                                                                 pt::time_from_string("2013-12-25 12:32:00") + pt::seconds(1));
-        disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2013-12-23 12:32:00"),
-                                                                pt::time_from_string("2013-12-25 12:32:00") + pt::seconds(1));
-        add_disruption(disruption_wrapper, *b.data->pt_data);
-
-        disruption_wrapper = DisruptionCreator();
-        disruption_wrapper.uri = "mess4";
-        disruption_wrapper.object_uri = "network:Test";
-        disruption_wrapper.object_type = chaos::PtObject::Type::PtObject_Type_network;
-        disruption_wrapper.application_period = pt::time_period(pt::time_from_string("2014-01-12 08:32:00"),
-                                                                pt::time_from_string("2014-02-02 18:32:00") + pt::seconds(1));
-        disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2014-01-02 08:32:00"),
-                                                                pt::time_from_string("2014-02-10 12:32:00") + pt::seconds(1));
-        disruption_wrapper.application_daily_start_hour = pt::duration_from_string("08:40");
-        disruption_wrapper.application_daily_end_hour = pt::duration_from_string("18:00");
-
+        disruption_wrapper.publication_period = pt::time_period(pt::time_from_string("2013-12-24 12:32:00"),
+                                                                pt::time_from_string("2013-12-26 12:32:00") + pt::seconds(1));
         add_disruption(disruption_wrapper, *b.data->pt_data);
     }
 };
 
 BOOST_FIXTURE_TEST_CASE(network_filter1, Params) {
     std::vector<std::string> forbidden_uris;
-    auto dt = "20131220T125000"_dt_time_stamp;
+    auto dt = "20131219T155000"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1, 10, 0, "network.uri=network:R", forbidden_uris);
+            dt, 1, 10, 0, "network.uri=network:R", forbidden_uris);
 
     BOOST_REQUIRE_EQUAL(resp.disruptions_size(), 1);
 
     pbnavitia::Disruptions disruptions = resp.disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruptions.lines_size(), 2);
+    BOOST_REQUIRE_EQUAL(disruptions.lines_size(), 1);
     BOOST_CHECK_EQUAL(disruptions.network().uri(), "network:R");
 
     pbnavitia::Line line = disruptions.lines(0);
@@ -234,19 +211,10 @@ BOOST_FIXTURE_TEST_CASE(network_filter1, Params) {
     BOOST_REQUIRE_EQUAL(line.disruptions_size(), 1);
     auto disruption = line.disruptions(0);
     BOOST_CHECK_EQUAL(disruption.uri(), "mess1");
+    BOOST_CHECK_EQUAL(disruption.status(), pbnavitia::ActiveStatus::future);
 
     BOOST_REQUIRE_EQUAL(disruption.application_periods_size(), 1);
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20131219T123200"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123200"));
-
-    line = disruptions.lines(1);
-    BOOST_REQUIRE_EQUAL(line.uri(), "line:S");
-
-    BOOST_REQUIRE_EQUAL(line.disruptions_size(), 1);
-    disruption = line.disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess0");
-    BOOST_REQUIRE_EQUAL(disruption.application_periods_size(), 1);
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20131219T123200"));
+    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20131220T123200"));
     BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123200"));
 
 
@@ -256,15 +224,7 @@ BOOST_FIXTURE_TEST_CASE(network_filter1, Params) {
         BOOST_REQUIRE_EQUAL(line.messages_size(), 1);
         pbnavitia::Message message = line.messages(0);
         BOOST_REQUIRE_EQUAL(message.uri(), "mess1");
-        BOOST_REQUIRE_EQUAL(message.start_application_date(), navitia::test::to_posix_timestamp("20131219T123200"));
-        BOOST_REQUIRE_EQUAL(message.end_application_date(), navitia::test::to_posix_timestamp("20131221T123200"));
-        BOOST_REQUIRE_EQUAL(message.start_application_daily_hour(), "000000");
-        BOOST_REQUIRE_EQUAL(message.end_application_daily_hour(), "235959");
-        line = disruptions.lines(1);
-        BOOST_REQUIRE_EQUAL(line.messages_size(), 1);
-        message = line.messages(0);
-        BOOST_REQUIRE_EQUAL(message.uri(), "mess0");
-        BOOST_REQUIRE_EQUAL(message.start_application_date(), navitia::test::to_posix_timestamp("20131219T123200"));
+        BOOST_REQUIRE_EQUAL(message.start_application_date(), navitia::test::to_posix_timestamp("20131220T123200"));
         BOOST_REQUIRE_EQUAL(message.end_application_date(), navitia::test::to_posix_timestamp("20131221T123200"));
         BOOST_REQUIRE_EQUAL(message.start_application_daily_hour(), "000000");
         BOOST_REQUIRE_EQUAL(message.end_application_daily_hour(), "235959");
@@ -275,17 +235,18 @@ BOOST_FIXTURE_TEST_CASE(network_filter2, Params) {
     std::vector<std::string> forbidden_uris;
     auto dt = "20131224T125000"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1, 10, 0, "network.uri=network:M", forbidden_uris);
+            dt, 1, 10, 0, "network.uri=network:K", forbidden_uris);
 
     BOOST_REQUIRE_EQUAL(resp.disruptions_size(), 1);
 
     pbnavitia::Disruptions disruptions = resp.disruptions(0);
     BOOST_REQUIRE_EQUAL(disruptions.lines_size(), 0);
-    BOOST_REQUIRE_EQUAL(disruptions.network().uri(), "network:M");
+    BOOST_REQUIRE_EQUAL(disruptions.network().uri(), "network:K");
     pbnavitia::Network network = disruptions.network();
     BOOST_REQUIRE_EQUAL(network.disruptions_size(), 1);
     auto disruption = network.disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess3");
+    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess2");
+    BOOST_CHECK_EQUAL(disruption.status(), pbnavitia::ActiveStatus::active);
     BOOST_REQUIRE_EQUAL(disruption.application_periods_size(), 1);
     BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20131223T123200"));
     BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20131225T123200"));
@@ -293,9 +254,9 @@ BOOST_FIXTURE_TEST_CASE(network_filter2, Params) {
 
 BOOST_FIXTURE_TEST_CASE(line_filter, Params) {
     std::vector<std::string> forbidden_uris;
-    auto dt = "20131220T125000"_dt_time_stamp;
+    auto dt = "20131221T085000"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1 ,10 ,0 , "line.uri=line:S", forbidden_uris);
+            dt, 1 ,10 ,0 , "line.uri=line:S", forbidden_uris);
 
     BOOST_REQUIRE_EQUAL(resp.disruptions_size(), 1);
 
@@ -309,9 +270,10 @@ BOOST_FIXTURE_TEST_CASE(line_filter, Params) {
     BOOST_REQUIRE_EQUAL(line.disruptions_size(), 1);
     auto disruption = line.disruptions(0);
     BOOST_REQUIRE_EQUAL(disruption.uri(), "mess0");
+    BOOST_CHECK_EQUAL(disruption.status(), pbnavitia::ActiveStatus::active);
 
     BOOST_REQUIRE_EQUAL(disruption.application_periods_size(), 1);
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20131219T123200"));
+    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20131221T083200"));
     BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123200"));
 }
 
@@ -319,61 +281,26 @@ BOOST_FIXTURE_TEST_CASE(Test1, Params) {
     std::vector<std::string> forbidden_uris;
     auto dt = "20140101T0900"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1, 10, 0, "", forbidden_uris);
+            dt, 1, 10, 0, "", forbidden_uris);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ResponseType::NO_SOLUTION);
 }
 
 BOOST_FIXTURE_TEST_CASE(Test2, Params) {
     std::vector<std::string> forbidden_uris;
-    auto dt = "20140103T0900"_dt_time_stamp;
+    auto dt = "20131226T0900"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1, 10, 0, "", forbidden_uris);
+            dt, 1, 10, 0, "", forbidden_uris);
     BOOST_REQUIRE_EQUAL(resp.disruptions_size(), 1);
 
     pbnavitia::Disruptions disruptions = resp.disruptions(0);
     BOOST_REQUIRE_EQUAL(disruptions.lines_size(), 0);
-    BOOST_REQUIRE_EQUAL(disruptions.network().uri(), "network:Test");
+    BOOST_REQUIRE_EQUAL(disruptions.network().uri(), "network:K");
 
     BOOST_REQUIRE_EQUAL(disruptions.network().disruptions_size(), 1);
 
     auto disruption = disruptions.network().disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess4");
-
-    auto nb_p = disruption.application_periods_size();
-    BOOST_REQUIRE(nb_p > 1);
-    //many date since it has been split by days
-    //check first and last
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20140112T084000"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20140112T180000"));
-
-    BOOST_CHECK_EQUAL(disruption.application_periods(nb_p - 1).begin(), navitia::test::to_posix_timestamp("20140202T084000"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(nb_p - 1).end(), navitia::test::to_posix_timestamp("20140202T180000"));
-}
-
-BOOST_FIXTURE_TEST_CASE(Test3, Params) {
-    std::vector<std::string> forbidden_uris;
-    auto dt = "20140113T0900"_dt_time_stamp;
-    pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-           dt, end_date, dt, 1, 10, 0, "", forbidden_uris);
-    BOOST_REQUIRE_EQUAL(resp.disruptions_size(), 1);
-
-    pbnavitia::Disruptions disruptions = resp.disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruptions.lines_size(), 0);
-    BOOST_REQUIRE_EQUAL(disruptions.network().uri(), "network:Test");
-
-    BOOST_REQUIRE_EQUAL(disruptions.network().disruptions_size(), 1);
-
-    auto disruption = disruptions.network().disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess4");
-    auto nb_p = disruption.application_periods_size();
-    BOOST_REQUIRE(nb_p > 1);
-    //many date since it has been split by days
-    //check first and last
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20140112T084000"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20140112T180000"));
-
-    BOOST_CHECK_EQUAL(disruption.application_periods(nb_p - 1).begin(), navitia::test::to_posix_timestamp("20140202T084000"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(nb_p - 1).end(), navitia::test::to_posix_timestamp("20140202T180000"));
+    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess2");
+    BOOST_CHECK_EQUAL(disruption.status(), pbnavitia::ActiveStatus::past);
 }
 
 BOOST_FIXTURE_TEST_CASE(Test4, Params) {
@@ -381,7 +308,7 @@ BOOST_FIXTURE_TEST_CASE(Test4, Params) {
     std::vector<std::string> forbidden_uris;
     auto dt = "20130203T0900"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1 , 10, 0, "", forbidden_uris);
+            dt, 1 , 10, 0, "", forbidden_uris);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ResponseType::NO_SOLUTION);
 }
 
@@ -389,33 +316,8 @@ BOOST_FIXTURE_TEST_CASE(Test5, Params) {
     std::vector<std::string> forbidden_uris;
     auto dt = "20130212T0900"_dt_time_stamp;
     pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1, 10, 0, "", forbidden_uris);
+            dt, 1, 10, 0, "", forbidden_uris);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ResponseType::NO_SOLUTION);
 }
 
-BOOST_FIXTURE_TEST_CASE(Test7, Params) {
-    std::vector<std::string> forbidden_uris;
-    auto dt = "20140113T1801"_dt_time_stamp;
-    pbnavitia::Response resp = navitia::disruption::disruptions(*(b.data),
-            dt, end_date, dt, 1, 10, 0, "", forbidden_uris);
-    BOOST_REQUIRE_EQUAL(resp.disruptions_size(), 1);
-
-    pbnavitia::Disruptions disruptions = resp.disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruptions.lines_size(), 0);
-    BOOST_REQUIRE_EQUAL(disruptions.network().uri(), "network:Test");
-
-    BOOST_REQUIRE_EQUAL(disruptions.network().disruptions_size(), 1);
-
-    auto disruption = disruptions.network().disruptions(0);
-    BOOST_REQUIRE_EQUAL(disruption.uri(), "mess4");
-    auto nb_p = disruption.application_periods_size();
-    BOOST_REQUIRE(nb_p > 1);
-    //many date since it has been split by days
-    //check first and last
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).begin(), navitia::test::to_posix_timestamp("20140112T084000"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(0).end(), navitia::test::to_posix_timestamp("20140112T180000"));
-
-    BOOST_CHECK_EQUAL(disruption.application_periods(nb_p - 1).begin(), navitia::test::to_posix_timestamp("20140202T084000"));
-    BOOST_CHECK_EQUAL(disruption.application_periods(nb_p - 1).end(), navitia::test::to_posix_timestamp("20140202T180000"));
-}

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -76,13 +76,6 @@ class Disruptions(ResourceUri):
                                 description="Number of disruptions per page")
         parser_get.add_argument("start_page", type=int, default=0,
                                 description="The current page")
-        parser_get.add_argument("period", type=int,
-                                description="Period in days from datetime. DEPRECATED use duration parameter")
-        parser_get.add_argument("duration", type=duration, default=timedelta(days=365),
-                                description="Duration from the period we want to display the disruption on")
-        parser_get.add_argument("datetime", type=date_time_format, default=datetime.now(), #TODO!! we have to take the local instance time
-                                description="The datetime from which you want the disruption "
-                                            "(filter on the disruption application periods)")
         parser_get.add_argument("_current_datetime", type=date_time_format, default=datetime.now(), #TODO!! we have to take the local instance time
                                 description="The datetime we want to publish the disruptions from."
                                             " Default is the current date and it is mainly used for debug."
@@ -114,12 +107,6 @@ class Disruptions(ResourceUri):
         else:
             args["filter"] = ""
 
-        #we compute the period end with the duration (or the deprecated 'period' argument)
-        period_end = args['datetime'] + args['duration']
-        if args.get('period'):
-            period_end = args['datetime'] + timedelta(days=args.get('period'))
-
-        args['period_end'] = period_end
         self._register_interpreted_parameters(args)
 
         response = i_manager.dispatch(args, "disruptions",
@@ -153,13 +140,6 @@ class TrafficReport(ResourceUri):
                                 description="Number of disruptions per page")
         parser_get.add_argument("start_page", type=int, default=0,
                                 description="The current page")
-        parser_get.add_argument("period", type=int,
-                                description="Period in days from datetime. DEPRECATED use duration parameter")
-        parser_get.add_argument("duration", type=duration, default=timedelta(days=365),
-                                description="Duration from the period we want to display the disruption on")
-        parser_get.add_argument("datetime", type=date_time_format, default=datetime.now(), #TODO!! we have to take the local instance time
-                                description="The datetime from which you want the disruption "
-                                            "(filter on the disruption application periods)")
         parser_get.add_argument("_current_datetime", type=date_time_format, default=datetime.now(), #TODO!! we have to take the local instance time
                                 description="The datetime we want to publish the disruptions from."
                                             " Default is the current date and it is mainly used for debug."
@@ -191,13 +171,6 @@ class TrafficReport(ResourceUri):
             args["filter"] = self.get_filter(uris)
         else:
             args["filter"] = ""
-
-        #we compute the period end with the duration (or the deprecated 'period' argument)
-        period_end = args['datetime'] + args['duration']
-        if args.get('period'):
-            period_end = args['datetime'] + timedelta(days=args.get('period'))
-
-        args['period_end'] = period_end
 
         response = i_manager.dispatch(args, "disruptions", instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -77,8 +77,6 @@ class Scenario(object):
         req.disruptions.filter = request['filter']
         req.disruptions.count = request['count']
         req.disruptions.start_page = request['start_page']
-        req.disruptions.application_period_begin = date_to_timestamp(request['datetime'])
-        req.disruptions.application_period_end = date_to_timestamp(request['period_end'])
         req.disruptions._current_datetime = date_to_timestamp(request['_current_datetime'])
 
         if request["forbidden_uris[]"]:

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -427,12 +427,12 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         test /disruptions and check that an update of a disruption is correctly done
         """
         self.wait_for_rabbitmq_cnx()
-        query = 'traffic_reports?datetime=20140101T000000&_current_datetime=20140101T000000'
+        query = 'traffic_reports?_current_datetime=20140101T000000'
         response = self.query_region(query)
 
         disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
-        eq_(len(disrupt), 1)
+        eq_(len(disrupt), 2)
 
         status = self.query_region('status')
         last_loaded_data = get_not_null(status['status'], 'last_rt_data_loaded')
@@ -447,7 +447,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
-        eq_(len(disrupt), 2)
+        eq_(len(disrupt), 3)
 
         for disruption in disrupt:
             if disruption['id'] == 'test_disruption':
@@ -464,7 +464,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
-        eq_(len(disrupt), 2)
+        eq_(len(disrupt), 3)
         for disruption in disrupt:
             if disruption['id'] == 'test_disruption':
                 eq_(disruption['messages'][0]['text'], 'update')
@@ -480,7 +480,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         disrupt = get_disruptions(response['traffic_reports'][0]['network'], response)
         assert disrupt
-        eq_(len(disrupt), 1)
+        eq_(len(disrupt), 2)
         for disruption in disrupt:
             assert disruption['uri'] != 'test_disruption', 'this disruption must have been deleted'
 

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -34,7 +34,7 @@ def get_impacts(response):
     return {d['impact_id']: d for d in response['disruptions']}
 
 # for the tests we need custom datetime to display the disruptions
-default_date_filter = 'datetime=20140101T000000&_current_datetime=20140101T000000'
+default_date_filter = '_current_datetime=20140101T000000'
 
 
 @dataset(["main_routing_test"])
@@ -53,46 +53,53 @@ class TestDisruptions(AbstractTestFixture):
         one impacted stop_area
         """
 
-        response = self.query_region('traffic_reports?' + default_date_filter, display=True)
+        response = self.query_region('traffic_reports?' + default_date_filter, display=False)
 
         traffic_report = get_not_null(response, 'traffic_reports')
 
         # the disruptions are grouped by network and we have only one network
-        assert len(traffic_report) == 1
+        eq_(len(traffic_report), 1)
 
         impacted_lines = get_not_null(traffic_report[0], 'lines')
-        assert len(impacted_lines) == 1
+        eq_(len(impacted_lines), 1)
         is_valid_line(impacted_lines[0], depth_check=0)
-        assert impacted_lines[0]['id'] == 'A'
+        eq_(impacted_lines[0]['id'], 'A')
 
         lines_disrupt = get_disruptions(impacted_lines[0], response)
-        assert len(lines_disrupt) == 1
+        eq_(len(lines_disrupt), 2)
         for d in lines_disrupt:
             is_valid_disruption(d)
-        assert lines_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert lines_disrupt[0]['impact_id'] == 'too_bad_again'
-        assert lines_disrupt[0]['severity']['name'] == 'bad severity'
+        eq_(lines_disrupt[0]['uri'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['impact_id'], 'too_bad_again')
+        eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
+
+        eq_(lines_disrupt[1]['uri'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[1]['impact_id'], 'later_impact')
+        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
         is_valid_network(impacted_network, depth_check=0)
-        assert impacted_network['id'] == 'base_network'
+        eq_(impacted_network['id'], 'base_network')
         network_disrupt = get_disruptions(impacted_network, response)
-        assert len(network_disrupt) == 1
+        eq_(len(network_disrupt), 2)
         for d in network_disrupt:
             is_valid_disruption(d)
-        assert network_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert network_disrupt[0]['impact_id'] == 'too_bad_again'
+        eq_(network_disrupt[0]['uri'], 'disruption_on_line_A')
+        eq_(network_disrupt[0]['impact_id'], 'too_bad_again')
+
+        eq_(network_disrupt[1]['uri'], 'disruption_on_line_A_but_later')
+        eq_(network_disrupt[1]['impact_id'], 'later_impact')
 
         impacted_stop_areas = get_not_null(traffic_report[0], 'stop_areas')
-        assert len(impacted_stop_areas) == 1
+        eq_(len(impacted_stop_areas), 1)
         is_valid_stop_area(impacted_stop_areas[0], depth_check=0)
-        assert impacted_stop_areas[0]['id'] == 'stopA'
+        eq_(impacted_stop_areas[0]['id'], 'stopA')
         stop_disrupt = get_disruptions(impacted_stop_areas[0], response)
-        assert len(stop_disrupt) == 1
+        eq_(len(stop_disrupt), 1)
         for d in stop_disrupt:
             is_valid_disruption(d)
-        assert stop_disrupt[0]['uri'] == 'disruption_on_stop_A'
-        assert stop_disrupt[0]['impact_id'] == 'too_bad'
+        eq_(stop_disrupt[0]['uri'], 'disruption_on_stop_A')
+        eq_(stop_disrupt[0]['impact_id'], 'too_bad')
 
         """
         by querying directly the impacted object, we find the same results
@@ -101,20 +108,20 @@ class TestDisruptions(AbstractTestFixture):
         # networks = self.query_region('networks/base_network?' + default_date_filter)
         # network = get_not_null(networks, 'networks')[0]
         # is_valid_network(network)
-        # assert get_not_null(network, 'disruptions') == network_disrupt
-        # assert get_not_null(network, 'messages') == get_not_null(impacted_network, 'messages')
+        # eq_(get_not_null(network, 'disruptions'), network_disrupt)
+        # eq_(get_not_null(network, 'messages'), get_not_null(impacted_network, 'messages'))
         #
         # lines = self.query_region('lines/A?' + default_date_filter)
         # line = get_not_null(lines, 'lines')[0]
         # is_valid_line(line)
-        # assert get_not_null(line, 'disruptions') == lines_disrupt
-        # assert get_not_null(line, 'messages') == get_not_null(impacted_lines[0], 'messages')
+        # eq_(get_not_null(line, 'disruptions'), lines_disrupt)
+        # eq_(get_not_null(line, 'messages'), get_not_null(impacted_lines[0], 'messages'))
         #
         # stops = self.query_region('stop_areas/stopA?' + default_date_filter)
         # stop = get_not_null(stops, 'stop_areas')[0]
         # is_valid_stop_area(stop)
-        # assert get_not_null(stop, 'disruptions') == stop_disrupt
-        # assert get_not_null(stop, 'messages') == get_not_null(impacted_stop_areas[0], 'messages')
+        # eq_(get_not_null(stop, 'disruptions'), stop_disrupt)
+        # eq_(get_not_null(stop, 'messages'), get_not_null(impacted_stop_areas[0], 'messages'))
 
     def test_disruption_with_stop_areas(self):
         """
@@ -124,7 +131,7 @@ class TestDisruptions(AbstractTestFixture):
         response = self.query_region('stop_areas/stopA')
 
         stops = get_not_null(response, 'stop_areas')
-        assert len(stops) == 1
+        eq_(len(stops), 1)
         stop = stops[0]
 
         #TODO: we can't make those test for the moment since we need to add a datetime param to those APIs
@@ -145,26 +152,26 @@ class TestDisruptions(AbstractTestFixture):
         response = self.query_region('stop_areas/stopB/disruptions?' + default_date_filter, display=True)
 
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 1
+        eq_(len(disruptions), 1)
 
         impacted_lines = get_not_null(disruptions[0], 'lines')
-        assert len(impacted_lines) == 1
+        eq_(len(impacted_lines), 1)
         is_valid_line(impacted_lines[0], depth_check=0)
-        assert impacted_lines[0]['id'] == 'A'
+        eq_(impacted_lines[0]['id'], 'A')
 
         lines_disrupt = get_not_null(impacted_lines[0], 'disruptions')
-        assert len(lines_disrupt) == 1
-        assert lines_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert lines_disrupt[0]['impact_id'] == 'too_bad_again'
+        eq_(len(lines_disrupt), 1)
+        eq_(lines_disrupt[0]['uri'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['impact_id'], 'too_bad_again')
 
         impacted_network = get_not_null(disruptions[0], 'network')
 
         is_valid_network(impacted_network, depth_check=0)
-        assert impacted_network['id'] == 'base_network'
+        eq_(impacted_network['id'], 'base_network')
         network_disrupt = get_not_null(impacted_network, 'disruptions')
-        assert len(network_disrupt) == 1
-        assert network_disrupt[0]['uri'] == 'disruption_on_line_A'
-        assert network_disrupt[0]['impact_id'] == 'too_bad_again'
+        eq_(len(network_disrupt), 1)
+        eq_(network_disrupt[0]['uri'], 'disruption_on_line_A')
+        eq_(network_disrupt[0]['impact_id'], 'too_bad_again')
 
         # but we should not have disruption on stop area, B is not disrupted
         assert 'stop_areas' not in disruptions[0]
@@ -175,37 +182,13 @@ class TestDisruptions(AbstractTestFixture):
         when calling the pt object stopB, we should get no disruptions
         """
 
-        response = self.query_region('stop_areas/stopB', display=True)
+        response = self.query_region('stop_areas/stopB', display=False)
 
         stops = get_not_null(response, 'stop_areas')
-        assert len(stops) == 1
+        eq_(len(stops), 1)
         stop = stops[0]
 
         assert 'disruptions' not in stop
-
-    def test_disruption_period_filter(self):
-        """
-        period filter
-
-        we ask for the disruption on the 3 next days
-        => we get 2 impacts (too_bad and too_bad_again)
-
-        we ask for the disruption on the 3 next yers
-        => we get 3 impacts (we get later_impact too)
-
-        """
-
-        response = self.query_region('traffic_reports?duration=P3D&' + default_date_filter)
-
-        impacts = get_impacts(response)
-        assert len(impacts) == 2
-        assert 'later_impact' not in impacts
-
-        response = self.query_region('traffic_reports?duration=P3Y&' + default_date_filter)
-
-        impacts = get_impacts(response)
-        assert len(impacts) == 3
-        assert 'later_impact' in impacts
 
     def test_disruption_publication_date_filter(self):
         """
@@ -215,16 +198,14 @@ class TestDisruptions(AbstractTestFixture):
 
         so at 9 it is not in the list, at 11, we get it
         """
-        response = self.query_region('traffic_reports?datetime=20140101T000000'
-                                     '&_current_datetime=20140128T090000', display=True)
+        response = self.query_region('traffic_reports?_current_datetime=20140128T090000', display=False)
 
         impacts = get_impacts(response)
-        assert len(impacts) == 2
+        eq_(len(impacts), 3)
         assert 'impact_published_later' not in impacts
 
-        response = self.query_region('traffic_reports?datetime=20140101T000000'
-                                     '&_current_datetime=20140128T130000', display=True)
+        response = self.query_region('traffic_reports?_current_datetime=20140128T130000', display=False)
 
         impacts = get_impacts(response)
-        assert len(impacts) == 3
+        eq_(len(impacts), 4)
         assert 'impact_published_later' in impacts

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -196,8 +196,6 @@ pbnavitia::Response Worker::disruptions(const pbnavitia::DisruptionsRequest &req
     for(int i = 0; i < request.forbidden_uris_size(); ++i)
         forbidden_uris.push_back(request.forbidden_uris(i));
     return navitia::disruption::disruptions(*data,
-                                                request.application_period_begin(),
-                                                request.application_period_end(),
                                                 request._current_datetime(),
                                                 request.depth(),
                                                 request.count(),

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -47,7 +47,7 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
     }
 
     // we check if we want to publish the impact
-    if (! disruption->publication_period.contains(publication_date)) {
+    if (! disruption->is_publishable(publication_date)) {
         return false;
     }
 
@@ -62,6 +62,19 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
         }
     }
     return false;
+
+}
+
+bool Disruption::is_publishable(const boost::posix_time::ptime& current_time) const{
+    if(current_time.is_not_a_date_time()){
+        return false;
+    }
+
+    if (this->publication_period.contains(current_time)) {
+        return true;
+    }
+    return false;
+
 }
 
 void Disruption::add_impact(const boost::shared_ptr<Impact>& impact){

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -62,7 +62,6 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
         }
     }
     return false;
-
 }
 
 bool Disruption::is_publishable(const boost::posix_time::ptime& current_time) const{
@@ -74,7 +73,6 @@ bool Disruption::is_publishable(const boost::posix_time::ptime& current_time) co
         return true;
     }
     return false;
-
 }
 
 void Disruption::add_impact(const boost::shared_ptr<Impact>& impact){

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -238,6 +238,8 @@ struct Disruption {
         return impacts;
     }
 
+    bool is_publishable(const boost::posix_time::ptime& current_time) const;
+
 private:
     //Disruption have the ownership of the Impacts.  Impacts are
     //shared_ptr and not unique_ptr because there are weak_ptr

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -50,18 +50,23 @@ namespace navitia{
 
 static pbnavitia::ActiveStatus
 compute_disruption_status(const boost::shared_ptr<type::new_disruption::Impact>& impact,
-                          const boost::posix_time::ptime& dt) {
+                          const boost::posix_time::time_period& action_period) {
 
-    auto disruption = impact->disruption;
-
-    if (disruption->publication_period.contains(dt)) {
-        return pbnavitia::active;
+    bool is_future = false;
+    for(const auto& period: impact->application_periods){
+        if(period.intersects(action_period)){
+            return pbnavitia::active;
+        }
+        if(!period.is_null() && period.begin() >= action_period.end()){
+            is_future = true;
+        }
     }
 
-    if (disruption->publication_period.begin() < dt) {
+    if(is_future){
+        return pbnavitia::future;
+    }else{
         return pbnavitia::past;
     }
-    return pbnavitia::future;
 }
 
 template <typename T>
@@ -98,7 +103,7 @@ void fill_address(const T* obj, const nt::Data& data,
 template <typename T>
 void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_weak_ptr,
         const type::Data&, T pb_object, int,
-        const boost::posix_time::ptime& now, const boost::posix_time::time_period&) {
+        const boost::posix_time::ptime&, const boost::posix_time::time_period& action_period) {
     auto impact = impact_weak_ptr.lock();
     if (! impact) {
         return; //impact is no longer valid, we have nothing to do
@@ -139,7 +144,7 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     }
 
     //we need to compute the active status
-    pb_disrution->set_status(compute_disruption_status(impact, now));
+    pb_disrution->set_status(compute_disruption_status(impact, action_period));
 
     // we also fill the old message for the customer using it.
     //will be removed as soon as possible
@@ -211,11 +216,13 @@ void fill_pb_object(const georef::Admin* adm, const nt::Data&,
 void fill_pb_object(const nt::Contributor*,
                     const nt::Data& , pbnavitia::Contributor* ,
                     int , const pt::ptime& ,
-                    const pt::time_period& , const bool ){}
+                    const pt::time_period& , const bool, const bool){}
+
 void fill_pb_object(const nt::StopArea * sa,
                     const nt::Data& data, pbnavitia::StopArea* stop_area,
                     int max_depth, const pt::ptime& now,
-                    const pt::time_period& action_period, const bool show_codes){
+                    const pt::time_period& action_period, const bool show_codes,
+                    const bool display_all_publishable_disruption){
     if(sa == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -237,8 +244,14 @@ void fill_pb_object(const nt::StopArea * sa,
         }
     }
 
-    for(const auto message : sa->get_applicable_messages(now, action_period)){
-        fill_message(message, data, stop_area, max_depth-1, now, action_period);
+    if(display_all_publishable_disruption){
+        for(const auto message : sa->get_publishable_messages(now)){
+            fill_message(message, data, stop_area, max_depth-1, now, action_period);
+        }
+    }else{
+        for(const auto message : sa->get_applicable_messages(now, action_period)){
+            fill_message(message, data, stop_area, max_depth-1, now, action_period);
+        }
     }
     if(show_codes) {
         for(auto type_value : sa->codes) {
@@ -250,7 +263,8 @@ void fill_pb_object(const nt::StopArea * sa,
 
 void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
                     pbnavitia::StopPoint* stop_point, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes,
+                    const bool display_all_publishable_disruption){
     if(sp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -309,11 +323,17 @@ void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
 
     if(depth > 0 && sp->stop_area != nullptr)
         fill_pb_object(sp->stop_area, data, stop_point->mutable_stop_area(),
-                       depth-1, now, action_period, show_codes);
+                       depth-1, now, action_period, show_codes, display_all_publishable_disruption);
 
 
-    for(const auto message : sp->get_applicable_messages(now, action_period)){
-        fill_message(message, data, stop_point, max_depth-1, now, action_period);
+    if(display_all_publishable_disruption){
+        for(const auto message : sp->get_publishable_messages(now)){
+            fill_message(message, data, stop_point, max_depth-1, now, action_period);
+        }
+    }else{
+        for(const auto message : sp->get_applicable_messages(now, action_period)){
+            fill_message(message, data, stop_point, max_depth-1, now, action_period);
+        }
     }
     if(show_codes) {
         for(auto type_value : sp->codes) {
@@ -348,7 +368,8 @@ void fill_pb_object(const navitia::type::GeographicalCoord& coord, const type::D
 
 void fill_pb_object(nt::Line const* l, const nt::Data& data,
         pbnavitia::Line * line, int max_depth, const pt::ptime& now,
-        const pt::time_period& action_period, const bool show_codes){
+        const pt::time_period& action_period, const bool show_codes,
+        const bool display_all_publishable_disruption){
     if(l == nullptr)
         return ;
 
@@ -369,19 +390,26 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
 
         std::vector<nt::idx_t> physical_mode_idxes;
         for(auto route : l->route_list) {
-            fill_pb_object(route, data, line->add_routes(), depth-1, now, action_period, show_codes);
+            fill_pb_object(route, data, line->add_routes(), depth-1, now, action_period, show_codes, display_all_publishable_disruption);
         }
         for(auto physical_mode : l->physical_mode_list){
             fill_pb_object(physical_mode, data, line->add_physical_mode(),
-                    depth-1);
+                    depth-1, now, action_period, show_codes, display_all_publishable_disruption);
         }
 
         fill_pb_object(l->commercial_mode, data,
-                line->mutable_commercial_mode(), depth-1);
-        fill_pb_object(l->network, data, line->mutable_network(), depth-1, now, action_period, show_codes);
+                line->mutable_commercial_mode(), depth-1, now, action_period, show_codes, display_all_publishable_disruption);
+        fill_pb_object(l->network, data, line->mutable_network(), depth-1, now, action_period, show_codes, display_all_publishable_disruption);
     }
-    for(const auto message : l->get_applicable_messages(now, action_period)){
-        fill_message(message, data, line, depth-1, now, action_period);
+
+    if(display_all_publishable_disruption){
+        for(const auto message : l->get_publishable_messages(now)){
+            fill_message(message, data, line, depth-1, now, action_period);
+        }
+    }else{
+        for(const auto message : l->get_applicable_messages(now, action_period)){
+            fill_message(message, data, line, depth-1, now, action_period);
+        }
     }
 
     if(show_codes) {
@@ -394,7 +422,8 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
 
 void fill_pb_object(const nt::JourneyPattern* jp, const nt::Data& data,
         pbnavitia::JourneyPattern * journey_pattern, int max_depth,
-        const pt::ptime& now, const pt::time_period& action_period, const bool){
+        const pt::ptime& now, const pt::time_period& action_period, const bool,
+        const bool display_all_publishable_disruption){
     if(jp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -403,7 +432,7 @@ void fill_pb_object(const nt::JourneyPattern* jp, const nt::Data& data,
     journey_pattern->set_uri(jp->uri);
     if(depth > 0 && jp->route != nullptr) {
         fill_pb_object(jp->route, data, journey_pattern->mutable_route(),
-                depth-1, now, action_period);
+                depth-1, now, action_period, display_all_publishable_disruption);
     }
 }
 
@@ -420,7 +449,8 @@ void fill_pb_object(const nt::MultiLineString& shape, pbnavitia::MultiLineString
 
 void fill_pb_object(const nt::Route* r, const nt::Data& data,
                     pbnavitia::Route* route, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes,
+                    const bool display_all_publishable_disruption){
     if(r == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -435,8 +465,14 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
     }
 
     route->set_uri(r->uri);
-    for(const auto& message : r->get_applicable_messages(now, action_period)){
-        fill_message(message, data, route, max_depth-1, now, action_period);
+    if(display_all_publishable_disruption){
+        for(const auto& message : r->get_publishable_messages(now)){
+            fill_message(message, data, route, max_depth-1, now, action_period);
+        }
+    }else{
+        for(const auto& message : r->get_applicable_messages(now, action_period)){
+            fill_message(message, data, route, max_depth-1, now, action_period);
+        }
     }
 
     if(show_codes) {
@@ -449,7 +485,7 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
     }
     if(r->line != nullptr) {
         fill_pb_object(r->line, data, route->mutable_line(), depth-1,
-                       now, action_period, show_codes);
+                       now, action_period, show_codes, display_all_publishable_disruption);
     }
 
     fill_pb_object(r->shape, route->mutable_geojson());
@@ -460,7 +496,7 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
         for(auto idx : thermometer.get_thermometer()) {
             auto stop_point = data.pt_data->stop_points[idx];
                 fill_pb_object(stop_point, data, route->add_stop_points(), depth-1,
-                        now, action_period, show_codes);
+                        now, action_period, show_codes, display_all_publishable_disruption);
         }
     }
 }
@@ -468,15 +504,22 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
 
 void fill_pb_object(const nt::Network* n, const nt::Data& data,
                     pbnavitia::Network* network, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes,
+                    const bool display_all_publishable_disruption){
     if(n == nullptr)
         return ;
 
     network->set_name(n->name);
     network->set_uri(n->uri);
 
-    for(const auto& message : n->get_applicable_messages(now, action_period)){
-        fill_message(message, data, network, max_depth-1, now, action_period);
+    if(display_all_publishable_disruption){
+        for(const auto& message : n->get_publishable_messages(now)){
+            fill_message(message, data, network, max_depth-1, now, action_period);
+        }
+    }else{
+        for(const auto& message : n->get_applicable_messages(now, action_period)){
+            fill_message(message, data, network, max_depth-1, now, action_period);
+        }
     }
     if(show_codes) {
         for(auto type_value : n->codes) {
@@ -488,7 +531,8 @@ void fill_pb_object(const nt::Network* n, const nt::Data& data,
 
 void fill_pb_object(const nt::CommercialMode* m, const nt::Data&,
                     pbnavitia::CommercialMode* commercial_mode,
-                    int, const pt::ptime&, const pt::time_period&, const bool){
+                    int, const pt::ptime&, const pt::time_period&, const bool,
+                    const bool){
     if(m == nullptr)
         return ;
 
@@ -499,7 +543,8 @@ void fill_pb_object(const nt::CommercialMode* m, const nt::Data&,
 
 void fill_pb_object(const nt::PhysicalMode* m, const nt::Data&,
                     pbnavitia::PhysicalMode* physical_mode, int,
-                    const pt::ptime&, const pt::time_period&, const bool){
+                    const pt::ptime&, const pt::time_period&, const bool,
+                    const bool){
     if(m == nullptr)
         return ;
 
@@ -510,7 +555,8 @@ void fill_pb_object(const nt::PhysicalMode* m, const nt::Data&,
 
 void fill_pb_object(const nt::Company* c, const nt::Data&,
                     pbnavitia::Company* company, int, const pt::ptime&,
-                    const pt::time_period&, const bool show_codes){
+                    const pt::time_period&, const bool show_codes,
+                    const bool){
     if(c == nullptr)
         return ;
 
@@ -547,7 +593,7 @@ void fill_pb_object(const nt::StopPointConnection* c, const nt::Data& data,
 
 void fill_pb_object(const nt::ValidityPattern* vp, const nt::Data&,
                     pbnavitia::ValidityPattern* validity_pattern, int,
-                    const pt::ptime&, const pt::time_period&, const bool){
+                    const pt::ptime&, const pt::time_period&, const bool, const bool){
     if(vp == nullptr)
         return;
     auto vp_string = boost::gregorian::to_iso_string(vp->beginning_date);
@@ -588,7 +634,8 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     int max_depth,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
-                    const bool show_codes){
+                    const bool show_codes,
+                    const bool display_all_publishable_disruption){
     if(vj == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -639,8 +686,14 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                                      action_period);
     }
 
-    for(auto message : vj->get_applicable_messages(now, action_period)){
-        fill_message(message, data, vehicle_journey, max_depth-1, now, action_period);
+    if(display_all_publishable_disruption){
+        for(auto message : vj->get_publishable_messages(now)){
+            fill_message(message, data, vehicle_journey, max_depth-1, now, action_period);
+        }
+    }else{
+        for(auto message : vj->get_applicable_messages(now, action_period)){
+            fill_message(message, data, vehicle_journey, max_depth-1, now, action_period);
+        }
     }
 
     //si on a un vj théorique rataché à notre vj, on récupére les messages qui le concerne
@@ -704,7 +757,8 @@ void fill_pb_object(const nt::StopTime* st, const type::Data& data,
 void fill_pb_object(const nt::JourneyPatternPoint* jpp, const nt::Data& data,
                     pbnavitia::JourneyPatternPoint * journey_pattern_point,
                     int max_depth, const pt::ptime& now,
-                    const pt::time_period& action_period, const bool show_codes){
+                    const pt::time_period& action_period, const bool show_codes,
+                    const bool display_all_publishable_disruption){
     if(jpp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -716,12 +770,12 @@ void fill_pb_object(const nt::JourneyPatternPoint* jpp, const nt::Data& data,
         if(jpp->stop_point != nullptr) {
             fill_pb_object(jpp->stop_point, data,
                            journey_pattern_point->mutable_stop_point(),
-                           depth-1, now, action_period);
+                           depth-1, now, action_period, display_all_publishable_disruption);
         }
         if(jpp->journey_pattern != nullptr) {
             fill_pb_object(jpp->journey_pattern, data,
                            journey_pattern_point->mutable_journey_pattern(),
-                           depth - 1, now, action_period, show_codes);
+                           depth - 1, now, action_period, show_codes, display_all_publishable_disruption);
         }
     }
 }
@@ -1424,7 +1478,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
 
 void fill_pb_object(const nt::Calendar* cal, const nt::Data& data,
                     pbnavitia::Calendar* pb_cal, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes)
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes, const bool)
 {
     pb_cal->set_uri(cal->uri);
     pb_cal->set_name(cal->name);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -90,7 +90,8 @@ struct EnhancedResponse {
 #define FILL_PB_CONSTRUCTOR(type_name, collection_name)\
     void fill_pb_object(const navitia::type::type_name* item, const navitia::type::Data& data, pbnavitia::type_name *, int max_depth = 0,\
             const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,\
-            const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes=false);
+            const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes=false,\
+            const bool display_all_publiable_disruption=false);
     ITERATE_NAVITIA_PT_TYPES(FILL_PB_CONSTRUCTOR)
 #undef FILL_PB_CONSTRUCTOR
 
@@ -207,7 +208,8 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     int max_depth,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
-                    const bool show_codes);
+                    const bool show_codes,
+                    const bool display_all_publiable_disruption);
 
 void fill_pb_object(const type::VehicleJourney* vj,
                     const type::Data& data,

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -80,6 +80,25 @@ std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_applicable
 
 }
 
+std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_publishable_messages(
+            const boost::posix_time::ptime& current_time) const{
+    std::vector<boost::weak_ptr<new_disruption::Impact>> result;
+
+    //we cleanup the released pointer (not in the loop for code clarity)
+    clean_up_weak_ptr(impacts);
+
+    for (auto impact : this->impacts) {
+        auto impact_acquired = impact.lock();
+        if (! impact_acquired) {
+            continue; //pointer might still have become invalid
+        }
+        if (impact_acquired->disruption->is_publishable(current_time)) {
+            result.push_back(impact);
+        }
+    }
+    return result;
+}
+
 bool HasMessages::has_applicable_message(
         const boost::posix_time::ptime& current_time,
         const boost::posix_time::time_period& action_period) const {
@@ -92,6 +111,22 @@ bool HasMessages::has_applicable_message(
             continue; //pointer might still have become invalid
         }
         if (impact_acquired->is_valid(current_time, action_period)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool HasMessages::has_publishable_message(const boost::posix_time::ptime& current_time) const{
+    //we cleanup the released pointer (not in the loop for code clarity)
+    clean_up_weak_ptr(impacts);
+
+    for (auto impact : this->impacts) {
+        auto impact_acquired = impact.lock();
+        if (! impact_acquired) {
+            continue; //pointer might still have become invalid
+        }
+        if (impact_acquired->disruption->is_publishable(current_time)) {
             return true;
         }
     }

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -299,6 +299,11 @@ public:
             const boost::posix_time::ptime& current_time,
             const boost::posix_time::time_period& action_period) const;
 
+    bool has_publishable_message(const boost::posix_time::ptime& current_time) const;
+
+    std::vector<boost::weak_ptr<new_disruption::Impact>> get_publishable_messages(
+            const boost::posix_time::ptime& current_time) const;
+
 
     std::vector<boost::weak_ptr<new_disruption::Impact>> get_impacts() const {
         return impacts;


### PR DESCRIPTION
All publishable disruption are returned, the status is dependant of the
application period.

The Api don't take date anymore, only the current date is used
