### PR TITLE
jormungandr: the link for a object must be to the impact not the disruption

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -401,7 +401,8 @@ disruption_severity = {
 
 disruption_marshaller = {
     "id": fields.String(attribute="uri"),
-    "impact_id": fields.String(attribute="impact_uri"),
+    "disruption_id": fields.String(attribute="disruption_uri"),
+    "impact_id": fields.String(attribute="uri"),
     "title": fields.String(),
     "application_periods": NonNullList(NonNullNested(period)),
     "status": disruption_status,
@@ -415,7 +416,7 @@ disruption_marshaller = {
 #OLD disruption, DEPRECATED
 disruption = deepcopy(disruption_marshaller)
 disruption_marshaller["uri"] = fields.String()
-disruption_marshaller["impact_uri"] = fields.String()
+disruption_marshaller["disruption_uri"] = fields.String()
 
 
 class DisruptionsField(fields.Raw):

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -138,7 +138,7 @@ class TestChaosDisruptions(ChaosDisruptionsFixture):
         #at first we got only one disruption on B
         assert len(disruptions) == 1
 
-        assert any(d['uri'] == 'bob_the_disruption' for d in disruptions)
+        assert any(d['disruption_id'] == 'bob_the_disruption' for d in disruptions)
 
 
 @dataset([("main_routing_test", ['--BROKER.rt_topics='+chaos_rt_topic, 'spawn_maintenance_worker'])])
@@ -175,7 +175,7 @@ class TestChaosDisruptionsLineSection(ChaosDisruptionsFixture):
 
         #at first we got only one disruption
         assert len(disruptions) == 1
-        assert any(d['uri'] == 'bobette_the_disruption' for d in disruptions)
+        assert any(d['disruption_id'] == 'bobette_the_disruption' for d in disruptions)
 
 
 @dataset([("main_routing_test", ['--BROKER.rt_topics='+chaos_rt_topic, 'spawn_maintenance_worker'])])
@@ -219,7 +219,7 @@ class TestChaosDisruptions2(ChaosDisruptionsFixture):
             #at first we got only one disruption on A
             assert len(disruptions) == 1
 
-            assert any(d['uri'] == 'bob_the_disruption' for d in disruptions)
+            assert any(d['disruption_id'] == 'bob_the_disruption' for d in disruptions)
 
 
 @dataset([("main_routing_test", ['--BROKER.rt_topics='+chaos_rt_topic, 'spawn_maintenance_worker'])])
@@ -409,7 +409,7 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
             real_disruptions = [all_disruptions[d['id']] for d in obj['links'] if d['type'] == 'disruption']
 
             for d in real_disruptions:
-                disruption_by_obj[d['id']].append((d, obj))
+                disruption_by_obj[d['disruption_id']].append((d, obj))
 
         utils.walk_dict(response, disruptions_filler)
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -716,7 +716,7 @@ def get_disruptions(obj, response):
 
 def is_valid_disruption(disruption):
     get_not_null(disruption, 'id')
-    get_not_null(disruption, 'impact_id')
+    get_not_null(disruption, 'disruption_id')
     s = get_not_null(disruption, 'severity')
     get_not_null(s, 'name')
     get_not_null(s, 'color')

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -31,7 +31,7 @@ from check_utils import *
 
 
 def get_impacts(response):
-    return {d['impact_id']: d for d in response['disruptions']}
+    return {d['id']: d for d in response['disruptions']}
 
 # for the tests we need custom datetime to display the disruptions
 default_date_filter = '_current_datetime=20140101T000000'
@@ -69,12 +69,12 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(lines_disrupt), 2)
         for d in lines_disrupt:
             is_valid_disruption(d)
-        eq_(lines_disrupt[0]['uri'], 'disruption_on_line_A')
-        eq_(lines_disrupt[0]['impact_id'], 'too_bad_again')
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
         eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
 
-        eq_(lines_disrupt[1]['uri'], 'disruption_on_line_A_but_later')
-        eq_(lines_disrupt[1]['impact_id'], 'later_impact')
+        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[1]['uri'], 'later_impact')
         eq_(lines_disrupt[1]['severity']['name'], 'information severity')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
@@ -84,11 +84,11 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(network_disrupt), 2)
         for d in network_disrupt:
             is_valid_disruption(d)
-        eq_(network_disrupt[0]['uri'], 'disruption_on_line_A')
-        eq_(network_disrupt[0]['impact_id'], 'too_bad_again')
+        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(network_disrupt[0]['uri'], 'too_bad_again')
 
-        eq_(network_disrupt[1]['uri'], 'disruption_on_line_A_but_later')
-        eq_(network_disrupt[1]['impact_id'], 'later_impact')
+        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(network_disrupt[1]['uri'], 'later_impact')
 
         impacted_stop_areas = get_not_null(traffic_report[0], 'stop_areas')
         eq_(len(impacted_stop_areas), 1)
@@ -98,8 +98,8 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(stop_disrupt), 1)
         for d in stop_disrupt:
             is_valid_disruption(d)
-        eq_(stop_disrupt[0]['uri'], 'disruption_on_stop_A')
-        eq_(stop_disrupt[0]['impact_id'], 'too_bad')
+        eq_(stop_disrupt[0]['disruption_id'], 'disruption_on_stop_A')
+        eq_(stop_disrupt[0]['uri'], 'too_bad')
 
         """
         by querying directly the impacted object, we find the same results

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -110,8 +110,8 @@ void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_we
     }
     auto pb_disrution = pb_object->add_disruptions();
 
-    pb_disrution->set_impact_uri(impact->uri);
-    pb_disrution->set_uri(impact->disruption->uri);
+    pb_disrution->set_disruption_uri(impact->disruption->uri);
+    pb_disrution->set_uri(impact->uri);
     for (const auto& app_period: impact->application_periods) {
         auto p = pb_disrution->add_application_periods();
         p->set_begin(navitia::to_posix_timestamp(app_period.begin()));

--- a/source/type/type.proto
+++ b/source/type/type.proto
@@ -126,8 +126,7 @@ message Severity {
 
 message Disruption {
     optional string uri                             = 1;
-    optional string impact_uri                      = 2;
-    optional string title                           = 3;
+    optional string disruption_uri                  = 2;
     repeated Period application_periods             = 10;
     optional ActiveStatus status                    = 11;
     optional uint64 updated_at                      = 12;


### PR DESCRIPTION
Previously the link in the response was to the disruption_id, it's now
on the impact, since a same disruption can have more than one impact
