### PR TITLE
All: Kraken headsign structure + fill in Ed

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -145,7 +145,8 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
     mvj->theoric_vj.push_back(vj);
     vj->meta_vj = mvj;
     vj->idx = b.data->pt_data->vehicle_journeys.size();
-    vj->name = "vehicle_journey " + std::to_string(vj->idx);
+    b.data->pt_data->headsign_handler.change_name_and_register_as_headsign(
+                                                *vj, "vehicle_journey " + std::to_string(vj->idx));
     vj->uri = vj->name;
     b.data->pt_data->vehicle_journeys.push_back(vj);
     b.data->pt_data->vehicle_journeys_map[vj->uri] = vj;

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -66,6 +66,23 @@ struct ArgsFixture {
    std::map<std::string, std::string> input_file_paths;
 };
 
+// check headsign value for stop times on given vjs
+static void check_headsigns(const navitia::type::Data& data, const std::string& headsign,
+                     size_t first_it_vj, size_t last_it_vj,
+                     size_t first_it_st = 0, size_t last_it_st = std::numeric_limits<size_t>::max()) {
+    const navitia::type::HeadsignHandler& headsigns = data.pt_data->headsign_handler;
+    auto& vj_vec = data.pt_data->vehicle_journeys;
+    for (size_t it_vj = first_it_vj; it_vj <= last_it_vj; ++it_vj) {
+        size_t real_last_it_st = vj_vec[it_vj]->stop_time_list.size() - 1;
+        if (real_last_it_st > last_it_st) {
+            real_last_it_st = last_it_st;
+        }
+        for (size_t it_st = first_it_st; it_st <= real_last_it_st; ++it_st) {
+            BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[it_vj]->stop_time_list[it_st]), headsign);
+        }
+    }
+}
+
 BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     const auto input_file = input_file_paths.at("ntfs_file");
     navitia::type::Data data;
@@ -81,38 +98,12 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     // check stop_time headsigns
     const navitia::type::HeadsignHandler& headsigns = data.pt_data->headsign_handler;
     auto& vj_vec = data.pt_data->vehicle_journeys;
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[0]), "N1");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[1]), "N1");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[2]), "N1");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[3]), "N2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[4]), "N2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[0]), "N1");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[1]), "N1");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[2]), "N1");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[3]), "N2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[4]), "N2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[0]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[1]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[2]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[3]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[4]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[0]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[1]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[2]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[3]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[4]), "vehiclejourney2");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[0]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[1]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[2]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[3]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[4]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[5]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[0]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[1]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[2]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[3]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[4]), "vehiclejourney3");
-    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[5]), "vehiclejourney3");
+    // check that vj 0 & 1 have headsign N1 from first 3 stpop_time, then N2
+    check_headsigns(data, "N1", 0, 1, 0, 2);
+    check_headsigns(data, "N2", 0, 1, 3, 4);
+    // vj 2 & 3 are named vehiclejourney2 with no headsign overload, 4 & 5 are named vehiclejourney3
+    check_headsigns(data, "vehiclejourney2", 2, 3);
+    check_headsigns(data, "vehiclejourney3", 4, 5);
     // check vj from headsign
     BOOST_CHECK_EQUAL(headsigns.get_vj_from_headsign("vehiclejourney1").size(), 2);
     BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney1"), vj_vec[0]));

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -78,5 +78,55 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     BOOST_CHECK_EQUAL(data.pt_data->networks[0]->name, "ligne flixible");
     BOOST_CHECK_EQUAL(data.pt_data->networks[0]->uri, "network:ligneflexible");
 
-    //TODO, have fun ! :)
+    // check stop_time headsigns
+    const navitia::type::HeadsignHandler& headsigns = data.pt_data->headsign_handler;
+    auto& vj_vec = data.pt_data->vehicle_journeys;
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[0]), "N1");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[1]), "N1");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[2]), "N1");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[3]), "N2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[0]->stop_time_list[4]), "N2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[0]), "N1");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[1]), "N1");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[2]), "N1");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[3]), "N2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[1]->stop_time_list[4]), "N2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[0]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[1]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[2]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[3]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[2]->stop_time_list[4]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[0]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[1]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[2]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[3]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[3]->stop_time_list[4]), "vehiclejourney2");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[0]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[1]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[2]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[3]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[4]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[4]->stop_time_list[5]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[0]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[1]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[2]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[3]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[4]), "vehiclejourney3");
+    BOOST_CHECK_EQUAL(headsigns.get_headsign(vj_vec[5]->stop_time_list[5]), "vehiclejourney3");
+    // check vj from headsign
+    BOOST_CHECK_EQUAL(headsigns.get_vj_from_headsign("vehiclejourney1").size(), 2);
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney1"), vj_vec[0]));
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney1"), vj_vec[1]));
+    BOOST_CHECK_EQUAL(headsigns.get_vj_from_headsign("N1").size(), 2);
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("N1"), vj_vec[0]));
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("N1"), vj_vec[1]));
+    BOOST_CHECK_EQUAL(headsigns.get_vj_from_headsign("N2").size(), 2);
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("N2"), vj_vec[0]));
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("N2"), vj_vec[1]));
+    BOOST_CHECK_EQUAL(headsigns.get_vj_from_headsign("vehiclejourney2").size(), 2);
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney2"), vj_vec[2]));
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney2"), vj_vec[3]));
+    BOOST_CHECK_EQUAL(headsigns.get_vj_from_headsign("vehiclejourney3").size(), 2);
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney3"), vj_vec[4]));
+    BOOST_CHECK(navitia::contains(headsigns.get_vj_from_headsign("vehiclejourney3"), vj_vec[5]));
 }

--- a/source/kraken/fill_disruption_from_chaos.cpp
+++ b/source/kraken/fill_disruption_from_chaos.cpp
@@ -328,7 +328,7 @@ struct functor_add_vj {
         vj->idx = pt_data.vehicle_journeys.size();
         vj->uri = make_adapted_uri_fast(vj_ref.uri, pt_data.vehicle_journeys.size());
         vj->is_adapted = true;
-        vj->name = vj_ref.name;
+        pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, vj_ref.name);
         vj->company = vj_ref.company;
         //TODO: we loose stay_in on impacted vj, we will need to work on this.
         vj->next_vj = nullptr;

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -65,6 +65,7 @@ SET(DATA_SRC
     data.cpp
     "${CMAKE_SOURCE_DIR}/third_party/lz4/lz4.c"
     pt_data.cpp
+    headsign_handler.cpp
 )
 
 SET(BOOST_LIBS ${Boost_FILESYSTEM_LIBRARY}
@@ -113,3 +114,7 @@ ADD_BOOST_TEST(aggregation_odt_test)
 add_executable(comments_test tests/comments_test.cpp)
 target_link_libraries(comments_test ed data types georef autocomplete utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
 ADD_BOOST_TEST(comments_test)
+
+add_executable(headsign_test tests/headsign_test.cpp)
+target_link_libraries(headsign_test ed data types georef autocomplete utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+ADD_BOOST_TEST(headsign_test)

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -44,30 +44,31 @@ void HeadsignHandler::change_name_and_register_as_headsign(VehicleJourney& vj,
 void HeadsignHandler::update_headsign_mvj_after_remove(const VehicleJourney& vj,
                                                        const std::string& removed_headsign) {
     // unregister meta-vj from headsign only if necessary
-    bool meta_has_headsign = false;
-    for (const auto& it_headsign_vj: get_vj_from_headsign(removed_headsign)) {
-        if (it_headsign_vj->meta_vj == vj.meta_vj) {
-            meta_has_headsign = true;
-            break;
-        }
+    auto has_mvj = [&] (const VehicleJourney* it_vj) {return it_vj->meta_vj == vj.meta_vj;};
+    if (navitia::contains_if(get_vj_from_headsign(removed_headsign), has_mvj)) {
+        return;
     }
-    if (!meta_has_headsign && navitia::contains(headsign_mvj, removed_headsign)) {
-        headsign_mvj[removed_headsign].erase(vj.meta_vj);
-        if (headsign_mvj[removed_headsign].empty()) {
-            headsign_mvj.erase(removed_headsign);
+    {
+        auto it_headsign_mvj = headsign_mvj.find(removed_headsign);
+        if (it_headsign_mvj == headsign_mvj.end()) {
+            return;
+        }
+        it_headsign_mvj->second.erase(vj.meta_vj);
+        if (it_headsign_mvj->second.empty()) {
+            headsign_mvj.erase(it_headsign_mvj);
         }
     }
 }
 
 const std::string& HeadsignHandler::get_headsign(const StopTime& stop_time) const{
     // if no headsign map for vj: return name
-    if (!navitia::contains(map_vj_map_stop_time_headsign_change, stop_time.vehicle_journey)) {
+    if (!navitia::contains(headsign_changes, stop_time.vehicle_journey)) {
         return stop_time.vehicle_journey->name;
     }
 
     // otherwise use headsign change map
     const auto& map_stop_time_headsign_change =
-            map_vj_map_stop_time_headsign_change.at(stop_time.vehicle_journey);
+            headsign_changes.at(stop_time.vehicle_journey);
     uint16_t order_stop_time = stop_time.journey_pattern_point->order;
 
     // if no headsign change stored: return name
@@ -95,30 +96,29 @@ bool HeadsignHandler::has_headsign_or_name(const VehicleJourney& vj,
         return true;
     }
 
-    if(!navitia::contains(map_vj_map_stop_time_headsign_change, &vj)) {
+    const auto it_vj_changes = headsign_changes.find(&vj);
+    if (it_vj_changes == headsign_changes.end()) {
         return false;
     }
 
-    for (const auto& change: map_vj_map_stop_time_headsign_change.at(&vj)) {
-        if (change.second == headsign) {
-            return true;
-        }
+    auto has_headsign = [&] (const std::pair<uint16_t, std::string>& it_change)
+                        {return it_change.second == headsign;};
+    if (navitia::contains_if(it_vj_changes->second, has_headsign)) {
+        return true;
     }
     return false;
 }
 
 std::vector<const VehicleJourney*>
 HeadsignHandler::get_vj_from_headsign(const std::string& headsign) const {
-    using namespace std;
-    vector<const VehicleJourney*> res;
+    std::vector<const VehicleJourney*> res;
     const auto& it_vj_set = headsign_mvj.find(headsign);
     if (it_vj_set == headsign_mvj.end()) {
         return res;
     }
 
     for (const MetaVehicleJourney* mvj: it_vj_set->second) {
-        vector<vector<VehicleJourney*>> vect_vect_vj{mvj->theoric_vj, mvj->adapted_vj, mvj->real_time_vj};
-        for (const auto vect_vj: vect_vect_vj) {
+        for (const auto& vect_vj: {mvj->theoric_vj, mvj->adapted_vj, mvj->real_time_vj}) {
             for (const VehicleJourney* vj: vect_vj) {
                 if (has_headsign_or_name(*vj, headsign)) {
                     res.push_back(vj);
@@ -132,33 +132,35 @@ HeadsignHandler::get_vj_from_headsign(const std::string& headsign) const {
 void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time,
                                                    const std::string& headsign) {
     const VehicleJourney* vj = stop_time.vehicle_journey;
-    headsign_mvj[vj->name].insert(vj->meta_vj); // for safety
+    assert(navitia::contains_if(get_vj_from_headsign(vj->name),
+           [&] (const VehicleJourney* it_vj) {return it_vj->meta_vj == vj->meta_vj;}));
     std::string prev_headsign_for_stop_time = get_headsign(stop_time);
     if (headsign == prev_headsign_for_stop_time) {
         return;
     }
 
     uint16_t order = stop_time.journey_pattern_point->order;
+    auto& vj_headsign_changes = headsign_changes[vj];
     // erase change if exists
-    if (navitia::contains(map_vj_map_stop_time_headsign_change[vj], order)) {
-        map_vj_map_stop_time_headsign_change[vj].erase(order);
+    if (navitia::contains(vj_headsign_changes, order)) {
+        vj_headsign_changes.erase(order);
     }
     // only if headsign erase is not enough: store change
     if (get_headsign(stop_time) != headsign) {
-        map_vj_map_stop_time_headsign_change[vj][order] = headsign;
+        vj_headsign_changes[order] = headsign;
     }
     // if next stop_time's value is prev_headsign_for_stop_time: store the change back to this
     // previous headsign. Done even if last, as we could add stop_time in the future
-    if (!navitia::contains(map_vj_map_stop_time_headsign_change[vj], order + 1)) {
-        map_vj_map_stop_time_headsign_change[vj][order + 1] = prev_headsign_for_stop_time;
+    if (!navitia::contains(vj_headsign_changes, order + 1)) {
+        vj_headsign_changes[order + 1] = prev_headsign_for_stop_time;
     }
     // if next stop_time changed to  headsign: erase mext change to merge
-    else if(map_vj_map_stop_time_headsign_change[vj][order + 1] == headsign) {
-        map_vj_map_stop_time_headsign_change[vj].erase(order + 1);
+    else if(vj_headsign_changes[order + 1] == headsign) {
+        vj_headsign_changes.erase(order + 1);
     }
     // if map for this vj is empty (all headsigns == vj.name): clean map
-    if (map_vj_map_stop_time_headsign_change[vj].empty()) {
-        map_vj_map_stop_time_headsign_change.erase(vj);
+    if (vj_headsign_changes.empty()) {
+        headsign_changes.erase(vj);
     }
 
     // register meta-vj from headsign

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -1,0 +1,169 @@
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "headsign_handler.h"
+#include "utils/functions.h"
+
+namespace navitia { namespace type {
+
+void HeadsignHandler::change_name_and_register_as_headsign(VehicleJourney& vj,
+                                                           const std::string& new_name) {
+    std::string prev_name = vj.name;
+    vj.name = new_name;
+    headsign_mvj[vj.name].insert(vj.meta_vj);
+    update_headsign_mvj_after_remove(vj, prev_name);
+}
+
+void HeadsignHandler::update_headsign_mvj_after_remove(const VehicleJourney& vj,
+                                                       const std::string& removed_headsign) {
+    // unregister meta-vj from headsign only if necessary
+    bool meta_has_headsign = false;
+    for (const auto& it_headsign_vj: get_vj_from_headsign(removed_headsign)) {
+        if (it_headsign_vj->meta_vj == vj.meta_vj) {
+            meta_has_headsign = true;
+            break;
+        }
+    }
+    if (!meta_has_headsign && navitia::contains(headsign_mvj, removed_headsign)) {
+        headsign_mvj[removed_headsign].erase(vj.meta_vj);
+        if (headsign_mvj[removed_headsign].empty()) {
+            headsign_mvj.erase(removed_headsign);
+        }
+    }
+}
+
+const std::string& HeadsignHandler::get_headsign(const StopTime& stop_time) const{
+    // if no headsign map for vj: return name
+    if (!navitia::contains(map_vj_map_stop_time_headsign_change, stop_time.vehicle_journey)) {
+        return stop_time.vehicle_journey->name;
+    }
+
+    // otherwise use headsign change map
+    const auto& map_stop_time_headsign_change =
+            map_vj_map_stop_time_headsign_change.at(stop_time.vehicle_journey);
+    uint16_t order_stop_time = stop_time.journey_pattern_point->order;
+
+    // if no headsign change stored: return name
+    if (map_stop_time_headsign_change.empty()) {
+        return stop_time.vehicle_journey->name;
+    }
+
+    // get next change
+    auto it_headsign = map_stop_time_headsign_change.upper_bound(order_stop_time);
+    // if next change is the first: return name
+    if(it_headsign == map_stop_time_headsign_change.begin()) {
+        return stop_time.vehicle_journey->name;
+    }
+
+    // get previous change and return headsign
+    if (it_headsign == map_stop_time_headsign_change.end()) {
+        return map_stop_time_headsign_change.rbegin()->second;
+    }
+    return (--it_headsign)->second;
+}
+
+bool HeadsignHandler::has_headsign_or_name(const VehicleJourney& vj,
+                                           const std::string& headsign) const {
+    if (vj.name == headsign) {
+        return true;
+    }
+
+    if(!navitia::contains(map_vj_map_stop_time_headsign_change, &vj)) {
+        return false;
+    }
+
+    for (const auto& change: map_vj_map_stop_time_headsign_change.at(&vj)) {
+        if (change.second == headsign) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<const VehicleJourney*>
+HeadsignHandler::get_vj_from_headsign(const std::string& headsign) const {
+    using namespace std;
+    vector<const VehicleJourney*> res;
+    const auto& it_vj_set = headsign_mvj.find(headsign);
+    if (it_vj_set == headsign_mvj.end()) {
+        return res;
+    }
+
+    for (const MetaVehicleJourney* mvj: it_vj_set->second) {
+        vector<vector<VehicleJourney*>> vect_vect_vj{mvj->theoric_vj, mvj->adapted_vj, mvj->real_time_vj};
+        for (const auto vect_vj: vect_vect_vj) {
+            for (const VehicleJourney* vj: vect_vj) {
+                if (has_headsign_or_name(*vj, headsign)) {
+                    res.push_back(vj);
+                }
+            }
+        }
+    }
+    return res;
+}
+
+void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time,
+                                                   const std::string& headsign) {
+    const VehicleJourney* vj = stop_time.vehicle_journey;
+    headsign_mvj[vj->name].insert(vj->meta_vj); // for safety
+    std::string prev_headsign_for_stop_time = get_headsign(stop_time);
+    if (headsign == prev_headsign_for_stop_time) {
+        return;
+    }
+
+    uint16_t order = stop_time.journey_pattern_point->order;
+    // erase change if exists
+    if (navitia::contains(map_vj_map_stop_time_headsign_change[vj], order)) {
+        map_vj_map_stop_time_headsign_change[vj].erase(order);
+    }
+    // only if headsign erase is not enough: store change
+    if (get_headsign(stop_time) != headsign) {
+        map_vj_map_stop_time_headsign_change[vj][order] = headsign;
+    }
+    // if next stop_time's value is prev_headsign_for_stop_time: store the change back to this
+    // previous headsign. Done even if last, as we could add stop_time in the future
+    if (!navitia::contains(map_vj_map_stop_time_headsign_change[vj], order + 1)) {
+        map_vj_map_stop_time_headsign_change[vj][order + 1] = prev_headsign_for_stop_time;
+    }
+    // if next stop_time changed to  headsign: erase mext change to merge
+    else if(map_vj_map_stop_time_headsign_change[vj][order + 1] == headsign) {
+        map_vj_map_stop_time_headsign_change[vj].erase(order + 1);
+    }
+    // if map for this vj is empty (all headsigns == vj.name): clean map
+    if (map_vj_map_stop_time_headsign_change[vj].empty()) {
+        map_vj_map_stop_time_headsign_change.erase(vj);
+    }
+
+    // register meta-vj from headsign
+    headsign_mvj[headsign].insert(vj->meta_vj);
+    update_headsign_mvj_after_remove(*vj, prev_headsign_for_stop_time);
+}
+
+}} //namespace navitia::type

--- a/source/type/headsign_handler.h
+++ b/source/type/headsign_handler.h
@@ -58,7 +58,7 @@ struct HeadsignHandler {
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
-        ar & map_vj_map_stop_time_headsign_change & headsign_mvj;
+        ar & headsign_changes & headsign_mvj;
     }
 
 protected:
@@ -69,8 +69,12 @@ protected:
     // for each VJ, map containing index of stop time and the new headsign (until next change)
     // as new stop_time might be added in the future, if map_vj_map_stop_time_headsign_change[vj]
     // exists, last change is always vj.name (and might happen after last stop_time)
+    // This gives following structure (vj.name = A) :
+    // stop times       : 1 2 3 4 5 6 7 8 (potential 9)
+    // headsigns        : A A A B B C B B
+    // headsign_changes :       B   C B   A
     std::unordered_map<const VehicleJourney*, boost::container::flat_map<uint16_t, std::string>>
-        map_vj_map_stop_time_headsign_change;
+        headsign_changes;
     // headsign to meta-vj map
     std::unordered_map<std::string, std::unordered_set<const MetaVehicleJourney*>> headsign_mvj;
 };

--- a/source/type/headsign_handler.h
+++ b/source/type/headsign_handler.h
@@ -1,0 +1,78 @@
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "type/type.h"
+#include "utils/serialization_flat_map.h"
+#include "utils/serialization_unordered_map.h"
+#include "utils/serialization_unordered_set.h"
+#include <boost/container/flat_map.hpp>
+#include <unordered_map>
+#include <unordered_set>
+
+#pragma once
+
+/**
+ * Headsign handler
+ *
+ * Contains and manages :
+ * - headsign at a given stop_time for VJ (default value for headsign at a stop_time is vj.name)
+ * - metaVJ from given headsign (one of the VJ in metaVJ contains given headsign)
+ */
+namespace navitia { namespace type {
+
+struct HeadsignHandler {
+    // changes vj's name and registers vj under its new name for headsign-to-vj map
+    // (remove previous name from headsign-to-vj map if necessary)
+    void change_name_and_register_as_headsign(VehicleJourney& vj, const std::string& new_name);
+    void affect_headsign_to_stop_time(const StopTime& stop_time, const std::string& headsign);
+
+    const std::string& get_headsign(const StopTime& stop_time) const;
+    std::vector<const VehicleJourney*> get_vj_from_headsign(const std::string& headsign) const;
+
+    template<class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar & map_vj_map_stop_time_headsign_change & headsign_mvj;
+    }
+
+protected:
+    bool has_headsign_or_name(const VehicleJourney& vj, const std::string& headsign) const;
+    void update_headsign_mvj_after_remove(const VehicleJourney& vj,
+                                          const std::string& removed_headsign);
+
+    // for each VJ, map containing index of stop time and the new headsign (until next change)
+    // as new stop_time might be added in the future, if map_vj_map_stop_time_headsign_change[vj]
+    // exists, last change is always vj.name (and might happen after last stop_time)
+    std::unordered_map<const VehicleJourney*, boost::container::flat_map<uint16_t, std::string>>
+        map_vj_map_stop_time_headsign_change;
+    // headsign to meta-vj map
+    std::unordered_map<std::string, std::unordered_set<const MetaVehicleJourney*>> headsign_mvj;
+};
+
+}} //namespace navitia::type

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -39,6 +39,7 @@ www.navitia.io
 #include "utils/flat_enum_map.h"
 #include "utils/functions.h"
 #include "comment_container.h"
+#include "headsign_handler.h"
 
 #include <boost/serialization/map.hpp>
 #include "utils/serialization_unordered_map.h"
@@ -108,6 +109,9 @@ struct PT_Data : boost::noncopyable{
     // Comments container
     Comments comments;
 
+    // Headsign handler
+    HeadsignHandler headsign_handler;
+
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
         ar
         #define SERIALIZE_ELEMENTS(type_name, collection_name) & collection_name & collection_name##_map
@@ -119,7 +123,8 @@ struct PT_Data : boost::noncopyable{
                 & disruption_holder
                 & meta_vj
                 & stop_points_by_area
-                & comments;
+                & comments
+                & headsign_handler;
     }
 
     /** Initialise tous les indexes

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -1,0 +1,153 @@
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_headsign
+
+#include <boost/test/unit_test.hpp>
+#include "utils/functions.h"
+#include "ed/build_helper.h"
+#include "type/pt_data.h"
+#include "type/type.h"
+#include "tests/utils_test.h"
+#include "type/headsign_handler.h"
+#include <memory>
+#include <boost/archive/text_oarchive.hpp>
+#include <string>
+#include <type_traits>
+
+
+struct logger_initialized {
+    logger_initialized()   { init_logger(); }
+};
+BOOST_GLOBAL_FIXTURE( logger_initialized )
+
+namespace nt = navitia::type;
+
+BOOST_AUTO_TEST_CASE(headsign_handler_functionnal_test) {
+
+    ed::builder b("20120614");
+    b.vj("A")("stop00", 8000, 8050)("stop01", 8100,8150);
+    b.vj("B")("stop10", 8000, 8050)("stop11", 8100,8150)("stop12", 8200, 8250);
+    b.vj("C")("stop20", 8000, 8050)("stop21", 8100,8150)("stop22", 8200, 8250);
+    b.vj("D")("stop30", 8000, 8050);
+    auto& vj_vec = b.data->pt_data->vehicle_journeys;
+    b.data->pt_data->index();
+    b.finish();
+
+    nt::HeadsignHandler& headsign_handler = b.data->pt_data->headsign_handler;
+
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(0), "A00");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(1), vj_vec[1]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(0), vj_vec[1]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(1), "B11");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(2), "B11");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[2]->stop_time_list.at(1), "C21");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), "D31");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), vj_vec[3]->name);
+
+    // check that stop_time headsigns are correct
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[0]->stop_time_list.at(0)), "A00");
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[0]->stop_time_list.at(1)), vj_vec[1]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(0)), vj_vec[1]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(1)), "B11");
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(2)), "B11");
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(0)), vj_vec[2]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(1)), "C21");
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(2)), vj_vec[2]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[3]->stop_time_list.at(0)), vj_vec[3]->name);
+
+    // check that we can retrieve every vj from matching headsign
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("vehicle_journey 0").size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[0]->name), vj_vec[0]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("A00").size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("A00"), vj_vec[0]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("vehicle_journey 1").size(), 2);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[1]->name), vj_vec[0]));
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[1]->name), vj_vec[1]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("B11").size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("B11"), vj_vec[1]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[2]->name).size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[2]->name), vj_vec[2]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("C21").size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("C21"), vj_vec[2]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[3]->name).size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[3]->name), vj_vec[3]));
+
+    boost::archive::text_oarchive oa(std::cout);
+    oa & b.data->pt_data;
+}
+
+struct HeadsignHandlerTest: nt::HeadsignHandler {
+    std::unordered_map<const nt::VehicleJourney*, boost::container::flat_map<uint16_t, std::string>>
+    get_map_vj_map_stop_time_headsign_change() {return map_vj_map_stop_time_headsign_change;}
+    std::unordered_map<std::string, std::unordered_set<const nt::MetaVehicleJourney*>>
+    get_headsign_mvj() {return headsign_mvj;}
+};
+
+BOOST_AUTO_TEST_CASE(headsign_handler_internal_test) {
+
+    ed::builder b("20120614");
+    b.vj("A")("stop00", 8000, 8050)("stop01", 8100,8150);
+    b.vj("B")("stop10", 8000, 8050)("stop11", 8100,8150)("stop12", 8200, 8250);
+    b.vj("C")("stop20", 8000, 8050)("stop21", 8100,8150)("stop22", 8200, 8250);
+    b.vj("D")("stop30", 8000, 8050);
+    auto& vj_vec = b.data->pt_data->vehicle_journeys;
+    b.data->pt_data->index();
+    b.finish();
+
+    HeadsignHandlerTest headsign_handler;
+
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(0), "A00");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(1), vj_vec[1]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(0), vj_vec[1]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(1), "B11");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(2), "B11");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[2]->stop_time_list.at(1), "C21");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), "D31");
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), vj_vec[3]->name);
+
+    // check that we only store changes, no more
+    BOOST_CHECK_EQUAL(headsign_handler.get_map_vj_map_stop_time_headsign_change().size(), 3);
+    BOOST_CHECK_EQUAL(headsign_handler.get_map_vj_map_stop_time_headsign_change()[vj_vec[0]].size(), 3);
+    BOOST_CHECK_EQUAL(headsign_handler.get_map_vj_map_stop_time_headsign_change()[vj_vec[1]].size(), 2);
+    BOOST_CHECK_EQUAL(headsign_handler.get_map_vj_map_stop_time_headsign_change()[vj_vec[2]].size(), 2);
+
+    // check that we store all matches, no more
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().size(), 7);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()[vj_vec[0]->name].size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()["A00"].size(), 1);
+    // check that only one meta-vj is stored for B (but 2 vj are behind)
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()[vj_vec[1]->name].size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()["B11"].size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()[vj_vec[2]->name].size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()["C21"].size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj()[vj_vec[3]->name].size(), 1);
+}


### PR DESCRIPTION
Headsign structure, aiming minimum memory print
- unit test
- test after bina (using docker test)

Tested on artemis/guichet_unique data, and working for headsign changes.

Memoy bench:
- fr-sncfnational: 520Mo versus 512Mo before PR (without stop_time headsign, we store vj's headsign only)
- artemis/guichet_unique: 564Mo vs 549Mo before PR (with stop_headsign)
