### PR TITLE
kraken: fix test on journey with a disruption on a network

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -426,7 +426,7 @@ void builder::connection(const std::string & name1, const std::string & name2, f
     this->data->pt_data->companies.push_back(company);
 
     const std::string default_network_name = "base_network";
-    if (data->pt_data->networks_map.find(default_network_name) == data->pt_data->networks_map.end()) {
+    if (this->nts.find(default_network_name) == this->nts.end()) {
         navitia::type::Network *network = new navitia::type::Network();
         network->idx = this->data->pt_data->networks.size();
         network->name = default_network_name;

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1704,7 +1704,6 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
     BOOST_REQUIRE_EQUAL(j.sections_size(), 1);
 }
 
-#ifdef __NETWORK_DISRUPTION_BUG__ //network disruption on journeys does not work for the moment see http://jira.canaltp.fr/browse/NAVP-161
 //test with network disruption too
 // we add 2 disruptions, and we check that the status of the journey is correct
 BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
@@ -1790,11 +1789,9 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
     navitia::type::Type_e destination_type = b.data->get_type_of_id("B");
     navitia::type::EntryPoint origin(origin_type, "A");
     navitia::type::EntryPoint destination(destination_type, "B");
-
     ng::StreetNetwork sn_worker(*b.data->geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20150315T080000")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, {}, sn_worker, false, true);
-
+    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20150314T080000")},
+                                             true, navitia::type::AccessibiliteParams()/*false*/, {}, sn_worker, false);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
 
@@ -1803,4 +1800,3 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
     const auto& j = resp.journeys(0);
     BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(), "DETOUR"); //we should have the network's disruption's effect
 }
-#endif


### PR DESCRIPTION
the buildhelper was creating 2 default_network one used by the lines and
one used for the disruption, so disruption was not visible in journeys
