### PR TITLE
Jormungandr: add coherence to some schedule links

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -235,23 +235,39 @@ class notes(fields.Raw):
             r.append({"id": note_.uri, "value": note_.note})
         return r
 
+
 class stop_time_properties_links(fields.Raw):
 
     def output(self, key, obj):
         properties = obj.properties
         r = []
+        #Note: all those links should be created with crete_{internal|external}_links,
+        # but for retrocompatibility purpose we cannot do that :( Change it for the v2!
         for note_ in properties.notes:
-            r.append({"id": note_.uri, "type": "notes", "value": note_.note,
+            r.append({"id": note_.uri,
+                      "type": "notes",  # type should be 'note' but retrocompatibility...
+                      "rel": "notes",
+                      "value": note_.note,
                       "internal": True})
         for exception in properties.exceptions:
-            r.append({"type": "exceptions", "id": exception.uri, "date": exception.date,
-                      "except_type": exception.type})
+            r.append({"type": "exceptions",  # type should be 'exception' but retrocompatibility...
+                      "rel": "exceptions",
+                      "id": exception.uri,
+                      "date": exception.date,
+                      "except_type": exception.type,
+                      "internal": True})
         if properties.destination and properties.destination.uri:
-            r.append({"type": "notes", "id": properties.destination.uri,
-                      "value": properties.destination.destination})
+            r.append({"type": "notes",
+                      "rel": "notes",
+                      "id": properties.destination.uri,
+                      "value": properties.destination.destination,
+                      "internal": True})
         if properties.vehicle_journey_id:
-            r.append({"type": "vehicle_journey", "rel": "vehicle_journey",
-                      "value": properties.vehicle_journey_id})
+            r.append({"type": "vehicle_journey",
+                      "rel": "vehicle_journeys",
+                      # the value has nothing to do here (it's the 'id' field), refactor for the v2
+                      "value": properties.vehicle_journey_id,
+                      "id": properties.vehicle_journey_id})
         return r
 
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -259,7 +259,7 @@ def get_links_dict(response):
     return links
 
 
-def check_links(object, tester):
+def check_links(object, tester, href_mandatory=True):
     """
     get the links as dict ordered by 'rel' and check:
      - all links must have the attributes:
@@ -283,13 +283,14 @@ def check_links(object, tester):
         internal = get_bool('internal')
         templated = get_bool('templated')
 
-        if not internal:
-            assert 'href' in link, "no href in link"
+        if href_mandatory:
+            if not internal:
+                assert 'href' in link, "no href in link"
 
-        if not templated and not internal:
-            #we check that the url is valid
-            assert check_url(tester, link['href'].replace('http://localhost', ''),
-                             might_have_additional_args=False), "href's link must be a valid url"
+            if not templated and not internal:
+                #we check that the url is valid
+                assert check_url(tester, link['href'].replace('http://localhost', ''),
+                                 might_have_additional_args=False), "href's link must be a valid url"
 
         if internal:
             assert 'rel' in link

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -53,9 +53,11 @@ def check_departure_board(schedules, tester, only_time=False):
             get_valid_time(dt)
         else:
             get_valid_datetime(dt)
+        #TODO remove href_mandatory=False after link refactor, they should always be there :)
+        check_links(dt_wrapper, tester, href_mandatory=False)
 
-    #TODO uncomment after link refactor
-    #check_links(schedule, tester)
+    #TODO remove href_mandatory=False after link refactor, they should always be there :)
+    check_links(schedule, tester, href_mandatory=False)
 
 
 def is_valid_route_schedule(schedules):


### PR DESCRIPTION
fix: http://jira.canaltp.fr/browse/NAVITIAII-1786

add a bit of coherence to some links.

a link has to have an id

``` json
        {
            "type": "vehicle_journey",
            "value": "vehicle_journey:2C8F640801B2A66FB96F04D5AC7DABC0:178_dst_2", --> value kept for retrocompatibilty
            "rel": "vehicle_journeys", --> type was 'vehicle_journey' and has been rename to add 's' since the rel should be the collection
            "id": "vehicle_journey:2C8F640801B2A66FB96F04D5AC7DABC0:178_dst_2" --> id added
        }
```

``` json
    "internal": true,
    "type": "notes",  -> type should be 'note'
    "id": "note:6063313734109125744",
    "rel": "notes" --> rel added, since an internal link should be look for in the response as /{rel}/{id}
},
```

unfortunatly we cannot be fully coherent as it will break the API, that will have to be done in the v2

Those changes should not break the API apart from wrong use of the `rel` field
