### PR TITLE
doc: remove documentation of the old authentication way

### DIFF
--- a/documentation/navitia.io/source/integration.rst
+++ b/documentation/navitia.io/source/integration.rst
@@ -134,17 +134,9 @@ Authentication
 
 You must authenticate to use **navitia.io**. When you register we give you a authentication key to the API.
 
-There is two ways for authentication, you can use a `Basic HTTP authentication`_, where the username is the key, and without password.
-
-The other method is to pass directly the key in the `HTTP Authorization header`_ like that:
-
-.. code-block:: none
-
-    Authorization: mysecretkey
+You must use the `Basic HTTP authentication`_, where the username is the key, and without password.
 
 .. _Basic HTTP authentication: http://tools.ietf.org/html/rfc2617#section-2
-
-.. _HTTP Authorization header: http://tools.ietf.org/html/rfc2616#section-14.8
 
 .. _paging:
 


### PR DESCRIPTION
The LB doesn't really handle this kind of nonstandard way to
authenticate, resulting an impossibility to use quota with it.

Since quota are only used on api.sncf.com we don't delete the code to
handle it but it won't work elsewhere than navitia.io.
