### PR TITLE
Fix autocomplete ghostword

### DIFF
--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -137,13 +137,13 @@ struct Autocomplete
       * – on découpe en mots la chaîne (tokens)
       * — on rajoute la position à la liste de chaque mot
       */
-    void add_string(std::string str, T position,
+    void add_string(std::string str, T position, const std::set<std::string>& ghostwords,
                     const autocomplete_map& synonyms){
         word_quality wc;
         int distance = 0;
 
         //Appeler la méthode pour traiter les synonymes avant de les ajouter dans le dictionaire:
-        auto vec_word = tokenize(str, synonyms);
+        auto vec_word = tokenize(str, ghostwords, synonyms);
         //créer des patterns pour chaque mot et les ajouter dans temp_pattern_map:
         add_vec_pattern(vec_word, position);
 
@@ -317,9 +317,10 @@ struct Autocomplete
     /** On passe une chaîne de charactère contenant des mots et on trouve toutes les positions contenant au moins un des mots*/
     std::vector<fl_quality> find_complete(const std::string & str,
                                           size_t nbmax,
-                                          std::function<bool(T)> keep_element)
+                                          std::function<bool(T)> keep_element,
+                                          const std::set<std::string>& ghostwords)
                                           const{
-        auto vec = tokenize(str);
+        auto vec = tokenize(str, ghostwords);
         int wordLength = 0;
         fl_quality quality;
         std::vector<T> index_result;
@@ -348,7 +349,8 @@ struct Autocomplete
     std::vector<fl_quality> find_partial_with_pattern(const std::string &str,
                                                       const int word_weight,
                                                       size_t nbmax,
-                                                      std::function<bool(T)> keep_element)
+                                                      std::function<bool(T)> keep_element,
+                                                      const std::set<std::string>& ghostwords)
                                                       const{
         //Map temporaire pour garder les patterns trouvé:
         std::unordered_map<T, fl_quality> fl_result;
@@ -360,7 +362,7 @@ struct Autocomplete
         std::vector<fl_quality> vec_quality;
         fl_quality quality;
 
-        auto vec_word = tokenize(str);
+        auto vec_word = tokenize(str, ghostwords);
         std::vector<std::string> vec_pattern = make_vec_pattern(vec_word, 2); //2-grams
         int wordLength = words_length(vec_word);
         int pattern_count = vec_pattern.size();
@@ -481,7 +483,7 @@ struct Autocomplete
         return str;
     }
 
-    std::set<std::string> tokenize(std::string strFind, const autocomplete_map& synonyms = autocomplete_map()) const{
+    std::set<std::string> tokenize(std::string strFind, const std::set<std::string>& ghostwords, const autocomplete_map& synonyms = autocomplete_map()) const{
         std::set<std::string> vec;
         boost::to_lower(strFind);
         strFind = boost::regex_replace(strFind, boost::regex("( ){2,}"), " ");
@@ -505,16 +507,13 @@ struct Autocomplete
             }
         }
 
-        //We discard the GhostWords like de, le, la configured in synonyms as below
+        //We discard the GhostWords like de, le, la configured in ghostwords as below
         //de,
         //le,
         //la,
-        //For each synonyms.key found in strTemp if synonyms.value is empty delete the substring
-        for(const auto & it : synonyms){
-            if  ((boost::regex_search(strTemp,boost::regex("\\<" + it.first + "\\>")))
-                && (it.second.empty())){
-                boost::algorithm::erase_all(strTemp, it.first);
-            }
+        //For each word in ghostwords found in strTemp delete it from strTemp
+        for(const auto& it : ghostwords){
+           strTemp = boost::regex_replace(strTemp,boost::regex("\\<" + it + "\\>"), "");
         }
 
         boost::tokenizer <> tokens(strTemp);
@@ -526,10 +525,10 @@ struct Autocomplete
         return vec;
     }
 
-    bool is_address_type(const std::string & str,
+    bool is_address_type(const std::string & str, const std::set<std::string>& ghostwords,
                          const autocomplete_map& synonyms) const{
         bool result = false;
-        auto vec_token = tokenize(str, synonyms);
+        auto vec_token = tokenize(str, ghostwords, synonyms);
         std::vector<std::string> vecTpye = {"rue", "avenue", "place", "boulevard","chemin", "impasse"};
         auto vtok = vec_token.begin();
         while(vtok != vec_token.end() && (result == false)){

--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -483,7 +483,8 @@ struct Autocomplete
         return str;
     }
 
-    std::set<std::string> tokenize(std::string strFind, const std::set<std::string>& ghostwords, const autocomplete_map& synonyms = autocomplete_map()) const{
+    std::set<std::string> tokenize(std::string strFind, const std::set<std::string>& ghostwords,
+                                   const autocomplete_map& synonyms = autocomplete_map()) const{
         std::set<std::string> vec;
         boost::to_lower(strFind);
         strFind = boost::regex_replace(strFind, boost::regex("( ){2,}"), " ");

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -226,7 +226,7 @@ pbnavitia::Response autocomplete(const std::string &q,
     std::vector<const georef::Admin*> admin_ptr = admin_uris_to_admin_ptr(admins, d);
 
     //Compute number of words in the query:
-    std::set<std::string> query_word_vec = d.geo_ref->fl_admin.tokenize(q);
+    std::set<std::string> query_word_vec = d.geo_ref->fl_admin.tokenize(q, d.geo_ref->ghostwords);
 
     ///Find max(100, count) éléments for each pt_object
     for(nt::Type_e type : filter) {
@@ -235,85 +235,85 @@ pbnavitia::Response autocomplete(const std::string &q,
         case nt::Type_e::StopArea:
             if (search_type==0) {
                 result = d.pt_data->stop_area_autocomplete.find_complete(q,
-                        nbmax,valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
+                        nbmax,valid_admin_ptr(d.pt_data->stop_areas, admin_ptr), d.geo_ref->ghostwords);
             } else {
                 result = d.pt_data->stop_area_autocomplete.find_partial_with_pattern(q,
                         d.geo_ref->word_weight,
-                        nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr));
+                        nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr), d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::StopPoint:
             if (search_type==0) {
                 result = d.pt_data->stop_point_autocomplete.find_complete(q,
-                        nbmax, valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
+                        nbmax, valid_admin_ptr(d.pt_data->stop_points, admin_ptr), d.geo_ref->ghostwords);
             } else {
                 result = d.pt_data->stop_point_autocomplete.find_partial_with_pattern(q,
                         d.geo_ref->word_weight, nbmax,
-                        valid_admin_ptr(d.pt_data->stop_points, admin_ptr));
+                        valid_admin_ptr(d.pt_data->stop_points, admin_ptr), d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::Admin:
             if (search_type==0) {
                 result = d.geo_ref->fl_admin.find_complete(q,
-                        nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
+                        nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr), d.geo_ref->ghostwords);
             } else {
                 result = d.geo_ref->fl_admin.find_partial_with_pattern(q,
                         d.geo_ref->word_weight,
-                        nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr));
+                        nbmax, valid_admin_ptr(d.geo_ref->admins, admin_ptr), d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::Address:
             result = d.geo_ref->find_ways(q, nbmax, search_type,
-                    valid_admin_ptr(d.geo_ref->ways, admin_ptr));
+                    valid_admin_ptr(d.geo_ref->ways, admin_ptr), d.geo_ref->ghostwords);
             break;
         case nt::Type_e::POI:
             if (search_type==0) {
                 result = d.geo_ref->fl_poi.find_complete(q,
-                        nbmax, valid_admin_ptr(d.geo_ref->pois, admin_ptr));
+                        nbmax, valid_admin_ptr(d.geo_ref->pois, admin_ptr), d.geo_ref->ghostwords);
             } else {
                 result = d.geo_ref->fl_poi.find_partial_with_pattern(q,
                         d.geo_ref->word_weight, nbmax,
-                        valid_admin_ptr(d.geo_ref->pois, admin_ptr));
+                        valid_admin_ptr(d.geo_ref->pois, admin_ptr), d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::Network:
             if (search_type==0) {
                 result = d.pt_data->network_autocomplete.find_complete(q,
-                         nbmax, [](type::idx_t){return true;});
+                         nbmax, [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             } else {
                 result = d.pt_data->network_autocomplete.find_partial_with_pattern(q,
                          d.geo_ref->word_weight, nbmax,
-                         [](type::idx_t){return true;});
+                         [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::CommercialMode:
             if (search_type==0) {
                 result = d.pt_data->mode_autocomplete.find_complete(q,
-                            nbmax, [](type::idx_t){return true;});
+                            nbmax, [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             } else {
                 result = d.pt_data->mode_autocomplete.find_partial_with_pattern(q,
                             d.geo_ref->word_weight, nbmax,
-                            [](type::idx_t){return true;});
+                            [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::Line:
             if (search_type==0) {
                 result = d.pt_data->line_autocomplete.find_complete(q,
-                        nbmax, [](type::idx_t){return true;});
+                        nbmax, [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             } else {
                 result = d.pt_data->line_autocomplete.find_partial_with_pattern(q,
                                             d.geo_ref->word_weight,
-                                            nbmax, [](type::idx_t){return true;});
+                                            nbmax, [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             }
             break;
         case nt::Type_e::Route:
             if (search_type==0) {
                 result = d.pt_data->route_autocomplete.find_complete(q,
-                            nbmax, [](type::idx_t){return true;});
+                            nbmax, [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             } else {
                 result = d.pt_data->route_autocomplete.find_partial_with_pattern(q,
                             d.geo_ref->word_weight,
-                            nbmax, [](type::idx_t){return true;});
+                            nbmax, [](type::idx_t){return true;}, d.geo_ref->ghostwords);
             }
             break;
         default: break;

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1426,7 +1426,14 @@ void EdReader::fill_synonyms(navitia::type::Data& data, pqxx::work& work){
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         const_it["key"].to(key);
         const_it["value"].to(value);
-        data.geo_ref->synonyms[key] = value;
+        boost::to_lower(key);
+        boost::to_lower(value);
+        if (!value.empty()){
+            data.geo_ref->synonyms[key] = value;
+        }
+        else{
+            data.geo_ref->ghostwords.insert(key);
+        }
     }
 }
 

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -387,7 +387,7 @@ void GeoRef::build_autocomplete_list(){
             // After this modification the result found with postal code in search string
             // should contain only this postal code but not others of the admin found.
             std::string key = way->way_type + " " + way->name + " " + admin->name + " " + admin->postal_codes_to_string();
-            fl_way.add_string(key, pos, this->synonyms);
+            fl_way.add_string(key, pos, this->ghostwords, this->synonyms);
 
         }
     }
@@ -401,13 +401,13 @@ void GeoRef::build_autocomplete_list(){
         if (auto admin = find_city_admin(poi->admin_list)) {
             key += " " + admin->name;
         }
-        fl_poi.add_string(key, poi->idx , this->synonyms);
+        fl_poi.add_string(key, poi->idx , this->ghostwords, this->synonyms);
     }
     fl_poi.build();
 
     fl_admin.clear();
     for(Admin* admin : admins){
-        fl_admin.add_string(admin->name + " " + admin->postal_codes_to_string(), admin->idx , this->synonyms);
+        fl_admin.add_string(admin->name + " " + admin->postal_codes_to_string(), admin->idx , this->ghostwords, this->synonyms);
     }
     fl_admin.build();
 }
@@ -452,7 +452,7 @@ void GeoRef::build_admin_map(){
     * Si le numéro est rensigné, on renvoie les coordonnées les plus proches
     * Sinon le barycentre de la rue
 */
-std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std::string & str, const int nbmax, const int search_type, std::function<bool(nt::idx_t)> keep_element) const{
+std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std::string & str, const int nbmax, const int search_type, std::function<bool(nt::idx_t)> keep_element, const std::set<std::string>& ghostwords) const{
     std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> to_return;
     boost::tokenizer<> tokens(str);
 
@@ -473,9 +473,9 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std
         search_str = str;
     }
     if (search_type == 0){
-        to_return = fl_way.find_complete(search_str, nbmax, keep_element);
+        to_return = fl_way.find_complete(search_str, nbmax, keep_element, ghostwords);
     }else{
-        to_return = fl_way.find_partial_with_pattern(search_str, word_weight, nbmax, keep_element);
+        to_return = fl_way.find_partial_with_pattern(search_str, word_weight, nbmax, keep_element, ghostwords);
     }
 
     /// récupération des coordonnées du numéro recherché pour chaque rue

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -39,7 +39,9 @@ www.navitia.io
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/utility.hpp>
+#include <boost/serialization/set.hpp>
 #include <map>
+#include <set>
 
 
 namespace nt = navitia::type;
@@ -252,13 +254,16 @@ struct GeoRef {
     /// number of vertex by transportation mode
     nt::idx_t nb_vertex_by_mode;
     navitia::autocomplete::autocomplete_map synonyms;
+    std::set<std::string> ghostwords;
+
+
     int word_weight = 5; //Pas serialisé : lu dans le fichier ini
 
     void init();
 
     template<class Archive> void save(Archive & ar, const unsigned int) const {
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & poi_proximity_list
+                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & ghostwords & poi_proximity_list
                 & nb_vertex_by_mode;
     }
 
@@ -267,7 +272,7 @@ struct GeoRef {
         // On avait donc une fuite de mémoire
         graph.clear();
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & poi_proximity_list
+                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & ghostwords & poi_proximity_list
                 & nb_vertex_by_mode;
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()
@@ -288,7 +293,7 @@ struct GeoRef {
     void build_pois_map();
 
     /// Recherche d'une adresse avec un numéro en utilisant Autocomplete
-    std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> find_ways(const std::string & str, const int nbmax, const int search_type,std::function<bool(nt::idx_t)> keep_element) const;
+    std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> find_ways(const std::string & str, const int nbmax, const int search_type,std::function<bool(nt::idx_t)> keep_element, const std::set<std::string>& ghostwords) const;
 
 
     const std::vector<Admin*> find_admins(const type::GeographicalCoord&) const;

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -669,6 +669,7 @@ BOOST_AUTO_TEST_CASE(build_autocomplete_test){
         navitia::georef::Edge e1;
         std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> result;
         int nbmax = 10;
+        std::set<std::string> ghostwords;
 
         navitia::georef::Way  way;
         way.name = "jeanne d'arc";
@@ -766,7 +767,7 @@ BOOST_AUTO_TEST_CASE(build_autocomplete_test){
 
         geo_ref.build_autocomplete_list();
 
-        result = geo_ref.find_ways("10 rue jean jaures", nbmax, false, [](int){return true;});
+        result = geo_ref.find_ways("10 rue jean jaures", nbmax, false, [](int){return true;}, ghostwords);
         if (result.empty())
             result.clear();
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -74,7 +74,7 @@ struct wrong_version : public navitia::exception {
 class Data : boost::noncopyable{
 public:
 
-    static const unsigned int data_version = 37; //< Data version number. *INCREMENT* every time serialized data are modified
+    static const unsigned int data_version = 38; //< Data version number. *INCREMENT* every time serialized data are modified
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -64,7 +64,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for( navitia::georef::Admin* admin : sa->admin_list){
                 if (admin->level ==8){key +=" " + admin->name;}
             }
-            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.synonyms);
+            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->stop_area_autocomplete.build();
@@ -77,7 +77,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for(navitia::georef::Admin* admin : sp->admin_list){
                 if (admin->level == 8){key += key + " " + admin->name;}
             }
-            this->stop_point_autocomplete.add_string(sp->name + " " + key, sp->idx, georef.synonyms);
+            this->stop_point_autocomplete.add_string(sp->name + " " + key, sp->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->stop_point_autocomplete.build();
@@ -89,7 +89,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             if (line->network){key = line->network->name;}
             if (line->commercial_mode) {key += " " + line->commercial_mode->name;}
             key += " " + line->code;
-            this->line_autocomplete.add_string(key + " " + line->name, line->idx, georef.synonyms);
+            this->line_autocomplete.add_string(key + " " + line->name, line->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->line_autocomplete.build();
@@ -97,7 +97,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
     this->network_autocomplete.clear();
     for(const Network* network : this->networks){
         if (!network->name.empty()){
-            this->network_autocomplete.add_string(network->name, network->idx, georef.synonyms);
+            this->network_autocomplete.add_string(network->name, network->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->network_autocomplete.build();
@@ -105,7 +105,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
     this->mode_autocomplete.clear();
     for(const CommercialMode* mode : this->commercial_modes){
         if (!mode->name.empty()){
-            this->mode_autocomplete.add_string(mode->name, mode->idx, georef.synonyms);
+            this->mode_autocomplete.add_string(mode->name, mode->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->mode_autocomplete.build();
@@ -119,7 +119,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
                 if (route->line->commercial_mode) {key += " " + route->line->commercial_mode->name;}
                 key += " " + route->line->code;
             }
-            this->route_autocomplete.add_string(key + " " + route->name, route->idx, georef.synonyms);
+            this->route_autocomplete.add_string(key + " " + route->name, route->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->route_autocomplete.build();


### PR DESCRIPTION
A variable ghostwords of type set added in georef.
ghostwords is filled from table synonys
synonyms and ghostwords are added seperately in the construction of dictionary.
only ghostwords is added during search.
data version incremented to 38
some tests added and some modified
concerns : http://jira.canaltp.fr/browse/NAVITIAII-1724
