### PR TITLE
time tables: use "ranked pairs" to order the vj in route_schedules

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1167,7 +1167,7 @@ bool add_comment(const std::unordered_map<std::string, std::vector<T>>& list_map
     return true;
 }
 
-void CommentLinksFusioHandler::handle_line(Data& data, const csv_row& row, bool) {
+void CommentLinksFusioHandler::handle_line(Data&, const csv_row& row, bool) {
     if(! has_col(object_id_c, row) || ! has_col(object_type_c, row) || ! has_col(comment_id_c, row)) {
         LOG4CPLUS_FATAL(logger, "Error while reading " + csv.filename +
                         "  impossible to find all needed fields");

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -164,7 +164,7 @@ std::vector<uint32_t> compute_order(const size_t nb_vertices, const std::vector<
     try {
         for (const auto& edge: edges) { add_edge(edge.source, edge.target, g); }
         order.clear();
-        topological_sort(g, std::back_inserter(order));
+        boost::topological_sort(g, std::back_inserter(order));
         return order;
     } catch (boost::not_a_dag&) {}
 

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -36,6 +36,10 @@ www.navitia.io
 #include "utils/paginate.h"
 #include "type/datetime.h"
 #include <boost/range/adaptor/reversed.hpp>
+#include <boost/range/algorithm/sort.hpp>
+#include <boost/range/algorithm_ext/for_each.hpp>
+#include <boost/graph/topological_sort.hpp>
+#include <boost/graph/adjacency_list.hpp>
 
 namespace pt = boost::posix_time;
 
@@ -92,67 +96,106 @@ get_all_stop_times(const vector_idx& journey_patterns,
     return result;
 }
 
-static std::vector<datetime_stop_time>::const_iterator
-get_first_dt_st_after(const std::vector<datetime_stop_time>& v, size_t order) {
-    if (order < v.size()) {
-        return std::find_if(v.begin() + order, v.end(),
-                            [](datetime_stop_time dt_st) {
-                                return dt_st.second != nullptr;
-                            });
-    }
-    return v.end();
+namespace {
+// The score is the number of aligned cells that are not on order
+// minus the number of aligned cells that are on order. Ex:
+// v1 v2
+//  1  2 => -1
+//  2  3 => -1
+//  3  4 => -1
+//  5  5
+//  7
+//  9  7 =>  1
+// score:   -2
+int score(const std::vector<datetime_stop_time>& v1,
+          const std::vector<datetime_stop_time>& v2) {
+    int res = 0;
+    boost::range::for_each(v1, v2, [&](const datetime_stop_time& a, const datetime_stop_time& b) {
+            if (a.second == nullptr || b.second == nullptr) { return; }
+            if (a.first < b.first) {
+                --res;
+            } else if (a.first > b.first) {
+                ++res;
+            }
+        });
+    return res;
 }
+typedef boost::adjacency_list<
+    boost::vecS,
+    boost::vecS,
+    boost::directedS
+    > Graph;
+struct Edge {
+    uint32_t source;
+    uint32_t target;
+    uint32_t score;
 
-static std::vector<datetime_stop_time>::const_iterator
-get_first_dt_st_before(const std::vector<datetime_stop_time>& v, size_t order) {
-    if (order < v.size()) {
-        for (auto it = v.rbegin()+order; it != v.rend(); ++ it) {
-            if (it->second != nullptr) {
-                return it.base() - 1;
+    friend bool operator<(const Edge& a, const Edge& b) {
+        if (a.score != b.score) { return a.score > b.score; }
+        if (a.source != b.source) { return a.source < b.source; }
+        return a.target < b.target;
+    }
+};
+std::vector<Edge> create_edges(std::vector<std::vector<datetime_stop_time>>& v) {
+    std::vector<Edge> edges;
+    for (uint32_t i = 0; i < v.size(); ++i) {
+        for (uint32_t j = i + 1; j < v.size(); ++j) {
+            const int s = score(v[i], v[j]);
+            if (s > 0) {
+                edges.push_back({i, j, uint32_t(s)});
+            } else if (s < 0) {
+                edges.push_back({j, i, uint32_t(-s)});
             }
         }
     }
-    return v.end();
+    boost::sort(edges);
+    return edges;
 }
+// Using http://en.wikipedia.org/wiki/Ranked_pairs to sort the vj.  As
+// if each stop time vote according to the time of the vj at its stop
+// time (don't care for the vj that don't stop).
+std::vector<uint32_t> compute_order(const size_t nb_vertices, const std::vector<Edge>& edges) {
+    Graph g(nb_vertices);
+    std::vector<uint32_t> order;
+    order.reserve(nb_vertices);
 
-/*
- *  We want to compare the first filled dt_st of v1, named d1 with order o1
- *  with the first filled dt_st of v2 having an order >= o1
- *  If cannot find such an element in v2, we will compare with the last filled
- *  dt_st in v2.
- *  We want to compare v2, with the first st in v1 before o2.
- */
-static bool compare(const std::vector<datetime_stop_time>& v1,
-                    const std::vector<datetime_stop_time>& v2) {
-    if (v1.empty()) {
-        return false;
-    }
-    if (v2.empty()) {
-        return true;
-    }
-    auto first_st_a_it = get_first_dt_st_after(v1, 0);
-    if (first_st_a_it == v1.end()) {
-        return false;
-    }
-    auto first_st_b_it = v2.end();
-    size_t order = std::distance(first_st_a_it, v1.begin());
-    if (order < v2.size()) {
-        first_st_b_it = get_first_dt_st_after(v2, order);
-    }
-    if (first_st_b_it == v2.end()) {
-        first_st_b_it = get_first_dt_st_before(v2, 0);
-        if (first_st_b_it == v2.end()) {
-            return true;
+    // most of the time, the graph will not have any cycle, thus we
+    // test directly a topological sort.
+    try {
+        for (const auto& edge: edges) { add_edge(edge.source, edge.target, g); }
+        order.clear();
+        topological_sort(g, std::back_inserter(order));
+        return order;
+    } catch (boost::not_a_dag&) {}
+
+    // there is a cycle, thus we run the complete algorithm.
+    g = Graph(nb_vertices);// remove all edges
+    for (const auto& edge: edges) {
+        const auto e_desc = add_edge(edge.source, edge.target, g).first;
+        try {
+            order.clear();
+            boost::topological_sort(g, std::back_inserter(order));
+        } catch (boost::not_a_dag&) {
+            remove_edge(e_desc, g);
         }
     }
-    auto r_first_st_b_it = std::reverse_iterator<std::vector<datetime_stop_time>::const_iterator>(first_st_b_it);
-    size_t distance = std::distance(v2.rbegin(), r_first_st_b_it);
-    // Even if r_first_st_b_it == v2.rbegin(), distance will be 1... So we need to decrease it.
-    --distance;
-    first_st_a_it = get_first_dt_st_before(v1, distance);
-    return first_st_a_it->first < first_st_b_it->first;
+    order.clear();
+    topological_sort(g, std::back_inserter(order));
+    return order;
 }
+void ranked_pairs_sort(std::vector<std::vector<datetime_stop_time>>& v) {
+    const auto edges = create_edges(v);
+    const auto order = compute_order(v.size(), edges);
 
+    // reordering v according to the given order
+    std::vector<std::vector<datetime_stop_time>> res;
+    res.reserve(v.size());
+    for (const auto& idx: order) {
+        res.push_back(std::move(v[idx]));
+    }
+    boost::swap(res, v);
+}
+}
 
 static std::vector<std::vector<datetime_stop_time> >
 make_matrice(const std::vector<std::vector<datetime_stop_time> >& stop_times,
@@ -170,13 +213,13 @@ make_matrice(const std::vector<std::vector<datetime_stop_time> >& stop_times,
         std::vector<uint32_t> orders = thermometer.match_journey_pattern(*journey_pattern);
         int order = 0;
         for(datetime_stop_time dt_stop_time : vec) {
-            tmp[y][orders[order]] = dt_stop_time;
+            tmp.at(y).at(orders.at(order)) = dt_stop_time;
             ++order;
         }
         ++y;
     }
 
-    std::sort(tmp.begin(), tmp.end(), compare);
+    ranked_pairs_sort(tmp);
     // We rotate the matrice, so it can be handle more easily in route_schedule
     for (size_t i=0; i<tmp.size(); ++i) {
         for (size_t j=0; j<tmp[i].size(); ++j) {
@@ -231,6 +274,7 @@ route_schedule(const std::string& filter,
         fill_pb_object(route, d, m_pt_display_informations, 0, now, action_period);
 
         std::vector<bool> is_vj_set(stop_times.size(), false);
+        for (size_t i = 0; i < stop_times.size(); ++i) { table->add_headers(); }
         for(unsigned int i=0; i < thermometer.get_thermometer().size(); ++i) {
             type::idx_t spidx=thermometer.get_thermometer()[i];
             const type::StopPoint* sp = d.pt_data->stop_points[spidx];
@@ -241,7 +285,7 @@ route_schedule(const std::string& filter,
             for(unsigned int j=0; j<stop_times.size(); ++j) {
                 datetime_stop_time dt_stop_time  = matrice[i][j];
                 if (!is_vj_set[j] && dt_stop_time.second != nullptr) {
-                    pbnavitia::Header* header = table->add_headers();
+                    pbnavitia::Header* header = table->mutable_headers(j);
                     pbnavitia::PtDisplayInfo* vj_display_information = header->mutable_pt_display_informations();
                     auto vj = dt_stop_time.second->vehicle_journey;
                     fill_pb_object(vj, d, vj_display_information, 0, now, action_period);

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -41,6 +41,29 @@ struct logger_initialized {
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized )
 
+const std::string& get_vj(const pbnavitia::RouteSchedule& r, int i) {
+    return r.table().headers(i).pt_display_informations().uris().vehicle_journey();
+}
+
+static void print_route_schedule(const pbnavitia::RouteSchedule& r) {
+    std::cout << "\t|";
+    for (const auto& row: r.table().headers()) {
+        std::cout << row.pt_display_informations().uris().vehicle_journey() << "\t|";
+    }
+    std::cout << std::endl;
+    for (const auto& row: r.table().rows()) {
+        std::cout << row.stop_point().uri() << "\t|";
+        for (const auto& elt: row.date_times()) {
+            if (elt.time() > 48 * 3600) {
+                std::cout << "-" << "\t|";
+            } else {
+                std::cout << elt.time() / 3600 << ":" << (elt.time() % 3600) / 60. << "\t|";
+            }
+        }
+        std::cout << std::endl;
+    }
+}
+
 //for more concice test
 static pt::ptime d(std::string str) {
     return boost::posix_time::from_iso_string(str);
@@ -55,12 +78,12 @@ static pt::ptime d(std::string str) {
 
         But the thermometer algorithm is buggy, is doesn't give the shorest common superstring..
         So, actually we have this schedule
-            VJ1
-        C
-        D
-        A   8h
-        B   8h10
-        D
+            VJ2    VJ1    VJ3    VJ4
+        C          8h05
+        D          9h30
+        A   8h00          8h05
+        B   8h10          8h20   8h25
+        D                        9h35
 
 With VJ1, and VJ2, we ensure that we are no more comparing the two first jpp of
 each VJ, but we have a more human order.
@@ -98,11 +121,9 @@ BOOST_FIXTURE_TEST_CASE(test1, route_schedule_fixture) {
                                                                    3, 10, 0, *(b.data), false, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
-    auto get_vj = [](pbnavitia::RouteSchedule r, int i) {
-        return r.table().headers(i).pt_display_informations().uris().vehicle_journey();
-    };
-    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 0), "1");
-    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 1), "2");
+    print_route_schedule(route_schedule);
+    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 0), "2");
+    BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 1), "1");
     BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 2), "3");
     BOOST_REQUIRE_EQUAL(get_vj(route_schedule, 3), "4");
 }
@@ -113,6 +134,7 @@ BOOST_FIXTURE_TEST_CASE(test_max_nb_stop_times, route_schedule_fixture) {
                                                                    3, 10, 0, *(b.data), false, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
+    print_route_schedule(route_schedule);
     BOOST_REQUIRE_EQUAL(route_schedule.table().headers().size(), 0);
 }
 
@@ -187,15 +209,12 @@ struct route_schedule_calendar_fixture {
         b.data->meta->production_date = boost::gregorian::date_period(begin, end);
     }
 
-    std::string get_vj(pbnavitia::RouteSchedule r, int i) {
-        return r.table().headers(i).pt_display_informations().uris().vehicle_journey();
-    }
-
     void check_calendar_results(boost::optional<const std::string> calendar, std::vector<std::string> expected_vjs) {
         pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=B", calendar, {}, d("20120615T070000"), 86400, 100,
                                                                        3, 10, 0, *(b.data), false, false);
         BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
         pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
+        print_route_schedule(route_schedule);
         BOOST_REQUIRE_EQUAL(route_schedule.table().headers_size(), expected_vjs.size());
         for(int i = 0 ; i < route_schedule.table().headers_size() ; i++) {
             BOOST_REQUIRE_EQUAL(get_vj(route_schedule, i), expected_vjs[i]);
@@ -212,4 +231,146 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_filter, route_schedule_calendar_fixture) {
     check_calendar_results(c3->uri, {vj6->uri});
     // No results for calendar C4
     check_calendar_results(c4->uri, {});
+}
+
+// We want:
+//     C A B
+// st1 2   1
+// st2     3
+// st3     5
+// st4 3 5 6
+// st5 4 6 7
+// st6 5 7 8
+BOOST_AUTO_TEST_CASE(complicated_order_1) {
+    ed::builder b = {"20120614"};
+    b.vj("L", "1111111", "", true, "A", "A", "A")
+        ("st4", "5:00"_t)
+        ("st5", "6:00"_t)
+        ("st6", "7:00"_t);
+    b.vj("L", "1111111", "", true, "B", "B", "B")
+        ("st1", "1:00"_t)
+        ("st2", "3:00"_t)
+        ("st3", "5:00"_t)
+        ("st4", "6:00"_t)
+        ("st5", "7:00"_t)
+        ("st6", "8:00"_t);
+    b.vj("L", "1111111", "", true, "C", "C", "C")
+        ("st1", "2:00"_t)
+        ("st4", "3:00"_t)
+        ("st5", "4:00"_t)
+        ("st6", "5:00"_t);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+
+    pbnavitia::Response resp = navitia::timetables::route_schedule(
+        "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
+        3, 10, 0, *b.data, false, false);
+    BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
+    pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
+    print_route_schedule(route_schedule);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 0), "C");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(3).date_times(0).time(), "3:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 1), "A");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(3).date_times(1).time(), "5:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 2), "B");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(3).date_times(2).time(), "6:00"_t);
+}
+
+// We want:
+//      C  A B
+// st1     1 2
+// st2     2 3
+// st3     3 4
+// st4     5
+// st5     7
+// st6  8  9 7
+// st7  9 10
+// st8 10 11
+BOOST_AUTO_TEST_CASE(complicated_order_2) {
+    ed::builder b = {"20120614"};
+    b.vj("L", "1111111", "", true, "A", "A", "A")
+        ("st1", "1:00"_t)
+        ("st2", "2:00"_t)
+        ("st3", "3:00"_t)
+        ("st4", "5:00"_t)
+        ("st5", "7:00"_t)
+        ("st6", "9:00"_t)
+        ("st7", "10:00"_t)
+        ("st8", "11:00"_t);
+    b.vj("L", "1111111", "", true, "B", "B", "B")
+        ("st1", "2:00"_t)
+        ("st2", "3:00"_t)
+        ("st3", "4:00"_t)
+        ("st6", "7:00"_t);
+    b.vj("L", "1111111", "", true, "C", "C", "C")
+        ("st6", "8:00"_t)
+        ("st7", "9:00"_t)
+        ("st8", "10:00"_t);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+
+    pbnavitia::Response resp = navitia::timetables::route_schedule(
+        "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
+        3, 10, 0, *b.data, false, false);
+    BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
+    pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
+    print_route_schedule(route_schedule);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 0), "C");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(5).date_times(0).time(), "8:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 1), "A");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(5).date_times(1).time(), "9:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 2), "B");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(5).date_times(2).time(), "7:00"_t);
+}
+
+// We want:
+//     A B C D E
+// st1   1 2 3 4
+// st2   2 3 4 5
+// st3 6 7
+// st4 7 8
+BOOST_AUTO_TEST_CASE(complicated_order_3) {
+    ed::builder b = {"20120614"};
+    b.vj("L", "1111111", "", true, "A", "A", "A")
+        ("st3", "6:00"_t)
+        ("st4", "7:00"_t);
+    b.vj("L", "1111111", "", true, "B", "B", "B")
+        ("st1", "1:00"_t)
+        ("st2", "2:00"_t)
+        ("st3", "7:00"_t)
+        ("st4", "8:00"_t);
+    b.vj("L", "1111111", "", true, "C", "C", "C")
+        ("st1", "2:00"_t)
+        ("st2", "3:00"_t);
+    b.vj("L", "1111111", "", true, "D", "D", "D")
+        ("st1", "3:00"_t)
+        ("st2", "4:00"_t);
+    b.vj("L", "1111111", "", true, "E", "E", "E")
+        ("st1", "4:00"_t)
+        ("st2", "5:00"_t);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+
+    pbnavitia::Response resp = navitia::timetables::route_schedule(
+        "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
+        3, 10, 0, *b.data, false, false);
+    BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
+    pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
+    print_route_schedule(route_schedule);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 0), "A");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(2).date_times(0).time(), "6:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 1), "B");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(0).date_times(1).time(), "1:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 2), "C");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(0).date_times(2).time(), "2:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 3), "D");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(0).date_times(3).time(), "3:00"_t);
+    BOOST_CHECK_EQUAL(get_vj(route_schedule, 4), "E");
+    BOOST_CHECK_EQUAL(route_schedule.table().rows(0).date_times(4).time(), "4:00"_t);
 }


### PR DESCRIPTION
fix http://jira.canaltp.fr/browse/NAVITIAII-1713
