### PR TITLE
Kraken: realtime level

### DIFF
--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
 
     georef::StreetNetwork sn_worker(*b.data->geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")},
-                                             true, type::AccessibiliteParams(), {}, sn_worker, true);
+                                             true, type::AccessibiliteParams(), {}, sn_worker, type::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff_no_data) {
 
     georef::StreetNetwork sn_worker(*b.data->geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")},
-                                             true, type::AccessibiliteParams(), {}, sn_worker, true);
+                                             true, type::AccessibiliteParams(), {}, sn_worker, type::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -100,7 +100,10 @@ class Scenario(simple.Scenario):
         req.journeys.max_duration = request["max_duration"]
         req.journeys.max_transfers = request["max_transfers"]
         req.journeys.wheelchair = request["wheelchair"]
-        req.journeys.disruption_active = request["disruption_active"]
+        if request["disruption_active"]:
+            req.journeys.realtime_level = request_pb2.ADAPTED
+        else:
+            req.journeys.realtime_level = request_pb2.THEORIC
         req.journeys.show_codes = request["show_codes"]
         if "details" in request and request["details"]:
             req.journeys.details = request["details"]

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -120,7 +120,10 @@ def create_pb_request(requested_type, request, dep_mode, arr_mode):
     req.journeys.max_duration = request["max_duration"]
     req.journeys.max_transfers = request["max_transfers"]
     req.journeys.wheelchair = request["wheelchair"]
-    req.journeys.disruption_active = request["disruption_active"]
+    if request["disruption_active"]:
+        req.journeys.realtime_level = request_pb2.ADAPTED
+    else:
+        req.journeys.realtime_level = request_pb2.THEORIC
     req.journeys.show_codes = request["show_codes"]
 
     if "details" in request and request["details"]:

--- a/source/kraken/fill_disruption_from_chaos.cpp
+++ b/source/kraken/fill_disruption_from_chaos.cpp
@@ -327,7 +327,7 @@ struct functor_add_vj {
         vj->journey_pattern = jp;
         vj->idx = pt_data.vehicle_journeys.size();
         vj->uri = make_adapted_uri_fast(vj_ref.uri, pt_data.vehicle_journeys.size());
-        vj->is_adapted = true;
+        vj->realtime_level = nt::RTLevel::Adapted;
         pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, vj_ref.name);
         vj->company = vj_ref.company;
         //TODO: we loose stay_in on impacted vj, we will need to work on this.

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -181,13 +181,13 @@ BOOST_AUTO_TEST_CASE(add_impact_on_stop_area) {
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 4);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->journey_patterns.size(), 2);
     bool has_adapted_vj = false;
-    for(const auto* vj: b.data->pt_data->vehicle_journeys){
-        if(vj->is_adapted){
+    for (const auto* vj: b.data->pt_data->vehicle_journeys) {
+        if (vj->realtime_level == nt::RTLevel::Adapted) {
             has_adapted_vj = true;
             BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                         stop_area_finder("stop_area:stop1")) == vj->journey_pattern->journey_pattern_point_list.end());
             BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern->days.to_string(), "000110"), vj->adapted_validity_pattern->days);
-        }else{
+        } else {
             BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                         stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
             BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern->days.to_string(), "000001"), vj->adapted_validity_pattern->days);
@@ -240,18 +240,18 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
         BOOST_CHECK_EQUAL(data.pt_data->vehicle_journeys.size(), 6);//two of them don't circulate :(
         BOOST_CHECK_EQUAL(data.pt_data->journey_patterns.size(), 4);//some of them aren't used
         bool has_adapted_vj = false;
-        for(const auto* vj: data.pt_data->vehicle_journeys){
-            if(vj->adapted_validity_pattern->days.none() && vj->validity_pattern->days.none()){
+        for (const auto* vj: data.pt_data->vehicle_journeys) {
+            if (vj->adapted_validity_pattern->days.none() && vj->validity_pattern->days.none()) {
                 //some vj don't circulate we don't want to check them
                 continue;
             }
-            if(vj->is_adapted){
+            if (vj->realtime_level == nt::RTLevel::Adapted) {
                 has_adapted_vj = true;
                 BOOST_CHECK_MESSAGE(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop1")) == vj->journey_pattern->journey_pattern_point_list.end(), dump_vj(*vj));
                 BOOST_CHECK_MESSAGE(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop2")) == vj->journey_pattern->journey_pattern_point_list.end(), dump_vj(*vj));
-            }else{
+            } else {
                 BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
             }
@@ -296,14 +296,14 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(b.data->pt_data->journey_patterns.size(), 1);
-    for(const auto* vj: b.data->pt_data->vehicle_journeys){
-        if(vj->is_adapted){
+    for (const auto* vj: b.data->pt_data->vehicle_journeys) {
+        if (vj->realtime_level == nt::RTLevel::Adapted) {
             BOOST_FAIL("no adapted vj expected");
         }
         BOOST_CHECK(vj->validity_pattern->days == vj->adapted_validity_pattern->days);
     }
-    for(const auto* sp: b.data->pt_data->stop_points){
-        if(sp->journey_pattern_point_list.size() > 1){
+    for (const auto* sp: b.data->pt_data->stop_points) {
+        if (sp->journey_pattern_point_list.size() > 1) {
             BOOST_FAIL("some adapted jpp are not removed for " << sp->uri);
         }
 

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -264,6 +264,7 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
                 BOOST_CHECK_MESSAGE(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop2")) == vj->journey_pattern->journey_pattern_point_list.end(), dump_vj(*vj));
                 break;
+            case nt::RTLevel::RealTime:
             default:
                 //TODO
                 throw navitia::exception("realtime check unhandled case");
@@ -309,7 +310,7 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(b.data->pt_data->journey_patterns.size(), 1);
     for (const auto* vj: b.data->pt_data->vehicle_journeys) {
-        BOOST_REQUIRE_NE(vj->realtime_level, nt::RTLevel::Adapted);
+        BOOST_REQUIRE(vj->realtime_level != nt::RTLevel::Adapted);
         BOOST_CHECK(vj->validity_pattern->days == vj->adapted_validity_pattern->days);
     }
     for (const auto* sp: b.data->pt_data->stop_points) {

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -182,16 +182,22 @@ BOOST_AUTO_TEST_CASE(add_impact_on_stop_area) {
     BOOST_REQUIRE_EQUAL(b.data->pt_data->journey_patterns.size(), 2);
     bool has_adapted_vj = false;
     for (const auto* vj: b.data->pt_data->vehicle_journeys) {
-        if (vj->realtime_level == nt::RTLevel::Adapted) {
-            has_adapted_vj = true;
-            BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
-                        stop_area_finder("stop_area:stop1")) == vj->journey_pattern->journey_pattern_point_list.end());
-            BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern->days.to_string(), "000110"), vj->adapted_validity_pattern->days);
-        } else {
+        switch (vj->realtime_level) {
+        case nt::RTLevel::Theoric:
             BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                         stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
             BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern->days.to_string(), "000001"), vj->adapted_validity_pattern->days);
             BOOST_CHECK_MESSAGE(ba::ends_with(vj->validity_pattern->days.to_string(), "000111"), vj->validity_pattern->days);
+            break;
+        case nt::RTLevel::Adapted:
+            has_adapted_vj = true;
+            BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
+                        stop_area_finder("stop_area:stop1")) == vj->journey_pattern->journey_pattern_point_list.end());
+            BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern->days.to_string(), "000110"), vj->adapted_validity_pattern->days);
+            break;
+        case nt::RTLevel::RealTime:
+            //TODO
+            throw navitia::exception("realtime check unhandled case");
         }
     }
     BOOST_REQUIRE(has_adapted_vj);
@@ -245,17 +251,23 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
                 //some vj don't circulate we don't want to check them
                 continue;
             }
-            if (vj->realtime_level == nt::RTLevel::Adapted) {
+
+            switch (vj->realtime_level) {
+            case nt::RTLevel::Theoric:
+                BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
+                            stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
+                break;
+            case nt::RTLevel::Adapted:
                 has_adapted_vj = true;
                 BOOST_CHECK_MESSAGE(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop1")) == vj->journey_pattern->journey_pattern_point_list.end(), dump_vj(*vj));
                 BOOST_CHECK_MESSAGE(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop2")) == vj->journey_pattern->journey_pattern_point_list.end(), dump_vj(*vj));
-            } else {
-                BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
-                            stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
+                break;
+            default:
+                //TODO
+                throw navitia::exception("realtime check unhandled case");
             }
-
         }
         BOOST_REQUIRE(has_adapted_vj);
 
@@ -297,18 +309,14 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(b.data->pt_data->journey_patterns.size(), 1);
     for (const auto* vj: b.data->pt_data->vehicle_journeys) {
-        if (vj->realtime_level == nt::RTLevel::Adapted) {
-            BOOST_FAIL("no adapted vj expected");
-        }
+        BOOST_REQUIRE_NE(vj->realtime_level, nt::RTLevel::Adapted);
         BOOST_CHECK(vj->validity_pattern->days == vj->adapted_validity_pattern->days);
     }
     for (const auto* sp: b.data->pt_data->stop_points) {
         if (sp->journey_pattern_point_list.size() > 1) {
             BOOST_FAIL("some adapted jpp are not removed for " << sp->uri);
         }
-
     }
-
 }
 
 

--- a/source/kraken/tests/worker_test.cpp
+++ b/source/kraken/tests/worker_test.cpp
@@ -52,7 +52,7 @@ static pbnavitia::Request create_request(bool wheelchair, std::string destinatio
     pbnavitia::JourneysRequest* j = req.mutable_journeys();
     j->set_clockwise(true);
     j->set_wheelchair(wheelchair);
-    j->set_disruption_active(true);
+    j->set_realtime_level(pbnavitia::ADAPTED);
     j->set_max_duration(std::numeric_limits<int32_t>::max());
     j->set_max_transfers(42);
     j->add_datetimes(navitia::test::to_posix_timestamp("20150314T080000"));

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -240,7 +240,7 @@ pbnavitia::Response Worker::calendars(const pbnavitia::CalendarsRequest &request
                                         forbidden_uris);
 }
 
-pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest &request,
+pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest& request,
         pbnavitia::API api) {
     const auto data = data_manager.get_data();
     int32_t max_date_times = request.has_max_date_times() ? request.max_date_times() : std::numeric_limits<int>::max();
@@ -258,25 +258,25 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
             return timetables::next_departures(request.departure_filter(),
                     forbidden_uri, from_datetime,
                     request.duration(), request.nb_stoptimes(), request.depth(),
-                    type::AccessibiliteParams(), *data, true, request.count(),
+                    type::AccessibiliteParams(), *data, type::RTLevel::Adapted, request.count(),
                     request.start_page(), request.show_codes(), current_datetime);
         case pbnavitia::NEXT_ARRIVALS:
             return timetables::next_arrivals(request.arrival_filter(),
                     forbidden_uri, from_datetime,
                     request.duration(), request.nb_stoptimes(), request.depth(),
-                    type::AccessibiliteParams(), *data, true, request.count(),
+                    type::AccessibiliteParams(), *data, type::RTLevel::Adapted, request.count(),
                     request.start_page(), request.show_codes(), current_datetime);
         case pbnavitia::PREVIOUS_DEPARTURES:
             return timetables::previous_departures(request.departure_filter(),
                     forbidden_uri, until_datetime,
                     request.duration(), request.nb_stoptimes(), request.depth(),
-                    type::AccessibiliteParams(), *data, true, request.count(),
+                    type::AccessibiliteParams(), *data, type::RTLevel::Adapted, request.count(),
                     request.start_page(), request.show_codes(), current_datetime);
         case pbnavitia::PREVIOUS_ARRIVALS:
             return timetables::previous_arrivals(request.arrival_filter(),
                     forbidden_uri, until_datetime,
                     request.duration(), request.nb_stoptimes(), request.depth(),
-                    type::AccessibiliteParams(), *data, true, request.count(),
+                    type::AccessibiliteParams(), *data, type::RTLevel::Adapted, request.count(),
                     request.start_page(), request.show_codes(), current_datetime);
         case pbnavitia::DEPARTURE_BOARDS:
             return timetables::departure_board(request.departure_filter(),
@@ -285,7 +285,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     forbidden_uri, from_datetime,
                     request.duration(),
                     request.depth(), max_date_times, request.interface_version(),
-                    request.count(), request.start_page(), *data, false, request.show_codes());
+                    request.count(), request.start_page(), *data, type::RTLevel::Theoric, request.show_codes());
         case pbnavitia::ROUTE_SCHEDULES:
             return timetables::route_schedule(request.departure_filter(),
                     request.has_calendar() ? boost::optional<const std::string>(request.calendar()) :
@@ -293,7 +293,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     forbidden_uri,
                     from_datetime,
                     request.duration(), max_date_times, request.depth(),
-                    request.count(), request.start_page(), *data, false, request.show_codes());
+                    request.count(), request.start_page(), *data, type::RTLevel::Theoric, request.show_codes());
         default:
             LOG4CPLUS_WARN(logger, "Unknown timetable query");
             pbnavitia::Response response;
@@ -496,6 +496,27 @@ pbnavitia::Response Worker::place_code(const pbnavitia::PlaceCodeRequest &reques
     return pb_response;
 }
 
+type::RTLevel get_realtime_level(const pbnavitia::JourneysRequest& request) {
+    // for retrocompatibility, we must handle both the new and the old way of setting the rt_level
+    // retrocompatibility will be droped after the migration
+    if (request.has_realtime_level()) {
+        switch (request.realtime_level()) {
+        case pbnavitia::RTLevel::THEORIC:
+            return type::RTLevel::Theoric;
+        case pbnavitia::RTLevel::ADAPTED:
+            return type::RTLevel::Adapted;
+        case pbnavitia::RTLevel::REAL_TIME:
+            return type::RTLevel::RealTime;
+        default:
+            throw navitia::exception("unhandled realtime level");
+        }
+    }
+    if (request.disruption_active()) {
+        return type::RTLevel::Adapted;
+    }
+    return type::RTLevel::Theoric;
+}
+
 pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, pbnavitia::API api) {
     const auto data = data_manager.get_data();
     this->init_worker_data(data);
@@ -568,6 +589,8 @@ pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, 
     accessibilite_params.properties.set(type::hasProperties::WHEELCHAIR_BOARDING, request.wheelchair());
     accessibilite_params.vehicle_properties.set(type::hasVehicleProperties::WHEELCHAIR_ACCESSIBLE, request.wheelchair());
 
+    const auto rt_level = get_realtime_level(request);
+
     switch(api) {
     case pbnavitia::ISOCHRONE: {
         type::EntryPoint ep;
@@ -593,20 +616,20 @@ pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, 
         return navitia::routing::make_isochrone(*planner, ep, request.datetimes(0),
                                                 request.clockwise(), accessibilite_params,
                                                 forbidden, *street_network_worker,
-                                                request.disruption_active(), request.max_duration(),
+                                                rt_level, request.max_duration(),
                                                 request.max_transfers(), request.show_codes());
     }
     case pbnavitia::NMPLANNER:
         return routing::make_nm_response(*planner, origins, destinations, datetimes[0],
                 request.clockwise(), accessibilite_params,
                 forbidden, *street_network_worker,
-                request.disruption_active(), request.max_duration(),
+                rt_level, request.max_duration(),
                 request.max_transfers(), request.show_codes());
     default:
         return routing::make_response(*planner, origins[0], destinations[0], datetimes,
                 request.clockwise(), accessibilite_params,
                 forbidden, *street_network_worker,
-                request.disruption_active(), request.max_duration(),
+                rt_level, request.max_duration(),
                 request.max_transfers(), request.show_codes());
     }
 }

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv){
         }
         auto res = router.compute(data.pt_data->stop_areas[demand.start], data.pt_data->stop_areas[demand.target],
                 demand.hour, demand.date, DateTimeUtils::set(demand.date + 1, demand.hour),
-                false, true, {}, 10);
+                type::RTLevel::Theoric, true, {}, 10);
 
         Path path;
         if(res.size() > 0) {

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -285,7 +285,7 @@ int main(int argc, char** argv){
               accessibilite_params,
               {},
               georef_worker,
-              false,
+              type::RTLevel::Theoric,
               std::numeric_limits<int>::max(), 10, false);
 
         if(resp.journeys_size() > 0) {

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -99,13 +99,13 @@ void NextStopTimeData::load(const type::PT_Data &data) {
 }
 
 inline static bool
-is_valid(const nt::StopTime* st,
+is_valid(const type::StopTime* st,
          const DateTime date,
          const bool clockwise,
-         const bool adapted,
+         const type::RTLevel rt_level,
          const type::VehicleProperties& vehicle_props)
 {
-    return st->is_valid_day(date, !clockwise, adapted) &&
+    return st->is_valid_day(date, !clockwise, rt_level) &&
         st->vehicle_journey->accessible(vehicle_props);
 }
 
@@ -122,7 +122,7 @@ next_valid_discrete(const StopEvent stop_event,
                     const dataRAPTOR& dataRaptor,
                     const JppIdx jpp_idx,
                     const DateTime dt,
-                    const bool adapted,
+                    const type::RTLevel rt_level,
                     const type::VehicleProperties& vehicle_props,
                     const DateTime bound) {
     auto date = DateTimeUtils::date(dt);
@@ -131,7 +131,7 @@ next_valid_discrete(const StopEvent stop_event,
         const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->departure_time : st->arrival_time;
         const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
         if (bound < cur_dt) { return {nullptr, DateTimeUtils::inf}; }
-        if (is_valid(st, date, true, adapted, vehicle_props)) {
+        if (is_valid(st, date, true, rt_level, vehicle_props)) {
             return {st, cur_dt};
         }
     }
@@ -143,7 +143,7 @@ next_valid_discrete(const StopEvent stop_event,
         const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->departure_time : st->arrival_time;
         const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
         if (bound < cur_dt) { return {nullptr, DateTimeUtils::inf}; }
-        if (is_valid(st, date, true, adapted, vehicle_props)) {
+        if (is_valid(st, date, true, rt_level, vehicle_props)) {
             return {st, cur_dt};
         }
     }
@@ -156,7 +156,7 @@ static std::pair<const type::StopTime*, DateTime>
 next_valid_frequency(const StopEvent stop_event,
                      const type::JourneyPatternPoint* jpp,
                      const DateTime dt,
-                     const bool adapted,
+                     const type::RTLevel rt_level,
                      const type::VehicleProperties &vehicle_props) {
     // to find the next frequency VJ, for the moment we loop through all frequency VJ of the JP
     // and for each jp, get compute the datetime on the jpp
@@ -168,7 +168,7 @@ next_valid_frequency(const StopEvent stop_event,
             continue;
         }
 
-        const auto next_dt = get_next_stop_time(stop_event, dt, *freq_vj, st, adapted);
+        const auto next_dt = get_next_stop_time(stop_event, dt, *freq_vj, st, rt_level);
 
         if (next_dt < best.second) {
             best = {&st, next_dt};
@@ -184,7 +184,7 @@ next_valid_frequency(const StopEvent stop_event,
                 continue;
             }
 
-            const auto next_dt = get_next_stop_time(stop_event, next_date, *freq_vj, st, adapted);
+            const auto next_dt = get_next_stop_time(stop_event, next_date, *freq_vj, st, rt_level);
 
             if (next_dt < best.second) {
                 best = {&st, next_dt};
@@ -198,7 +198,7 @@ static std::pair<const type::StopTime*, DateTime>
 previous_valid_frequency(const StopEvent stop_event,
                          const type::JourneyPatternPoint* jpp,
                          const DateTime dt,
-                         const bool adapted,
+                         const type::RTLevel rt_level,
                          const type::VehicleProperties &vehicle_props) {
     std::pair<const type::StopTime*, DateTime> best = {nullptr, DateTimeUtils::not_valid};
     for (const auto& freq_vj: jpp->journey_pattern->frequency_vehicle_journey_list) {
@@ -208,7 +208,7 @@ previous_valid_frequency(const StopEvent stop_event,
             continue;
         }
 
-        const auto previous_dt = get_previous_stop_time(stop_event, dt, *freq_vj, st, adapted);
+        const auto previous_dt = get_previous_stop_time(stop_event, dt, *freq_vj, st, rt_level);
 
         if (previous_dt == DateTimeUtils::not_valid) {
             continue;
@@ -232,7 +232,7 @@ previous_valid_frequency(const StopEvent stop_event,
             }
 
             const auto previous_dt = get_previous_stop_time(stop_event, previous_date, *freq_vj,
-                                                            st, adapted);
+                                                            st, rt_level);
 
             if (previous_dt == DateTimeUtils::not_valid) {
                 continue;
@@ -250,7 +250,7 @@ previous_valid_discrete(const StopEvent stop_event,
                         const dataRAPTOR& dataRaptor,
                         const JppIdx jpp_idx,
                         const DateTime dt,
-                        const bool adapted,
+                        const type::RTLevel rt_level,
                         const type::VehicleProperties& vehicle_props,
                         const DateTime bound) {
     auto date = DateTimeUtils::date(dt);
@@ -259,7 +259,7 @@ previous_valid_discrete(const StopEvent stop_event,
         const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->departure_time : st->arrival_time;
         const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
         if (bound > cur_dt) { return {nullptr, DateTimeUtils::not_valid}; }
-        if (is_valid(st, date, false, adapted, vehicle_props)) {
+        if (is_valid(st, date, false, rt_level, vehicle_props)) {
             return {st, cur_dt};
         }
     }
@@ -274,7 +274,7 @@ previous_valid_discrete(const StopEvent stop_event,
         const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->departure_time : st->arrival_time;
         const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
         if (bound > cur_dt) { return {nullptr, DateTimeUtils::not_valid}; }
-        if (is_valid(st, date, false, adapted, vehicle_props)) {
+        if (is_valid(st, date, false, rt_level, vehicle_props)) {
             return {st, cur_dt};
         }
     }
@@ -286,17 +286,17 @@ std::pair<const type::StopTime*, DateTime>
 NextStopTime::earliest_stop_time(const StopEvent stop_event,
                                  const JppIdx jpp_idx,
                                  const DateTime dt,
-                                 const bool adapted,
+                                 const type::RTLevel rt_level,
                                  const type::VehicleProperties& vehicle_props,
                                  const bool check_freq,
                                  const DateTime bound) const
 {
     const auto first_discrete_st_pair =
-        next_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, adapted, vehicle_props, bound);
+        next_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
 
     if (check_freq) {
         const auto first_frequency_st_pair =
-            next_valid_frequency(stop_event, get_jpp(jpp_idx, data), dt, adapted, vehicle_props);
+            next_valid_frequency(stop_event, get_jpp(jpp_idx, data), dt, rt_level, vehicle_props);
 
         if (first_frequency_st_pair.second < first_discrete_st_pair.second) {
             return first_frequency_st_pair;
@@ -310,17 +310,17 @@ std::pair<const type::StopTime*, DateTime>
 NextStopTime::tardiest_stop_time(const StopEvent stop_event,
                                  const JppIdx jpp_idx,
                                  const DateTime dt,
-                                 const bool adapted,
+                                 const type::RTLevel rt_level,
                                  const type::VehicleProperties& vehicle_props,
                                  const bool check_freq,
                                  const DateTime bound) const
 {
     const auto first_discrete_st_pair =
-        previous_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, adapted, vehicle_props, bound);
+        previous_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
 
     if (check_freq) {
         const auto first_frequency_st_pair =
-            previous_valid_frequency(stop_event, get_jpp(jpp_idx, data), dt, adapted, vehicle_props);
+            previous_valid_frequency(stop_event, get_jpp(jpp_idx, data), dt, rt_level, vehicle_props);
 
         // since the default value is DateTimeUtils::not_valid (== DateTimeUtils::max)
         // we need to check first that they are
@@ -371,7 +371,7 @@ DateTime get_next_stop_time(const StopEvent stop_event,
                             DateTime dt,
                             const type::FrequencyVehicleJourney& freq_vj,
                             const type::StopTime& st,
-                            const bool adapted) {
+                            const type::RTLevel rt_level) {
     const u_int32_t considered_time = (stop_event == StopEvent::pick_up) ? st.departure_time : st.arrival_time;
     const u_int32_t lower_bound = DateTimeUtils::hour(freq_vj.start_time + considered_time);
     const u_int32_t upper_bound = DateTimeUtils::hour(freq_vj.end_time + considered_time);
@@ -385,7 +385,7 @@ DateTime get_next_stop_time(const StopEvent stop_event,
     // but in case of midnight overrun, hour should be in [higher, lower]
     if (normal_case) {
         if (hour <= lower_bound) {
-            if (freq_vj.is_valid(date, adapted)) {
+            if (freq_vj.is_valid(date, rt_level)) {
                 return DateTimeUtils::set(date, lower_bound);
             }
             return DateTimeUtils::inf;
@@ -399,7 +399,7 @@ DateTime get_next_stop_time(const StopEvent stop_event,
     if (normal_case || //in classic case, we must be in [start, end]
             (! normal_case && within(hour, {lower_bound, DateTimeUtils::SECONDS_PER_DAY}))) {
         //we need to check if the vj is valid for our day
-        if (! freq_vj.is_valid(date, adapted)) {
+        if (! freq_vj.is_valid(date, rt_level)) {
             return DateTimeUtils::inf;
         }
 
@@ -410,13 +410,13 @@ DateTime get_next_stop_time(const StopEvent stop_event,
 
     // overnight case and hour > midnight
     if (hour > upper_bound) {
-        if (freq_vj.is_valid(date, adapted)) {
+        if (freq_vj.is_valid(date, rt_level)) {
             return DateTimeUtils::set(date, lower_bound);
         }
         return DateTimeUtils::inf;
     }
     //we need to see if the vj was valid the day before
-    if (! freq_vj.is_valid(date - 1, adapted)) {
+    if (! freq_vj.is_valid(date - 1, rt_level)) {
         //the vj was not valid, next departure is lower
         return DateTimeUtils::set(date, lower_bound);
     }
@@ -431,7 +431,7 @@ DateTime get_previous_stop_time(const StopEvent stop_event,
                                 DateTime dt,
                                 const type::FrequencyVehicleJourney& freq_vj,
                                 const type::StopTime& st,
-                                const bool adapted) {
+                                const type::RTLevel rt_level) {
     const u_int32_t considered_time = (stop_event == StopEvent::pick_up) ?
                                       st.departure_time : st.arrival_time;
     const u_int32_t lower_bound = DateTimeUtils::hour(freq_vj.start_time + considered_time);
@@ -446,7 +446,7 @@ DateTime get_previous_stop_time(const StopEvent stop_event,
     // but in case of midnight overrun, hour should be in [higher, lower]
     if (normal_case) {
         if (hour >= upper_bound) {
-            if (freq_vj.is_valid(date, adapted)) {
+            if (freq_vj.is_valid(date, rt_level)) {
                 return DateTimeUtils::set(date, upper_bound);
             }
             return DateTimeUtils::not_valid;
@@ -460,7 +460,7 @@ DateTime get_previous_stop_time(const StopEvent stop_event,
     if (normal_case || //in classic case, we must be in [start, end]
             (! normal_case && within(hour, {lower_bound, DateTimeUtils::SECONDS_PER_DAY}))) {
         //we need to check if the vj is valid for our day
-        if (! freq_vj.is_valid(date, adapted)) {
+        if (! freq_vj.is_valid(date, rt_level)) {
             return DateTimeUtils::not_valid;
         }
 
@@ -472,13 +472,13 @@ DateTime get_previous_stop_time(const StopEvent stop_event,
     // overnight case and hour > midnight
     if (hour > upper_bound) {
         //case with hour in [upper_bound, lower_boud]
-        if (freq_vj.is_valid(date, adapted)) {
+        if (freq_vj.is_valid(date, rt_level)) {
             return DateTimeUtils::set(date, upper_bound);
         }
         return DateTimeUtils::not_valid;
     }
     //we need to see if the vj was valid the day before
-    if (! freq_vj.is_valid(date - 1, adapted)) {
+    if (! freq_vj.is_valid(date - 1, rt_level)) {
         //the vj was not valid, next departure is lower
         return DateTimeUtils::not_valid;
     }

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -33,6 +33,7 @@ www.navitia.io
 #include "routing/stop_event.h"
 #include "routing/raptor_utils.h"
 #include "utils/idx_map.h"
+#include "type/rt_level.h"
 
 #include <boost/range/algorithm/lower_bound.hpp>
 #include <boost/range/algorithm/upper_bound.hpp>
@@ -149,15 +150,15 @@ struct NextStopTime {
                    const JppIdx jpp_idx,
                    const DateTime dt,
                    const bool clockwise,
-                   const bool adapted,
+                   const type::RTLevel rt_level,
                    const type::VehicleProperties& vehicle_props,
                    const bool check_freq = true,
                    const boost::optional<DateTime>& bound = boost::none) const {
         if (clockwise) {
-            return earliest_stop_time(stop_event, jpp_idx, dt, adapted, vehicle_props,
+            return earliest_stop_time(stop_event, jpp_idx, dt, rt_level, vehicle_props,
                                       check_freq, bound ? *bound : DateTimeUtils::inf);
         } else {
-            return tardiest_stop_time(stop_event, jpp_idx, dt, adapted, vehicle_props,
+            return tardiest_stop_time(stop_event, jpp_idx, dt, rt_level, vehicle_props,
                                       check_freq, bound ? *bound : DateTimeUtils::min);
         }
     }
@@ -170,7 +171,7 @@ struct NextStopTime {
     earliest_stop_time(const StopEvent stop_event,
                        const JppIdx jpp_idx,
                        const DateTime dt,
-                       const bool adapted,
+                       const type::RTLevel rt_level,
                        const type::VehicleProperties& vehicle_props,
                        const bool check_freq = true,
                        const DateTime bound = DateTimeUtils::inf) const;
@@ -183,7 +184,7 @@ struct NextStopTime {
     tardiest_stop_time(const StopEvent stop_event,
                        const JppIdx jpp_idx,
                        const DateTime dt,
-                       const bool adapted,
+                       const type::RTLevel rt_level,
                        const type::VehicleProperties& vehicle_props,
                        const bool check_freq = true,
                        const DateTime bound = DateTimeUtils::min) const;
@@ -196,12 +197,12 @@ DateTime get_next_stop_time(const StopEvent stop_event,
                             DateTime dt,
                             const type::FrequencyVehicleJourney& freq_vj,
                             const type::StopTime& st,
-                            const bool adapted = false);
+                            const type::RTLevel rt_level = type::RTLevel::Theoric);
 DateTime get_previous_stop_time(const StopEvent stop_event,
                                 DateTime dt,
                                 const type::FrequencyVehicleJourney& freq_vj,
                                 const type::StopTime& st,
-                                const bool adapted = false);
+                                const type::RTLevel rt_level = type::RTLevel::Theoric);
 
 
 }} // namespace navitia::routing

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -412,12 +412,14 @@ void RAPTOR::set_valid_jp_and_jpp(
     const std::vector<std::string>& forbidden,
     const nt::RTLevel rt_level)
 {
-
-    if (rt_level == nt::RTLevel::Adapted) {
-        valid_journey_patterns = data.dataRaptor->jp_adapted_validity_pattern[date];
-    } else if (rt_level == nt::RTLevel::Theoric) {
+    switch (rt_level) {
+    case nt::RTLevel::Theoric:
         valid_journey_patterns = data.dataRaptor->jp_validity_patterns[date];
-    } else {
+        break;
+    case nt::RTLevel::Adapted:
+        valid_journey_patterns = data.dataRaptor->jp_adapted_validity_pattern[date];
+        break;
+    case nt::RTLevel::RealTime:
         throw navitia::exception("rt not implemented yet");
     }
     boost::dynamic_bitset<> valid_journey_pattern_points(data.pt_data->journey_pattern_points.size());

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -35,6 +35,7 @@ www.navitia.io
 #include "type/type.h"
 #include "type/data.h"
 #include "type/datetime.h"
+#include "type/rt_level.h"
 #include "routing.h"
 #include "utils/timer.h"
 #include "boost/dynamic_bitset.hpp"
@@ -123,7 +124,7 @@ struct RAPTOR
             int departure_hour,
             int departure_day,
             DateTime bound,
-            bool disruption_active,
+            const nt::RTLevel rt_level,
             bool clockwise = true,
             const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
             uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
@@ -139,7 +140,7 @@ struct RAPTOR
     compute_all(const map_stop_point_duration& departs,
                 const map_stop_point_duration& destinations,
                 const DateTime& departure_datetime,
-                bool disruption_active,
+                const nt::RTLevel rt_level,
                 const DateTime& bound = DateTimeUtils::inf,
                 const uint32_t max_transfers = 10,
                 const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
@@ -156,7 +157,7 @@ struct RAPTOR
     compute_nm_all(const std::vector<std::pair<type::EntryPoint, map_stop_point_duration>>& departures,
                    const std::vector<std::pair<type::EntryPoint, map_stop_point_duration>>& arrivals,
                    const DateTime& departure_datetime,
-                   bool disruption_active, 
+                   const nt::RTLevel rt_level,
                    const DateTime& bound,
                    const uint32_t max_transfers,
                    const type::AccessibiliteParams& accessibilite_params,
@@ -176,7 +177,7 @@ struct RAPTOR
               const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
               const std::vector<std::string>& forbidden = std::vector<std::string>(),
               bool clockwise = true,
-              bool disruption_active = false);
+              const nt::RTLevel rt_level = nt::RTLevel::Theoric);
 
 
     /// Désactive les journey_patterns qui n'ont pas de vj valides la veille, le jour, et le lendemain du calcul
@@ -184,12 +185,12 @@ struct RAPTOR
     void set_valid_jp_and_jpp(uint32_t date,
                               const type::AccessibiliteParams& accessibilite_params,
                               const std::vector<std::string>& forbidden,
-                              bool disruption_active);
+                              const nt::RTLevel rt_level);
 
     ///Boucle principale, parcourt les journey_patterns,
     void boucleRAPTOR(const type::AccessibiliteParams& accessibilite_params,
                       bool clockwise,
-                      bool disruption_active,
+                      const nt::RTLevel rt_level,
                       const uint32_t max_transfers);
 
     /// Apply foot pathes to labels
@@ -199,14 +200,14 @@ struct RAPTOR
     /// Returns true if we improve at least one label, false otherwise
     template<typename Visitor>
     bool apply_vj_extension(const Visitor& v,
-                            const bool disruption_active,
+                            const nt::RTLevel rt_level,
                             const RoutingState& state);
 
     ///Main loop
     template<typename Visitor>
     void raptor_loop(Visitor visitor,
                      const type::AccessibiliteParams& accessibilite_params,
-                     bool disruption_active,
+                     const nt::RTLevel rt_level,
                      uint32_t max_transfers=std::numeric_limits<uint32_t>::max());
 
     /// Return the round that has found the best solution for this stop point
@@ -217,7 +218,7 @@ struct RAPTOR
     /// externalized for testing purposes
     void first_raptor_loop(const map_stop_point_duration& dep,
                            const DateTime& departure_datetime,
-                           bool disruption_active,
+                           const nt::RTLevel rt_level,
                            const DateTime& bound,
                            const uint32_t max_transfers,
                            const type::AccessibiliteParams& accessibilite_params,

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -863,7 +863,7 @@ make_response(RAPTOR &raptor, const type::EntryPoint& origin,
               const type::AccessibiliteParams& accessibilite_params,
               std::vector<std::string> forbidden,
               georef::StreetNetwork& worker,
-              bool disruption_active,
+              const type::RTLevel rt_level,
               uint32_t max_duration, uint32_t max_transfers, bool show_codes) {
 
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
@@ -927,7 +927,7 @@ make_response(RAPTOR &raptor, const type::EntryPoint& origin,
             bound = clockwise ? init_dt + max_duration : init_dt - max_duration;
         }
         std::vector<Path> tmp = raptor.compute_all(
-            departures, destinations, init_dt, disruption_active, bound, max_transfers,
+            departures, destinations, init_dt, rt_level, bound, max_transfers,
             accessibilite_params, forbidden, clockwise, direct_path_dur);
         LOG4CPLUS_DEBUG(logger, "raptor found " << tmp.size() << " solutions");
 
@@ -960,7 +960,7 @@ make_nm_response(RAPTOR &raptor, const std::vector<type::EntryPoint> &origins,
                  const type::AccessibiliteParams & accessibilite_params,
                  std::vector<std::string> forbidden,
                  georef::StreetNetwork & worker,
-                 bool disruption_active,
+                 const type::RTLevel rt_level,
                  uint32_t max_duration, uint32_t max_transfers,
                  bool show_codes) {
 
@@ -1027,7 +1027,7 @@ make_nm_response(RAPTOR &raptor, const std::vector<type::EntryPoint> &origins,
 
         // compute m trip in one call
         auto paths_by_entrypoint = raptor.
-                compute_nm_all(departures, arrivals, init_dt, disruption_active, bound, max_transfers,
+                compute_nm_all(departures, arrivals, init_dt, rt_level, bound, max_transfers,
                                accessibilite_params, forbidden, clockwise);
 
         // compute isochron style result at "m point"
@@ -1066,7 +1066,7 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
                                    const type::AccessibiliteParams & accessibilite_params,
                                    std::vector<std::string> forbidden,
                                    georef::StreetNetwork & worker,
-                                   bool disruption_active,
+                                   const type::RTLevel rt_level,
                                    int max_duration, uint32_t max_transfers, bool show_codes) {
     pbnavitia::Response response;
 
@@ -1091,7 +1091,7 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
     DateTime bound = clockwise ? init_dt + max_duration : init_dt - max_duration;
 
     raptor.isochrone(departures, init_dt, bound, max_transfers,
-                           accessibilite_params, forbidden, clockwise, disruption_active);
+                           accessibilite_params, forbidden, clockwise, rt_level);
 
     add_isochrone_response(raptor, response, raptor.data.pt_data->stop_points, clockwise,
                            init_dt, bound, max_duration, show_codes, false);

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -32,6 +32,8 @@ www.navitia.io
 #include "type/type.pb.h"
 #include "type/response.pb.h"
 #include "type/request.pb.h"
+#include "utils/flat_enum_map.h"
+#include "type/rt_level.h"
 #include <limits>
 
 namespace navitia{
@@ -56,7 +58,7 @@ pbnavitia::Response make_response(RAPTOR &raptor,
                                   const type::AccessibiliteParams & accessibilite_params,
                                   std::vector<std::string> forbidden,
                                   georef::StreetNetwork & worker,
-                                  bool disruption_active,
+                                  const type::RTLevel rt_level,
                                   uint32_t max_duration=std::numeric_limits<uint32_t>::max(),
                                   uint32_t max_transfers=std::numeric_limits<uint32_t>::max(),
                                   bool show_codes = false);
@@ -67,7 +69,7 @@ pbnavitia::Response make_nm_response(RAPTOR &raptor, const std::vector<type::Ent
                                      const type::AccessibiliteParams & accessibilite_params,
                                      std::vector<std::string> forbidden,
                                      georef::StreetNetwork & worker,
-                                     bool disruption_active,
+                                     const type::RTLevel rt_level,
                                      uint32_t max_duration, uint32_t max_transfers,
                                      bool show_codes);
 
@@ -77,7 +79,7 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
                                    const type::AccessibiliteParams & accessibilite_params,
                                    std::vector<std::string> forbidden,
                                    georef::StreetNetwork & worker,
-                                   bool disruption_active,
+                                   const type::RTLevel rt_level,
                                    int max_duration = 3600,
                                    uint32_t max_transfers=std::numeric_limits<uint32_t>::max(),
                                    bool show_codes = false);

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -125,7 +125,7 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
             StopEvent::pick_up,
             JppIdx(*cur_jpp),
             prev_s->get_out_dt + conn->duration,
-            reader.disruption_active,
+            reader.rt_level,
             reader.accessibilite_params.vehicle_properties);
         if (new_st_dt.second < cur_s.get_in_dt) {
             const auto out_st_dt = get_out_st_dt(new_st_dt, cur_s.get_out_st->journey_pattern_point);
@@ -320,14 +320,14 @@ struct RaptorSolutionReader {
                          const DateTime& departure_dt,
                          const routing::map_stop_point_duration& deps,
                          const routing::map_stop_point_duration& arrs,
-                         const bool disruption,
+                         const type::RTLevel rt_level,
                          const type::AccessibiliteParams& access):
         raptor(r),
         v(vis),
         departure_datetime(departure_dt),
         sp_dur_deps(deps),
         sp_dur_arrs(arrs),
-        disruption_active(disruption),
+        rt_level(rt_level),
         accessibilite_params(access),
         // Dominates need request_clockwise (the same as reader's visitor)
         solutions(Dominates(v.clockwise()))
@@ -337,7 +337,7 @@ struct RaptorSolutionReader {
     const DateTime departure_datetime;
     const routing::map_stop_point_duration& sp_dur_deps;// departures (not clockwise dependent)
     const routing::map_stop_point_duration& sp_dur_arrs;// arrivals (not clockwise dependent)
-    const bool disruption_active;
+    const type::RTLevel rt_level;
     const type::AccessibiliteParams& accessibilite_params;
     Solutions solutions;
 
@@ -450,7 +450,7 @@ struct RaptorSolutionReader {
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
             const auto begin_st_dt = raptor.next_st.next_stop_time(
-                        v.stop_event(), jpp.idx, begin_dt, v.clockwise(), disruption_active,
+                        v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
                         accessibilite_params.vehicle_properties, /*jpp.has_freq*/ true, begin_limit);
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
@@ -488,7 +488,7 @@ struct RaptorSolutionReader {
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
             const auto begin_st_dt = raptor.next_st.next_stop_time(
-                                v.stop_event(), jpp.idx, begin_dt, v.clockwise(), disruption_active,
+                                v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
                                 accessibilite_params.vehicle_properties/*, jpp.has_freq*/);
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
@@ -505,11 +505,11 @@ Solutions read_solutions(const RAPTOR& raptor,
                          const DateTime& departure_datetime,
                          const routing::map_stop_point_duration& deps,
                          const routing::map_stop_point_duration& arrs,
-                         const bool disruption_active,
+                         const type::RTLevel rt_level,
                          const type::AccessibiliteParams& accessibilite_params)
 {
     auto reader = RaptorSolutionReader<Visitor>(
-        raptor, v, departure_datetime, deps, arrs, disruption_active, accessibilite_params);
+        raptor, v, departure_datetime, deps, arrs, rt_level, accessibilite_params);
 
     for (unsigned count = 1; count <= raptor.count; ++count) {
         auto& working_labels = raptor.labels[count];
@@ -575,15 +575,15 @@ Solutions read_solutions(const RAPTOR& raptor,
                          const DateTime& departure_datetime,
                          const routing::map_stop_point_duration& deps,
                          const routing::map_stop_point_duration& arrs,
-                         const bool disruption_active,
+                         const type::RTLevel rt_level,
                          const type::AccessibiliteParams& accessibilite_params)
 {
     if (clockwise) {
         return read_solutions(raptor, raptor_reverse_visitor(), departure_datetime, deps, arrs,
-                              disruption_active, accessibilite_params);
+                              rt_level, accessibilite_params);
     } else {
         return read_solutions(raptor, raptor_visitor(), departure_datetime, deps, arrs,
-                              disruption_active, accessibilite_params);
+                              rt_level, accessibilite_params);
     }
 }
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -86,7 +86,7 @@ read_solutions(const RAPTOR& raptor,
                const DateTime& departure_datetime,
                const routing::map_stop_point_duration& deps,
                const routing::map_stop_point_duration& arrs,
-               const bool disruption_active,
+               const type::RTLevel rt_level,
                const type::AccessibiliteParams& accessibilite_params);
 
 Path make_path(const Journey& journey, const type::Data& data);

--- a/source/routing/routing_cli_utils.cpp
+++ b/source/routing/routing_cli_utils.cpp
@@ -75,7 +75,7 @@ namespace navitia { namespace cli {
             }
             pb::Response resp = make_response(*raptor, origin, destination, {ntest::to_posix_timestamp(date)},
                     clockwise, navitia::type::AccessibiliteParams(), forbidden,
-                    sn_worker, false, true);
+                    sn_worker, type::RTLevel::Theoric, true);
 
             if (vm.count("protobuf")) {
                 std::cout << resp.DebugString() << "\n";

--- a/source/routing/tests/co2_emission_test.cpp
+++ b/source/routing/tests/co2_emission_test.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_higher_0) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, false);
+                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_equal_0) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, false);
+                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_lower_0) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, false);
+                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 

--- a/source/routing/tests/frequency_raptor_test.cpp
+++ b/source/routing/tests/frequency_raptor_test.cpp
@@ -58,13 +58,13 @@ BOOST_AUTO_TEST_CASE(freq_vj) {
     RAPTOR raptor(*(b.data));
     const type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 8*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 8*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), 8*3600 + 10*60);
 
-    res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 9*3600, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 9*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), 9*3600 + 10*60);
 }
@@ -81,18 +81,18 @@ BOOST_AUTO_TEST_CASE(freq_vj_pam) {
     RAPTOR raptor(*(b.data));
     const type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 23*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 23*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), 23*3600 + 10*60);
 
-    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 24*3600, 0, DateTimeUtils::inf, false, true);
+    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 24*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res1[0].items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), (24*3600 + 10*60)% DateTimeUtils::SECONDS_PER_DAY);
 
-    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 25*3600, 0, DateTimeUtils::inf, false, true);
+    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 25*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res1[0].items[0].arrival, *(b.data))), 1);
@@ -128,13 +128,13 @@ BOOST_AUTO_TEST_CASE(freq_vj_stop_times) {
         BOOST_CHECK_EQUAL(section.departures[2], "20120614T094000"_dt);
     };
 
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600, 0, DateTimeUtils::inf, false, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
     //same but tardiest departure
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 30*60, 0, DateTimeUtils::min, false, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);
@@ -174,13 +174,13 @@ BOOST_AUTO_TEST_CASE(freq_vj_different_departure_arrival_duration) {
         BOOST_CHECK_EQUAL(section.departures[2], "20120614T100500"_dt);
     };
 
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
     //same but tardiest departure
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 10*3600, 0, DateTimeUtils::min, false, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 10*3600, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);
@@ -220,13 +220,13 @@ BOOST_AUTO_TEST_CASE(freq_vj_overmidnight_different_dep_arr) {
     };
 
     //leaving at 22:15, we have to wait for the next departure at 23:10
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 22*3600 + 15*60, 2, DateTimeUtils::inf, false, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 22*3600 + 15*60, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
     //wwe want to arrive before 01:00 we'll take the same trip
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 1*3600, 3, DateTimeUtils::min, false, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 1*3600, 3, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
@@ -290,12 +290,12 @@ BOOST_AUTO_TEST_CASE(freq_vj_transfer_with_regular_vj) {
 
     // leaving after 10:20, we have to wait for the next bus at 11:15
     // then we can catch the bus B at 12:10 and finish at 12:30
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "10:20"_t, 2, DateTimeUtils::inf, false, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "10:20"_t, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "12:40"_t, 2, DateTimeUtils::min, false, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "12:40"_t, 2, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);
@@ -370,12 +370,12 @@ BOOST_AUTO_TEST_CASE(transfer_between_freq) {
     // leaving after 11:10, we would have to wait for the bus B after so the 2nd pass makes us wait
     // so we leave at 12:10 to arrive at 13:20
     // then we have to wait for the begin of the bust B at 14:04 and finish at 14:35
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "11:10"_t, 2, DateTimeUtils::inf, false, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "11:10"_t, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "14:35"_t, 2, DateTimeUtils::min, false, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "14:35"_t, 2, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);

--- a/source/routing/tests/next_stop_time_test.cpp
+++ b/source/routing/tests/next_stop_time_test.cpp
@@ -85,9 +85,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     //SP1
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1),
-                                                        sp1_departure - 1, false, false);
+                                                        sp1_departure - 1, nt::RTLevel::Theoric, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1),
-                                                        sp1_departure - 1, false, false);
+                                                        sp1_departure - 1, nt::RTLevel::Theoric, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -95,9 +95,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1),
-                                                        sp1_departure, false, false);
+                                                        sp1_departure, nt::RTLevel::Theoric, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1),
-                                                        sp1_departure, false, false);
+                                                        sp1_departure, nt::RTLevel::Theoric, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -105,9 +105,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1),
-                                                        sp1_departure + 1, false, false);
+                                                        sp1_departure + 1, nt::RTLevel::Theoric, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1),
-                                                        sp1_departure + 1, false, false);
+                                                        sp1_departure + 1, nt::RTLevel::Theoric, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -116,9 +116,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     //SP2
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2),
-                                                        sp2_departure - 1, false, false);
+                                                        sp2_departure - 1, nt::RTLevel::Theoric, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2),
-                                                        sp2_departure - 1, false, false);
+                                                        sp2_departure - 1, nt::RTLevel::Theoric, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -126,9 +126,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2),
-                                                        sp2_departure, false, false);
+                                                        sp2_departure, nt::RTLevel::Theoric, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2),
-                                                        sp2_departure, false, false);
+                                                        sp2_departure, nt::RTLevel::Theoric, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -136,9 +136,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2),
-                                                        sp2_arrival + 1, false, false);
+                                                        sp2_arrival + 1, nt::RTLevel::Theoric, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2),
-                                                        sp2_arrival + 1, false, false);
+                                                        sp2_arrival + 1, nt::RTLevel::Theoric, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -193,9 +193,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(DateTimeUtils::date(dt_test), sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -206,9 +206,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(DateTimeUtils::date(dt_test), sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -219,9 +219,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -295,9 +295,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -309,9 +309,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, dt_test);
         BOOST_CHECK(st1 == nullptr);
@@ -323,9 +323,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -376,9 +376,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -389,9 +389,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -402,9 +402,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -416,9 +416,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         // we ask for the previous departure from 23:59 the day 1
         // the previous departure is the day 1, at 100 (same as the day 0 at 86400 + 100)
@@ -431,9 +431,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -444,9 +444,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -457,9 +457,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -516,9 +516,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -529,9 +529,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -542,9 +542,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -576,7 +576,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -606,7 +606,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -626,7 +626,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -637,9 +637,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -650,9 +650,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -663,9 +663,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -717,7 +717,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
@@ -726,7 +726,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
@@ -735,7 +735,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
@@ -745,7 +745,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -754,7 +754,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(2, sp2_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1 - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -836,7 +836,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1 + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure2);
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure2 - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure2);
@@ -854,7 +854,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure2);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure2);
@@ -863,7 +863,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure2 + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -873,7 +873,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp2_arrival1 + 1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival1);
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp2_arrival1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival1);
@@ -891,7 +891,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival1 - 1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival2);
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp2_arrival2 + 1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival2);
@@ -968,7 +968,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1 - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -977,7 +977,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -996,7 +996,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(2, sp2_arrival1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival2));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival2);
@@ -1005,7 +1005,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival2 - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival1));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival1);
@@ -1058,9 +1058,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1071,9 +1071,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1084,9 +1084,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1096,7 +1096,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -1104,7 +1104,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         //We test if we can find the train leaving after midnight
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -1114,7 +1114,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1124,7 +1124,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -1134,7 +1134,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1145,14 +1145,14 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr); // No departure because this is a terminus
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st2 == nullptr);
         // There are no trip leaving before
@@ -1160,9 +1160,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1173,9 +1173,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1231,9 +1231,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1244,9 +1244,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1257,9 +1257,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1269,21 +1269,21 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st2 == nullptr);
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, 0));
         BOOST_CHECK(st1 != nullptr);
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1293,7 +1293,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, 0));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -1303,7 +1303,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1315,9 +1315,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         //The day 0 is unactive
         DateTime dt_test = DateTimeUtils::set(0, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1326,9 +1326,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1337,9 +1337,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1350,9 +1350,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1422,9 +1422,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1434,9 +1434,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1446,9 +1446,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time + headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1458,9 +1458,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time - (headway_sec) + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1470,9 +1470,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1482,9 +1482,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1497,9 +1497,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour2 = start_time + (sp2_arrival - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, hour2));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1512,9 +1512,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = start_time + (sp2_departure - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, departure_hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1526,9 +1526,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = start_time + (sp2_departure - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, departure_hour + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour + headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1540,9 +1540,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = 7050;
         DateTime dt_test = DateTimeUtils::set(0, arrival_hour - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour - headway_sec));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1554,9 +1554,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = 7050;
         DateTime dt_test = DateTimeUtils::set(0, arrival_hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1568,9 +1568,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = 7050;
         DateTime dt_test = DateTimeUtils::set(0, arrival_hour + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1582,9 +1582,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour = start_time + (sp3_arrival - sp2_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1594,9 +1594,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour = start_time + (sp3_arrival - sp2_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1606,9 +1606,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour = start_time + (sp3_arrival - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, hour));
         BOOST_CHECK(st1 == nullptr);
@@ -1650,9 +1650,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         uint32_t hour = start_time - 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1664,9 +1664,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         uint32_t hour = start_time;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1677,9 +1677,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         uint32_t hour = start_time + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time + headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1690,9 +1690,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, last_time - headway_sec - 10);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time - headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1703,9 +1703,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(1, 0);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1717,9 +1717,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time + sp2_arrival - sp1_departure));
         BOOST_CHECK(st1 == nullptr);
@@ -1730,9 +1730,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time + sp2_arrival - sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time + sp2_arrival - sp1_departure));
         BOOST_CHECK(st1 == nullptr);
@@ -1743,9 +1743,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, last_time - headway_sec - 10);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time - 2 * headway_sec + sp2_arrival - sp1_departure ));
         BOOST_CHECK(st1 == nullptr);
@@ -1756,9 +1756,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(1, 0);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_CHECK(st1 == nullptr);
@@ -1807,7 +1807,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 - 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1817,7 +1817,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1827,7 +1827,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 + 1 ;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time1 + headway_sec));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1837,7 +1837,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, end_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1847,7 +1847,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time1 + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1857,7 +1857,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1868,7 +1868,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2 + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time2 + headway_sec));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1878,7 +1878,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86100;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1888,7 +1888,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86400;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1898,7 +1898,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 100;
         DateTime dt_test = DateTimeUtils::set(1, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1908,7 +1908,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = last_time2;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1918,7 +1918,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time2;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1929,7 +1929,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time2 + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time2 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1939,7 +1939,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 + sp2_arrival - sp1_departure;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time1 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1949,7 +1949,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 + sp2_arrival - sp1_departure + headway_sec + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time1 + headway_sec + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1959,7 +1959,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = last_time1 + sp2_arrival - sp1_departure;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time1 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1969,7 +1969,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time1 + sp2_arrival - sp1_departure + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time1 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1979,7 +1979,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2 + sp2_arrival - sp1_departure;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time2 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1989,7 +1989,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2 + sp2_arrival - sp1_departure + headway_sec + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time2 + sp2_arrival - sp1_departure + headway_sec));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1999,7 +1999,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86100;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2009,7 +2009,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86400;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2019,7 +2019,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86610;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, 86600);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2029,7 +2029,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = last_time2 + sp2_arrival - sp1_departure + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        false, false);
+                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, last_time2 + sp2_arrival - sp1_departure);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(direct){
     b.data->build_raptor();
     RAPTOR raptor(*b.data);
 
-    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(res.items[0].arrivals[1], "20120614T021500"_dt);
     BOOST_CHECK_EQUAL(res.items[0].departures[1], "20120614T021550"_dt);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), false, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8101), false, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8101), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), false, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(change){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8401), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8401), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 /****
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items.back().arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::hour(to_datetime(res.items.back().arrival, *(b.data))), 7*3600 + 15*60);
 
-    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), false, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60 + 1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60 + 1), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -439,30 +439,30 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9201), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9201), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(forbidden_uri){
     RAPTOR raptor(*b.data);
 
     auto res1 = raptor.compute(b.data->pt_data->stop_areas[0],
-            b.data->pt_data->stop_areas[3], 7900, 0, DateTimeUtils::inf, false,
+            b.data->pt_data->stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric,
             true, {}, std::numeric_limits<uint32_t>::max(), {"stop2"});
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
@@ -522,7 +522,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9201), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9201), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20+1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20+1), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -617,7 +617,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
@@ -642,7 +642,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }));
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -665,7 +665,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }
     ));
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60+1), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60+1), type::RTLevel::Theoric, true);
 
     // As the bound is tight, we now only have the shortest trip.
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
 
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60), type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(pam_veille) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -731,7 +731,7 @@ BOOST_AUTO_TEST_CASE(pam_3) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
 
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 9*3600 + 20 * 60);
 }
@@ -771,7 +771,7 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type, ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(stay_in_short) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type, ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
@@ -814,7 +814,7 @@ BOOST_AUTO_TEST_CASE(stay_in_nl) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 60780, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 60780, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type, ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 63180);
@@ -839,7 +839,7 @@ BOOST_AUTO_TEST_CASE(stay_in_nl_counterclock) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 63200, 0, DateTimeUtils::inf, false);
+    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 63200, 0, DateTimeUtils::inf, type::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type,  ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 63180);
@@ -858,7 +858,7 @@ BOOST_AUTO_TEST_CASE(stay_in_teleport) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type,  ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
@@ -877,7 +877,7 @@ BOOST_AUTO_TEST_CASE(stay_in_departure_last_of_first_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(stay_in_complex) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 11*3600+10*60);
 }
@@ -924,7 +924,7 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
                     return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 15*60;}));
@@ -947,7 +947,7 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
 }
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -984,7 +984,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -1023,12 +1023,12 @@ BOOST_AUTO_TEST_CASE(itl) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 10*3600);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 8*3600+20*60);
 }
@@ -1047,14 +1047,14 @@ BOOST_AUTO_TEST_CASE(mdi) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 5*60, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop4"],d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop4"],d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
 
@@ -1081,7 +1081,7 @@ BOOST_AUTO_TEST_CASE(multiples_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
@@ -1098,13 +1098,13 @@ BOOST_AUTO_TEST_CASE(max_duration){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8101), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8101), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8099), false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8099), type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -1126,7 +1126,7 @@ BOOST_AUTO_TEST_CASE(max_transfers){
 
     for(uint32_t nb_transfers=0; nb_transfers<=2; ++nb_transfers) {
         //        type::Properties p;
-        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, false, true, type::AccessibiliteParams(), nb_transfers);
+        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, nt::RTLevel::Theoric, true, type::AccessibiliteParams(), nb_transfers);
         BOOST_REQUIRE(res1.size()>=1);
         for(auto r : res1) {
             BOOST_REQUIRE(r.nb_changes <= nb_transfers);
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE(destination_over_writing) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_special) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -1210,11 +1210,11 @@ BOOST_AUTO_TEST_CASE(invalid_stay_in_overmidnight) {
 
     // Here we want to check if the second vehicle_journey is not taken on the
     // first day
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
     
     // There must be a journey the second day
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 1, DateTimeUtils::inf, false, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 1, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
 
@@ -1253,7 +1253,7 @@ BOOST_AUTO_TEST_CASE(no_departure_before_given_date) {
     departures[SpIdx(*b.sps["stop1"])] = 1500_s;
     arrivals[SpIdx(*b.sps["stop5"])] = 0_s;
 
-    auto results = raptor.compute_all(departures, arrivals, 6000, false);
+    auto results = raptor.compute_all(departures, arrivals, 6000, type::RTLevel::Theoric);
 
     BOOST_CHECK_EQUAL(results.size(), 2);
     for (const auto& res: results) {
@@ -1293,7 +1293,7 @@ BOOST_AUTO_TEST_CASE(less_fallback) {
     destinations[SpIdx(*d.stop_areas_map["stop1"]->stop_point_list.front())] = 560_s;
     destinations[SpIdx(*d.stop_areas_map["stop2"]->stop_point_list.front())] = 320_s;
     destinations[SpIdx(*d.stop_areas_map["stop3"]->stop_point_list.front())] = 0_s;
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -1346,7 +1346,7 @@ BOOST_AUTO_TEST_CASE(pareto_front) {
     // We are going to J point, so we add the walking times
     destinations[SpIdx(*d.stop_areas_map["stop2"]->stop_point_list.front())] = 15_min;
     destinations[SpIdx(*d.stop_areas_map["stop3"]->stop_point_list.front())] = 0_s;
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), false);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -1371,7 +1371,7 @@ BOOST_AUTO_TEST_CASE(overlapping_on_first_st) {
     b.finish();
     b.data->build_raptor();
     RAPTOR raptor(*b.data);
-    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -1397,7 +1397,7 @@ BOOST_AUTO_TEST_CASE(stay_in_unnecessary) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items.size(), 1);
 }
@@ -1417,7 +1417,7 @@ BOOST_AUTO_TEST_CASE(stay_in_unnecessary2) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items.size(), 3);
 }
@@ -1442,7 +1442,7 @@ BOOST_AUTO_TEST_CASE(forbid_transfer_between_2_odt){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -1462,7 +1462,7 @@ BOOST_AUTO_TEST_CASE(simple_odt){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     const auto& journey = res1.front();
     BOOST_REQUIRE_EQUAL(journey.items.size(), 1);
@@ -1488,7 +1488,7 @@ BOOST_AUTO_TEST_CASE(simple_odt_virtual_with_stop_time){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     const auto& journey = res1.front();
     BOOST_REQUIRE_EQUAL(journey.items.size(), 1);
@@ -1533,9 +1533,9 @@ BOOST_AUTO_TEST_CASE(y_line_the_ultimate_political_blocking_bug){
     RAPTOR raptor(*(b.data));
     const type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 7900, 0, DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     check_y_line_the_ultimate_political_blocking_bug(res1);
-    auto res2 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 9000, 0, DateTimeUtils::min, false, false);
+    auto res2 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 9000, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     check_y_line_the_ultimate_political_blocking_bug(res2);
 }
 
@@ -1566,7 +1566,7 @@ BOOST_AUTO_TEST_CASE(finish_on_service_extension) {
     routing::map_stop_point_duration departs;
     departs[routing::SpIdx(*d.stop_points_map["A"])] = {};
 
-    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), false, DateTimeUtils::inf,
+    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), nt::RTLevel::Theoric, DateTimeUtils::inf,
                              std::numeric_limits<uint32_t>::max(), {}, {}, true);
 
     //and raptor has to stop on count 2
@@ -1602,7 +1602,7 @@ BOOST_AUTO_TEST_CASE(finish_on_foot_path) {
     routing::map_stop_point_duration departs;
     departs[routing::SpIdx(*d.stop_points_map["A"])] = {};
 
-    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), false, DateTimeUtils::inf,
+    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), type::RTLevel::Theoric, DateTimeUtils::inf,
                              std::numeric_limits<uint32_t>::max(), {}, {}, true);
 
     //and raptor has to stop on count 2
@@ -1665,11 +1665,11 @@ BOOST_AUTO_TEST_CASE(test_2nd_and_3rd_pass) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                               7900, 0, DateTimeUtils::inf, false, true);
+                               7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     test_2nd_and_3rd_pass_checks(res1);
 
     // non clockwise test
-    auto res2 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 16100, 0, 0, false, false);
+    auto res2 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 16100, 0, 0, type::RTLevel::Theoric, false);
     test_2nd_and_3rd_pass_checks(res2);
 }
 
@@ -1739,12 +1739,12 @@ BOOST_AUTO_TEST_CASE(test_2nd_and_3rd_pass_ext) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                               7900, 0, DateTimeUtils::inf, false, true);
+                               7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     test_2nd_and_3rd_pass_ext_checks(res1);
 
     // non clockwise test
     auto res2 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                               16100, 0, 0, false, false);
+                               16100, 0, 0, type::RTLevel::Theoric, false);
     test_2nd_and_3rd_pass_ext_checks(res2);
 }
 
@@ -1767,7 +1767,7 @@ BOOST_AUTO_TEST_CASE(direct_and_1trans_at_same_dt) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("C"),
-                              7900, 0, DateTimeUtils::inf, false, true);
+                              7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     const auto& direct = res[0].items.size() == 1 ? res[0] : res[1];
@@ -1817,7 +1817,7 @@ BOOST_AUTO_TEST_CASE(dont_return_dominated_solutions) {
     departures[SpIdx(*d.stop_areas_map.at("A")->stop_point_list.front())] = 1000_s;
     departures[SpIdx(*d.stop_areas_map.at("D")->stop_point_list.front())] = 3000_s;
     arrivals[SpIdx(*d.stop_areas_map.at("C")->stop_point_list.front())] = 0_s;
-    auto res = raptor.compute_all(departures, arrivals, 1000, false);
+    auto res = raptor.compute_all(departures, arrivals, 1000, type::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     const auto& direct = res[0].items.size() == 1 ? res[0] : res[1];
@@ -1875,7 +1875,7 @@ BOOST_AUTO_TEST_CASE(second_pass) {
     arrivals[SpIdx(*d.stop_areas_map.at("GM1")->stop_point_list.front())] = 0_s;
     arrivals[SpIdx(*d.stop_areas_map.at("GM2")->stop_point_list.front())] = 0_s;
 
-    auto res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:30"_t), false,
+    auto res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:30"_t), type::RTLevel::Theoric,
                                   DateTimeUtils::inf, 10, {}, {}, true);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -1928,12 +1928,12 @@ BOOST_AUTO_TEST_CASE(good_connection_when_walking_as_fast_as_bus) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                               "8:00"_t, 0, DateTimeUtils::inf, false, true);
+                               "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
     test_good_connection_when_walking_as_fast_as_bus(res1);
 
     // non clockwise test
     auto res2 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                               "12:00"_t, 0, 0, false, false);
+                               "12:00"_t, 0, 0, type::RTLevel::Theoric, false);
     test_good_connection_when_walking_as_fast_as_bus(res2);
 }
 
@@ -1962,13 +1962,13 @@ BOOST_AUTO_TEST_CASE(accessible_on_first_sp) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("B"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items.back().arrival, time_from_string("2015-01-01 10:00:00"));
 
     // non clockwise test
     res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("B"),
-                         "10:00"_t, 0, 0, false, false, params);
+                         "10:00"_t, 0, 0, type::RTLevel::Theoric, false, params);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items.back().arrival, time_from_string("2015-01-01 10:00:00"));
 }
@@ -1997,7 +1997,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  false,
+                                  type::RTLevel::Theoric,
                                   DateTimeUtils::inf,
                                   10,
                                   {},
@@ -2009,7 +2009,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     res = raptor.compute_all(departures,
                              arrivals,
                              DateTimeUtils::set(2, "08:00"_t),
-                             false,
+                             type::RTLevel::Theoric,
                              DateTimeUtils::inf,
                              10,
                              {},
@@ -2022,7 +2022,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     res = raptor.compute_all(departures,
                              arrivals,
                              DateTimeUtils::set(2, "08:03"_t),
-                             false,
+                             type::RTLevel::Theoric,
                              0,
                              10,
                              {},
@@ -2034,7 +2034,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     res = raptor.compute_all(departures,
                              arrivals,
                              DateTimeUtils::set(2, "08:03"_t),
-                             false,
+                             type::RTLevel::Theoric,
                              0,
                              10,
                              {},
@@ -2073,7 +2073,7 @@ BOOST_AUTO_TEST_CASE(no_iti_from_to_same_sa) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "07:50"_t),
-                                  false,
+                                  type::RTLevel::Theoric,
                                   0,
                                   10,
                                   {},
@@ -2116,7 +2116,7 @@ BOOST_AUTO_TEST_CASE(no_going_backward) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(0, "08:30"_t),
-                                  false,
+                                  type::RTLevel::Theoric,
                                   0,
                                   10,
                                   {},
@@ -2159,7 +2159,7 @@ BOOST_AUTO_TEST_CASE(walking_doesnt_break_connection) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(0, "08:00"_t),
-                                  false);
+                                  type::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_REQUIRE_EQUAL(res[0].items.size(), 3);
     using boost::posix_time::time_from_string;
@@ -2210,7 +2210,7 @@ BOOST_AUTO_TEST_CASE(accessibility_drop_off_forbidden) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2273,7 +2273,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx_no_solution) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 0);
 }
@@ -2321,7 +2321,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2379,7 +2379,7 @@ BOOST_AUTO_TEST_CASE(forbidden_uri_cnx) {
     const std::vector<std::string> forbid = {"B1"};
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, type::AccessibiliteParams(),
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, type::AccessibiliteParams(),
                               10, forbid);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -2439,7 +2439,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx_2) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2507,7 +2507,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx_3) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("Arr"),
-                              "8:00"_t, 0, DateTimeUtils::inf, false, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2552,7 +2552,7 @@ BOOST_AUTO_TEST_CASE(begin_different_zone1) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  false);
+                                  type::RTLevel::Theoric);
     BOOST_CHECK_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
     BOOST_CHECK_EQUAL(res.at(0).items.front().departure, time_from_string("2015-01-03 08:00:00"));
@@ -2583,7 +2583,7 @@ BOOST_AUTO_TEST_CASE(begin_different_zone2) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  false);
+                                  type::RTLevel::Theoric);
     BOOST_CHECK_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
     BOOST_CHECK_EQUAL(res.at(0).items.front().departure, time_from_string("2015-01-03 08:10:00"));
@@ -2616,7 +2616,7 @@ BOOST_AUTO_TEST_CASE(begin_different_zone3) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  false);
+                                  type::RTLevel::Theoric);
 
     // We should find this solution, but...
     /*

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(direct){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0,8050-1000), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0,8050-1000), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050-1), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(change){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1000), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1000), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1000), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1000), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600 - 1000), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600 - 1000), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"],  50*60, 1, DateTimeUtils::set(0, 23*3600 - 1000), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"],  50*60, 1, DateTimeUtils::set(0, 23*3600 - 1000), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600-1), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit4){
     type::PT_Data & d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"],
-            24*3600+15*60, 3, DateTimeUtils::min, false, false);
+            24*3600+15*60, 3, DateTimeUtils::min, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7000, 1, DateTimeUtils::min, false, false);
+    auto res = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7000, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res.size(), 0);
 }
 
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050 - 1000), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050 - 1000), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050-1), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(sn_fin) {
     RAPTOR raptor(*(b.data));
 
 
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 9*3600 + 20 * 60), false);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 9*3600 + 20 * 60), nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].departure.time_of_day().total_seconds(), 8*3600);
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, true, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, true, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
                           return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 25*60;}));
@@ -513,7 +513,7 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, true, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
 }
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, true, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, true, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -566,12 +566,12 @@ BOOST_AUTO_TEST_CASE(itl) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9*3600+15*60, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9*3600+15*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600+20*60, 0, DateTimeUtils::min, false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600+20*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].departure.time_of_day().total_seconds(), 8*3600+10*60);
 
@@ -590,14 +590,14 @@ BOOST_AUTO_TEST_CASE(mdi) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 17*3600+30*60, 0, DateTimeUtils::min, false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop5"], 17*3600+30*60, 0, DateTimeUtils::min, false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop5"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
 
@@ -611,13 +611,13 @@ BOOST_AUTO_TEST_CASE(max_duration){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::min, false, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8049), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8049), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8051), false, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8051), type::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(max_transfers){
     type::PT_Data & d = *b.data->pt_data;
 
     for(uint32_t nb_transfers=0; nb_transfers<=2;++nb_transfers) {
-        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 86400, 0, DateTimeUtils::inf, false, true, type::AccessibiliteParams(), nb_transfers);
+        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 86400, 0, DateTimeUtils::inf, nt::RTLevel::Theoric, true, type::AccessibiliteParams(), nb_transfers);
         BOOST_REQUIRE(res1.size()>=1);
         for(auto r : res1) {
             BOOST_REQUIRE(r.nb_changes <= nb_transfers);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -38,6 +38,7 @@ www.navitia.io
 #include "routing/raptor.h"
 #include "georef/street_network.h"
 #include "type/data.h"
+#include "type/rt_level.h"
 #include <boost/range/algorithm/count.hpp>
 
 struct logger_initialized {
@@ -109,7 +110,7 @@ BOOST_AUTO_TEST_CASE(simple_journey) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -174,7 +175,7 @@ BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                              {ntest::to_posix_timestamp("20120614T021000")},
                                              true, navitia::type::AccessibiliteParams()/*false*/,
-                                             forbidden, sn_worker, false);
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -206,7 +207,7 @@ BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     resp = make_response(raptor, origin, destination,
                          {ntest::to_posix_timestamp("20120614T021000")},
                          true, navitia::type::AccessibiliteParams()/*false*/,
-                         forbidden, sn_worker, false);
+                         forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -254,7 +255,10 @@ BOOST_AUTO_TEST_CASE(journey_stay_in) {
     navitia::type::EntryPoint destination(destination_type, "rs");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")}, true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                            {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -311,7 +315,9 @@ BOOST_AUTO_TEST_CASE(journey_stay_in_teleport) {
     navitia::type::EntryPoint destination(destination_type, "rs");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")}, true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -375,7 +381,9 @@ BOOST_AUTO_TEST_CASE(journey_stay_in_shortteleport) {
     navitia::type::EntryPoint destination(destination_type, "rs");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")}, true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -448,8 +456,10 @@ BOOST_AUTO_TEST_CASE(journey_departure_from_a_stay_in) {
     navitia::type::EntryPoint destination(destination_type, "end");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                            {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -513,8 +523,10 @@ BOOST_AUTO_TEST_CASE(journey_arrival_before_a_stay_in) {
     navitia::type::EntryPoint destination(destination_type, "end");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                             {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -567,8 +579,10 @@ BOOST_AUTO_TEST_CASE(journey_arrival_in_a_stay_in) {
     navitia::type::EntryPoint destination(destination_type, "end");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                            {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     dump_response(resp, "arrival_before");
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
@@ -632,8 +646,10 @@ BOOST_AUTO_TEST_CASE(journey_arrival_before_a_stay_in_without_teleport) {
     navitia::type::EntryPoint destination(destination_type, "end");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                             {ntest::to_posix_timestamp("20120614T165300")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -677,7 +693,10 @@ BOOST_AUTO_TEST_CASE(journey_stay_in_shortteleport_counterclockwise) {
     navitia::type::EntryPoint destination(destination_type, "rs");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T174000")}, false, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                            {ntest::to_posix_timestamp("20120614T174000")}, false,
+                                             navitia::type::AccessibiliteParams(), forbidden,
+                                             sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -736,7 +755,8 @@ BOOST_AUTO_TEST_CASE(journey_array){
     //we put the time not in the right order to check that they are correctly sorted
     std::vector<uint64_t> datetimes({ntest::to_posix_timestamp("20120614T080000"), ntest::to_posix_timestamp("20120614T090000")});
     pbnavitia::Response resp = nr::make_response(raptor, origin, destination, datetimes, true,
-                                                 navitia::type::AccessibiliteParams(), forbidden, sn_worker, false);
+                                                 navitia::type::AccessibiliteParams(),
+                                                 forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2);
@@ -771,7 +791,9 @@ struct streetnetworkmode_fixture : public routing_api_data<speed_provider_trait>
     pbnavitia::Response make_response() {
         ng::StreetNetwork sn_worker(*this->b.data->geo_ref);
         nr::RAPTOR raptor(*this->b.data);
-        return nr::make_response(raptor, this->origin, this->destination, this->datetimes, true, navitia::type::AccessibiliteParams(), this->forbidden, sn_worker, false);
+        return nr::make_response(raptor, this->origin, this->destination, this->datetimes,
+                                 true, navitia::type::AccessibiliteParams(),
+                                 this->forbidden, sn_worker, nt::RTLevel::Theoric);
     }
 };
 
@@ -1273,7 +1295,7 @@ BOOST_FIXTURE_TEST_CASE(bus_car_parking, streetnetworkmode_fixture<test_speed_pr
 
     ng::StreetNetwork sn_worker(*this->b.data->geo_ref);
     nr::RAPTOR raptor(*this->b.data);
-    auto resp = nr::make_response(raptor, this->destination, this->origin, this->datetimes, true, navitia::type::AccessibiliteParams(), this->forbidden, sn_worker, false);
+    auto resp = nr::make_response(raptor, this->destination, this->origin, this->datetimes, true, navitia::type::AccessibiliteParams(), this->forbidden, sn_worker, nt::RTLevel::Theoric);
 
     dump_response(resp, "bus_car_parking");
 
@@ -1627,7 +1649,7 @@ BOOST_AUTO_TEST_CASE(projection_on_one_way) {
     nr::RAPTOR raptor(*b.data);
     auto resp = nr::make_response(raptor, origin, destination,
                                   {navitia::test::to_posix_timestamp("20120614T080000")},
-                                  true, navitia::type::AccessibiliteParams(), {}, sn_worker, false, true);
+                                  true, navitia::type::AccessibiliteParams(), {}, sn_worker, nt::RTLevel::Theoric, true);
 
 
     dump_response(resp, "biking length test");
@@ -1749,7 +1771,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
                                      {},
                                      {},
                                      sn_worker,
-                                     false,
+                                     nt::RTLevel::Theoric,
                                      3 * 60 * 60);
 
     BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
@@ -1783,7 +1805,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
                                      {},
                                      {},
                                      sn_worker,
-                                     false,
+                                     nt::RTLevel::Theoric,
                                      3 * 60 * 60);
 
     BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
@@ -1810,7 +1832,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone_duration_limit, isochrone_fixture) {
                                      {},
                                      {},
                                      sn_worker,
-                                     false,
+                                     nt::RTLevel::Theoric,
                                      1 * 60 * 60);
 
     BOOST_REQUIRE_EQUAL(result.journeys_size(), 1);
@@ -1907,8 +1929,10 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
     navitia::type::EntryPoint destination(destination_type, "B");
 
     ng::StreetNetwork sn_worker(*b.data->geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20150315T080000")},
-                                             true, navitia::type::AccessibiliteParams(), {}, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                             {ntest::to_posix_timestamp("20150315T080000")},
+                                             true, nt::AccessibiliteParams(),
+                                             {}, sn_worker, nt::RTLevel::Theoric);
 
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
@@ -2007,8 +2031,10 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
     navitia::type::EntryPoint origin(origin_type, "A");
     navitia::type::EntryPoint destination(destination_type, "B");
     ng::StreetNetwork sn_worker(*b.data->geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20150314T080000")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, {}, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                            {ntest::to_posix_timestamp("20150314T080000")},
+                                            true, navitia::type::AccessibiliteParams(),
+                                            {}, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
 
@@ -2038,8 +2064,10 @@ BOOST_AUTO_TEST_CASE(journey_with_forbidden) {
     navitia::type::EntryPoint destination(destination_type, "stop_area:stop2");
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
-    pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+    pbnavitia::Response resp = make_response(raptor, origin, destination,
+                                                {ntest::to_posix_timestamp("20120614T021000")},
+                                             true, navitia::type::AccessibiliteParams(),
+                                             forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);
@@ -2047,7 +2075,8 @@ BOOST_AUTO_TEST_CASE(journey_with_forbidden) {
 
     forbidden.push_back("A");
     resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, false);
+                         true, navitia::type::AccessibiliteParams(),
+                         forbidden, sn_worker, nt::RTLevel::Theoric);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -98,7 +98,7 @@ departure_board(const std::string& request,
                 uint32_t duration, uint32_t depth,
                 uint32_t max_date_times,
                 int interface_version,
-                int count, int start_page, const type::Data &data, bool disruption_active,
+                int count, int start_page, const type::Data &data, const type::RTLevel rt_level,
                 bool show_codes) {
 
     RequestHandle handler(request, forbidden_uris, date,  duration, data, calendar_id);
@@ -158,7 +158,7 @@ departure_board(const std::string& request,
             std::vector<datetime_stop_time> tmp;
             if (! calendar_id) {
                 tmp = get_stop_times(navitia::routing::StopEvent::pick_up, {jpp->idx}, handler.date_time,
-                                     handler.max_datetime, max_date_times, data, disruption_active);
+                                     handler.max_datetime, max_date_times, data, rt_level);
             } else {
                 tmp = get_stop_times({jpp->idx}, DateTimeUtils::hour(handler.date_time),
                                      DateTimeUtils::hour(handler.max_datetime), data, *calendar_id);

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -46,7 +46,7 @@ pbnavitia::Response departure_board(const std::string &filter,
                                     uint32_t duration,
                                     uint32_t depth, uint32_t max_date_times,
                                     int interface_version,
-                                    int count, int start_page, const type::Data &data, bool disruption_active,
+                                    int count, int start_page, const type::Data &data, const type::RTLevel rt_level,
                                     bool show_codes=false);
 }
 

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -41,7 +41,7 @@ std::vector<datetime_stop_time> get_stop_times(const navitia::routing::StopEvent
                                                const DateTime& max_dt,
                                                const size_t max_departures,
                                                const type::Data& data, 
-                                               bool disruption_active,
+                                               const type::RTLevel rt_level,
                                                const type::AccessibiliteParams& accessibilite_params) {
     const bool clockwise(max_dt >= dt);
     std::vector<datetime_stop_time> result;
@@ -63,7 +63,7 @@ std::vector<datetime_stop_time> get_stop_times(const navitia::routing::StopEvent
                 continue;
             }
             auto st = next_st.next_stop_time(stop_event, routing::JppIdx(*jpp),
-                                             next_requested_datetime[jpp_idx], clockwise, disruption_active,
+                                             next_requested_datetime[jpp_idx], clockwise, rt_level,
                                              accessibilite_params.vehicle_properties, true);
 
             if (st.first != nullptr) {

--- a/source/time_tables/get_stop_times.h
+++ b/source/time_tables/get_stop_times.h
@@ -55,7 +55,7 @@ get_stop_times(const navitia::routing::StopEvent stop_event,
                const DateTime& max_dt,
                const size_t max_departures,
                const type::Data& data,
-               bool disruption_active,
+               const type::RTLevel rt_level,
                const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams());
 
 

--- a/source/time_tables/next_passages.cpp
+++ b/source/time_tables/next_passages.cpp
@@ -49,7 +49,7 @@ next_passages(const std::string &request,
               const pt::ptime datetime,
               uint32_t duration, uint32_t nb_stoptimes, const int depth,
               const type::AccessibiliteParams & accessibilite_params,
-              const type::Data & data, bool disruption_active, Visitor vis, uint32_t count,
+              const type::Data & data, const type::RTLevel rt_level, Visitor vis, uint32_t count,
               uint32_t start_page, const bool show_codes, const boost::posix_time::ptime current_datetime) {
     RequestHandle handler(request, forbidden_uris, datetime, duration, data, {});
 
@@ -64,7 +64,7 @@ next_passages(const std::string &request,
                                  StopEvent::pick_up : StopEvent::drop_off;
     auto passages_dt_st = get_stop_times(stop_event, handler.journey_pattern_points,
                                          handler.date_time, handler.max_datetime, nb_stoptimes,
-                                         data, disruption_active, accessibilite_params);
+                                         data, rt_level, accessibilite_params);
     size_t total_result = passages_dt_st.size();
     passages_dt_st = paginate(passages_dt_st, count, start_page);
 
@@ -115,7 +115,7 @@ pbnavitia::Response next_departures(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const pt::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const pt::ptime current_datetime) {
 
     struct vis_next_departures {
@@ -135,7 +135,7 @@ pbnavitia::Response next_departures(const std::string &request,
     };
     vis_next_departures vis(data);
     return next_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
-                         accessibilite_params, data, disruption_active, vis, count, start_page, show_codes, current_datetime);
+                         accessibilite_params, data, rt_level, vis, count, start_page, show_codes, current_datetime);
 }
 
 
@@ -143,7 +143,7 @@ pbnavitia::Response next_arrivals(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const pt::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const pt::ptime current_datetime) {
 
     struct vis_next_arrivals {
@@ -161,7 +161,7 @@ pbnavitia::Response next_arrivals(const std::string &request,
     };
     vis_next_arrivals vis(data);
     return next_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
-            accessibilite_params, data, disruption_active, vis,count , start_page, show_codes, current_datetime);
+            accessibilite_params, data, rt_level, vis,count , start_page, show_codes, current_datetime);
 }
 
 

--- a/source/time_tables/next_passages.h
+++ b/source/time_tables/next_passages.h
@@ -37,13 +37,13 @@ pbnavitia::Response next_departures(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const boost::posix_time::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const boost::posix_time::ptime current_datetime);
 pbnavitia::Response next_arrivals(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const boost::posix_time::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const boost::posix_time::ptime current_datetime);
 
 }}

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -49,7 +49,7 @@ previous_passages(const std::string &request,
               const pt::ptime datetime,
               uint32_t duration, uint32_t nb_stoptimes, const int depth,
               const type::AccessibiliteParams & accessibilite_params,
-              const type::Data & data, bool disruption_active, Visitor vis, uint32_t count,
+              const type::Data & data, const type::RTLevel rt_level, Visitor vis, uint32_t count,
               uint32_t start_page, const bool show_codes, const boost::posix_time::ptime current_datetime) {
     RequestHandle handler(request, forbidden_uris, datetime, duration, data, {}, false);
 
@@ -64,7 +64,7 @@ previous_passages(const std::string &request,
                                  StopEvent::pick_up : StopEvent::drop_off;
     auto passages_dt_st = get_stop_times(stop_event, handler.journey_pattern_points,
                                          handler.date_time, handler.max_datetime, nb_stoptimes,
-                                         data, disruption_active, accessibilite_params);
+                                         data, rt_level, accessibilite_params);
     size_t total_result = passages_dt_st.size();
     passages_dt_st = paginate(passages_dt_st, count, start_page);
 
@@ -115,7 +115,7 @@ pbnavitia::Response previous_departures(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const pt::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const boost::posix_time::ptime current_datetime) {
 
     struct vis_previous_departures {
@@ -142,7 +142,7 @@ pbnavitia::Response previous_departures(const std::string &request,
                              depth,
                              accessibilite_params,
                              data,
-                             disruption_active,
+                             rt_level,
                              vis,
                              count,
                              start_page,
@@ -156,7 +156,7 @@ pbnavitia::Response previous_arrivals(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const pt::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const boost::posix_time::ptime current_datetime) {
 
     struct vis_previous_arrivals {
@@ -174,7 +174,7 @@ pbnavitia::Response previous_arrivals(const std::string &request,
     };
     vis_previous_arrivals vis(data);
     return previous_passages(request, forbidden_uris, datetime, duration, nb_stoptimes, depth,
-            accessibilite_params, data, disruption_active, vis,count , start_page, show_codes, current_datetime);
+            accessibilite_params, data, rt_level, vis,count , start_page, show_codes, current_datetime);
 }
 
 

--- a/source/time_tables/previous_passages.h
+++ b/source/time_tables/previous_passages.h
@@ -37,13 +37,13 @@ pbnavitia::Response previous_departures(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const boost::posix_time::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const boost::posix_time::ptime current_datetime);
 pbnavitia::Response previous_arrivals(const std::string &request,
         const std::vector<std::string>& forbidden_uris,
         const boost::posix_time::ptime datetime, uint32_t duration, uint32_t nb_stoptimes,
         const int depth, const type::AccessibiliteParams & accessibilite_params,
-        const type::Data & data, bool disruption_active, uint32_t count, uint32_t start_page,
+        const type::Data & data, const type::RTLevel rt_level, uint32_t count, uint32_t start_page,
         const bool show_codes, const boost::posix_time::ptime current_datetime);
 
 }}

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -51,7 +51,7 @@ get_all_stop_times(const vector_idx& journey_patterns,
                    const DateTime& max_datetime,
                    const size_t max_stop_date_times,
                    const type::Data& d,
-                   bool disruption_active,
+                   const type::RTLevel rt_level,
                    const boost::optional<const std::string> calendar_id) {
     std::vector<std::vector<datetime_stop_time> > result;
 
@@ -68,7 +68,7 @@ get_all_stop_times(const vector_idx& journey_patterns,
         // If there is no calendar we get all stop times in
         // the desired timeframe
         first_dt_st = get_stop_times(navitia::routing::StopEvent::pick_up, first_journey_pattern_points,
-                                     dateTime, max_datetime, max_stop_date_times, d, disruption_active);
+                                     dateTime, max_datetime, max_stop_date_times, d, rt_level);
     }
     else {
         // Otherwise we only take stop_times in a vehicle_journey associated to
@@ -234,7 +234,7 @@ route_schedule(const std::string& filter,
                const pt::ptime datetime,
                uint32_t duration, size_t max_stop_date_times,
                const uint32_t max_depth, int count, int start_page,
-               const type::Data &d, bool disruption_active, const bool show_codes) {
+               const type::Data &d, const type::RTLevel rt_level, const bool show_codes) {
     RequestHandle handler(filter, forbidden_uris, datetime, duration, d, {});
 
     if(handler.pb_response.has_error()) {
@@ -254,7 +254,7 @@ route_schedule(const std::string& filter,
         //On récupère les stop_times
         auto stop_times = get_all_stop_times(jps, handler.date_time,
                                              handler.max_datetime, max_stop_date_times,
-                                             d, disruption_active, calendar_id);
+                                             d, rt_level, calendar_id);
         std::vector<vector_idx> stop_points;
         for(auto jp_idx : jps) {
             auto jp = d.pt_data->journey_patterns[jp_idx];

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -76,13 +76,13 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
 
     b.data->meta->production_date = boost::gregorian::date_period(begin, end);
     // normal departure board
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(),1);
 
     // no departure for route "A"
-    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(),1);
 
     // no departure for all routes
-    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 
     // no departure for route "B"
-    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 
     // Terminus for route "A"
-    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
     BOOST_CHECK_EQUAL(resp.stop_schedules(0).response_status(), pbnavitia::ResponseStatus::terminus);
@@ -117,12 +117,12 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).date_times_size(), 1);
 
     // Terminus for route "B"
-    resp = departure_board("stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    resp = departure_board("stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "B");
     BOOST_CHECK_EQUAL(resp.stop_schedules(0).response_status(), pbnavitia::ResponseStatus::terminus);
 
-    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
 }
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
 
     b.data->meta->production_date = boost::gregorian::date_period(begin, end);
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     pbnavitia::StopSchedule stop_schedule = resp.stop_schedules(0);
     BOOST_CHECK(stop_schedule.date_times_size() == 2);
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
     //when asked on non existent calendar, we get an error
     const boost::optional<const std::string> calendar_id{"bob_the_calendar"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     BOOST_REQUIRE(resp.has_error());
     BOOST_REQUIRE(! resp.error().message().empty());
@@ -202,7 +202,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
     const boost::optional<const std::string> calendar_id{"weekend_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     BOOST_REQUIRE(! resp.has_error());
     BOOST_CHECK_EQUAL(resp.stop_schedules_size(), 1);
@@ -225,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
     boost::optional<const std::string> calendar_id{"week_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     BOOST_REQUIRE(! resp.has_error());
     BOOST_CHECK_EQUAL(resp.stop_schedules_size(), 1);
@@ -249,7 +249,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
     boost::optional<const std::string> calendar_id{"not_associated_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     BOOST_REQUIRE(! resp.has_error());
     BOOST_CHECK_EQUAL(resp.stop_schedules_size(), 1);
@@ -299,7 +299,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
 
     boost::optional<const std::string> calendar_id{"nearly_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), false);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     //it should match only the 'all' vj
     BOOST_REQUIRE(! resp.has_error());
@@ -376,7 +376,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time, small_cal_fixture) {
 
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
                                                 86400, 0, std::numeric_limits<int>::max(),
-                                                1, 10, 0, *(b.data), false);
+                                                1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     //we should get a nice schedule, first stop at 08:10, last at 07:10
     BOOST_REQUIRE(! resp.has_error());
@@ -403,7 +403,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_matched_cal, small_cal_fixture) {
 
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("empty_cal"), {}, d("20120615T080000"),
                                                 86400, 0, std::numeric_limits<int>::max(),
-                                                1, 10, 0, *(b.data), false);
+                                                1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     BOOST_REQUIRE(! resp.has_error());
     //no error but no results
@@ -422,7 +422,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period, small_cal_fixture) {
     auto duration = nb_hour*60*60;
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
                                                duration, 0, std::numeric_limits<int>::max(),
-                                               1, 10, 0, *(b.data), false);
+                                               1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     //we should get a nice schedule, first stop at 08:10, last at 13:10
     BOOST_REQUIRE(! resp.has_error());
@@ -452,7 +452,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period_before, small_cal_fixtur
     auto duration = nb_hour*60*60;
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("cal"), {}, d("20120615T200000"),
                                                duration, 0, std::numeric_limits<int>::max(),
-                                               1, 10, 0, *(b.data), false);
+                                               1, 10, 0, *(b.data), nt::RTLevel::Theoric);
 
     //we should get a nice schedule, first stop at 20:10, last at 04:10
     BOOST_REQUIRE(! resp.has_error());
@@ -476,7 +476,7 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
     navitia::routing::RAPTOR raptor(*(b.data));
     navitia::type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8*60*60, 0, navitia::DateTimeUtils::inf, false, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8*60*60, 0, navitia::DateTimeUtils::inf, nt::RTLevel::Theoric, true);
 
     //we must have a journey
     BOOST_REQUIRE_EQUAL(res1.size(), 1);

--- a/source/time_tables/tests/get_stop_times_test.cpp
+++ b/source/time_tables/tests/get_stop_times_test.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test1){
         jpps.push_back(jpp->idx);
 
     auto result = get_stop_times(StopEvent::pick_up, jpps, navitia::DateTimeUtils::min,
-                                 navitia::DateTimeUtils::set(1, 0), 100, *b.data, false);
+                                 navitia::DateTimeUtils::set(1, 0), 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
                             [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 0;}));
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test1){
                             [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 1;}));
 
     result = get_stop_times(StopEvent::drop_off, jpps, navitia::DateTimeUtils::set(0, 86399),
-                            navitia::DateTimeUtils::min, 100, *b.data, false, {});
+                            navitia::DateTimeUtils::min, 100, *b.data, nt::RTLevel::Theoric, {});
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
                             [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 1;}));
@@ -382,47 +382,47 @@ BOOST_AUTO_TEST_CASE(test_discrete_next_arrivals_prev_departures){
     const navitia::DateTime today_8h45 = navitia::DateTimeUtils::set(1, 8*3600 + 45*60);
     const navitia::DateTime tomorrow = navitia::DateTimeUtils::set(2, 0);
     auto result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop1"),
-                                               today, tomorrow, 100, *b.data, false);
+                                               today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_CHECK_EQUAL(result_next_arrivals.size(), 0);
     auto result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop1"),
-                                                 today, yesterday, 100, *b.data, false);
+                                                 today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 1);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "8:01"_t);
 
     result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop2"),
-                                          today, tomorrow, 100, *b.data, false);
+                                          today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_next_arrivals.size(), 1);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(0).first, "24:00"_t + "9:00"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop2"),
-                                            today, yesterday, 100, *b.data, false);
+                                            today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 2);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "9:01"_t);
     BOOST_CHECK_EQUAL(result_prev_departures.at(1).first, "8:31"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop2"),
-                                            today_8h45, today, 100, *b.data, false);
+                                            today_8h45, today, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 1);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "24:00"_t + "8:31"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop2"),
-                                            today_8h45, yesterday_8h45, 100, *b.data, false);
+                                            today_8h45, yesterday_8h45, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 2);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "24:00"_t + "8:31"_t);
     BOOST_CHECK_EQUAL(result_prev_departures.at(1).first, "9:01"_t);
 
     result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop3"),
-                                          today, tomorrow, 100, *b.data, false);
+                                          today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_next_arrivals.size(), 2);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(0).first, "24:00"_t + "09:30"_t);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(1).first, "24:00"_t + "10:00"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop3"),
-                                            today, yesterday, 100, *b.data, false);
+                                            today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 1);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "9:31"_t);
 
     result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop4"),
-                                          today, tomorrow, 100, *b.data, false);
+                                          today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(result_next_arrivals.size(), 1);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(0).first, "24:00"_t + "10:30"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop4"),
-                                            today, yesterday, 100, *b.data, false);
+                                            today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
     BOOST_CHECK_EQUAL(result_prev_departures.size(), 0);
 }

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -118,7 +118,7 @@ struct route_schedule_fixture {
 BOOST_FIXTURE_TEST_CASE(test1, route_schedule_fixture) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=A", {}, {}, d("20120615T070000"), 86400, 100,
-                                                                   3, 10, 0, *(b.data), false, false);
+                                                                   3, 10, 0, *(b.data), nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -131,7 +131,7 @@ BOOST_FIXTURE_TEST_CASE(test1, route_schedule_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(test_max_nb_stop_times, route_schedule_fixture) {
     pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=A", {}, {}, d("20120615T070000"), 86400, 0,
-                                                                   3, 10, 0, *(b.data), false, false);
+                                                                   3, 10, 0, *(b.data), nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -211,7 +211,7 @@ struct route_schedule_calendar_fixture {
 
     void check_calendar_results(boost::optional<const std::string> calendar, std::vector<std::string> expected_vjs) {
         pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=B", calendar, {}, d("20120615T070000"), 86400, 100,
-                                                                       3, 10, 0, *(b.data), false, false);
+                                                                       3, 10, 0, *(b.data), nt::RTLevel::Theoric, false);
         BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
         pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
         print_route_schedule(route_schedule);
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_1) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule(
         "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
-        3, 10, 0, *b.data, false, false);
+        3, 10, 0, *b.data, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_2) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule(
         "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
-        3, 10, 0, *b.data, false, false);
+        3, 10, 0, *b.data, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_3) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule(
         "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
-        3, 10, 0, *b.data, false, false);
+        3, 10, 0, *b.data, nt::RTLevel::Theoric, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -617,7 +617,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
         com->set_type("standard");
     }
     vehicle_journey->set_odt_message(vj->odt_message);
-    vehicle_journey->set_is_adapted(vj->is_adapted);
+    vehicle_journey->set_is_adapted(vj->realtime_level == nt::RTLevel::Adapted);
 
     vehicle_journey->set_wheelchair_accessible(vj->wheelchair_accessible());
     vehicle_journey->set_bike_accepted(vj->bike_accepted());

--- a/source/type/rt_level.h
+++ b/source/type/rt_level.h
@@ -28,6 +28,8 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 #pragma once
+#include <ostream>
+#include "utils/flat_enum_map.h"
 
 namespace navitia {
 
@@ -46,4 +48,17 @@ struct enum_size_trait<type::RTLevel> {
     }
 };
 
+}
+
+inline std::ostream& operator<<(std::ostream& ss, navitia::type::RTLevel l) {
+    switch (l) {
+    case navitia::type::RTLevel::Theoric:
+        return ss << "Theoric";
+    case navitia::type::RTLevel::Adapted:
+        return ss << "Adapted";
+    case navitia::type::RTLevel::RealTime:
+        return ss << "RealTime";
+    default:
+        return ss;
+    }
 }

--- a/source/type/rt_level.h
+++ b/source/type/rt_level.h
@@ -1,49 +1,49 @@
-/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
-
 #pragma once
-#include "type/type.h"
-#include "routing/routing.h"
-#include "get_stop_times.h"
-#include "type/pb_converter.h"
 
-namespace navitia { namespace timetables {
+namespace navitia {
 
-typedef std::vector<std::string> vector_string;
-typedef std::pair<DateTime, const type::StopTime*> vector_date_time;
+namespace type {
+enum class RTLevel : char {
+    Theoric = 0,
+    Adapted,
+    RealTime
+};
+}
 
-pbnavitia::Response route_schedule(const std::string & line_externalcode,
-        const boost::optional<const std::string> calendar_id,
-        const std::vector<std::string>& forbidden_uris,
-        const boost::posix_time::ptime datetime, uint32_t duration, size_t max_stop_date_times,
-        const uint32_t max_depth, int count, int start_page, const type::Data &d, const type::RTLevel rt_level,
-        const bool show_codes);
+template <>
+struct enum_size_trait<type::RTLevel> {
+    static constexpr typename get_enum_type<type::RTLevel>::type size() {
+        return 3;
+    }
+};
 
-}}
+}

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -140,11 +140,13 @@ bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel 
             return false;
         --day;
     }
-    if (rt_level == RTLevel::Theoric) {
+
+    switch (rt_level) {
+    case nt::RTLevel::Theoric:
         return vehicle_journey->validity_pattern->check(day);
-    } else if (rt_level == RTLevel::Adapted) {
+    case nt::RTLevel::Adapted:
         return vehicle_journey->adapted_validity_pattern->check(day);
-    } else {
+    case nt::RTLevel::RealTime:
         throw navitia::exception("realtime not handled yet");
     }
     //TODO use:
@@ -194,16 +196,17 @@ uint32_t StopTime::f_departure_time(const u_int32_t hour, bool clockwise) const 
 bool FrequencyVehicleJourney::is_valid(int day, const RTLevel rt_level) const {
     if (day < 0)
         return false;
-    if (rt_level == RTLevel::Theoric) {
+
+    switch (rt_level) {
+    case nt::RTLevel::Theoric:
         return validity_pattern->check(day);
-    } else if (rt_level == RTLevel::Theoric) {
+    case nt::RTLevel::Adapted:
         return adapted_validity_pattern->check(day);
-    } else {
+    case nt::RTLevel::RealTime:
         throw navitia::exception("realtime not handled yet");
     }
     //TODO use:
     //return validity_patterns[rt_level]->check(day);
-//    return validity_patterns[rt_level]->check(day);
 }
 
 bool VehicleJourney::has_datetime_estimated() const {

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -140,7 +140,15 @@ bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel 
             return false;
         --day;
     }
-    return vehicle_journey->validity_patterns[rt_level]->check(day);
+    if (rt_level == RTLevel::Theoric) {
+        return vehicle_journey->validity_pattern->check(day);
+    } else if (rt_level == RTLevel::Adapted) {
+        return vehicle_journey->adapted_validity_pattern->check(day);
+    } else {
+        throw navitia::exception("realtime not handled yet");
+    }
+    //TODO use:
+    //return vehicle_journey->validity_patterns[rt_level]->check(day);
 }
 
 bool StopTime::operator<(const StopTime& other) const {
@@ -186,7 +194,16 @@ uint32_t StopTime::f_departure_time(const u_int32_t hour, bool clockwise) const 
 bool FrequencyVehicleJourney::is_valid(int day, const RTLevel rt_level) const {
     if (day < 0)
         return false;
-    return validity_patterns[rt_level]->check(day);
+    if (rt_level == RTLevel::Theoric) {
+        return validity_pattern->check(day);
+    } else if (rt_level == RTLevel::Theoric) {
+        return adapted_validity_pattern->check(day);
+    } else {
+        throw navitia::exception("realtime not handled yet");
+    }
+    //TODO use:
+    //return validity_patterns[rt_level]->check(day);
+//    return validity_patterns[rt_level]->check(day);
 }
 
 bool VehicleJourney::has_datetime_estimated() const {

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -147,6 +147,7 @@ bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel 
     case nt::RTLevel::Adapted:
         return vehicle_journey->adapted_validity_pattern->check(day);
     case nt::RTLevel::RealTime:
+    default:
         throw navitia::exception("realtime not handled yet");
     }
     //TODO use:
@@ -203,6 +204,7 @@ bool FrequencyVehicleJourney::is_valid(int day, const RTLevel rt_level) const {
     case nt::RTLevel::Adapted:
         return adapted_validity_pattern->check(day);
     case nt::RTLevel::RealTime:
+    default:
         throw navitia::exception("realtime not handled yet");
     }
     //TODO use:

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -133,18 +133,14 @@ bool HasMessages::has_publishable_message(const boost::posix_time::ptime& curren
     return false;
 }
 
-bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const bool is_adapted) const{
+bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel rt_level) const {
     if((is_arrival && arrival_time >= DateTimeUtils::SECONDS_PER_DAY)
        || (!is_arrival && departure_time >= DateTimeUtils::SECONDS_PER_DAY)) {
         if(day == 0)
             return false;
         --day;
     }
-    if(!is_adapted) {
-        return vehicle_journey->validity_pattern->check(day);
-    } else {
-        return vehicle_journey->adapted_validity_pattern->check(day);
-    }
+    return vehicle_journey->validity_patterns[rt_level]->check(day);
 }
 
 bool StopTime::operator<(const StopTime& other) const {
@@ -187,14 +183,10 @@ uint32_t StopTime::f_departure_time(const u_int32_t hour, bool clockwise) const 
     }
 }
 
-bool FrequencyVehicleJourney::is_valid(int day, const bool is_adapted) const {
+bool FrequencyVehicleJourney::is_valid(int day, const RTLevel rt_level) const {
     if (day < 0)
         return false;
-    if (! is_adapted) {
-        return validity_pattern->check(day);
-    } else {
-        return adapted_validity_pattern->check(day);
-    }
+    return validity_patterns[rt_level]->check(day);
 }
 
 bool VehicleJourney::has_datetime_estimated() const {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -58,7 +58,24 @@ namespace navitia { namespace georef {
  struct Admin;
  struct GeoRef;
 }}
-namespace navitia { namespace type {
+namespace navitia {
+
+namespace type {
+enum class RTLevel : char {
+    Theoric = 0,
+    Adapted,
+    RealTime
+};
+}
+template <>
+struct enum_size_trait<type::RTLevel> {
+    static constexpr typename get_enum_type<type::RTLevel>::type size() {
+        return 3;
+    }
+};
+
+
+namespace type {
 typedef navitia::idx_t idx_t;
 
 const idx_t invalid_idx = std::numeric_limits<idx_t>::max();
@@ -719,7 +736,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     // thus we store the shit needed to convert all stop times of the vehicle journey to local
     int16_t utc_to_local_offset = 0; //in seconds
 
-    bool is_adapted = false; //REMOVE (change to enum ?)
+    RTLevel realtime_level = RTLevel::Theoric;
     ValidityPattern* adapted_validity_pattern = nullptr; //REMOVE
     std::vector<VehicleJourney*> adapted_vehicle_journey_list; //REMOVE
     VehicleJourney* theoric_vehicle_journey = nullptr; //REMOVE
@@ -736,7 +753,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     bool operator<(const VehicleJourney& other) const;
     template<class Archive> void serialize(Archive& ar, const unsigned int ) {
         ar & name & uri & journey_pattern & company & validity_pattern
-            & idx & stop_time_list & is_adapted
+            & idx & stop_time_list & realtime_level
             & adapted_validity_pattern & adapted_vehicle_journey_list
             & theoric_vehicle_journey & vehicle_journey_type
             & odt_message & _vehicle_properties & impacts

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -700,7 +700,6 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     ValidityPattern* validity_pattern = nullptr;
     std::vector<StopTime> stop_time_list;
 
-    flat_enum_map<RTLevel, ValidityPattern*> validity_patterns;
     // These variables are used in the case of an extension of service
     // They indicate what's the vj you can take directly after or before this one
     // They have the same block id

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -32,6 +32,7 @@ www.navitia.io
 
 #include "type/time_duration.h"
 #include "datetime.h"
+#include "rt_level.h"
 #include "geographical_coord.h"
 #include "utils/flat_enum_map.h"
 #include "utils/exception.h"
@@ -59,21 +60,6 @@ namespace navitia { namespace georef {
  struct GeoRef;
 }}
 namespace navitia {
-
-namespace type {
-enum class RTLevel : char {
-    Theoric = 0,
-    Adapted,
-    RealTime
-};
-}
-template <>
-struct enum_size_trait<type::RTLevel> {
-    static constexpr typename get_enum_type<type::RTLevel>::type size() {
-        return 3;
-    }
-};
-
 
 namespace type {
 typedef navitia::idx_t idx_t;
@@ -714,6 +700,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     ValidityPattern* validity_pattern = nullptr;
     std::vector<StopTime> stop_time_list;
 
+    flat_enum_map<RTLevel, ValidityPattern*> validity_patterns;
     // These variables are used in the case of an extension of service
     // They indicate what's the vj you can take directly after or before this one
     // They have the same block id
@@ -792,7 +779,7 @@ struct FrequencyVehicleJourney: public VehicleJourney {
     uint32_t headway_secs = std::numeric_limits<uint32_t>::max(); // Seconds between each departure.
     virtual ~FrequencyVehicleJourney();
 
-    bool is_valid(int day, const bool is_adapted) const;
+    bool is_valid(int day, const RTLevel rt_level) const;
     template<class Archive> void serialize(Archive& ar, const unsigned int) {
         ar & boost::serialization::base_object<VehicleJourney>(*this);
 
@@ -926,7 +913,7 @@ struct StopTime {
         return DateTimeUtils::shift(dt, is_frequency() ? f_arrival_time(DateTimeUtils::hour(dt), true): arrival_time);
     }
 
-    bool is_valid_day(u_int32_t day, const bool is_arrival, const bool is_adapted) const;
+    bool is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel rt_level) const;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
             ar & arrival_time & departure_time & vehicle_journey & journey_pattern_point
@@ -1150,6 +1137,7 @@ struct enum_size_trait<type::Mode_e> {
         return 4;
     }
 };
+
 
 } //namespace navitia
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -59,9 +59,8 @@ namespace navitia { namespace georef {
  struct Admin;
  struct GeoRef;
 }}
-namespace navitia {
 
-namespace type {
+namespace navitia { namespace type {
 typedef navitia::idx_t idx_t;
 
 const idx_t invalid_idx = std::numeric_limits<idx_t>::max();
@@ -1137,6 +1136,4 @@ struct enum_size_trait<type::Mode_e> {
     }
 };
 
-
 } //namespace navitia
-


### PR DESCRIPTION
Technical refactoring, nothing added.

Change the boolean disruption_active to an enum that has 3 values: `theoric`, `adapted`, `realtime`

needed for the realtime integration
