### PR TITLE
Streetnetwork: add bss virtual cost

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -60,8 +60,8 @@ void StreetNetwork::init(const type::EntryPoint& start, boost::optional<const ty
                                start.streetnetwork_params.speed_factor, start.streetnetwork_params.bss_additional_cost);
 
     if (end) {
-        arrival_path_finder.init((*end).coordinates, (*end).streetnetwork_params.mode,
-                                 (*end).streetnetwork_params.speed_factor, (*end).streetnetwork_params.bss_additional_cost);
+        arrival_path_finder.init(end->coordinates, end->streetnetwork_params.mode,
+                                 end->streetnetwork_params.speed_factor, end->streetnetwork_params.bss_additional_cost);
     }
 }
 
@@ -177,7 +177,7 @@ Path StreetNetwork::get_direct_path(const type::EntryPoint& origin,
 PathFinder::PathFinder(const GeoRef& gref):
     geo_ref(gref) {}
 
-void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mode,
+void PathFinder::init(const type::GeographicalCoord& start_coord, const nt::Mode_e mode,
                       const float speed_factor, const navitia::time_duration bss_cost) {
     computation_launch = false;
     bss_additional_cost = bss_cost;
@@ -190,7 +190,7 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mod
 
     //we initialize the distances to the maximum value
     size_t n = boost::num_vertices(geo_ref.graph);
-    distances.assign(n, {bt::pos_infin});
+    distances.assign(n, cost());
     //for the predecessors no need to clean the values, the important one will be updated during search
     predecessors.resize(n);
 

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -56,10 +56,12 @@ StreetNetwork::StreetNetwork(const GeoRef &geo_ref) :
 {}
 
 void StreetNetwork::init(const type::EntryPoint& start, boost::optional<const type::EntryPoint&> end) {
-    departure_path_finder.init(start.coordinates, start.streetnetwork_params.mode, start.streetnetwork_params.speed_factor);
+    departure_path_finder.init(start.coordinates, start.streetnetwork_params.mode,
+                               start.streetnetwork_params.speed_factor, start.streetnetwork_params.bss_additional_cost);
 
     if (end) {
-        arrival_path_finder.init((*end).coordinates, (*end).streetnetwork_params.mode, (*end).streetnetwork_params.speed_factor);
+        arrival_path_finder.init((*end).coordinates, (*end).streetnetwork_params.mode,
+                                 (*end).streetnetwork_params.speed_factor, (*end).streetnetwork_params.bss_additional_cost);
     }
 }
 
@@ -133,12 +135,12 @@ Path StreetNetwork::get_direct_path(const type::EntryPoint& origin,
         const type::EntryPoint& destination) {
     if (!departure_launched()) {
         departure_path_finder.init(origin.coordinates, origin.streetnetwork_params.mode,
-                                   origin.streetnetwork_params.speed_factor);
+                                   origin.streetnetwork_params.speed_factor, origin.streetnetwork_params.bss_additional_cost);
         departure_path_finder.start_distance_dijkstra(origin.streetnetwork_params.max_duration);
     }
     if (!arrival_launched() || origin.streetnetwork_params.mode != destination.streetnetwork_params.mode) {
         arrival_path_finder.init(destination.coordinates, origin.streetnetwork_params.mode,
-                                 origin.streetnetwork_params.speed_factor);
+                                 origin.streetnetwork_params.speed_factor, origin.streetnetwork_params.bss_additional_cost);
         //@TODO: use the max_duration of the origin?
         arrival_path_finder.start_distance_dijkstra(destination.streetnetwork_params.max_duration);
     }
@@ -148,12 +150,14 @@ Path StreetNetwork::get_direct_path(const type::EntryPoint& origin,
     navitia::time_duration min_dist = bt::pos_infin;
     vertex_t target = std::numeric_limits<size_t>::max();
     for(vertex_t u = 0; u != num_vertices; ++u) {
-        if((departure_path_finder.distances[u] <= origin.streetnetwork_params.max_duration)
-                && (arrival_path_finder.distances[u] != destination.streetnetwork_params.max_duration)
-                && ((departure_path_finder.distances[u] + arrival_path_finder.distances[u]) < min_dist)) {
+        auto dep_dur = departure_path_finder.get_real_duration(u);
+        auto arr_dur = arrival_path_finder.get_real_duration(u);
+        if((dep_dur <= origin.streetnetwork_params.max_duration)
+                && (arr_dur != destination.streetnetwork_params.max_duration)
+                && (dep_dur + arr_dur < min_dist)) {
             target = u;
 
-            min_dist = departure_path_finder.distances[u] + arrival_path_finder.distances[u];
+            min_dist = dep_dur + arr_dur;
         }
     }
 
@@ -170,10 +174,13 @@ Path StreetNetwork::get_direct_path(const type::EntryPoint& origin,
     return result;
 }
 
-PathFinder::PathFinder(const GeoRef& gref) : geo_ref(gref) {}
+PathFinder::PathFinder(const GeoRef& gref):
+    geo_ref(gref) {}
 
-void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor) {
+void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mode,
+                      const float speed_factor, const navitia::time_duration bss_cost) {
     computation_launch = false;
+    bss_additional_cost = bss_cost;
     // we look for the nearest edge from the start coorinate in the right transport mode (walk, bike, car, ...) (ie offset)
     this->mode = mode;
     this->speed_factor = speed_factor; //the speed factor is the factor we have to multiply the edge cost with
@@ -183,14 +190,14 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mod
 
     //we initialize the distances to the maximum value
     size_t n = boost::num_vertices(geo_ref.graph);
-    distances.assign(n, bt::pos_infin);
+    distances.assign(n, {bt::pos_infin});
     //for the predecessors no need to clean the values, the important one will be updated during search
     predecessors.resize(n);
 
     if (starting_edge.found) {
         //durations initializations
-        distances[starting_edge[source_e]] = crow_fly_duration(starting_edge.distances[source_e]); //for the projection, we use the default walking speed.
-        distances[starting_edge[target_e]] = crow_fly_duration(starting_edge.distances[target_e]);
+        distances[starting_edge[source_e]] = {crow_fly_duration(starting_edge.distances[source_e])}; //for the projection, we use the default walking speed.
+        distances[starting_edge[target_e]] = {crow_fly_duration(starting_edge.distances[target_e])};
         predecessors[starting_edge[source_e]] = starting_edge[source_e];
         predecessors[starting_edge[target_e]] = starting_edge[target_e];
 
@@ -198,19 +205,32 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mod
         if (starting_edge.distances[source_e] < 0.01) {
             predecessors[starting_edge[target_e]] = starting_edge[source_e];
             auto e = boost::edge(starting_edge[source_e], starting_edge[target_e], geo_ref.graph).first;
-            distances[starting_edge[target_e]] = geo_ref.graph[e].duration;
+            distances[starting_edge[target_e]] = {geo_ref.graph[e].duration};
         } else if (starting_edge.distances[target_e] < 0.01) {
             predecessors[starting_edge[source_e]] = starting_edge[target_e];
             auto edge_pair = boost::edge(starting_edge[target_e], starting_edge[source_e], geo_ref.graph);
             if (edge_pair.second) {
-                distances[starting_edge[source_e]] = geo_ref.graph[edge_pair.first].duration;
+                distances[starting_edge[source_e]] = {geo_ref.graph[edge_pair.first].duration};
             } else {
                 // since we reverse the edge (from target to source) the edge might not exists
                 // (for one way street for example). we thus forbid to start from the source
-                distances[starting_edge[source_e]] = bt::pos_infin;
+                distances[starting_edge[source_e]] = {bt::pos_infin};
             }
         }
     }
+}
+
+navitia::time_duration PathFinder::get_real_duration(const vertex_t v) const {
+    auto dur = distances[v].duration;
+    if (distances[v].bss_taken) {
+        //a virtual cost has been added as the bss was taken, so we need to remove it
+        dur -= bss_additional_cost;
+    }
+    return dur;
+}
+
+bool PathFinder::has_been_visited(const vertex_t v) const {
+    return distances[v].duration != bt::pos_infin;
 }
 
 void PathFinder::start_distance_dijkstra(navitia::time_duration radius) {
@@ -262,10 +282,11 @@ PathFinder::find_nearest_stop_points(navitia::time_duration radius, const proxim
         // Est-ce que le stop point a pu être raccroché au street network
         if(projection.found){
             navitia::time_duration best_dist = max;
-            if (distances[projection[source_e]] < max) {
-                best_dist = distances[projection[source_e]] + crow_fly_duration(projection.distances[source_e]); }
-            if (distances[projection[target_e]] < max) {
-                best_dist = std::min(best_dist, distances[projection[target_e]] + crow_fly_duration(projection.distances[target_e]));
+            if (has_been_visited(projection[source_e])) {
+                best_dist = get_real_duration(projection[source_e]) + crow_fly_duration(projection.distances[source_e]);
+            }
+            if (has_been_visited(projection[target_e])) {
+                best_dist = std::min(best_dist, get_real_duration(projection[target_e]) + crow_fly_duration(projection.distances[target_e]));
             }
             if (best_dist <= radius) {
                 result.push_back(std::make_pair(element.first, best_dist));
@@ -294,11 +315,11 @@ std::pair<navitia::time_duration, ProjectionData::Direction> PathFinder::find_ne
     if (! target.found)
         return {max, source_e};
 
-    if (distances[target[source_e]] == max) //if one distance has not been reached, both have not been reached
+    if (! has_been_visited(target[source_e])) //if one distance has not been reached, both have not been reached
         return {max, source_e};
 
-    auto source_dist = distances[target[source_e]] + crow_fly_duration(target.distances[source_e]);
-    auto target_dist = distances[target[target_e]] + crow_fly_duration(target.distances[target_e]);
+    auto source_dist = get_real_duration(target[source_e]) + crow_fly_duration(target.distances[source_e]);
+    auto target_dist = get_real_duration(target[target_e]) + crow_fly_duration(target.distances[target_e]);
 
     if (target_dist < source_dist)
         return {target_dist, target_e};
@@ -445,7 +466,7 @@ std::pair<navitia::time_duration, ProjectionData::Direction> PathFinder::update_
 
     computation_launch = true;
 
-    if (distances[target[source_e]] == max || distances[target[target_e]] == max) {
+    if (! has_been_visited(target[source_e]) || ! has_been_visited(target[target_e])) {
         bool found = false;
         try {
             dijkstra(starting_edge[source_e], target_all_visitor({target[source_e], target[target_e]}));
@@ -469,7 +490,7 @@ std::pair<navitia::time_duration, ProjectionData::Direction> PathFinder::update_
 
     }
     //if we succeded in the first search, we must have found one of the other distances
-    assert(distances[target[source_e]] != max && distances[target[target_e]] != max);
+    assert(get_real_duration(target[source_e]) != max && get_real_duration(target[target_e]) != max);
 
     return find_nearest_vertex(target);
 }

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -196,8 +196,8 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, const nt::Mode
 
     if (starting_edge.found) {
         //durations initializations
-        distances[starting_edge[source_e]] = {crow_fly_duration(starting_edge.distances[source_e])}; //for the projection, we use the default walking speed.
-        distances[starting_edge[target_e]] = {crow_fly_duration(starting_edge.distances[target_e])};
+        distances[starting_edge[source_e]] = cost{crow_fly_duration(starting_edge.distances[source_e])}; //for the projection, we use the default walking speed.
+        distances[starting_edge[target_e]] = cost{crow_fly_duration(starting_edge.distances[target_e])};
         predecessors[starting_edge[source_e]] = starting_edge[source_e];
         predecessors[starting_edge[target_e]] = starting_edge[target_e];
 
@@ -205,16 +205,16 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, const nt::Mode
         if (starting_edge.distances[source_e] < 0.01) {
             predecessors[starting_edge[target_e]] = starting_edge[source_e];
             auto e = boost::edge(starting_edge[source_e], starting_edge[target_e], geo_ref.graph).first;
-            distances[starting_edge[target_e]] = {geo_ref.graph[e].duration};
+            distances[starting_edge[target_e]] = cost{geo_ref.graph[e].duration};
         } else if (starting_edge.distances[target_e] < 0.01) {
             predecessors[starting_edge[source_e]] = starting_edge[target_e];
             auto edge_pair = boost::edge(starting_edge[target_e], starting_edge[source_e], geo_ref.graph);
             if (edge_pair.second) {
-                distances[starting_edge[source_e]] = {geo_ref.graph[edge_pair.first].duration};
+                distances[starting_edge[source_e]] = cost{geo_ref.graph[edge_pair.first].duration};
             } else {
                 // since we reverse the edge (from target to source) the edge might not exists
                 // (for one way street for example). we thus forbid to start from the source
-                distances[starting_edge[source_e]] = {bt::pos_infin};
+                distances[starting_edge[source_e]] = cost{bt::pos_infin};
             }
         }
     }

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -134,22 +134,9 @@ struct TransportationModeFilter {
     template <typename vertex_t>
     bool operator()(const vertex_t& e) const {
         int graph_number = e / nb_vertex_by_mode;
-
-//        std::cout << "for node " << e << " in graph " << graph_number << " we can " << (acceptable_modes[graph_number] ? " " : "not ") << "go" << std::endl;
         return acceptable_modes[graph_number];
     }
 };
-
-struct edge_getter: std::unary_function<edge_t, edge_t> {
-    edge_getter(const Graph& g): graph(g) {}
-    const Graph& graph;
-
-    edge_t operator()(edge_t e) const {
-        return e;
-//        return graph[e];
-    }
-};
-
 
 struct PathFinder {
     const GeoRef & geo_ref;
@@ -215,8 +202,8 @@ struct PathFinder {
 
         boost::dijkstra_shortest_paths_no_init(filtered_graph(geo_ref.graph, {}, TransportationModeFilter(mode, geo_ref)),
                                                start, &predecessors[0], &distances[0],
-                                               boost::make_function_property_map<edge_t, edge_t, edge_getter>(edge_getter(geo_ref.graph)), // weigth map
-                                               boost::identity_property_map(),
+                                               boost::typed_identity_property_map<edge_t>(), // weigth map
+                                               boost::typed_identity_property_map<vertex_t>(),
                                                std::less<cost>(),
                                                speed_combiner,
                                                cost(navitia::seconds(0), false),

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -35,20 +35,65 @@ www.navitia.io
 #include <boost/graph/two_bit_color_map.hpp>
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/format.hpp>
+#include <boost/property_map/function_property_map.hpp>
 
 namespace bt = boost::posix_time;
 
 namespace navitia { namespace georef {
 
-struct SpeedDistanceCombiner : public std::binary_function<navitia::time_duration, navitia::time_duration, navitia::time_duration> {
+struct cost {
+    cost(navitia::time_duration d, bool b): duration(d), bss_taken(b) {}
+    cost(navitia::time_duration d): duration(d) {}
+    cost() {}
+    bool operator<(const cost& c) const { return duration < c.duration; }
+    bool operator==(const cost& c) const { return duration == c.duration && bss_taken == c.bss_taken; }
+    navitia::time_duration duration = {};
+    bool bss_taken = false;
+};
+
+struct SpeedDistanceCombiner : public std::binary_function<cost, cost, edge_t> {
     /// speed factor compared to the default speed of the transportation mode
     /// speed_factor = 2 means the speed is twice the default speed of the given transportation mode
+    ///
+    /// for bss we also store if the bss has been taken to be able to handle an addtional cost
     float speed_factor;
-    SpeedDistanceCombiner(float speed_) : speed_factor(speed_) {}
-    inline navitia::time_duration operator()(navitia::time_duration a, navitia::time_duration b) const {
-        if (a == bt::pos_infin || b == bt::pos_infin)
-            return bt::pos_infin;
-        return a + b / speed_factor;
+    type::idx_t nb_vertex_by_mode;
+    const Graph& graph;
+    navitia::time_duration bss_additional_cost;
+    bool bss_allowed;
+
+    SpeedDistanceCombiner(float speed_, const georef::GeoRef& geo_ref, navitia::time_duration d, bool can_have_bss):
+        speed_factor(speed_),
+        nb_vertex_by_mode(geo_ref.nb_vertex_by_mode),
+        graph(geo_ref.graph),
+        bss_additional_cost(d),
+        bss_allowed(can_have_bss)
+    {}
+    inline cost operator()(cost a, edge_t e) const {
+        if (a.duration == bt::pos_infin) {
+            return {bt::pos_infin, false};
+        }
+
+        const Edge& edge = graph[e];
+
+        auto b = edge.duration;
+        if (b == bt::pos_infin) {
+            return {bt::pos_infin, false};
+        }
+        auto d = a.duration + b / speed_factor;
+        if ( ! bss_allowed || a.bss_taken) {
+            return {d, a.bss_taken};
+        }
+
+        auto origin_mode = boost::source(e, graph) / nb_vertex_by_mode;
+        auto destination_mode = boost::target(e, graph) / nb_vertex_by_mode;
+        bool bss_taken = (static_cast<type::Mode_e>(origin_mode) == type::Mode_e::Walking
+                          && static_cast<type::Mode_e>(destination_mode) == type::Mode_e::Bike);
+
+        if (bss_taken) {
+            d += bss_additional_cost;
+        }
+        return {d, bss_taken};
     }
 };
 template <typename T>
@@ -95,6 +140,17 @@ struct TransportationModeFilter {
     }
 };
 
+struct edge_getter: std::unary_function<edge_t, edge_t> {
+    edge_getter(const Graph& g): graph(g) {}
+    const Graph& graph;
+
+    edge_t operator()(edge_t e) const {
+        return e;
+//        return graph[e];
+    }
+};
+
+
 struct PathFinder {
     const GeoRef & geo_ref;
 
@@ -109,10 +165,13 @@ struct PathFinder {
     float speed_factor = 0.;
 
     /// Distance array for the Dijkstra
-    std::vector<navitia::time_duration> distances;
+    std::vector<cost> distances;
 
     /// Predecessors array for the Dijkstra
     std::vector<vertex_t> predecessors;
+
+    /// virtual cost on the bss
+    navitia::time_duration bss_additional_cost;
 
     PathFinder(const GeoRef& geo_ref);
 
@@ -120,7 +179,10 @@ struct PathFinder {
      *  Update the structure for a given starting point and transportation mode
      *  The init HAS to be called before any other methods
      */
-    void init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor);
+    void init(const type::GeographicalCoord& start_coord,
+              nt::Mode_e mode,
+              const float speed_factor,
+              const navitia::time_duration);
 
     void start_distance_dijkstra(navitia::time_duration radius);
 
@@ -148,13 +210,16 @@ struct PathFinder {
 
         //we filter the graph to only use certain mean of transport
         using filtered_graph = boost::filtered_graph<georef::Graph, boost::keep_all, TransportationModeFilter>;
+
+        auto speed_combiner = SpeedDistanceCombiner(speed_factor, geo_ref, bss_additional_cost, mode == nt::Mode_e::Bss);
+
         boost::dijkstra_shortest_paths_no_init(filtered_graph(geo_ref.graph, {}, TransportationModeFilter(mode, geo_ref)),
                                                start, &predecessors[0], &distances[0],
-                                               boost::get(&Edge::duration, geo_ref.graph), // weigth map
+                                               boost::make_function_property_map<edge_t, edge_t, edge_getter>(edge_getter(geo_ref.graph)), // weigth map
                                                boost::identity_property_map(),
-                                               std::less<navitia::time_duration>(),
-                                               SpeedDistanceCombiner(speed_factor), //we multiply the edge duration by a speed factor
-                                               navitia::seconds(0),
+                                               std::less<cost>(),
+                                               speed_combiner,
+                                               cost(navitia::seconds(0), false),
                                                visitor,
                                                color
                                                );
@@ -168,6 +233,9 @@ struct PathFinder {
      *  return a pair with the edge corresponding to the target and the distance
      */
     std::pair<navitia::time_duration, ProjectionData::Direction> update_path(const ProjectionData& target);
+
+    navitia::time_duration get_real_duration(const vertex_t) const;
+    bool has_been_visited(const vertex_t) const;
 
 private:
     /// find the nearest vertex from the projection. return the distance to this vertex and the vertex
@@ -242,9 +310,9 @@ struct target_visitor : public boost::dijkstra_visitor<> {
 // Visitor who stops (throw a DestinationFound exception) when a certain distance is reached
 struct distance_visitor : public boost::dijkstra_visitor<> {
     navitia::time_duration max_duration;
-    const std::vector<navitia::time_duration>& durations;
+    const std::vector<cost>& durations;
 
-    distance_visitor(time_duration max_dur, const std::vector<time_duration>& dur):
+    distance_visitor(time_duration max_dur, const std::vector<cost>& dur):
         max_duration(max_dur), durations(dur) {}
 
     /*
@@ -252,7 +320,7 @@ struct distance_visitor : public boost::dijkstra_visitor<> {
      */
     template<typename G>
     void examine_vertex(typename boost::graph_traits<G>::vertex_descriptor u, const G&) {
-        if (durations[u] > max_duration)
+        if (durations[u].duration > max_duration)
             throw DestinationFound();
     }
 };

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -35,7 +35,6 @@ www.navitia.io
 #include <boost/graph/two_bit_color_map.hpp>
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/format.hpp>
-#include <boost/property_map/function_property_map.hpp>
 
 namespace bt = boost::posix_time;
 
@@ -47,7 +46,7 @@ struct cost {
     cost() {}
     bool operator<(const cost& c) const { return duration < c.duration; }
     bool operator==(const cost& c) const { return duration == c.duration && bss_taken == c.bss_taken; }
-    navitia::time_duration duration = {};
+    navitia::time_duration duration = bt::pos_infin;
     bool bss_taken = false;
 };
 
@@ -167,7 +166,7 @@ struct PathFinder {
      *  The init HAS to be called before any other methods
      */
     void init(const type::GeographicalCoord& start_coord,
-              nt::Mode_e mode,
+              const nt::Mode_e mode,
               const float speed_factor,
               const navitia::time_duration);
 
@@ -206,7 +205,7 @@ struct PathFinder {
                                                boost::typed_identity_property_map<vertex_t>(),
                                                std::less<cost>(),
                                                speed_combiner,
-                                               cost(navitia::seconds(0), false),
+                                               cost(0_s, false),
                                                visitor,
                                                color
                                                );

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -50,7 +50,7 @@ struct cost {
     bool bss_taken = false;
 };
 
-struct SpeedDistanceCombiner : public std::binary_function<cost, cost, edge_t> {
+struct SpeedDistanceCombiner : public std::binary_function<edge_t, cost, cost> {
     /// speed factor compared to the default speed of the transportation mode
     /// speed_factor = 2 means the speed is twice the default speed of the given transportation mode
     ///

--- a/source/georef/tests/builder.cpp
+++ b/source/georef/tests/builder.cpp
@@ -86,4 +86,29 @@ edge_t GraphBuilder::get(const std::string &source_name, const std::string &targ
     else return e;
 }
 
+GraphBuilder & GraphBuilder::operator()(GraphBuilder::edge_and_mode source, GraphBuilder::edge_and_mode target, navitia::time_duration dur, bool bidirectionnal) {
+    vertex_t source_idx, target_idx;
+    auto it = this->vertex_map.find(source.first);
+    if(it == this->vertex_map.end()) {
+        throw navitia::exception("source not found");
+    }
+    source_idx = it->second;
+    source_idx += geo_ref.offsets[source.second];
+
+    it = this->vertex_map.find(target.first);
+    if(it == this->vertex_map.end()) {
+        throw navitia::exception("source not found");
+    }
+    target_idx = it->second;
+    target_idx += geo_ref.offsets[target.second];
+
+    Edge edge;
+    edge.duration = dur;
+
+    boost::add_edge(source_idx, target_idx, edge, this->geo_ref.graph);
+    if(bidirectionnal)
+        boost::add_edge(target_idx, source_idx, edge, this->geo_ref.graph);
+
+    return *this;
+}
 }}

--- a/source/georef/tests/builder.h
+++ b/source/georef/tests/builder.h
@@ -36,38 +36,35 @@ namespace navitia { namespace georef {
     C'est essentiellement destiné aux tests unitaires
   */
 struct GraphBuilder{
-    /// Graphe que l'on veut construire
-    //StreetNetwork & street_network;
     GeoRef & geo_ref;
 
-    /// Associe une chaine de caractères à un nœud
     std::map<std::string, vertex_t> vertex_map;
 
-    /// Le constructeur : on précise sur quel graphe on va construire
-    //GraphBuilder(StreetNetwork & street_network) : street_network(street_network){}
     GraphBuilder(GeoRef & geo_ref) : geo_ref(geo_ref){}
 
-    /// Ajoute un nœud, s'il existe déjà, les informations sont mises à jour
+    /// Add or update a vertex
     GraphBuilder & add_vertex(std::string node_name, float x, float y);
 
-    /// Ajoute un arc. Si un nœud n'existe pas, il est créé automatiquement
-    /// Si la longueur n'est pas précisée, il s'agit de la longueur à vol d'oiseau
+    /// add an edge. create the vertex if it does not exists.
+    /// if no duration provided a default one is taken (crow fly)
     GraphBuilder & add_edge(std::string source_name, std::string target_name, navitia::time_duration dur = {}, bool bidirectionnal = false);
 
-    /// Surchage de la création de nœud pour plus de confort
+    /// Node creation
     GraphBuilder & operator()(std::string node_name, float x, float y){ return add_vertex(node_name, x, y);}
 
 
-    /// Surchage de la création d'arc pour plus de confort
+    /// Edge creation
     GraphBuilder & operator()(std::string source_name, std::string target_name, navitia::time_duration dur = {}, bool bidirectionnal = false){
         return add_edge(source_name, target_name, dur, bidirectionnal);
     }
 
+    /// edge creation for different mode.
+    /// The vertex has to be created before and the init method called
+    typedef std::pair<std::string, nt::Mode_e> edge_and_mode;
+    GraphBuilder & operator()(edge_and_mode source, edge_and_mode target, navitia::time_duration dur = {}, bool bidirectionnal = false);
 
-    /// Retourne le nœud demandé, jette une exception si on ne trouve pas
     vertex_t get(const std::string & node_name);
 
-    /// Retourne l'arc demandé, jette une exception si on ne trouve pas
     edge_t get(const std::string & source_name, const std::string & target_name);
 };
 

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -969,27 +969,32 @@ BOOST_AUTO_TEST_CASE(angle_computation_lon_lat) {
 }
 
 ////small test to make sure the time manipulation works in the SpeedDistanceCombiner
-//BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test) {
-//    navitia::time_duration dur = 10_s;
+BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test) {
+    GeoRef sn;
+    GraphBuilder b(sn);
+    navitia::time_duration dur = 10_s;
+    b("a","b",60_s);
 
-//    SpeedDistanceCombiner comb(2);
+    SpeedDistanceCombiner comb(2, sn, 0_s, false);
 
-//    BOOST_CHECK_EQUAL(dur / 2, 5_s);
+    BOOST_CHECK_EQUAL(dur / 2, 5_s);
 
-//    navitia::time_duration dur2 = 60_s;
-//    BOOST_CHECK_EQUAL(comb(dur, dur2), navitia::seconds(10+60/2));
-//}
+    BOOST_CHECK_EQUAL(comb({dur}, b.get("a", "b")).duration, navitia::seconds(10+60/2));
+}
 
-//BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test2) {
-//    navitia::time_duration dur = 10_s;
+BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test2) {
+    GeoRef sn;
+    GraphBuilder b(sn);
+    navitia::time_duration dur = 10_s;
+    b("a","b",60_s);
 
-//    SpeedDistanceCombiner comb(0.5);
 
-//    BOOST_CHECK_EQUAL(dur / 0.5, 20_s);
+    SpeedDistanceCombiner comb(0.5, sn, 0_s, false);
 
-//    navitia::time_duration dur2 = 60_s;
-//    BOOST_CHECK_EQUAL(comb(dur, dur2), 130_s);
-//}
+    BOOST_CHECK_EQUAL(dur / 0.5, 20_s);
+
+    BOOST_CHECK_EQUAL(comb({dur}, b.get("a", "b")).duration, 130_s);
+}
 
 //test allowed mode creation
 BOOST_AUTO_TEST_CASE(transportation_mode_creation) {

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -979,7 +979,7 @@ BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test) {
 
     BOOST_CHECK_EQUAL(dur / 2, 5_s);
 
-    BOOST_CHECK_EQUAL(comb({dur}, b.get("a", "b")).duration, navitia::seconds(10+60/2));
+    BOOST_CHECK_EQUAL(comb(cost{dur}, b.get("a", "b")).duration, navitia::seconds(10+60/2));
 }
 
 BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test2) {
@@ -993,7 +993,7 @@ BOOST_AUTO_TEST_CASE(SpeedDistanceCombiner_test2) {
 
     BOOST_CHECK_EQUAL(dur / 0.5, 20_s);
 
-    BOOST_CHECK_EQUAL(comb({dur}, b.get("a", "b")).duration, 130_s);
+    BOOST_CHECK_EQUAL(comb(cost{dur}, b.get("a", "b")).duration, 130_s);
 }
 
 //test allowed mode creation

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -198,6 +198,11 @@ class Instance(object):
         return get_value_or_default('min_car', instance_db, self.name)
 
     @property
+    def bss_additional_cost(self):
+        instance_db = self._get_models()
+        return get_value_or_default('bss_additional_cost', instance_db, self.name)
+
+    @property
     def factor_too_long_journey(self):
         instance_db = self._get_models()
         return get_value_or_default('factor_too_long_journey', instance_db, self.name)

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -76,6 +76,18 @@ class Scenario(simple.Scenario):
         if not request['car_speed']:
             request['car_speed'] = instance.car_speed
 
+        if not request.get('min_bike_duration'):
+            request['min_bike_duration'] = instance.min_bike
+
+        if not request.get('min_bss_duration'):
+            request['min_bss_duration'] = instance.min_bss
+
+        if not request.get('min_car_duration'):
+            request['min_car_duration'] = instance.min_car
+
+        if not request.get('bss_additional_cost'):
+            request['bss_additional_cost'] = instance.bss_additional_cost
+
     def parse_journey_request(self, requested_type, request):
         """Parse the request dict and create the protobuf version"""
         req = request_pb2.Request()
@@ -112,6 +124,11 @@ class Scenario(simple.Scenario):
         sn_params.max_bike_duration_to_pt = request["max_bike_duration_to_pt"]
         sn_params.max_bss_duration_to_pt = request["max_bss_duration_to_pt"]
         sn_params.max_car_duration_to_pt = request["max_car_duration_to_pt"]
+        sn_params.min_bike_duration = request["min_bike_duration"]
+        sn_params.min_bss_duration = request["min_bss_duration"]
+        sn_params.min_car_duration = request["min_car_duration"]
+        sn_params.bss_additional_cost = request["bss_additional_cost"]
+
         sn_params.walking_speed = request["walking_speed"]
         sn_params.bike_speed = request["bike_speed"]
         sn_params.car_speed = request["car_speed"]
@@ -288,7 +305,6 @@ class Scenario(simple.Scenario):
             cpt_attempt += 1
 
         if not request['debug']:
-            self._remove_not_long_enough_fallback(resp.journeys, instance)
             self._remove_not_long_enough_tc_with_fallback(resp.journeys, instance)
             self._delete_too_long_journey(resp.journeys, instance, request['clockwise'])
         self.sort_journeys(resp, instance.journey_order, request['clockwise'])
@@ -489,29 +505,6 @@ class Scenario(simple.Scenario):
 
     def isochrone(self, request, instance):
         return self.__on_journeys(type_pb2.ISOCHRONE, request, instance)
-
-    def _remove_not_long_enough_fallback(self, journeys, instance):
-        to_delete = []
-        for idx, journey in enumerate(journeys):
-            if journey.type in non_pt_types:
-                continue
-            bike_dur = bike_duration(journey)
-            car_dur = car_duration(journey)
-            bss_dur = bss_duration(journey)
-            if bike_dur and bike_dur < instance.min_bike:
-                to_delete.append(idx)
-            elif bss_dur and bss_dur < instance.min_bss:
-                to_delete.append(idx)
-            elif car_dur and car_dur < instance.min_car:
-                to_delete.append(idx)
-
-        logger = logging.getLogger(__name__)
-        logger.debug('remove %s journey with not enough fallback duration: %s',
-                len(to_delete), [journeys[i].type for i in to_delete])
-        to_delete.sort(reverse=True)
-        for idx in to_delete:
-            del journeys[idx]
-
 
     def _remove_not_long_enough_tc_with_fallback(self, journeys, instance):
         to_delete = []

--- a/source/jormungandr/jormungandr/scenarios/tests/destineo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/destineo_tests.py
@@ -580,8 +580,6 @@ def remove_not_long_enough_no_removal_test():
     section.duration = 60
 
     scenario = destineo.Scenario()
-    scenario._remove_not_long_enough_fallback(response.journeys, Instance())
-    eq_(len(response.journeys), 2)
     scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
     eq_(len(response.journeys), 2)
 
@@ -671,15 +669,11 @@ def remove_not_long_enough_bss_test():
     section.duration = 60
 
     scenario = destineo.Scenario()
-    scenario._remove_not_long_enough_fallback(response.journeys, Instance())
+    scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
     eq_(len(response.journeys), 3)
     eq_(response.journeys[0], journey1)
-    eq_(response.journeys[1], journey3)
+    eq_(response.journeys[1], journey2)
     eq_(response.journeys[2], journey4)
-    scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], journey1)
-    eq_(response.journeys[1], journey4)
 
 
 def remove_not_long_enough_bike_test():
@@ -738,15 +732,11 @@ def remove_not_long_enough_bike_test():
     section.duration = 30
 
     scenario = destineo.Scenario()
-    scenario._remove_not_long_enough_fallback(response.journeys, Instance())
+    scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
     eq_(len(response.journeys), 3)
     eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey3)
+    eq_(response.journeys[1], journey2)
     eq_(response.journeys[2], journey4)
-    scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey4)
 
 
 def remove_not_long_enough_car_test():
@@ -805,15 +795,11 @@ def remove_not_long_enough_car_test():
     section.duration = 20
 
     scenario = destineo.Scenario()
-    scenario._remove_not_long_enough_fallback(response.journeys, Instance())
+    scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
     eq_(len(response.journeys), 3)
     eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey3)
+    eq_(response.journeys[1], journey2)
     eq_(response.journeys[2], journey4)
-    scenario._remove_not_long_enough_tc_with_fallback(response.journeys, Instance())
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey4)
 
 
 def get_walking_walking_journey():

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -384,6 +384,10 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
             break;
     }
     result.max_duration = navitia::seconds(max_non_pt);
+    result.min_duration = navitia::seconds(min_non_pt);
+
+    result.bss_additional_cost = navitia::seconds(request.bss_additional_cost());
+
     return result;
 }
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -361,21 +361,25 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
         result.set_filter(request.destination_filter());
     }
     int max_non_pt;
+    int min_non_pt(0);
     switch(result.mode){
         case type::Mode_e::Bike:
             result.offset = data->geo_ref->offsets[type::Mode_e::Bike];
             result.speed_factor = request.bike_speed() / georef::default_speed[type::Mode_e::Bike];
             max_non_pt = request.max_bike_duration_to_pt();
+            min_non_pt = request.min_bike_duration();
             break;
         case type::Mode_e::Car:
             result.offset = data->geo_ref->offsets[type::Mode_e::Car];
             result.speed_factor = request.car_speed() / georef::default_speed[type::Mode_e::Car];
             max_non_pt = request.max_car_duration_to_pt();
+            min_non_pt = request.min_car_duration();
             break;
         case type::Mode_e::Bss:
             result.offset = data->geo_ref->offsets[type::Mode_e::Bss];
             result.speed_factor = request.bss_speed() / georef::default_speed[type::Mode_e::Bss];
             max_non_pt = request.max_bss_duration_to_pt();
+            min_non_pt = request.min_bss_duration();
             break;
         default:
             result.offset = data->geo_ref->offsets[type::Mode_e::Walking];

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -62,6 +62,8 @@ min_tc_with_bike = 5*60
 
 min_tc_with_bss = 5*60
 
+bss_additional_cost = 3*60  # we take a bss if it reduce the travel time by 'bss_additional_cost' seconds
+
 min_bike = 4*60
 
 min_bss = 4*60 + 3*60 #we want 4minute on the bike, so we add the time to pick and put back the bss

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -177,6 +177,8 @@ class Instance(db.Model):
 
     min_car = db.Column(db.Integer, default=default_values.min_car, nullable=False)
 
+    bss_additional_cost = db.Column(db.Integer, nullable=True)
+
     factor_too_long_journey = db.Column(db.Float, default=default_values.factor_too_long_journey, nullable=False)
 
     min_duration_too_long_journey = db.Column(db.Integer, default=default_values.min_duration_too_long_journey, \

--- a/source/routing/raptor_visitors.h
+++ b/source/routing/raptor_visitors.h
@@ -4,6 +4,7 @@
 
 namespace navitia { namespace routing {
 struct raptor_visitor {
+    raptor_visitor() = default;
     typedef std::vector<type::StopTime>::const_iterator stop_time_iterator;
     typedef boost::iterator_range<stop_time_iterator> stop_time_range;
 
@@ -61,6 +62,7 @@ struct raptor_visitor {
 
 
 struct raptor_reverse_visitor {
+    raptor_reverse_visitor() = default;
     typedef std::vector<type::StopTime>::const_reverse_iterator stop_time_iterator;
     typedef boost::iterator_range<stop_time_iterator> stop_time_range;
 

--- a/source/type/request.proto
+++ b/source/type/request.proto
@@ -63,6 +63,12 @@ message StreetNetworkParams{
     optional int32 max_bike_duration_to_pt      = 14;
     optional int32 max_bss_duration_to_pt       = 15;
     optional int32 max_car_duration_to_pt       = 16;
+
+    optional int32 min_bss_duration             = 17 [default = 0];
+    optional int32 min_bike_duration            = 18 [default = 0];
+    optional int32 min_car_duration             = 19 [default = 0];
+
+    optional int32 bss_additional_cost          = 20 [default = 0];
 }
 
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -1086,6 +1086,9 @@ struct StreetNetworkParams{
     void set_filter(const std::string & param_uri);
 
     navitia::time_duration max_duration = 1_s;
+    navitia::time_duration min_duration = 0_s;
+
+    navitia::time_duration bss_additional_cost = 0_s;
 };
 /**
   Gestion de l'accessibilié

--- a/source/tyr/migrations/versions/38d5cb312ba4_bss_additional_cost.py
+++ b/source/tyr/migrations/versions/38d5cb312ba4_bss_additional_cost.py
@@ -1,0 +1,22 @@
+""" add bss_additional_cost column
+
+Revision ID: 38d5cb312ba4
+Revises: 2a77596bdf40
+Create Date: 2015-04-20 17:59:30.209730
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '38d5cb312ba4'
+down_revision = '2a77596bdf40'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('instance', sa.Column('bss_additional_cost', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('instance', 'bss_additional_cost')


### PR DESCRIPTION
add a virtual additional cost to bss : "les 2 minutes du peuple" for BSS/walking "connection".

It can be viewed as "the bss has to at least improve the walking
solution by that time to be taken".

It does not change the real fallback duration, only the computation in
the shortest path.

On Paris instance, add 10ms on the street network computation time per query.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1003)

<!-- Reviewable:end -->
