### PR TITLE
Jormun: use pypy as interpreter and some improvements

### DIFF
--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -214,7 +214,7 @@ class InstanceManager(object):
         return instances
 
     def region_exists(self, region_str):
-        if region_str in self.instances:
+        if region_str in self.instances.keys():
             return True
         else:
             raise RegionNotFound(region=region_str)

--- a/source/jormungandr/jormungandr/interfaces/v1/errors.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/errors.py
@@ -79,9 +79,9 @@ class ManageError(object):
                 response_pb2.Error.no_solution: 200
             }
             if response.HasField("error") and\
-               response.error.id in errors:
+               response.error.id in errors.keys():
                 code = errors[response.error.id]
-                if code == 400 and "filter" not in request.args:
+                if code == 400 and "filter" not in request.args.keys():
                     response.error.id = response_pb2.Error.unknown_object
                     code = 404
 

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -93,17 +93,17 @@ class generate_links(object):
     def prepare_objetcs(self, objects, hasCollections=False):
         if isinstance(objects, tuple):
             objects = objects[0]
-        if "links" not in objects:
+        if not "links" in objects.keys():
             objects["links"] = []
         elif hasattr(self, "collections"):
             for link in objects["links"]:
-                if "type" in link:
+                if "type" in link.keys():
                     self.collections.remove(link["type"])
         return objects
 
     def prepare_kwargs(self, kwargs, objects):
-        if "region" not in kwargs and "lon" not in kwargs\
-           and "regions" in objects:
+        if not "region" in kwargs.keys() and not "lon" in kwargs.keys()\
+           and "regions" in objects.keys():
             kwargs["region"] = "{regions.id}"
 
         if "uri" in kwargs:
@@ -132,17 +132,17 @@ class add_pagination_links(object):
                     pagination = value
                 elif key in collections_to_resource_type.keys():
                     endpoint = "v1." + key + "."
-                    endpoint += "id" if "id" in kwargs else "collection"
+                    endpoint += "id" if "id" in kwargs.keys() else "collection"
                 elif key in ["journeys", "stop_schedules", "route_schedules",
                              "departures", "arrivals", "places_nearby", "calendars"]:
                     endpoint = "v1." + key
             if pagination and endpoint and "region" in kwargs:
                 pagination = data["pagination"]
-                if "start_page" in pagination and \
-                        "items_on_page" in pagination and \
-                        "items_per_page" in pagination and \
-                        "total_result" in pagination:
-                    if "links" not in data:
+                if "start_page" in pagination.keys() and \
+                        "items_on_page" in pagination.keys() and \
+                        "items_per_page" in pagination.keys() and \
+                        "total_result" in pagination.keys():
+                    if not "links" in data.keys():
                         data["links"] = []
                     start_page = int(pagination["start_page"])
                     items_per_page = int(pagination["items_per_page"])
@@ -261,18 +261,21 @@ class add_id_links(generate_links):
             data = self.prepare_objetcs(objects, True)
             kwargs = self.prepare_kwargs(kwargs, data)
             uri_id = None
-            if "id" in kwargs and\
-               "collection" in kwargs and \
-               kwargs["collection"] in data:
+            if "id" in kwargs.keys() and\
+               "collection" in kwargs.keys() and \
+               kwargs["collection"] in data.keys():
                 uri_id = kwargs["id"]
             for obj in self.data:
-                kwargs["collection"] = resource_type_to_collection.get(obj, obj)
-                if kwargs["collection"] in collections_to_resource_type:
+                if obj in resource_type_to_collection.keys():
+                    kwargs["collection"] = resource_type_to_collection[obj]
+                else:
+                    kwargs["collection"] = obj
+                if kwargs["collection"] in collections_to_resource_type.keys():
                     if not uri_id:
                         kwargs["id"] = "{" + obj + ".id}"
                     endpoint = "v1." + kwargs["collection"] + "."
-                    endpoint += "id" if "region" in kwargs or\
-                        "lon" in kwargs\
+                    endpoint += "id" if "region" in kwargs.keys() or\
+                        "lon" in kwargs.keys()\
                                         else "redirect"
                     collection = kwargs["collection"]
                     to_pass = {k:v for k,v in kwargs.iteritems() if k != "collection"}
@@ -287,8 +290,8 @@ class add_id_links(generate_links):
 
     def get_objets(self, data, collection_name=None):
         if hasattr(data, 'keys'):
-            if "id" in data \
-               and ("href" not in data) \
+            if "id" in data.keys() \
+               and (not "href" in data.keys()) \
                and collection_name:
                 self.data.add(collection_name)
             for key, value in data.iteritems():
@@ -310,7 +313,7 @@ class clean_links(object):
                     return data, code, header
             else:
                 data = response
-            if isinstance(data, OrderedDict) and "links" in data:
+            if isinstance(data, OrderedDict) and "links" in data.keys():
                 for link in data['links']:
                     link['href'] = link['href'].replace("%7B", "{")\
                                                .replace("%7D", "}")\

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -952,3 +952,16 @@ def is_valid_stop_date_time(stop_date_time):
     get_not_null(stop_date_time, 'departure_date_time')
     assert get_valid_datetime(stop_date_time['departure_date_time'])
 
+def get_interpreter():
+    """
+    Return the current interpreter(python, pypy.... etc.)
+    It should only be used in unit tests.
+    :return: str
+    """
+    # sys.executable is the whole path of the interpreter
+    exe = sys.executable
+
+    if 'python' in exe:
+        return 'python'
+    if 'pypy' in exe:
+        return 'pypy'

--- a/source/jormungandr/tests/overlapping_routing_tests.py
+++ b/source/jormungandr/tests/overlapping_routing_tests.py
@@ -160,4 +160,4 @@ class TestOverlappingCoverage(AbstractTestFixture):
         """
         response, error_code = self.query_no_assert("/v1/coord/-0.9;-0.9", display=True)
         assert error_code == 404
-        assert set(response['regions']) == {"empty_routing_test", "main_routing_test"}
+        assert response['regions'] == ["empty_routing_test", "main_routing_test"]


### PR DESCRIPTION
- remove keys() in jormungandr
- fix some unit tests to prepare the use of pypy
- some other improvements

Notes about using pypy:
- install pip for pypy
- install modules with `pypy -m pip install`
- pyzmq >= 3.0 and libzmq >= 3.0
- remember that if a lib calls c/c++ code in the back, it's not compatible with pypy. That's the reason why we cannot activate protobuf c++ bindings for pypy and why we replaced `ujson` by `simplejson`. 
- We can probably activate protobuf c++ interface by using `cppyy` and `reflex` but we need more investigations to figure out how that works and to test if we'll have an important gain(probably the answer is Yes). [see this link](http://docs.cython.org/src/userguide/pypy.html)
- some implementations in pypy are very different from python's. Like `datetime` module is completely reimplemented in pypy in pure python, so error messages are different in some cases. `dict` type is implemented in pypy in the way of `OrderedDict`. That's the reason why output of pypy is arranged in different order than the output of python. The `exception` class is also implemented in a different way. So remember to write also portable syntax.
-  `for loop` is not necessarily slower than `map` in pypy. so is `list comprehension`.
