### PR TITLE
Jormungandr: add a datetime parameter to uris API

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -78,10 +78,7 @@ class Disruptions(ResourceUri):
                                 description="The current page")
         parser_get.add_argument("_current_datetime", type=date_time_format, default=datetime.utcnow(),
                                 description="The datetime we want to publish the disruptions from."
-                                            " Default is the current date and it is mainly used for debug."
-                                            " Note: it is not the same as 'datetime' which, combined with"
-                                            " duration form a period used to filter the disruption"
-                                            " application periods")
+                                            " Default is the current date and it is mainly used for debug.")
         parser_get.add_argument("forbidden_id[]", type=unicode,
                                 description="forbidden ids",
                                 dest="forbidden_uris[]",

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -42,7 +42,7 @@ from VehicleJourney import vehicle_journey
 from collections import OrderedDict
 from ResourceUri import ResourceUri
 from jormungandr.interfaces.argument import ArgumentDoc
-from jormungandr.interfaces.parsers import depth_argument
+from jormungandr.interfaces.parsers import depth_argument, date_time_format
 from errors import ManageError
 from Coord import Coord
 from jormungandr.interfaces.v1.fields import DisruptionsField, use_old_disruptions_if_needed
@@ -51,6 +51,7 @@ from flask.ext.restful.types import boolean
 from jormungandr.interfaces.parsers import option_value
 from jormungandr.interfaces.common import odt_levels
 import navitiacommon.type_pb2 as type_pb2
+from datetime import datetime
 
 class Uri(ResourceUri):
     parsers = {}
@@ -83,6 +84,12 @@ class Uri(ResourceUri):
                                 description="temporary boolean to use the old disruption interface. "
                                             "Will be deleted soon, just needed for synchronization with the front end",
                                 default=False)
+        parser.add_argument("_current_datetime", type=date_time_format, default=datetime.utcnow(),
+                                description="The datetime used to consider the state of the pt object"
+                                            " Default is the current date and it is used for debug."
+                                            " Note: it will mainly change the disruptions that concern the object"
+                                            " The timezone should be specified in the format,"
+                                            " else we consider it as UTC")
 
         if is_collection:
             parser.add_argument("filter", type=str, default="",

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -35,6 +35,7 @@ import navitiacommon.response_pb2 as response_pb2
 from jormungandr.interfaces.common import pb_odt_level
 from jormungandr.scenarios.utils import pb_type, pt_object_type
 from jormungandr.scenarios.utils import build_pagination
+from datetime import datetime
 
 
 class Scenario(object):
@@ -232,6 +233,7 @@ class Scenario(object):
         req.ptref.start_page = request["start_page"]
         req.ptref.count = request["count"]
         req.ptref.show_codes = request["show_codes"]
+        req.ptref.datetime = date_to_timestamp(request["_current_datetime"])
         if request["odt_level"]:
             req.ptref.odt_level = pb_odt_level[request["odt_level"]]
         if request["forbidden_uris[]"]:

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -54,7 +54,7 @@ def date_to_timestamp(date):
     """
     convert a datatime objet to a posix timestamp (number of seconds from 1070/1/1)
     """
-    return int(calendar.timegm(date.timetuple()))
+    return int(calendar.timegm(date.utctimetuple()))
 
 
 class ResourceUtc:

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -166,7 +166,7 @@ class TestDisruptions(AbstractTestFixture):
         and the impacts on the network
         """
 
-        response = self.query_region('stop_areas/stopB/traffic_reports?' + default_date_filter, display=True)
+        response = self.query_region('stop_areas/stopB/traffic_reports?' + default_date_filter)
 
         traffic_report = get_not_null(response, 'traffic_reports')
         eq_(len(traffic_report), 1)
@@ -256,3 +256,4 @@ class TestDisruptions(AbstractTestFixture):
 
         #UTC - 1, so in UTC it's 00h59 => disruptions
         assert len(response['disruptions']) > 0
+

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -53,7 +53,7 @@ class TestDisruptions(AbstractTestFixture):
         one impacted stop_area
         """
 
-        response = self.query_region('traffic_reports?' + default_date_filter, display=False)
+        response = self.query_region('traffic_reports?' + default_date_filter)
 
         traffic_report = get_not_null(response, 'traffic_reports')
 
@@ -104,38 +104,57 @@ class TestDisruptions(AbstractTestFixture):
         """
         by querying directly the impacted object, we find the same results
         """
-        # TODO: we can't make those test for the moment since we need to add a datetime param to those APIs
-        # networks = self.query_region('networks/base_network?' + default_date_filter)
-        # network = get_not_null(networks, 'networks')[0]
-        # is_valid_network(network)
-        # eq_(get_not_null(network, 'disruptions'), network_disrupt)
-        # eq_(get_not_null(network, 'messages'), get_not_null(impacted_network, 'messages'))
-        #
-        # lines = self.query_region('lines/A?' + default_date_filter)
-        # line = get_not_null(lines, 'lines')[0]
-        # is_valid_line(line)
-        # eq_(get_not_null(line, 'disruptions'), lines_disrupt)
-        # eq_(get_not_null(line, 'messages'), get_not_null(impacted_lines[0], 'messages'))
-        #
-        # stops = self.query_region('stop_areas/stopA?' + default_date_filter)
-        # stop = get_not_null(stops, 'stop_areas')[0]
-        # is_valid_stop_area(stop)
-        # eq_(get_not_null(stop, 'disruptions'), stop_disrupt)
-        # eq_(get_not_null(stop, 'messages'), get_not_null(impacted_stop_areas[0], 'messages'))
+        networks = self.query_region('networks/base_network?' + default_date_filter)
+        network = get_not_null(networks, 'networks')[0]
+        is_valid_network(network)
+        network_disrupt = get_disruptions(network, response)
+        eq_(len(network_disrupt), 2)
+        for d in network_disrupt:
+            is_valid_disruption(d)
+        eq_(network_disrupt[0]['uri'], 'disruption_on_line_A')
+        eq_(network_disrupt[0]['impact_id'], 'too_bad_again')
+        eq_(network_disrupt[1]['uri'], 'disruption_on_line_A_but_later')
+        eq_(network_disrupt[1]['impact_id'], 'later_impact')
+
+        lines = self.query_region('lines/A?' + default_date_filter)
+        line = get_not_null(lines, 'lines')[0]
+        is_valid_line(line)
+        lines_disrupt = get_disruptions(impacted_lines[0], response)
+        eq_(len(lines_disrupt), 2)
+        for d in lines_disrupt:
+            is_valid_disruption(d)
+        eq_(lines_disrupt[0]['uri'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['impact_id'], 'too_bad_again')
+        eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
+
+        eq_(lines_disrupt[1]['uri'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[1]['impact_id'], 'later_impact')
+        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
+
+        stops = self.query_region('stop_areas/stopA?' + default_date_filter)
+        stop = get_not_null(stops, 'stop_areas')[0]
+        is_valid_stop_area(stop)
+        stop_disrupt = get_disruptions(impacted_stop_areas[0], response)
+        eq_(len(stop_disrupt), 1)
+        for d in stop_disrupt:
+            is_valid_disruption(d)
+        eq_(stop_disrupt[0]['uri'], 'disruption_on_stop_A')
+        eq_(stop_disrupt[0]['impact_id'], 'too_bad')
 
     def test_disruption_with_stop_areas(self):
         """
         when calling the pt object stopA, we should get its disruptions
         """
 
-        response = self.query_region('stop_areas/stopA')
+        response = self.query_region('stop_areas/stopA?' + default_date_filter)
 
         stops = get_not_null(response, 'stop_areas')
         eq_(len(stops), 1)
         stop = stops[0]
 
-        #TODO: we can't make those test for the moment since we need to add a datetime param to those APIs
-        #get_not_null(stop, 'disruptions')
+        disruptions = get_disruptions(stop, response)
+        eq_(len(disruptions), 1)
+        is_valid_disruption(disruptions[0])
 
     def test_direct_disruption_call(self):
         """
@@ -143,46 +162,43 @@ class TestDisruptions(AbstractTestFixture):
         we should get the disruption summary filtered on the stopB
 
         so
-        we get the impact on the line A (it goes through stopB),
-        and the impact on the network
+        we get the impacts on the line A (it goes through stopB),
+        and the impacts on the network
         """
 
-        """
-        TODO: we can't make those test for the moment since we need to add a datetime param to those APIs
-        response = self.query_region('stop_areas/stopB/disruptions?' + default_date_filter, display=True)
+        response = self.query_region('stop_areas/stopB/traffic_reports?' + default_date_filter, display=True)
 
-        disruptions = get_not_null(response, 'disruptions')
-        eq_(len(disruptions), 1)
+        traffic_report = get_not_null(response, 'traffic_reports')
+        eq_(len(traffic_report), 1)
 
-        impacted_lines = get_not_null(disruptions[0], 'lines')
+        impacted_lines = get_not_null(traffic_report[0], 'lines')
         eq_(len(impacted_lines), 1)
         is_valid_line(impacted_lines[0], depth_check=0)
         eq_(impacted_lines[0]['id'], 'A')
 
-        lines_disrupt = get_not_null(impacted_lines[0], 'disruptions')
-        eq_(len(lines_disrupt), 1)
+        lines_disrupt = get_disruptions(impacted_lines[0], response)
+        eq_(len(lines_disrupt), 2)
         eq_(lines_disrupt[0]['uri'], 'disruption_on_line_A')
         eq_(lines_disrupt[0]['impact_id'], 'too_bad_again')
 
-        impacted_network = get_not_null(disruptions[0], 'network')
+        impacted_network = get_not_null(traffic_report[0], 'network')
 
         is_valid_network(impacted_network, depth_check=0)
         eq_(impacted_network['id'], 'base_network')
-        network_disrupt = get_not_null(impacted_network, 'disruptions')
-        eq_(len(network_disrupt), 1)
+        network_disrupt = get_disruptions(impacted_network, response)
+        eq_(len(network_disrupt), 2)
         eq_(network_disrupt[0]['uri'], 'disruption_on_line_A')
         eq_(network_disrupt[0]['impact_id'], 'too_bad_again')
 
         # but we should not have disruption on stop area, B is not disrupted
-        assert 'stop_areas' not in disruptions[0]
-        """
+        assert 'stop_areas' not in traffic_report[0]
 
     def test_no_disruption(self):
         """
         when calling the pt object stopB, we should get no disruptions
         """
 
-        response = self.query_region('stop_areas/stopB', display=False)
+        response = self.query_region('stop_areas/stopB')
 
         stops = get_not_null(response, 'stop_areas')
         eq_(len(stops), 1)
@@ -198,14 +214,45 @@ class TestDisruptions(AbstractTestFixture):
 
         so at 9 it is not in the list, at 11, we get it
         """
-        response = self.query_region('traffic_reports?_current_datetime=20140128T090000', display=False)
+        response = self.query_region('traffic_reports?_current_datetime=20140128T090000')
 
         impacts = get_impacts(response)
         eq_(len(impacts), 3)
         assert 'impact_published_later' not in impacts
 
-        response = self.query_region('traffic_reports?_current_datetime=20140128T130000', display=False)
+        response = self.query_region('traffic_reports?_current_datetime=20140128T130000')
 
         impacts = get_impacts(response)
         eq_(len(impacts), 4)
         assert 'impact_published_later' in impacts
+
+    def test_disruption_datefilter_limits(self):
+        """
+        the _current_datetime is by default in UTC, we test that this is correctly taken into account
+        disruption_on_line_A is applied from 20140101T000000 to 20140201T115959
+        """
+        response = self.query_region('stop_areas/stopB/traffic_reports?_current_datetime=20140101T000000Z')
+
+        #we should have disruptions at this date
+        assert len(response['disruptions']) > 0
+
+        response = self.query_region('stop_areas/stopB/traffic_reports?_current_datetime=20131231T235959Z')
+
+        #before the start of the period => no disruptions
+        assert len(response['disruptions']) == 0
+
+        #%2B is the code for '+'
+        response = self.query_region('stop_areas/stopB/traffic_reports?_current_datetime=20140101T005959%2B0100')
+
+        #UTC + 1, so in UTC it's 23h59 the day before => no disruption
+        assert len(response['disruptions']) == 0
+
+        response = self.query_region('stop_areas/stopB/traffic_reports?_current_datetime=20140101T000000-0100')
+
+        #UTC - 1, so in UTC it's 01h => disruptions
+        assert len(response['disruptions']) > 0
+
+        response = self.query_region('stop_areas/stopB/traffic_reports?_current_datetime=20131231T235959-0100')
+
+        #UTC - 1, so in UTC it's 00h59 => disruptions
+        assert len(response['disruptions']) > 0

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -578,7 +578,10 @@ pbnavitia::Response Worker::pt_ref(const pbnavitia::PTRefRequest &request){
                                     get_odt_level(request.odt_level()),
                                     request.depth(), request.show_codes(),
                                     request.start_page(),
-                                    request.count(), *data);
+                                    request.count(), *data,
+                                    //no check on this datetime, it's not important
+                                    //for it to be in the production period, it's used to filter the disruptions
+                                    bt::from_time_t(request.datetime()));
 }
 
 

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -41,75 +41,74 @@ namespace navitia{ namespace ptref{
 static pbnavitia::Response extract_data(const type::Data & data,
                                         type::Type_e requested_type,
                                         std::vector<type::idx_t> & rows,
-                                        const int depth, const bool show_codes) {
+                                        const int depth, const bool show_codes,
+                                        boost::posix_time::ptime current_time) {
     pbnavitia::Response result;
-    //on utilise la date courante pour choisir si on doit afficher les  messages de perturbation
-    pt::ptime today = pt::second_clock::local_time();
     for(auto idx : rows){
         switch(requested_type){
         case Type_e::ValidityPattern:
             fill_pb_object(data.pt_data->validity_patterns[idx], data,
-                           result.add_validity_patterns(), depth, today);
+                           result.add_validity_patterns(), depth, current_time);
             break;
         case Type_e::Line:
             fill_pb_object(data.pt_data->lines[idx], data, result.add_lines(),
-                           depth, today, null_time_period, show_codes);
+                           depth, current_time, null_time_period, show_codes);
             break;
         case Type_e::JourneyPattern:
             fill_pb_object(data.pt_data->journey_patterns[idx], data,
-                           result.add_journey_patterns(), depth, today);
+                           result.add_journey_patterns(), depth, current_time);
             break;
         case Type_e::StopPoint:
             fill_pb_object(data.pt_data->stop_points[idx], data,
-                           result.add_stop_points(), depth, today, null_time_period, show_codes);
+                           result.add_stop_points(), depth, current_time, null_time_period, show_codes);
             break;
         case Type_e::StopArea:
             fill_pb_object(data.pt_data->stop_areas[idx], data,
-                           result.add_stop_areas(), depth, today, null_time_period, show_codes);
+                           result.add_stop_areas(), depth, current_time, null_time_period, show_codes);
             break;
         case Type_e::Network:
             fill_pb_object(data.pt_data->networks[idx], data,
-                           result.add_networks(), depth, today, null_time_period, show_codes);
+                           result.add_networks(), depth, current_time, null_time_period, show_codes);
             break;
         case Type_e::PhysicalMode:
             fill_pb_object(data.pt_data->physical_modes[idx], data,
-                           result.add_physical_modes(), depth, today);
+                           result.add_physical_modes(), depth, current_time);
             break;
         case Type_e::CommercialMode:
             fill_pb_object(data.pt_data->commercial_modes[idx], data,
-                           result.add_commercial_modes(), depth, today);
+                           result.add_commercial_modes(), depth, current_time);
             break;
         case Type_e::JourneyPatternPoint:
             fill_pb_object(data.pt_data->journey_pattern_points[idx], data,
-                           result.add_journey_pattern_points(), depth, today);
+                           result.add_journey_pattern_points(), depth, current_time);
             break;
         case Type_e::Company:
             fill_pb_object(data.pt_data->companies[idx], data,
-                           result.add_companies(), depth, today);
+                           result.add_companies(), depth, current_time);
             break;
         case Type_e::Route:
             fill_pb_object(data.pt_data->routes[idx], data,
-                    result.add_routes(), depth, today, null_time_period, show_codes);
+                    result.add_routes(), depth, current_time, null_time_period, show_codes);
             break;
         case Type_e::POI:
             fill_pb_object(data.geo_ref->pois[idx], data,
-                           result.add_pois(), depth, today);
+                           result.add_pois(), depth, current_time);
             break;
         case Type_e::POIType:
             fill_pb_object(data.geo_ref->poitypes[idx], data,
-                           result.add_poi_types(), depth, today);
+                           result.add_poi_types(), depth, current_time);
             break;
         case Type_e::Connection:
             fill_pb_object(data.pt_data->stop_point_connections[idx], data,
-                           result.add_connections(), depth, today);
+                           result.add_connections(), depth, current_time);
             break;
         case Type_e::VehicleJourney:
             fill_pb_object(data.pt_data->vehicle_journeys[idx], data,
-                           result.add_vehicle_journeys(), depth, today, null_time_period, show_codes);
+                           result.add_vehicle_journeys(), depth, current_time, null_time_period, show_codes);
             break;
         case Type_e::Calendar:
             fill_pb_object(data.pt_data->calendars[idx], data,
-                           result.add_calendars(), depth, today, null_time_period, show_codes);
+                           result.add_calendars(), depth, current_time, null_time_period, show_codes);
             break;
         default: break;
         }
@@ -126,7 +125,8 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
                              const bool show_codes,
                              const int startPage,
                              const int count,
-                             const type::Data& data){
+                             const type::Data& data,
+                             boost::posix_time::ptime current_time){
     std::vector<type::idx_t> final_indexes;
     pbnavitia::Response pb_response;
     int total_result;
@@ -142,7 +142,7 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
     total_result = final_indexes.size();
     final_indexes = paginate(final_indexes, count, startPage);
 
-    pb_response = extract_data(data, requested_type, final_indexes, depth, show_codes);
+    pb_response = extract_data(data, requested_type, final_indexes, depth, show_codes, current_time);
     auto pagination = pb_response.mutable_pagination();
     pagination->set_totalresult(total_result);
     pagination->set_startpage(startPage);

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -33,13 +33,14 @@ www.navitia.io
 namespace pbnavitia { class Response;}
 
 namespace navitia{ namespace ptref{
-/// Execute une requête et génère la sortie protobuf
+/// build the protobuf response of a pt ref query
 pbnavitia::Response extract_data(const type::Data & data,
                                  type::Type_e requested_type,
                                  std::vector<type::idx_t> & rows,
-                                 const int depth);
+                                 const int depth,
+                                 boost::posix_time::ptime current_time); //this date is used to filter the disruptions
 
-/// Construit la réponse proto buf, une fois que l'on trouvé les indices
+/// execute the pt ref query and return the protobuf response
 pbnavitia::Response query_pb(type::Type_e requested_type,
                              const std::string& request,
                              const std::vector<std::string>& forbidden_uris,
@@ -48,5 +49,6 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
                              const bool show_codes,
                              const int startPage,
                              const int count,
-                             const type::Data& data);
+                             const type::Data& data,
+                             boost::posix_time::ptime current_time);
 }}

--- a/source/type/request.proto
+++ b/source/type/request.proto
@@ -120,6 +120,7 @@ message PTRefRequest {
     optional bool show_codes            = 7;
     optional OdtLevel odt_level         = 8;
     repeated string forbidden_uri       = 6;
+    optional uint64 datetime            = 9;
 }
 
 message Request {


### PR DESCRIPTION
for disruption test purposes we need a mean to give the current datetime
to the jormungandr collection api (stop_areas, lines, ...)
