### PR TITLE
Kraken: always put an address in the response even if we didn't find one

### DIFF
--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1111,9 +1111,14 @@ void fill_pb_placemark(const type::EntryPoint& point, const type::Data &data,
             fill_pb_placemark(address.second, data, place, address.first, point.coordinates, max_depth, now,
                     action_period);
         }catch(proximitylist::NotFound){
+            //we didn't find a address at this coordinate, we fill the address manually with the coord, so we have a valid output
             place->set_name("");
             place->set_uri(point.coordinates.uri());
             place->set_embedded_type(pbnavitia::ADDRESS);
+            auto addr = place->mutable_address();
+            auto c = addr->mutable_coord();
+            c->set_lon(point.coordinates.lon());
+            c->set_lat(point.coordinates.lat());
         }
 
     }


### PR DESCRIPTION
Before this change it was possible to have an invalid response if we didn't find an address for the given coordinate.
The response looked like this:

```
"to": {

    "embedded_type": "address",
    "quality": 0,
    "id": "5.32097;43.446764000000002",
    "name": ""
},
```

Refer to: http://jira.canaltp.fr/browse/NAVITIAII-1661
