### PR TITLE
streetnetwork: fix a bug when the origin and the destination where projected on the same edge

### DIFF
--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -183,7 +183,7 @@ private:
     void add_custom_projections_to_path(Path& p, bool append_to_begin, const ProjectionData& projection, ProjectionData::Direction d) const;
 
     /// Build a path with a destination and the predecessors list
-    Path build_path(vertex_t best_destination) const;
+    Path build_path(vertex_t best_destination, ProjectionData::Direction) const;
 
     /// compute the reachable stop points within the radius with a simple crow fly
     std::vector<std::pair<type::idx_t, type::GeographicalCoord>>
@@ -225,7 +225,11 @@ struct StreetNetwork {
 };
 
 /// Build a path from a reverse path list
-Path create_path(const GeoRef& georef, std::vector<vertex_t> reverse_path, bool add_one_elt);
+Path create_path(const GeoRef& georef,
+                 std::vector<vertex_t> reverse_path,
+                 bool add_one_elt,
+                 const std::vector<navitia::time_duration>& distances,
+                 const navitia::time_duration& projection_time);
 
 /// Compute the angle between the last segment of the path and the next point
 int compute_directions(const navitia::georef::Path& path, const nt::GeographicalCoord& c_coord);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -881,6 +881,7 @@ BOOST_FIXTURE_TEST_CASE(walking_test, streetnetworkmode_fixture<test_speed_provi
     // from the stop times.
     journey = resp.journeys(0);
     BOOST_CHECK_EQUAL(journey.most_serious_disruption_effect(), ""); //no disruption should be found
+    BOOST_CHECK_EQUAL(journey.duration(), 112);
 
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
     section = journey.sections(1);


### PR DESCRIPTION
It was possible to not count the cost of the edge and only count the
projection.

Example:

```
       * O
A-----------------------------------------B
                                     *D
```

We go from O to D: each point is projected on the two vertexes of the
edge. The calculation is done fine but when we reconstruct the path since we used only one
vertex we aren't able to reconstruct anything, so we were keeping only
the two smallest projection for each point.

With this commit, if we have a reverse path of only one element we used
the initialized values of the dijkstra for finding the right duration.
