### PR TITLE
Raptor api: explicit fall back when used for admin

### DIFF
--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -301,7 +301,8 @@ class TestPtRefPlace(AbstractTestFixture):
 
         #the default is the search for all stops within 200m, so we should have A and C
         eq_(len(stops), 2)
-        assert ["stopA", "stopC"] == [s['name'] for s in stops]
+
+        assert set(["stopA", "stopC"]) == set([s['name'] for s in stops])
 
     def test_with_coord_distance_different(self):
         """same as test_with_coord, but with 300m radius. so we find all stops"""
@@ -313,7 +314,7 @@ class TestPtRefPlace(AbstractTestFixture):
             is_valid_stop_area(s)
 
         eq_(len(stops), 3)
-        assert ["stopA", "stopB", "stopC"] == [s['name'] for s in stops]
+        assert set(["stopA", "stopB", "stopC"]) == set([s['name'] for s in stops])
 
     def test_with_coord_and_filter(self):
         """
@@ -332,4 +333,4 @@ class TestPtRefPlace(AbstractTestFixture):
         #the default is the search for all stops within 200m, so we should have all 3 stops
         #we should have 3 stops
         eq_(len(stops), 2)
-        assert ["stopA", "stopC"] == [s['name'] for s in stops]
+        assert set(["stopA", "stopC"]) == set([s['name'] for s in stops])

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -795,20 +795,19 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
         }
         const auto admin = data.geo_ref->admins[it_admin->second];
 
+        //we add the center of the admin, and look for the stop points around
+        auto nearest = worker.find_nearest_stop_points(
+                    ep.streetnetwork_params.max_duration,
+                    data.pt_data->stop_point_proximity_list,
+                    use_second);
+        for (const auto& elt: nearest) {
+            result.push_back({SpIdx(elt.first), elt.second});
+        }
         if (! admin->main_stop_areas.empty()) {
             for (auto stop_area: admin->main_stop_areas) {
                 for(auto stop_point : stop_area->stop_point_list) {
                     result.push_back({SpIdx(*stop_point), {}});
                 }
-            }
-        } else {
-            //we only add the center of the admin, and look for the stop points around
-            auto nearest = worker.find_nearest_stop_points(
-                        ep.streetnetwork_params.max_duration,
-                        data.pt_data->stop_point_proximity_list,
-                        use_second);
-            for (const auto& elt: nearest) {
-                result.push_back({SpIdx(elt.first), elt.second});
             }
         }
         LOG4CPLUS_DEBUG(logger, result.size() << " sp found for admin");

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -86,20 +86,13 @@ bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_poi
         //we only do a crowfly section if the used stop point belongs to this stop area
         return point.uri == stop_point->stop_area->uri;
     }else if(point.type == type::Type_e::Admin){
-        //if we have an admin in the request,
-        //we only do a crowfly section if the used stop point belongs to this admin
-        auto admin_it = find_if(begin(stop_point->stop_area->admin_list), end(stop_point->stop_area->admin_list),
-                [point](const navitia::georef::Admin* admin){return (admin->uri == point.uri);});
-        if(admin_it != end(stop_point->stop_area->admin_list)){
-            return true;
-        }else{//we handle the main_stop_area of an admin here
-            //we want a crowfly for all main_stop_areas of an admin,
-            //even if the stop_area is not in the admin
-            auto admin = data.geo_ref->admins[data.geo_ref->admin_map[point.uri]];
-            auto it = find_if(begin(admin->main_stop_areas), end(admin->main_stop_areas),
-                    [stop_point](const type::StopArea* stop_area){return stop_area == stop_point->stop_area;});
-            return it != end(admin->main_stop_areas);
-        }
+        //we handle the main_stop_area of an admin here
+        //we want a crowfly for all main_stop_areas of an admin,
+        //even if the stop_area is not in the admin
+        auto admin = data.geo_ref->admins[data.geo_ref->admin_map[point.uri]];
+        auto it = find_if(begin(admin->main_stop_areas), end(admin->main_stop_areas),
+                [stop_point](const type::StopArea* stop_area){return stop_area == stop_point->stop_area;});
+        return it != end(admin->main_stop_areas);
     }else{
         //if the request is on any other type we don't want a crowfly section
         return false;

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1087,7 +1087,7 @@ BOOST_FIXTURE_TEST_CASE(admin_explicit_fall_back, streetnetworkmode_fixture<test
     destination.streetnetwork_params.max_duration = navitia::seconds(100);
 
     auto resp = make_response();
-    dump_response(resp, "admin_explicit_fall_back", true);
+    dump_response(resp, "admin_explicit_fall_back");
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -1997,7 +1997,7 @@ BOOST_FIXTURE_TEST_CASE(direct_path_filtering_test, streetnetworkmode_fixture<te
     forbidden = {"A", "B", "D"};
 
     pbnavitia::Response resp = make_response();
-    dump_response(resp, "direct_path_filtering", true);
+    dump_response(resp, "direct_path_filtering");
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -160,6 +160,8 @@ struct routing_api_data {
         admin->insee = "32107";
         admin->level = 8;
         admin->postal_codes.push_back("32100");
+        admin->coord = nt::GeographicalCoord(D.lon(), D.lat());
+        admin->idx = 0;
 
         navitia::georef::Way* way;
         way = new navitia::georef::Way();
@@ -437,6 +439,8 @@ struct routing_api_data {
             }
         }
 
+        b.data->complete();
+        b.manage_admin();
         b.finish();
         b.data->build_uri();
         b.data->pt_data->index();


### PR DESCRIPTION
Fall back for admin is now explicit when used.

We used to hide fall-back when starting from the center of an admin or a stop point out of the main stop area, which was not easy to understand for users.
For example a journey was impossible when walking (center too far from any stop point), and possible when biking but not mentioning any bike section in that case.

Partially processing http://jira.canaltp.fr/browse/NAVITIAII-1784
