### PR TITLE
Ed: add two fusio files to import associated calendars

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1045,12 +1045,12 @@ void GridCalendarTripExceptionDatesFusioHandler::handle_line(Data&, const csv_ro
     }
     auto meta_vj = gtfs_data.metavj_by_external_code.find(row[trip_c]);
     if (meta_vj == gtfs_data.metavj_by_external_code.end()) {
-        LOG4CPLUS_ERROR(logger, "CalendarTripFusioHandler: Impossible to find the trip " << row[trip_c]);
+        LOG4CPLUS_WARN(logger, "CalendarTripFusioHandler: Impossible to find the trip " << row[trip_c]);
         return;
     }
     boost::gregorian::date date(parse_date(row[date_c]));
     if(date.is_not_a_date()) {
-        LOG4CPLUS_ERROR(logger, "GridCalendarTripExceptionDatesFusioHandler: Date format not valid, we do not add the exception " <<
+        LOG4CPLUS_WARN(logger, "GridCalendarTripExceptionDatesFusioHandler: Date format not valid, we do not add the exception " <<
                        row[type_c] << " for " << row[calendar_c]);
         return;
     }

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -283,6 +283,22 @@ struct CalendarLineFusioHandler : public GenericHandler {
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"calendar_id", "line_external_code"}; }
 };
+
+struct CalendarTripFusioHandler : public GenericHandler {
+    CalendarTripFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
+    int calendar_c, trip_c;
+    void init(Data&);
+    void handle_line(Data& data, const csv_row& row, bool is_first_line);
+    const std::vector<std::string> required_headers() const { return {"calendar_id", "trip_external_code"}; }
+};
+
+struct GridCalendarTripExceptionDatesFusioHandler : public GenericHandler {
+    GridCalendarTripExceptionDatesFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
+    int calendar_c, trip_c, date_c, type_c;
+    void init(Data&);
+    void handle_line(Data& data, const csv_row& row, bool is_first_line);
+    const std::vector<std::string> required_headers() const { return {"calendar_id", "trip_external_code", "date", "type"}; }
+};
 }
 
 struct AdminStopAreaFusioHandler : public GenericHandler {

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -88,6 +88,7 @@ struct GtfsData {
     std::unordered_map<std::string, ed::types::Line*> line_map;
     std::unordered_map<std::string, ed::types::Line*> line_map_by_external_code;
     std::unordered_map<std::string, ed::types::Route*> route_map;
+    std::unordered_map<std::string, ed::types::MetaVehicleJourney*> metavj_by_external_code;
     std::unordered_map<std::string, ed::types::PhysicalMode*> physical_mode_map;
     std::unordered_map<std::string, ed::types::Network*> network_map;
     ed::types::Network* default_network = nullptr;

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -674,11 +674,18 @@ void Data::build_associated_calendar() {
     std::multimap<types::ValidityPattern, types::AssociatedCalendar*> associated_vp;
     size_t nb_not_matched_vj(0);
     size_t nb_matched(0);
+    size_t nb_ignored(0);
 
     for(auto meta_vj_pair : meta_vj_map) {
         auto& meta_vj = meta_vj_map[meta_vj_pair.first]; //meta_vj_pair.second;
 
         assert (! meta_vj.theoric_vj.empty());
+
+        if(!meta_vj.associated_calendars.empty()) {
+            LOG4CPLUS_TRACE(log, "The meta_vj " << meta_vj_pair.first << " was already linked to a grid_calendar");
+            nb_ignored++;
+            continue;
+        }
 
         // we check the theoric vj of a meta vj
         // because we start from the postulate that the theoric VJs are the same VJ
@@ -754,6 +761,9 @@ void Data::build_associated_calendar() {
     LOG4CPLUS_INFO(log, nb_matched << " vehicle journeys have been matched to at least one calendar");
     if (nb_not_matched_vj) {
         LOG4CPLUS_WARN(log, "no calendar found for " << nb_not_matched_vj << " vehicle journey");
+    }
+    if (nb_ignored) {
+        LOG4CPLUS_WARN(log, nb_ignored << " vehicle journey were already linked and therefore ignored" );
     }
 }
 

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -763,7 +763,7 @@ void Data::build_associated_calendar() {
         LOG4CPLUS_WARN(log, "no calendar found for " << nb_not_matched_vj << " vehicle journey");
     }
     if (nb_ignored) {
-        LOG4CPLUS_WARN(log, nb_ignored << " vehicle journey were already linked and therefore ignored" );
+        LOG4CPLUS_INFO(log, nb_ignored << " vehicle journey were already linked and therefore ignored" );
     }
 }
 


### PR DESCRIPTION
Add two new files to fusio to explicitly link trips to certain grid calendars.
grid_rel_calendar_trip.txt works the same way as grid_rel_calendar_line.txt by
referencing a trip by its external code and associating it to the grid calendar referenced
by its id.
grid_rel_calendar_exception_dates.txt works like grid_exception_dates.txt and list
exceptions for each trip / grid_calendar association.
In build_associated_calendars, during data completion at the end of the import
process, when a meta_vj has been explicitly linked to one or more grid calendars via the fusio
files it will be ignored (a WARN log will mention how many has been ignored at the end).
