### PR TITLE
Optional feature added : Allow to deactivate HATEOAS links generation

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -44,14 +44,16 @@ import navitiacommon.type_pb2 as type_pb2
 
 class ResourceUri(StatedResource):
 
-    def __init__(self, authentication=True, *args, **kwargs):
+    def __init__(self, authentication=True, links=True, *args, **kwargs):
         StatedResource.__init__(self, *args, **kwargs)
         self.region = None
-        self.method_decorators.append(add_id_links())
+        if (links):
+            self.method_decorators.append(add_id_links())
+            self.method_decorators.append(add_computed_resources(self))
+            self.method_decorators.append(add_pagination_links())
+            self.method_decorators.append(clean_links())
         self.method_decorators.append(add_address_poi_id(self))
-        self.method_decorators.append(add_computed_resources(self))
-        self.method_decorators.append(add_pagination_links())
-        self.method_decorators.append(clean_links())
+
         if authentication:
             #some rare API (eg journey) must handle the authenfication by themself, thus deactivate it
             #by default ALWAYS use authentication=True


### PR DESCRIPTION
Without effect in jormungandr default settings.
Allow to create modules using kraken to generate other output than navitia.io API.
By example this one : https://data.toulouse-metropole.fr/les-donnees/-/opendata/card/14505-api-temps-reel-tisseo
