### PR TITLE
Kraken: fix handling of disruption in ptref

### DIFF
--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -73,9 +73,7 @@ class TestDisruptions(AbstractTestFixture):
         eq_(lines_disrupt[0]['uri'], 'too_bad_again')
         eq_(lines_disrupt[0]['severity']['name'], 'bad severity')
 
-        eq_(lines_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
         eq_(lines_disrupt[1]['uri'], 'later_impact')
-        eq_(lines_disrupt[1]['severity']['name'], 'information severity')
 
         impacted_network = get_not_null(traffic_report[0], 'network')
         is_valid_network(impacted_network, depth_check=0)
@@ -102,19 +100,17 @@ class TestDisruptions(AbstractTestFixture):
         eq_(stop_disrupt[0]['uri'], 'too_bad')
 
         """
-        by querying directly the impacted object, we find the same results
+        by querying directly the impacted object, we only find active disruptions
         """
         networks = self.query_region('networks/base_network?' + default_date_filter)
         network = get_not_null(networks, 'networks')[0]
         is_valid_network(network)
         network_disrupt = get_disruptions(network, response)
-        eq_(len(network_disrupt), 2)
+        eq_(len(network_disrupt), 1)
         for d in network_disrupt:
             is_valid_disruption(d)
         eq_(network_disrupt[0]['disruption_id'], 'disruption_on_line_A')
         eq_(network_disrupt[0]['uri'], 'too_bad_again')
-        eq_(network_disrupt[1]['disruption_id'], 'disruption_on_line_A_but_later')
-        eq_(network_disrupt[1]['uri'], 'later_impact')
 
         lines = self.query_region('lines/A?' + default_date_filter)
         line = get_not_null(lines, 'lines')[0]

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -44,71 +44,72 @@ static pbnavitia::Response extract_data(const type::Data & data,
                                         const int depth, const bool show_codes,
                                         boost::posix_time::ptime current_time) {
     pbnavitia::Response result;
+    auto action_period = pt::time_period(current_time, pt::seconds(1));
     for(auto idx : rows){
         switch(requested_type){
         case Type_e::ValidityPattern:
             fill_pb_object(data.pt_data->validity_patterns[idx], data,
-                           result.add_validity_patterns(), depth, current_time);
+                           result.add_validity_patterns(), depth, current_time, action_period);
             break;
         case Type_e::Line:
             fill_pb_object(data.pt_data->lines[idx], data, result.add_lines(),
-                           depth, current_time, null_time_period, show_codes);
+                           depth, current_time, action_period, show_codes);
             break;
         case Type_e::JourneyPattern:
             fill_pb_object(data.pt_data->journey_patterns[idx], data,
-                           result.add_journey_patterns(), depth, current_time);
+                           result.add_journey_patterns(), depth, current_time, action_period);
             break;
         case Type_e::StopPoint:
             fill_pb_object(data.pt_data->stop_points[idx], data,
-                           result.add_stop_points(), depth, current_time, null_time_period, show_codes);
+                           result.add_stop_points(), depth, current_time, action_period, show_codes);
             break;
         case Type_e::StopArea:
             fill_pb_object(data.pt_data->stop_areas[idx], data,
-                           result.add_stop_areas(), depth, current_time, null_time_period, show_codes);
+                           result.add_stop_areas(), depth, current_time, action_period, show_codes);
             break;
         case Type_e::Network:
             fill_pb_object(data.pt_data->networks[idx], data,
-                           result.add_networks(), depth, current_time, null_time_period, show_codes);
+                           result.add_networks(), depth, current_time, action_period, show_codes);
             break;
         case Type_e::PhysicalMode:
             fill_pb_object(data.pt_data->physical_modes[idx], data,
-                           result.add_physical_modes(), depth, current_time);
+                           result.add_physical_modes(), depth, current_time, action_period);
             break;
         case Type_e::CommercialMode:
             fill_pb_object(data.pt_data->commercial_modes[idx], data,
-                           result.add_commercial_modes(), depth, current_time);
+                           result.add_commercial_modes(), depth, current_time, action_period);
             break;
         case Type_e::JourneyPatternPoint:
             fill_pb_object(data.pt_data->journey_pattern_points[idx], data,
-                           result.add_journey_pattern_points(), depth, current_time);
+                           result.add_journey_pattern_points(), depth, current_time, action_period);
             break;
         case Type_e::Company:
             fill_pb_object(data.pt_data->companies[idx], data,
-                           result.add_companies(), depth, current_time);
+                           result.add_companies(), depth, current_time, action_period);
             break;
         case Type_e::Route:
             fill_pb_object(data.pt_data->routes[idx], data,
-                    result.add_routes(), depth, current_time, null_time_period, show_codes);
+                    result.add_routes(), depth, current_time, action_period, show_codes);
             break;
         case Type_e::POI:
             fill_pb_object(data.geo_ref->pois[idx], data,
-                           result.add_pois(), depth, current_time);
+                           result.add_pois(), depth, current_time, action_period);
             break;
         case Type_e::POIType:
             fill_pb_object(data.geo_ref->poitypes[idx], data,
-                           result.add_poi_types(), depth, current_time);
+                           result.add_poi_types(), depth, current_time, action_period);
             break;
         case Type_e::Connection:
             fill_pb_object(data.pt_data->stop_point_connections[idx], data,
-                           result.add_connections(), depth, current_time);
+                           result.add_connections(), depth, current_time, action_period);
             break;
         case Type_e::VehicleJourney:
             fill_pb_object(data.pt_data->vehicle_journeys[idx], data,
-                           result.add_vehicle_journeys(), depth, current_time, null_time_period, show_codes);
+                           result.add_vehicle_journeys(), depth, current_time, action_period, show_codes);
             break;
         case Type_e::Calendar:
             fill_pb_object(data.pt_data->calendars[idx], data,
-                           result.add_calendars(), depth, current_time, null_time_period, show_codes);
+                           result.add_calendars(), depth, current_time, action_period, show_codes);
             break;
         default: break;
         }


### PR DESCRIPTION
No action_period were used in ptref, so every impact were mark as past.
