### PR TITLE
osm2ed: fix import of blind alley

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -315,6 +315,9 @@ void OSMCache::insert_edges() {
                     || (node == way.nodes.back() && prev_node != nodes.end())) {
                 // If a node is used more than once, it is an intersection,
                 // hence it's a node of the street network graph
+                // If a node is only used by one way we can simplify the and reduce the number of edges, we don't need
+                // to have the perfect representation of the way on the graph, but we have the correct representation
+                // in the linestring
                 geog << node->coord_to_string() << ")";
                 lotus.insert({std::to_string(prev_node->osm_id),
                         std::to_string(node->osm_id), std::to_string(ref_way_id),

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -311,7 +311,8 @@ void OSMCache::insert_edges() {
             if (!node->is_defined()) {
                 continue;
             }
-            if (node->is_used_more_than_once() && prev_node != nodes.end()) {
+            if ((node->is_used_more_than_once() && prev_node != nodes.end())
+                    || (node == way.nodes.back() && prev_node != nodes.end())) {
                 // If a node is used more than once, it is an intersection,
                 // hence it's a node of the street network graph
                 geog << node->coord_to_string() << ")";


### PR DESCRIPTION
We were only importing edge with nodes used at least by two edges, but
in case of blind alley we need this edges too, so, we now import all
edges from a street even is they are used only one time!
