### PR TITLE
Add line groups to navitia

### DIFF
--- a/fixtures/ed/ntfs/line_group_links.txt
+++ b/fixtures/ed/ntfs/line_group_links.txt
@@ -1,3 +1,4 @@
 line_group_id,line_id
 lg1,l2
 lg1,l3
+lg1,l3

--- a/fixtures/ed/ntfs/line_group_links.txt
+++ b/fixtures/ed/ntfs/line_group_links.txt
@@ -1,0 +1,3 @@
+line_group_id,line_id
+lg1,l2
+lg1,l3

--- a/fixtures/ed/ntfs/line_groups.txt
+++ b/fixtures/ed/ntfs/line_groups.txt
@@ -1,0 +1,4 @@
+line_group_id,line_group_name,main_line_id
+lg1,"Groupe lignes B",l2
+lg2,"Groupe ligne Bs seule",l3
+lg3,"Groupe inconnu",iddeligneprincipalequinexistepas

--- a/fixtures/ed/ntfs/line_groups.txt
+++ b/fixtures/ed/ntfs/line_groups.txt
@@ -1,4 +1,4 @@
 line_group_id,line_group_name,main_line_id
-lg1,"Groupe lignes B",l2
-lg2,"Groupe ligne Bs seule",l3
-lg3,"Groupe inconnu",iddeligneprincipalequinexistepas
+lg1,"B lines group",l2
+lg2,"Bn line only group",l3
+lg3,"Unknown group",unknownlineidtotestifitiscorrectlyignored

--- a/fixtures/ed/ntfs/lines.txt
+++ b/fixtures/ed/ntfs/lines.txt
@@ -1,2 +1,4 @@
 line_id,line_code,line_name,forward_line_name,forward_direction,backward_line_name,backward_direction,line_color,line_sort,network_id,commercial_mode_id,contributor_id,geometry_id,line_opening_time,line_closing_time
 l1,"A","ligne A Flexible",,,,,,,ligneflexible,BUS,,,00:00:00,23:59:00
+l2,"B","ligne B Journée",,,,,,,ligneflexible,BUS,,,00:05:00,21:00:00
+l3,"Bs","ligne B Soirée",,,,,,,ligneflexible,BUS,,,00:21:00,01:00:00

--- a/fixtures/ed/ntfs/lines.txt
+++ b/fixtures/ed/ntfs/lines.txt
@@ -1,4 +1,4 @@
 line_id,line_code,line_name,forward_line_name,forward_direction,backward_line_name,backward_direction,line_color,line_sort,network_id,commercial_mode_id,contributor_id,geometry_id,line_opening_time,line_closing_time
 l1,"A","ligne A Flexible",,,,,,,ligneflexible,BUS,,,00:00:00,23:59:00
-l2,"B","ligne B Journée",,,,,,,ligneflexible,BUS,,,00:05:00,21:00:00
-l3,"Bs","ligne B Soirée",,,,,,,ligneflexible,BUS,,,00:21:00,01:00:00
+l2,"B","B line",,,,,,,ligneflexible,BUS,,,00:05:00,21:00:00
+l3,"Bn","B line (night bus)",,,,,,,ligneflexible,BUS,,,00:21:00,01:00:00

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -684,7 +684,7 @@ void LineGroupFusioHandler::handle_line(Data& data, const csv_row& row, bool) {
     line_group_link.line = line->second;
     line_group_link.is_main_line = true;
 
-    line_group->linkedLinesURI.insert(line->second->uri);
+    gtfs_data.linked_lines_by_line_group_uri[line_group->uri].push_back(line->second->uri);
 
     data.line_groups.push_back(line_group);
     data.line_group_links.push_back(line_group_link);
@@ -713,7 +713,8 @@ void LineGroupLinksFusioHandler::handle_line(Data& data, const csv_row& row, boo
         return;
     }
 
-    if(line_group->second->linkedLinesURI.find(line->second->uri) != line_group->second->linkedLinesURI.end()) {
+    std::vector<std::string> linked_lines = gtfs_data.linked_lines_by_line_group_uri[line_group->second->uri];
+    if(std::find(linked_lines.begin(), linked_lines.end(), line->second->uri) != linked_lines.end()) {
         // Don't insert duplicates
         return;
     }
@@ -723,7 +724,7 @@ void LineGroupLinksFusioHandler::handle_line(Data& data, const csv_row& row, boo
     line_group_link.line = line->second;
     // To know if the line is the main line of the group, we compare URI
     line_group_link.is_main_line = (line_group->second->main_line->uri == line->second->uri);
-    line_group->second->linkedLinesURI.insert(line->second->uri);
+    gtfs_data.linked_lines_by_line_group_uri[line_group->second->uri].push_back(line->second->uri);
     data.line_group_links.push_back(line_group_link);
 }
 

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -166,6 +166,25 @@ struct LineFusioHandler : public GenericHandler{
     const std::vector<std::string> required_headers() const { return {"line_id", "line_name", "commercial_mode_id"}; }
 };
 
+struct LineGroupFusioHandler : public GenericHandler{
+    LineGroupFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
+    int id_c,
+    name_c,
+    main_line_id_c;
+    void init(Data &);
+    void handle_line(Data& data, const csv_row& line, bool is_first_line);
+    const std::vector<std::string> required_headers() const { return {"line_group_id", "line_group_name", "main_line_id"}; }
+};
+
+struct LineGroupLinksFusioHandler : public GenericHandler{
+    LineGroupLinksFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
+    int line_group_id_c,
+    line_id_c;
+    void init(Data &);
+    void handle_line(Data& data, const csv_row& line, bool is_first_line);
+    const std::vector<std::string> required_headers() const { return {"line_group_id", "line_id"}; }
+};
+
 struct CompanyFusioHandler : public GenericHandler {
     CompanyFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
     int id_c,

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -87,6 +87,7 @@ struct GtfsData {
     std::unordered_map<std::string, ed::types::StopArea*> stop_area_map;
     std::unordered_map<std::string, ed::types::Line*> line_map;
     std::unordered_map<std::string, ed::types::Line*> line_map_by_external_code;
+    std::unordered_map<std::string, ed::types::LineGroup*> line_group_map;
     std::unordered_map<std::string, ed::types::Route*> route_map;
     std::unordered_map<std::string, ed::types::MetaVehicleJourney*> metavj_by_external_code;
     std::unordered_map<std::string, ed::types::PhysicalMode*> physical_mode_map;

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -107,6 +107,9 @@ struct GtfsData {
     //for gtfs we group the comments together, so the key is the comment and the value is the id of the comment
     std::unordered_map<std::string, std::string> comments_id_map;
 
+    // Store lines linked for each group to avoid duplicates
+    std::unordered_map<std::string, std::vector<std::string>> linked_lines_by_line_group_uri;
+
     // timezone management
     TzHandler tz;
 

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -35,6 +35,7 @@ www.navitia.io
 #include "utils/csv.h"
 #include "utils/logger.h"
 #include "utils/functions.h"
+#include <boost/container/flat_set.hpp>
 #include <boost/date_time/time_zone_base.hpp>
 #include <boost/date_time/local_time/local_time.hpp>
 #include "tz_db_wrapper.h"
@@ -108,7 +109,7 @@ struct GtfsData {
     std::unordered_map<std::string, std::string> comments_id_map;
 
     // Store lines linked for each group to avoid duplicates
-    std::unordered_map<std::string, std::vector<std::string>> linked_lines_by_line_group_uri;
+    std::unordered_map<std::string, boost::container::flat_set<std::string>> linked_lines_by_line_group_uri;
 
     // timezone management
     TzHandler tz;

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -58,6 +58,7 @@ void Data::normalize_uri(){
     ::ed::normalize_uri(companies);
     ::ed::normalize_uri(commercial_modes);
     ::ed::normalize_uri(lines);
+    ::ed::normalize_uri(line_groups);
     ::ed::normalize_uri(physical_modes);
     ::ed::normalize_uri(stop_areas);
     ::ed::normalize_uri(stop_points);

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -98,6 +98,7 @@ public:
 
     std::vector<ed::types::AdminStopArea*>  admin_stop_areas;
 
+    std::vector<ed::types::LineGroupLink> line_group_links;
 
     std::map<std::string, types::MetaVehicleJourney> meta_vj_map; //meta vj by original vj name
 

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -212,6 +212,7 @@ int main(int argc, char * argv[])
     data.meta->publication_date = pt::microsec_clock::local_time();
 
     LOG4CPLUS_INFO(logger, "line: " << data.pt_data->lines.size());
+    LOG4CPLUS_INFO(logger, "line_groups: " << data.pt_data->line_groups.size());
     LOG4CPLUS_INFO(logger, "route: " << data.pt_data->routes.size());
     LOG4CPLUS_INFO(logger, "journey_pattern: " << data.pt_data->journey_patterns.size());
     LOG4CPLUS_INFO(logger, "stoparea: " << data.pt_data->stop_areas.size());

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -743,7 +743,7 @@ void EdPersistor::insert_line_groups(const std::vector<types::LineGroup*>& group
 
     this->lotus.prepare_bulk_insert("navitia.line_group_link", {"group_id","line_id","is_main_line"});
     for(const auto& group_link: group_links) {
-        const auto& line_group = std::find(groups.begin(),groups.end(),group_link.line_group);
+        const auto& line_group = std::find(groups.begin(), groups.end(), group_link.line_group);
         if(line_group == groups.end())
         {
             LOG4CPLUS_ERROR(logger, "Group " << group_link.line_group->idx << " not found when trying to insert line_group_link");

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -331,6 +331,9 @@ void EdPersistor::persist(const ed::Data& data){
     LOG4CPLUS_INFO(logger, "Begin: insert lines");
     this->insert_lines(data.lines);
     LOG4CPLUS_INFO(logger, "End: insert lines");
+    LOG4CPLUS_INFO(logger, "Begin: insert line groups");
+    this->insert_line_groups(data.line_groups, data.line_group_links);
+    LOG4CPLUS_INFO(logger, "End: insert line groups");
     LOG4CPLUS_INFO(logger, "Begin: insert routes");
     this->insert_routes(data.routes);
     LOG4CPLUS_INFO(logger, "End: insert routes");
@@ -470,7 +473,8 @@ void EdPersistor::clean_db(){
         "navitia.connection, navitia.calendar, navitia.period, "
         "navitia.week_pattern, "
         "navitia.meta_vj, navitia.rel_metavj_vj, navitia.object_properties, navitia.object_code, "
-        "navitia.comments, navitia.ptobject_comments"
+        "navitia.comments, navitia.ptobject_comments, "
+        "navitia.line_group, navitia.line_group_link"
         " CASCADE");
     //we remove the parameters (but we do not truncate the table since the shape might have been updated with fusio2ed)
     this->lotus.exec("update navitia.parameters set"
@@ -724,6 +728,35 @@ void EdPersistor::insert_lines(const std::vector<types::Line*>& lines){
 
     this->lotus.finish_bulk_insert();
 
+}
+
+void EdPersistor::insert_line_groups(const std::vector<types::LineGroup*>& groups, const std::vector<types::LineGroupLink>& group_links){
+    this->lotus.prepare_bulk_insert("navitia.line_group", {"id","uri","name"});
+    for(const auto& line_group: groups) {
+        this->lotus.insert({
+            std::to_string(line_group->idx),
+            navitia::encode_uri(line_group->uri),
+            line_group->name
+        });
+    }
+    this->lotus.finish_bulk_insert();
+
+    this->lotus.prepare_bulk_insert("navitia.line_group_link", {"group_id","line_id","is_main_line"});
+    for(const auto& group_link: group_links) {
+        const auto& line_group = std::find(groups.begin(),groups.end(),group_link.line_group);
+        if(line_group == groups.end())
+        {
+            LOG4CPLUS_ERROR(logger, "Group " << group_link.line_group->idx << " not found when trying to insert line_group_link");
+            break;
+        }
+        bool is_main_line = ((*line_group)->main_line->idx == group_link.line->idx);
+        this->lotus.insert({
+            std::to_string(group_link.line_group->idx),
+            std::to_string(group_link.line->idx),
+            std::to_string(is_main_line)
+        });
+    }
+    this->lotus.finish_bulk_insert();
 }
 
 void EdPersistor::insert_stop_point_connections(const std::vector<types::StopPointConnection*>& connections){

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -93,6 +93,7 @@ private:
 
     void insert_stop_points(const std::vector<types::StopPoint*>& stop_points);
     void insert_lines(const std::vector<types::Line*>& lines);
+    void insert_line_groups(const std::vector<types::LineGroup*>& groups, const std::vector<types::LineGroupLink>& group_links);
     void insert_routes(const std::vector<types::Route*>& routes);
     void insert_journey_patterns(const std::vector<types::JourneyPattern*>& journey_pattern);
     void insert_validity_patterns(const std::vector<types::ValidityPattern*>& validity_patterns);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -552,28 +552,26 @@ void EdReader::fill_lines(nt::Data& data, pqxx::work& work){
 }
 
 void EdReader::fill_line_groups(nt::Data& data, pqxx::work& work){
-    std::string request = "SELECT id, uri, name FROM navitia.line_group";
+    std::string request = "SELECT id, uri, name, main_line_id FROM navitia.line_group";
 
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         nt::LineGroup* line_group = new nt::LineGroup();
         const_it["uri"].to(line_group->uri);
         const_it["name"].to(line_group->name);
+        line_group->main_line = this->line_map[const_it["main_line_id"].as<idx_t>()];
         this->line_group_map[const_it["id"].as<idx_t>()] = line_group;
         data.pt_data->line_groups.push_back(line_group);
     }
 
-    pqxx::result line_group_result = work.exec("SELECT group_id, line_id, is_main_line FROM navitia.line_group_link");
+    pqxx::result line_group_result = work.exec("SELECT group_id, line_id FROM navitia.line_group_link");
     for(auto const_it = line_group_result.begin(); const_it != line_group_result.end(); ++const_it){
-        bool isMainLine(const_it["is_main_line"].as<bool>());
         auto group_it = this->line_group_map.find(const_it["group_id"].as<idx_t>());
         if(group_it !=  this->line_group_map.end()) {
             auto line_it = this->line_map.find(const_it["line_id"].as<idx_t>());
             if(line_it != this->line_map.end()) {
-                if(isMainLine)
-                    group_it->second->main_line = line_it->second;
                 group_it->second->line_list.push_back(line_it->second);
-                line_it->second->group_list.push_back(std::pair<nt::LineGroup*,bool>(group_it->second, isMainLine));
+                line_it->second->line_group_list.push_back(group_it->second);
             }
         }
     }

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -72,6 +72,7 @@ private:
     std::unordered_map<idx_t, navitia::type::StopArea*> stop_area_map;
     std::unordered_map<idx_t, navitia::type::StopPoint*> stop_point_map;
     std::unordered_map<idx_t, navitia::type::Line*> line_map;
+    std::unordered_map<idx_t, navitia::type::LineGroup*> line_group_map;
     std::unordered_map<idx_t, navitia::type::Route*> route_map;
     std::unordered_map<idx_t, navitia::type::JourneyPattern*> journey_pattern_map;
     std::unordered_map<idx_t, navitia::type::ValidityPattern*> validity_pattern_map;
@@ -105,6 +106,8 @@ private:
     void fill_stop_areas(navitia::type::Data& data, pqxx::work& work);
     void fill_stop_points(navitia::type::Data& data, pqxx::work& work);
     void fill_lines(navitia::type::Data& data, pqxx::work& work);
+    void fill_line_groups(navitia::type::Data& data, pqxx::work& work);
+
     void fill_routes(navitia::type::Data& data, pqxx::work& work);
     void fill_journey_patterns(navitia::type::Data& data, pqxx::work& work);
     void fill_validity_patterns(navitia::type::Data& data, pqxx::work& work);

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -160,6 +160,7 @@ int main(int argc, char * argv[])
     }
 
     LOG4CPLUS_INFO(logger, "line: " << data.lines.size());
+    LOG4CPLUS_INFO(logger, "line_group: " << data.line_groups.size());
     LOG4CPLUS_INFO(logger, "route: " << data.routes.size());
     LOG4CPLUS_INFO(logger, "journey_pattern: " << data.journey_patterns.size());
     LOG4CPLUS_INFO(logger, "stoparea: " << data.stop_areas.size());

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -156,8 +156,6 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     BOOST_CHECK_EQUAL(data.line_group_links[2].line->uri, "l3");
     BOOST_CHECK_EQUAL(data.line_group_links[0].line->uri, "l2");
     BOOST_CHECK_EQUAL(data.line_group_links[2].line->uri, "l3");
-    BOOST_CHECK_EQUAL(data.line_group_links[0].is_main_line, true);
-    BOOST_CHECK_EQUAL(data.line_group_links[2].is_main_line, false);
 
     // Second group, only one line, only defined as the main_line
     BOOST_REQUIRE(data.line_groups[1]->main_line != nullptr);
@@ -165,6 +163,5 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     BOOST_CHECK_EQUAL(data.line_groups[1]->main_line->uri, "l3");
     BOOST_CHECK_EQUAL(data.line_group_links[1].line_group->uri, "lg2");
     BOOST_CHECK_EQUAL(data.line_group_links[1].line->uri, "l3");
-    BOOST_CHECK_EQUAL(data.line_group_links[1].is_main_line, true);
 }
 

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -132,9 +132,10 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
 
     /* Line groups.
      * 3 groups in the file, 3 use cases :
-     *   - The first one has 2 lines, both linked to the group in line_group_links.txt,
+     *   - The first one has 2 lines, both linked to the group in line_group_links.txt.
+     *     One link is twice in the file and one of the entry should be ignored,
      *   - The second one has only one line, linked only via the main_line_id field of line_groups.txt,
-     *   - The first one has an unknown main_line_id and should be ignored
+     *   - The third one has an unknown main_line_id and should be ignored
      *
      * At the start of the vector data.line_group_links we are going to have each main_line, since
      * those links are created in LineGroupFusioHandler, to allow use case number 2 where the line is not

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -130,5 +130,40 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list[3]->local_traffic_zone, 2);
     BOOST_REQUIRE_EQUAL(vj->stop_time_list[4]->local_traffic_zone, std::numeric_limits<uint16_t>::max());
 
+    /* Line groups.
+     * 3 groups in the file, 3 use cases :
+     *   - The first one has 2 lines, both linked to the group in line_group_links.txt,
+     *   - The second one has only one line, linked only via the main_line_id field of line_groups.txt,
+     *   - The first one has an unknown main_line_id and should be ignored
+     *
+     * At the start of the vector data.line_group_links we are going to have each main_line, since
+     * those links are created in LineGroupFusioHandler, to allow use case number 2 where the line is not
+     * in line_group_links.txt.
+     */
+
+    // Check group, only 2 must be created since the last one in line_groups.txt reference an unknown main_line_id
+    BOOST_REQUIRE_EQUAL(data.line_groups.size(), 2);
+    BOOST_REQUIRE_EQUAL(data.line_group_links.size(), 3);
+
+    // First group
+    BOOST_REQUIRE(data.line_groups[0]->main_line != nullptr);
+
+    BOOST_CHECK_EQUAL(data.line_groups[0]->main_line->uri, "l2");
+    BOOST_CHECK_EQUAL(data.line_group_links[0].line_group->uri, "lg1");
+    BOOST_CHECK_EQUAL(data.line_group_links[2].line_group->uri, "lg1");
+    BOOST_CHECK_EQUAL(data.line_group_links[0].line->uri, "l2");
+    BOOST_CHECK_EQUAL(data.line_group_links[2].line->uri, "l3");
+    BOOST_CHECK_EQUAL(data.line_group_links[0].line->uri, "l2");
+    BOOST_CHECK_EQUAL(data.line_group_links[2].line->uri, "l3");
+    BOOST_CHECK_EQUAL(data.line_group_links[0].is_main_line, true);
+    BOOST_CHECK_EQUAL(data.line_group_links[2].is_main_line, false);
+
+    // Second group, only one line, only defined as the main_line
+    BOOST_REQUIRE(data.line_groups[1]->main_line != nullptr);
+
+    BOOST_CHECK_EQUAL(data.line_groups[1]->main_line->uri, "l3");
+    BOOST_CHECK_EQUAL(data.line_group_links[1].line_group->uri, "lg2");
+    BOOST_CHECK_EQUAL(data.line_group_links[1].line->uri, "l3");
+    BOOST_CHECK_EQUAL(data.line_group_links[1].is_main_line, true);
 }
 

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -89,7 +89,7 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
                             return sp->is_zonal && sp->name == "Beleymas" && sp->area;
                         }), 1);
 
-    BOOST_REQUIRE_EQUAL(data.lines.size(), 1);
+    BOOST_REQUIRE_EQUAL(data.lines.size(), 3);
     BOOST_REQUIRE_EQUAL(data.routes.size(), 3);
 
     //chekc comments

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -114,6 +114,10 @@ bool Line::operator<(const Line& other) const {
     }
 }
 
+bool LineGroup::operator<(const LineGroup& other) const {
+    return this->name < other.name || (this->name == other.name && this < &other);
+}
+
 bool Route::operator<(const Route& other) const {
     if(this->line == other.line){
         BOOST_ASSERT(this->uri != other.uri);

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -115,7 +115,10 @@ bool Line::operator<(const Line& other) const {
 }
 
 bool LineGroup::operator<(const LineGroup& other) const {
-    return this->name < other.name || (this->name == other.name && this < &other);
+    if (this->name != other.name) {
+        return this->name < other.name;
+    }
+    return this->idx < other.idx;
 }
 
 bool Route::operator<(const Route& other) const {

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -224,6 +224,21 @@ struct Line : public Header, Nameable {
 
 };
 
+struct LineGroup : public Header, Nameable {
+    const static nt::Type_e type = nt::Type_e::LineGroup;
+    std::string name;
+    Line* main_line;
+    std::set<std::string> linkedLinesURI;
+
+    bool operator<(const LineGroup & other) const;
+};
+
+struct LineGroupLink {
+    LineGroup* line_group;
+    Line* line;
+    bool is_main_line;
+};
+
 struct Route : public Header, Nameable{
     const static nt::Type_e type = nt::Type_e::Route;
     Line * line;

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -235,7 +235,6 @@ struct LineGroup : public Header, Nameable {
 struct LineGroupLink {
     LineGroup* line_group;
     Line* line;
-    bool is_main_line;
 };
 
 struct Route : public Header, Nameable{

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -228,7 +228,6 @@ struct LineGroup : public Header, Nameable {
     const static nt::Type_e type = nt::Type_e::LineGroup;
     std::string name;
     Line* main_line;
-    std::set<std::string> linkedLinesURI;
 
     bool operator<(const LineGroup & other) const;
 };

--- a/source/jormungandr/jormungandr/interfaces/uri.py
+++ b/source/jormungandr/jormungandr/interfaces/uri.py
@@ -33,7 +33,7 @@ collections_to_resource_type = {
     "stop_points": "stop_point", "routes": "route",
     "networks": "network", "commercial_modes": "commercial_mode",
     "physical_modes": "physical_mode", "companies": "company",
-    "stop_areas": "stop_area", "lines": "line",
+    "stop_areas": "stop_area", "lines": "line", "line_groups": "line_group",
     "addresses": "address", "coords": "coord"}
 
 resource_type_to_collection = dict((resource_type, collection)
@@ -119,7 +119,7 @@ class Uri:
     def valid_resource_type(self, resource_type):
         resource_types = ["connections", "stop_points", "networks",
                           "commercial_modes", "physical_modes", "companies",
-                          "stop_areas", "routes", "lines", "addresses",
+                          "stop_areas", "routes", "lines", "line_groups", "addresses",
                           "administrative_regions", "coords", "pois"]
 
         return resource_type in resource_types

--- a/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
@@ -49,7 +49,7 @@ pt_objects = {
     "error": PbField(error, attribute='error'),
 }
 
-pt_object_type_values = ["network", "commercial_mode", "line", "route", "stop_area"]
+pt_object_type_values = ["network", "commercial_mode", "line", "line_group", "route", "stop_area"]
 
 
 class Ptobjects(ResourceUri):

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -34,8 +34,8 @@ from flask.ext.restful import fields, marshal_with, reqparse, abort
 from flask.globals import g
 from jormungandr import i_manager, authentication
 from converters_collection_type import collections_to_resource_type
-from fields import stop_point, stop_area, route, line, physical_mode, \
-    commercial_mode, company, network, pagination,\
+from fields import stop_point, stop_area, route, line, line_group, \
+    physical_mode, commercial_mode, company, network, pagination,\
     journey_pattern_point, NonNullList, poi, poi_type,\
     journey_pattern, connection, error, PbField
 from VehicleJourney import vehicle_journey
@@ -381,6 +381,29 @@ def routes(is_collection):
                             description="original uri of the object you"
                                     "want to query")
     return Routes
+
+
+def line_groups(is_collection):
+    class LineGroups(Uri):
+        """ Retrieves line_groups"""
+
+        def __init__(self):
+            Uri.__init__(self, is_collection, "line_groups")
+            self.collections = [
+                ("line_groups",
+                 NonNullList(fields.Nested(line_group,
+                                           display_null=False))),
+                ("pagination", PbField(pagination)),
+                ("error", PbField(error)),
+                ("disruptions", DisruptionsField),
+            ]
+            collections = marshal_with(OrderedDict(self.collections),
+                                       display_null=False)
+            self.method_decorators.insert(1, collections)
+            self.parsers["get"].add_argument("original_id", type=unicode,
+                            description="original uri of the object you"
+                                    "want to query")
+    return LineGroups
 
 
 def lines(is_collection):

--- a/source/jormungandr/jormungandr/interfaces/v1/converters_collection_type.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/converters_collection_type.py
@@ -31,7 +31,7 @@ collections_to_resource_type = {
     "stop_points": "stop_point", "routes": "route",
     "networks": "network", "commercial_modes": "commercial_mode",
     "physical_modes": "physical_mode", "companies": "company",
-    "stop_areas": "stop_area", "lines": "line",
+    "stop_areas": "stop_area", "lines": "line", "line_groups": "line_group",
     "addresses": "address", "coords": "coord",
     "journey_pattern_points": "journey_pattern_point",
     "journey_patterns": "journey_pattern",

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -512,7 +512,19 @@ stop_time = {
     "journey_pattern_point": NonNullProtobufNested(journey_pattern_point)
 }
 
+line_group = deepcopy(generic_type)
 line = deepcopy(generic_type)
+
+group_link = {
+    "is_main_line": fields.Boolean(),
+    "group": PbField(line_group)
+}
+
+line_link = {
+    "is_main_line": fields.Boolean(),
+    "line": PbField(line)
+}
+
 line["links"] = DisruptionLinks()
 line["code"] = fields.String()
 line["color"] = fields.String()
@@ -524,6 +536,10 @@ line["geojson"] = MultiLineString(attribute="geojson")
 line["opening_time"] = SplitDateTime(date=None, time="opening_time")
 line["closing_time"] = SplitDateTime(date=None, time="closing_time")
 line["properties"] = NonNullList(NonNullNested(prop))
+line["groups"] = NonNullList(NonNullNested(group_link))
+
+line_group["lines"] = NonNullList(NonNullNested(line_link))
+line_group["comments"] = NonNullList(NonNullNested(comment))
 
 route = deepcopy(generic_type)
 route["links"] = DisruptionLinks()

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -512,18 +512,8 @@ stop_time = {
     "journey_pattern_point": NonNullProtobufNested(journey_pattern_point)
 }
 
-line_group = deepcopy(generic_type)
 line = deepcopy(generic_type)
-
-group_link = {
-    "is_main_line": fields.Boolean(),
-    "group": PbField(line_group)
-}
-
-line_link = {
-    "is_main_line": fields.Boolean(),
-    "line": PbField(line)
-}
+line_group = deepcopy(generic_type)
 
 line["links"] = DisruptionLinks()
 line["code"] = fields.String()
@@ -536,9 +526,10 @@ line["geojson"] = MultiLineString(attribute="geojson")
 line["opening_time"] = SplitDateTime(date=None, time="opening_time")
 line["closing_time"] = SplitDateTime(date=None, time="closing_time")
 line["properties"] = NonNullList(NonNullNested(prop))
-line["groups"] = NonNullList(NonNullNested(group_link))
+line["groups"] = NonNullList(NonNullNested(line_group))
 
-line_group["lines"] = NonNullList(NonNullNested(line_link))
+line_group["lines"] = NonNullList(NonNullNested(line))
+line_group["main_line"] = PbField(line)
 line_group["comments"] = NonNullList(NonNullNested(comment))
 
 route = deepcopy(generic_type)

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -526,7 +526,7 @@ line["geojson"] = MultiLineString(attribute="geojson")
 line["opening_time"] = SplitDateTime(date=None, time="opening_time")
 line["closing_time"] = SplitDateTime(date=None, time="closing_time")
 line["properties"] = NonNullList(NonNullNested(prop))
-line["groups"] = NonNullList(NonNullNested(line_group))
+line["line_groups"] = NonNullList(NonNullNested(line_group))
 
 line_group["lines"] = NonNullList(NonNullNested(line))
 line_group["main_line"] = PbField(line)

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -147,7 +147,7 @@ class V1Routing(AModule):
                 collection + '.redirect',
                 Uri.Redirect)
 
-        collecs = ["routes", "lines", "networks", "stop_areas", "stop_points",
+        collecs = ["routes", "lines", "line_groups", "networks", "stop_areas", "stop_points",
                    "vehicle_journeys"]
         for collection in collecs:
             self.add_resource(getattr(Uri, collection)(True),

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -254,6 +254,9 @@ class Scenario(object):
     def lines(self, request, instance):
         return self.__on_ptref("lines", type_pb2.LINE, request, instance)
 
+    def line_groups(self, request, instance):
+        return self.__on_ptref("line_groups", type_pb2.LINE_GROUP, request, instance)
+
     def routes(self, request, instance):
         return self.__on_ptref("routes", type_pb2.ROUTE, request, instance)
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -603,7 +603,8 @@ def is_valid_line_group(line_group, depth_check=1):
     get_not_null(line_group, "id")
 
     if depth_check > 0:
-        is_valid_line(get_not_null(line_group, "main_line"), depth_check - 1)
+        # the main_line is always displayed with a depth of 0 to reduce duplicated informations
+        is_valid_line(get_not_null(line_group, "main_line"), 0)
         for l in line_group.get('lines', []):
             is_valid_line(l, depth_check - 1)
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -598,6 +598,13 @@ def is_valid_line(line, depth_check=1):
     g = line.get('geojson')
     g is None or shape(g) #TODO check length
 
+def is_valid_line_group(line_group, depth_check=1):
+    get_not_null(line_group, "name")
+    get_not_null(line_group, "id")
+
+    for l in line_group.get('lines', []):
+        get_not_null(l, "is_main_line")
+        is_valid_line(l.get('line'), 0)
 
 def is_valid_codes(codes):
     for code in codes:

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -602,9 +602,10 @@ def is_valid_line_group(line_group, depth_check=1):
     get_not_null(line_group, "name")
     get_not_null(line_group, "id")
 
-    for l in line_group.get('lines', []):
-        get_not_null(l, "is_main_line")
-        is_valid_line(l.get('line'), 0)
+    if depth_check > 0:
+        is_valid_line(get_not_null(line_group, "main_line"), depth_check - 1)
+        for l in line_group.get('lines', []):
+            is_valid_line(l, depth_check - 1)
 
 def is_valid_codes(codes):
     for code in codes:

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -119,7 +119,7 @@ class TestPtRef(AbstractTestFixture):
         assert physical_modes[0]['id'] == 'physical_mode:Car'
         assert physical_modes[0]['name'] == 'name physical_mode:Car'
 
-        group = get_not_null(l, 'groups')
+        group = get_not_null(l, 'line_groups')
         assert len(group) == 1
         assert group[0]['name'] == 'A group'
         assert group[0]['id'] == 'group:A'

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -119,27 +119,38 @@ class TestPtRef(AbstractTestFixture):
         assert physical_modes[0]['id'] == 'physical_mode:Car'
         assert physical_modes[0]['name'] == 'name physical_mode:Car'
 
-        group = get_not_null(l, 'line_groups')
-        assert len(group) == 1
-        assert group[0]['name'] == 'A group'
-        assert group[0]['id'] == 'group:A'
+        line_group = get_not_null(l, 'line_groups')
+        assert len(line_group) == 1
+        is_valid_line_group(line_group[0], depth_check=0)
+        assert line_group[0]['name'] == 'A group'
+        assert line_group[0]['id'] == 'group:A'
 
     def test_line_groups(self):
         """test line group formating"""
-        response = self.query_region("v1/line_groups")
+        # Test for each possible range to ensure main_line is always at a depth of 0
+        for depth in range(0,3):
+            response = self.query_region("line_groups?depth={0}".format(depth))
 
+            line_groups = get_not_null(response, 'line_groups')
+
+            assert len(line_groups) == 1
+
+            lg = line_groups[0]
+
+            is_valid_line_group(lg, depth_check=depth)
+
+            if depth > 0:
+                com = get_not_null(lg, 'comments')
+                assert len(com) == 1
+                assert com[0]['type'] == 'standard'
+                assert com[0]['value'] == "I'm a happy comment"
+
+        # test if line_groups are accessible through the ptref graph
+        response = self.query_region("routes/line:A:0/line_groups")
         line_groups = get_not_null(response, 'line_groups')
-
         assert len(line_groups) == 1
-
         lg = line_groups[0]
-
-        is_valid_line_group(lg, depth_check=1)
-
-        com = get_not_null(lg, 'comments')
-        assert len(com) == 1
-        assert com[0]['type'] == 'standard'
-        assert com[0]['value'] == "I'm a happy comment"
+        is_valid_line_group(lg)
 
     def test_line_codes(self):
         """test line formating"""

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -121,9 +121,8 @@ class TestPtRef(AbstractTestFixture):
 
         group = get_not_null(l, 'groups')
         assert len(group) == 1
-        assert group[0]['is_main_line'] == True
-        assert group[0]['group']['name'] == 'A group'
-        assert group[0]['group']['id'] == 'group:A'
+        assert group[0]['name'] == 'A group'
+        assert group[0]['id'] == 'group:A'
 
     def test_line_groups(self):
         """test line group formating"""

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -119,6 +119,29 @@ class TestPtRef(AbstractTestFixture):
         assert physical_modes[0]['id'] == 'physical_mode:Car'
         assert physical_modes[0]['name'] == 'name physical_mode:Car'
 
+        group = get_not_null(l, 'groups')
+        assert len(group) == 1
+        assert group[0]['is_main_line'] == True
+        assert group[0]['group']['name'] == 'A group'
+        assert group[0]['group']['id'] == 'group:A'
+
+    def test_line_groups(self):
+        """test line group formating"""
+        response = self.query_region("v1/line_groups")
+
+        line_groups = get_not_null(response, 'line_groups')
+
+        assert len(line_groups) == 1
+
+        lg = line_groups[0]
+
+        is_valid_line_group(lg, depth_check=1)
+
+        com = get_not_null(lg, 'comments')
+        assert len(com) == 1
+        assert com[0]['type'] == 'standard'
+        assert com[0]['value'] == "I'm a happy comment"
+
     def test_line_codes(self):
         """test line formating"""
         response = self.query_region("v1/lines/line:A?show_codes=true")

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -56,6 +56,7 @@ static nt::Type_e get_type(pbnavitia::NavitiaType pb_type) {
     case pbnavitia::STOP_AREA: return nt::Type_e::StopArea;
     case pbnavitia::STOP_POINT: return nt::Type_e::StopPoint;
     case pbnavitia::LINE: return nt::Type_e::Line;
+    case pbnavitia::LINE_GROUP: return nt::Type_e::LineGroup;
     case pbnavitia::ROUTE: return nt::Type_e::Route;
     case pbnavitia::JOURNEY_PATTERN: return nt::Type_e::JourneyPattern;
     case pbnavitia::NETWORK: return nt::Type_e::Network;

--- a/source/ptreferential/ptref_graph.cpp
+++ b/source/ptreferential/ptref_graph.cpp
@@ -110,6 +110,10 @@ Jointures::Jointures() {
     //from line to calendar
     boost::add_edge(vertex_map[Type_e::Calendar], vertex_map[Type_e::Line], g);
     boost::add_edge(vertex_map[Type_e::Line], vertex_map[Type_e::Calendar], g);
+
+    // from line_group to lines
+    boost::add_edge(vertex_map[Type_e::LineGroup], vertex_map[Type_e::Line], g);
+    boost::add_edge(vertex_map[Type_e::Line], vertex_map[Type_e::LineGroup], g);
 }
 
 // Retourne un map qui indique pour chaque type par quel type on peut l'atteindre

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -55,6 +55,10 @@ static pbnavitia::Response extract_data(const type::Data & data,
             fill_pb_object(data.pt_data->lines[idx], data, result.add_lines(),
                            depth, current_time, action_period, show_codes);
             break;
+        case Type_e::LineGroup:
+            fill_pb_object(data.pt_data->line_groups[idx], data, result.add_line_groups(),
+                           depth, current_time, action_period, show_codes);
+            break;
         case Type_e::JourneyPattern:
             fill_pb_object(data.pt_data->journey_patterns[idx], data,
                            result.add_journey_patterns(), depth, current_time, action_period);

--- a/source/sql/alembic/versions/291c8dbbaed1_create_line_group_and_line_group_link_.py
+++ b/source/sql/alembic/versions/291c8dbbaed1_create_line_group_and_line_group_link_.py
@@ -1,8 +1,8 @@
 """create line_group and line_group_link tables
 
 Revision ID: 291c8dbbaed1
-Revises: 3bea0b3cb116
-Create Date: 2015-05-12 15:24:02.969762
+Revises: 538bc4ea9cd1
+Create Date: 2015-06-18 17:18:35.194740
 
 """
 
@@ -20,16 +20,17 @@ def upgrade():
     sa.Column('id', sa.BIGINT(), nullable=False),
     sa.Column('uri', sa.TEXT(), nullable=False),
     sa.Column('name', sa.TEXT(), nullable=False),
-    sa.PrimaryKeyConstraint('id', name=u'line_group_pkey'),
+    sa.Column('main_line_id', sa.BIGINT(), nullable=False),
+    sa.ForeignKeyConstraint(['main_line_id'], [u'navitia.line.id'], name=u'line_group_line_id_fkey'),
+    sa.PrimaryKeyConstraint('id'),
     schema='navitia'
     )
     op.create_table('line_group_link',
     sa.Column('group_id', sa.BIGINT(), nullable=False),
     sa.Column('line_id', sa.BIGINT(), nullable=False),
-    sa.Column('is_main_line', sa.BOOLEAN(), nullable=False),
     sa.ForeignKeyConstraint(['group_id'], [u'navitia.line_group.id'], name=u'line_group_link_group_id_fkey'),
     sa.ForeignKeyConstraint(['line_id'], [u'navitia.line.id'], name=u'line_group_link_line_id_fkey'),
-    sa.PrimaryKeyConstraint('group_id', 'line_id', name=u'line_group_link_pkey'),
+    sa.PrimaryKeyConstraint('group_id', 'line_id'),
     schema='navitia'
     )
     op.execute("INSERT INTO navitia.object_type VALUES (25, 'LineGroup');")

--- a/source/sql/alembic/versions/291c8dbbaed1_create_line_group_and_line_group_link_.py
+++ b/source/sql/alembic/versions/291c8dbbaed1_create_line_group_and_line_group_link_.py
@@ -1,0 +1,41 @@
+"""create line_group and line_group_link tables
+
+Revision ID: 291c8dbbaed1
+Revises: 3bea0b3cb116
+Create Date: 2015-05-12 15:24:02.969762
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '291c8dbbaed1'
+down_revision = '538bc4ea9cd1'
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2 as ga
+
+
+def upgrade():
+    op.create_table('line_group',
+    sa.Column('id', sa.BIGINT(), nullable=False),
+    sa.Column('uri', sa.TEXT(), nullable=False),
+    sa.Column('name', sa.TEXT(), nullable=False),
+    sa.PrimaryKeyConstraint('id', name=u'line_group_pkey'),
+    schema='navitia'
+    )
+    op.create_table('line_group_link',
+    sa.Column('group_id', sa.BIGINT(), nullable=False),
+    sa.Column('line_id', sa.BIGINT(), nullable=False),
+    sa.Column('is_main_line', sa.BOOLEAN(), nullable=False),
+    sa.ForeignKeyConstraint(['group_id'], [u'navitia.line_group.id'], name=u'line_group_link_group_id_fkey'),
+    sa.ForeignKeyConstraint(['line_id'], [u'navitia.line.id'], name=u'line_group_link_line_id_fkey'),
+    sa.PrimaryKeyConstraint('group_id', 'line_id', name=u'line_group_link_pkey'),
+    schema='navitia'
+    )
+    op.execute("INSERT INTO navitia.object_type VALUES (25, 'LineGroup');")
+
+def downgrade():
+    op.drop_table('line_group_link', schema='navitia')
+    op.drop_table('line_group', schema='navitia')
+    op.execute("DELETE FROM navitia.object_type WHERE id = 25;")
+

--- a/source/sql/models/navitia.py
+++ b/source/sql/models/navitia.py
@@ -382,6 +382,19 @@ line = Table('line', metadata,*[
     ForeignKeyConstraint(['network_id'], [u'navitia.network.id'], name=u'line_network_id_fkey'),],
     schema='navitia')
 
+line_group = Table('line_group', metadata,*[
+    Column('id', BIGINT(), primary_key=True, nullable=False),
+    Column('uri', TEXT(), primary_key=False, nullable=False),
+    Column('name', TEXT(), primary_key=False),],
+    schema='navitia')
+
+line_group_link = Table('line_group_link', metadata,*[
+    Column('group_id', BIGINT(), primary_key=False, nullable=False),
+    Column('line_id', BIGINT(), primary_key=False, nullable=False),
+    Column('is_main_line', BOOLEAN(), primary_key=False),
+    ForeignKeyConstraint(['group_id'], [u'navitia.line_group.id'], name=u'line_group_link_group_id_fkey'),
+    ForeignKeyConstraint(['line_id'], [u'navitia.line.id'], name=u'line_group_link_line_id_fkey'),],
+    schema='navitia')
 
 calendar = Table('calendar', metadata,*[
     Column('id', BIGINT(), primary_key=True, nullable=False, default=text(u'nextval(\'"navitia".calendar_id_seq\'::regclass)')),

--- a/source/sql/models/navitia.py
+++ b/source/sql/models/navitia.py
@@ -385,13 +385,14 @@ line = Table('line', metadata,*[
 line_group = Table('line_group', metadata,*[
     Column('id', BIGINT(), primary_key=True, nullable=False),
     Column('uri', TEXT(), primary_key=False, nullable=False),
-    Column('name', TEXT(), primary_key=False),],
+    Column('name', TEXT(), primary_key=False, nullable=False),
+    Column('main_line_id', BIGINT(), primary_key=False, nullable=False),
+    ForeignKeyConstraint(['main_line_id'], [u'navitia.line.id'], name=u'line_group_line_id_fkey'),],
     schema='navitia')
 
 line_group_link = Table('line_group_link', metadata,*[
-    Column('group_id', BIGINT(), primary_key=False, nullable=False),
-    Column('line_id', BIGINT(), primary_key=False, nullable=False),
-    Column('is_main_line', BOOLEAN(), primary_key=False),
+    Column('group_id', BIGINT(), primary_key=True, nullable=False),
+    Column('line_id', BIGINT(), primary_key=True, nullable=False),
     ForeignKeyConstraint(['group_id'], [u'navitia.line_group.id'], name=u'line_group_link_group_id_fkey'),
     ForeignKeyConstraint(['line_id'], [u'navitia.line.id'], name=u'line_group_link_line_id_fkey'),],
     schema='navitia')

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -98,8 +98,6 @@ struct data_set {
         vj->validity_pattern->add(boost::gregorian::from_undelimited_string("20140101"),
                                   boost::gregorian::from_undelimited_string("20140111"), monday_cal->week_pattern);
 
-        b.data->complete();
-
         //we add some comments
         auto& comments = b.data->pt_data->comments;
         comments.add(b.data->pt_data->routes_map["line:A:0"], "I'm a happy comment");
@@ -129,6 +127,8 @@ struct data_set {
         b.lines["line:A"]->line_group_list.push_back(lg);
         comments.add(lg, "I'm a happy comment");
         b.data->pt_data->line_groups.push_back(lg);
+
+        b.data->complete();
     }
 
     ed::builder b;

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -126,7 +126,7 @@ struct data_set {
         lg->uri = "group:A";
         lg->main_line = b.lines["line:A"];
         lg->line_list.push_back(b.lines["line:A"]);
-        b.lines["line:A"]->group_list.push_back(std::make_pair(lg, true));
+        b.lines["line:A"]->line_group_list.push_back(lg);
         comments.add(lg, "I'm a happy comment");
         b.data->pt_data->line_groups.push_back(lg);
     }

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -120,6 +120,15 @@ struct data_set {
         cmp->uri = "CMP1";
         b.lines["line:A"]->company_list.push_back(cmp);
 
+        // LineGroup added
+        navitia::type::LineGroup* lg = new navitia::type::LineGroup();
+        lg->name = "A group";
+        lg->uri = "group:A";
+        lg->main_line = b.lines["line:A"];
+        lg->line_list.push_back(b.lines["line:A"]);
+        b.lines["line:A"]->group_list.push_back(std::make_pair(lg, true));
+        comments.add(lg, "I'm a happy comment");
+        b.data->pt_data->line_groups.push_back(lg);
     }
 
     ed::builder b;

--- a/source/type/comment_container.h
+++ b/source/type/comment_container.h
@@ -121,6 +121,7 @@ private:
             fusion_pair_comment_map<navitia::type::Line>,
             fusion_pair_comment_map<navitia::type::Route>,
             fusion_pair_comment_map<navitia::type::VehicleJourney>,
+            fusion_pair_comment_map<navitia::type::LineGroup>,
             boost::fusion::pair<navitia::type::StopTime, std::map<stop_time_key, comment_list>>
     > comment_map_type;
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -74,7 +74,7 @@ struct wrong_version : public navitia::exception {
 class Data : boost::noncopyable{
 public:
 
-    static const unsigned int data_version = 39; //< Data version number. *INCREMENT* every time serialized data are modified
+    static const unsigned int data_version = 40; //< Data version number. *INCREMENT* every time serialized data are modified
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -394,9 +394,7 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
         fill_pb_object(l->network, data, line->mutable_network(), depth-1, now, action_period, show_codes);
 
         for(const auto& group_pair : l->group_list) {
-            pbnavitia::GroupLink* group_link = line->add_groups();
-            group_link->set_is_main_line(group_pair.second);
-            fill_pb_object(group_pair.first, data, group_link->mutable_group(), depth-1, now, action_period, show_codes);
+            fill_pb_object(group_pair.first, data, line->add_groups(), depth-1, now, action_period, show_codes);
         }
     }
 
@@ -433,10 +431,9 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
 
     if(depth > 0) {
         for(const auto& line : lg->line_list) {
-            pbnavitia::LineLink* line_link = line_group->add_lines();
-            line_link->set_is_main_line(line->idx == lg->main_line->idx);
-            fill_pb_object(line, data, line_link->mutable_line(), depth-1, now, action_period, show_codes);
+            fill_pb_object(line, data, line_group->add_lines(), depth-1, now, action_period, show_codes);
         }
+        fill_pb_object(lg->main_line, data, line_group->mutable_main_line(), depth-1, now, action_period, show_codes);
     }
 }
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -393,8 +393,8 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
                 line->mutable_commercial_mode(), depth-1, now, action_period, show_codes);
         fill_pb_object(l->network, data, line->mutable_network(), depth-1, now, action_period, show_codes);
 
-        for(const auto& group_pair : l->group_list) {
-            fill_pb_object(group_pair.first, data, line->add_groups(), depth-1, now, action_period, show_codes);
+        for(const auto& line_group : l->line_group_list) {
+            fill_pb_object(line_group, data, line->add_line_groups(), depth-1, now, action_period, show_codes);
         }
     }
 
@@ -433,7 +433,7 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
         for(const auto& line : lg->line_list) {
             fill_pb_object(line, data, line_group->add_lines(), depth-1, now, action_period, show_codes);
         }
-        fill_pb_object(lg->main_line, data, line_group->mutable_main_line(), depth-1, now, action_period, show_codes);
+        fill_pb_object(lg->main_line, data, line_group->mutable_main_line(), 0, now, action_period, show_codes);
     }
 }
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -420,12 +420,6 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
 
-    for (const auto& comment: data.pt_data->comments.get(lg)) {
-        auto com = line_group->add_comments();
-        com->set_value(comment);
-        com->set_type("standard");
-    }
-
     line_group->set_name(lg->name);
     line_group->set_uri(lg->uri);
 
@@ -434,6 +428,12 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
             fill_pb_object(line, data, line_group->add_lines(), depth-1, now, action_period, show_codes);
         }
         fill_pb_object(lg->main_line, data, line_group->mutable_main_line(), 0, now, action_period, show_codes);
+
+        for (const auto& comment: data.pt_data->comments.get(lg)) {
+            auto com = line_group->add_comments();
+            com->set_value(comment);
+            com->set_type("standard");
+        }
     }
 }
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -544,6 +544,7 @@ std::vector<idx_t> Line::get(Type_e type, const PT_Data&) const {
     case Type_e::Network: result.push_back(network->idx); break;
     case Type_e::Route: return indexes(route_list);
     case Type_e::Calendar: return indexes(calendar_list);
+    case Type_e::LineGroup: return indexes(line_group_list);
     default: break;
     }
     return result;

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -329,6 +329,7 @@ static_data * static_data::get() {
         boost::assign::insert(temp->types_string)
                 (Type_e::ValidityPattern, "validity_pattern")
                 (Type_e::Line, "line")
+                (Type_e::LineGroup, "line_group")
                 (Type_e::JourneyPattern, "journey_pattern")
                 (Type_e::VehicleJourney, "vehicle_journey")
                 (Type_e::StopPoint, "stop_point")
@@ -554,6 +555,15 @@ type::hasOdtProperties Line::get_odt_properties() const{
         for (const auto route : this->route_list) {
             result |= route->get_odt_properties();
         }
+    }
+    return result;
+}
+
+std::vector<idx_t> LineGroup::get(Type_e type, const PT_Data&) const {
+    std::vector<idx_t> result;
+    switch(type) {
+    case Type_e::Line: return indexes(line_list);
+    default: break;
     }
     return result;
 }

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -620,7 +620,6 @@ struct Line : public Header, Nameable, HasMessages, Codes{
 
     std::map<std::string,std::string> properties;
 
-    //The bool part of the pair stand for "is_main_line"
     std::vector<LineGroup*> line_group_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
@@ -652,7 +651,6 @@ struct Line : public Header, Nameable, HasMessages, Codes{
 
 struct LineGroup : public Header, Nameable{
     const static Type_e type = Type_e::LineGroup;
-    std::string name;
 
     Line* main_line;
     std::vector<Line*> line_list;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -71,6 +71,7 @@ struct Impact;
 #define ITERATE_NAVITIA_PT_TYPES(FUN)\
     FUN(ValidityPattern, validity_patterns)\
     FUN(Line, lines)\
+    FUN(LineGroup, line_groups)\
     FUN(JourneyPattern, journey_patterns)\
     FUN(VehicleJourney, vehicle_journeys)\
     FUN(StopPoint, stop_points)\
@@ -110,7 +111,8 @@ enum class Type_e {
     Way                             = 21,
     Admin                           = 22,
     POIType                         = 23,
-    Calendar                        = 24
+    Calendar                        = 24,
+    LineGroup                       = 25
 };
 
 enum class Mode_e {
@@ -593,6 +595,8 @@ struct hasOdtProperties {
     }
 };
 
+struct LineGroup;
+
 struct Line : public Header, Nameable, HasMessages, Codes{
     const static Type_e type = Type_e::Line;
     std::string code;
@@ -616,12 +620,15 @@ struct Line : public Header, Nameable, HasMessages, Codes{
 
     std::map<std::string,std::string> properties;
 
+    //The bool part of the pair stand for "is_main_line"
+    std::vector<std::pair<LineGroup*, bool>> group_list;
+
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & code & forward_name & backward_name
                 & additional_data & color & sort & commercial_mode
                 & company_list & network & route_list & physical_mode_list
                 & impacts & calendar_list & codes & shape & closing_time
-                & opening_time & properties;
+                & opening_time & properties & group_list;
     }
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
 
@@ -641,6 +648,20 @@ struct Line : public Header, Nameable, HasMessages, Codes{
         return this < &other;
     }
     type::hasOdtProperties get_odt_properties() const;
+};
+
+struct LineGroup : public Header, Nameable{
+    const static Type_e type = Type_e::LineGroup;
+    std::string name;
+
+    Line* main_line;
+    std::vector<Line*> line_list;
+
+    template<class Archive> void serialize(Archive & ar, const unsigned int ) {
+        ar & idx & name & uri & main_line & line_list;
+    }
+    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    bool operator<(const LineGroup & other) const { return this < &other; }
 };
 
 struct Route : public Header, Nameable, HasMessages, Codes{

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -621,14 +621,14 @@ struct Line : public Header, Nameable, HasMessages, Codes{
     std::map<std::string,std::string> properties;
 
     //The bool part of the pair stand for "is_main_line"
-    std::vector<std::pair<LineGroup*, bool>> group_list;
+    std::vector<LineGroup*> line_group_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & code & forward_name & backward_name
                 & additional_data & color & sort & commercial_mode
                 & company_list & network & route_list & physical_mode_list
                 & impacts & calendar_list & codes & shape & closing_time
-                & opening_time & properties & group_list;
+                & opening_time & properties & line_group_list;
     }
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
 


### PR DESCRIPTION
This Pull Request add the concept of line_groups in navitia based on "Group of lines" in transmodel.
Things added : 
- 2 new tables in ed : 
  - line_group (id, uri, name),
  - line_group_link (group_id, line_id, is_main_line).
- 2 more files imported in fusio2ed : 
  - line_groups.txt (line_group_id, line_group_name, main_line_id),
  - line_group_links.txt (line_group_id, line_id).
- Necessary code to write to ed, read from ed and load in kraken,
- Necessary code to write to protobuf in kraken and read protobuf in jormungandr,
- New URL in jormungandr : http://<ip>/coverage/<instance>/v1/line_groups
  ![line_groups](https://cloud.githubusercontent.com/assets/5136553/8086759/4ab1367c-0f97-11e5-8096-b382e9997172.png)
- Output group in v1/lines if the line is part of one or more 
  ![line_with_group](https://cloud.githubusercontent.com/assets/5136553/8086781/739ba950-0f97-11e5-876a-5545ee6be12b.png)
- Unit test for fusio2ed, jormungandr integration and ptref.

Some .proto files have been modified but they are stored in another repository. It's necessary to merge the pull request from this repository (navitia-proto) first, since in this one, source/navitia-proto refers to a new commit. ( see https://github.com/CanalTP/navitia-proto/pull/1 )

Waiting for your feedback, let me know if there is anything to change / improve :) !
