### PR TITLE
Optimisation

### DIFF
--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -128,8 +128,8 @@ results Fare::compute_fare(const routing::Path& path) const {
     results res;
     int nb_nodes = boost::num_vertices(g);
 
-    if (! nb_nodes) {
-        LOG4CPLUS_WARN(logger, "no fare data loaded, cannot compute fare");
+    if (nb_nodes < 2) {
+        LOG4CPLUS_TRACE(logger, "no fare data loaded, cannot compute fare");
         return res;
     }
     std::vector< std::vector<Label> > labels(nb_nodes);

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -171,10 +171,6 @@ BOOST_AUTO_TEST_CASE(test_protobuff_no_data) {
     //fare structures check
     const pbnavitia::Fare& pb_fare = journey.fare();
 
-    BOOST_REQUIRE_EQUAL(pb_fare.ticket_id_size(), 1);
-    BOOST_REQUIRE_EQUAL(pb_fare.ticket_id(0), "unknown_ticket");
-    BOOST_CHECK_EQUAL(pb_fare.found(), false);
-
-    BOOST_REQUIRE_EQUAL(resp.tickets_size(), 1);
-    BOOST_REQUIRE_EQUAL(resp.tickets(0).id(), "unknown_ticket");
+    BOOST_REQUIRE_EQUAL(pb_fare.ticket_id_size(), 0);
+    BOOST_REQUIRE_EQUAL(resp.tickets_size(), 0);
 }

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -218,7 +218,7 @@ ticket = {
 journeys = {
     "journeys": NonNullList(NonNullNested(journey)),
     "error": PbField(error, attribute='error'),
-    "tickets": NonNullList(NonNullNested(ticket)),
+    "tickets": fields.List(NonNullNested(ticket)),
     "disruptions": DisruptionsField,
 }
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -401,7 +401,7 @@ def is_valid_journey_response(response, tester, query_str):
     # check the fare section
     # the fares must be structurally valid and all link to sections must be ok
     all_tickets = unique_dict('id')
-    fares = get_not_null(response, "tickets")
+    fares = response['tickets']
     for f in fares:
         is_valid_ticket(f, tester)
         all_tickets[f['id']] = f

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -330,8 +330,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                 // For a waiting section, if the previous public transport section,
                 // has estimated datetime we need to set it has estimated too.
                 if (pb_journey->sections_size() > 1) {
-                    for (int i=pb_journey->sections_size()-1; i>=0; --i) {
-                        auto section = pb_journey->sections(i);
+                    for (const auto& section: pb_journey->sections()) {
                         if (section.type() == pbnavitia::PUBLIC_TRANSPORT) {
                             if (section.add_info_vehicle_journey().has_date_time_estimated()) {
                                 pb_section->mutable_add_info_vehicle_journey()->set_has_date_time_estimated(true);


### PR DESCRIPTION
Don't calculate fare if we only have a default ticket

It's taking a lot of time for doing nothing.
If there is fare data, the response now contains no tickets

Also remove a useless copy of section in raptor_api
