### PR TITLE
kraken: serialize channel properties in message for the copy

### DIFF
--- a/source/type/message.h
+++ b/source/type/message.h
@@ -154,7 +154,7 @@ struct Message {
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
-        ar & text & created_at & updated_at;
+        ar & text & created_at & updated_at & channel_id & channel_name & channel_content_type;
     }
 };
 


### PR DESCRIPTION
We don't need to increment the version number of the data because we
don't put any disruption in the data.nav
