### PR TITLE
jormungandr: fix a bug in stat manager when the first init failed

### DIFF
--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -467,6 +467,9 @@ class StatManager(object):
         pbf = stat_request.SerializeToString()
         with self.lock:
             try:
+                if self.producer is None:
+                    #if the initialization failed we have to retry the creation of the objects
+                    self._init_rabbitmq()
                 self.producer.publish(pbf)
             except self.connection.connection_errors + self.connection.channel_errors:
                 logging.getLogger(__name__).exception('Server went away, will be reconnected..')


### PR DESCRIPTION
If we weren't able to connect to rabbitmq at the start of jormungandr
the producer is not created, and since we use is to call publish an
exception is raise since producer is None. We were only catching
exception directly link to the protocols, so we didn't try to reconnect.
