### PR TITLE
Kraken: remove duplicate impact on vehicle journey

### DIFF
--- a/source/type/data.h
+++ b/source/type/data.h
@@ -74,7 +74,7 @@ struct wrong_version : public navitia::exception {
 class Data : boost::noncopyable{
 public:
 
-    static const unsigned int data_version = 34; //< Data version number. *INCREMENT* every time serialized data are modified
+    static const unsigned int data_version = 35; //< Data version number. *INCREMENT* every time serialized data are modified
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -680,6 +680,10 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
 
     VehicleJourneyType vehicle_journey_type = VehicleJourneyType::regular;
 
+    // impacts not directly on this vj, by example an impact on a line will impact the vj, so we add the impact here
+    // because it's not really on the vj
+    std::vector<boost::weak_ptr<new_disruption::Impact>> impacted_by;
+
     // all times are stored in UTC
     // however, sometime we do not have a date to convert the time to a local value (in jormungandr)
     // For example for departure board over a period (calendar)
@@ -713,7 +717,8 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
             & theoric_vehicle_journey & comment & vehicle_journey_type
             & odt_message & _vehicle_properties & impacts
             & codes & next_vj & prev_vj
-            & meta_vj & utc_to_local_offset;
+            & meta_vj & utc_to_local_offset
+            & impacted_by;
     }
 
     type::OdtLevel_e get_odt_level() const;


### PR DESCRIPTION
For blocking impact we have to update the vehicle_journeys attached at the impacted object, typically a line or a route. For being able to update a impact we have to store each impact impacting the vj. But this impacts must not be displayed for this vj else we will have duplicate items on the response.

So impacts not directly on a vj are stored in a new attributes: `impacted_by`.
