### PR TITLE
ptref: activate filtering on code attribute

### DIFF
--- a/documentation/navitia.io/source/integration.rst
+++ b/documentation/navitia.io/source/integration.rst
@@ -363,7 +363,7 @@ especially lines themselves and routes.
 
 Examples :
 https://api.navitia.io/v1/coverage/fr-idf/lines?filter=line.code=4
-https://api.navitia.io/v1/coverage/fr-idf/routes?filter=line.code=347
+https://api.navitia.io/v1/coverage/fr-idf/routes?filter=line.code="métro 347"
 
 
 Examples

--- a/documentation/navitia.io/source/integration.rst
+++ b/documentation/navitia.io/source/integration.rst
@@ -346,6 +346,26 @@ ________
 If you specify coords in your filter, you can modify the radius used for the proximity search.
 https://api.navitia.io/v1/coverage/fr-idf/coords/2.377310;48.847002/stop_schedules?distance=500
 
+
+Filter
+######
+
+It is possible to apply a filter to the returned collection, using "filter" parameter.
+If no object matches the filter, a "bad_filter" error is sent.
+If filter can not be parsed, an "unable_to_parse" error is sent.
+If object or attribute provided is not handled, the filter is ignored.
+
+line.code
+_________
+
+It allows you to request navitia objects referencing a line whose code is the one provided,
+especially lines themselves and routes.
+
+Examples :
+https://api.navitia.io/v1/coverage/fr-idf/lines?filter=line.code=4
+https://api.navitia.io/v1/coverage/fr-idf/routes?filter=line.code=347
+
+
 Examples
 ########
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -365,3 +365,47 @@ class TestPtRefPlace(AbstractTestFixture):
         #we should have 3 stops
         eq_(len(stops), 2)
         assert set(["stopA", "stopC"]) == set([s['name'] for s in stops])
+
+
+@dataset(["main_routing_test"])
+class TestPtRefLineCode(AbstractTestFixture):
+
+    def test_all_lines(self):
+        """test with all lines in the pt call"""
+        response = self.query('v1/coverage/main_routing_test/lines')
+        assert 'error' not in response
+        lines = get_not_null(response, 'lines')
+        eq_(len(lines), 4)
+        assert {"1A", "1B", "1C", "1D"} == {l['code'] for l in lines}
+
+    def test_line_filter_line_code(self):
+        """test filtering lines from line code 1A in the pt call"""
+        response = self.query('v1/coverage/main_routing_test/lines?filter=line.code=1A')
+        assert 'error' not in response
+        lines = get_not_null(response, 'lines')
+        eq_(len(lines), 1)
+        assert "1A" == lines[0]['code']
+
+    def test_line_filter_line_code_no_line(self):
+        """test filtering lines from line code bob (no line coded "bob") in the pt call"""
+        url = 'v1/coverage/main_routing_test/lines?filter=line.code=bob'
+        response, status = self.query_no_assert(url)
+        assert status == 400
+        assert 'error' in response
+        assert 'bad_filter' in response['error']['id']
+
+    def test_line_filter_route_code_impossible(self):
+        """test filtering lines from route code (no code attribute for route) bob in the pt call"""
+        response = self.query('v1/coverage/main_routing_test/lines?filter=route.code=bob')
+        assert 'error' not in response
+        lines = get_not_null(response, 'lines')
+        eq_(len(lines), 4)
+        assert {"1A", "1B", "1C", "1D"} == {l['code'] for l in lines}
+
+    def test_route_filter_line_code(self):
+        """test filtering routes from line code 1B in the pt call"""
+        response = self.query('v1/coverage/main_routing_test/routes?filter=line.code=1B')
+        assert 'error' not in response
+        routes = get_not_null(response, 'routes')
+        eq_(len(routes), 1)
+        assert "1B" == routes[0]['line']['code']

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -319,7 +319,7 @@ class TestPtRef(AbstractTestFixture):
 
 
 @dataset(["main_routing_test"])
-class TestPtRefPlace(AbstractTestFixture):
+class TestPtRef(AbstractTestFixture):
 
     def test_with_coord(self):
         """test with a coord in the pt call, so a place nearby is actually called"""
@@ -366,10 +366,6 @@ class TestPtRefPlace(AbstractTestFixture):
         eq_(len(stops), 2)
         assert set(["stopA", "stopC"]) == set([s['name'] for s in stops])
 
-
-@dataset(["main_routing_test"])
-class TestPtRefLineCode(AbstractTestFixture):
-
     def test_all_lines(self):
         """test with all lines in the pt call"""
         response = self.query('v1/coverage/main_routing_test/lines')
@@ -386,21 +382,25 @@ class TestPtRefLineCode(AbstractTestFixture):
         eq_(len(lines), 1)
         assert "1A" == lines[0]['code']
 
-    def test_line_filter_line_code_no_line(self):
-        """test filtering lines from line code bob (no line coded "bob") in the pt call"""
+    def test_line_filter_line_code_empty_response(self):
+        """test filtering lines from line code bob in the pt call
+        as no line has the code "bob" response returns no object"""
         url = 'v1/coverage/main_routing_test/lines?filter=line.code=bob'
         response, status = self.query_no_assert(url)
         assert status == 400
         assert 'error' in response
         assert 'bad_filter' in response['error']['id']
 
-    def test_line_filter_route_code_impossible(self):
-        """test filtering lines from route code (no code attribute for route) bob in the pt call"""
+    def test_line_filter_route_code_ignored(self):
+        """test filtering lines from route code bob in the pt call
+        as there is no attribute "code" for route, filter is invalid and ignored"""
+        response_all_lines = self.query('v1/coverage/main_routing_test/lines')
+        all_lines = get_not_null(response_all_lines, 'lines')
         response = self.query('v1/coverage/main_routing_test/lines?filter=route.code=bob')
         assert 'error' not in response
         lines = get_not_null(response, 'lines')
         eq_(len(lines), 4)
-        assert {"1A", "1B", "1C", "1D"} == {l['code'] for l in lines}
+        assert {l['code'] for l in all_lines} == {l['code'] for l in lines}
 
     def test_route_filter_line_code(self):
         """test filtering routes from line code 1B in the pt call"""

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -102,12 +102,20 @@ template<class T>
 WhereWrapper<T> build_clause(std::vector<Filter> filters) {
     WhereWrapper<T> wh(new BaseWhere<T>());
     for(const Filter & filter : filters) {
-        if(filter.attribute == "uri") {
-            wh = wh && WHERE(ptr_uri<T>(), filter.op, filter.value);
-        } else if(filter.attribute == "name") {
-            wh = wh && WHERE(ptr_name<T>(), filter.op, filter.value);
-        } else {
-            LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "unhandled filter type: " << filter.attribute << " the filter is ignored");
+        try {
+            if(filter.attribute == "uri") {
+                wh = wh && WHERE(ptr_uri<T>(), filter.op, filter.value);
+            } else if(filter.attribute == "name") {
+                wh = wh && WHERE(ptr_name<T>(), filter.op, filter.value);
+            } else if(filter.attribute == "code") {
+                wh = wh && WHERE(ptr_code<T>(), filter.op, filter.value);
+            } else {
+                LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
+                        "unhandled filter type: " << filter.attribute << ". The filter is ignored");
+            }
+        } catch (unknown_member) {
+            LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
+                    "given object has no member: " << filter.attribute << ". The filter is ignored");
         }
     }
     return wh;

--- a/source/ptreferential/reflexion.h
+++ b/source/ptreferential/reflexion.h
@@ -34,7 +34,7 @@ www.navitia.io
 
 namespace navitia{ namespace ptref {
 
-/// Exception thrown when an unknown memner is asked for
+/// Exception thrown when an unknown member is asked for
 struct unknown_member{};
 
 /*

--- a/source/ptreferential/reflexion.h
+++ b/source/ptreferential/reflexion.h
@@ -70,5 +70,6 @@ DECL_HAS_MEMBER(id)
 DECL_HAS_MEMBER(idx)
 DECL_HAS_MEMBER(name)
 DECL_HAS_MEMBER(validity_pattern)
+DECL_HAS_MEMBER(code)
 
 }}

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -348,11 +348,11 @@ BOOST_AUTO_TEST_CASE(line_code) {
 
     //find line by code
     auto indexes = make_query(navitia::type::Type_e::Line, "line.code=line_A", *(b.data));
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
     BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line_A");
 
     indexes = make_query(navitia::type::Type_e::Line, "line.code=\"line C\"", *(b.data));
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
     BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line C");
 
     //no line B
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(line_code) {
 
     //find route by line code
     indexes = make_query(navitia::type::Type_e::Route, "line.code=line_A", *(b.data));
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
     BOOST_CHECK_EQUAL(b.data->pt_data->routes[indexes.front()]->line->code, "line_A");
 
     //route has no code attribute, no filter can be used

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -54,6 +54,15 @@ BOOST_AUTO_TEST_CASE(parser){
     BOOST_CHECK_EQUAL(filters[0].op, EQ);
 }
 
+BOOST_AUTO_TEST_CASE(parse_code){
+    std::vector<Filter> filters = parse("line.code=42");
+    BOOST_REQUIRE_EQUAL(filters.size(), 1);
+    BOOST_CHECK_EQUAL(filters[0].object, "line");
+    BOOST_CHECK_EQUAL(filters[0].attribute, "code");
+    BOOST_CHECK_EQUAL(filters[0].value, "42");
+    BOOST_CHECK_EQUAL(filters[0].op, EQ);
+}
+
 BOOST_AUTO_TEST_CASE(whitespaces){
     std::vector<Filter> filters = parse("  stop_areas.uri    =  42    ");
     BOOST_REQUIRE_EQUAL(filters.size(), 1);
@@ -324,6 +333,40 @@ BOOST_AUTO_TEST_CASE(make_query_filtre_direct) {
 
     indexes = make_query(navitia::type::Type_e::Route, "route.uri=A:0", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(line_code) {
+
+    ed::builder b("201303011T1739");
+    b.generate_dummy_basis();
+    b.vj("A")("stop1", 8000, 8050);
+    b.lines["A"]->code = "line_A";
+    b.vj("C")("stop2", 8000, 8050);
+    b.lines["C"]->code = "line C";
+    b.data->build_relations();
+    b.finish();
+
+    //find line by code
+    auto indexes = make_query(navitia::type::Type_e::Line, "line.code=line_A", *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line_A");
+
+    indexes = make_query(navitia::type::Type_e::Line, "line.code=\"line C\"", *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line C");
+
+    //no line B
+    BOOST_CHECK_THROW(make_query(navitia::type::Type_e::Line, "line.code=\"line B\"", *(b.data)),
+                      ptref_error);
+
+    //find route by line code
+    indexes = make_query(navitia::type::Type_e::Route, "line.code=line_A", *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->routes[indexes.front()]->line->code, "line_A");
+
+    //route has no code attribute, no filter can be used
+    indexes = make_query(navitia::type::Type_e::Line, "route.code=test", *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 2);
 }
 
 BOOST_AUTO_TEST_CASE(forbidden_uri) {

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -409,17 +409,20 @@ struct routing_api_data {
                 ("stop_point:stopB", 8*3600 + 1*60, 8*3600 + 1 * 60)
                 ("stop_point:stopA", 8*3600 + 1 * 60 + 2, 8*3600 + 1*60 + 2)
                 .st_shape({B, I, A});
+            b.lines["A"]->code = "1A";
 
             //add another bus, much later. we'll use that one for disruptions
             b.vj("B")
                 ("stop_point:stopB", 18*3600 + 1*60, 18*3600 + 1 * 60)
                 ("stop_point:stopA", 18*3600 + 1 * 60 + 2, 18*3600 + 1*60 + 2)
                 .st_shape({B, I, A});
+            b.lines["B"]->code = "1B";
 
             b.vj("C")
                 ("stop_point:stopA", 8*3600 + 1*60, 8*3600 + 1 * 60)
                 ("stop_point:stopB", 8*3600 + 1 * 60 + 2, 8*3600 + 1*60 + 2)
                 .st_shape({A, I, B});
+            b.lines["C"]->code = "1C";
 
             //we add another stop not used in the routing tests, but used for ptref tests
 
@@ -429,6 +432,7 @@ struct routing_api_data {
                 ("stop_point:stopA", 8*3600 + 1*60, 8*3600 + 1 * 60)
                 ("stop_point:stopC", 8*3600 + 1 * 60 + 2, 8*3600 + 1*60 + 2)
                 .st_shape({A, K, J});
+            b.lines["D"]->code = "1D";
             auto jp_d = builder_vj.vj->journey_pattern;
             jp_d->physical_mode = b.data->pt_data->physical_modes[1]; //the metro is the second physical mode
             assert (jp_d->physical_mode->name == "Metro");


### PR DESCRIPTION
It is now possible to filter on code attribute in ptref filter.
Add some tests + light doc as the whole feature is not properly tested.
