### PR TITLE
Jormungandr: handle special char in uris

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -514,8 +514,8 @@ class Journeys(ResourceUri, ResourceUtc):
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
         parser_get = self.parsers["get"]
-        parser_get.add_argument("from", type=str, dest="origin")
-        parser_get.add_argument("to", type=str, dest="destination")
+        parser_get.add_argument("from", type=unicode, dest="origin")
+        parser_get.add_argument("to", type=unicode, dest="destination")
         parser_get.add_argument("datetime", type=date_time_format)
         parser_get.add_argument("datetime_represents", dest="clockwise",
                                 type=dt_represents, default=True)

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -42,6 +42,12 @@ from jormungandr.authentication import authentication_required
 import navitiacommon.type_pb2 as type_pb2
 
 
+def protect(uri):
+    """
+    we protect the uri so there can be special character in them
+    """
+    return '"' + uri + '"'
+
 class ResourceUri(StatedResource):
 
     def __init__(self, authentication=True, links=True, *args, **kwargs):
@@ -87,11 +93,11 @@ class ResourceUri(StatedResource):
                             obj=object_type, lon=lon, lat=lat, distance=args.get('distance', 200))
                         filter_list.append(filter_)
                     else:
-                        filter_list.append(type_ + ".uri=" + item)
+                        filter_list.append(type_ + ".uri=" + protect(item))
                 elif type_ == 'poi':
-                    filter_list.append(type_ + '.uri=' + item.split(":")[-1])
+                    filter_list.append(type_ + '.uri=' + protect(item.split(":")[-1]))
                 else:
-                    filter_list.append(type_ + ".uri=" + item)
+                    filter_list.append(type_ + ".uri=" + protect(item))
                 type_ = None
         return " and ".join(filter_list)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -46,7 +46,7 @@ def protect(uri):
     """
     we protect the uri so there can be special character in them
     """
-    return '"' + uri + '"'
+    return '"' + uri.replace('"', '\\"') + '"'
 
 class ResourceUri(StatedResource):
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -40,7 +40,7 @@ from fields import stop_point, stop_area, route, line, line_group, \
     journey_pattern, connection, error, PbField
 from VehicleJourney import vehicle_journey
 from collections import OrderedDict
-from ResourceUri import ResourceUri
+from ResourceUri import ResourceUri, protect
 from jormungandr.interfaces.argument import ArgumentDoc
 from jormungandr.interfaces.parsers import depth_argument, date_time_format
 from errors import ManageError
@@ -139,7 +139,7 @@ class Uri(ResourceUri):
             return {"error": "No region"}, 404
         if collection and id:
             args["filter"] = collections_to_resource_type[collection] + ".uri="
-            args["filter"] += '"' + id + '"'
+            args["filter"] += protect(id)
         elif uri:
             if uri[-1] == "/":
                 uri = uri[:-1]

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -29,3 +29,4 @@ retrying==1.2.3
 aniso8601==0.82
 elasticsearch==1.4.0
 ujson==1.33
+urllib3==1.10.1

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
@@ -47,7 +48,7 @@ class TestPtRef(AbstractTestFixture):
 
         #we check afterward that we have the right data
         #we know there is only one vj in the dataset
-        assert len(vjs) == 1
+        assert len(vjs) == 2
         vj = vjs[0]
         assert vj['id'] == 'vj1'
 
@@ -104,7 +105,7 @@ class TestPtRef(AbstractTestFixture):
 
         lines = get_not_null(response, 'lines')
 
-        assert len(lines) == 1
+        assert len(lines) == 2
 
         l = lines[0]
 
@@ -181,7 +182,7 @@ class TestPtRef(AbstractTestFixture):
 
         routes = get_not_null(response, 'routes')
 
-        assert len(routes) == 1
+        assert len(routes) == 2
 
         r = routes[0]
         is_valid_route(r, depth_check=1)
@@ -201,7 +202,7 @@ class TestPtRef(AbstractTestFixture):
 
         stops = get_not_null(response, 'stop_areas')
 
-        assert len(stops) == 2
+        assert len(stops) == 3
 
         s = next((s for s in stops if s['name'] == 'stop_area:stop1'))
         is_valid_stop_area(s, depth_check=1)
@@ -219,7 +220,7 @@ class TestPtRef(AbstractTestFixture):
 
         stops = get_not_null(response, 'stop_points')
 
-        assert len(stops) == 2
+        assert len(stops) == 3
 
         s = next((s for s in stops if s['name'] == 'stop_area:stop2'))
         is_valid_stop_area(s, depth_check=1)
@@ -256,7 +257,7 @@ class TestPtRef(AbstractTestFixture):
         response = self.query_region("v1/lines")
 
         lines = get_not_null(response, 'lines')
-        assert len(lines) == 1
+        assert len(lines) == 2
 
         assert len(lines[0]['physical_modes']) == 1
         assert lines[0]['physical_modes'][0]['id'] == 'physical_mode:Car'
@@ -285,6 +286,23 @@ class TestPtRef(AbstractTestFixture):
         assert len(pt_objs) == 1
 
         assert get_not_null(pt_objs[0], 'id') == 'stop_area:stop2'
+
+    def test_query_with_strange_char(self):
+        response = self.query_region('stop_points/stop_point:stop_with name é')
+
+        stops = get_not_null(response, 'stop_points')
+
+        assert len(stops) == 1
+
+        is_valid_stop_point(stops[0], depth_check=1)
+        assert stops[0]["id"] == u'stop_point:stop_with name é'
+
+    def test_journey_with_strange_char(self):
+        #we use an encoded url to be able to check the links
+        query = 'journeys?from=stop_with name é&to=stop_area:stop1&datetime=20140105T070000'
+        response = self.query_region(query, display=True)
+
+        is_valid_journey_response(response, self.tester, query)
 
 
 @dataset(["main_routing_test"])

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -200,7 +200,6 @@ class AbstractTestFixture:
             return self.query(real_url, display)
         return self.query_no_assert(real_url, display)
 
-
     def query_no_assert(self, url, display=False):
         """
         query url without checking the status code

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -74,8 +74,12 @@ namespace qi = boost::spirit::qi;
         // Attention, le - dans un qi::char_ *peut* avoir une signification particulière telle que a-z
         word = qi::lexeme[+(qi::alnum|qi::char_("_:\x7c-"))];
         text = qi::lexeme[+(qi::alnum|qi::char_("_:=.<>\x7c ")|qi::char_("-"))];
-        escaped_string = '"' >> qi::lexeme[+(qi::alnum|qi::char_("_: &.\x7c")|qi::char_("-"))] >> '"';
-        bracket_string = '(' >> qi::lexeme[+(qi::alnum|qi::char_("_:=.<> \x7c")|qi::char_("-")|qi::char_(","))] /*qi::lexeme[+(qi::alnum|qi::char_("_: &,.-"))] */>> ')';
+
+        escaped_string =  '"'
+                >>  *((qi::char_ - qi::char_('\\') - qi::char_('"')) | ('\\' >> qi::char_))
+                 >> '"';
+
+        bracket_string = '(' >> qi::lexeme[+(qi::alnum|qi::char_("_:=.<> \x7c")|qi::char_("-")|qi::char_(","))] >> ')';
         bin_op =  qi::string("<=")[qi::_val = LEQ]
                 | qi::string(">=")[qi::_val = GEQ]
                 | qi::string("<>")[qi::_val = NEQ]

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -75,9 +75,9 @@ namespace qi = boost::spirit::qi;
         word = qi::lexeme[+(qi::alnum|qi::char_("_:\x7c-"))];
         text = qi::lexeme[+(qi::alnum|qi::char_("_:=.<>\x7c ")|qi::char_("-"))];
 
-        escaped_string =  '"'
-                >>  *((qi::char_ - qi::char_('\\') - qi::char_('"')) | ('\\' >> qi::char_))
-                 >> '"';
+        escaped_string = '"'
+                        >>  *((qi::char_ - qi::char_('\\') - qi::char_('"')) | ('\\' >> qi::char_))
+                        >> '"';
 
         bracket_string = '(' >> qi::lexeme[+(qi::alnum|qi::char_("_:=.<> \x7c")|qi::char_("-")|qi::char_(","))] >> ')';
         bin_op =  qi::string("<=")[qi::_val = LEQ]

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -64,14 +64,14 @@ namespace qi = boost::spirit::qi;
         struct select_r
             : qi::grammar<Iterator, std::vector<Filter>(), qi::space_type>
 {
-    qi::rule<Iterator, std::string(), qi::space_type> word, text; // Match un mot simple, une chaine échappée par des "" et entourée de ()
+    qi::rule<Iterator, std::string(), qi::space_type> word, text; // Match a simple word, a string escaped by "" or enclosed by ()
     qi::rule<Iterator, std::string()> escaped_string, bracket_string;
-    qi::rule<Iterator, Operator_e(), qi::space_type> bin_op; // Match une operator binaire telle que <, =...
-    qi::rule<Iterator, std::vector<Filter>(), qi::space_type> filter; // La string complète a parser
-    qi::rule<Iterator, Filter(), qi::space_type> single_clause, having_clause, after_clause; // La string complète à parser
+    qi::rule<Iterator, Operator_e(), qi::space_type> bin_op; // Match a binary operator like <, =...
+    qi::rule<Iterator, std::vector<Filter>(), qi::space_type> filter; // the complete string to parse
+    qi::rule<Iterator, Filter(), qi::space_type> single_clause, having_clause, after_clause;
 
     select_r() : select_r::base_type(filter) {
-        // Attention, le - dans un qi::char_ *peut* avoir une signification particulière telle que a-z
+        // Warning, the '-' in a qi::char_ can have a particular meaning as 'a-z'
         word = qi::lexeme[+(qi::alnum|qi::char_("_:\x7c-"))];
         text = qi::lexeme[+(qi::alnum|qi::char_("_:=.<>\x7c ")|qi::char_("-"))];
 
@@ -97,7 +97,7 @@ namespace qi = boost::spirit::qi;
 };
 
 
-// vérification d'une clause WHERE
+// WHERE condition check
 template<class T>
 WhereWrapper<T> build_clause(std::vector<Filter> filters) {
     WhereWrapper<T> wh(new BaseWhere<T>());

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -149,11 +149,20 @@ BOOST_AUTO_TEST_CASE(parser_escaped_string_with_particular_char_quote) {
 
 
 BOOST_AUTO_TEST_CASE(parser_escaped_string_with_nested_quote) {
-    std::vector<Filter> filters = parse("stop_areas.uri=\"bob the \\\"coolést\\\"\"");
+    std::vector<Filter> filters = parse(R"(stop_areas.uri="bob the \"coolést\"")");
     BOOST_REQUIRE_EQUAL(filters.size(), 1);
     BOOST_CHECK_EQUAL(filters[0].object, "stop_areas");
     BOOST_CHECK_EQUAL(filters[0].attribute, "uri");
     BOOST_CHECK_EQUAL(filters[0].value, "bob the \"coolést\"");
+    BOOST_CHECK_EQUAL(filters[0].op, EQ);
+}
+
+BOOST_AUTO_TEST_CASE(parser_escaped_string_with_slash) {
+    std::vector<Filter> filters = parse(R"(stop_areas.uri="bob the \\ er")");
+    BOOST_REQUIRE_EQUAL(filters.size(), 1);
+    BOOST_CHECK_EQUAL(filters[0].object, "stop_areas");
+    BOOST_CHECK_EQUAL(filters[0].attribute, "uri");
+    BOOST_CHECK_EQUAL(filters[0].value, R"(bob the \ er)");
     BOOST_CHECK_EQUAL(filters[0].op, EQ);
 }
 

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -129,6 +129,34 @@ BOOST_AUTO_TEST_CASE(exception){
     BOOST_CHECK_THROW(parse("stop_areas.uri==42"), parsing_error);
 }
 
+BOOST_AUTO_TEST_CASE(parser_escaped_string) {
+    std::vector<Filter> filters = parse("stop_areas.uri=\"bob the coolest\"");
+    BOOST_REQUIRE_EQUAL(filters.size(), 1);
+    BOOST_CHECK_EQUAL(filters[0].object, "stop_areas");
+    BOOST_CHECK_EQUAL(filters[0].attribute, "uri");
+    BOOST_CHECK_EQUAL(filters[0].value, "bob the coolest");
+    BOOST_CHECK_EQUAL(filters[0].op, EQ);
+}
+
+BOOST_AUTO_TEST_CASE(parser_escaped_string_with_particular_char_quote) {
+    std::vector<Filter> filters = parse("stop_areas.uri=\"bob the coolést\"");
+    BOOST_REQUIRE_EQUAL(filters.size(), 1);
+    BOOST_CHECK_EQUAL(filters[0].object, "stop_areas");
+    BOOST_CHECK_EQUAL(filters[0].attribute, "uri");
+    BOOST_CHECK_EQUAL(filters[0].value, "bob the coolést");
+    BOOST_CHECK_EQUAL(filters[0].op, EQ);
+}
+
+
+BOOST_AUTO_TEST_CASE(parser_escaped_string_with_nested_quote) {
+    std::vector<Filter> filters = parse("stop_areas.uri=\"bob the \\\"coolést\\\"\"");
+    BOOST_REQUIRE_EQUAL(filters.size(), 1);
+    BOOST_CHECK_EQUAL(filters[0].object, "stop_areas");
+    BOOST_CHECK_EQUAL(filters[0].attribute, "uri");
+    BOOST_CHECK_EQUAL(filters[0].value, "bob the \"coolést\"");
+    BOOST_CHECK_EQUAL(filters[0].op, EQ);
+}
+
 
 struct Moo {
     int bli;

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -77,6 +77,11 @@ struct data_set {
         b.lines["line:A"]->calendar_list.push_back(wednesday_cal);
         b.lines["line:A"]->calendar_list.push_back(monday_cal);
 
+        // we add a stop area with a strange name (with space and special char)
+        b.sa("stop_with name é", 20, 20);
+        b.vj("line:B", "", "", true, "vj_b", "", "", "physical_mode:Car")
+                ("stop_point:stop_with name é", "8:00"_t)("stop_area:stop1", "9:00"_t);
+
         //add a mock shape
         b.lines["line:A"]->shape = {
                                     {{1,2}, {2,2}, {4,5}},

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -78,9 +78,9 @@ struct data_set {
         b.lines["line:A"]->calendar_list.push_back(monday_cal);
 
         // we add a stop area with a strange name (with space and special char)
-        b.sa("stop_with name é", 20, 20);
+        b.sa("stop_with name bob \" , é", 20, 20);
         b.vj("line:B", "", "", true, "vj_b", "", "", "physical_mode:Car")
-                ("stop_point:stop_with name é", "8:00"_t)("stop_area:stop1", "9:00"_t);
+                ("stop_point:stop_with name bob \" , é", "8:00"_t)("stop_area:stop1", "9:00"_t);
 
         //add a mock shape
         b.lines["line:A"]->shape = {
@@ -94,6 +94,9 @@ struct data_set {
                 {{10,20}, {20,20}, {40,50}}
             };
             r->destination = b.sas.find("stop_area:stop2")->second;
+        }
+        for (auto r: b.lines["line:B"]->route_list) {
+            r->destination = b.sas.find("stop_area:stop1")->second;
         }
         b.lines["line:A"]->codes["external_code"] = "A";
         b.lines["line:A"]->codes["codeB"] = "B";


### PR DESCRIPTION
quote the uris in the query to be able to handle special char

like:
`https://api.sncf.com/v1/coverage/sncf/commercial_modes/commercial_mode:intercites/lines/line:OCE:CorailIntercité-87723197-87481002/route_schedules`
