### PR TITLE
Places fix tokenizer navitiaii 1158

### DIFF
--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -143,7 +143,6 @@ struct Autocomplete
         int distance = 0;
 
         //Appeler la méthode pour traiter les synonymes avant de les ajouter dans le dictionaire:
-        //auto vec_word = tokenize_without_replace(str, synonyms);
         auto vec_word = tokenize(str, synonyms);
         //créer des patterns pour chaque mot et les ajouter dans temp_pattern_map:
         add_vec_pattern(vec_word, position);
@@ -487,22 +486,19 @@ struct Autocomplete
         std::string strTemp = strFind;
 
         //if synonyms contains something, add all synonyms if found while serching on ket et value.
-        if (synonyms.size() > 0){
-            //For each synonyms.key found in strFind add synonyms.value
-            for(const auto& it : synonyms){
-                if  (boost::regex_search(strFind,boost::regex("\\<" + it.first + "\\>"))){
-                    strTemp += " " + it.second;
-                }
-            }
-
-            //For each synonyms.value found in strFind add synonyms.key
-            for(const auto& it : synonyms){
-                if  (boost::regex_search(strFind,boost::regex("\\<" + it.second + "\\>"))){
-                    strTemp += " " + it.first;
-                }
+        //For each synonyms.key found in strFind add synonyms.value
+        for(const auto& it : synonyms){
+            if  (boost::regex_search(strFind,boost::regex("\\<" + it.first + "\\>"))){
+                strTemp += " " + it.second;
             }
         }
 
+        //For each synonyms.value found in strFind add synonyms.key
+        for(const auto& it : synonyms){
+            if  (boost::regex_search(strFind,boost::regex("\\<" + it.second + "\\>"))){
+                strTemp += " " + it.first;
+            }
+        }
 
         boost::tokenizer <> tokens(strTemp);
         for (auto token_it: tokens){
@@ -512,31 +508,6 @@ struct Autocomplete
         }
         return vec;
     }
-
-    std::set<std::string> tokenize_without_replace(std::string strFind, const autocomplete_map& synonyms) const{
-        std::set<std::string> vec;
-
-        boost::to_lower(strFind);
-        strFind = boost::regex_replace(strFind, boost::regex("( ){2,}"), " ");
-
-        //traiter les caractères accentués
-        strFind = strip_accents(strFind);
-
-        for(const auto& it : synonyms){
-            if  (boost::regex_search(strFind,boost::regex("\\<" + it.first + "\\>"))){
-                strFind += " " + it.second;
-            }
-         }
-
-        boost::tokenizer <> tokens(strFind);
-        for (auto token_it: tokens){
-            if (!token_it.empty()){
-                vec.insert(token_it);
-            }
-        }
-        return vec;
-    }
-
 
     bool is_address_type(const std::string & str,
                          const autocomplete_map& synonyms) const{

--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -310,7 +310,6 @@ struct Autocomplete
 
     /** On passe une chaîne de charactère contenant des mots et on trouve toutes les positions contenant au moins un des mots*/
     std::vector<fl_quality> find_complete(const std::string & str,
-                                          const autocomplete_map& synonyms,
                                           size_t nbmax,
                                           std::function<bool(T)> keep_element)
                                           const{
@@ -341,7 +340,7 @@ struct Autocomplete
 
     /** Recherche des patterns les plus proche : faute de frappe */
     std::vector<fl_quality> find_partial_with_pattern(const std::string &str,
-                                                      const autocomplete_map& synonyms, const int word_weight,
+                                                      const int word_weight,
                                                       size_t nbmax,
                                                       std::function<bool(T)> keep_element)
                                                       const{
@@ -355,7 +354,7 @@ struct Autocomplete
         std::vector<fl_quality> vec_quality;
         fl_quality quality;
 
-        auto vec_word = tokenize(str, synonyms);
+        auto vec_word = tokenize(str);
         std::vector<std::string> vec_pattern = make_vec_pattern(vec_word, 2); //2-grams
         int wordLength = words_length(vec_word);
         int pattern_count = vec_pattern.size();

--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -143,8 +143,8 @@ struct Autocomplete
         int distance = 0;
 
         //Appeler la méthode pour traiter les synonymes avant de les ajouter dans le dictionaire:
+        //auto vec_word = tokenize_without_replace(str, synonyms);
         auto vec_word = tokenize(str, synonyms);
-
         //créer des patterns pour chaque mot et les ajouter dans temp_pattern_map:
         add_vec_pattern(vec_word, position);
 
@@ -315,7 +315,7 @@ struct Autocomplete
                                           size_t nbmax,
                                           std::function<bool(T)> keep_element)
                                           const{
-        auto vec = tokenize(str, synonyms);
+        auto vec = tokenize(str);
         int wordLength = 0;
         fl_quality quality;
         std::vector<T> index_result;
@@ -477,17 +477,56 @@ struct Autocomplete
         return str;
     }
 
-    std::set<std::string> tokenize(std::string strFind, const autocomplete_map& synonyms) const{
+    std::set<std::string> tokenize(std::string strFind, const autocomplete_map& synonyms = autocomplete_map()) const{
         std::set<std::string> vec;
         boost::to_lower(strFind);
         strFind = boost::regex_replace(strFind, boost::regex("( ){2,}"), " ");
 
         //traiter les caractères accentués
         strFind = strip_accents(strFind);
+        std::string strTemp = strFind;
 
-       for(const auto& it : synonyms){
-            strFind = boost::regex_replace(strFind,boost::regex("\\<" + it.first + "\\>"), it.second);
+        //if synonyms contains something, add all synonyms if found while serching on ket et value.
+        if (synonyms.size() > 0){
+            //For each synonyms.key found in strFind add synonyms.value
+            for(const auto& it : synonyms){
+                if  (boost::regex_search(strFind,boost::regex("\\<" + it.first + "\\>"))){
+                    strTemp += " " + it.second;
+                }
+            }
+
+            //For each synonyms.value found in strFind add synonyms.key
+            for(const auto& it : synonyms){
+                if  (boost::regex_search(strFind,boost::regex("\\<" + it.second + "\\>"))){
+                    strTemp += " " + it.first;
+                }
+            }
         }
+
+
+        boost::tokenizer <> tokens(strTemp);
+        for (auto token_it: tokens){
+            if (!token_it.empty()){
+                vec.insert(token_it);
+            }
+        }
+        return vec;
+    }
+
+    std::set<std::string> tokenize_without_replace(std::string strFind, const autocomplete_map& synonyms) const{
+        std::set<std::string> vec;
+
+        boost::to_lower(strFind);
+        strFind = boost::regex_replace(strFind, boost::regex("( ){2,}"), " ");
+
+        //traiter les caractères accentués
+        strFind = strip_accents(strFind);
+
+        for(const auto& it : synonyms){
+            if  (boost::regex_search(strFind,boost::regex("\\<" + it.first + "\\>"))){
+                strFind += " " + it.second;
+            }
+         }
 
         boost::tokenizer <> tokens(strFind);
         for (auto token_it: tokens){
@@ -497,6 +536,7 @@ struct Autocomplete
         }
         return vec;
     }
+
 
     bool is_address_type(const std::string & str,
                          const autocomplete_map& synonyms) const{

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -226,7 +226,7 @@ pbnavitia::Response autocomplete(const std::string &q,
     std::vector<const georef::Admin*> admin_ptr = admin_uris_to_admin_ptr(admins, d);
 
     //Compute number of words in the query:
-    std::set<std::string> query_word_vec = d.geo_ref->fl_admin.tokenize(q,d.geo_ref->synonyms);
+    std::set<std::string> query_word_vec = d.geo_ref->fl_admin.tokenize(q);
 
     ///Find max(100, count) éléments for each pt_object
     for(nt::Type_e type : filter) {

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -235,33 +235,30 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::StopArea:
             if (search_type==0) {
                 result = d.pt_data->stop_area_autocomplete.find_complete(q,
-                        d.geo_ref->synonyms, nbmax,
-                        valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
+                        nbmax,valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
             } else {
                 result = d.pt_data->stop_area_autocomplete.find_partial_with_pattern(q,
-                        d.geo_ref->synonyms, d.geo_ref->word_weight,
+                        d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
             }
             break;
         case nt::Type_e::StopPoint:
             if (search_type==0) {
                 result = d.pt_data->stop_point_autocomplete.find_complete(q,
-                        d.geo_ref->synonyms,
                         nbmax, valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
             } else {
                 result = d.pt_data->stop_point_autocomplete.find_partial_with_pattern(q,
-                        d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
+                        d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
             }
             break;
         case nt::Type_e::Admin:
             if (search_type==0) {
                 result = d.geo_ref->fl_admin.find_complete(q,
-                        d.geo_ref->synonyms,
                         nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
             } else {
                 result = d.geo_ref->fl_admin.find_partial_with_pattern(q,
-                        d.geo_ref->synonyms, d.geo_ref->word_weight,
+                        d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
             }
             break;
@@ -272,52 +269,50 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::POI:
             if (search_type==0) {
                 result = d.geo_ref->fl_poi.find_complete(q,
-                        d.geo_ref->synonyms,
                         nbmax, valid_admin_ptr(d.geo_ref->pois, admin_ptr));
             } else {
                 result = d.geo_ref->fl_poi.find_partial_with_pattern(q,
-                        d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
+                        d.geo_ref->word_weight, nbmax,
                         valid_admin_ptr(d.geo_ref->pois, admin_ptr));
             }
             break;
         case nt::Type_e::Network:
             if (search_type==0) {
                 result = d.pt_data->network_autocomplete.find_complete(q,
-                         d.geo_ref->synonyms, nbmax, [](type::idx_t){return true;});
+                         nbmax, [](type::idx_t){return true;});
             } else {
                 result = d.pt_data->network_autocomplete.find_partial_with_pattern(q,
-                         d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
+                         d.geo_ref->word_weight, nbmax,
                          [](type::idx_t){return true;});
             }
             break;
         case nt::Type_e::CommercialMode:
             if (search_type==0) {
                 result = d.pt_data->mode_autocomplete.find_complete(q,
-                            d.geo_ref->synonyms, nbmax, [](type::idx_t){return true;});
+                            nbmax, [](type::idx_t){return true;});
             } else {
                 result = d.pt_data->mode_autocomplete.find_partial_with_pattern(q,
-                            d.geo_ref->synonyms, d.geo_ref->word_weight, nbmax,
+                            d.geo_ref->word_weight, nbmax,
                             [](type::idx_t){return true;});
             }
             break;
         case nt::Type_e::Line:
             if (search_type==0) {
                 result = d.pt_data->line_autocomplete.find_complete(q,
-                        d.geo_ref->synonyms,
                         nbmax, [](type::idx_t){return true;});
             } else {
                 result = d.pt_data->line_autocomplete.find_partial_with_pattern(q,
-                                            d.geo_ref->synonyms, d.geo_ref->word_weight,
+                                            d.geo_ref->word_weight,
                                             nbmax, [](type::idx_t){return true;});
             }
             break;
         case nt::Type_e::Route:
             if (search_type==0) {
                 result = d.pt_data->route_autocomplete.find_complete(q,
-                            d.geo_ref->synonyms, nbmax, [](type::idx_t){return true;});
+                            nbmax, [](type::idx_t){return true;});
             } else {
                 result = d.pt_data->route_autocomplete.find_partial_with_pattern(q,
-                            d.geo_ref->synonyms, d.geo_ref->word_weight,
+                            d.geo_ref->word_weight,
                             nbmax, [](type::idx_t){return true;});
             }
             break;

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -61,28 +61,15 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     synonyms["hotel de ville"]="mairie";
     synonyms["cc"]="centre commercial";
     synonyms["ld"]="Lieu-Dit";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
 
     synonyms["st"]="saint";
     synonyms["ste"]="sainte";
     synonyms["cc"]="centre commercial";
     synonyms["chu"]="hopital";
     synonyms["chr"]="hopital";
-    synonyms["all"]="allée";
-    synonyms["allee"]="allée";
-    synonyms["ave"]="avenue";
-    synonyms["av"]="avenue";
     synonyms["bvd"]="boulevard";
     synonyms["bld"]="boulevard";
     synonyms["bd"]="boulevard";
-    synonyms["b"]="boulevard";
-    synonyms["r"]="rue";
-    synonyms["pl"]="place";
 
     Autocomplete<unsigned int> ac;
     ac.add_string("hotel de ville paris", 0, synonyms);
@@ -171,14 +158,7 @@ BOOST_AUTO_TEST_CASE(regex_toknize_with_synonyms_tests){
     synonyms["hotel de ville"]="mairie";
     synonyms["cc"]="centre commercial";
     synonyms["ld"]="Lieu-Dit";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
     synonyms["st"]="saint";
-    synonyms["r"]="rue";
 
     Autocomplete<unsigned int> ac;
     std::set<std::string> vec;
@@ -220,14 +200,7 @@ BOOST_AUTO_TEST_CASE(regex_toknize_without_tests){
     synonyms["hotel de ville"]="mairie";
     synonyms["cc"]="centre commercial";
     synonyms["ld"]="Lieu-Dit";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
     synonyms["st"]="saint";
-    synonyms["r"]="rue";
 
     Autocomplete<unsigned int> ac;
     std::set<std::string> vec;
@@ -265,15 +238,7 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
     autocomplete_map synonyms;
     synonyms["gare sncf"]="gare";
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
     synonyms["st"]="saint";
-    synonyms["av"]="avenue";
-    synonyms["r"]="rue";
     synonyms["bvd"]="boulevard";
     synonyms["bld"]="boulevard";
     synonyms["bd"]="boulevard";
@@ -520,30 +485,15 @@ BOOST_AUTO_TEST_CASE(autocompletesynonym_and_weight_test){
         autocomplete_map synonyms;
         std::vector<std::string> admins;
         std::string admin_uri;
-        int nbmax = 10;
-
-        synonyms["de"]="";
-        synonyms["la"]="";
-        synonyms["les"]="";
-        synonyms["des"]="";
-        synonyms["d"]="";
-        synonyms["l"]="";
-
+        int nbmax = 10;        
         synonyms["st"]="saint";
         synonyms["ste"]="sainte";
         synonyms["cc"]="centre commercial";
         synonyms["chu"]="hopital";
         synonyms["chr"]="hopital";
-        synonyms["all"]="allée";
-        synonyms["allee"]="allée";
-        synonyms["ave"]="avenue";
-        synonyms["av"]="avenue";
         synonyms["bvd"]="boulevard";
         synonyms["bld"]="boulevard";
         synonyms["bd"]="boulevard";
-        synonyms["b"]="boulevard";
-        synonyms["r"]="rue";
-        synonyms["pl"]="place";
 
         Autocomplete<unsigned int> ac;
         ac.add_string("rue jeanne d'arc", 0, synonyms);
@@ -597,29 +547,14 @@ BOOST_AUTO_TEST_CASE(autocomplete_duplicate_words_and_weight_test){
     std::string admin_uri;
     int nbmax = 10;
 
-    synonyms["de"]="";
-    synonyms["la"]="";
-    synonyms["le"]="";
-    synonyms["les"]="";
-    synonyms["des"]="";
-    synonyms["d"]="";
-    synonyms["l"]="";
-
     synonyms["st"]="saint";
     synonyms["ste"]="sainte";
     synonyms["cc"]="centre commercial";
     synonyms["chu"]="hopital";
     synonyms["chr"]="hopital";
-    synonyms["all"]="allée";
-    synonyms["allee"]="allée";
-    synonyms["ave"]="avenue";
-    synonyms["av"]="avenue";
     synonyms["bvd"]="boulevard";
     synonyms["bld"]="boulevard";
     synonyms["bd"]="boulevard";
-    synonyms["b"]="boulevard";
-    synonyms["r"]="rue";
-    synonyms["pl"]="place";
 
     Autocomplete<unsigned int> ac;
     ac.add_string("gare de Tours Tours", 0, synonyms);
@@ -984,5 +919,105 @@ BOOST_AUTO_TEST_CASE(autocomplete_pt_object_Network_Mode_Line_Route_stop_area_te
     BOOST_CHECK_EQUAL(resp.places(2).embedded_type(), pbnavitia::LINE);
     BOOST_CHECK_EQUAL(resp.places(3).embedded_type(), pbnavitia::ROUTE);
     BOOST_CHECK_EQUAL(resp.places(4).embedded_type(), pbnavitia::ROUTE);
+}
+
+BOOST_AUTO_TEST_CASE(find_with_synonyms_mairie_de_vannes_test){
+    int nbmax = 10;
+    autocomplete_map synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["cc"]="centre commercial";
+    synonyms["gare sncf"]="gare";
+    synonyms["bd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bvd"]="boulevard";
+    synonyms["chr"]="hopital";
+    synonyms["chu"]="hopital";
+    synonyms["ld"]="lieu-dit";
+    synonyms["pt"]="pont";
+    synonyms["rle"]="ruelle";
+    synonyms["rte"]="route";
+    synonyms["sq"]="square";
+    synonyms["st"]="saint";
+    synonyms["ste"]="sainte";
+    synonyms["vla"]="villa";
+
+    Autocomplete<unsigned int> ac;
+    ac.add_string("mairie vannes", 0, synonyms);
+    ac.add_string("place hotel de ville vannes", 1, synonyms);
+    ac.add_string("rue DE L'HOTEL DIEU vannes", 2, synonyms);
+    ac.add_string("place vannes", 3, synonyms);
+    ac.add_string("Hôtel-Dieu vannes", 4, synonyms);
+    ac.add_string("Hôtel de Région vannes", 5, synonyms);
+    ac.add_string("Centre Commercial Caluire 2", 6, synonyms);
+    ac.add_string("Rue René", 7, synonyms);
+    ac.build();
+
+    //Dans le dictionnaire : "mairie vannes" -> "mairie hotel de ville vannes"
+    //search : "hotel vannes" -> "hotel vannes" no synonym is applied for search string
+    //Found : mairie vannes et place hotel de ville vannes
+    auto res = ac.find_complete("mairie vannes", nbmax, [](int){return true;});
+    BOOST_REQUIRE_EQUAL(res.size(), 2);
+
+    //Dans le dictionnaire : "mairie vannes" -> "mairie hotel de ville vannes"
+    //search : "hotel vannes" -> "hotel vannes" no synonym is applied for search
+    //Found : mairie vannes, place hotel de ville vannes, rue DE L'HOTEL DIEU vannes, Hôtel-Dieu vannes et Hôtel de Région vannes
+    auto res1 = ac.find_complete("hotel vannes", nbmax, [](int){return true;});
+    BOOST_REQUIRE_EQUAL(res1.size(), 5);
+}
+
+BOOST_AUTO_TEST_CASE(find_with_synonyms_gare_with_or_without_sncf_test){
+    int nbmax = 10;
+    autocomplete_map synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["cc"]="centre commercial";
+    synonyms["gare sncf"]="gare";
+    synonyms["bd"]="boulevard";
+    synonyms["bld"]="boulevard";
+    synonyms["bvd"]="boulevard";
+    synonyms["chr"]="hopital";
+    synonyms["chu"]="hopital";
+    synonyms["ld"]="lieu-dit";
+    synonyms["pt"]="pont";
+    synonyms["rle"]="ruelle";
+    synonyms["rte"]="route";
+    synonyms["sq"]="square";
+    synonyms["st"]="saint";
+    synonyms["ste"]="sainte";
+    synonyms["vla"]="villa";
+
+    Autocomplete<unsigned int> ac;
+    ac.add_string("gare SNCF et routière Rennes", 0, synonyms);
+    ac.add_string("Pré Garel Rennes", 1, synonyms);
+    ac.add_string("Gare Sud Féval Rennes", 2, synonyms);
+    ac.add_string("Parking gare SNCF et routière Rennes", 3, synonyms);
+    ac.add_string("place DE LA GARE Rennes", 4, synonyms);
+    ac.add_string("rue DU PRE GAREL Rennes", 5, synonyms);
+    ac.add_string("Parking SNCF Rennes", 6, synonyms);
+    ac.add_string("parc de la victoire Rennes", 7, synonyms);
+    ac.build();
+
+    //Dans le dictionnaire :
+    //"gare SNCF et routière Rennes" -> "gare sncf et routiere rennes"
+    //"Pré Garel Rennes" -> "Pre garel rennes"
+    //"Gare Sud Féval Rennes" -> "gare sud feval rennes sncf"
+    //"Parking gare SNCF et routière Rennes" -> "parking gare sncf et routiere rennes"
+    //"place DE LA GARE Rennes" -> "place de la gare rennes sncf"
+    //"rue DU PRE GAREL Rennes" -> "rue du pre garel rennes"
+    //"Parking SNCF Rennes" -> "parking sncf rennes"
+
+    //search : "Gare SNCF Rennes" -> "gare sncf rennes" no synonym is applied for search string
+    //Found : "gare SNCF et routière Rennes", "Gare Sud Féval Rennes", "Parking gare SNCF et routière Rennes" et "place DE LA GARE Rennes"
+    auto res = ac.find_complete("gare sncf rennes", nbmax, [](int){return true;});
+    BOOST_REQUIRE_EQUAL(res.size(), 4);
+
+    //search : "SNCF Rennes" -> "sncf rennes" no synonym is applied for search string
+    //Found : "gare SNCF et routière Rennes", "Gare Sud Féval Rennes", "Parking gare SNCF et routière Rennes" ,"place DE LA GARE Rennes" et "Parking SNCF Rennes"
+    auto res1 = ac.find_complete("sncf rennes", nbmax, [](int){return true;});
+    BOOST_REQUIRE_EQUAL(res1.size(), 5);
+
+    //search : "Gare Rennes" -> "gare rennes" no synonym is applied for search string
+    //Found : "gare SNCF et routière Rennes", "Gare Sud Féval Rennes", "Parking gare SNCF et routière Rennes" ,"place DE LA GARE Rennes" et "Parking SNCF Rennes"
+    auto res2 = ac.find_complete("gare rennes", nbmax, [](int){return true;});
+    BOOST_REQUIRE_EQUAL(res2.size(), 6);
 
 }

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -232,27 +232,15 @@ BOOST_AUTO_TEST_CASE(regex_toknize_without_tests){
     Autocomplete<unsigned int> ac;
     std::set<std::string> vec;
 
-    //synonyme : "cc" = "centre commercial" / synonym : de = ""
+    //synonyme : "cc" = "centre commercial"
     //"cc Carré de Soie" -> "cc centre commercial carré de soie"
-    vec = ac.tokenize_without_replace("cc Carré de Soie", synonyms);
+    vec = ac.tokenize("cc Carré de Soie", synonyms);
     BOOST_CHECK(vec.find("cc") != vec.end());
     BOOST_CHECK(vec.find("carre") != vec.end());
     BOOST_CHECK(vec.find("centre") != vec.end());
     BOOST_CHECK(vec.find("commercial") != vec.end());
     BOOST_CHECK(vec.find("de") != vec.end());
-    BOOST_CHECK(vec.find("soie") != vec.end());
-
-
-    vec.clear();
-    //synonyme : "cc"= "centre commercial" / synonym : de = ""
-    //"c c Carré de Soie" -> "centre commercial carré de soie"
-    vec = ac.tokenize_without_replace("cc Carré de Soie", synonyms);
-    BOOST_CHECK(vec.find("cc") != vec.end());
-    BOOST_CHECK(vec.find("carre") != vec.end());
-    BOOST_CHECK(vec.find("centre") != vec.end());
-    BOOST_CHECK(vec.find("commercial") != vec.end());
-    BOOST_CHECK(vec.find("de") != vec.end());
-    BOOST_CHECK(vec.find("soie") != vec.end());
+    BOOST_CHECK(vec.find("soie") != vec.end());    
 }
 
 BOOST_AUTO_TEST_CASE(regex_address_type_tests){

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -59,10 +59,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
 
     autocomplete_map synonyms;
     synonyms["hotel de ville"]="mairie";
-    synonyms["c c"]="centre commercial";
     synonyms["cc"]="centre commercial";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
     synonyms["ld"]="Lieu-Dit";
     synonyms["de"]="";
     synonyms["la"]="";
@@ -76,8 +73,6 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     synonyms["cc"]="centre commercial";
     synonyms["chu"]="hopital";
     synonyms["chr"]="hopital";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
     synonyms["all"]="allée";
     synonyms["allee"]="allée";
     synonyms["ave"]="avenue";
@@ -170,14 +165,11 @@ BOOST_AUTO_TEST_CASE(regex_replace_tests){
     BOOST_CHECK_EQUAL( boost::regex_replace(std::string("bonjour c c revoir"), re , "centre commercial"), "bonjour centre commercial revoir");
 }
 
-BOOST_AUTO_TEST_CASE(regex_toknize_tests){
+BOOST_AUTO_TEST_CASE(regex_toknize_with_synonyms_tests){
 
     autocomplete_map synonyms;
     synonyms["hotel de ville"]="mairie";
-    synonyms["c c"]="centre commercial";
     synonyms["cc"]="centre commercial";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
     synonyms["ld"]="Lieu-Dit";
     synonyms["de"]="";
     synonyms["la"]="";
@@ -200,12 +192,66 @@ BOOST_AUTO_TEST_CASE(regex_toknize_tests){
     BOOST_CHECK(vec.find("soie") != vec.end());
 
     vec.clear();
-    //synonyme : "c c"= "centre commercial" / synonym : de = ""
-    //"c c Carré de Soie" -> "centre commercial carré de soie"
-    vec = ac.tokenize("c c Carré de Soie", synonyms);
+    //synonyme : "cc"= "centre commercial" / synonym : de = ""
+    //"c Carré de Soie" -> "centre commercial carré de soie"
+    vec = ac.tokenize("cc Carré de Soie", synonyms);
     BOOST_CHECK(vec.find("carre") != vec.end());
     BOOST_CHECK(vec.find("centre") != vec.end());
     BOOST_CHECK(vec.find("commercial") != vec.end());
+    BOOST_CHECK(vec.find("soie") != vec.end());
+}
+
+BOOST_AUTO_TEST_CASE(regex_toknize_without_synonyms_tests){
+
+    Autocomplete<unsigned int> ac;
+    std::set<std::string> vec;
+
+    //"cc Carré de Soie" -> "cc carre de soie"
+    vec = ac.tokenize("cc Carré de Soie");
+    BOOST_CHECK(vec.find("cc") != vec.end());
+    BOOST_CHECK(vec.find("carre") != vec.end());
+    BOOST_CHECK(vec.find("de") != vec.end());
+    BOOST_CHECK(vec.find("soie") != vec.end());
+}
+
+BOOST_AUTO_TEST_CASE(regex_toknize_without_tests){
+
+    autocomplete_map synonyms;
+    synonyms["hotel de ville"]="mairie";
+    synonyms["cc"]="centre commercial";
+    synonyms["ld"]="Lieu-Dit";
+    synonyms["de"]="";
+    synonyms["la"]="";
+    synonyms["les"]="";
+    synonyms["des"]="";
+    synonyms["d"]="";
+    synonyms["l"]="";
+    synonyms["st"]="saint";
+    synonyms["r"]="rue";
+
+    Autocomplete<unsigned int> ac;
+    std::set<std::string> vec;
+
+    //synonyme : "cc" = "centre commercial" / synonym : de = ""
+    //"cc Carré de Soie" -> "cc centre commercial carré de soie"
+    vec = ac.tokenize_without_replace("cc Carré de Soie", synonyms);
+    BOOST_CHECK(vec.find("cc") != vec.end());
+    BOOST_CHECK(vec.find("carre") != vec.end());
+    BOOST_CHECK(vec.find("centre") != vec.end());
+    BOOST_CHECK(vec.find("commercial") != vec.end());
+    BOOST_CHECK(vec.find("de") != vec.end());
+    BOOST_CHECK(vec.find("soie") != vec.end());
+
+
+    vec.clear();
+    //synonyme : "cc"= "centre commercial" / synonym : de = ""
+    //"c c Carré de Soie" -> "centre commercial carré de soie"
+    vec = ac.tokenize_without_replace("cc Carré de Soie", synonyms);
+    BOOST_CHECK(vec.find("cc") != vec.end());
+    BOOST_CHECK(vec.find("carre") != vec.end());
+    BOOST_CHECK(vec.find("centre") != vec.end());
+    BOOST_CHECK(vec.find("commercial") != vec.end());
+    BOOST_CHECK(vec.find("de") != vec.end());
     BOOST_CHECK(vec.find("soie") != vec.end());
 }
 
@@ -213,10 +259,7 @@ BOOST_AUTO_TEST_CASE(regex_address_type_tests){
 
     autocomplete_map synonyms;
     synonyms["hotel de ville"]="mairie";
-    synonyms["c c"]="centre commercial";
     synonyms["cc"]="centre commercial";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
     synonyms["ld"]="Lieu-Dit";
     synonyms["av"]="avenue";
     synonyms["r"]="rue";
@@ -234,9 +277,6 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
 
     autocomplete_map synonyms;
     synonyms["gare sncf"]="gare";
-    synonyms["gare snc"]="gare";
-    synonyms["gare sn"]="gare";
-    synonyms["gare s"]="gare";
     synonyms["de"]="";
     synonyms["la"]="";
     synonyms["les"]="";
@@ -254,61 +294,35 @@ BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
     std::set<std::string> vec;
 
     //synonyme : "gare sncf" = "gare"
-    //"gare sncf" -> "gare"
+    //"gare sncf" -> "gare sncf"
     vec = ac.tokenize("gare sncf", synonyms);
-    BOOST_CHECK_EQUAL(vec.size(),1);
-    vec.clear();
-
-    //synonyme : "gare snc" = "gare"
-    //"gare snc" -> "gare"
-    vec = ac.tokenize("gare snc", synonyms);
-    BOOST_CHECK_EQUAL(vec.size(),1);
-    vec.clear();
-
-    //synonyme : "gare sn" = "gare"
-    //"gare sn" -> "gare"
-    vec = ac.tokenize("gare sn", synonyms);
-    BOOST_CHECK(vec.find("gare") != vec.end());
-    BOOST_CHECK_EQUAL(vec.size(),1);
-    vec.clear();
-
-    //synonyme : "gare s" = "gare"
-    //"gare s" -> "gare"
-    vec = ac.tokenize("gare s", synonyms);
-    BOOST_CHECK(vec.find("gare") != vec.end());
-    BOOST_CHECK_EQUAL(vec.size(),1);
-    vec.clear();
-
-    //synonyme : "gare sn nantes" = "gare nantes"
-    //"gare sn nantes" -> "gare nantes"
-    vec = ac.tokenize("gare sn nantes", synonyms);
-    BOOST_CHECK(vec.find("gare") != vec.end());
-    BOOST_CHECK(vec.find("nantes") != vec.end());
     BOOST_CHECK_EQUAL(vec.size(),2);
     vec.clear();
 
-    //synonyme : "gare sn nantes" = "gare nantes"
-    //"gare sn  nantes" -> "gare nantes"
+    //synonyme : "gare sncf" = "gare"
+    //"gare snc" -> "gare sncf snc"
+    vec = ac.tokenize("gare snc", synonyms);
+    BOOST_CHECK_EQUAL(vec.size(),3);
+    vec.clear();
+
+    //synonyme : "gare sncf" = "gare"
+    //"gare sn  nantes" -> "gare sncf sn nantes"
     vec = ac.tokenize("gare sn  nantes", synonyms);
     BOOST_CHECK(vec.find("gare") != vec.end());
     BOOST_CHECK(vec.find("nantes") != vec.end());
-    BOOST_CHECK_EQUAL(vec.size(),2);
+    BOOST_CHECK(vec.find("sncf") != vec.end());
+    BOOST_CHECK(vec.find("sn") != vec.end());
+    BOOST_CHECK_EQUAL(vec.size(),4);
     vec.clear();
 
-    //synonyme : "gare sn nantes" = "gare nantes"
-    //"gare s  nantes" -> "gare nantes"
+    //synonyme : "gare sncf" = "gare"
+    //"gare s nantes" -> "gare s sncf nantes"
     vec = ac.tokenize("gare  s  nantes", synonyms);
     BOOST_CHECK(vec.find("gare") != vec.end());
     BOOST_CHECK(vec.find("nantes") != vec.end());
-    BOOST_CHECK_EQUAL(vec.size(),2);
-    vec.clear();
-
-    //synonyme : "gare sn nantes" = "gare nantes"
-    //"gare s    nantes" -> "gare nantes"
-    vec = ac.tokenize("gare  s    nantes", synonyms);
-    BOOST_CHECK(vec.find("gare") != vec.end());
-    BOOST_CHECK(vec.find("nantes") != vec.end());
-    BOOST_CHECK_EQUAL(vec.size(),2);
+    BOOST_CHECK(vec.find("sncf") != vec.end());
+    BOOST_CHECK(vec.find("s") != vec.end());
+    BOOST_CHECK_EQUAL(vec.size(),4);
     vec.clear();
 }
 
@@ -532,8 +546,6 @@ BOOST_AUTO_TEST_CASE(autocompletesynonym_and_weight_test){
         synonyms["cc"]="centre commercial";
         synonyms["chu"]="hopital";
         synonyms["chr"]="hopital";
-        synonyms["c.h.u"]="hopital";
-        synonyms["c.h.r"]="hopital";
         synonyms["all"]="allée";
         synonyms["allee"]="allée";
         synonyms["ave"]="avenue";
@@ -610,8 +622,6 @@ BOOST_AUTO_TEST_CASE(autocomplete_duplicate_words_and_weight_test){
     synonyms["cc"]="centre commercial";
     synonyms["chu"]="hopital";
     synonyms["chr"]="hopital";
-    synonyms["c.h.u"]="hopital";
-    synonyms["c.h.r"]="hopital";
     synonyms["all"]="allée";
     synonyms["allee"]="allée";
     synonyms["ave"]="avenue";

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     //Recherche : "mai paris" -> "mai paris"
     // distance = 3 / word_weight = 0*5 = 0
     // Qualité = 100 - (3 + 0) = 97
-    auto res = ac.find_complete("mai paris", synonyms, nbmax, [](int){return true;});
+    auto res = ac.find_complete("mai paris", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res.at(0).quality, 100);
 
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     //Recherche : "hotel de ville par" -> "mairie par"
     // distance = 3 / word_weight = 0*5 = 0
     // Qualité = 100 - (2 + 0) = 98
-    auto res1 = ac.find_complete("hotel de ville par", synonyms, nbmax, [](int){return true;});
+    auto res1 = ac.find_complete("hotel de ville par", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.at(0).quality, 100);
 
@@ -116,19 +116,19 @@ BOOST_AUTO_TEST_CASE(parse_find_with_synonym_and_synonyms_test){
     // distance = 5 / word_weight = 0*5 = 0
     // Qualité = 100 - (5 + 0) = 95
 
-    auto res2 = ac.find_complete("c c ca 2",synonyms, nbmax, [](int){return true;});
+    auto res2 = ac.find_complete("c c ca 2",nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res2.size(), 1);
     BOOST_CHECK_EQUAL(res2.at(0).quality, 100);
 
-    auto res3 = ac.find_complete("cc ca 2", synonyms, nbmax,[](int){return true;});
+    auto res3 = ac.find_complete("cc ca 2", nbmax,[](int){return true;});
     BOOST_REQUIRE_EQUAL(res3.size(), 1);
     BOOST_CHECK_EQUAL(res3.at(0).quality, 100);
 
-    auto res4 = ac.find_complete("rue rene", synonyms, nbmax, [](int){return true;});
+    auto res4 = ac.find_complete("rue rene", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res4.size(), 1);
     BOOST_CHECK_EQUAL(res4.at(0).quality, 100);
 
-    auto res5 = ac.find_complete("rue rené", synonyms, nbmax, [](int){return true;});
+    auto res5 = ac.find_complete("rue rené", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res5.size(), 1);
     BOOST_CHECK_EQUAL(res5.at(0).quality, 100);
 }
@@ -424,12 +424,12 @@ BOOST_AUTO_TEST_CASE(Faute_de_frappe_One){
 
         ac.build();
 
-        auto res = ac.find_partial_with_pattern("batau", synonyms,word_weight, nbmax, [](int){return true;});
+        auto res = ac.find_partial_with_pattern("batau", word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res.size(), 1);
         BOOST_CHECK_EQUAL(res.at(0).idx, 1);
         BOOST_CHECK_EQUAL(res.at(0).quality, 90);
 
-        auto res1 = ac.find_partial_with_pattern("gare patea", synonyms,word_weight, nbmax, [](int){return true;});
+        auto res1 = ac.find_partial_with_pattern("gare patea", word_weight, nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res1.size(), 3);
         BOOST_CHECK_EQUAL(res1.at(0).idx, 4);
         BOOST_CHECK_EQUAL(res1.at(1).idx, 1);
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_find_quality_test){
 
     ac.build();
 
-    auto res = ac.find_complete("rue jean", synonyms, nbmax,[](int){return true;});
+    auto res = ac.find_complete("rue jean", nbmax,[](int){return true;});
     std::vector<int> expected = {6,7,0,2};
     BOOST_REQUIRE_EQUAL(res.size(), 4);
     BOOST_CHECK_EQUAL(res.at(0).quality, 100);
@@ -508,7 +508,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_add_string_with_Line){
 
     ac.build();
 
-    auto res = ac.find_complete("jean-jau", synonyms, nbmax, [](int){return true;});
+    auto res = ac.find_complete("jean-jau", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res.size(), 3);
     BOOST_CHECK_EQUAL(res.at(0).idx, 1);
     BOOST_CHECK_EQUAL(res.at(1).idx, 3);
@@ -559,30 +559,30 @@ BOOST_AUTO_TEST_CASE(autocompletesynonym_and_weight_test){
 
         ac.build();
 
-        auto res = ac.find_complete("rue jean", synonyms, nbmax, [](int){return true;});
+        auto res = ac.find_complete("rue jean", nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res.size(), 4);
         BOOST_CHECK_EQUAL(res.at(0).quality, 100);
 
-        auto res1 = ac.find_complete("r jean", synonyms, nbmax, [](int){return true;});
+        auto res1 = ac.find_complete("r jean", nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res1.size(), 4);
 
         BOOST_CHECK_EQUAL(res1.at(0).quality, 100);
 
-        auto res2 = ac.find_complete("av jean", synonyms, nbmax, [](int){return true;});
+        auto res2 = ac.find_complete("av jean", nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res2.size(), 1);
         //rue jean zay
         // distance = 6 / word_weight = 1*5 = 5
         // Qualité = 100 - (6 + 5) = 89
         BOOST_CHECK_EQUAL(res2.at(0).quality, 100);
 
-        auto res3 = ac.find_complete("av jean", synonyms, nbmax,[](int){return true;});
+        auto res3 = ac.find_complete("av jean", nbmax,[](int){return true;});
         BOOST_REQUIRE_EQUAL(res3.size(), 1);
         //rue jean zay
         // distance = 6 / word_weight = 1*10 = 10
         // Qualité = 100 - (6 + 10) = 84
         BOOST_CHECK_EQUAL(res3.at(0).quality, 100);
 
-        auto res4 = ac.find_complete("chu gau", synonyms, nbmax, [](int){return true;});
+        auto res4 = ac.find_complete("chu gau", nbmax, [](int){return true;});
         BOOST_REQUIRE_EQUAL(res4.size(), 1);
         //hopital paul gaultier
         // distance = 9 / word_weight = 1*10 = 10
@@ -644,7 +644,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_duplicate_words_and_weight_test){
 
     ac.build();
 
-    auto res = ac.find_complete("gare", synonyms, nbmax, [](int){return true;});
+    auto res = ac.find_complete("gare", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res.size(), 8);
     BOOST_CHECK_EQUAL(res.at(0).quality, 100);
     BOOST_CHECK_EQUAL(res.at(0).idx, 1);
@@ -658,15 +658,15 @@ BOOST_AUTO_TEST_CASE(autocomplete_duplicate_words_and_weight_test){
     BOOST_CHECK_EQUAL(res.at(7).quality, 100);
 
 
-    auto res1 = ac.find_complete("gare tours", synonyms, nbmax, [](int){return true;});
+    auto res1 = ac.find_complete("gare tours", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.at(0).quality, 100);
 
-    auto res2 = ac.find_complete("gare tours tours", synonyms, nbmax, [](int){return true;});
+    auto res2 = ac.find_complete("gare tours tours", nbmax, [](int){return true;});
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.at(0).quality, 100);
 
-    auto res3 = ac.find_complete("les Sorinières", synonyms, nbmax,[](int){return true;});
+    auto res3 = ac.find_complete("les Sorinières", nbmax,[](int){return true;});
     BOOST_REQUIRE_EQUAL(res3.size(), 10);
     BOOST_CHECK_EQUAL(res3.at(0).quality, 100);
 }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -486,9 +486,9 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std
         search_str = str;
     }
     if (search_type == 0){
-        to_return = fl_way.find_complete(search_str, this->synonyms, nbmax, keep_element);
+        to_return = fl_way.find_complete(search_str, nbmax, keep_element);
     }else{
-        to_return = fl_way.find_partial_with_pattern(search_str, this->synonyms, word_weight, nbmax, keep_element);
+        to_return = fl_way.find_partial_with_pattern(search_str, word_weight, nbmax, keep_element);
     }
 
     /// récupération des coordonnées du numéro recherché pour chaque rue


### PR DESCRIPTION
This pull request concerns : http://jira.canaltp.fr/browse/NAVITIAII-1158
Modifications are as followings:
1. While creation dictionnary, for each key of synonym existing in name, words in values are also added instead of replacing.
2. While creation dictionnary, for each value of synonym existing in name, words in key are also added instead of replacing.
3. While searching ("find_complete" and "find_partial_with_pattern"), synonym is not used.

For more examples please see http://jira.canaltp.fr/browse/NAVITIAII-1158
