### PR TITLE
streetnetwork: fix a bug when the origin and the destination where projected on the same edge

### DIFF
--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -317,6 +317,7 @@ void ProjectionData::init(const type::GeographicalCoord & coord, const GeoRef & 
     // On calcule la distance « initiale » déjà parcourue avant d'atteindre ces extrémité d'où on effectue le calcul d'itinéraire
     distances[Direction::Source] = projected.distance_to(vertex1_coord);
     distances[Direction::Target] = projected.distance_to(vertex2_coord);
+    this->real_coord = coord;
 }
 
 /**

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -366,6 +366,9 @@ struct ProjectionData {
     /// The coordinate projected on the edge
     type::GeographicalCoord projected;
 
+    //the original coordinate before projection
+    type::GeographicalCoord real_coord;
+
     /// Distance between the projected point and the ends
     flat_enum_map<Direction, double> distances {{{-1, -1}}};
 
@@ -376,7 +379,7 @@ struct ProjectionData {
     ProjectionData(const type::GeographicalCoord & coord, const GeoRef &sn, type::idx_t offset, const proximitylist::ProximityList<vertex_t> &prox);
 
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
-        ar & vertices & projected & distances & found;
+        ar & vertices & projected & distances & found & real_coord;
     }
 
     void init(const type::GeographicalCoord & coord, const GeoRef & sn, edge_t nearest_edge);

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -545,7 +545,7 @@ Path PathFinder::build_path(vertex_t best_destination) const {
 
 
 Path create_path(const GeoRef& geo_ref,
-                 std::vector<vertex_t> reverse_path,
+                 const std::vector<vertex_t>& reverse_path,
                  bool add_one_elt) {
     Path p;
 

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -176,6 +176,9 @@ struct PathFinder {
     /// find the nearest vertex from the projection. return the distance to this vertex and the vertex
     std::pair<navitia::time_duration, ProjectionData::Direction> find_nearest_vertex(const ProjectionData& target, bool handle_on_node = false) const;
 
+    //return the duration between two projection on the same edge
+    navitia::time_duration path_duration_on_same_edge(const ProjectionData& p1, const ProjectionData& p2);
+
 private:
     ///return the time the travel the distance at the current speed (used for projections)
     navitia::time_duration crow_fly_duration(const double val) const;
@@ -225,7 +228,9 @@ struct StreetNetwork {
 };
 
 /// Build a path from a reverse path list
-Path create_path(const GeoRef& georef, std::vector<vertex_t> reverse_path, bool add_one_elt);
+Path create_path(const GeoRef& georef,
+                 std::vector<vertex_t> reverse_path,
+                 bool add_one_elt);
 
 /// Compute the angle between the last segment of the path and the next point
 int compute_directions(const navitia::georef::Path& path, const nt::GeographicalCoord& c_coord);

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -229,7 +229,7 @@ struct StreetNetwork {
 
 /// Build a path from a reverse path list
 Path create_path(const GeoRef& georef,
-                 std::vector<vertex_t> reverse_path,
+                 const std::vector<vertex_t>& reverse_path,
                  bool add_one_elt);
 
 /// Compute the angle between the last segment of the path and the next point

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -43,7 +43,7 @@ www.navitia.io
 #include <boost/graph/detail/adjacency_list.hpp>
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized() { init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized )
 
@@ -400,14 +400,14 @@ BOOST_AUTO_TEST_CASE(compute_nearest){
     res = w.find_nearest_stop_points(100_s, pl, false);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].first , 0);
-    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(50 / (default_speed[Mode_e::Walking] * 2))); //the projection is done with the same mean of transport, at the same speed
+    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(60 / (default_speed[Mode_e::Walking] * 2))); //the projection is done with the same mean of transport, at the same speed
 
     w.init(starting_point);
     res = w.find_nearest_stop_points(1000_s, pl, false);
     std::sort(res.begin(), res.end());
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     BOOST_CHECK_EQUAL(res[0].first , 0);
-    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(50 / (default_speed[Mode_e::Walking] * 2)));
+    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(60 / (default_speed[Mode_e::Walking] * 2)));
     BOOST_CHECK_EQUAL(res[1].first , 1);
     //1 projections at the arrival, and 3 edges (100s each but at twice the speed)
     BOOST_CHECK_EQUAL(res[1].second, navitia::seconds(50 / (default_speed[Mode_e::Walking] * 2)) + 150_s);
@@ -996,5 +996,80 @@ BOOST_AUTO_TEST_CASE(list_postal_codes) {
     navitia::georef::Admin* admin = new navitia::georef::Admin();
     admin->postal_codes = {"44000", "44100", "44200", "44300"};
     BOOST_CHECK_EQUAL(admin->postal_codes_to_string(), "44000;44100;44200;44300");
+
+}
+
+BOOST_AUTO_TEST_CASE(find_nearest_on_same_edge){
+    using namespace navitia::type;
+
+    GraphBuilder b;
+
+    /*                      0          1
+     *                      +          +
+     *    o-----------o---------------------o----------------o
+     *    a           b                     c                d
+     *                     +             +
+     *                     2             3
+     */
+
+    b("a", 0, 0)("b", 100, 0)("c", 300, 0)("d", 400, 0);
+    b("a", "b", 100_s)("b", "a", 100_s)("b", "c", 200_s)("c", "b", 200_s)("c", "d", 100_s)("d", "c", 100_s);
+
+    GeographicalCoord c0(120, 10, false);
+    GeographicalCoord c1(250, 20, false);
+    GeographicalCoord c2(110, -10, false);
+    GeographicalCoord c3(280, -30, false);
+    navitia::proximitylist::ProximityList<idx_t> pl;
+    pl.add(c0, 0);
+    pl.add(c1, 1);
+    pl.add(c2, 2);
+    pl.add(c3, 3);
+    pl.build();
+    b.geo_ref.init();
+
+    StopPoint* sp0 = new StopPoint();
+    sp0->coord = c0;
+    sp0->idx = 0;
+    StopPoint* sp1 = new StopPoint();
+    sp1->coord = c1;
+    sp1->idx = 1;
+    StopPoint* sp2 = new StopPoint();
+    sp2->coord = c2;
+    sp2->idx = 2;
+    StopPoint* sp3 = new StopPoint();
+    sp3->coord = c3;
+    std::vector<StopPoint*> stop_points;
+    stop_points.push_back(sp0);
+    stop_points.push_back(sp1);
+    stop_points.push_back(sp2);
+    stop_points.push_back(sp3);
+    b.geo_ref.project_stop_points(stop_points);
+
+
+    StreetNetwork w(b.geo_ref);
+    EntryPoint starting_point;
+    starting_point.coordinates = c3;
+    starting_point.streetnetwork_params.mode = Mode_e::Walking;
+    starting_point.streetnetwork_params.speed_factor = 1;
+    w.init(starting_point);
+    auto res = w.find_nearest_stop_points(10_s, pl, false);
+    BOOST_CHECK_EQUAL(res.size(), 0);
+
+    w.init(starting_point);//not mandatory, but reinit to clean the distance table to get fresh dijsktra
+    res = w.find_nearest_stop_points(180_s, pl, false);
+    BOOST_REQUIRE_EQUAL(res.size(), 3);
+
+    //if you give the coord of the stop_point, you have to go to the street then go back to the stop_point, too bad!
+    BOOST_CHECK_EQUAL(res[0].first , 3);
+    BOOST_CHECK_EQUAL(res[0].second, navitia::seconds(60 / default_speed[Mode_e::Walking]));
+    BOOST_CHECK_EQUAL(w.get_path(res[0].first, false).duration, navitia::seconds(60 / default_speed[Mode_e::Walking]));
+
+    BOOST_CHECK_EQUAL(res[1].first , 1);
+    BOOST_CHECK_EQUAL(res[1].second, navitia::seconds(80 / default_speed[Mode_e::Walking]));
+    BOOST_CHECK_EQUAL(w.get_path(res[1].first, false).duration, navitia::seconds(80 / default_speed[Mode_e::Walking]));
+
+    BOOST_CHECK_EQUAL(res[2].first , 0);
+    BOOST_CHECK_EQUAL(res[2].second, navitia::seconds(200 / default_speed[Mode_e::Walking]));
+    BOOST_CHECK_EQUAL(w.get_path(res[2].first, false).duration, navitia::seconds(200 / default_speed[Mode_e::Walking]));
 
 }

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -882,6 +882,7 @@ BOOST_FIXTURE_TEST_CASE(walking_test, streetnetworkmode_fixture<test_speed_provi
     // from the stop times.
     journey = resp.journeys(0);
     BOOST_CHECK_EQUAL(journey.most_serious_disruption_effect(), ""); //no disruption should be found
+    BOOST_CHECK_EQUAL(journey.duration(), 112);
 
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
     section = journey.sections(1);
@@ -964,7 +965,9 @@ BOOST_FIXTURE_TEST_CASE(biking, streetnetworkmode_fixture<test_speed_provider>) 
     BOOST_CHECK_EQUAL(resp.journeys(0).sections(1).co2_emission().unit(), "gEC");
 
     // Walk mode
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).has_co2_emission(), false);
+    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).has_co2_emission(), true);
+    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).co2_emission().value(), 0.);
+    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).street_network().mode(), pbnavitia::StreetNetworkMode::Bike);
     // Aggregator co2_emission
     BOOST_CHECK_EQUAL(resp.journeys(0).has_co2_emission(), true);
     BOOST_CHECK_EQUAL(resp.journeys(0).co2_emission().value(), 0.58);

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -74,7 +74,7 @@ struct wrong_version : public navitia::exception {
 class Data : boost::noncopyable{
 public:
 
-    static const unsigned int data_version = 40; //< Data version number. *INCREMENT* every time serialized data are modified
+    static const unsigned int data_version = 41; //< Data version number. *INCREMENT* every time serialized data are modified
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded


### PR DESCRIPTION
It was possible to not count the cost of the edge and only count the
projection.

Example:

```
       * O
A-----------------------------------------B
                                     *D
```

We go from O to D: each point is projected on the two vertexes of the
edge. The calculation is done fine but when we reconstruct the path since we used only one
vertex we aren't able to reconstruct anything, so we were keeping only
the two smallest projection for each point.

With this commit, we calculate the distance to the edge, then the
distance to the projected point, and finally the distance from the
projected destination to the real destination.
