### PR TITLE
jormungandr: don't use journey with 0 duration as standard for too long journeys

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -324,7 +324,8 @@ class Scenario(simple.Scenario):
         section_is_walking_or_pt = lambda section: section.type not in \
                 (response_pb2.STREET_NETWORK, response_pb2.CROW_FLY) \
                            or section.street_network.mode == response_pb2.Walking
-        filter_journey = lambda journey: all(section_is_walking_or_pt(section) for section in journey.sections)
+        filter_journey = lambda journey: all(section_is_walking_or_pt(section) for section in journey.sections) \
+                and journey.duration > 0
 
         list_journeys = filter(filter_journey, journeys)
         if not list_journeys:


### PR DESCRIPTION
Since currently TAD can provide teleport journey with a duration as 0 we
don't want to use them as etalon for finding too long journey.
