### PR TITLE
kraken: use UTC time for "now" in all API

### DIFF
--- a/source/calendar/calendar.h
+++ b/source/calendar/calendar.h
@@ -43,7 +43,7 @@ public:
                     const std::vector<std::string>& forbidden_uris,
                     const type::Data &d,
                     const boost::gregorian::date_period filter_period,
-                    const boost::posix_time::ptime now = boost::posix_time::microsec_clock::local_time());
+                    const boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time());
 };
 }
 }

--- a/source/calendar/calendar_api.cpp
+++ b/source/calendar/calendar_api.cpp
@@ -45,7 +45,7 @@ pbnavitia::Response calendars(const navitia::type::Data &d,
     const std::vector<std::string>& forbidden_uris) {
     pbnavitia::Response pb_response;
     std::vector<type::idx_t> calendar_list;
-    auto now = boost::posix_time::second_clock::local_time();
+    auto now = boost::posix_time::second_clock::universal_time();
     boost::gregorian::date start_period(boost::gregorian::not_a_date_time);
     boost::gregorian::date end_period(boost::gregorian::not_a_date_time);
     if((!start_date.empty()) && (!end_date.empty())) {

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -67,7 +67,7 @@ void doWork(zmq::context_t & context, DataManager<navitia::type::Data>& data_man
 
         pbnavitia::Request pb_req;
         pbnavitia::Response result;
-        pt::ptime start = pt::microsec_clock::local_time();
+        pt::ptime start = pt::microsec_clock::universal_time();
         pbnavitia::API api = pbnavitia::UNKNOWN_API;
         if(pb_req.ParseFromArray(request.data(), request.size())){
             api = pb_req.requested_api();
@@ -102,7 +102,7 @@ void doWork(zmq::context_t & context, DataManager<navitia::type::Data>& data_man
 
         if(api != pbnavitia::METADATAS){
             LOG4CPLUS_DEBUG(logger, "processing time : "
-                            << (pt::microsec_clock::local_time() - start).total_milliseconds());
+                            << (pt::microsec_clock::universal_time() - start).total_milliseconds());
         }
     }
 }

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -48,7 +48,7 @@ static void create_pb(const std::vector<t_result>& result, uint32_t depth, const
     for(auto result_item : result){
         pbnavitia::PtObject* place = pb_response.add_places_nearby();
         //on récupére la date pour les impacts
-        auto current_date = boost::posix_time::second_clock::local_time();
+        auto current_date = boost::posix_time::second_clock::universal_time();
         auto idx = std::get<0>(result_item);
         auto coord_item = std::get<1>(result_item);
         auto type = std::get<2>(result_item);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -266,7 +266,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                        const bool show_codes) {
     pbnavitia::Response& pb_response = enhanced_response.response;
 
-    bt::ptime now = bt::second_clock::local_time();
+    bt::ptime now = bt::second_clock::universal_time();
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
     for(Path path : paths) {
@@ -620,7 +620,7 @@ static void add_isochrone_response(RAPTOR& raptor,
                                    int max_duration,
                                    bool show_codes,
                                    bool show_stop_area) {
-    bt::ptime now = bt::second_clock::local_time();
+    bt::ptime now = bt::second_clock::universal_time();
     for(const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
         const auto best_lbl = raptor.best_labels_pts[sp_idx];

--- a/source/time_tables/2stops_schedules.cpp
+++ b/source/time_tables/2stops_schedules.cpp
@@ -96,7 +96,7 @@ pbnavitia::Response stops_schedule(const std::string &departure_filter, const st
         return pb_response;
     }
 
-    auto current_time = pt::second_clock::local_time();
+    auto current_time = pt::second_clock::universal_time();
     pt::time_period action_period(to_posix_time(dt, data), to_posix_time(max_dt, data));
 
     for(auto pair_dt_idx : board) {

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -50,8 +50,7 @@ render_v1(const std::map<uint32_t, pbnavitia::ResponseStatus>& response_status,
           const bool show_codes,
           const type::Data& data) {
     pbnavitia::Response response;
-    auto current_time = pt::second_clock::local_time();
-    auto now = pt::second_clock::local_time();
+    auto current_time = pt::second_clock::universal_time();
     pt::time_period action_period(to_posix_time(datetime, data),
                                   to_posix_time(max_datetime, data));
 
@@ -80,7 +79,7 @@ render_v1(const std::map<uint32_t, pbnavitia::ResponseStatus>& response_status,
         for(auto dt_st : id_vec.second) {
             auto date_time = schedule->add_date_times();
             fill_pb_object(dt_st.second, data, date_time, 0,
-                           now, action_period, dt_st.first, calendar_id);
+                           current_time, action_period, dt_st.first, calendar_id);
         }
         const auto& it = response_status.find(id_vec.first.second);
         if(it != response_status.end()){

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -242,7 +242,7 @@ route_schedule(const std::string& filter,
     if(handler.pb_response.has_error()) {
         return handler.pb_response;
     }
-    auto now = pt::second_clock::local_time();
+    auto now = pt::second_clock::universal_time();
     auto pt_datetime = to_posix_time(handler.date_time, d);
     auto pt_max_datetime = to_posix_time(handler.max_datetime, d);
     pt::time_period action_period(pt_datetime, pt_max_datetime);


### PR DESCRIPTION
quick fix for http://jira.canaltp.fr/browse/NAVITIAII-1743
We have to always use the current_date provided by jormungandr and test it!
