### PR TITLE
[monitor-kraken] Set 0mq linger to 0 to discard messages when closing socket

### DIFF
--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -60,6 +60,8 @@ def monitor():
 
     uri = uri.replace('*', 'localhost')
     sock = context.socket(zmq.REQ)
+    # discard messages when socket closed
+    sock.setsockopt(zmq.LINGER, 0)
     try:
         sock.connect(uri)
         req = request_pb2.Request()


### PR DESCRIPTION
sock.close() before returning _"status": "timeout"_ seems to be ineffective here, because there is messages pending.
The real fix seems to be to tell zmq to discard pending messages when closing / socket destroy context.

Reproducing the problem is simple: just call _monitor-kraken/?instance=<instance_name>_ where instance_name is a non started kraken instance.

monitor-kraken patched only on one production node works well.

Sources:
https://github.com/zeromq/pyzmq/issues/132
http://api.zeromq.org/2-1:zmq-setsockopt#toc15
