### PR TITLE
Kraken: don't mess with the origin of the streetnetwork section

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -207,14 +207,17 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                     departure_time = path.items.front().departure - walking_time.to_posix();
                     fill_street_sections(enhanced_response, origin, temp, d, pb_journey,
                         departure_time);
-                    auto section = pb_journey->mutable_sections(pb_journey->mutable_sections()->size()-1);
-                    bt::time_period action_period(navitia::from_posix_timestamp(section->begin_date_time()),
-                                                  navitia::from_posix_timestamp(section->end_date_time()));
-                    // We add coherence with the origin of the request
-                    fill_pb_placemark(origin, d, section->mutable_origin(), 2, now, action_period, show_codes);
-                    // We add coherence with the first pt section
-                    section->mutable_destination()->Clear();
-                    fill_pb_placemark(departure_stop_point, d, section->mutable_destination(), 2, now, action_period, show_codes);
+                    if(pb_journey->sections_size() > 0){
+                        auto first_section = pb_journey->mutable_sections(0);
+                        auto last_section = pb_journey->mutable_sections(pb_journey->sections_size()-1);
+                        bt::time_period action_period(navitia::from_posix_timestamp(first_section->begin_date_time()),
+                                                      navitia::from_posix_timestamp(last_section->end_date_time()));
+                        // We add coherence with the origin of the request
+                        fill_pb_placemark(origin, d, first_section->mutable_origin(), 2, now, action_period, show_codes);
+                        // We add coherence with the first pt section
+                        last_section->mutable_destination()->Clear();
+                        fill_pb_placemark(departure_stop_point, d, last_section->mutable_destination(), 2, now, action_period, show_codes);
+                    }
                 }
             }
         }

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1049,7 +1049,7 @@ BOOST_FIXTURE_TEST_CASE(car_parking_bus, streetnetworkmode_fixture<test_speed_pr
 
     // section 2: goto B
     BOOST_CHECK_EQUAL(sections.Get(2).type(), pbnavitia::SectionType::STREET_NETWORK);
-    BOOST_CHECK_EQUAL(sections.Get(2).origin().address().name(), "rue bs");
+    BOOST_CHECK_EQUAL(sections.Get(2).origin().address().name(), "rue bd");
     BOOST_CHECK_EQUAL(sections.Get(2).destination().name(), "stop_point:stopB");
     BOOST_CHECK_EQUAL(sections.Get(2).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
     BOOST_CHECK_EQUAL(sections.Get(2).street_network().duration(), 10);


### PR DESCRIPTION
When we create the sections for the street network (eventually more than
one) we set the departure and the arrivals of these to the requested
departure and to the stop_point used for the PT part, this way we have
some coherence in the response.

Before this change only the last section of the streetnetwork was
modified, so the origin of the last section (typically the bss_put_back
or park section) was the origin of journey.

Refer to: http://jira.canaltp.fr/browse/NAVITIAII-1663
