### PR TITLE
Traffic reports

### DIFF
--- a/source/disruption/disruption.cpp
+++ b/source/disruption/disruption.cpp
@@ -46,6 +46,20 @@ static int min_priority(const DisruptionSet& disruptions){
     return min;
 }
 
+
+bool Comp::operator()(const boost::weak_ptr<type::new_disruption::Impact>& lhs,
+                      const boost::weak_ptr<type::new_disruption::Impact>& rhs){
+    auto i1 = lhs.lock();
+    auto i2 = rhs.lock();
+    if(!i1){
+        return true;
+    }
+    if(!i2){
+        return false;
+    }
+    return *i1 < *i2;
+}
+
 Disrupt& Disruption::find_or_create(const type::Network* network){
     auto find_predicate = [&](const Disrupt& network_disrupt) {
         return network == network_disrupt.network;

--- a/source/disruption/disruption.cpp
+++ b/source/disruption/disruption.cpp
@@ -47,11 +47,6 @@ static int min_priority(const DisruptionSet& disruptions){
 }
 
 
-bool Comp::operator()(const boost::shared_ptr<type::new_disruption::Impact>& lhs,
-                      const boost::shared_ptr<type::new_disruption::Impact>& rhs){
-    return *lhs < *rhs;
-}
-
 Disrupt& Disruption::find_or_create(const type::Network* network){
     auto find_predicate = [&](const Disrupt& network_disrupt) {
         return network == network_disrupt.network;

--- a/source/disruption/disruption.cpp
+++ b/source/disruption/disruption.cpp
@@ -76,7 +76,12 @@ void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
         }
         for(auto stop_area_idx: line_list){
             const auto* stop_area = d.pt_data->stop_areas[stop_area_idx];
-            if (stop_area->has_publishable_message(now)){
+            auto v = stop_area->get_publishable_messages(now);
+            for(const auto* stop_point: stop_area->stop_point_list){
+                auto vsp = stop_point->get_publishable_messages(now);
+                v.insert(v.end(), vsp.begin(), vsp.end());
+            }
+            if (!v.empty()){
                 Disrupt& dist = this->find_or_create(network);
                 auto find_predicate = [&](const std::pair<const type::StopArea*, DisruptionSet>& item) {
                     return item.first == stop_area;
@@ -84,7 +89,6 @@ void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
                 auto it = std::find_if(dist.stop_areas.begin(),
                                        dist.stop_areas.end(),
                                        find_predicate);
-                auto v = stop_area->get_publishable_messages(now);
                 if(it == dist.stop_areas.end()){
                     dist.stop_areas.push_back(std::make_pair(stop_area, DisruptionSet(v.begin(), v.end())));
                 }else{

--- a/source/disruption/disruption.cpp
+++ b/source/disruption/disruption.cpp
@@ -34,27 +34,27 @@ www.navitia.io
 
 namespace navitia { namespace disruption {
 
-type::idx_t Disruption::find_or_create(const type::Network* network){
-    auto find_predicate = [&](disrupt network_disrupt) {
-        return network->idx == network_disrupt.network_idx;
+Disrupt& Disruption::find_or_create(const type::Network* network){
+    auto find_predicate = [&](const Disrupt& network_disrupt) {
+        return network == network_disrupt.network;
     };
     auto it = std::find_if(this->disrupts.begin(),
                            this->disrupts.end(),
                            find_predicate);
     if(it == this->disrupts.end()){
-        disrupt dist;
-        dist.network_idx = network->idx;
+        Disrupt dist;
+        dist.network = network;
         dist.idx = this->disrupts.size();
         this->disrupts.push_back(dist);
-        return dist.idx;
+        return disrupts.back();
     }
-    return it->idx;
+    return *it;
 }
 
 void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
-                      const type::Data &d,
+                      const type::Data& d,
                       const boost::posix_time::ptime now){
 
     for(auto idx : network_idx){
@@ -74,18 +74,18 @@ void Disruption::add_stop_areas(const std::vector<type::idx_t>& network_idx,
         } catch(const ptref::ptref_error &ptref_error){
             LOG4CPLUS_WARN(logger, "Disruption::add_stop_areas : ptref : "  + ptref_error.more);
         }
-        for(auto stop_area_idx : line_list){
+        for(auto stop_area_idx: line_list){
             const auto* stop_area = d.pt_data->stop_areas[stop_area_idx];
             if (stop_area->has_publishable_message(now)){
-                disrupt& dist = this->disrupts[this->find_or_create(network)];
-                auto find_predicate = [&](type::idx_t idx ) {
-                    return stop_area->idx == idx;
+                Disrupt& dist = this->find_or_create(network);
+                auto find_predicate = [&](const type::StopArea* sa) {
+                    return stop_area == sa;
                 };
-                auto it = std::find_if(dist.stop_area_idx.begin(),
-                                       dist.stop_area_idx.end(),
+                auto it = std::find_if(dist.stop_areas.begin(),
+                                       dist.stop_areas.end(),
                                        find_predicate);
-                if(it == dist.stop_area_idx.end()){
-                    dist.stop_area_idx.push_back(stop_area->idx);
+                if(it == dist.stop_areas.end()){
+                    dist.stop_areas.push_back(stop_area);
                 }
             }
         }
@@ -99,14 +99,14 @@ void Disruption::add_networks(const std::vector<type::idx_t>& network_idx,
     for(auto idx : network_idx){
         const auto* network = d.pt_data->networks[idx];
         if (network->has_publishable_message(now)){
-            this->disrupts[this->find_or_create(network)];
+            this->find_or_create(network);
         }
     }
 }
 
 void Disruption::add_lines(const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
-                      const type::Data &d,
+                      const type::Data& d,
                       const boost::posix_time::ptime now){
 
     std::vector<type::idx_t> line_list;
@@ -121,54 +121,50 @@ void Disruption::add_lines(const std::string& filter,
     for(auto idx : line_list){
         const auto* line = d.pt_data->lines[idx];
         if (line->has_publishable_message(now)){
-            disrupt& dist = this->disrupts[this->find_or_create(line->network)];
-            auto find_predicate = [&](type::idx_t idx ) {
-                return line->idx == idx;
+            Disrupt& dist = this->find_or_create(line->network);
+            auto find_predicate = [&](const type::Line* l) {
+                return line == l;
             };
-            auto it = std::find_if(dist.line_idx.begin(),
-                                   dist.line_idx.end(),
+            auto it = std::find_if(dist.lines.begin(),
+                                   dist.lines.end(),
                                    find_predicate);
-            if(it == dist.line_idx.end()){
-                dist.line_idx.push_back(line->idx);
+            if(it == dist.lines.end()){
+                dist.lines.push_back(line);
             }
         }
     }
 }
 
-void Disruption::sort_disruptions(const type::Data &d){
+void Disruption::sort_disruptions(){
 
-    auto sort_disruption = [&](disrupt d1, disrupt d2){
-        const auto & n1 = *(d.pt_data->networks[d1.network_idx]);
-        const auto & n2 = *(d.pt_data->networks[d2.network_idx]);
-            return n1 < n2;
+    auto sort_disruption = [&](const Disrupt& d1, const Disrupt& d2){
+            return d1.network->idx < d2.network->idx;
     };
 
-    auto sort_lines = [&](type::idx_t l1_, type::idx_t l2_) {
-        const auto & l1 = *(d.pt_data->lines[l1_]);
-        const auto & l2 = *(d.pt_data->lines[l2_]);
+    auto sort_lines = [&](const type::Line* l1, const type::Line* l2) {
         return l1 < l2;
     };
 
     std::sort(this->disrupts.begin(), this->disrupts.end(), sort_disruption);
-    for(auto disrupt : this->disrupts){
-        std::sort(disrupt.line_idx.begin(), disrupt.line_idx.end(), sort_lines);
+    for(auto& disrupt : this->disrupts){
+        std::sort(disrupt.lines.begin(), disrupt.lines.end(), sort_lines);
     }
 
 }
 
 void Disruption::disruptions_list(const std::string& filter,
                         const std::vector<std::string>& forbidden_uris,
-                        const type::Data &d,
+                        const type::Data& d,
                         const boost::posix_time::ptime now){
 
     std::vector<type::idx_t> network_idx = ptref::make_query(type::Type_e::Network, filter,
-                                                                                      forbidden_uris, d);
+                                                             forbidden_uris, d);
     add_networks(network_idx, d, now);
     add_lines(filter, forbidden_uris, d, now);
     add_stop_areas(network_idx, filter, forbidden_uris, d, now);
-    sort_disruptions(d);
+    sort_disruptions();
 }
-const std::vector<disrupt>& Disruption::get_disrupts() const{
+const std::vector<Disrupt>& Disruption::get_disrupts() const{
     return this->disrupts;
 }
 

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -33,15 +33,12 @@ www.navitia.io
 #include "type/pt_data.h"
 #include "utils/logger.h"
 #include "boost/date_time/posix_time/posix_time.hpp"
+#include "utils/functions.h"
 
 namespace navitia { namespace disruption {
 
-struct Comp{
-    bool operator()(const boost::shared_ptr<type::new_disruption::Impact>& lhs,
-                    const boost::shared_ptr<type::new_disruption::Impact>& rhs);
-};
 
-using DisruptionSet = std::set<boost::shared_ptr<type::new_disruption::Impact>, Comp>;
+using DisruptionSet = std::set<boost::shared_ptr<type::new_disruption::Impact>, Less>;
 
 struct Disrupt{
     type::idx_t idx;

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -33,10 +33,16 @@ www.navitia.io
 #include "type/pt_data.h"
 #include "utils/logger.h"
 #include "boost/date_time/posix_time/posix_time.hpp"
+#include <boost/smart_ptr/owner_less.hpp>
 
 namespace navitia { namespace disruption {
 
-using DisruptionSet = std::set<boost::weak_ptr<type::new_disruption::Impact>>;
+struct Comp{
+    bool operator()(const boost::weak_ptr<type::new_disruption::Impact>& lhs,
+                    const boost::weak_ptr<type::new_disruption::Impact>& rhs);
+};
+
+using DisruptionSet = std::set<boost::weak_ptr<type::new_disruption::Impact>, Comp>;
 
 struct Disrupt{
     type::idx_t idx;

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -37,20 +37,20 @@ www.navitia.io
 namespace navitia { namespace disruption {
 
 
-struct disrupt{
+struct Disrupt{
     type::idx_t idx;
-    type::idx_t network_idx;
-    std::vector<type::idx_t> line_idx;
-    std::vector<type::idx_t> stop_area_idx;
+    const type::Network* network = nullptr;
+    std::vector<const type::Line*> lines;
+    std::vector<const type::StopArea*> stop_areas;
 };
 
 class Disruption{
 private:
 
-    std::vector<disrupt> disrupts;
+    std::vector<Disrupt> disrupts;
     log4cplus::Logger logger;
 
-    type::idx_t find_or_create(const type::Network* network);
+    Disrupt& find_or_create(const type::Network* network);
     void add_stop_areas(const std::vector<type::idx_t>& network_idx,
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
@@ -64,7 +64,7 @@ private:
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
                       const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
-    void sort_disruptions(const type::Data &d);
+    void sort_disruptions();
 public:
     Disruption():logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"))){}
 
@@ -73,7 +73,7 @@ public:
                     const type::Data &d,
                     const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
 
-    const std::vector<disrupt>& get_disrupts() const;
+    const std::vector<Disrupt>& get_disrupts() const;
     size_t get_disrupts_size();
 };
 }}

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -33,16 +33,15 @@ www.navitia.io
 #include "type/pt_data.h"
 #include "utils/logger.h"
 #include "boost/date_time/posix_time/posix_time.hpp"
-#include <boost/smart_ptr/owner_less.hpp>
 
 namespace navitia { namespace disruption {
 
 struct Comp{
-    bool operator()(const boost::weak_ptr<type::new_disruption::Impact>& lhs,
-                    const boost::weak_ptr<type::new_disruption::Impact>& rhs);
+    bool operator()(const boost::shared_ptr<type::new_disruption::Impact>& lhs,
+                    const boost::shared_ptr<type::new_disruption::Impact>& rhs);
 };
 
-using DisruptionSet = std::set<boost::weak_ptr<type::new_disruption::Impact>, Comp>;
+using DisruptionSet = std::set<boost::shared_ptr<type::new_disruption::Impact>, Comp>;
 
 struct Disrupt{
     type::idx_t idx;

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -36,12 +36,14 @@ www.navitia.io
 
 namespace navitia { namespace disruption {
 
+using DisruptionSet = std::set<boost::weak_ptr<type::new_disruption::Impact>>;
 
 struct Disrupt{
     type::idx_t idx;
     const type::Network* network = nullptr;
-    std::vector<const type::Line*> lines;
-    std::vector<const type::StopArea*> stop_areas;
+    DisruptionSet network_disruptions;
+    std::vector<std::pair<const type::Line*, DisruptionSet>> lines;
+    std::vector<std::pair<const type::StopArea*, DisruptionSet>> stop_areas;
 };
 
 class Disruption{
@@ -55,15 +57,15 @@ private:
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
-                      const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
+                      const boost::posix_time::ptime now);
 
     void add_networks(const std::vector<type::idx_t>& network_idx,
                       const type::Data &d,
-                      const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
+                      const boost::posix_time::ptime now);
     void add_lines(const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
-                      const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
+                      const boost::posix_time::ptime now);
     void sort_disruptions();
 public:
     Disruption():logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"))){}
@@ -71,7 +73,7 @@ public:
     void disruptions_list(const std::string& filter,
                     const std::vector<std::string>& forbidden_uris,
                     const type::Data &d,
-                    const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
+                    const boost::posix_time::ptime now);
 
     const std::vector<Disrupt>& get_disrupts() const;
     size_t get_disrupts_size();

--- a/source/disruption/disruption.h
+++ b/source/disruption/disruption.h
@@ -44,6 +44,7 @@ struct Disrupt{
     type::idx_t idx;
     const type::Network* network = nullptr;
     DisruptionSet network_disruptions;
+    //we use a vector of pair because we need to sort by the priority of the impacts
     std::vector<std::pair<const type::Line*, DisruptionSet>> lines;
     std::vector<std::pair<const type::StopArea*, DisruptionSet>> stop_areas;
 };

--- a/source/disruption/disruption_api.cpp
+++ b/source/disruption/disruption_api.cpp
@@ -68,21 +68,21 @@ pbnavitia::Response disruptions(const navitia::type::Data& d,
         pbnavitia::Disruptions* pb_disruption = pb_response.add_disruptions();
         pbnavitia::Network* pb_network = pb_disruption->mutable_network();
         for(const auto& impact: dist.network_disruptions){
-            fill_message(impact, d, pb_network, depth-1, now_dt, action_period);
+            fill_message(*impact, d, pb_network, depth-1, now_dt, action_period);
         }
         navitia::fill_pb_object(dist.network, d, pb_network, depth, bt::not_a_date_time, action_period, false);
         for (const auto& line_item: dist.lines) {
             pbnavitia::Line* pb_line = pb_disruption->add_lines();
             navitia::fill_pb_object(line_item.first, d, pb_line, depth-1, bt::not_a_date_time, action_period, false);
             for(const auto& impact: line_item.second){
-                fill_message(impact, d, pb_line, depth-1, now_dt, action_period);
+                fill_message(*impact, d, pb_line, depth-1, now_dt, action_period);
             }
         }
         for (const auto& sa_item: dist.stop_areas) {
             pbnavitia::StopArea* pb_stop_area = pb_disruption->add_stop_areas();
             navitia::fill_pb_object(sa_item.first, d, pb_stop_area, depth-1, bt::not_a_date_time, action_period, false);
             for(const auto& impact: sa_item.second){
-                fill_message(impact, d, pb_stop_area, depth-1, now_dt, action_period);
+                fill_message(*impact, d, pb_stop_area, depth-1, now_dt, action_period);
             }
         }
     }

--- a/source/disruption/disruption_api.cpp
+++ b/source/disruption/disruption_api.cpp
@@ -67,14 +67,23 @@ pbnavitia::Response disruptions(const navitia::type::Data& d,
     for (const Disrupt& dist: disrupts) {
         pbnavitia::Disruptions* pb_disruption = pb_response.add_disruptions();
         pbnavitia::Network* pb_network = pb_disruption->mutable_network();
-        navitia::fill_pb_object(dist.network, d, pb_network, depth, now_dt, action_period, false, true);
-        for (const type::Line* line: dist.lines) {
-            pbnavitia::Line* pb_line = pb_disruption->add_lines();
-            navitia::fill_pb_object(line, d, pb_line, depth-1, now_dt, action_period, false, true);
+        for(const auto& impact: dist.network_disruptions){
+            fill_message(impact, d, pb_network, depth-1, now_dt, action_period);
         }
-        for (const type::StopArea* stop_area: dist.stop_areas) {
+        navitia::fill_pb_object(dist.network, d, pb_network, depth, bt::not_a_date_time, action_period, false);
+        for (const auto& line_item: dist.lines) {
+            pbnavitia::Line* pb_line = pb_disruption->add_lines();
+            navitia::fill_pb_object(line_item.first, d, pb_line, depth-1, bt::not_a_date_time, action_period, false);
+            for(const auto& impact: line_item.second){
+                fill_message(impact, d, pb_line, depth-1, now_dt, action_period);
+            }
+        }
+        for (const auto& sa_item: dist.stop_areas) {
             pbnavitia::StopArea* pb_stop_area = pb_disruption->add_stop_areas();
-            navitia::fill_pb_object(stop_area, d, pb_stop_area, depth-1, now_dt, action_period, false, true);
+            navitia::fill_pb_object(sa_item.first, d, pb_stop_area, depth-1, bt::not_a_date_time, action_period, false);
+            for(const auto& impact: sa_item.second){
+                fill_message(impact, d, pb_stop_area, depth-1, now_dt, action_period);
+            }
         }
     }
     auto pagination = pb_response.mutable_pagination();

--- a/source/disruption/disruption_api.cpp
+++ b/source/disruption/disruption_api.cpp
@@ -42,7 +42,7 @@ pbnavitia::Response disruptions(const navitia::type::Data& d,
                                 const size_t depth,
                                 size_t count,
                                 size_t start_page,
-                                const std::string &filter,
+                                const std::string& filter,
                                 const std::vector<std::string>& forbidden_uris) {
     pbnavitia::Response pb_response;
 
@@ -63,18 +63,18 @@ pbnavitia::Response disruptions(const navitia::type::Data& d,
     }
 
     size_t total_result = result.get_disrupts_size();
-    std::vector<disrupt> disrupts = paginate(result.get_disrupts(), count, start_page);
-    for (disrupt dist: disrupts) {
+    std::vector<Disrupt> disrupts = paginate(result.get_disrupts(), count, start_page);
+    for (const Disrupt& dist: disrupts) {
         pbnavitia::Disruptions* pb_disruption = pb_response.add_disruptions();
         pbnavitia::Network* pb_network = pb_disruption->mutable_network();
-        navitia::fill_pb_object(d.pt_data->networks[dist.network_idx], d, pb_network, depth, now_dt, action_period, false, true);
-        for (type::idx_t idx : dist.line_idx) {
+        navitia::fill_pb_object(dist.network, d, pb_network, depth, now_dt, action_period, false, true);
+        for (const type::Line* line: dist.lines) {
             pbnavitia::Line* pb_line = pb_disruption->add_lines();
-            navitia::fill_pb_object(d.pt_data->lines[idx], d, pb_line, depth-1, now_dt, action_period, false, true);
+            navitia::fill_pb_object(line, d, pb_line, depth-1, now_dt, action_period, false, true);
         }
-        for (type::idx_t idx : dist.stop_area_idx) {
+        for (const type::StopArea* stop_area: dist.stop_areas) {
             pbnavitia::StopArea* pb_stop_area = pb_disruption->add_stop_areas();
-            navitia::fill_pb_object(d.pt_data->stop_areas[idx], d, pb_stop_area, depth-1, now_dt, action_period, false, true);
+            navitia::fill_pb_object(stop_area, d, pb_stop_area, depth-1, now_dt, action_period, false, true);
         }
     }
     auto pagination = pb_response.mutable_pagination();
@@ -90,5 +90,5 @@ pbnavitia::Response disruptions(const navitia::type::Data& d,
     }
     return pb_response;
 }
-}
-}
+
+}}//namespace

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -298,7 +298,7 @@ class TestDisruptions(AbstractTestFixture):
 
     def test_disruption_on_route(self):
         """
-        check that disruption on route are displayed a disruption on line
+        check that disruption on route are displayed on the corresponding line
         """
         response = self.query_region('traffic_reports?_current_datetime=20150325T090000')
 

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -327,6 +327,9 @@ class TestDisruptions(AbstractTestFixture):
         eq_(lines_disrupt[0]['uri'], 'too_bad_route_A:0')
 
     def test_disruption_on_route_and_line(self):
+        """
+        and we check the sort order of the lines
+        """
         response = self.query_region('traffic_reports?_current_datetime=20150125T090000')
 
         impacts = get_impacts(response)
@@ -335,18 +338,20 @@ class TestDisruptions(AbstractTestFixture):
         response = self.query_region('traffic_reports?_current_datetime=20150127T090000')
 
         impacts = get_impacts(response)
-        eq_(len(impacts), 1)
+        eq_(len(impacts), 3)
         assert 'too_bad_route_A:0_and_line' in impacts
 
         traffic_report = get_not_null(response, 'traffic_reports')
         eq_(len(traffic_report), 1)
 
         impacted_lines = get_not_null(traffic_report[0], 'lines')
-        eq_(len(impacted_lines), 1)
+        eq_(len(impacted_lines), 3)
         is_valid_line(impacted_lines[0], depth_check=0)
-        eq_(impacted_lines[0]['id'], 'A')
+        eq_(impacted_lines[0]['id'], 'B')
+        eq_(impacted_lines[1]['id'], 'A')
+        eq_(impacted_lines[2]['id'], 'C')
 
-        lines_disrupt = get_disruptions(impacted_lines[0], response)
+        lines_disrupt = get_disruptions(impacted_lines[1], response)
         eq_(len(lines_disrupt), 1)
         for d in lines_disrupt:
             is_valid_disruption(d)

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -69,13 +69,13 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(lines_disrupt), 2)
         for d in lines_disrupt:
             is_valid_disruption(d)
-        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
-        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
-        eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
+        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[1]['uri'], 'too_bad_again')
+        eq_(lines_disrupt[1]['severity']['name'], 'bad severity')
 
-        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(lines_disrupt[1]['uri'], 'later_impact')
-        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[0]['uri'], 'later_impact')
+        eq_(lines_disrupt[0]['severity']['name'], 'information severity')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
         is_valid_network(impacted_network, depth_check=0)
@@ -84,11 +84,11 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(network_disrupt), 2)
         for d in network_disrupt:
             is_valid_disruption(d)
-        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A')
-        eq_(network_disrupt[0]['uri'], 'too_bad_again')
+        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A')
+        eq_(network_disrupt[1]['uri'], 'too_bad_again')
 
-        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(network_disrupt[1]['uri'], 'later_impact')
+        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(network_disrupt[0]['uri'], 'later_impact')
 
         impacted_stop_areas = get_not_null(traffic_report[0], 'stop_areas')
         eq_(len(impacted_stop_areas), 1)
@@ -123,13 +123,13 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(lines_disrupt), 2)
         for d in lines_disrupt:
             is_valid_disruption(d)
-        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
-        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
-        eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
+        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[1]['uri'], 'too_bad_again')
+        eq_(lines_disrupt[1]['severity']['name'], 'bad severity')
 
-        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(lines_disrupt[1]['uri'], 'later_impact')
-        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[0]['uri'], 'later_impact')
+        eq_(lines_disrupt[0]['severity']['name'], 'information severity')
 
         stops = self.query_region('stop_areas/stopA?' + default_date_filter)
         stop = get_not_null(stops, 'stop_areas')[0]
@@ -217,8 +217,8 @@ class TestDisruptions(AbstractTestFixture):
 
         lines_disrupt = get_disruptions(impacted_lines[0], response)
         eq_(len(lines_disrupt), 2)
-        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
-        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
+        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[1]['uri'], 'too_bad_again')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
 
@@ -226,8 +226,8 @@ class TestDisruptions(AbstractTestFixture):
         eq_(impacted_network['id'], 'base_network')
         network_disrupt = get_disruptions(impacted_network, response)
         eq_(len(network_disrupt), 2)
-        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A')
-        eq_(network_disrupt[0]['uri'], 'too_bad_again')
+        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A')
+        eq_(network_disrupt[1]['uri'], 'too_bad_again')
 
         # but we should not have disruption on stop area, B is not disrupted
         assert 'stop_areas' not in traffic_report[0]
@@ -296,3 +296,59 @@ class TestDisruptions(AbstractTestFixture):
         #UTC - 1, so in UTC it's 00h59 => disruptions
         assert len(response['disruptions']) > 0
 
+    def test_disruption_on_route(self):
+        """
+        check that disruption on route are displayed a disruption on line
+        """
+        response = self.query_region('traffic_reports?_current_datetime=20150325T090000')
+
+        impacts = get_impacts(response)
+        eq_(len(impacts), 0)
+
+        response = self.query_region('traffic_reports?_current_datetime=20150327T090000')
+
+        impacts = get_impacts(response)
+        eq_(len(impacts), 1)
+        assert 'too_bad_route_A:0' in impacts
+
+        traffic_report = get_not_null(response, 'traffic_reports')
+        eq_(len(traffic_report), 1)
+
+        impacted_lines = get_not_null(traffic_report[0], 'lines')
+        eq_(len(impacted_lines), 1)
+        is_valid_line(impacted_lines[0], depth_check=0)
+        eq_(impacted_lines[0]['id'], 'A')
+
+        lines_disrupt = get_disruptions(impacted_lines[0], response)
+        eq_(len(lines_disrupt), 1)
+        for d in lines_disrupt:
+            is_valid_disruption(d)
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_route_A:0')
+        eq_(lines_disrupt[0]['uri'], 'too_bad_route_A:0')
+
+    def test_disruption_on_route_and_line(self):
+        response = self.query_region('traffic_reports?_current_datetime=20150125T090000')
+
+        impacts = get_impacts(response)
+        eq_(len(impacts), 0)
+
+        response = self.query_region('traffic_reports?_current_datetime=20150127T090000')
+
+        impacts = get_impacts(response)
+        eq_(len(impacts), 1)
+        assert 'too_bad_route_A:0_and_line' in impacts
+
+        traffic_report = get_not_null(response, 'traffic_reports')
+        eq_(len(traffic_report), 1)
+
+        impacted_lines = get_not_null(traffic_report[0], 'lines')
+        eq_(len(impacted_lines), 1)
+        is_valid_line(impacted_lines[0], depth_check=0)
+        eq_(impacted_lines[0]['id'], 'A')
+
+        lines_disrupt = get_disruptions(impacted_lines[0], response)
+        eq_(len(lines_disrupt), 1)
+        for d in lines_disrupt:
+            is_valid_disruption(d)
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_route_A:0_and_line')
+        eq_(lines_disrupt[0]['uri'], 'too_bad_route_A:0_and_line')

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -69,13 +69,13 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(lines_disrupt), 2)
         for d in lines_disrupt:
             is_valid_disruption(d)
-        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A')
-        eq_(lines_disrupt[1]['uri'], 'too_bad_again')
-        eq_(lines_disrupt[1]['severity']['name'], 'bad severity')
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
+        eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
 
-        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(lines_disrupt[0]['uri'], 'later_impact')
-        eq_(lines_disrupt[0]['severity']['name'], 'information severity')
+        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[1]['uri'], 'later_impact')
+        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
         is_valid_network(impacted_network, depth_check=0)
@@ -84,11 +84,11 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(network_disrupt), 2)
         for d in network_disrupt:
             is_valid_disruption(d)
-        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A')
-        eq_(network_disrupt[1]['uri'], 'too_bad_again')
+        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(network_disrupt[0]['uri'], 'too_bad_again')
 
-        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(network_disrupt[0]['uri'], 'later_impact')
+        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(network_disrupt[1]['uri'], 'later_impact')
 
         impacted_stop_areas = get_not_null(traffic_report[0], 'stop_areas')
         eq_(len(impacted_stop_areas), 1)
@@ -123,13 +123,13 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(lines_disrupt), 2)
         for d in lines_disrupt:
             is_valid_disruption(d)
-        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A')
-        eq_(lines_disrupt[1]['uri'], 'too_bad_again')
-        eq_(lines_disrupt[1]['severity']['name'], 'bad severity')
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
+        eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
 
-        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(lines_disrupt[0]['uri'], 'later_impact')
-        eq_(lines_disrupt[0]['severity']['name'], 'information severity')
+        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
+        eq_(lines_disrupt[1]['uri'], 'later_impact')
+        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
 
         stops = self.query_region('stop_areas/stopA?' + default_date_filter)
         stop = get_not_null(stops, 'stop_areas')[0]
@@ -217,8 +217,8 @@ class TestDisruptions(AbstractTestFixture):
 
         lines_disrupt = get_disruptions(impacted_lines[0], response)
         eq_(len(lines_disrupt), 2)
-        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A')
-        eq_(lines_disrupt[1]['uri'], 'too_bad_again')
+        eq_(lines_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(lines_disrupt[0]['uri'], 'too_bad_again')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
 
@@ -226,8 +226,8 @@ class TestDisruptions(AbstractTestFixture):
         eq_(impacted_network['id'], 'base_network')
         network_disrupt = get_disruptions(impacted_network, response)
         eq_(len(network_disrupt), 2)
-        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A')
-        eq_(network_disrupt[1]['uri'], 'too_bad_again')
+        eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A')
+        eq_(network_disrupt[0]['uri'], 'too_bad_again')
 
         # but we should not have disruption on stop area, B is not disrupted
         assert 'stop_areas' not in traffic_report[0]

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -493,13 +493,22 @@ struct routing_api_data {
         info_severity->uri = "info";
         info_severity->wording = "information severity";
         info_severity->color = "#FFFF00";
+        info_severity->priority = 25;
         holder.severities[info_severity->uri] = info_severity;
 
         auto bad_severity = boost::make_shared<Severity>();
         bad_severity->uri = "disruption";
         bad_severity->wording = "bad severity";
         bad_severity->color = "#FFFFF0";
+        bad_severity->priority = 0;
         holder.severities[bad_severity->uri] = bad_severity;
+
+        auto foo_severity = boost::make_shared<Severity>();
+        foo_severity->uri = "foo";
+        foo_severity->wording = "foo severity";
+        foo_severity->color = "#FFFFF0";
+        foo_severity->priority = 50;
+        holder.severities[foo_severity->uri] = foo_severity;
 
         {
             //we create one disruption on stop A
@@ -679,6 +688,30 @@ struct routing_api_data {
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "A", *b.data->pt_data, impact));
 
             impact->messages.push_back({"no luck", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});
+
+            disruption->add_impact(impact);
+
+            impact = boost::make_shared<Impact>();
+            impact->uri = "too_bad_line_B";
+            impact->application_periods = {period};
+
+            impact->severity = bad_severity;
+
+            impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "B", *b.data->pt_data, impact));
+
+            impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});
+
+            disruption->add_impact(impact);
+
+            impact = boost::make_shared<Impact>();
+            impact->uri = "too_bad_line_C";
+            impact->application_periods = {period};
+
+            impact->severity = foo_severity;
+
+            impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "C", *b.data->pt_data, impact));
+
             impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});
 
             disruption->add_impact(impact);

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -36,6 +36,7 @@ www.navitia.io
 #include "type/message.h"
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
+#include <boost/test/unit_test.hpp>
 
 namespace ng = navitia::georef;
 
@@ -621,6 +622,61 @@ struct routing_api_data {
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "A", *b.data->pt_data, impact));
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "B", *b.data->pt_data, impact));
             impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "C", *b.data->pt_data, impact));
+
+            impact->messages.push_back({"no luck", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});
+
+            disruption->add_impact(impact);
+
+            holder.disruptions.push_back(std::move(disruption));
+        }
+
+        {
+            auto period = boost::posix_time::time_period("20150326T060000"_dt, "20150330T120000"_dt);
+            //we create one disruption on line A
+            auto disruption = std::make_unique<Disruption>();
+            disruption->uri = "disruption_route_A:0";
+            disruption->publication_period = period;
+            auto tag = boost::make_shared<Tag>();
+            tag->uri = "tag";
+            tag->name = "tag name";
+            disruption->tags.push_back(tag);
+
+            auto impact = boost::make_shared<Impact>();
+            impact->uri = "too_bad_route_A:0";
+            impact->application_periods = {period};
+
+            impact->severity = info_severity;
+
+            impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Route, "A:0", *b.data->pt_data, impact));
+
+            impact->messages.push_back({"no luck", "sms", "sms", "content type", default_date, default_date});
+            impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});
+
+            disruption->add_impact(impact);
+
+            holder.disruptions.push_back(std::move(disruption));
+        }
+
+        {
+            auto period = boost::posix_time::time_period("20150126T060000"_dt, "20150130T120000"_dt);
+            //we create one disruption on line A
+            auto disruption = std::make_unique<Disruption>();
+            disruption->uri = "disruption_route_A:0_and_line";
+            disruption->publication_period = period;
+            auto tag = boost::make_shared<Tag>();
+            tag->uri = "tag";
+            tag->name = "tag name";
+            disruption->tags.push_back(tag);
+
+            auto impact = boost::make_shared<Impact>();
+            impact->uri = "too_bad_route_A:0_and_line";
+            impact->application_periods = {period};
+
+            impact->severity = info_severity;
+
+            impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Route, "A:0", *b.data->pt_data, impact));
+            impact->informed_entities.push_back(make_pt_obj(nt::Type_e::Line, "A", *b.data->pt_data, impact));
 
             impact->messages.push_back({"no luck", "sms", "sms", "content type", default_date, default_date});
             impact->messages.push_back({"try again", "sms", "sms", "content type", default_date, default_date});

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -111,9 +111,6 @@ PtObj make_pt_obj(Type_e type,
 }
 
 bool Impact::operator<(const Impact& other){
-    if(this->uri == other.uri){
-        return false;
-    }
     if(this->severity->priority != other.severity->priority){
         return this->severity->priority < other.severity->priority;
     }if(this->created_at != other.created_at){

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -110,4 +110,17 @@ PtObj make_pt_obj(Type_e type,
     }
 }
 
+bool Impact::operator<(const Impact& other){
+    if(this->uri == other.uri){
+        return false;
+    }
+    if(this->severity->priority != other.severity->priority){
+        return this->severity->priority < other.severity->priority;
+    }if(this->created_at != other.created_at){
+        return this->created_at < other.created_at;
+    }else{
+        return this->uri < other.uri;
+    }
+}
+
 }}}//namespace

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -187,6 +187,8 @@ struct Impact {
     }
 
     bool is_valid(const boost::posix_time::ptime& current_time, const boost::posix_time::time_period& action_period) const;
+
+    bool operator<(const Impact& other);
 };
 
 struct Tag {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -71,7 +71,7 @@ compute_disruption_status(const boost::shared_ptr<type::new_disruption::Impact>&
 
 template <typename T>
 void fill_address(const T* obj, const nt::Data& data,
-                    pbnavitia::Address* address, const std::string address_name, int house_number,
+                    pbnavitia::Address* address, const std::string& address_name, int house_number,
                     const type::GeographicalCoord& coord, int max_depth,
                     const pt::ptime& now, const pt::time_period& action_period) {
     if(obj == nullptr)
@@ -216,13 +216,12 @@ void fill_pb_object(const georef::Admin* adm, const nt::Data&,
 void fill_pb_object(const nt::Contributor*,
                     const nt::Data& , pbnavitia::Contributor* ,
                     int , const pt::ptime& ,
-                    const pt::time_period& , const bool, const bool){}
+                    const pt::time_period& , const bool){}
 
-void fill_pb_object(const nt::StopArea * sa,
+void fill_pb_object(const nt::StopArea* sa,
                     const nt::Data& data, pbnavitia::StopArea* stop_area,
                     int max_depth, const pt::ptime& now,
-                    const pt::time_period& action_period, const bool show_codes,
-                    const bool display_all_publishable_disruption){
+                    const pt::time_period& action_period, const bool show_codes){
     if(sa == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -249,24 +248,18 @@ void fill_pb_object(const nt::StopArea * sa,
         for (const nt::idx_t idx : indexes) {
             nt::CommercialMode* commercial_mode = data.pt_data->commercial_modes[idx];
             fill_pb_object(commercial_mode, data, stop_area->add_commercial_modes(), 0, now, action_period,
-                           show_codes, display_all_publishable_disruption);
+                           show_codes);
         }
         indexes = sa->get(navitia::type::Type_e::PhysicalMode, *(data.pt_data));
         for (const nt::idx_t idx : indexes) {
             nt::PhysicalMode* physical_mode = data.pt_data->physical_modes[idx];
             fill_pb_object(physical_mode, data, stop_area->add_physical_modes(), 0, now, action_period,
-                           show_codes, display_all_publishable_disruption);
+                           show_codes);
         }
     }
 
-    if(display_all_publishable_disruption){
-        for(const auto message : sa->get_publishable_messages(now)){
-            fill_message(message, data, stop_area, max_depth-1, now, action_period);
-        }
-    }else{
-        for(const auto message : sa->get_applicable_messages(now, action_period)){
-            fill_message(message, data, stop_area, max_depth-1, now, action_period);
-        }
+    for(const auto message : sa->get_applicable_messages(now, action_period)){
+        fill_message(message, data, stop_area, max_depth-1, now, action_period);
     }
     if(show_codes) {
         for(auto type_value : sa->codes) {
@@ -278,8 +271,7 @@ void fill_pb_object(const nt::StopArea * sa,
 
 void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
                     pbnavitia::StopPoint* stop_point, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes,
-                    const bool display_all_publishable_disruption){
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
     if(sp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -340,17 +332,11 @@ void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
 
     if(depth > 0 && sp->stop_area != nullptr)
         fill_pb_object(sp->stop_area, data, stop_point->mutable_stop_area(),
-                       depth-1, now, action_period, show_codes, display_all_publishable_disruption);
+                       depth-1, now, action_period, show_codes);
 
 
-    if(display_all_publishable_disruption){
-        for(const auto message : sp->get_publishable_messages(now)){
-            fill_message(message, data, stop_point, max_depth-1, now, action_period);
-        }
-    }else{
-        for(const auto message : sp->get_applicable_messages(now, action_period)){
-            fill_message(message, data, stop_point, max_depth-1, now, action_period);
-        }
+    for(const auto message : sp->get_applicable_messages(now, action_period)){
+        fill_message(message, data, stop_point, max_depth-1, now, action_period);
     }
     if(show_codes) {
         for(auto type_value : sp->codes) {
@@ -385,8 +371,7 @@ void fill_pb_object(const navitia::type::GeographicalCoord& coord, const type::D
 
 void fill_pb_object(nt::Line const* l, const nt::Data& data,
         pbnavitia::Line * line, int max_depth, const pt::ptime& now,
-        const pt::time_period& action_period, const bool show_codes,
-        const bool display_all_publishable_disruption){
+        const pt::time_period& action_period, const bool show_codes){
     if(l == nullptr)
         return ;
 
@@ -413,26 +398,20 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
 
         std::vector<nt::idx_t> physical_mode_idxes;
         for(auto route : l->route_list) {
-            fill_pb_object(route, data, line->add_routes(), depth-1, now, action_period, show_codes, display_all_publishable_disruption);
+            fill_pb_object(route, data, line->add_routes(), depth-1, now, action_period, show_codes);
         }
         for(auto physical_mode : l->physical_mode_list){
             fill_pb_object(physical_mode, data, line->add_physical_mode(),
-                    depth-1, now, action_period, show_codes, display_all_publishable_disruption);
+                    depth-1, now, action_period, show_codes);
         }
 
         fill_pb_object(l->commercial_mode, data,
-                line->mutable_commercial_mode(), depth-1, now, action_period, show_codes, display_all_publishable_disruption);
-        fill_pb_object(l->network, data, line->mutable_network(), depth-1, now, action_period, show_codes, display_all_publishable_disruption);
+                line->mutable_commercial_mode(), depth-1, now, action_period, show_codes);
+        fill_pb_object(l->network, data, line->mutable_network(), depth-1, now, action_period, show_codes);
     }
 
-    if(display_all_publishable_disruption){
-        for(const auto message : l->get_publishable_messages(now)){
-            fill_message(message, data, line, depth-1, now, action_period);
-        }
-    }else{
-        for(const auto message : l->get_applicable_messages(now, action_period)){
-            fill_message(message, data, line, depth-1, now, action_period);
-        }
+    for(const auto message : l->get_applicable_messages(now, action_period)){
+        fill_message(message, data, line, depth-1, now, action_period);
     }
 
     if(show_codes) {
@@ -445,8 +424,7 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
 
 void fill_pb_object(const nt::JourneyPattern* jp, const nt::Data& data,
         pbnavitia::JourneyPattern * journey_pattern, int max_depth,
-        const pt::ptime& now, const pt::time_period& action_period, const bool,
-        const bool display_all_publishable_disruption){
+        const pt::ptime& now, const pt::time_period& action_period, const bool){
     if(jp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -455,7 +433,7 @@ void fill_pb_object(const nt::JourneyPattern* jp, const nt::Data& data,
     journey_pattern->set_uri(jp->uri);
     if(depth > 0 && jp->route != nullptr) {
         fill_pb_object(jp->route, data, journey_pattern->mutable_route(),
-                depth-1, now, action_period, display_all_publishable_disruption);
+                depth-1, now, action_period);
     }
 }
 
@@ -472,8 +450,7 @@ void fill_pb_object(const nt::MultiLineString& shape, pbnavitia::MultiLineString
 
 void fill_pb_object(const nt::Route* r, const nt::Data& data,
                     pbnavitia::Route* route, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes,
-                    const bool display_all_publishable_disruption){
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
     if(r == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -488,14 +465,8 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
     }
 
     route->set_uri(r->uri);
-    if(display_all_publishable_disruption){
-        for(const auto& message : r->get_publishable_messages(now)){
-            fill_message(message, data, route, max_depth-1, now, action_period);
-        }
-    }else{
-        for(const auto& message : r->get_applicable_messages(now, action_period)){
-            fill_message(message, data, route, max_depth-1, now, action_period);
-        }
+    for(const auto& message : r->get_applicable_messages(now, action_period)){
+        fill_message(message, data, route, max_depth-1, now, action_period);
     }
 
     if(show_codes) {
@@ -508,7 +479,7 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
     }
     if(r->line != nullptr) {
         fill_pb_object(r->line, data, route->mutable_line(), depth-1,
-                       now, action_period, show_codes, display_all_publishable_disruption);
+                       now, action_period, show_codes);
     }
 
     fill_pb_object(r->shape, route->mutable_geojson());
@@ -519,7 +490,7 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
         for(auto idx : thermometer.get_thermometer()) {
             auto stop_point = data.pt_data->stop_points[idx];
                 fill_pb_object(stop_point, data, route->add_stop_points(), depth-1,
-                        now, action_period, show_codes, display_all_publishable_disruption);
+                        now, action_period, show_codes);
         }
         std::set<nt::PhysicalMode*> physical_modes;
         for (auto journey_pattern : r->journey_pattern_list) {
@@ -527,7 +498,7 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
         }
         for (auto physical_mode : physical_modes) {
             fill_pb_object(physical_mode, data, route->add_physical_modes(), 0, now, action_period,
-                           show_codes, display_all_publishable_disruption);
+                           show_codes);
         }
     }
 }
@@ -535,22 +506,15 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
 
 void fill_pb_object(const nt::Network* n, const nt::Data& data,
                     pbnavitia::Network* network, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes,
-                    const bool display_all_publishable_disruption){
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
     if(n == nullptr)
         return ;
 
     network->set_name(n->name);
     network->set_uri(n->uri);
 
-    if(display_all_publishable_disruption){
-        for(const auto& message : n->get_publishable_messages(now)){
-            fill_message(message, data, network, max_depth-1, now, action_period);
-        }
-    }else{
-        for(const auto& message : n->get_applicable_messages(now, action_period)){
-            fill_message(message, data, network, max_depth-1, now, action_period);
-        }
+    for(const auto& message : n->get_applicable_messages(now, action_period)){
+        fill_message(message, data, network, max_depth-1, now, action_period);
     }
     if(show_codes) {
         for(auto type_value : n->codes) {
@@ -562,8 +526,7 @@ void fill_pb_object(const nt::Network* n, const nt::Data& data,
 
 void fill_pb_object(const nt::CommercialMode* m, const nt::Data&,
                     pbnavitia::CommercialMode* commercial_mode,
-                    int, const pt::ptime&, const pt::time_period&, const bool,
-                    const bool){
+                    int, const pt::ptime&, const pt::time_period&, const bool){
     if(m == nullptr)
         return ;
 
@@ -574,8 +537,7 @@ void fill_pb_object(const nt::CommercialMode* m, const nt::Data&,
 
 void fill_pb_object(const nt::PhysicalMode* m, const nt::Data&,
                     pbnavitia::PhysicalMode* physical_mode, int,
-                    const pt::ptime&, const pt::time_period&, const bool,
-                    const bool){
+                    const pt::ptime&, const pt::time_period&, const bool){
     if(m == nullptr)
         return ;
 
@@ -586,8 +548,7 @@ void fill_pb_object(const nt::PhysicalMode* m, const nt::Data&,
 
 void fill_pb_object(const nt::Company* c, const nt::Data&,
                     pbnavitia::Company* company, int, const pt::ptime&,
-                    const pt::time_period&, const bool show_codes,
-                    const bool){
+                    const pt::time_period&, const bool show_codes){
     if(c == nullptr)
         return ;
 
@@ -624,7 +585,7 @@ void fill_pb_object(const nt::StopPointConnection* c, const nt::Data& data,
 
 void fill_pb_object(const nt::ValidityPattern* vp, const nt::Data&,
                     pbnavitia::ValidityPattern* validity_pattern, int,
-                    const pt::ptime&, const pt::time_period&, const bool, const bool){
+                    const pt::ptime&, const pt::time_period&, const bool){
     if(vp == nullptr)
         return;
     auto vp_string = boost::gregorian::to_iso_string(vp->beginning_date);
@@ -665,8 +626,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     int max_depth,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
-                    const bool show_codes,
-                    const bool display_all_publishable_disruption){
+                    const bool show_codes){
     if(vj == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -717,14 +677,8 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                                      action_period);
     }
 
-    if(display_all_publishable_disruption){
-        for(auto message : vj->get_publishable_messages(now)){
-            fill_message(message, data, vehicle_journey, max_depth-1, now, action_period);
-        }
-    }else{
-        for(auto message : vj->get_applicable_messages(now, action_period)){
-            fill_message(message, data, vehicle_journey, max_depth-1, now, action_period);
-        }
+    for(auto message : vj->get_applicable_messages(now, action_period)){
+        fill_message(message, data, vehicle_journey, max_depth-1, now, action_period);
     }
 
     //si on a un vj théorique rataché à notre vj, on récupére les messages qui le concerne
@@ -788,8 +742,7 @@ void fill_pb_object(const nt::StopTime* st, const type::Data& data,
 void fill_pb_object(const nt::JourneyPatternPoint* jpp, const nt::Data& data,
                     pbnavitia::JourneyPatternPoint * journey_pattern_point,
                     int max_depth, const pt::ptime& now,
-                    const pt::time_period& action_period, const bool show_codes,
-                    const bool display_all_publishable_disruption){
+                    const pt::time_period& action_period, const bool show_codes){
     if(jpp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -801,12 +754,12 @@ void fill_pb_object(const nt::JourneyPatternPoint* jpp, const nt::Data& data,
         if(jpp->stop_point != nullptr) {
             fill_pb_object(jpp->stop_point, data,
                            journey_pattern_point->mutable_stop_point(),
-                           depth-1, now, action_period, display_all_publishable_disruption);
+                           depth-1, now, action_period);
         }
         if(jpp->journey_pattern != nullptr) {
             fill_pb_object(jpp->journey_pattern, data,
                            journey_pattern_point->mutable_journey_pattern(),
-                           depth - 1, now, action_period, show_codes, display_all_publishable_disruption);
+                           depth - 1, now, action_period, show_codes);
         }
     }
 }
@@ -1550,7 +1503,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
 
 void fill_pb_object(const nt::Calendar* cal, const nt::Data& data,
                     pbnavitia::Calendar* pb_cal, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes, const bool)
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes)
 {
     pb_cal->set_uri(cal->uri);
     pb_cal->set_name(cal->name);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -101,10 +101,9 @@ void fill_address(const T* obj, const nt::Data& data,
 }
 
 template <typename T>
-void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact_weak_ptr,
+void fill_message(const boost::shared_ptr<type::new_disruption::Impact>& impact,
         const type::Data&, T pb_object, int,
         const boost::posix_time::ptime&, const boost::posix_time::time_period& action_period) {
-    auto impact = impact_weak_ptr.lock();
     if (! impact) {
         return; //impact is no longer valid, we have nothing to do
     }

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -90,8 +90,7 @@ struct EnhancedResponse {
 #define FILL_PB_CONSTRUCTOR(type_name, collection_name)\
     void fill_pb_object(const navitia::type::type_name* item, const navitia::type::Data& data, pbnavitia::type_name *, int max_depth = 0,\
             const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,\
-            const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes=false,\
-            const bool display_all_publiable_disruption=false);
+            const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes=false);
     ITERATE_NAVITIA_PT_TYPES(FILL_PB_CONSTRUCTOR)
 #undef FILL_PB_CONSTRUCTOR
 
@@ -208,8 +207,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     int max_depth,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
-                    const bool show_codes,
-                    const bool display_all_publiable_disruption);
+                    const bool show_codes);
 
 void fill_pb_object(const type::VehicleJourney* vj,
                     const type::Data& data,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -162,7 +162,7 @@ void fill_street_sections(EnhancedResponse& response, const type::EntryPoint &or
         const boost::posix_time::time_period& action_period = null_time_period);
 
 template <typename T>
-void fill_message(const boost::shared_ptr<type::new_disruption::Impact>& impact, const type::Data &data, T pb_object, int max_depth = 0,
+void fill_message(const type::new_disruption::Impact& impact, const type::Data &data, T pb_object, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period);
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -162,7 +162,7 @@ void fill_street_sections(EnhancedResponse& response, const type::EntryPoint &or
         const boost::posix_time::time_period& action_period = null_time_period);
 
 template <typename T>
-void fill_message(const boost::weak_ptr<type::new_disruption::Impact>& impact, const type::Data &data, T pb_object, int max_depth = 0,
+void fill_message(const boost::shared_ptr<type::new_disruption::Impact>& impact, const type::Data &data, T pb_object, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period);
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -58,10 +58,10 @@ std::string VehicleJourney::get_direction() const {
     return "";
 }
 
-std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_applicable_messages(
+std::vector<boost::shared_ptr<new_disruption::Impact>> HasMessages::get_applicable_messages(
         const boost::posix_time::ptime& current_time,
         const boost::posix_time::time_period& action_period) const {
-    std::vector<boost::weak_ptr<new_disruption::Impact>> result;
+    std::vector<boost::shared_ptr<new_disruption::Impact>> result;
 
     //we cleanup the released pointer (not in the loop for code clarity)
     clean_up_weak_ptr(impacts);
@@ -72,7 +72,7 @@ std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_applicable
             continue; //pointer might still have become invalid
         }
         if (impact_acquired->is_valid(current_time, action_period)) {
-            result.push_back(impact);
+            result.push_back(impact_acquired);
         }
     }
 
@@ -80,9 +80,9 @@ std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_applicable
 
 }
 
-std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_publishable_messages(
+std::vector<boost::shared_ptr<new_disruption::Impact>> HasMessages::get_publishable_messages(
             const boost::posix_time::ptime& current_time) const{
-    std::vector<boost::weak_ptr<new_disruption::Impact>> result;
+    std::vector<boost::shared_ptr<new_disruption::Impact>> result;
 
     //we cleanup the released pointer (not in the loop for code clarity)
     clean_up_weak_ptr(impacts);
@@ -93,7 +93,7 @@ std::vector<boost::weak_ptr<new_disruption::Impact>> HasMessages::get_publishabl
             continue; //pointer might still have become invalid
         }
         if (impact_acquired->disruption->is_publishable(current_time)) {
-            result.push_back(impact);
+            result.push_back(impact_acquired);
         }
     }
     return result;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -293,7 +293,7 @@ protected:
 public:
     void add_impact(const boost::shared_ptr<new_disruption::Impact>& i) {impacts.push_back(i);}
 
-    std::vector<boost::weak_ptr<new_disruption::Impact>> get_applicable_messages(
+    std::vector<boost::shared_ptr<new_disruption::Impact>> get_applicable_messages(
             const boost::posix_time::ptime& current_time,
             const boost::posix_time::time_period& action_period) const;
 
@@ -303,7 +303,7 @@ public:
 
     bool has_publishable_message(const boost::posix_time::ptime& current_time) const;
 
-    std::vector<boost::weak_ptr<new_disruption::Impact>> get_publishable_messages(
+    std::vector<boost::shared_ptr<new_disruption::Impact>> get_publishable_messages(
             const boost::posix_time::ptime& current_time) const;
 
 


### PR DESCRIPTION
Refacto on traffic_reports.

We display the impact on routes as impact of their parent line, and impact on stop_points as impact of their parent stop_areas.

The lines are sorted by the priority of their impacts.
