### PR TITLE
Ptref: filter on the validity period

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -98,9 +98,9 @@ class Uri(ResourceUri, ResourceUtc):
         parser.add_argument("distance", type=int, default=200,
                                 description="Distance range of the query. Used only if a coord is in the query")
         parser.add_argument("since", type=date_time_format,
-                            description="filter objects not valid before this date")
+                            description="filters objects not valid before this date")
         parser.add_argument("until", type=date_time_format,
-                            description="filter objects not valid after this date")
+                            description="filters objects not valid after this date")
 
         if is_collection:
             parser.add_argument("filter", type=str, default="",

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -94,6 +94,10 @@ class Uri(ResourceUri):
                                             " else we consider it as UTC")
         parser.add_argument("distance", type=int, default=200,
                                 description="Distance range of the query. Used only if a coord is in the query")
+        parser.add_argument("since", type=date_time_format,
+                            description="filter objects not valid before this date")
+        parser.add_argument("until", type=date_time_format,
+                            description="filter objects not valid after this date")
 
         if is_collection:
             parser.add_argument("filter", type=str, default="",

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -138,8 +138,7 @@ class Uri(ResourceUri):
         if not self.region:
             return {"error": "No region"}, 404
         if collection and id:
-            args["filter"] = collections_to_resource_type[collection] + ".uri="
-            args["filter"] += protect(id)
+            args["filter"] = '{o}.uri={v}'.format(o=collections_to_resource_type[collection], v=protect(id))
         elif uri:
             if uri[-1] == "/":
                 uri = uri[:-1]
@@ -147,8 +146,7 @@ class Uri(ResourceUri):
             if collection is None:
                 collection = uris[-1] if len(uris) % 2 != 0 else uris[-2]
             args["filter"] = self.get_filter(uris, args)
-        #else:
-        #    abort(503, message="Not implemented")
+
         response = i_manager.dispatch(args, collection,
                                       instance_name=self.region)
         return response

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -240,6 +240,10 @@ class Scenario(object):
         if request["forbidden_uris[]"]:
             for forbidden_uri in request["forbidden_uris[]"]:
                 req.ptref.forbidden_uri.append(forbidden_uri)
+        if request['since']:
+            req.ptref.since = request['since']
+        if request['until']:
+            req.ptref.until = request['until']
 
         resp = instance.send_and_receive(req)
         build_pagination(request, resp)

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -241,9 +241,9 @@ class Scenario(object):
             for forbidden_uri in request["forbidden_uris[]"]:
                 req.ptref.forbidden_uri.append(forbidden_uri)
         if request['since']:
-            req.ptref.since = request['since']
+            req.ptref.since_datetime = request['since']
         if request['until']:
-            req.ptref.until = request['until']
+            req.ptref.until_datetime = request['until']
 
         resp = instance.send_and_receive(req)
         build_pagination(request, resp)

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -332,7 +332,7 @@ class TestPtRef(AbstractTestFixture):
         vjs = get_not_null(response, 'vehicle_journeys')
         assert 'vj1' in (vj['id'] for vj in vjs)
 
-        # we the vj stop the 01/11, so the 01/12, we can't find it
+        # the vj stops the 01/11, so the 01/12, we can't find it
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/vehicle_journeys?since=20140105T070000")
 
         assert code == 404

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -317,6 +317,27 @@ class TestPtRef(AbstractTestFixture):
 
         is_valid_journey_response(response, self.tester, urllib.quote_plus(query))
 
+    def test_vj_period_filter(self):
+        """with just a since in the middle of the period, we find vj1"""
+        response = self.query_region("vehicle_journeys?since=20140105T070000")
+
+        vjs = get_not_null(response, 'vehicle_journeys')
+        for vj in vjs:
+            is_valid_vehicle_journey(vj, depth_check=1)
+
+        assert 'vj1' in (vj['id'] for vj in vjs)
+
+        # same with an until at the end of the day
+        response = self.query_region("vehicle_journeys?since=20140112T000000&until=20140112T2359")
+        vjs = get_not_null(response, 'vehicle_journeys')
+        assert 'vj1' in (vj['id'] for vj in vjs)
+
+        # we the vj stop the 01/11, so the 01/12, we can't find it
+        response, code = self.query_no_assert("v1/coverage/main_ptref_test/vehicle_journeys?since=20140105T070000")
+
+        assert code == 404
+        assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
+
 
 @dataset(["main_routing_test"])
 class TestPtRef(AbstractTestFixture):

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -626,7 +626,6 @@ pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, 
     }
 }
 
-
 pbnavitia::Response Worker::pt_ref(const pbnavitia::PTRefRequest &request){
     const auto data = data_manager.get_data();
     std::vector<std::string> forbidden_uri;
@@ -637,7 +636,12 @@ pbnavitia::Response Worker::pt_ref(const pbnavitia::PTRefRequest &request){
                                     get_odt_level(request.odt_level()),
                                     request.depth(), request.show_codes(),
                                     request.start_page(),
-                                    request.count(), *data,
+                                    request.count(),
+                                    (request.has_since_datetime() ?
+                                         boost::make_optional(bt::from_time_t(request.since_datetime())) : boost::none),
+                                    (request.has_until_datetime() ?
+                                         boost::make_optional(bt::from_time_t(request.until_datetime())) : boost::none),
+                                    *data,
                                     //no check on this datetime, it's not important
                                     //for it to be in the production period, it's used to filter the disruptions
                                     bt::from_time_t(request.datetime()));

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -626,24 +626,29 @@ pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, 
     }
 }
 
-pbnavitia::Response Worker::pt_ref(const pbnavitia::PTRefRequest &request){
+pbnavitia::Response Worker::pt_ref(const pbnavitia::PTRefRequest &request) {
     const auto data = data_manager.get_data();
     std::vector<std::string> forbidden_uri;
-    for(int i = 0; i < request.forbidden_uri_size(); ++i)
+    for (int i = 0; i < request.forbidden_uri_size(); ++i) {
         forbidden_uri.push_back(request.forbidden_uri(i));
+    }
     return navitia::ptref::query_pb(get_type(request.requested_type()),
-                                    request.filter(), forbidden_uri,
+                                    request.filter(),
+                                    forbidden_uri,
                                     get_odt_level(request.odt_level()),
-                                    request.depth(), request.show_codes(),
+                                    request.depth(),
+                                    request.show_codes(),
                                     request.start_page(),
                                     request.count(),
-                                    (request.has_since_datetime() ?
-                                         boost::make_optional(bt::from_time_t(request.since_datetime())) : boost::none),
-                                    (request.has_until_datetime() ?
-                                         boost::make_optional(bt::from_time_t(request.until_datetime())) : boost::none),
+                                    boost::make_optional(request.has_since_datetime(),
+                                                         bt::from_time_t(request.since_datetime())),
+                                    boost::make_optional(request.has_until_datetime(),
+                                                         bt::from_time_t(request.until_datetime())),
                                     *data,
-                                    //no check on this datetime, it's not important
-                                    //for it to be in the production period, it's used to filter the disruptions
+                                    //no check on this datetime, it's
+                                    //not important for it to be in
+                                    //the production period, it's used
+                                    //to filter the disruptions
                                     bt::from_time_t(request.datetime()));
 }
 

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -285,7 +285,7 @@ bool keep_vj(const nt::VehicleJourney* vj,
     if (vj->stop_time_list.empty()) {
         return false; //no stop time, so it cannot be valid
     }
-    const auto first_departure_dt = vj->stop_time_list.front().departure_time;
+    const auto& first_departure_dt = vj->stop_time_list.front().departure_time;
 
     for (boost::gregorian::day_iterator it(period.begin().date()); it <= period.last().date(); ++it) {
         if (! vj->validity_pattern->check(*it)) { continue; }
@@ -324,7 +324,7 @@ std::vector<idx_t> filter_vj_on_period(const std::vector<type::idx_t>& indexes,
             end = *until;
         }
     }
-    bt::time_period period {start, end + bt::seconds(1)}; //the end is not in the period, so we add one second
+    bt::time_period period {start, end};
 
     std::vector<idx_t> res;
     for (const idx_t idx: indexes) {
@@ -341,14 +341,12 @@ std::vector<idx_t> filter_on_period(const std::vector<type::idx_t>& indexes,
                                     boost::optional<boost::posix_time::ptime> until,
                                     const type::Data & data) {
 
-    switch(requested_type) {
-        case nt::Type_e::VehicleJourney: {
-            return filter_vj_on_period(indexes, since, until, data);
-        }
+    switch (requested_type) {
+    case nt::Type_e::VehicleJourney:
+        return filter_vj_on_period(indexes, since, until, data);
     default:
-        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("log"),
-                       "cannot filter on validity period for this type");
-        break;
+        throw parsing_error(parsing_error::error_type::global_error,
+                            "cannot filter on validity period for this type");
     }
 
     return indexes;

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -275,9 +275,19 @@ std::vector<idx_t> manage_odt_level(const std::vector<type::idx_t>& final_indexe
     return final_indexes;
 }
 
+std::vector<idx_t> filter_on_period(const std::vector<type::idx_t>& final_indexes,
+                                    const navitia::type::Type_e requested_type,
+                                    boost::optional<boost::posix_time::ptime> since,
+                                    boost::optional<boost::posix_time::ptime> until,
+                                    const type::Data & data) {
+    return final_indexes;
+}
+
 std::vector<idx_t> make_query(Type_e requested_type, std::string request,
                               const std::vector<std::string>& forbidden_uris,
                               const type::OdtLevel_e odt_level,
+                              boost::optional<boost::posix_time::ptime> since,
+                              boost::optional<boost::posix_time::ptime> until,
                               const Data & data) {
     std::vector<Filter> filters;
 
@@ -349,8 +359,14 @@ std::vector<idx_t> make_query(Type_e requested_type, std::string request,
         }
         final_indexes = get_difference(final_indexes, forbidden_idx);
     }
-       // Manage OdtLevel
+    // Manage OdtLevel
     final_indexes = manage_odt_level(final_indexes, requested_type, odt_level, data);
+
+    // filter on validity periods
+    if (since || until) {
+        final_indexes = filter_on_period(final_indexes, requested_type, since, until, data);
+    }
+
     // When the filters have emptied the results
     if(final_indexes.empty()){
         throw ptref_error("Filters: Unable to find object");
@@ -385,7 +401,7 @@ std::vector<type::idx_t> make_query(type::Type_e requested_type,
                                     std::string request,
                                     const std::vector<std::string>& forbidden_uris,
                                     const type::Data &data) {
-    return make_query(requested_type, request, forbidden_uris, navitia::type::OdtLevel_e::all, data);
+    return make_query(requested_type, request, forbidden_uris, navitia::type::OdtLevel_e::all, boost::none, boost::none, data);
 }
 
 std::vector<type::idx_t> make_query(type::Type_e requested_type,

--- a/source/ptreferential/ptreferential.h
+++ b/source/ptreferential/ptreferential.h
@@ -95,22 +95,22 @@ struct parsing_error : public ptref_error{
 };
 
 /// Exécute une requête sur les données Data : retourne les idx des objets demandés
-std::vector<type::idx_t> make_query(type::Type_e requested_type,
-                                    std::string request,
+std::vector<type::idx_t> make_query(const type::Type_e requested_type,
+                                    const std::string& request,
                                     const std::vector<std::string>& forbidden_uris,
                                     const type::OdtLevel_e odt_level,
-                                    boost::optional<boost::posix_time::ptime> since,
-                                    boost::optional<boost::posix_time::ptime> until,
-                                    const type::Data &data);
+                                    const boost::optional<boost::posix_time::ptime>& since,
+                                    const boost::optional<boost::posix_time::ptime>& until,
+                                    const type::Data& data);
 
-std::vector<type::idx_t> make_query(type::Type_e requested_type,
-                                    std::string request,
+std::vector<type::idx_t> make_query(const type::Type_e requested_type,
+                                    const std::string& request,
                                     const std::vector<std::string>& forbidden_uris,
-                                    const type::Data &data);
+                                    const type::Data& data);
 
-std::vector<type::idx_t> make_query(type::Type_e requested_type,
-                                    std::string request,
-                                    const type::Data &data);
+std::vector<type::idx_t> make_query(const type::Type_e requested_type,
+                                    const std::string& request,
+                                    const type::Data& data);
 
 
 /// Trouve le chemin d'un type de données à un autre

--- a/source/ptreferential/ptreferential.h
+++ b/source/ptreferential/ptreferential.h
@@ -99,6 +99,8 @@ std::vector<type::idx_t> make_query(type::Type_e requested_type,
                                     std::string request,
                                     const std::vector<std::string>& forbidden_uris,
                                     const type::OdtLevel_e odt_level,
+                                    boost::optional<boost::posix_time::ptime> since,
+                                    boost::optional<boost::posix_time::ptime> until,
                                     const type::Data &data);
 
 std::vector<type::idx_t> make_query(type::Type_e requested_type,

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -130,13 +130,15 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
                              const bool show_codes,
                              const int startPage,
                              const int count,
+                             boost::optional<boost::posix_time::ptime> since,
+                             boost::optional<boost::posix_time::ptime> until,
                              const type::Data& data,
-                             boost::posix_time::ptime current_time){
+                             boost::posix_time::ptime current_time) {
     std::vector<type::idx_t> final_indexes;
     pbnavitia::Response pb_response;
     int total_result;
     try {
-        final_indexes = make_query(requested_type, request, forbidden_uris, odt_level, data);
+        final_indexes = make_query(requested_type, request, forbidden_uris, odt_level, since, until, data);
     } catch(const parsing_error &parse_error) {
         fill_pb_error(pbnavitia::Error::unable_to_parse, "Unable to parse :" + parse_error.more, pb_response.mutable_error());
         return pb_response;

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -38,11 +38,12 @@ namespace pt = boost::posix_time;
 
 namespace navitia{ namespace ptref{
 
-static pbnavitia::Response extract_data(const type::Data & data,
-                                        type::Type_e requested_type,
-                                        std::vector<type::idx_t> & rows,
-                                        const int depth, const bool show_codes,
-                                        boost::posix_time::ptime current_time) {
+static pbnavitia::Response extract_data(const type::Data& data,
+                                        const type::Type_e requested_type,
+                                        const std::vector<type::idx_t>& rows,
+                                        const int depth,
+                                        const bool show_codes,
+                                        const boost::posix_time::ptime& current_time) {
     pbnavitia::Response result;
     auto action_period = pt::time_period(current_time, pt::seconds(1));
     for(auto idx : rows){
@@ -122,7 +123,7 @@ static pbnavitia::Response extract_data(const type::Data & data,
 }
 
 
-pbnavitia::Response query_pb(type::Type_e requested_type,
+pbnavitia::Response query_pb(const type::Type_e requested_type,
                              const std::string& request,
                              const std::vector<std::string>& forbidden_uris,
                              const type::OdtLevel_e odt_level,
@@ -130,10 +131,10 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
                              const bool show_codes,
                              const int startPage,
                              const int count,
-                             boost::optional<boost::posix_time::ptime> since,
-                             boost::optional<boost::posix_time::ptime> until,
+                             const boost::optional<boost::posix_time::ptime>& since,
+                             const boost::optional<boost::posix_time::ptime>& until,
                              const type::Data& data,
-                             boost::posix_time::ptime current_time) {
+                             const boost::posix_time::ptime& current_time) {
     std::vector<type::idx_t> final_indexes;
     pbnavitia::Response pb_response;
     int total_result;

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -49,6 +49,8 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
                              const bool show_codes,
                              const int startPage,
                              const int count,
+                             boost::optional<boost::posix_time::ptime> since,
+                             boost::optional<boost::posix_time::ptime> until,
                              const type::Data& data,
                              boost::posix_time::ptime current_time);
 }}

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -34,14 +34,14 @@ namespace pbnavitia { class Response;}
 
 namespace navitia{ namespace ptref{
 /// build the protobuf response of a pt ref query
-pbnavitia::Response extract_data(const type::Data & data,
-                                 type::Type_e requested_type,
-                                 std::vector<type::idx_t> & rows,
+pbnavitia::Response extract_data(const type::Data& data,
+                                 const type::Type_e requested_type,
+                                 const std::vector<type::idx_t> & rows,
                                  const int depth,
-                                 boost::posix_time::ptime current_time); //this date is used to filter the disruptions
+                                 const boost::posix_time::ptime& current_time); //this date is used to filter the disruptions
 
 /// execute the pt ref query and return the protobuf response
-pbnavitia::Response query_pb(type::Type_e requested_type,
+pbnavitia::Response query_pb(const type::Type_e requested_type,
                              const std::string& request,
                              const std::vector<std::string>& forbidden_uris,
                              const type::OdtLevel_e odt_level,
@@ -49,8 +49,8 @@ pbnavitia::Response query_pb(type::Type_e requested_type,
                              const bool show_codes,
                              const int startPage,
                              const int count,
-                             boost::optional<boost::posix_time::ptime> since,
-                             boost::optional<boost::posix_time::ptime> until,
+                             const boost::optional<boost::posix_time::ptime>& since,
+                             const boost::optional<boost::posix_time::ptime>& until,
                              const type::Data& data,
-                             boost::posix_time::ptime current_time);
+                             const boost::posix_time::ptime& current_time);
 }}

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -39,6 +39,7 @@ www.navitia.io
 #include <boost/graph/strong_components.hpp>
 #include <boost/graph/connected_components.hpp>
 #include "type/pt_data.h"
+#include "tests/utils_test.h"
 
 namespace navitia{namespace ptref {
 template<typename T> std::vector<type::idx_t> get_indexes(Filter filter,  Type_e requested_type, const type::Data & d);
@@ -427,4 +428,88 @@ BOOST_AUTO_TEST_CASE(find_path_test){
 
     // Type qui n'existe pas dans le graph : il n'y a pas de chemin
     BOOST_CHECK_THROW(find_path(navitia::type::Type_e::Unknown), ptref_error);
+}
+
+//helper to get default values
+std::vector<nt::idx_t> query(nt::Type_e requested_type, std::string request,
+                             const nt::Data& data,
+                             boost::optional<boost::posix_time::ptime> since = boost::none,
+                             boost::optional<boost::posix_time::ptime> until = boost::none,
+                             bool fail = false) {
+    try {
+       return navitia::ptref::make_query(requested_type, request, {}, navitia::type::OdtLevel_e::all, since, until, data);
+    } catch (const navitia::ptref::ptref_error& e) {
+        if (fail) {
+            throw e;
+        }
+        BOOST_CHECK_MESSAGE(false, " error on ptref request" + std::string(e.what()));
+        return {};
+    }
+}
+
+/*
+ * Test the filtering on the period
+  */
+BOOST_AUTO_TEST_CASE(vj_filtering) {
+    ed::builder builder("20130311");
+    builder.generate_dummy_basis();
+    builder.vj("A", "0110")("stop1", "08:00"_t)("stop2", "09:00"_t);
+    builder.vj("B", "1011")("stop3", "10:00"_t)("stop2", "11:00"_t);
+    builder.vj("C", "1000")("stop3", "10:00"_t)("stop2", "11:00"_t);
+    builder.finish();
+    nt::idx_t a = 0;
+    nt::idx_t b = 1;
+    nt::idx_t c = 2;
+
+    auto check = [](const std::vector<nt::idx_t>& col, std::initializer_list<nt::idx_t> ref) {
+        std::set<nt::idx_t> s_col(std::begin(col), std::end(col));
+        std::set<nt::idx_t> s_ref(ref);
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(s_col), std::end(s_col), std::begin(s_ref), std::end(s_ref));
+        return s_col == s_ref;
+    };
+
+    //not limited, we get 3 vj
+    auto indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data));
+    BOOST_CHECK(check(indexes, {a, b, c}));
+
+    // the second day A and B are activ
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130312T0700"_dt}, {"20130312T2359"_dt});
+    BOOST_CHECK(check(indexes, {a, b}));
+
+    // but the third only A works
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130313T0700"_dt}, {"20130313T2359"_dt});
+    BOOST_CHECK(check(indexes, {a}));
+
+    // on day 3 and 4, A, B and C are valid only one day, so it's ok
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130313T0700"_dt}, {"20130314T2359"_dt});
+    BOOST_CHECK(check(indexes, {a, b, c}));
+
+    //with just a since, we check til the end of the period
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130313T0000"_dt}, {});
+    BOOST_CHECK(check(indexes, {a, b, c})); // all are valid from the 3rd day
+
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130314T0000"_dt}, {});
+    BOOST_CHECK(check(indexes, {b, c})); // only B and C are valid from the 4th day
+
+    // with just an until, we check from the begining of the validity period
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {}, {"20130313T0000"_dt});
+    BOOST_CHECK(check(indexes, {a, b}));
+
+    //tests with the time
+    // we want the vj valid from 11pm only the first day, B is valid at 10, so not it the period
+    BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130311T1100"_dt}, {"20130311T2359"_dt}, true), ptref_error);
+
+    // we want the vj valid from 11pm the first day to 07:59 the second, we still have no vj
+    BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130311T1100"_dt}, {"20130312T0759"_dt}, true), ptref_error);
+
+    // we want the vj valid from 11pm the first day to 08::00 the second, we now have A in the results
+    indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130311T1100"_dt}, {"20130312T0800"_dt});
+    BOOST_CHECK(check(indexes, {a}));
+
+    // we give a period after or before the validitity period, it's KO
+    BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20110311T1100"_dt}, {"20110312T0800"_dt}, true), ptref_error);
+    BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20160311T1100"_dt}, {"20160312T0800"_dt}, true), ptref_error);
+
+    // we give a since > until, it's an error
+    BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130316T1100"_dt}, {"20130311T0759"_dt}, true), ptref_error);
 }

--- a/source/ptreferential/tests/ptret_test.cpp
+++ b/source/ptreferential/tests/ptret_test.cpp
@@ -465,39 +465,37 @@ BOOST_AUTO_TEST_CASE(vj_filtering) {
     nt::idx_t b = 1;
     nt::idx_t c = 2;
 
-    auto check = [](const std::vector<nt::idx_t>& col, std::initializer_list<nt::idx_t> ref) {
+    auto check = [](const std::vector<nt::idx_t>& col, std::set<nt::idx_t> s_ref) {
         std::set<nt::idx_t> s_col(std::begin(col), std::end(col));
-        std::set<nt::idx_t> s_ref(ref);
-        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(s_col), std::end(s_col), std::begin(s_ref), std::end(s_ref));
-        return s_col == s_ref;
+        BOOST_CHECK_EQUAL(s_col, s_ref);
     };
 
     //not limited, we get 3 vj
     auto indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data));
-    BOOST_CHECK(check(indexes, {a, b, c}));
+    check(indexes, {a, b, c});
 
     // the second day A and B are activ
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130312T0700"_dt}, {"20130313T0000"_dt});
-    BOOST_CHECK(check(indexes, {a, b}));
+    check(indexes, {a, b});
 
     // but the third only A works
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130313T0700"_dt}, {"20130314T0000"_dt});
-    BOOST_CHECK(check(indexes, {a}));
+    check(indexes, {a});
 
     // on day 3 and 4, A, B and C are valid only one day, so it's ok
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130313T0700"_dt}, {"20130315T0000"_dt});
-    BOOST_CHECK(check(indexes, {a, b, c}));
+    check(indexes, {a, b, c});
 
     //with just a since, we check til the end of the period
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130313T0000"_dt}, {});
-    BOOST_CHECK(check(indexes, {a, b, c})); // all are valid from the 3rd day
+    check(indexes, {a, b, c}); // all are valid from the 3rd day
 
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130314T0000"_dt}, {});
-    BOOST_CHECK(check(indexes, {b, c})); // only B and C are valid from the 4th day
+    check(indexes, {b, c}); // only B and C are valid from the 4th day
 
     // with just an until, we check from the begining of the validity period
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {}, {"20130313T0000"_dt});
-    BOOST_CHECK(check(indexes, {a, b}));
+    check(indexes, {a, b});
 
     //tests with the time
     // we want the vj valid from 11pm only the first day, B is valid at 10, so not it the period
@@ -508,7 +506,7 @@ BOOST_AUTO_TEST_CASE(vj_filtering) {
 
     // we want the vj valid from 11pm the first day to 08::00 the second, we now have A in the results
     indexes = query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20130311T1100"_dt}, {"20130312T080001"_dt});
-    BOOST_CHECK(check(indexes, {a}));
+    check(indexes, {a});
 
     // we give a period after or before the validitity period, it's KO
     BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data), {"20110311T1100"_dt}, {"20110312T0800"_dt}, true), ptref_error);


### PR DESCRIPTION
add new ptref filter on a period:

`since`, and `until` that take both a datetime

eg:
`api.navitia.io/v1/coverage/fr_idf/vehicle_journeys?since=20150912T120000&until=20150913T110000`

The param names can be discussed :wink: 

both params are optional.

for the moment it can only be used with vehicle_journeys
