### PR TITLE
kraken: don't calculate the adress of the stop_point in journeys

### DIFF
--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -333,6 +333,8 @@ void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
             fill_pb_object(adm, data,  stop_point->add_administrative_regions(),
                            depth-1, now, action_period);
         }
+    }
+    if(depth > 2){
         fill_pb_object(sp->coord, data, stop_point->mutable_address(), depth - 1, now, action_period);
     }
 


### PR DESCRIPTION
before: 199s
after: 114

refer to: http://jira.canaltp.fr/browse/NAVITIAII-1662
