### PR TITLE
Jormungandr: add some journey's debug indicators

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -159,6 +159,24 @@ class section_place(PbField):
             return super(PbField, self).output(key, obj)
 
 
+class JourneyDebugInfo(fields.Raw):
+    def output(self, key, obj):
+        if not hasattr(g, 'debug') or not g.debug:
+            return None
+
+        debug = {
+            'streetnetwork_duration': obj.sn_dur,
+            'transfer_duration': obj.transfer_dur,
+            'min_waiting_duration': obj.min_waiting_dur,
+            'nb_vj_extentions': obj.nb_vj_extentions,
+            'nb_sections': obj.nb_sections,
+        }
+        if hasattr(obj, 'internal_id'):
+            debug['internal_id'] = obj.internal_id
+
+        return debug
+
+
 section = {
     "type": section_type(),
     "id": fields.String(),
@@ -209,6 +227,7 @@ journey = {
     "status": fields.String(attribute="most_serious_disruption_effect"),
     "calendars": NonNullList(NonNullNested(calendar)),
     "co2_emission": Co2Emission(),
+    "debug": JourneyDebugInfo()
 }
 
 ticket = {
@@ -628,6 +647,9 @@ class Journeys(ResourceUri, ResourceUtc):
 
         if not (args['destination'] or args['origin']):
             abort(400, message="you should at least provide either a 'from' or a 'to' argument")
+
+        if args['debug']:
+            g.debug = True
 
         #we transform the origin/destination url to add information
         if args['origin']:

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -459,6 +459,11 @@ def is_valid_journey_response(response, tester, query_str):
     for feed_publisher in feed_publishers:
         is_valid_feed_publisher(feed_publisher)
 
+    if query_dict.get('debug', False):
+        assert 'debug' in response
+    else:
+        assert 'debug' not in response
+
 
 def is_valid_journey(journey, tester, query):
     arrival = get_valid_datetime(journey['arrival_date_time'])
@@ -491,6 +496,11 @@ def is_valid_journey(journey, tester, query):
 
     assert last_arrival == arrival
     assert get_valid_datetime(journey['sections'][-1]['arrival_date_time']) == last_arrival
+
+    if query.get('debug', False):
+        assert 'debug' in journey
+    else:
+        assert 'debug' not in journey
 
 
 def is_valid_section(section, query):

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -283,6 +283,12 @@ static void add_pathes(EnhancedResponse& enhanced_response,
         pb_journey->set_nb_transfers(path.nb_changes);
         pb_journey->set_requested_date_time(navitia::to_posix_timestamp(path.request_time));
 
+        pb_journey->set_sn_dur(path.sn_dur.total_seconds());
+        pb_journey->set_transfer_dur(path.transfer_dur.total_seconds());
+        pb_journey->set_min_waiting_dur(path.min_waiting_dur.total_seconds());
+        pb_journey->set_nb_vj_extentions(path.nb_vj_extentions);
+        pb_journey->set_nb_sections(path.nb_sections);
+
         if (path.items.empty()) {
             continue;
         }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -674,6 +674,12 @@ Path make_path(const Journey& journey, const type::Data& data) {
 
     path.duration = navitia::time_duration::from_boost_duration(path.items.back().arrival - path.items.front().departure);
 
+    path.sn_dur = journey.sn_dur;
+    path.transfer_dur = journey.transfer_dur;
+    path.min_waiting_dur = journey.min_waiting_dur;
+    path.nb_vj_extentions = journey.nb_vj_extentions;
+    path.nb_sections = journey.sections.size();
+
     return path;
 }
 

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -118,6 +118,13 @@ struct Path {
     std::vector<PathItem> items;
     type::EntryPoint origin;
 
+    // for debug purpose, we store the reader's computed values
+    navitia::time_duration sn_dur = 0_s;// street network duration
+    navitia::time_duration transfer_dur = 0_s;// walking duration during transfer
+    navitia::time_duration min_waiting_dur = 0_s;// minimal waiting duration on every transfers
+    uint8_t nb_vj_extentions = 0;// number of vehicle journey extentions (I love useless comments!)
+    uint8_t nb_sections = 0;
+
     void print() const {
         for(auto item : items)
             std::cout << item.print() << std::endl;


### PR DESCRIPTION
for debug purpose, output some of the raptor reader's indicator on the
journeys

they are outputed in a debug section on a journey:

``` json
journeys: [ {
...
"debug":
{
    "internal_id": "1-0",
    "nb_vj_extentions": 0,
    "transfer_duration": 120,
    "streetnetwork_duration": 481,
    "min_waiting_duration": 0
},
]}

```
