### PR TITLE
ed2nav: fix bug with lacking edges on street network

### DIFF
--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1007,6 +1007,7 @@ void EdReader::fill_vector_to_ignore(navitia::type::Data& , pqxx::work& work,
     std::unordered_map<uint64_t, idx_t> node_map_temp;
     std::unordered_map<idx_t, size_t> way_nb_edges;
 
+
     // chargement des vertex
     std::string request = "select id, ST_X(coord::geometry) as lon, ST_Y(coord::geometry) as lat from georef.node;";
     pqxx::result result = work.exec(request);
@@ -1078,8 +1079,9 @@ void EdReader::fill_vector_to_ignore(navitia::type::Data& , pqxx::work& work,
         BOOST_FOREACH(navitia::georef::edge_t e, boost::out_edges(vertex_idx, geo_ref_temp.graph)) {
             uint64_t target = boost::target(e, geo_ref_temp.graph);
             edge_to_ignore.insert({source, target});
-            node_to_ignore.insert(target);
+            node_to_ignore.insert(osmid_idex[target]);
             graph_edge_to_ignore.insert(e); //used for the ways
+
         }
     }
 
@@ -1134,17 +1136,20 @@ void EdReader::fill_graph(navitia::type::Data& data, pqxx::work& work) {
         auto it_source = node_map.find(const_it["source_node_id"].as<uint64_t>());
         auto it_target = node_map.find(const_it["target_node_id"].as<uint64_t>());
 
-        if (it_source == node_map.end() || it_target == node_map.end())
+        if (it_source == node_map.end() || it_target == node_map.end()){
             continue;
+        }
 
         uint64_t source = it_source->second;
         uint64_t target = it_target->second;
 
-        if (source == std::numeric_limits<uint64_t>::max() || target == std::numeric_limits<uint64_t>::max())
+        if (source == std::numeric_limits<uint64_t>::max() || target == std::numeric_limits<uint64_t>::max()){
             continue;
+        }
 
-        if (edge_to_ignore.find({source, target}) != edge_to_ignore.end())
+        if (edge_to_ignore.find({source, target}) != edge_to_ignore.end()){
             continue;
+        }
 
         if (! way) {
             nb_edges_no_way ++;

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1077,6 +1077,7 @@ void EdReader::fill_vector_to_ignore(navitia::type::Data& , pqxx::work& work,
         node_to_ignore.insert(source);
         BOOST_FOREACH(navitia::georef::edge_t e, boost::out_edges(vertex_idx, geo_ref_temp.graph)) {
             uint64_t target = boost::target(e, geo_ref_temp.graph);
+            //no need to store the edge to ignore since we won't import the required nodes
             node_to_ignore.insert(map_idx_to_id[target]);
             graph_edge_to_ignore.insert(e); //used for the ways
         }

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -90,7 +90,6 @@ private:
 
     // ces deux vectors servent pour ne pas charger les graphes secondaires
     std::set<uint64_t> way_to_ignore; //TODO if bottleneck change to flat_set
-    std::set<std::pair<uint64_t, uint64_t>> edge_to_ignore;
     std::set<uint64_t> node_to_ignore;
 
     void fill_meta(navitia::type::Data& data, pqxx::work& work);

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -155,7 +155,7 @@ public:
     template <typename Stream, typename G>
     void print(Stream& stream, const G& g){
         for(auto& edge: this->edges){
-            stream << "LINESTRING(" << g[edge.first].coord.lon() << " " << g[edge.first].coord.lat()
+            stream << std::setprecision(16) << "LINESTRING(" << g[edge.first].coord.lon() << " " << g[edge.first].coord.lat()
                    << ", " << g[edge.second].coord.lon() << " " << g[edge.second].coord.lat() << ")" << std::endl;
         }
     }

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -151,6 +151,16 @@ public:
     }
     std::string get_label() const;
 
+#ifdef _DEBUG_DIJKSTRA_QUANTUM_
+    template <typename Stream, typename G>
+    void print(Stream& stream, const G& g){
+        for(auto& edge: this->edges){
+            stream << "LINESTRING(" << g[edge.first].coord.lon() << " " << g[edge.first].coord.lat()
+                   << ", " << g[edge.second].coord.lon() << " " << g[edge.second].coord.lat() << ")" << std::endl;
+        }
+    }
+#endif
+
 private:
       nt::GeographicalCoord get_geographical_coord(const std::vector<HouseNumber>&, const int) const;
       nt::GeographicalCoord extrapol_geographical_coord(int) const;

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -266,9 +266,9 @@ struct printer_distance_visitor : public distance_visitor {
 
     void init_files() {
         file_vertex.open((boost::format("vertexes_%s.csv") % name).str());
-        file_vertex << "idx; lat; lon; vertex_id" << std::endl;
+        file_vertex << std::setprecision(16) << "idx; lat; lon; vertex_id" << std::endl;
         file_edge.open((boost::format("edges_%s.csv") % name).str());
-        file_edge << "idx; lat from; lon from; lat to; long to; wkt; duration; edge" << std::endl;
+        file_edge << std::setprecision(16) << "idx; lat from; lon from; lat to; long to; wkt; duration; edge" << std::endl;
     }
 
     printer_distance_visitor(time_duration max_dur, const std::vector<time_duration>& dur, const std::string& name) :


### PR DESCRIPTION
When choosing nodes to be ignored in the graph we were using the
vertex_t of the node and not it's id, so we were deleting the wrong
node, that caused some edge to be deleted too.

Ironically when removing small connected component we were in fact
randomly created some of them.

Refer to: http://jira.canaltp.fr/browse/NAVITIAII-1691
