### PR TITLE
kraken: don't listen to request before data are loaded

### DIFF
--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -88,6 +88,7 @@ int main(int argn, char** argv){
 
     int nb_threads = conf.nb_thread();
     // Launch pool of worker threads
+    LOG4CPLUS_INFO(logger, "starting workers threads");
     for(int thread_nbr = 0; thread_nbr < nb_threads; ++thread_nbr) {
         threads.create_thread(std::bind(&doWork, std::ref(context), std::ref(data_manager), conf));
     }

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -56,6 +56,7 @@ class MaintenanceWorker{
 
         void handle_task(AmqpClient::Envelope::ptr_t envelope);
         void handle_rt(AmqpClient::Envelope::ptr_t envelope);
+        bool is_initialized = false;
 
     public:
         MaintenanceWorker(DataManager<type::Data>& data_manager, const kraken::Configuration conf);


### PR DESCRIPTION
We also used a named queue for rabbitmq, this way if there is a small
disconnection we don't loose messages. The drawbacks are that we can't
anymore start two kraken for the same instance on the same host. And if
an host/instance is deleted, the queues associated won't be delete from
rabbitmq.
