### PR TITLE
Jormungandr: changes on VJ API

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -553,7 +553,8 @@ stop_time = {
     "arrival_time": SplitDateTime(date=None, time='arrival_time'),
     "departure_time": SplitDateTime(date=None, time='departure_time'),
     "headsign": fields.String(attribute="headsign"),
-    "journey_pattern_point": NonNullProtobufNested(journey_pattern_point)
+    "journey_pattern_point": NonNullProtobufNested(journey_pattern_point),
+    "stop_point": NonNullProtobufNested(stop_point)
 }
 
 line = deepcopy(generic_type)

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -824,7 +824,9 @@ def is_valid_vehicle_journey(vj, depth_check=1):
         for st in stoptimes:
             get_valid_time(get_not_null(st, 'arrival_time'))
             get_valid_time(get_not_null(st, 'departure_time'))
+            is_valid_stop_point(get_not_null(st, 'stop_point'), depth_check=depth_check-1)
 
+            # the JPP are kept only for backward compatibility
             if depth_check > 1:
                 #with depth > 1 (we are already in the stoptime nested object), we don't want jpp
                 is_valid_journey_pattern_point(get_not_null(st, 'journey_pattern_point'), depth_check - 2)

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -120,8 +120,6 @@ class TestPtRef(AbstractTestFixture):
             code_uic = [c for c in codes if c['type'] == 'code_uic']
             assert len(code_uic) == 1 and code_uic[0]['value'] == 'bobette'
 
-
-
     def test_line(self):
         """test line formating"""
         response = self.query_region("v1/lines")

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -99,6 +99,29 @@ class TestPtRef(AbstractTestFixture):
         for vj in vjs:
             is_valid_vehicle_journey(vj, depth_check=3)
 
+    def test_vj_show_codes_propagation(self):
+        """stop_area:stop1 has a code, we should be able to find it when accessing it by the vj"""
+        response = self.query_region("stop_areas/stop_area:stop1/vehicle_journeys?show_codes=true")
+
+        vjs = get_not_null(response, 'vehicle_journeys')
+
+        assert vjs
+
+        for vj in vjs:
+            is_valid_vehicle_journey(vj, depth_check=1)
+
+        stop_points = [get_not_null(st, 'stop_point') for vj in vjs for st in vj['stop_times']]
+        stops1 = [s for s in stop_points if s['id'] == 'stop_area:stop1']
+        assert stops1
+
+        for stop1 in stops1:
+            # all reference to stop1 must have it's codes
+            codes = get_not_null(stop1, 'codes')
+            code_uic = [c for c in codes if c['type'] == 'code_uic']
+            assert len(code_uic) == 1 and code_uic[0]['value'] == 'bobette'
+
+
+
     def test_line(self):
         """test line formating"""
         response = self.query_region("v1/lines")

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -109,6 +109,8 @@ struct data_set {
         b.data->pt_data->codes.add(b.lines["line:A"], "external_code", "A");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeB", "B");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeC", "C");
+        b.data->pt_data->codes.add(b.sps.at("stop_area:stop1"), "code_uic", "bobette");
+        b.data->pt_data->codes.add(b.sas.at("stop_area:stop1"), "code_uic", "baba");
 
         b.data->build_uri();
 

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -110,7 +110,6 @@ struct data_set {
         b.data->pt_data->codes.add(b.lines["line:A"], "codeB", "B");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeC", "C");
         b.data->pt_data->codes.add(b.sps.at("stop_area:stop1"), "code_uic", "bobette");
-        b.data->pt_data->codes.add(b.sas.at("stop_area:stop1"), "code_uic", "baba");
 
         b.data->build_uri();
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -442,7 +442,7 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
 void fill_pb_object(const nt::JourneyPattern* jp, const nt::Data& data,
         pbnavitia::JourneyPattern * journey_pattern, int max_depth,
         const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
-    if (jp == nullptr) { return ; }
+    if (jp == nullptr) { return; }
     int depth = (max_depth <= 3) ? max_depth : 3;
 
     journey_pattern->set_name(jp->name);
@@ -606,7 +606,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
                     const bool show_codes){
-    if (vj == nullptr) { return ; }
+    if (vj == nullptr) { return; }
     int depth = (max_depth <= 3) ? max_depth : 3;
 
     vehicle_journey->set_name(vj->name);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -441,16 +441,15 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
 
 void fill_pb_object(const nt::JourneyPattern* jp, const nt::Data& data,
         pbnavitia::JourneyPattern * journey_pattern, int max_depth,
-        const pt::ptime& now, const pt::time_period& action_period, const bool){
-    if(jp == nullptr)
-        return ;
+        const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+    if (jp == nullptr) { return ; }
     int depth = (max_depth <= 3) ? max_depth : 3;
 
     journey_pattern->set_name(jp->name);
     journey_pattern->set_uri(jp->uri);
     if(depth > 0 && jp->route != nullptr) {
         fill_pb_object(jp->route, data, journey_pattern->mutable_route(),
-                depth-1, now, action_period);
+                depth-1, now, action_period, show_codes);
     }
 }
 
@@ -607,8 +606,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
                     const bool show_codes){
-    if(vj == nullptr)
-        return ;
+    if (vj == nullptr) { return ; }
     int depth = (max_depth <= 3) ? max_depth : 3;
 
     vehicle_journey->set_name(vj->name);
@@ -644,7 +642,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                 stop_time.arrival_time += vj->utc_to_local_offset;
             }
             fill_pb_object(&stop_time, data, vehicle_journey->add_stop_times(),
-                           depth-1, now, action_period);
+                           depth-1, now, action_period, show_codes);
         }
         fill_pb_object(vj->journey_pattern->physical_mode, data,
                        vehicle_journey->mutable_journey_pattern()->mutable_physical_mode(), depth-1,
@@ -682,9 +680,8 @@ void fill_pb_object(const nt::VehicleJourney* vj,
 
 void fill_pb_object(const nt::StopTime* st, const type::Data &data,
                     pbnavitia::StopTime *stop_time, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period){
-    if(st == nullptr)
-        return ;
+                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes) {
+    if (st == nullptr) { return; }
     int depth = (max_depth <= 3) ? max_depth : 3;
 
     //arrival/departure in protobuff are also as seconds from midnight (in UTC of course)
@@ -694,16 +691,25 @@ void fill_pb_object(const nt::StopTime* st, const type::Data &data,
 
     stop_time->set_pickup_allowed(st->pick_up_allowed());
     stop_time->set_drop_off_allowed(st->drop_off_allowed());
-    if(st->journey_pattern_point != nullptr && depth > 0) {
+
+    // TODO V2: the dump of the JPP is deprecated, but we keep it for retrocompatibility
+    if (st->journey_pattern_point != nullptr && depth > 0) {
         fill_pb_object(st->journey_pattern_point, data,
                        stop_time->mutable_journey_pattern_point(), depth-1,
-                       now, action_period);
+                       now, action_period, show_codes);
+    }
+
+    if (st->journey_pattern_point) {
+        // we always dump the stop point (with the same depth)
+        fill_pb_object(st->journey_pattern_point->stop_point, data,
+                       stop_time->mutable_stop_point(), depth,
+                       now, action_period, show_codes);
     }
 
     if(st->vehicle_journey != nullptr && depth > 0) {
         fill_pb_object(st->vehicle_journey, data,
                        stop_time->mutable_vehicle_journey(), depth-1, now,
-                       action_period);
+                       action_period, show_codes);
     }
 }
 
@@ -737,7 +743,7 @@ void fill_pb_object(const nt::JourneyPatternPoint* jpp, const nt::Data& data,
         if(jpp->stop_point != nullptr) {
             fill_pb_object(jpp->stop_point, data,
                            journey_pattern_point->mutable_stop_point(),
-                           depth-1, now, action_period);
+                           depth-1, now, action_period, show_codes);
         }
         if(jpp->journey_pattern != nullptr) {
             fill_pb_object(jpp->journey_pattern, data,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -105,7 +105,7 @@ void fill_pb_object(const navitia::type::GeographicalCoord& coord, const type::D
 
 void fill_pb_object(const navitia::type::StopTime* st, const type::Data &data, pbnavitia::StopTime *stop_time, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
-        const boost::posix_time::time_period& action_period = null_time_period);
+        const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes = false);
 
 void fill_pb_object(const navitia::type::StopTime* st, const type::Data &data, pbnavitia::StopDateTime * stop_date_time, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,


### PR DESCRIPTION
1/ the codes was not propagated on the vj api to the stop points
now with a ?show_codes=true on the vj api, the codes of the subobjects are displayed too

2/ Add the stop_points in the stoptimes of the VJ
The JPP are kept, but only for backward compatibility, they will be removed in the V2

now the vj api looks like:

``` json
{
  "vehicle_journeys":[
    {
      "comment":"hello",
      "name":"vehicle_journey 0",
      "journey_pattern":{
        "name":"line:A:0:0",
        "id":"line:A:0:0"
      },
      "calendars":[
        {
          "active_periods":[
            {
              "begin":"20140105",
              "end":"20140106"
            }
          ],
          "week_pattern":{
            "monday":false,
            "tuesday":false,
            "friday":false,
            "wednesday":false,
            "thursday":false,
            "sunday":true,
            "saturday":false
          }
        }
      ],
      "stop_times":[
        {
          "arrival_time":"101500",
          "headsign":"vehicle_journey 0",
          "departure_time":"101500",
          "stop_point":{
            "codes":[
              {
                "type":"code_uic",
                "value":"bobette"
              }
            ],
            "name":"stop_area:stop1",
            "links":[

            ],
            "coord":{
              "lat":"9.0",
              "lon":"9.0"
            },
            "label":"stop_area:stop1",
            "equipments":[
              "has_wheelchair_boarding"
            ],
            "id":"stop_area:stop1"
          }
        },
        {
          "arrival_time":"111000",
          "headsign":"vehicle_journey 0",
          "departure_time":"111000",
          "stop_point":{
            "comment":"hello bob",
            "name":"stop_area:stop2",
            "links":[

            ],
            "coord":{
              "lat":"10.0",
              "lon":"10.0"
            },
            "label":"stop_area:stop2",
            "equipments":[
              "has_wheelchair_boarding"
            ],
            "comments":[
              {
                "type":"standard",
                "value":"hello bob"
              }
            ],
            "id":"stop_area:stop2"
          }
        }
      ],
      "comments":[
        {
          "type":"standard",
          "value":"hello"
        }
      ],
      "validity_pattern":{
        "beginning_date":"20140101",
        "days":"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000"
      },
      "id":"vj1"
    }
  ]
}
```
