### PR TITLE
Raptor: fix nb_transfers for isochrone

### DIFF
--- a/source/jormungandr/tests/isochrone_tests.py
+++ b/source/jormungandr/tests/isochrone_tests.py
@@ -61,6 +61,17 @@ class TestIsochrone(AbstractTestFixture):
         assert response["journeys"][1]["duration"] == 25200
         assert response["journeys"][1]["to"]["stop_point"]["id"] == "D"
 
+    def test_stop_point_isochrone_coord_no_transfers(self):
+        #same query as the test_stop_point_isochrone_coord test, but this time we forbid to do a transfers
+        #we should be able to touch only 'B'
+        query = "v1/coverage/basic_routing_test/stop_points/A/journeys?" \
+                "max_duration=25500&datetime=20120614T080000" \
+                "&max_nb_transfers=0"
+        response = self.query(query)
+        assert len(response["journeys"]) == 1
+        assert response["journeys"][0]["duration"] == 300
+        assert response["journeys"][0]["to"]["stop_point"]["id"] == "B"
+
     def test_to_isochrone_coord(self):
         #NOTE: we query /v1/coverage/basic_routing_test/journeys and not directly /v1/journeys
         #not to use the jormungandr database

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -381,7 +381,7 @@ RAPTOR::isochrone(const vec_stop_point_duration& departures,
     clear(clockwise, bound);
     init(departures, departure_datetime, true, accessibilite_params.properties);
 
-    boucleRAPTOR(accessibilite_params, clockwise, max_transfers);
+    boucleRAPTOR(accessibilite_params, clockwise, disruption_active, max_transfers);
 }
 
 
@@ -610,7 +610,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
 void RAPTOR::boucleRAPTOR(const type::AccessibiliteParams& accessibilite_params,
                           bool clockwise,
                           bool disruption_active,
-                          uint32_t max_transfers){
+                          uint32_t max_transfers) {
     if(clockwise) {
         raptor_loop(raptor_visitor(), accessibilite_params, disruption_active, max_transfers);
     } else {

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -180,7 +180,7 @@ struct RAPTOR
     void boucleRAPTOR(const type::AccessibiliteParams& accessibilite_params,
                       bool clockwise,
                       bool disruption_active,
-                      const uint32_t max_transfers=std::numeric_limits<uint32_t>::max());
+                      const uint32_t max_transfers);
 
     /// Apply foot pathes to labels
     /// Return true if it improves at least one label, false otherwise


### PR DESCRIPTION
there was a #$*ù$# default param, so the max_nb_transfers param was
casted in the 'disruption_active' boolean...
