### PR TITLE
Ed: integration tests

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(log4cplus)
 find_package(GoogleTcmalloc)
 find_package(Protoc)
 
+# add custom target to build docker tests not to have a strong docker dependendy
+add_custom_target(docker_test COMMAND ${CMAKE_CTEST_COMMAND})
+
 if(Boost_VERSION)
     # be silent if already found
     set(Boost_FIND_QUIETLY TRUE)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(GoogleTcmalloc)
 find_package(Protoc)
 
 # add custom target to build docker tests not to have a strong docker dependendy
-add_custom_target(docker_test COMMAND ${CMAKE_CTEST_COMMAND})
+add_custom_target(docker_test)
 
 if(Boost_VERSION)
     # be silent if already found

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(GoogleTcmalloc)
 find_package(Protoc)
 
 # add custom target to build docker tests not to have a strong docker dependendy
+# obviously to run this target you should have docker installed (and the right to run it)
 add_custom_target(docker_test)
 
 if(Boost_VERSION)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -49,3 +49,7 @@ add_executable(synonym2ed synonym2ed.cpp)
 target_link_libraries(synonym2ed transportation_data_import connectors)
 
 INSTALL_TARGETS(/usr/bin/ gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
+
+# Ed integration tests with docker, build with the docker_test target and not with the defaut target not to have a strong docker dependency
+#add_subdirectory(docker_tests EXCLUDE_FROM_ALL)  #TODO!
+add_subdirectory(docker_tests)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -51,5 +51,4 @@ target_link_libraries(synonym2ed transportation_data_import connectors)
 INSTALL_TARGETS(/usr/bin/ gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 
 # Ed integration tests with docker, build with the docker_test target and not with the defaut target not to have a strong docker dependency
-#add_subdirectory(docker_tests EXCLUDE_FROM_ALL)  #TODO!
-add_subdirectory(docker_tests)
+add_subdirectory(docker_tests EXCLUDE_FROM_ALL)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -50,5 +50,6 @@ target_link_libraries(synonym2ed transportation_data_import connectors)
 
 INSTALL_TARGETS(/usr/bin/ gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 
-# Ed integration tests with docker, build with the docker_test target and not with the defaut target not to have a strong docker dependency
+# Ed integration tests with docker, build with the docker_test target 
+# and not with the default target not to have a strong docker dependency
 add_subdirectory(docker_tests EXCLUDE_FROM_ALL)

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+#We use the BOOST_LIBS define is the parent
+SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+SET(DATA_NAV_NAME "data.nav.lz4")
+
+SET(DATA_DIR_TO_LOAD
+    ${FIXTURES_DIR}/ed/ntfs/
+)
+
+#TODO clean up it should be automatic
+SET(DATA_NAV_TO_CREATE
+    ${FIXTURES_DIR}/ed/ntfs/${DATA_NAV_NAME}
+)
+
+SET(EITRI "${CMAKE_SOURCE_DIR}/eitri/eitri.py")
+
+SET_PROPERTY(TARGET eitri PROPERTY
+    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_SOURCE_DIR}/navitiacommon")
+
+SET_PROPERTY(TARGET eitri APPEND PROPERTY
+    ENVIRONMENT "ED_COMPONENT_PATH=${CMAKE_BINARY_DIR}/ed")
+
+add_custom_command(OUTPUT ${DATA_NAV_TO_CREATE}
+    COMMAND ${EITRI}
+    ARGS ${FIXTURES_DIR}/ed/ntfs/${DATA_NAV_NAME} # todo for all DATA_NAV_TO_CREATE
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/type" VERBATIM
+)
+
+add_custom_target(datanav_files DEPENDS ${DATA_NAV_TO_CREATE})
+set_source_files_properties(${DATA_NAV_TO_CREATE} PROPERTIES GENERATED TRUE)
+
+
+add_executable(ed_integration_test ed_integration_tests.cpp)
+target_link_libraries(ed_integration_test ed types utils ${BOOST_LIBS} log4cplus)
+ADD_BOOST_TEST(ed_integration_test)
+
+add_dependencies(docker_test ed_integration_test)
+
+add_dependencies(ed_integration_test datanav_files) # TODO add dependency to ed_integration_test

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -7,32 +7,30 @@ SET(DATA_DIR_TO_LOAD
     ${FIXTURES_DIR}/ed/ntfs/
 )
 
-#TODO clean up it should be automatic
+#TODO clean up, it should be automatic (loop on DIR_TO_LOAD?)s
 SET(DATA_NAV_TO_CREATE
-    ${FIXTURES_DIR}/ed/ntfs/${DATA_NAV_NAME}
+    ${CMAKE_CURRENT_BINARY_DIR}/ntfs_${DATA_NAV_NAME}
 )
 
 SET(EITRI "${CMAKE_SOURCE_DIR}/eitri/eitri.py")
 
-SET_PROPERTY(TARGET eitri PROPERTY
-    ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_SOURCE_DIR}/navitiacommon")
-
-SET_PROPERTY(TARGET eitri APPEND PROPERTY
-    ENVIRONMENT "ED_COMPONENT_PATH=${CMAKE_BINARY_DIR}/ed")
-
+set($ENV{PYTHONPATH} "${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_SOURCE_DIR}/navitiacommon")
 add_custom_command(OUTPUT ${DATA_NAV_TO_CREATE}
     COMMAND ${EITRI}
-    ARGS ${FIXTURES_DIR}/ed/ntfs/${DATA_NAV_NAME} # todo for all DATA_NAV_TO_CREATE
+    ARGS "${FIXTURES_DIR}/ed/ntfs/" --output-file ${DATA_NAV_TO_CREATE} --ed-component-path "${CMAKE_BINARY_DIR}/ed" --add-pythonpath "${CMAKE_SOURCE_DIR}/navitiacommon" # todo for all DATA_NAV_TO_CREATE
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/type" VERBATIM
 )
 
 add_custom_target(datanav_files DEPENDS ${DATA_NAV_TO_CREATE})
+
 set_source_files_properties(${DATA_NAV_TO_CREATE} PROPERTIES GENERATED TRUE)
 
 
 add_executable(ed_integration_test ed_integration_tests.cpp)
-target_link_libraries(ed_integration_test ed types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(ed_integration_test data georef types utils ${BOOST_LIBS} log4cplus)
 ADD_BOOST_TEST(ed_integration_test)
+
+SET_PROPERTY(TEST ed_integration_test APPEND PROPERTY ENVIRONMENT "INPUT_FILE_PATH=${DATA_NAV_TO_CREATE}")
 
 add_dependencies(docker_test ed_integration_test)
 

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -1,37 +1,47 @@
-#We use the BOOST_LIBS define is the parent
-SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
 SET(DATA_NAV_NAME "data.nav.lz4")
-
-SET(DATA_DIR_TO_LOAD
-    ${FIXTURES_DIR}/ed/ntfs/
-)
-
-#TODO clean up, it should be automatic (loop on DIR_TO_LOAD?)s
-SET(DATA_NAV_TO_CREATE
-    ${CMAKE_CURRENT_BINARY_DIR}/ntfs_${DATA_NAV_NAME}
-)
-
 SET(EITRI "${CMAKE_SOURCE_DIR}/eitri/eitri.py")
 
-set($ENV{PYTHONPATH} "${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_SOURCE_DIR}/navitiacommon")
+# TODO: if more data.nav have to be created, refactor this to be more generic
+
+# == Nav generation ==
+SET(DATA_DIR_TO_LOAD ${FIXTURES_DIR}/ed/ntfs/)
+
+SET(DATA_NAV_TO_CREATE ${CMAKE_CURRENT_BINARY_DIR}/ntfs_${DATA_NAV_NAME})
+
 add_custom_command(OUTPUT ${DATA_NAV_TO_CREATE}
     COMMAND ${EITRI}
-    ARGS "${FIXTURES_DIR}/ed/ntfs/" --output-file ${DATA_NAV_TO_CREATE} --ed-component-path "${CMAKE_BINARY_DIR}/ed" --add-pythonpath "${CMAKE_SOURCE_DIR}/navitiacommon" # todo for all DATA_NAV_TO_CREATE
+    ARGS "${FIXTURES_DIR}/ed/ntfs/" --output-file ${DATA_NAV_TO_CREATE} --ed-component-path "${CMAKE_BINARY_DIR}/ed" --add-pythonpath "${CMAKE_SOURCE_DIR}/navitiacommon"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/type" VERBATIM
 )
-
-add_custom_target(datanav_files DEPENDS ${DATA_NAV_TO_CREATE})
-
 set_source_files_properties(${DATA_NAV_TO_CREATE} PROPERTIES GENERATED TRUE)
 
 
+# == create a target with all generated files ==
+add_custom_target(datanav_files DEPENDS ${DATA_NAV_TO_CREATE})
+
+# ==
+# add all the tests
+#
+# Note: each tests should have their data set given with the environment variable 'INPUT_FILE_PATH'
+# ==
+
+SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
 add_executable(ed_integration_test ed_integration_tests.cpp)
 target_link_libraries(ed_integration_test data georef types utils ${BOOST_LIBS} log4cplus)
-ADD_BOOST_TEST(ed_integration_test)
 
-SET_PROPERTY(TEST ed_integration_test APPEND PROPERTY ENVIRONMENT "INPUT_FILE_PATH=${DATA_NAV_TO_CREATE}")
+# the test is not added with 'add_test', because we don't want 'make test' to handle it
+# it is added as a post build command to 'make docker_test', called after all the build
+add_custom_command(TARGET ed_integration_test
+                    POST_BUILD COMMAND ed_integration_test
+                    ARGS --log_format=XML --log_sink=results_ed_integration_test.xml --log_level=all --report_level=no --ntfs_file=${DATA_NAV_TO_CREATE})
+
+
+#set_target_properties(ed_integration_test PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+add_dependencies(ed_integration_test datanav_files)
+
 
 add_dependencies(docker_test ed_integration_test)
 
-add_dependencies(ed_integration_test datanav_files) # TODO add dependency to ed_integration_test

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -38,10 +38,6 @@ add_custom_command(TARGET ed_integration_test
                     ARGS --log_format=XML --log_sink=results_ed_integration_test.xml --log_level=all --report_level=no --ntfs_file=${DATA_NAV_TO_CREATE})
 
 
-#set_target_properties(ed_integration_test PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
 add_dependencies(ed_integration_test datanav_files)
-
-
 add_dependencies(docker_test ed_integration_test)
 

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -77,4 +77,6 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     BOOST_REQUIRE_EQUAL(data.pt_data->networks.size(), 1);
     BOOST_CHECK_EQUAL(data.pt_data->networks[0]->name, "ligne flixible");
     BOOST_CHECK_EQUAL(data.pt_data->networks[0]->uri, "network:ligneflexible");
+
+    //TODO, have fun ! :)
 }

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -1,0 +1,44 @@
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+  
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+ 
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+  
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+   
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+   
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+  
+Stay tuned using
+twitter @navitia 
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE associated_calendar_test
+#include <boost/test/unit_test.hpp>
+#include "utils/logger.h"
+
+struct logger_initialized {
+    logger_initialized()   { init_logger(); }
+};
+BOOST_GLOBAL_FIXTURE( logger_initialized )
+
+
+BOOST_AUTO_TEST_CASE(fusio_test) {
+
+}

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -32,6 +32,8 @@ www.navitia.io
 #define BOOST_TEST_MODULE associated_calendar_test
 #include <boost/test/unit_test.hpp>
 #include "utils/logger.h"
+#include "type/data.h"
+#include "type/pt_data.h"
 
 struct logger_initialized {
     logger_initialized()   { init_logger(); }
@@ -40,5 +42,14 @@ BOOST_GLOBAL_FIXTURE( logger_initialized )
 
 
 BOOST_AUTO_TEST_CASE(fusio_test) {
+    const auto input_file = std::getenv("INPUT_FILE_PATH");
+    navitia::type::Data data;
 
+    const auto res = data.load(input_file);
+
+    BOOST_REQUIRE(res);
+
+    BOOST_REQUIRE_EQUAL(data.pt_data->networks.size(), 1);
+    BOOST_CHECK_EQUAL(data.pt_data->networks[0]->name, "ligne flixible");
+    BOOST_CHECK_EQUAL(data.pt_data->networks[0]->uri, "network:ligneflexible");
 }

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -34,6 +34,7 @@ www.navitia.io
 #include "utils/logger.h"
 #include "type/data.h"
 #include "type/pt_data.h"
+#include <boost/algorithm/string.hpp>
 
 struct logger_initialized {
     logger_initialized()   { init_logger(); }
@@ -41,8 +42,32 @@ struct logger_initialized {
 BOOST_GLOBAL_FIXTURE( logger_initialized )
 
 
-BOOST_AUTO_TEST_CASE(fusio_test) {
-    const auto input_file = std::getenv("INPUT_FILE_PATH");
+struct ArgsFixture {
+   ArgsFixture() {
+       auto argc = boost::unit_test::framework::master_test_suite().argc;
+       auto argv = boost::unit_test::framework::master_test_suite().argv;
+
+       //we should have at least more than one arg, the first is the exe name, the rest is the input file paths
+       BOOST_REQUIRE(argc > 1);
+
+       for (int i(1); i < argc; ++i) {
+           std::vector<std::string> arg;
+
+           std::string raw_arg = argv[i];
+           // dumb method, we erase all '-' not to bother with the '--bob=toto' format
+           boost::erase_all(raw_arg, "-");
+           boost::split(arg, raw_arg, boost::is_any_of("="));
+
+           BOOST_REQUIRE_EQUAL(arg.size(), 2);
+           input_file_paths[arg.at(0)] = arg.at(1);
+       }
+   }
+
+   std::map<std::string, std::string> input_file_paths;
+};
+
+BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
+    const auto input_file = input_file_paths.at("ntfs_file");
     navitia::type::Data data;
 
     const auto res = data.load(input_file);

--- a/source/eitri/ed_handler.py
+++ b/source/eitri/ed_handler.py
@@ -38,9 +38,6 @@ import logging
 
 ALEMBIC_PATH = os.environ.get('ALEMBIC_PATH', '../sql')
 
-# optional env var to give the path to the ed component
-ED_COMPONENT_PATH = os.environ.get('ED_COMPONENT_PATH')
-
 
 @contextmanager
 def cd(new_dir):
@@ -55,17 +52,17 @@ def cd(new_dir):
         os.chdir(prev_dir)
 
 
-def binarize(db_params, output):
+def binarize(db_params, output, ed_component_path):
     logging.getLogger(__name__).info('creating data.nav')
     ed2nav = 'ed2nav'
-    if ED_COMPONENT_PATH:
-        ed2nav = os.path.join(ED_COMPONENT_PATH, ed2nav)
+    if ed_component_path:
+        ed2nav = os.path.join(ed_component_path, ed2nav)
     launch_exec(ed2nav,
                 ["-o", output,
                  "--connection-string", db_params.old_school_cnx_string()], logging.getLogger(__name__))
 
 
-def import_data(data_dir, db_params):
+def import_data(data_dir, db_params, ed_component_path):
     """
     call the right component to import the data in the directory
 
@@ -80,8 +77,8 @@ def import_data(data_dir, db_params):
 
     # Note, we consider that we only have to load one kind of data per directory
     import_component = data_type + '2ed'
-    if ED_COMPONENT_PATH:
-        import_component = os.path.join(ED_COMPONENT_PATH, import_component)
+    if ed_component_path:
+        import_component = os.path.join(ed_component_path, import_component)
 
     if file_to_load.endswith('.zip') or file_to_load.endswith('.geopal'):
         #TODO: handle geopal as non zip
@@ -98,11 +95,11 @@ def import_data(data_dir, db_params):
         exit(1)
 
 
-def load_data(data_dirs, db_params):
+def load_data(data_dirs, db_params, ed_component_path):
     logging.getLogger(__name__).info('loading {}'.format(data_dirs))
 
     for d in data_dirs:
-        import_data(d, db_params)
+        import_data(d, db_params, ed_component_path)
 
 
 def update_db(db_params):
@@ -128,7 +125,7 @@ def update_db(db_params):
             raise Exception('problem with db update')
 
 
-def generate_nav(data_dir, db_params, output_file):
+def generate_nav(data_dir, db_params, output_file, ed_component_path):
     """
     load all data either directly in data_dir if there is no sub dir, or all data in the subdir
     """
@@ -145,6 +142,6 @@ def generate_nav(data_dir, db_params, output_file):
 
     update_db(db_params)
 
-    load_data(data_dirs, db_params)
+    load_data(data_dirs, db_params, ed_component_path)
 
-    binarize(db_params, output_file)
+    binarize(db_params, output_file, ed_component_path)

--- a/source/eitri/eitri.py
+++ b/source/eitri/eitri.py
@@ -27,10 +27,9 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
+import sys
 
-from docker_wrapper import PostgresDocker
 from clingon import clingon
-from ed_handler import generate_nav
 import logging
 """
 Nav generator
@@ -42,12 +41,18 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 @clingon.clize()
-def eitri(data_dir, output_file='./data.nav.lz4'):
+def eitri(data_dir, output_file='./data.nav.lz4', ed_component_path='', add_pythonpath=[]):
     """
     Generate a data.nav.lz4 file
 
     :param data_dir: directory with data. if several dataset (osm/gtfs/...) are available, they need to be in separate directory
     :param output_file: output data.nav.lz4 file path
     """
+    for p in add_pythonpath:
+        sys.path.append(p)
+
+    from ed_handler import generate_nav
+    from docker_wrapper import PostgresDocker
+
     with PostgresDocker() as docker:
-        generate_nav(data_dir, docker.get_db_params(), output_file)
+        generate_nav(data_dir, docker.get_db_params(), output_file, ed_component_path=ed_component_path)

--- a/source/eitri/eitri.py
+++ b/source/eitri/eitri.py
@@ -48,6 +48,9 @@ def eitri(data_dir, output_file='./data.nav.lz4', ed_component_path='', add_pyth
     :param data_dir: directory with data. if several dataset (osm/gtfs/...) are available, they need to be in separate directory
     :param output_file: output data.nav.lz4 file path
     """
+
+    # there is some problems with environment variables and cmake, so all args
+    # can be given through cli
     for p in add_pythonpath:
         sys.path.append(p)
 


### PR DESCRIPTION
use the new Eitri module (based on docker for the DB) to handle ed integration tests

`make` and `make test` do not build/run the ed integration tests

to run them call `make docker_test`

Note: you need of course to have docker installed to run them.
if you haven't added your user to the docker group you need the root privilege to run docker
