### PR TITLE
Raptor: add a crow fly when no street network

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -266,7 +266,9 @@ VJ & VJ::operator()(const std::string & sp_name, int arrivee, int depart, uint16
     return *this;
 }
 
-SA::SA(builder & b, const std::string & sa_name, double x, double y, bool wheelchair_boarding) : b(b) {
+SA::SA(builder & b, const std::string & sa_name, double x, double y,
+       bool create_sp, bool wheelchair_boarding)
+       : b(b) {
     sa = new navitia::type::StopArea();
     sa->idx = b.data->pt_data->stop_areas.size();
     b.data->pt_data->stop_areas.push_back(sa);
@@ -278,19 +280,21 @@ SA::SA(builder & b, const std::string & sa_name, double x, double y, bool wheelc
         sa->set_property(types::hasProperties::WHEELCHAIR_BOARDING);
     b.sas[sa_name] = sa;
 
-    auto sp = new navitia::type::StopPoint();
-    sp->idx = b.data->pt_data->stop_points.size();
-    b.data->pt_data->stop_points.push_back(sp);
-    sp->name = "stop_point:"+ sa_name;
-    sp->uri = sp->name;
-    if(wheelchair_boarding)
-        sp->set_property(navitia::type::hasProperties::WHEELCHAIR_BOARDING);
-    sp->coord.set_lon(x);
-    sp->coord.set_lat(y);
+    if (create_sp) {
+        auto sp = new navitia::type::StopPoint();
+        sp->idx = b.data->pt_data->stop_points.size();
+        b.data->pt_data->stop_points.push_back(sp);
+        sp->name = "stop_point:"+ sa_name;
+        sp->uri = sp->name;
+        if(wheelchair_boarding)
+            sp->set_property(navitia::type::hasProperties::WHEELCHAIR_BOARDING);
+        sp->coord.set_lon(x);
+        sp->coord.set_lat(y);
 
-    sp->stop_area = sa;
-    b.sps[sp->name] = sp;
-    sa->stop_point_list.push_back(sp);
+        sp->stop_area = sa;
+        b.sps[sp->name] = sp;
+        sa->stop_point_list.push_back(sp);
+    }
 }
 
 SA & SA::operator()(const std::string & sp_name, double x, double y, bool wheelchair_boarding){
@@ -386,8 +390,9 @@ VJ builder::frequency_vj(const std::string& line_name,
 }
 
 
-SA builder::sa(const std::string &name, double x, double y, const bool wheelchair_boarding){
-    return SA(*this, name, x, y, wheelchair_boarding);
+SA builder::sa(const std::string &name, double x, double y,
+               const bool create_sp, const bool wheelchair_boarding) {
+    return SA(*this, name, x, y, create_sp, wheelchair_boarding);
 }
 
 

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -54,7 +54,7 @@ struct VJ {
     /// Construit un nouveau vehicle journey
     VJ(builder & b, const std::string &line_name, const std::string &validity_pattern,
        bool is_frequency,
-       const std::string & block_id, bool is_adapted = true, const std::string& uri="",
+       const std::string & block_id, bool wheelchair_boarding = true, const std::string& uri="",
        std::string meta_vj_name = "", std::string jp_uri = "", const std::string& physical_mode = "");
 
     /// Ajout un nouveau stopTime
@@ -76,10 +76,10 @@ struct SA {
 
     /// Construit un nouveau stopArea
     SA(builder & b, const std::string & sa_name, double x, double y,
-       bool create_sp = true, bool is_adapted = true);
+       bool create_sp = true, bool wheelchair_boarding = true);
 
     /// Construit un stopPoint appartenant au stopArea courant
-    SA & operator()(const std::string & sp_name, double x = 0, double y = 0, bool is_adapted = true);
+    SA & operator()(const std::string & sp_name, double x = 0, double y = 0, bool wheelchair_boarding = true);
 };
 
 
@@ -142,10 +142,10 @@ struct builder{
 
     /// Crée un nouveau stop area
     SA sa(const std::string & name, double x = 0, double y = 0,
-          const bool create_sp = true, const bool is_adapted = true);
+          const bool create_sp = true, const bool wheelchair_boarding = true);
     SA sa(const std::string & name, navitia::type::GeographicalCoord geo,
-          const bool create_sp = true, bool is_adapted = true) {
-        return sa(name, geo.lon(), geo.lat(), create_sp, is_adapted);
+          const bool create_sp = true, bool wheelchair_boarding = true) {
+        return sa(name, geo.lon(), geo.lat(), create_sp, wheelchair_boarding);
     }
 
     /// Crée une connexion

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -75,7 +75,8 @@ struct SA {
     navitia::type::StopArea* sa;
 
     /// Construit un nouveau stopArea
-    SA(builder & b, const std::string & sa_name, double x, double y, bool is_adapted = true);
+    SA(builder & b, const std::string & sa_name, double x, double y,
+       bool create_sp = true, bool is_adapted = true);
 
     /// Construit un stopPoint appartenant au stopArea courant
     SA & operator()(const std::string & sp_name, double x = 0, double y = 0, bool is_adapted = true);
@@ -140,8 +141,12 @@ struct builder{
                     const std::string& physical_mode = "");
 
     /// Crée un nouveau stop area
-    SA sa(const std::string & name, double x = 0, double y = 0, const bool is_adapted = true);
-    SA sa(const std::string & name, navitia::type::GeographicalCoord geo, bool is_adapted = true ){return sa(name,geo.lon(), geo.lat(), is_adapted);}
+    SA sa(const std::string & name, double x = 0, double y = 0,
+          const bool create_sp = true, const bool is_adapted = true);
+    SA sa(const std::string & name, navitia::type::GeographicalCoord geo,
+          const bool create_sp = true, bool is_adapted = true) {
+        return sa(name, geo.lon(), geo.lat(), create_sp, is_adapted);
+    }
 
     /// Crée une connexion
     void connection(const std::string & name1, const std::string & name2, float length);

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -255,12 +255,16 @@ PathFinder::find_nearest_stop_points(navitia::time_duration radius,
         // if no street network, return stop_points that are within
         // radius distance (with sqrt(2) security factor)
         std::vector<std::pair<type::idx_t, navitia::time_duration>> result;
-        for (auto element: elements) {
-            navitia::time_duration duration =
-                    crow_fly_duration(start_coord.distance_to(element.second)) * sqrt(2);
-            if (duration < radius) {
-                result.push_back({element.first, duration});
-                distance_to_entry_point[routing::SpIdx(element.first)] = duration;
+        // if we are not dealing with 0,0 coordinates (incorrect data), allow crow fly
+        if(start_coord != type::GeographicalCoord(0, 0)) {
+            for (auto element: elements) {
+                navitia::time_duration duration =
+                        crow_fly_duration(start_coord.distance_to(element.second)) * sqrt(2);
+                // if the radius is still ok with sqrt(2) factor
+                if (duration < radius) {
+                    result.push_back({element.first, duration});
+                    distance_to_entry_point[routing::SpIdx(element.first)] = duration;
+                }
             }
         }
         return result;

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -258,7 +258,10 @@ PathFinder::find_nearest_stop_points(navitia::time_duration radius,
         std::vector<std::pair<type::idx_t, navitia::time_duration>> result;
         // if we are not dealing with 0,0 coordinates (incorrect data), allow crow fly
         if(start_coord != type::GeographicalCoord(0, 0)) {
-            for (auto element: elements) {
+            for (const auto& element: elements) {
+                if (element.second == type::GeographicalCoord(0, 0)) {
+                    continue;
+                }
                 navitia::time_duration duration =
                         crow_fly_duration(start_coord.distance_to(element.second)) * sqrt(2);
                 // if the radius is still ok with sqrt(2) factor

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -182,6 +182,7 @@ void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mod
     this->start_coord = start_coord;
     starting_edge = ProjectionData(start_coord, this->geo_ref, offset, this->geo_ref.pl);
 
+    distance_to_entry_point.clear();
     //we initialize the distances to the maximum value
     size_t n = boost::num_vertices(geo_ref.graph);
     distances.assign(n, bt::pos_infin);
@@ -261,9 +262,10 @@ PathFinder::find_nearest_stop_points(navitia::time_duration radius,
                 navitia::time_duration duration =
                         crow_fly_duration(start_coord.distance_to(element.second)) * sqrt(2);
                 // if the radius is still ok with sqrt(2) factor
-                if (duration < radius) {
+                auto sp_idx = routing::SpIdx(element.first);
+                if (duration < radius && distance_to_entry_point.count(sp_idx) == 0) {
                     result.push_back({element.first, duration});
-                    distance_to_entry_point[routing::SpIdx(element.first)] = duration;
+                    distance_to_entry_point[sp_idx] = duration;
                 }
             }
         }

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -30,6 +30,7 @@ www.navitia.io
 
 #pragma once
 #include "georef.h"
+#include "routing/raptor_utils.h"
 #include "type/time_duration.h"
 #include <boost/graph/filtered_graph.hpp>
 #include <boost/graph/two_bit_color_map.hpp>
@@ -108,6 +109,9 @@ struct PathFinder {
     nt::Mode_e mode;
     float speed_factor = 0.;
 
+    /// Distance map between entry point and stop point
+    std::map<routing::SpIdx, navitia::time_duration> distance_to_entry_point;
+
     /// Distance array for the Dijkstra
     std::vector<navitia::time_duration> distances;
 
@@ -180,6 +184,11 @@ private:
 
     /// Build a path with a destination and the predecessors list
     Path build_path(vertex_t best_destination) const;
+
+    /// compute the reachable stop points within the radius with a simple crow fly
+    std::vector<std::pair<type::idx_t, type::GeographicalCoord>>
+    crow_fly_find_nearest_stop_points(navitia::time_duration radius,
+                                      const proximitylist::ProximityList<type::idx_t>& pl);
 
 #ifdef _DEBUG_DIJKSTRA_QUANTUM_
     void dump_dijkstra_for_quantum(const ProjectionData& target);

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -592,7 +592,7 @@ class Journeys(ResourceUri, ResourceUtc):
             profile = travelers_profile[args['traveler_type']]
             profile.override_params(args)
 
-        if args['max_duration_to_pt']:
+        if args['max_duration_to_pt'] is not None:
             #retrocompatibility: max_duration_to_pt override all individual value by mode
             args['max_walking_duration_to_pt'] = args['max_duration_to_pt']
             args['max_bike_duration_to_pt'] = args['max_duration_to_pt']

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -333,6 +333,8 @@ class SectionGeoJson(fields.Raw):
 
         if obj.type == response_pb2.STREET_NETWORK:
             coords = obj.street_network.coordinates
+        elif obj.type == response_pb2.CROW_FLY and len(obj.shape) != 0:
+            coords = obj.shape
         elif obj.type == response_pb2.PUBLIC_TRANSPORT:
             coords = obj.shape
         elif obj.type == response_pb2.TRANSFER:

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -221,31 +221,31 @@ def get_or_default(request, val, default):
     return default
 
 def updated_request_with_default(request, instance):
-    if not request['max_walking_duration_to_pt']:
+    if request['max_walking_duration_to_pt'] is None:
         request['max_walking_duration_to_pt'] = instance.max_walking_duration_to_pt
 
-    if not request['max_bike_duration_to_pt']:
+    if request['max_bike_duration_to_pt'] is None:
         request['max_bike_duration_to_pt'] = instance.max_bike_duration_to_pt
 
-    if not request['max_bss_duration_to_pt']:
+    if request['max_bss_duration_to_pt'] is None:
         request['max_bss_duration_to_pt'] = instance.max_bss_duration_to_pt
 
-    if not request['max_car_duration_to_pt']:
+    if request['max_car_duration_to_pt'] is None:
         request['max_car_duration_to_pt'] = instance.max_car_duration_to_pt
 
-    if not request['max_transfers']:
+    if request['max_transfers'] is None:
         request['max_transfers'] = instance.max_nb_transfers
 
-    if not request['walking_speed']:
+    if request['walking_speed'] is None:
         request['walking_speed'] = instance.walking_speed
 
-    if not request['bike_speed']:
+    if request['bike_speed'] is None:
         request['bike_speed'] = instance.bike_speed
 
-    if not request['bss_speed']:
+    if request['bss_speed'] is None:
         request['bss_speed'] = instance.bss_speed
 
-    if not request['car_speed']:
+    if request['car_speed'] is None:
         request['car_speed'] = instance.car_speed
 
 def change_ids(new_journeys, journey_count):

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -462,6 +462,8 @@ def is_valid_journey(journey, tester, query):
     request = get_valid_datetime(journey['requested_date_time'])
 
     assert arrival >= departure
+    # test if duration time is consistent with arrival and departure
+    # as we sometimes loose a second in rounding section duration, tolerance is added
     assert (arrival - departure).seconds - journey['duration'] <= len(journey['sections']) - 1
 
     if 'datetime_represents' not in query or query['datetime_represents'] == "departure":

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -448,12 +448,8 @@ def is_valid_journey_response(response, tester, query_str):
             assert query_dict[k] == v, "we must have the same query"
 
     feed_publishers = get_not_null(response, "feed_publishers")
-    feed_publisher = feed_publishers[0]
-    is_valid_feed_publisher(feed_publisher)
-    assert (feed_publisher["id"] == "builder")
-    assert (feed_publisher["name"] == 'routing api data')
-    assert (feed_publisher["license"] == "ODBL")
-    assert (feed_publisher["url"] == "www.canaltp.fr")
+    for feed_publisher in feed_publishers:
+        is_valid_feed_publisher(feed_publisher)
 
 
 def is_valid_journey(journey, tester, query):

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -462,6 +462,7 @@ def is_valid_journey(journey, tester, query):
     request = get_valid_datetime(journey['requested_date_time'])
 
     assert arrival >= departure
+    assert (arrival - departure).seconds - journey['duration'] <= len(journey['sections']) - 1
 
     if 'datetime_represents' not in query or query['datetime_represents'] == "departure":
         #for 'departure after' query, the departure must be... after \o/
@@ -482,6 +483,7 @@ def is_valid_journey(journey, tester, query):
         g = s.get('geojson')
         g is None or shape(g)
 
+    assert last_arrival == arrival
     assert get_valid_datetime(journey['sections'][-1]['arrival_date_time']) == last_arrival
 
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -246,6 +246,13 @@ class TestPtRef(AbstractTestFixture):
         company = companies[0]
         assert company['id'] == 'CMP1'
 
+    def test_simple_crow_fly(self):
+        journey_basic_query = "journeys?from=9;9.001&to=stop_area%3Astop2&datetime=20140105T000000"
+        response = self.query_region(journey_basic_query)
+
+        #the response must be still valid (this test the kraken data reloading)
+        is_valid_journey_response(response, self.tester, journey_basic_query)
+
 @dataset(["main_routing_test"])
 class TestPtRefPlace(AbstractTestFixture):
 

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -48,6 +48,14 @@ class TestJourneys(AbstractTestFixture):
 
         is_valid_journey_response(response, self.tester, journey_basic_query)
 
+        feed_publishers = get_not_null(response, "feed_publishers")
+        assert (len(feed_publishers) == 1)
+        feed_publisher = feed_publishers[0]
+        assert (feed_publisher["id"] == "builder")
+        assert (feed_publisher["name"] == 'routing api data')
+        assert (feed_publisher["license"] == "ODBL")
+        assert (feed_publisher["url"] == "www.canaltp.fr")
+
     def test_error_on_journeys(self):
         """ if we got an error with kraken, an error should be returned"""
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -318,9 +318,10 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                                               path.items.front().departures.front() + bt::minutes(1));
                 const time_duration& crow_fly_duration = find_or_default(SpIdx(*departure_stop_point),
                                             worker.departure_path_finder.distance_to_entry_point);
+                departure_time = path.items.front().departures.front()- crow_fly_duration.to_posix();
                 fill_crowfly_section(origin, destination_tmp, crow_fly_duration,
                                      get_crowfly_mode(sn_departure_path),
-                                     path.items.front().departures.front(), d, enhanced_response,
+                                     departure_time, d, enhanced_response,
                                      pb_journey, now, action_period);
 
             } else if (!sn_departure_path.path_items.empty()) {
@@ -529,6 +530,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                                               path.items.back().departures.back()+bt::minutes(1));
                 const time_duration& crow_fly_duration = find_or_default(SpIdx(*arrival_stop_point),
                                                 worker.arrival_path_finder.distance_to_entry_point);
+                arrival_time = arrival_time + crow_fly_duration.to_posix();
                 fill_crowfly_section(origin_tmp, destination, crow_fly_duration,
                                      get_crowfly_mode(sn_arrival_path),
                                      path.items.back().departures.back(), d, enhanced_response,

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -329,7 +329,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                 //exactly the routing one
                 nt::GeographicalCoord routing_first_coord = departure_stop_point->coord;
                 if (sn_departure_path.path_items.back().coordinates.back() != routing_first_coord) {
-                    //if it's the case, we artificialy add the missing segment
+                    //if it's the case, we artificially add the missing segment
                     sn_departure_path.path_items.back().coordinates.push_back(routing_first_coord);
                 }
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -721,12 +721,16 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
                 || ep.type == type::Type_e::POI) {
         std::set<SpIdx> stop_points;
 
+        georef::PathFinder& concerned_path_finder = use_second ? worker.arrival_path_finder :
+                                                                worker.departure_path_finder;
+
         if (ep.type == type::Type_e::StopArea) {
             auto it = data.pt_data->stop_areas_map.find(ep.uri);
             if (it!= data.pt_data->stop_areas_map.end()) {
                 for (auto stop_point : it->second->stop_point_list) {
                     const SpIdx sp_idx = SpIdx(*stop_point);
                     if (stop_points.find(sp_idx) == stop_points.end()) {
+                        concerned_path_finder.distance_to_entry_point[sp_idx] = {};
                         result.push_back({sp_idx, {}});
                         stop_points.insert(sp_idx);
                     }
@@ -741,6 +745,7 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
             for (const auto* odt_admin_stop_point: admin->odt_stop_points) {
                 const SpIdx sp_idx = SpIdx(*odt_admin_stop_point);
                 if (stop_points.find(sp_idx) == stop_points.end()) {
+                    concerned_path_finder.distance_to_entry_point[sp_idx] = {};
                     result.push_back({sp_idx, {}});
                     stop_points.insert(sp_idx);
                 }
@@ -752,6 +757,7 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
         for (const auto* sp: zonal_sps) {
             const SpIdx sp_idx = SpIdx(*sp);
             if (stop_points.find(sp_idx) == stop_points.end()) {
+                concerned_path_finder.distance_to_entry_point[sp_idx] = {};
                 result.push_back({sp_idx, {}});
                 stop_points.insert(sp_idx);
             }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -314,6 +314,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             if (use_crow_fly(origin, path.items.front().stop_points.front(), sn_departure_path, d)){
                 const auto& sp_dest = path.items.front().stop_points.front();
                 type::EntryPoint destination_tmp(type::Type_e::StopPoint, sp_dest->uri);
+                destination_tmp.coordinates = sp_dest->coord;
                 bt::time_period action_period(path.items.front().departures.front(),
                                               path.items.front().departures.front() + bt::minutes(1));
                 const time_duration& crow_fly_duration = find_or_default(
@@ -526,6 +527,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             if (use_crow_fly(destination, path.items.back().stop_points.back(), sn_arrival_path, d)) {
                 const auto sp_orig = path.items.back().stop_points.back();
                 type::EntryPoint origin_tmp(type::Type_e::StopPoint, sp_orig->uri);
+                origin_tmp.coordinates = sp_orig->coord;
                 bt::time_period action_period(path.items.back().departures.back(),
                                               path.items.back().departures.back()+bt::minutes(1));
                 const time_duration& crow_fly_duration = find_or_default(

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -311,15 +311,13 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             const auto& departure_stop_point = path.items.front().stop_points.front();
             georef::Path sn_departure_path = worker.get_path(departure_stop_point->idx);
 
-            if (use_crow_fly(origin, path.items.front().stop_points.front(), sn_departure_path, d)){
-                const auto& sp_dest = path.items.front().stop_points.front();
-                type::EntryPoint destination_tmp(type::Type_e::StopPoint, sp_dest->uri);
-                destination_tmp.coordinates = sp_dest->coord;
+            if (use_crow_fly(origin, departure_stop_point, sn_departure_path, d)){
+                type::EntryPoint destination_tmp(type::Type_e::StopPoint, departure_stop_point->uri);
+                destination_tmp.coordinates = departure_stop_point->coord;
                 bt::time_period action_period(path.items.front().departures.front(),
                                               path.items.front().departures.front() + bt::minutes(1));
-                const time_duration& crow_fly_duration = find_or_default(
-                        SpIdx(*path.items.front().stop_points.front()),
-                        worker.departure_path_finder.distance_to_entry_point);
+                const time_duration& crow_fly_duration = find_or_default(SpIdx(*departure_stop_point),
+                                            worker.departure_path_finder.distance_to_entry_point);
                 fill_crowfly_section(origin, destination_tmp, crow_fly_duration,
                                      get_crowfly_mode(sn_departure_path),
                                      path.items.front().departures.front(), d, enhanced_response,
@@ -521,18 +519,16 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             // last is 'taxi like' ODT, we do nothing, there is no walking nor crow fly section,
             // but we have to updated the end of the journey
         } else if (!path.items.empty() && !path.items.back().stop_points.empty()) {
-            const auto& arrival_stop_point = path.items.back().stop_points.back();
+            const auto arrival_stop_point = path.items.back().stop_points.back();
             georef::Path sn_arrival_path = worker.get_path(arrival_stop_point->idx, true);
 
-            if (use_crow_fly(destination, path.items.back().stop_points.back(), sn_arrival_path, d)) {
-                const auto sp_orig = path.items.back().stop_points.back();
-                type::EntryPoint origin_tmp(type::Type_e::StopPoint, sp_orig->uri);
-                origin_tmp.coordinates = sp_orig->coord;
+            if (use_crow_fly(destination, arrival_stop_point, sn_arrival_path, d)) {
+                type::EntryPoint origin_tmp(type::Type_e::StopPoint, arrival_stop_point->uri);
+                origin_tmp.coordinates = arrival_stop_point->coord;
                 bt::time_period action_period(path.items.back().departures.back(),
                                               path.items.back().departures.back()+bt::minutes(1));
-                const time_duration& crow_fly_duration = find_or_default(
-                        SpIdx(*path.items.front().stop_points.front()),
-                        worker.arrival_path_finder.distance_to_entry_point);
+                const time_duration& crow_fly_duration = find_or_default(SpIdx(*arrival_stop_point),
+                                                worker.arrival_path_finder.distance_to_entry_point);
                 fill_crowfly_section(origin_tmp, destination, crow_fly_duration,
                                      get_crowfly_mode(sn_arrival_path),
                                      path.items.back().departures.back(), d, enhanced_response,

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -73,18 +73,28 @@ std::string PathItem::print() const {
 }
 
 
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point, const type::Data& data){
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point,
+                  const georef::Path& street_network_path, const type::Data& data) {
+    if (point.type == type::Type_e::StopPoint && point.uri == stop_point->uri) {
+        return false;
+    }
+    if (street_network_path.path_items.empty()) {
+        return true;
+    }
     if(point.type == type::Type_e::StopArea){
-        //if we have a stop area in the request, we only do a crowfly section if the used stop point belongs to this stop area
+        //if we have a stop area in the request,
+        //we only do a crowfly section if the used stop point belongs to this stop area
         return point.uri == stop_point->stop_area->uri;
     }else if(point.type == type::Type_e::Admin){
-        //if we have a admin in the request, we only do a crowfly section if the used stop point belongs to this admin
+        //if we have an admin in the request,
+        //we only do a crowfly section if the used stop point belongs to this admin
         auto admin_it = find_if(begin(stop_point->stop_area->admin_list), end(stop_point->stop_area->admin_list),
                 [point](const navitia::georef::Admin* admin){return (admin->uri == point.uri);});
         if(admin_it != end(stop_point->stop_area->admin_list)){
             return true;
         }else{//we handle the main_stop_area of an admin here
-            //we want a crowfly for all main_stop_areas of a admin, even if the stop_area is not in the admin
+            //we want a crowfly for all main_stop_areas of an admin,
+            //even if the stop_area is not in the admin
             auto admin = data.geo_ref->admins[data.geo_ref->admin_map[point.uri]];
             auto it = find_if(begin(admin->main_stop_areas), end(admin->main_stop_areas),
                     [stop_point](const type::StopArea* stop_area){return stop_area == stop_point->stop_area;});

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -30,6 +30,7 @@ www.navitia.io
 
 #pragma once
 
+#include "georef/street_network.h"
 #include "type/pt_data.h"
 #include "type/datetime.h"
 
@@ -127,12 +128,18 @@ struct Path {
 bool operator==(const PathItem & a, const PathItem & b);
 
 /**
- * Choose if we must use a crowfly or a streetnework for a section. This function is call for the first and last section of a journey
+ * Choose if we must use a crowfly or a streetnework for a section.
+ * This function is called for the first and last section of a journey.
  *
- * @param point: the object where we are going/coming: the requested origin for the first section or the destination for the last section
- * @param stop_point: for the first section, the stop point where we are going, or for the last section the stop point from where we come
+ * @param point: the object where we are going/from where we are coming:
+ *               the requested origin for the first section or the destination for the last section
+ * @param stop_point: for the first section, the stop point where we are going,
+ *                    or for the last section the stop point from where we come
+ * @param street_network_path: the street network path between point and stop_point
+ * @param data: reference datas of the instance
  */
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point, const type::Data& data);
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point,
+                  const georef::Path& street_network_path, const type::Data& data);
 
 
 }}

--- a/source/routing/tests/co2_emission_test.cpp
+++ b/source/routing/tests/co2_emission_test.cpp
@@ -80,8 +80,8 @@ BOOST_AUTO_TEST_CASE(co2_emission_higher_0) {
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
-    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 1);
-    pbnavitia::Section section = resp.journeys(0).sections(0);
+    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);
+    pbnavitia::Section section = resp.journeys(0).sections(1);
     pbnavitia::Co2Emission co2_emission = section.co2_emission();
     int32_t distance = dep->coord.distance_to(arr->coord);
     BOOST_REQUIRE_EQUAL(co2_emission.unit(), "gEC");
@@ -119,8 +119,8 @@ BOOST_AUTO_TEST_CASE(co2_emission_equal_0) {
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
-    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 1);
-    pbnavitia::Section section = resp.journeys(0).sections(0);
+    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);
+    pbnavitia::Section section = resp.journeys(0).sections(1);
     pbnavitia::Co2Emission co2_emission = section.co2_emission();
     BOOST_REQUIRE_EQUAL(co2_emission.unit(), "gEC");
     BOOST_REQUIRE_EQUAL(co2_emission.value(), 0.);
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_lower_0) {
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
-    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 1);
-    pbnavitia::Section section = resp.journeys(0).sections(0);
+    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);
+    pbnavitia::Section section = resp.journeys(0).sections(1);
     BOOST_REQUIRE_EQUAL(section.has_co2_emission(), false);
 }

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -69,6 +69,8 @@ struct data_set {
         }
         b.data->pt_data->calendars.push_back(monday_cal);
         //add lines
+        b.sa("stop_area:stop1", 9, 9, false, true)("stop_area:stop1", 9, 9);
+        b.sa("stop_area:stop2", 10, 10, false, true)("stop_area:stop2", 10, 10);
         b.vj("line:A", "", "", true, "vj1", "", "", "physical_mode:Car")
                 ("stop_area:stop1", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)
                 ("stop_area:stop2", 11 * 3600 + 10 * 60, 11 * 3600 + 10 * 60);
@@ -129,6 +131,7 @@ struct data_set {
         b.data->pt_data->line_groups.push_back(lg);
 
         b.data->complete();
+        b.data->build_raptor();
     }
 
     ed::builder b;

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -627,6 +627,8 @@ Type_e Data::get_type_of_id(const std::string & id) const {
         return Type_e::Address;
     if(id.size()>6 && id.substr(0,6) == "admin:")
         return Type_e::Admin;
+    if(id.size()>10 && id.substr(0,10) == "stop_area:")
+        return Type_e::StopArea;
     #define GET_TYPE(type_name, collection_name) \
     const auto &collection_name##_map = pt_data->collection_name##_map;\
     if(collection_name##_map.count(id) != 0 )\

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1072,14 +1072,14 @@ void fill_pb_placemark(const type::EntryPoint& point, const type::Data &data,
 
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
                           const time_duration& crow_fly_duration, type::Mode_e mode,
-                          boost::posix_time::ptime time, const type::Data& data, EnhancedResponse& response,
-                          pbnavitia::Journey* pb_journey, const pt::ptime& now,
-                          const pt::time_period& action_period) {
+                          boost::posix_time::ptime origin_time, const type::Data& data,
+                          EnhancedResponse& response, pbnavitia::Journey* pb_journey,
+                          const pt::ptime& now, const pt::time_period& action_period) {
     pbnavitia::Section* section = pb_journey->add_sections();
     section->set_id(response.register_section());
     fill_pb_placemark(origin, data, section->mutable_origin(), 2, now, action_period);
     fill_pb_placemark(destination, data, section->mutable_destination(), 2, now, action_period);
-    section->set_begin_date_time(navitia::to_posix_timestamp(time));
+    section->set_begin_date_time(navitia::to_posix_timestamp(origin_time));
     section->set_duration(crow_fly_duration.total_seconds());
     if(crow_fly_duration.total_seconds() > 0){
         section->set_length(origin.coordinates.distance_to(destination.coordinates));
@@ -1092,7 +1092,7 @@ void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint
     }else{
         section->set_length(0);
     }
-    section->set_end_date_time(navitia::to_posix_timestamp(time));
+    section->set_end_date_time(navitia::to_posix_timestamp(origin_time + crow_fly_duration.to_posix()));
     section->set_type(pbnavitia::SectionType::CROW_FLY);
 
     //we want to store the transportation mode used

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1071,7 +1071,7 @@ void fill_pb_placemark(const type::EntryPoint& point, const type::Data &data,
 }
 
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
-                          type::Mode_e mode,
+                          const time_duration& crow_fly_duration, type::Mode_e mode,
                           boost::posix_time::ptime time, const type::Data& data, EnhancedResponse& response,
                           pbnavitia::Journey* pb_journey, const pt::ptime& now,
                           const pt::time_period& action_period) {
@@ -1080,7 +1080,7 @@ void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint
     fill_pb_placemark(origin, data, section->mutable_origin(), 2, now, action_period);
     fill_pb_placemark(destination, data, section->mutable_destination(), 2, now, action_period);
     section->set_begin_date_time(navitia::to_posix_timestamp(time));
-    section->set_duration(0);
+    section->set_duration(crow_fly_duration.total_seconds());
     section->set_length(0);
     section->set_end_date_time(navitia::to_posix_timestamp(time));
     section->set_type(pbnavitia::SectionType::CROW_FLY);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1081,7 +1081,7 @@ void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint
     fill_pb_placemark(destination, data, section->mutable_destination(), 2, now, action_period);
     section->set_begin_date_time(navitia::to_posix_timestamp(origin_time));
     section->set_duration(crow_fly_duration.total_seconds());
-    if(crow_fly_duration.total_seconds() > 0){
+    if (crow_fly_duration.total_seconds() > 0) {
         section->set_length(origin.coordinates.distance_to(destination.coordinates));
         auto* new_coord = section->add_shape();
         new_coord->set_lon(origin.coordinates.lon());
@@ -1089,7 +1089,7 @@ void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint
         new_coord = section->add_shape();
         new_coord->set_lon(destination.coordinates.lon());
         new_coord->set_lat(destination.coordinates.lat());
-    }else{
+    } else {
         section->set_length(0);
     }
     section->set_end_date_time(navitia::to_posix_timestamp(origin_time + crow_fly_duration.to_posix()));

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1081,7 +1081,17 @@ void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint
     fill_pb_placemark(destination, data, section->mutable_destination(), 2, now, action_period);
     section->set_begin_date_time(navitia::to_posix_timestamp(time));
     section->set_duration(crow_fly_duration.total_seconds());
-    section->set_length(0);
+    if(crow_fly_duration.total_seconds() > 0){
+        section->set_length(origin.coordinates.distance_to(destination.coordinates));
+        auto* new_coord = section->add_shape();
+        new_coord->set_lon(origin.coordinates.lon());
+        new_coord->set_lat(origin.coordinates.lat());
+        new_coord = section->add_shape();
+        new_coord->set_lon(destination.coordinates.lon());
+        new_coord->set_lat(destination.coordinates.lat());
+    }else{
+        section->set_length(0);
+    }
     section->set_end_date_time(navitia::to_posix_timestamp(time));
     section->set_type(pbnavitia::SectionType::CROW_FLY);
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -154,7 +154,7 @@ inline pbnavitia::StopPoint* get_sub_object(const type::StopPoint*, pbnavitia::P
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
                           const time_duration& crow_fly_duration, type::Mode_e mode,
                           boost::posix_time::ptime origin_time, const type::Data& data,
-                          EnhancedResponse &response,  pbnavitia::Journey* pb_journey,
+                          EnhancedResponse& response,  pbnavitia::Journey* pb_journey,
                           const pt::ptime& now, const pt::time_period& action_period);
 
 void fill_fare_section(EnhancedResponse& pb_response, pbnavitia::Journey* pb_journey, const fare::results& fare);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -153,7 +153,7 @@ inline pbnavitia::StopPoint* get_sub_object(const type::StopPoint*, pbnavitia::P
 
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
                           const time_duration& crow_fly_duration, type::Mode_e mode,
-                          boost::posix_time::ptime time, const type::Data& data,
+                          boost::posix_time::ptime origin_time, const type::Data& data,
                           EnhancedResponse &response,  pbnavitia::Journey* pb_journey,
                           const pt::ptime& now, const pt::time_period& action_period);
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -151,8 +151,10 @@ inline pbnavitia::StopArea* get_sub_object(const type::StopArea*, pbnavitia::PtO
 inline pbnavitia::StopPoint* get_sub_object(const type::StopPoint*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_stop_point(); }
 
 
-void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination, type::Mode_e mode, boost::posix_time::ptime time,
-                          const type::Data& data, EnhancedResponse &response,  pbnavitia::Journey* pb_journey,
+void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
+                          const time_duration& crow_fly_duration, type::Mode_e mode,
+                          boost::posix_time::ptime time, const type::Data& data,
+                          EnhancedResponse &response,  pbnavitia::Journey* pb_journey,
                           const pt::ptime& now, const pt::time_period& action_period);
 
 void fill_fare_section(EnhancedResponse& pb_response, pbnavitia::Journey* pb_journey, const fare::results& fare);


### PR DESCRIPTION
 add a crow fly when no street network at the departure or arrival
fix http://jira.canaltp.fr/browse/NAVP-201

Use-case :
For fr-ne, Gare de l'Est (which is not in the street network coverage) to Amiens : http://api.navitia.io/v1/coverage/fr-ne/journeys?from=stop_area:SIN:SA:OCE87113001&to=stop_area:SIN:SA:OCE87313874
Before there was no direct path from Gare de l'Est to Gare du Nord (which is also not in the coverage, but more interesting for this journey), now a crow-fly is created between the two stop areas.
