### PR TITLE
requirements: do not force a version number for protobuf

### DIFF
--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -15,7 +15,7 @@ dict2xml==1.1
 itsdangerous==0.23
 mock==1.0.1
 nose==1.3.1
-protobuf==2.4.1
+protobuf
 psycopg2==2.4.5
 pyzmq==2.1.11
 redis==2.9.1

--- a/source/monitor/requirements.txt
+++ b/source/monitor/requirements.txt
@@ -4,6 +4,6 @@ MarkupSafe==0.18
 Werkzeug==0.9.4
 argparse==1.2.1
 itsdangerous==0.23
-protobuf==2.4.1
+protobuf
 pyzmq==14.0.1
 wsgiref==0.1.2

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -20,7 +20,7 @@ celery==3.1.7
 configobj==4.7.2
 itsdangerous==0.23
 kombu==3.0.8
-protobuf==2.4.1
+protobuf
 psycopg2==2.5.2
 pydns==2.3.6
 pytz==2013.9


### PR DESCRIPTION
this allow to use the distrib packages if installed.  Thanks to that, we
will be able to use the c++ implementation of python-protobuf if availlable.
