### PR TITLE
RT: train cancelling

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -154,7 +154,7 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
     }
 
     nt::MetaVehicleJourney* mvj = b.get_or_create_metavj(name);
-    mvj->theoric_vj.push_back(vj);
+    mvj->base_vj.push_back(vj);
     vj->meta_vj = mvj;
 
     b.data->pt_data->headsign_handler.change_name_and_register_as_headsign(

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -135,24 +135,31 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
     }
 
     vj->journey_pattern = jp;
-    //if we have a meta_vj, we add it in that
-    nt::MetaVehicleJourney* mvj;
-    if (! meta_vj_name.empty()) {
-        mvj = b.get_or_create_metavj(meta_vj_name);
-    } else {
-        mvj = b.get_or_create_metavj(uri);
-    }
-    mvj->theoric_vj.push_back(vj);
-    vj->meta_vj = mvj;
-    vj->idx = b.data->pt_data->vehicle_journeys.size();
-    b.data->pt_data->headsign_handler.change_name_and_register_as_headsign(
-                                                *vj, "vehicle_journey " + std::to_string(vj->idx));
 
+    vj->idx = b.data->pt_data->vehicle_journeys.size();
     if (! uri.empty()) {
         vj->uri = uri;
     } else {
         vj->uri = "vj:" + line_name + ":" + std::to_string(vj->idx);
     }
+
+    // NOTE: the meta vj name should be the same as the vj's name
+    std::string name;
+    if (! meta_vj_name.empty()) {
+        name = meta_vj_name;
+    } else if (! uri.empty()) {
+        name = uri;
+    } else {
+        name = "vehicle_journey " + std::to_string(vj->idx);
+    }
+
+    nt::MetaVehicleJourney* mvj = b.get_or_create_metavj(name);
+    mvj->theoric_vj.push_back(vj);
+    vj->meta_vj = mvj;
+
+    b.data->pt_data->headsign_handler.change_name_and_register_as_headsign(
+                                                *vj, name);
+
     b.data->pt_data->vehicle_journeys.push_back(vj);
     b.data->pt_data->vehicle_journeys_map[vj->uri] = vj;
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -147,7 +147,12 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
     vj->idx = b.data->pt_data->vehicle_journeys.size();
     b.data->pt_data->headsign_handler.change_name_and_register_as_headsign(
                                                 *vj, "vehicle_journey " + std::to_string(vj->idx));
-    vj->uri = vj->name;
+
+    if (! uri.empty()) {
+        vj->uri = uri;
+    } else {
+        vj->uri = "vj:" + line_name + ":" + std::to_string(vj->idx);
+    }
     b.data->pt_data->vehicle_journeys.push_back(vj);
     b.data->pt_data->vehicle_journeys_map[vj->uri] = vj;
 
@@ -169,7 +174,6 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
     if(wheelchair_boarding){
         vj->set_vehicle(navitia::type::hasVehicleProperties::WHEELCHAIR_ACCESSIBLE);
     }
-    vj->uri = uri;
 
     if(!b.data->pt_data->companies.empty())
         vj->company = b.data->pt_data->companies.front();

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -173,7 +173,7 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
     } else {
          b.data->pt_data->validity_patterns.push_back(vp);
     }
-    //by default we assign all the validity patterns (theoric/adapted/realtime) to the same vp
+    //by default we assign all the validity patterns (base/adapted/realtime) to the same vp
     for (const auto& vj_vp: vj->validity_patterns) {
         vj_vp.second = vp;
     }

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -157,13 +157,14 @@ VJ::VJ(builder & b, const std::string &line_name, const std::string &validity_pa
                         b.data->pt_data->validity_patterns.end(), find_vp_predicate);
     if(it_vp != b.data->pt_data->validity_patterns.end()) {
         delete vp;
-        vj->validity_patterns[nt::RTLevel::Theoric] = *(it_vp);
+        vp = *(it_vp);
     } else {
          b.data->pt_data->validity_patterns.push_back(vp);
-         vj->validity_patterns[nt::RTLevel::Theoric] = vp;
     }
-    b.vps[validity_pattern] = vj->validity_patterns[nt::RTLevel::Theoric];
-    vj->validity_patterns[nt::RTLevel::Adapted] = vj->validity_patterns[nt::RTLevel::Theoric];
+    //by default we assign all the validity patterns (theoric/adapted/realtime) to the same vp
+    for (const auto& vj_vp: vj->validity_patterns) {
+        vj_vp.second = vp;
+    }
 
     if(wheelchair_boarding){
         vj->set_vehicle(navitia::type::hasVehicleProperties::WHEELCHAIR_ACCESSIBLE);

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -85,7 +85,6 @@ struct SA {
 
 struct builder {
     std::map<std::string, navitia::type::Line *> lines;
-    std::map<std::string, navitia::type::ValidityPattern *> vps;
     std::map<std::string, navitia::type::StopArea *> sas;
     std::map<std::string, navitia::type::StopPoint *> sps;
     std::map<std::string, navitia::type::Network *> nts;

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -822,6 +822,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
         if(!const_it["validity_pattern_id"].is_null()){
             vj->validity_patterns[RTLevel::Theoric] =
                     validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
+            vj->validity_patterns[RTLevel::RealTime] = vj->validity_patterns[RTLevel::Theoric];
         }
 
         if(!const_it["theoric_vehicle_journey_id"].is_null()){

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -949,7 +949,7 @@ void EdReader::fill_meta_vehicle_journeys(nt::Data& data, pqxx::work& work) {
 
         const std::string vj_class = const_it["vj_class"].as<std::string>();
         if (vj_class == "Theoric") {
-            meta_vj->theoric_vj.push_back(vj);
+            meta_vj->base_vj.push_back(vj);
         } else if (vj_class == "Adapted") {
             meta_vj->adapted_vj.push_back(vj);
         } else if (vj_class == "RealTime") {

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -820,9 +820,9 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
                 validity_pattern_map[const_it["adapted_validity_pattern_id"].as<idx_t>()];
 
         if(!const_it["validity_pattern_id"].is_null()){
-            vj->validity_patterns[RTLevel::Theoric] =
+            vj->validity_patterns[RTLevel::Base] =
                     validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
-            vj->validity_patterns[RTLevel::RealTime] = vj->validity_patterns[RTLevel::Theoric];
+            vj->validity_patterns[RTLevel::RealTime] = vj->validity_patterns[RTLevel::Base];
         }
 
         if(!const_it["theoric_vehicle_journey_id"].is_null()){

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
 
     georef::StreetNetwork sn_worker(*b.data->geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")},
-                                             true, type::AccessibiliteParams(), {}, sn_worker, type::RTLevel::Theoric);
+                                             true, type::AccessibiliteParams(), {}, sn_worker, type::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(test_protobuff_no_data) {
 
     georef::StreetNetwork sn_worker(*b.data->geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")},
-                                             true, type::AccessibiliteParams(), {}, sn_worker, type::RTLevel::Theoric);
+                                             true, type::AccessibiliteParams(), {}, sn_worker, type::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -570,7 +570,7 @@ class Journeys(ResourceUri, ResourceUtc):
         parser_get.add_argument("disruption_active", type=boolean, default=False)  # for retrocomp
         # no default value for data_freshness because we need to maintain retrocomp with disruption_active
         parser_get.add_argument("data_freshness",
-                                type=option_value(['theoric', 'adapted', 'realtime']))
+                                type=option_value(['base_schedule', 'adapted_schedule', 'realtime']))
 # a supprimer
         parser_get.add_argument("max_duration", type=int, default=3600*24)
         parser_get.add_argument("wheelchair", type=boolean, default=False)
@@ -628,7 +628,8 @@ class Journeys(ResourceUri, ResourceUtc):
 
         if args['data_freshness'] is None:
             # retrocompatibilty handling
-            args['data_freshness'] = 'adapted' if args['disruption_active'] is True else 'theoric'
+            args['data_freshness'] = \
+                'adapted_schedule' if args['disruption_active'] is True else 'base_schedule'
 
         # TODO : Changer le protobuff pour que ce soit propre
         if args['destination_mode'] == 'vls':

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -567,8 +567,10 @@ class Journeys(ResourceUri, ResourceUtc):
         parser_get.add_argument("max_nb_journeys", type=int)
         parser_get.add_argument("type", type=option_value(types),
                                 default="all")
-        parser_get.add_argument("disruption_active",
-                                type=boolean, default=False)
+        parser_get.add_argument("disruption_active", type=boolean, default=False)  # for retrocomp
+        # no default value for data_freshness because we need to maintain retrocomp with disruption_active
+        parser_get.add_argument("data_freshness",
+                                type=option_value(['theoric', 'adapted', 'realtime']))
 # a supprimer
         parser_get.add_argument("max_duration", type=int, default=3600*24)
         parser_get.add_argument("wheelchair", type=boolean, default=False)
@@ -623,6 +625,10 @@ class Journeys(ResourceUri, ResourceUtc):
             args['max_bike_duration_to_pt'] = args['max_duration_to_pt']
             args['max_bss_duration_to_pt'] = args['max_duration_to_pt']
             args['max_car_duration_to_pt'] = args['max_duration_to_pt']
+
+        if args['data_freshness'] is None:
+            # retrocompatibilty handling
+            args['data_freshness'] = 'adapted' if args['disruption_active'] is True else 'theoric'
 
         # TODO : Changer le protobuff pour que ce soit propre
         if args['destination_mode'] == 'vls':

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -100,10 +100,14 @@ class Scenario(simple.Scenario):
         req.journeys.max_duration = request["max_duration"]
         req.journeys.max_transfers = request["max_transfers"]
         req.journeys.wheelchair = request["wheelchair"]
-        if request["disruption_active"]:
+
+        if request["data_freshness"] == 'realtime':
+            req.journeys.realtime_level = request_pb2.REAL_TIME
+        elif request["data_freshness"] == 'adapted':
             req.journeys.realtime_level = request_pb2.ADAPTED
         else:
             req.journeys.realtime_level = request_pb2.THEORIC
+
         req.journeys.show_codes = request["show_codes"]
         if "details" in request and request["details"]:
             req.journeys.details = request["details"]

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -101,9 +101,9 @@ class Scenario(simple.Scenario):
         req.journeys.max_transfers = request["max_transfers"]
         req.journeys.wheelchair = request["wheelchair"]
 
-        if request["data_freshness"] == 'realtime':
+        if request['data_freshness'] == 'realtime':
             req.journeys.realtime_level = request_pb2.REAL_TIME
-        elif request["data_freshness"] == 'adapted':
+        elif request['data_freshness'] == 'adapted':
             req.journeys.realtime_level = request_pb2.ADAPTED
         else:
             req.journeys.realtime_level = request_pb2.THEORIC

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -103,10 +103,10 @@ class Scenario(simple.Scenario):
 
         if request['data_freshness'] == 'realtime':
             req.journeys.realtime_level = request_pb2.REAL_TIME
-        elif request['data_freshness'] == 'adapted':
+        elif request['data_freshness'] == 'adapted_schedule':
             req.journeys.realtime_level = request_pb2.ADAPTED
         else:
-            req.journeys.realtime_level = request_pb2.THEORIC
+            req.journeys.realtime_level = request_pb2.BASE
 
         req.journeys.show_codes = request["show_codes"]
         if "details" in request and request["details"]:

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -120,10 +120,12 @@ def create_pb_request(requested_type, request, dep_mode, arr_mode):
     req.journeys.max_duration = request["max_duration"]
     req.journeys.max_transfers = request["max_transfers"]
     req.journeys.wheelchair = request["wheelchair"]
-    if request["disruption_active"]:
+    if request['data_freshness'] == 'realtime':
+        req.journeys.realtime_level = request_pb2.REAL_TIME
+    elif request['data_freshness'] == 'adapted_schedule':
         req.journeys.realtime_level = request_pb2.ADAPTED
     else:
-        req.journeys.realtime_level = request_pb2.THEORIC
+        req.journeys.realtime_level = request_pb2.BASE
     req.journeys.show_codes = request["show_codes"]
 
     if "details" in request and request["details"]:

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -78,6 +78,7 @@ class FakeUser:
         self.login = name
         self.have_access_to_free_instances = have_access_to_free_instances
         self.is_super_user = is_super_user
+        self.end_point_id = None
 
     @classmethod
     def get_from_token(cls, token):

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -283,7 +283,7 @@ class TestChaosDisruptionsBlocking(ChaosDisruptionsFixture):
         by the journey.
         Then we delete it and test if use the blocked object
         """
-        response = self.query_region(journey_basic_query, display=True)
+        response = self.query_region(journey_basic_query)
 
         assert "journeys" in response
 
@@ -299,7 +299,7 @@ class TestChaosDisruptionsBlocking(ChaosDisruptionsFixture):
 
         Then we delete it and test if use the blocked object
         """
-        response = self.query_region(journey_basic_query, display=True)
+        response = self.query_region(journey_basic_query)
 
         assert "journeys" in response
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -29,6 +29,7 @@
 
 # Note: the tests_mechanism should be the first
 # import for the conf to be loaded correctly when only this test is ran
+from nose.tools.trivial import eq_
 from tests.tests_mechanism import dataset
 
 from jormungandr import utils
@@ -77,20 +78,20 @@ class TestKirinOnVJDeletion(MockKirinDisruptionsFixture):
         """
         response = self.query_region(journey_basic_query + "&data_freshness=realtime")
 
-        # with no cancellation, we have 2 jounrneys, one direct and one with the vj:A:0
-        assert _get_arrivals(response) == ['20120614T080222', '20120614T080435']
-        assert _get_used_vj(response) == [['vj:A:0'], []]
+        # with no cancellation, we have 2 journeys, one direct and one with the vj:A:0
+        eq_(_get_arrivals(response), ['20120614T080222', '20120614T080435'])
+        eq_(_get_used_vj(response), [['vjA'], []])
 
-        self.send_mock("vj:A:0", "20120614", 'cancelled')
+        self.send_mock("vjA", "20120614", 'canceled')
 
         new_response = self.query_region(journey_basic_query + "&data_freshness=realtime")
-        assert _get_arrivals(new_response) == ['20120614T080435', '20120614T180222']
-        assert _get_used_vj(new_response) == [[], ['vj:B:1']]
+        eq_(_get_arrivals(new_response), ['20120614T080435', '20120614T180222'])
+        eq_(_get_used_vj(new_response), [[], ['vj:B:1']])
 
         # it should not have changed anything for the theoric
         new_theoric = self.query_region(journey_basic_query + "&data_freshness=theoric")
-        assert _get_arrivals(new_theoric) == ['20120614T080222', '20120614T080435']
-        assert _get_used_vj(new_theoric) == [['vj:A:0'], []]
+        eq_(_get_arrivals(new_theoric), ['20120614T080222', '20120614T080435'])
+        eq_(_get_used_vj(new_theoric), [['vjA'], []])
         assert new_theoric['journeys'] == response['journeys']
 
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -33,7 +33,7 @@ from tests.tests_mechanism import dataset
 
 from jormungandr import utils
 from tests import gtfs_realtime_pb2
-from tests.check_utils import is_valid_vehicle_journey, get_not_null
+from tests.check_utils import is_valid_vehicle_journey, get_not_null, journey_basic_query
 from tests.rabbitmq_utils import RabbitMQCnxFixture, rt_topic
 
 
@@ -45,21 +45,56 @@ class MockKirinDisruptionsFixture(RabbitMQCnxFixture):
         return make_mock_kirin_item(*args, **kwargs)
 
 
+def _get_arrivals(response):
+    """
+    return a list with the journeys arrival times
+    """
+    return [j['arrival_date_time'] for j in get_not_null(response, 'journeys')]
+
+
+def _get_used_vj(response):
+    """
+    return for each journeys the list of taken vj
+    """
+    journeys_vj = []
+    for j in get_not_null(response, 'journeys'):
+        vjs = []
+        for s in get_not_null(j, 'sections'):
+            for l in s.get('links', []):
+                if l['type'] == 'vehicle_journey':
+                    vjs.append(l['id'])
+                    break
+        journeys_vj.append(vjs)
+
+    return journeys_vj
+
+
 @dataset([("main_routing_test", ['--BROKER.rt_topics='+rt_topic, 'spawn_maintenance_worker'])])
 class TestKirinOnVJDeletion(MockKirinDisruptionsFixture):
     def test_vj_deletion(self):
         """
-        send a mock kirin vj deletion and test the VJ API
+        send a mock kirin vj cancellation and test that the vj is not taken
         """
-        self.send_mock()
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime")
 
-        response = self.query_region('vehicle_journeys')
-        assert len(response) > 0
+        # with no cancellation, we have 2 jounrneys, one direct and one with the vj:A:0
+        assert _get_arrivals(response) == ['20120614T080222', '20120614T080435']
+        assert _get_used_vj(response) == [['vj:A:0'], []]
 
-        #TODO
+        self.send_mock("vj:A:0", "20120614", 'cancelled')
+
+        new_response = self.query_region(journey_basic_query + "&data_freshness=realtime")
+        assert _get_arrivals(new_response) == ['20120614T080435', '20120614T180222']
+        assert _get_used_vj(new_response) == [[], ['vj:B:1']]
+
+        # it should not have changed anything for the theoric
+        new_theoric = self.query_region(journey_basic_query + "&data_freshness=theoric")
+        assert _get_arrivals(new_theoric) == ['20120614T080222', '20120614T080435']
+        assert _get_used_vj(new_theoric) == [['vj:A:0'], []]
+        assert new_theoric['journeys'] == response['journeys']
 
 
-def make_mock_kirin_item(*args, **kwargs):
+def make_mock_kirin_item(vj_id, date, status='delayed'):
     feed_message = gtfs_realtime_pb2.FeedMessage()
     feed_message.header.gtfs_realtime_version = '1.0'
     feed_message.header.incrementality = gtfs_realtime_pb2.FeedHeader.DIFFERENTIAL
@@ -70,13 +105,13 @@ def make_mock_kirin_item(*args, **kwargs):
     trip_update = entity.trip_update
 
     trip = trip_update.trip
-    trip.trip_id = "vehicle_journey:OCETrainTER-87212027-85000109-3:15554"
-    trip.start_date = "20150728"
-    trip.schedule_relationship = gtfs_realtime_pb2.TripDescriptor.SCHEDULED
+    trip.trip_id = vj_id  #
+    trip.start_date = date
 
-    stop_time = trip_update.stop_time_update.add()
-    stop_time.stop_id = "stop_point:OCE:SP:TrainTER-87212027"
-    stop_time.arrival.time = utils.str_to_time_stamp("20150728T1721")
-    stop_time.departure.time = utils.str_to_time_stamp("20150728T1721")
+    if status == 'canceled':
+        trip.schedule_relationship = gtfs_realtime_pb2.TripDescriptor.CANCELED
+    else:
+        #TODO
+        pass
 
     return feed_message.SerializeToString()

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -89,10 +89,10 @@ class TestKirinOnVJDeletion(MockKirinDisruptionsFixture):
         eq_(_get_used_vj(new_response), [[], ['vj:B:1']])
 
         # it should not have changed anything for the theoric
-        new_theoric = self.query_region(journey_basic_query + "&data_freshness=theoric")
-        eq_(_get_arrivals(new_theoric), ['20120614T080222', '20120614T080435'])
-        eq_(_get_used_vj(new_theoric), [['vjA'], []])
-        assert new_theoric['journeys'] == response['journeys']
+        new_base = self.query_region(journey_basic_query + "&data_freshness=base_schedule")
+        eq_(_get_arrivals(new_base), ['20120614T080222', '20120614T080435'])
+        eq_(_get_used_vj(new_base), [['vjA'], []])
+        assert new_base['journeys'] == response['journeys']
 
 
 def make_mock_kirin_item(vj_id, date, status='delayed'):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -480,7 +480,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
 
     def test_headsign(self):
         """test basic usage of headsign"""
-        response = self.query_region('vehicle_journeys?headsign=vehicle_journey 0')
+        response = self.query_region('vehicle_journeys?headsign=vjA')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         eq_(len(vjs), 1)
@@ -488,7 +488,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
     def test_headsign_with_resource_uri(self):
         """test usage of headsign with resource uri"""
         response = self.query_region('physical_modes/physical_mode:0x0/vehicle_journeys'
-                                     '?headsign=vehicle_journey 0')
+                                     '?headsign=vjA')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         eq_(len(vjs), 1)
@@ -496,7 +496,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
     def test_headsign_with_code_filter_and_resource_uri(self):
         """test usage of headsign with code filter and resource uri"""
         response = self.query_region('physical_modes/physical_mode:0x0/vehicle_journeys'
-                                     '?headsign=vehicle_journey 0&filter=line.code=1A')
+                                     '?headsign=vjA&filter=line.code=1A')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         eq_(len(vjs), 1)
@@ -536,13 +536,13 @@ class TestPtRefRoutingCov(AbstractTestFixture):
 
     def test_headsign_stop_time_vj(self):
         """test basic print of headsign in stop_times for vj"""
-        response = self.query_region('vehicle_journeys?filter=vehicle_journey.name="vehicle_journey 0"')
+        response = self.query_region('vehicle_journeys?filter=vehicle_journey.name="vjA"')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         eq_(len(vjs), 1)
         eq_(len(vjs[0]['stop_times']), 2)
         eq_(vjs[0]['stop_times'][0]['headsign'], "A00")
-        eq_(vjs[0]['stop_times'][1]['headsign'], "vehicle_journey 0")
+        eq_(vjs[0]['stop_times'][1]['headsign'], "vjA")
 
     def test_headsign_display_info_journeys(self):
         """test basic print of headsign in section for journeys"""
@@ -577,5 +577,5 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         eq_(len(route_schedules), 1)
         eq_(len(route_schedules[0]['table']['headers']), 1)
         display_info = route_schedules[0]['table']['headers'][0]['display_informations']
-        eq_(display_info['headsign'], "vehicle_journey 0")
-        assert {"A00", "vehicle_journey 0"} == set(display_info['headsigns'])
+        eq_(display_info['headsign'], "vjA")
+        assert {"A00", "vjA"} == set(display_info['headsigns'])

--- a/source/kraken/fill_disruption_from_chaos.cpp
+++ b/source/kraken/fill_disruption_from_chaos.cpp
@@ -405,7 +405,7 @@ struct functor_add_vj {
 
         // The vehicle_journey is never active on theorical validity_pattern
         tmp_vp.reset();
-        vj->validity_patterns[nt::RTLevel::Theoric] = pt_data.get_or_create_validity_pattern(tmp_vp);
+        vj->validity_patterns[nt::RTLevel::Base] = pt_data.get_or_create_validity_pattern(tmp_vp);
         size_t order = 0;
         // We skip the stop_time linked to impacted stop_point
         for (const auto& st_ref : vj_ref.stop_time_list) {
@@ -524,7 +524,7 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
     // We set all the validity pattern to the theorical one, we will re-apply
     // other disruptions after
     bool func_on_vj(nt::VehicleJourney& vj) {
-        vj.validity_patterns[nt::RTLevel::Adapted] = vj.validity_patterns[nt::RTLevel::Theoric];
+        vj.validity_patterns[nt::RTLevel::Adapted] = vj.validity_patterns[nt::RTLevel::Base];
         ++ nb_vj_reassigned;
         const auto& impact = this->impact;
         boost::range::remove_erase_if(vj.impacted_by,

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -41,7 +41,7 @@ void cancel_vj(type::MetaVehicleJourney* meta_vj,
                const transit_realtime::TripUpdate& /*trip_update*/,
                const type::Data& data) {
     // we need to cancel all vj of the meta vj
-    for (const auto& vect_vj: {meta_vj->theoric_vj, meta_vj->adapted_vj, meta_vj->real_time_vj}) {
+    for (const auto& vect_vj: {meta_vj->base_vj, meta_vj->adapted_vj, meta_vj->real_time_vj}) {
         for (auto* vj: vect_vj) {
             // the train is canceled on one day, we just need to unset its realtime validitypattern
 

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -12,7 +12,10 @@ add_executable(fill_disruption_from_chaos_tests fill_disruption_from_chaos_tests
 target_link_libraries(fill_disruption_from_chaos_tests fill_disruption_from_chaos ed workers data types pb_lib utils log4cplus tcmalloc ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
 ADD_BOOST_TEST(fill_disruption_from_chaos_tests)
 
-
 add_executable(worker_test worker_test.cpp)
 target_link_libraries(worker_test ed workers data types pb_lib utils log4cplus tcmalloc ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
 ADD_BOOST_TEST(worker_test)
+
+add_executable(realtime_test realtime_test.cpp)
+target_link_libraries(realtime_test ed workers data types pb_lib utils log4cplus tcmalloc ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+ADD_BOOST_TEST(realtime_test)

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -71,7 +71,7 @@ static std::string dump_vj(const nt::VehicleJourney& vj){
     for(const auto& st: vj.stop_time_list){
     ss << "\t" << st.journey_pattern_point->stop_point->uri << ": " << st.arrival_time << " - " << st.departure_time << std::endl;
     }
-    ss << "\tvalidity_pattern: " << ba::trim_left_copy_if(vj.theoric_validity_pattern()->days.to_string(), boost::is_any_of("0")) << std::endl;
+    ss << "\tvalidity_pattern: " << ba::trim_left_copy_if(vj.base_validity_pattern()->days.to_string(), boost::is_any_of("0")) << std::endl;
     ss << "\tadapted_validity_pattern: " << ba::trim_left_copy_if(vj.adapted_validity_pattern()->days.to_string(), boost::is_any_of("0")) << std::endl;
     return ss.str();
 }
@@ -115,15 +115,15 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line) {
     BOOST_REQUIRE_EQUAL(b.data->pt_data->journey_patterns.size(), 1);
     auto* vj = b.data->pt_data->vehicle_journeys_map["vj:1"];
     BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000001"), vj->adapted_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
 
     vj = b.data->pt_data->vehicle_journeys_map["vj:2"];
     BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000001"), vj->adapted_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
 
     vj = b.data->pt_data->vehicle_journeys_map["vj:3"];
     BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "001100"), vj->adapted_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "001101"), vj->theoric_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "001101"), vj->base_validity_pattern()->days);
 
     //we delete the disruption, all must be as before!
     navitia::delete_disruption("test01", *b.data->pt_data, *b.data->meta);
@@ -132,15 +132,15 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line) {
     BOOST_REQUIRE_EQUAL(b.data->pt_data->journey_patterns.size(), 1);
     vj = b.data->pt_data->vehicle_journeys_map["vj:1"];
     BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000111"), vj->adapted_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
 
     vj = b.data->pt_data->vehicle_journeys_map["vj:2"];
     BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000111"), vj->adapted_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
 
     vj = b.data->pt_data->vehicle_journeys_map["vj:3"];
     BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "001101"), vj->adapted_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "001101"), vj->theoric_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "001101"), vj->base_validity_pattern()->days);
 }
 
 /*
@@ -186,11 +186,11 @@ BOOST_AUTO_TEST_CASE(add_impact_on_stop_area) {
     bool has_adapted_vj = false;
     for (const auto* vj: b.data->pt_data->vehicle_journeys) {
         switch (vj->realtime_level) {
-        case nt::RTLevel::Theoric:
+        case nt::RTLevel::Base:
             BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                         stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
             BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000001"), vj->adapted_validity_pattern()->days);
-            BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+            BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
             break;
         case nt::RTLevel::Adapted:
             has_adapted_vj = true;
@@ -250,13 +250,13 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
         BOOST_CHECK_EQUAL(data.pt_data->journey_patterns.size(), 4);//some of them aren't used
         bool has_adapted_vj = false;
         for (const auto* vj: data.pt_data->vehicle_journeys) {
-            if (vj->adapted_validity_pattern()->days.none() && vj->theoric_validity_pattern()->days.none()) {
+            if (vj->adapted_validity_pattern()->days.none() && vj->base_validity_pattern()->days.none()) {
                 //some vj don't circulate we don't want to check them
                 continue;
             }
 
             switch (vj->realtime_level) {
-            case nt::RTLevel::Theoric:
+            case nt::RTLevel::Base:
                 BOOST_CHECK(boost::find_if(vj->journey_pattern->journey_pattern_point_list,
                             stop_area_finder("stop_area:stop1")) != vj->journey_pattern->journey_pattern_point_list.end());
                 break;
@@ -277,11 +277,11 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
 
         auto* vj = data.pt_data->vehicle_journeys_map["vj:1"];
         BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000001"), vj->adapted_validity_pattern()->days);
-        BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+        BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
 
         vj = data.pt_data->vehicle_journeys_map["vj:2"];
         BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000001"), vj->adapted_validity_pattern()->days);
-        BOOST_CHECK_MESSAGE(ba::ends_with(vj->theoric_validity_pattern()->days.to_string(), "000111"), vj->theoric_validity_pattern()->days);
+        BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000111"), vj->base_validity_pattern()->days);
 
         //useless vj, need to be deleted...
         vj = data.pt_data->vehicle_journeys_map["vj:1:adapted-2"];
@@ -294,11 +294,11 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
         BOOST_CHECK(vj->adapted_validity_pattern()->days.none());
 
         vj = data.pt_data->vehicle_journeys_map["vj:1:adapted-2:adapted-4"];
-        BOOST_CHECK(vj->theoric_validity_pattern()->days.none());
+        BOOST_CHECK(vj->base_validity_pattern()->days.none());
         BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000110"), vj->adapted_validity_pattern()->days);
 
         vj = data.pt_data->vehicle_journeys_map["vj:2:adapted-3:adapted-5"];
-        BOOST_CHECK(vj->theoric_validity_pattern()->days.none());
+        BOOST_CHECK(vj->base_validity_pattern()->days.none());
         BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000110"), vj->adapted_validity_pattern()->days);
     };
 
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
     BOOST_CHECK_EQUAL(b.data->pt_data->journey_patterns.size(), 1);
     for (const auto* vj: b.data->pt_data->vehicle_journeys) {
         BOOST_REQUIRE(vj->realtime_level != nt::RTLevel::Adapted);
-        BOOST_CHECK(vj->theoric_validity_pattern()->days == vj->adapted_validity_pattern()->days);
+        BOOST_CHECK(vj->base_validity_pattern()->days == vj->adapted_validity_pattern()->days);
     }
     for (const auto* sp: b.data->pt_data->stop_points) {
         if (sp->journey_pattern_point_list.size() > 1) {

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -40,7 +40,8 @@ www.navitia.io
 
 namespace nt = navitia::type;
 
-transit_realtime::TripUpdate make_cancellation_message(std::string vj_uri, std::string date) {
+static transit_realtime::TripUpdate
+make_cancellation_message(const std::string& vj_uri, const std::string& date) {
     transit_realtime::TripUpdate trip_update;
     auto trip = trip_update.mutable_trip();
     trip->set_trip_id(vj_uri);
@@ -55,7 +56,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     b.vj("A", "000001", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
 
     transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150928");
-    auto& pt_data = b.data->pt_data;
+    const auto& pt_data = b.data->pt_data;
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -95,7 +96,7 @@ BOOST_AUTO_TEST_CASE(train_cancellation_on_unused_day) {
     b.vj("A", "000001", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
 
     transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150929");
-    auto& pt_data = b.data->pt_data;
+    const auto& pt_data = b.data->pt_data;
 
     navitia::handle_realtime(trip_update, *b.data);
 
@@ -112,7 +113,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation_routing) {
     b.vj("A", "000001", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
 
     transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150928");
-    auto& pt_data = b.data->pt_data;
+    const auto& pt_data = b.data->pt_data;
 
     pt_data->index();
     b.finish();
@@ -129,7 +130,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation_routing) {
     auto res = compute(nt::RTLevel::Theoric);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
 
-    //on the realtime level, we should also gt one solution, since for the moment there is no cancellation
+    //on the realtime level, we should also get one solution, since for the moment there is no cancellation
     res = compute(nt::RTLevel::RealTime);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
 
@@ -150,7 +151,7 @@ BOOST_AUTO_TEST_CASE(train_cancellation_with_choice_routing) {
     b.vj("B")("stop1", "08:00"_t)("stop2", "09:30"_t);
 
     transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150928");
-    auto& pt_data = b.data->pt_data;
+    const auto& pt_data = b.data->pt_data;
 
     pt_data->index();
     b.finish();

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1,0 +1,186 @@
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_realtime
+#include <boost/test/unit_test.hpp>
+#include "type/gtfs-realtime.pb.h"
+#include "type/pt_data.h"
+#include "kraken/realtime.h"
+#include "ed/build_helper.h"
+#include "tests/utils_test.h"
+#include "routing/raptor.h"
+
+namespace nt = navitia::type;
+
+transit_realtime::TripUpdate make_cancellation_message(std::string vj_uri, std::string date) {
+    transit_realtime::TripUpdate trip_update;
+    auto trip = trip_update.mutable_trip();
+    trip->set_trip_id(vj_uri);
+    trip->set_start_date(date);
+    trip->set_schedule_relationship(transit_realtime::TripDescriptor_ScheduleRelationship_CANCELED);
+
+    return trip_update;
+}
+
+BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
+    ed::builder b("20150928");
+    b.vj("A", "000001", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
+
+    transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150928");
+    auto& pt_data = b.data->pt_data;
+    BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 1);
+    auto vj = pt_data->vehicle_journeys.front();
+    BOOST_CHECK_EQUAL(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+
+    navitia::handle_realtime(trip_update, *b.data);
+
+    // we should not have created any objects save for one validity_pattern
+    BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 2);
+    BOOST_CHECK_NE(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+
+    //the rt vp must be empty
+    BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, navitia::type::ValidityPattern::year_bitset());
+
+    // we add a second time the realtime message, it should not change anything
+    navitia::handle_realtime(trip_update, *b.data);
+
+    // we should not have created any objects save for one validity_pattern
+    BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 2);
+    BOOST_CHECK_NE(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+}
+
+/*
+ * the vj:1 is not in service the 09/29, so the cancellation on this day should not change anything
+ *
+ */
+BOOST_AUTO_TEST_CASE(train_cancellation_on_unused_day) {
+    ed::builder b("20150928");
+    b.vj("A", "000001", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
+
+    transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150929");
+    auto& pt_data = b.data->pt_data;
+
+    navitia::handle_realtime(trip_update, *b.data);
+
+    BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 1);
+    auto vj = pt_data->vehicle_journeys.front();
+    BOOST_CHECK_EQUAL(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+}
+
+BOOST_AUTO_TEST_CASE(simple_train_cancellation_routing) {
+    ed::builder b("20150928");
+    b.vj("A", "000001", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
+
+    transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150928");
+    auto& pt_data = b.data->pt_data;
+
+    pt_data->index();
+    b.finish();
+    b.data->build_raptor();
+    b.data->build_uri();
+    navitia::routing::RAPTOR raptor(*(b.data));
+
+    auto compute = [&](nt::RTLevel level) {
+        return raptor.compute(pt_data->stop_areas_map.at("stop1"), pt_data->stop_areas_map.at("stop2"),
+                              "08:00"_t, 0, navitia::DateTimeUtils::inf, level, true);
+    };
+
+    //on the theoric level, we should get one solution
+    auto res = compute(nt::RTLevel::Theoric);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+
+    //on the realtime level, we should also gt one solution, since for the moment there is no cancellation
+    res = compute(nt::RTLevel::RealTime);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+
+    navitia::handle_realtime(trip_update, *b.data);
+
+    //on the theoric level, we should still get one solution
+    res = compute(nt::RTLevel::Theoric);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+
+    //on the realtime we should now have no solution
+    res = compute(nt::RTLevel::RealTime);
+    BOOST_REQUIRE_EQUAL(res.size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(train_cancellation_with_choice_routing) {
+    ed::builder b("20150928");
+    b.vj("A", "111", "", true, "vj:1")("stop1", "08:00"_t)("stop2", "09:00"_t);
+    b.vj("B")("stop1", "08:00"_t)("stop2", "09:30"_t);
+
+    transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150928");
+    auto& pt_data = b.data->pt_data;
+
+    pt_data->index();
+    b.finish();
+    b.data->build_raptor();
+    b.data->build_uri();
+    navitia::routing::RAPTOR raptor(*(b.data));
+
+    auto compute = [&](nt::RTLevel level) {
+        return raptor.compute(pt_data->stop_areas_map.at("stop1"), pt_data->stop_areas_map.at("stop2"),
+                              "08:00"_t, 0, navitia::DateTimeUtils::inf, level, true);
+    };
+
+    //on the theoric and realtime level, we should arrive at 9:00 (with line A)
+    auto res = compute(nt::RTLevel::Theoric);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0900"_dt);
+    res = compute(nt::RTLevel::RealTime);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0900"_dt);
+
+    // we cancel the vj1
+    navitia::handle_realtime(trip_update, *b.data);
+
+    // on the theoric, nothing has changed
+    res = compute(nt::RTLevel::Theoric);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0900"_dt);
+
+    // but on the realtime we now arrive at 09:30
+    res = compute(nt::RTLevel::RealTime);
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0930"_dt);
+}

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 1);
     auto vj = pt_data->vehicle_journeys.front();
-    BOOST_CHECK_EQUAL(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+    BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     navitia::handle_realtime(trip_update, *b.data);
 
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 2);
-    BOOST_CHECK_NE(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+    BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     //the rt vp must be empty
     BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, navitia::type::ValidityPattern::year_bitset());
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 2);
-    BOOST_CHECK_NE(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+    BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 }
 
 /*
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(train_cancellation_on_unused_day) {
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 1);
     auto vj = pt_data->vehicle_journeys.front();
-    BOOST_CHECK_EQUAL(vj->theoric_validity_pattern(), vj->rt_validity_pattern());
+    BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 }
 
 BOOST_AUTO_TEST_CASE(simple_train_cancellation_routing) {
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation_routing) {
     };
 
     //on the theoric level, we should get one solution
-    auto res = compute(nt::RTLevel::Theoric);
+    auto res = compute(nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
 
     //on the realtime level, we should also get one solution, since for the moment there is no cancellation
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation_routing) {
     navitia::handle_realtime(trip_update, *b.data);
 
     //on the theoric level, we should still get one solution
-    res = compute(nt::RTLevel::Theoric);
+    res = compute(nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
 
     //on the realtime we should now have no solution
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(train_cancellation_with_choice_routing) {
     };
 
     //on the theoric and realtime level, we should arrive at 9:00 (with line A)
-    auto res = compute(nt::RTLevel::Theoric);
+    auto res = compute(nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0900"_dt);
     res = compute(nt::RTLevel::RealTime);
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(train_cancellation_with_choice_routing) {
     navitia::handle_realtime(trip_update, *b.data);
 
     // on the theoric, nothing has changed
-    res = compute(nt::RTLevel::Theoric);
+    res = compute(nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0900"_dt);
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -285,7 +285,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     forbidden_uri, from_datetime,
                     request.duration(),
                     request.depth(), max_date_times, request.interface_version(),
-                    request.count(), request.start_page(), *data, type::RTLevel::Theoric, request.show_codes());
+                    request.count(), request.start_page(), *data, type::RTLevel::Base, request.show_codes());
         case pbnavitia::ROUTE_SCHEDULES:
             return timetables::route_schedule(request.departure_filter(),
                     request.has_calendar() ? boost::optional<const std::string>(request.calendar()) :
@@ -293,7 +293,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     forbidden_uri,
                     from_datetime,
                     request.duration(), max_date_times, request.depth(),
-                    request.count(), request.start_page(), *data, type::RTLevel::Theoric, request.show_codes());
+                    request.count(), request.start_page(), *data, type::RTLevel::Base, request.show_codes());
         default:
             LOG4CPLUS_WARN(logger, "Unknown timetable query");
             pbnavitia::Response response;
@@ -501,8 +501,8 @@ type::RTLevel get_realtime_level(const pbnavitia::JourneysRequest& request) {
     // retrocompatibility will be droped after the migration
     if (request.has_realtime_level()) {
         switch (request.realtime_level()) {
-        case pbnavitia::RTLevel::THEORIC:
-            return type::RTLevel::Theoric;
+        case pbnavitia::RTLevel::BASE:
+            return type::RTLevel::Base;
         case pbnavitia::RTLevel::ADAPTED:
             return type::RTLevel::Adapted;
         case pbnavitia::RTLevel::REAL_TIME:
@@ -514,7 +514,7 @@ type::RTLevel get_realtime_level(const pbnavitia::JourneysRequest& request) {
     if (request.disruption_active()) {
         return type::RTLevel::Adapted;
     }
-    return type::RTLevel::Theoric;
+    return type::RTLevel::Base;
 }
 
 pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, pbnavitia::API api) {

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -333,7 +333,7 @@ static bool keep_vj(const nt::VehicleJourney* vj,
     const auto& first_departure_dt = vj->stop_time_list.front().departure_time;
 
     for (boost::gregorian::day_iterator it(period.begin().date()); it <= period.last().date(); ++it) {
-        if (! vj->theoric_validity_pattern()->check(*it)) { continue; }
+        if (! vj->base_validity_pattern()->check(*it)) { continue; }
         bt::ptime vj_dt = bt::ptime(*it, bt::seconds(first_departure_dt));
         if (period.contains(vj_dt)) { return true; }
     }

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv){
         }
         auto res = router.compute(data.pt_data->stop_areas[demand.start], data.pt_data->stop_areas[demand.target],
                 demand.hour, demand.date, DateTimeUtils::set(demand.date + 1, demand.hour),
-                type::RTLevel::Theoric, true, {}, 10);
+                type::RTLevel::Base, true, {}, 10);
 
         Path path;
         if(res.size() > 0) {

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -285,7 +285,7 @@ int main(int argc, char** argv){
               accessibilite_params,
               {},
               georef_worker,
-              type::RTLevel::Theoric,
+              type::RTLevel::Base,
               std::numeric_limits<int>::max(), 10, false);
 
         if(resp.journeys_size() > 0) {

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -94,10 +94,10 @@ void dataRAPTOR::load(const type::PT_Data &data)
         const auto rt_level = level_cont.first;
         auto& jp_vp = level_cont.second;
         jp_vp.assign(366, boost::dynamic_bitset<>(data.journey_patterns.size()));
-        for(const type::JourneyPattern* journey_pattern : data.journey_patterns) {
-            for(int i=0; i<=365; ++i) {
+        for (const type::JourneyPattern* journey_pattern : data.journey_patterns) {
+            for (int i = 0; i <= 365; ++i) {
                 journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
-                    if(vj.validity_patterns[rt_level]->check2(i)) {
+                    if (vj.validity_patterns[rt_level]->check2(i)) {
                         jp_vp[i].set(journey_pattern->idx);
                         return false;
                     }

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -90,29 +90,20 @@ void dataRAPTOR::load(const type::PT_Data &data)
     jpps_from_jp.load(data);
     next_stop_time_data.load(data);
 
-    jp_validity_patterns.assign(366, boost::dynamic_bitset<>(data.journey_patterns.size()));
-    jp_adapted_validity_pattern.assign(366, boost::dynamic_bitset<>(data.journey_patterns.size()));
-
-    for(const type::JourneyPattern* journey_pattern : data.journey_patterns) {
-        for(int i=0; i<=365; ++i) {
-            journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
-                if(vj.theoric_validity_pattern()->check2(i)) {
-                    jp_validity_patterns[i].set(journey_pattern->idx);
-                    return false;
-                }
-                return true;
-            });
-        }
-
-        //A journey pattern is valid is at least one validity pattern of its vj is valid on [day-1;day+1]
-        for(int i=0; i<=365; ++i) {
-            journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
-                if(vj.adapted_validity_pattern()->check2(i)) {
-                    jp_adapted_validity_pattern[i].set(journey_pattern->idx);
-                    return false;
-                }
-                return true;
-            });
+    for (auto level_cont: jp_validity_patterns) {
+        const auto rt_level = level_cont.first;
+        auto& jp_vp = level_cont.second;
+        jp_vp.assign(366, boost::dynamic_bitset<>(data.journey_patterns.size()));
+        for(const type::JourneyPattern* journey_pattern : data.journey_patterns) {
+            for(int i=0; i<=365; ++i) {
+                journey_pattern->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
+                    if(vj.validity_patterns[rt_level]->check2(i)) {
+                        jp_vp[i].set(journey_pattern->idx);
+                        return false;
+                    }
+                    return true;
+                });
+            }
         }
     }
 }

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -104,11 +104,7 @@ struct dataRAPTOR {
     Labels labels_const_reverse;
 
     // jp_validity_patterns[date][jp_idx] == any(vj.validity_pattern->check2(date) for vj in jp)
-    std::vector<boost::dynamic_bitset<> > jp_validity_patterns;
-
-    // as jp_validity_patterns for the adapted ones
-    std::vector<boost::dynamic_bitset<> > jp_adapted_validity_pattern;
-
+    flat_enum_map<type::RTLevel, std::vector<boost::dynamic_bitset<>>> jp_validity_patterns;
 
     dataRAPTOR() {}
     void load(const navitia::type::PT_Data &data);

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -197,12 +197,12 @@ DateTime get_next_stop_time(const StopEvent stop_event,
                             DateTime dt,
                             const type::FrequencyVehicleJourney& freq_vj,
                             const type::StopTime& st,
-                            const type::RTLevel rt_level = type::RTLevel::Theoric);
+                            const type::RTLevel rt_level = type::RTLevel::Base);
 DateTime get_previous_stop_time(const StopEvent stop_event,
                                 DateTime dt,
                                 const type::FrequencyVehicleJourney& freq_vj,
                                 const type::StopTime& st,
-                                const type::RTLevel rt_level = type::RTLevel::Theoric);
+                                const type::RTLevel rt_level = type::RTLevel::Base);
 
 
 }} // namespace navitia::routing

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -412,7 +412,6 @@ void RAPTOR::set_valid_jp_and_jpp(
     const std::vector<std::string>& forbidden,
     const nt::RTLevel rt_level)
 {
-
     valid_journey_patterns = data.dataRaptor->jp_validity_patterns[rt_level][date];
     boost::dynamic_bitset<> valid_journey_pattern_points(data.pt_data->journey_pattern_points.size());
     valid_journey_pattern_points.set();

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -412,16 +412,8 @@ void RAPTOR::set_valid_jp_and_jpp(
     const std::vector<std::string>& forbidden,
     const nt::RTLevel rt_level)
 {
-    switch (rt_level) {
-    case nt::RTLevel::Theoric:
-        valid_journey_patterns = data.dataRaptor->jp_validity_patterns[date];
-        break;
-    case nt::RTLevel::Adapted:
-        valid_journey_patterns = data.dataRaptor->jp_adapted_validity_pattern[date];
-        break;
-    case nt::RTLevel::RealTime:
-        throw navitia::exception("rt not implemented yet");
-    }
+
+    valid_journey_patterns = data.dataRaptor->jp_validity_patterns[rt_level][date];
     boost::dynamic_bitset<> valid_journey_pattern_points(data.pt_data->journey_pattern_points.size());
     valid_journey_pattern_points.set();
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -177,7 +177,7 @@ struct RAPTOR
               const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
               const std::vector<std::string>& forbidden = std::vector<std::string>(),
               bool clockwise = true,
-              const nt::RTLevel rt_level = nt::RTLevel::Theoric);
+              const nt::RTLevel rt_level = nt::RTLevel::Base);
 
 
     /// Désactive les journey_patterns qui n'ont pas de vj valides la veille, le jour, et le lendemain du calcul

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -382,10 +382,10 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                 type::VehicleJourney const *const vj = item.get_vj();
 
                 if (!vp) {
-                    vp = *vj->theoric_validity_pattern();
+                    vp = *vj->base_validity_pattern();
                 } else {
-                    assert(vp->beginning_date == vj->theoric_validity_pattern()->beginning_date);
-                    vp->days &= vj->theoric_validity_pattern()->days;
+                    assert(vp->beginning_date == vj->base_validity_pattern()->beginning_date);
+                    vp->days &= vj->base_validity_pattern()->days;
                 }
 
                 const size_t nb_sps = item.stop_points.size();

--- a/source/routing/routing_cli_utils.cpp
+++ b/source/routing/routing_cli_utils.cpp
@@ -75,7 +75,7 @@ namespace navitia { namespace cli {
             }
             pb::Response resp = make_response(*raptor, origin, destination, {ntest::to_posix_timestamp(date)},
                     clockwise, navitia::type::AccessibiliteParams(), forbidden,
-                    sn_worker, type::RTLevel::Theoric, true);
+                    sn_worker, type::RTLevel::Base, true);
 
             if (vm.count("protobuf")) {
                 std::cout << resp.DebugString() << "\n";

--- a/source/routing/tests/co2_emission_test.cpp
+++ b/source/routing/tests/co2_emission_test.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_higher_0) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_equal_0) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(co2_emission_lower_0) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             true, navitia::type::AccessibiliteParams(), forbidden, sn_worker, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 

--- a/source/routing/tests/frequency_raptor_test.cpp
+++ b/source/routing/tests/frequency_raptor_test.cpp
@@ -58,13 +58,13 @@ BOOST_AUTO_TEST_CASE(freq_vj) {
     RAPTOR raptor(*(b.data));
     const type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 8*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 8*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), 8*3600 + 10*60);
 
-    res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 9*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 9*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), 9*3600 + 10*60);
 }
@@ -81,18 +81,18 @@ BOOST_AUTO_TEST_CASE(freq_vj_pam) {
     RAPTOR raptor(*(b.data));
     const type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 23*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 23*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), 23*3600 + 10*60);
 
-    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 24*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 24*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res1[0].items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(res1[0].items[0].arrival.time_of_day().total_seconds(), (24*3600 + 10*60)% DateTimeUtils::SECONDS_PER_DAY);
 
-    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 25*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    /*auto*/ res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop2"), 25*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res1[0].items[0].arrival, *(b.data))), 1);
@@ -128,13 +128,13 @@ BOOST_AUTO_TEST_CASE(freq_vj_stop_times) {
         BOOST_CHECK_EQUAL(section.departures[2], "20120614T094000"_dt);
     };
 
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
     //same but tardiest departure
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 30*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);
@@ -174,13 +174,13 @@ BOOST_AUTO_TEST_CASE(freq_vj_different_departure_arrival_duration) {
         BOOST_CHECK_EQUAL(section.departures[2], "20120614T100500"_dt);
     };
 
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 9*3600 + 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
     //same but tardiest departure
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 10*3600, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 10*3600, 0, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);
@@ -220,13 +220,13 @@ BOOST_AUTO_TEST_CASE(freq_vj_overmidnight_different_dep_arr) {
     };
 
     //leaving at 22:15, we have to wait for the next departure at 23:10
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 22*3600 + 15*60, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 22*3600 + 15*60, 2, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
     //wwe want to arrive before 01:00 we'll take the same trip
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 1*3600, 3, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop3"), 1*3600, 3, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
@@ -290,12 +290,12 @@ BOOST_AUTO_TEST_CASE(freq_vj_transfer_with_regular_vj) {
 
     // leaving after 10:20, we have to wait for the next bus at 11:15
     // then we can catch the bus B at 12:10 and finish at 12:30
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "10:20"_t, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "10:20"_t, 2, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "12:40"_t, 2, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "12:40"_t, 2, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);
@@ -370,12 +370,12 @@ BOOST_AUTO_TEST_CASE(transfer_between_freq) {
     // leaving after 11:10, we would have to wait for the bus B after so the 2nd pass makes us wait
     // so we leave at 12:10 to arrive at 13:20
     // then we have to wait for the begin of the bust B at 14:04 and finish at 14:35
-    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "11:10"_t, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res_earliest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "11:10"_t, 2, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res_earliest.size(), 1);
     check_journey(res_earliest[0]);
 
-    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "14:35"_t, 2, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res_tardiest = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop5"), "14:35"_t, 2, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res_tardiest.size(), 1);
     check_journey(res_tardiest[0]);

--- a/source/routing/tests/next_stop_time_test.cpp
+++ b/source/routing/tests/next_stop_time_test.cpp
@@ -85,9 +85,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     //SP1
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1),
-                                                        sp1_departure - 1, nt::RTLevel::Theoric, false);
+                                                        sp1_departure - 1, nt::RTLevel::Base, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1),
-                                                        sp1_departure - 1, nt::RTLevel::Theoric, false);
+                                                        sp1_departure - 1, nt::RTLevel::Base, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -95,9 +95,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1),
-                                                        sp1_departure, nt::RTLevel::Theoric, false);
+                                                        sp1_departure, nt::RTLevel::Base, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1),
-                                                        sp1_departure, nt::RTLevel::Theoric, false);
+                                                        sp1_departure, nt::RTLevel::Base, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -105,9 +105,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1),
-                                                        sp1_departure + 1, nt::RTLevel::Theoric, false);
+                                                        sp1_departure + 1, nt::RTLevel::Base, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1),
-                                                        sp1_departure + 1, nt::RTLevel::Theoric, false);
+                                                        sp1_departure + 1, nt::RTLevel::Base, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -116,9 +116,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     //SP2
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2),
-                                                        sp2_departure - 1, nt::RTLevel::Theoric, false);
+                                                        sp2_departure - 1, nt::RTLevel::Base, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2),
-                                                        sp2_departure - 1, nt::RTLevel::Theoric, false);
+                                                        sp2_departure - 1, nt::RTLevel::Base, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -126,9 +126,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2),
-                                                        sp2_departure, nt::RTLevel::Theoric, false);
+                                                        sp2_departure, nt::RTLevel::Base, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2),
-                                                        sp2_departure, nt::RTLevel::Theoric, false);
+                                                        sp2_departure, nt::RTLevel::Base, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -136,9 +136,9 @@ BOOST_AUTO_TEST_CASE(dropoff_pickup) {
     }
     {
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2),
-                                                        sp2_arrival + 1, nt::RTLevel::Theoric, false);
+                                                        sp2_arrival + 1, nt::RTLevel::Base, false);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2),
-                                                        sp2_arrival + 1, nt::RTLevel::Theoric, false);
+                                                        sp2_arrival + 1, nt::RTLevel::Base, false);
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 == nullptr);
@@ -193,9 +193,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(DateTimeUtils::date(dt_test), sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -206,9 +206,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(DateTimeUtils::date(dt_test), sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -219,9 +219,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -273,7 +273,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -295,9 +295,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -309,9 +309,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, dt_test);
         BOOST_CHECK(st1 == nullptr);
@@ -323,9 +323,9 @@ BOOST_AUTO_TEST_CASE(base) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -376,9 +376,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -389,9 +389,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -402,9 +402,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -416,9 +416,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         // we ask for the previous departure from 23:59 the day 1
         // the previous departure is the day 1, at 100 (same as the day 0 at 86400 + 100)
@@ -431,9 +431,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -444,9 +444,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -457,9 +457,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_1) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -516,9 +516,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -529,9 +529,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -542,9 +542,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -556,7 +556,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->departure_time, sp2_departure);
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp2_departure);
@@ -576,7 +576,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -606,7 +606,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -616,7 +616,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -626,7 +626,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -637,9 +637,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -650,9 +650,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -663,9 +663,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -717,7 +717,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
@@ -726,7 +726,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
@@ -735,7 +735,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure);
@@ -745,7 +745,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -754,7 +754,7 @@ BOOST_AUTO_TEST_CASE(base_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(2, sp2_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1 - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -827,7 +827,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -836,7 +836,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1 + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure2);
@@ -845,7 +845,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure2 - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure2);
@@ -854,7 +854,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure2);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp1_departure2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure2);
@@ -863,7 +863,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure2 + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -873,7 +873,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp2_arrival1 + 1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival1);
@@ -882,7 +882,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp2_arrival1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival1);
@@ -891,7 +891,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival1 - 1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival2);
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(vj2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp2_arrival2 + 1);
         std::tie(st1, dt1) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, sp2_arrival2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival2);
@@ -968,7 +968,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1 - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -977,7 +977,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -986,7 +986,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->departure_time, sp1_departure1);
@@ -996,7 +996,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(2, sp2_arrival1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival2));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival2);
@@ -1005,7 +1005,7 @@ BOOST_AUTO_TEST_CASE(vp2) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival2 - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival1));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival1);
@@ -1058,9 +1058,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1071,9 +1071,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1084,9 +1084,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1096,7 +1096,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st2 == nullptr);
     }
@@ -1104,7 +1104,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
         //We test if we can find the train leaving after midnight
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -1114,7 +1114,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1124,7 +1124,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp2_departure));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -1134,7 +1134,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1145,14 +1145,14 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr); // No departure because this is a terminus
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st2 == nullptr);
         // There are no trip leaving before
@@ -1160,9 +1160,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1173,9 +1173,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1231,9 +1231,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1244,9 +1244,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, sp1_departure));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1257,9 +1257,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1269,21 +1269,21 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival - 101);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st2 == nullptr);
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure - 101);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, 0));
         BOOST_CHECK(st1 != nullptr);
     }
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1293,7 +1293,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_departure);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(2, 0));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->arrival_time, sp2_arrival);
@@ -1303,7 +1303,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp2_arrival + 1);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp2_arrival));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->arrival_time, sp2_arrival);
@@ -1315,9 +1315,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
         //The day 0 is unactive
         DateTime dt_test = DateTimeUtils::set(0, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1326,9 +1326,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1337,9 +1337,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1350,9 +1350,9 @@ BOOST_AUTO_TEST_CASE(passe_minuit_3_vp) {
     {
         DateTime dt_test = DateTimeUtils::set(1, sp3_arrival + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(1, sp3_arrival));
         BOOST_CHECK(st1 == nullptr);
@@ -1422,9 +1422,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1434,9 +1434,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1446,9 +1446,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time + headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1458,9 +1458,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time - (headway_sec) + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1470,9 +1470,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1482,9 +1482,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1497,9 +1497,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour2 = start_time + (sp2_arrival - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, hour2));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1512,9 +1512,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = start_time + (sp2_departure - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, departure_hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1526,9 +1526,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = start_time + (sp2_departure - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, departure_hour + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour + headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1540,9 +1540,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = 7050;
         DateTime dt_test = DateTimeUtils::set(0, arrival_hour - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour - headway_sec));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1554,9 +1554,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = 7050;
         DateTime dt_test = DateTimeUtils::set(0, arrival_hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1568,9 +1568,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t departure_hour = 7050;
         DateTime dt_test = DateTimeUtils::set(0, arrival_hour + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, departure_hour));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, arrival_hour));
         BOOST_REQUIRE(st1 != nullptr);
@@ -1582,9 +1582,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour = start_time + (sp3_arrival - sp2_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour - 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1594,9 +1594,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour = start_time + (sp3_arrival - sp2_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_CHECK(st1 == nullptr);
@@ -1606,9 +1606,9 @@ BOOST_AUTO_TEST_CASE(freq_base) {
         uint32_t hour = start_time + (sp3_arrival - sp1_departure);
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp3), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, hour));
         BOOST_CHECK(st1 == nullptr);
@@ -1650,9 +1650,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         uint32_t hour = start_time - 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1664,9 +1664,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         uint32_t hour = start_time;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1677,9 +1677,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
         uint32_t hour = start_time + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time + headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1690,9 +1690,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, last_time - headway_sec - 10);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time - headway_sec));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1703,9 +1703,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(1, 0);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::inf);
         BOOST_REQUIRE(st1 != nullptr);
@@ -1717,9 +1717,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, end_time + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time + sp2_arrival - sp1_departure));
         BOOST_CHECK(st1 == nullptr);
@@ -1730,9 +1730,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, start_time + sp2_arrival - sp1_departure + 1);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time + sp2_arrival - sp1_departure));
         BOOST_CHECK(st1 == nullptr);
@@ -1743,9 +1743,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(0, last_time - headway_sec - 10);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time - 2 * headway_sec + sp2_arrival - sp1_departure ));
         BOOST_CHECK(st1 == nullptr);
@@ -1756,9 +1756,9 @@ BOOST_AUTO_TEST_CASE(freq_pam) {
     {
         DateTime dt_test = DateTimeUtils::set(1, 0);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::inf);
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_CHECK(st1 == nullptr);
@@ -1807,7 +1807,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 - 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1817,7 +1817,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1827,7 +1827,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 + 1 ;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time1 + headway_sec));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1837,7 +1837,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, end_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1847,7 +1847,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time1 + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1857,7 +1857,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1868,7 +1868,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2 + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, start_time2 + headway_sec));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1878,7 +1878,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86100;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1888,7 +1888,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86400;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1898,7 +1898,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 100;
         DateTime dt_test = DateTimeUtils::set(1, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, 100));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1908,7 +1908,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = last_time2;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(0, last_time2));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1918,7 +1918,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time2;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st1, dt1) = next_st.earliest_stop_time(StopEvent::pick_up, JppIdx(*jpp1), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt1, DateTimeUtils::set(1, start_time1));
         BOOST_REQUIRE(st1 != nullptr);
         BOOST_CHECK_EQUAL(st1->journey_pattern_point->stop_point->stop_area->name, spa1);
@@ -1929,7 +1929,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time2 + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time2 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1939,7 +1939,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 + sp2_arrival - sp1_departure;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time1 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1949,7 +1949,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time1 + sp2_arrival - sp1_departure + headway_sec + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time1 + headway_sec + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1959,7 +1959,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = last_time1 + sp2_arrival - sp1_departure;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time1 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1969,7 +1969,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = end_time1 + sp2_arrival - sp1_departure + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, last_time1 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1979,7 +1979,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2 + sp2_arrival - sp1_departure;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time2 + sp2_arrival - sp1_departure));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1989,7 +1989,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = start_time2 + sp2_arrival - sp1_departure + headway_sec + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, DateTimeUtils::set(0, start_time2 + sp2_arrival - sp1_departure + headway_sec));
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -1999,7 +1999,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86100;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2009,7 +2009,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86400;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, 86100);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2019,7 +2019,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = 86610;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, 86600);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2029,7 +2029,7 @@ BOOST_AUTO_TEST_CASE(freq_base_pam) {
         uint32_t hour = last_time2 + sp2_arrival - sp1_departure + 1;
         DateTime dt_test = DateTimeUtils::set(0, hour);
         std::tie(st2, dt2) = next_st.tardiest_stop_time(StopEvent::drop_off, JppIdx(*jpp2), dt_test,
-                                                        nt::RTLevel::Theoric, nt::VehicleProperties());
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
         BOOST_CHECK_EQUAL(dt2, last_time2 + sp2_arrival - sp1_departure);
         BOOST_REQUIRE(st2 != nullptr);
         BOOST_CHECK_EQUAL(st2->journey_pattern_point->stop_point->stop_area->name, spa2);
@@ -2047,7 +2047,7 @@ struct classic_freq_dataset {
     classic_freq_dataset() {
         vp = type::ValidityPattern(date(2012,7,7), "11");
 
-        vj.validity_patterns[type::RTLevel::Theoric] = &vp;
+        vj.validity_patterns[type::RTLevel::Base] = &vp;
         vj.start_time = 10 * 60 * 60;
         vj.end_time = 15 * 60 * 60;
         vj.headway_secs = 20 * 60;
@@ -2100,7 +2100,7 @@ struct midnight_freq_dataset {
     midnight_freq_dataset() {
         vp = type::ValidityPattern(date(2012,7,7), "11");
 
-        vj.validity_patterns[type::RTLevel::Theoric] = &vp;
+        vj.validity_patterns[type::RTLevel::Base] = &vp;
         vj.start_time = 17 * 60 * 60;
         vj.end_time = 10 * 60 * 60;
         vj.headway_secs = 20 * 60;
@@ -2146,7 +2146,7 @@ struct midnight_freq_dataset_no_valid_first_day {
     midnight_freq_dataset_no_valid_first_day() {
         vp = type::ValidityPattern(date(2012,7,7), "10");
 
-        vj.validity_patterns[type::RTLevel::Theoric] = &vp;
+        vj.validity_patterns[type::RTLevel::Base] = &vp;
         vj.start_time = 17 * 60 * 60;
         vj.end_time = 10 * 60 * 60;
         vj.headway_secs = 20 * 60;

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(direct){
     b.data->build_raptor();
     RAPTOR raptor(*b.data);
 
-    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(res.items[0].arrivals[1], "20120614T021500"_dt);
     BOOST_CHECK_EQUAL(res.items[0].departures[1], "20120614T021550"_dt);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8200), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8101), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8101), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::set(0, 8100), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(change){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0,8500), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8401), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8401), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 /****
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["A"], d.stop_areas_map["D"], 7*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items.back().arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::hour(to_datetime(res.items.back().arrival, *(b.data))), 7*3600 + 15*60);
 
-    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["D"], d.stop_areas_map["A"], 7*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 20*60), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 5000), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -356,7 +356,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60 + 1), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 20*60), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 3600), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -411,7 +411,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60 + 1), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60 + 1), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 0, DateTimeUtils::set(1, 40*60), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -439,30 +439,30 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9201), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9201), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -497,7 +497,7 @@ BOOST_AUTO_TEST_CASE(forbidden_uri){
     RAPTOR raptor(*b.data);
 
     auto res1 = raptor.compute(b.data->pt_data->stop_areas[0],
-            b.data->pt_data->stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric,
+            b.data->pt_data->stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base,
             true, {}, std::numeric_limits<uint32_t>::max(), {"stop2"});
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
@@ -522,7 +522,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,10000), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9201), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9201), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -546,7 +546,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0,9200), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -568,7 +568,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , (3*3600+20)), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20+1), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20+1), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam){
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 2*3600+20);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(1 , 2*3600+20), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -617,7 +617,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
@@ -642,7 +642,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }));
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, (9*3600+45*60)), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -665,7 +665,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
                 p.items[4].arrival.time_of_day().total_seconds() == 8*3600+45*60;
     }
     ));
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60+1), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60+1), type::RTLevel::Base, true);
 
     // As the bound is tight, we now only have the shortest trip.
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
@@ -691,7 +691,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
 
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8*3600 + 15*60, 0, DateTimeUtils::set(0, 8*3600+45*60), type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(pam_veille) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -731,7 +731,7 @@ BOOST_AUTO_TEST_CASE(pam_3) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE(sn_debut) {
     b.data->build_uri();
     RAPTOR raptor(*(b.data));
 
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Theoric);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 9*3600 + 20 * 60);
 }
@@ -771,7 +771,7 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type, ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
@@ -789,7 +789,7 @@ BOOST_AUTO_TEST_CASE(stay_in_short) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type, ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
@@ -814,7 +814,7 @@ BOOST_AUTO_TEST_CASE(stay_in_nl) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 60780, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 60780, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type, ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 63180);
@@ -839,7 +839,7 @@ BOOST_AUTO_TEST_CASE(stay_in_nl_counterclock) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 63200, 0, DateTimeUtils::inf, type::RTLevel::Theoric);
+    auto res1 = raptor.compute(d.stop_areas_map["bet"], d.stop_areas_map["rs"], 63200, 0, DateTimeUtils::inf, type::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type,  ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 63180);
@@ -858,7 +858,7 @@ BOOST_AUTO_TEST_CASE(stay_in_teleport) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items[1].type,  ItemType::stay_in);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
@@ -877,7 +877,7 @@ BOOST_AUTO_TEST_CASE(stay_in_departure_last_of_first_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(stay_in_complex) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 11*3600+10*60);
 }
@@ -924,7 +924,7 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
                     return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 15*60;}));
@@ -947,7 +947,7 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
 }
@@ -967,7 +967,7 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -984,7 +984,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -1023,12 +1023,12 @@ BOOST_AUTO_TEST_CASE(itl) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 10*3600);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].arrival.time_of_day().total_seconds(), 8*3600+20*60);
 }
@@ -1047,14 +1047,14 @@ BOOST_AUTO_TEST_CASE(mdi) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop4"],d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop4"],d.stop_areas_map["stop5"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
 
@@ -1081,7 +1081,7 @@ BOOST_AUTO_TEST_CASE(multiples_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
@@ -1098,13 +1098,13 @@ BOOST_AUTO_TEST_CASE(max_duration){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8101), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8101), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8099), type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::set(0, 8099), type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -1126,7 +1126,7 @@ BOOST_AUTO_TEST_CASE(max_transfers){
 
     for(uint32_t nb_transfers=0; nb_transfers<=2; ++nb_transfers) {
         //        type::Properties p;
-        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, nt::RTLevel::Theoric, true, type::AccessibiliteParams(), nb_transfers);
+        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, nt::RTLevel::Base, true, type::AccessibiliteParams(), nb_transfers);
         BOOST_REQUIRE(res1.size()>=1);
         for(auto r : res1) {
             BOOST_REQUIRE(r.nb_changes <= nb_transfers);
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE(destination_over_writing) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_special) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -1210,11 +1210,11 @@ BOOST_AUTO_TEST_CASE(invalid_stay_in_overmidnight) {
 
     // Here we want to check if the second vehicle_journey is not taken on the
     // first day
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
     
     // There must be a journey the second day
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 1, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 1, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
 
@@ -1253,7 +1253,7 @@ BOOST_AUTO_TEST_CASE(no_departure_before_given_date) {
     departures[SpIdx(*b.sps["stop1"])] = 1500_s;
     arrivals[SpIdx(*b.sps["stop5"])] = 0_s;
 
-    auto results = raptor.compute_all(departures, arrivals, 6000, type::RTLevel::Theoric);
+    auto results = raptor.compute_all(departures, arrivals, 6000, type::RTLevel::Base);
 
     BOOST_CHECK_EQUAL(results.size(), 2);
     for (const auto& res: results) {
@@ -1293,7 +1293,7 @@ BOOST_AUTO_TEST_CASE(less_fallback) {
     destinations[SpIdx(*d.stop_areas_map["stop1"]->stop_point_list.front())] = 560_s;
     destinations[SpIdx(*d.stop_areas_map["stop2"]->stop_point_list.front())] = 320_s;
     destinations[SpIdx(*d.stop_areas_map["stop3"]->stop_point_list.front())] = 0_s;
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Theoric);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -1346,7 +1346,7 @@ BOOST_AUTO_TEST_CASE(pareto_front) {
     // We are going to J point, so we add the walking times
     destinations[SpIdx(*d.stop_areas_map["stop2"]->stop_point_list.front())] = 15_min;
     destinations[SpIdx(*d.stop_areas_map["stop3"]->stop_point_list.front())] = 0_s;
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Theoric);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 8*3600), type::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(),
@@ -1371,7 +1371,7 @@ BOOST_AUTO_TEST_CASE(overlapping_on_first_st) {
     b.finish();
     b.data->build_raptor();
     RAPTOR raptor(*b.data);
-    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -1397,7 +1397,7 @@ BOOST_AUTO_TEST_CASE(stay_in_unnecessary) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_REQUIRE_EQUAL(res1.back().items.size(), 1);
 }
@@ -1417,7 +1417,7 @@ BOOST_AUTO_TEST_CASE(stay_in_unnecessary2) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items.size(), 3);
 }
@@ -1442,7 +1442,7 @@ BOOST_AUTO_TEST_CASE(forbid_transfer_between_2_odt){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -1462,7 +1462,7 @@ BOOST_AUTO_TEST_CASE(simple_odt){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     const auto& journey = res1.front();
     BOOST_REQUIRE_EQUAL(journey.items.size(), 1);
@@ -1488,7 +1488,7 @@ BOOST_AUTO_TEST_CASE(simple_odt_virtual_with_stop_time){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     const auto& journey = res1.front();
     BOOST_REQUIRE_EQUAL(journey.items.size(), 1);
@@ -1533,9 +1533,9 @@ BOOST_AUTO_TEST_CASE(y_line_the_ultimate_political_blocking_bug){
     RAPTOR raptor(*(b.data));
     const type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     check_y_line_the_ultimate_political_blocking_bug(res1);
-    auto res2 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 9000, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res2 = raptor.compute(d.stop_areas_map.at("stop1"), d.stop_areas_map.at("stop4"), 9000, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     check_y_line_the_ultimate_political_blocking_bug(res2);
 }
 
@@ -1566,7 +1566,7 @@ BOOST_AUTO_TEST_CASE(finish_on_service_extension) {
     routing::map_stop_point_duration departs;
     departs[routing::SpIdx(*d.stop_points_map["A"])] = {};
 
-    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), nt::RTLevel::Theoric, DateTimeUtils::inf,
+    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), nt::RTLevel::Base, DateTimeUtils::inf,
                              std::numeric_limits<uint32_t>::max(), {}, {}, true);
 
     //and raptor has to stop on count 2
@@ -1602,7 +1602,7 @@ BOOST_AUTO_TEST_CASE(finish_on_foot_path) {
     routing::map_stop_point_duration departs;
     departs[routing::SpIdx(*d.stop_points_map["A"])] = {};
 
-    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), type::RTLevel::Theoric, DateTimeUtils::inf,
+    raptor.first_raptor_loop(departs, DateTimeUtils::set(0, 7900), type::RTLevel::Base, DateTimeUtils::inf,
                              std::numeric_limits<uint32_t>::max(), {}, {}, true);
 
     //and raptor has to stop on count 2
@@ -1665,11 +1665,11 @@ BOOST_AUTO_TEST_CASE(test_2nd_and_3rd_pass) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                               7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+                               7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     test_2nd_and_3rd_pass_checks(res1);
 
     // non clockwise test
-    auto res2 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 16100, 0, 0, type::RTLevel::Theoric, false);
+    auto res2 = raptor.compute(d.stop_areas[0], d.stop_areas[3], 16100, 0, 0, type::RTLevel::Base, false);
     test_2nd_and_3rd_pass_checks(res2);
 }
 
@@ -1739,12 +1739,12 @@ BOOST_AUTO_TEST_CASE(test_2nd_and_3rd_pass_ext) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                               7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+                               7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     test_2nd_and_3rd_pass_ext_checks(res1);
 
     // non clockwise test
     auto res2 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                               16100, 0, 0, type::RTLevel::Theoric, false);
+                               16100, 0, 0, type::RTLevel::Base, false);
     test_2nd_and_3rd_pass_ext_checks(res2);
 }
 
@@ -1767,7 +1767,7 @@ BOOST_AUTO_TEST_CASE(direct_and_1trans_at_same_dt) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("C"),
-                              7900, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+                              7900, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     const auto& direct = res[0].items.size() == 1 ? res[0] : res[1];
@@ -1817,7 +1817,7 @@ BOOST_AUTO_TEST_CASE(dont_return_dominated_solutions) {
     departures[SpIdx(*d.stop_areas_map.at("A")->stop_point_list.front())] = 1000_s;
     departures[SpIdx(*d.stop_areas_map.at("D")->stop_point_list.front())] = 3000_s;
     arrivals[SpIdx(*d.stop_areas_map.at("C")->stop_point_list.front())] = 0_s;
-    auto res = raptor.compute_all(departures, arrivals, 1000, type::RTLevel::Theoric);
+    auto res = raptor.compute_all(departures, arrivals, 1000, type::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     const auto& direct = res[0].items.size() == 1 ? res[0] : res[1];
@@ -1875,7 +1875,7 @@ BOOST_AUTO_TEST_CASE(second_pass) {
     arrivals[SpIdx(*d.stop_areas_map.at("GM1")->stop_point_list.front())] = 0_s;
     arrivals[SpIdx(*d.stop_areas_map.at("GM2")->stop_point_list.front())] = 0_s;
 
-    auto res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:30"_t), type::RTLevel::Theoric,
+    auto res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:30"_t), type::RTLevel::Base,
                                   DateTimeUtils::inf, 10, {}, {}, true);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -1928,12 +1928,12 @@ BOOST_AUTO_TEST_CASE(good_connection_when_walking_as_fast_as_bus) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                               "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true);
+                               "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true);
     test_good_connection_when_walking_as_fast_as_bus(res1);
 
     // non clockwise test
     auto res2 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                               "12:00"_t, 0, 0, type::RTLevel::Theoric, false);
+                               "12:00"_t, 0, 0, type::RTLevel::Base, false);
     test_good_connection_when_walking_as_fast_as_bus(res2);
 }
 
@@ -1962,13 +1962,13 @@ BOOST_AUTO_TEST_CASE(accessible_on_first_sp) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("B"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, params);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items.back().arrival, time_from_string("2015-01-01 10:00:00"));
 
     // non clockwise test
     res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("B"),
-                         "10:00"_t, 0, 0, type::RTLevel::Theoric, false, params);
+                         "10:00"_t, 0, 0, type::RTLevel::Base, false, params);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items.back().arrival, time_from_string("2015-01-01 10:00:00"));
 }
@@ -1997,7 +1997,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  type::RTLevel::Theoric,
+                                  type::RTLevel::Base,
                                   DateTimeUtils::inf,
                                   10,
                                   {},
@@ -2009,7 +2009,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     res = raptor.compute_all(departures,
                              arrivals,
                              DateTimeUtils::set(2, "08:00"_t),
-                             type::RTLevel::Theoric,
+                             type::RTLevel::Base,
                              DateTimeUtils::inf,
                              10,
                              {},
@@ -2022,7 +2022,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     res = raptor.compute_all(departures,
                              arrivals,
                              DateTimeUtils::set(2, "08:03"_t),
-                             type::RTLevel::Theoric,
+                             type::RTLevel::Base,
                              0,
                              10,
                              {},
@@ -2034,7 +2034,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     res = raptor.compute_all(departures,
                              arrivals,
                              DateTimeUtils::set(2, "08:03"_t),
-                             type::RTLevel::Theoric,
+                             type::RTLevel::Base,
                              0,
                              10,
                              {},
@@ -2073,7 +2073,7 @@ BOOST_AUTO_TEST_CASE(no_iti_from_to_same_sa) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "07:50"_t),
-                                  type::RTLevel::Theoric,
+                                  type::RTLevel::Base,
                                   0,
                                   10,
                                   {},
@@ -2116,7 +2116,7 @@ BOOST_AUTO_TEST_CASE(no_going_backward) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(0, "08:30"_t),
-                                  type::RTLevel::Theoric,
+                                  type::RTLevel::Base,
                                   0,
                                   10,
                                   {},
@@ -2159,7 +2159,7 @@ BOOST_AUTO_TEST_CASE(walking_doesnt_break_connection) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(0, "08:00"_t),
-                                  type::RTLevel::Theoric);
+                                  type::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_REQUIRE_EQUAL(res[0].items.size(), 3);
     using boost::posix_time::time_from_string;
@@ -2210,7 +2210,7 @@ BOOST_AUTO_TEST_CASE(accessibility_drop_off_forbidden) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2273,7 +2273,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx_no_solution) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 0);
 }
@@ -2321,7 +2321,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2379,7 +2379,7 @@ BOOST_AUTO_TEST_CASE(forbidden_uri_cnx) {
     const std::vector<std::string> forbid = {"B1"};
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, type::AccessibiliteParams(),
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, type::AccessibiliteParams(),
                               10, forbid);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -2439,7 +2439,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx_2) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("D"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2507,7 +2507,7 @@ BOOST_AUTO_TEST_CASE(accessibility_on_departure_cnx_3) {
     const type::PT_Data& d = *b.data->pt_data;
 
     auto res = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("Arr"),
-                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Theoric, true, params);
+                              "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, true, params);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
@@ -2552,7 +2552,7 @@ BOOST_AUTO_TEST_CASE(begin_different_zone1) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  type::RTLevel::Theoric);
+                                  type::RTLevel::Base);
     BOOST_CHECK_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
     BOOST_CHECK_EQUAL(res.at(0).items.front().departure, time_from_string("2015-01-03 08:00:00"));
@@ -2583,7 +2583,7 @@ BOOST_AUTO_TEST_CASE(begin_different_zone2) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  type::RTLevel::Theoric);
+                                  type::RTLevel::Base);
     BOOST_CHECK_EQUAL(res.size(), 1);
     using boost::posix_time::time_from_string;
     BOOST_CHECK_EQUAL(res.at(0).items.front().departure, time_from_string("2015-01-03 08:10:00"));
@@ -2616,7 +2616,7 @@ BOOST_AUTO_TEST_CASE(begin_different_zone3) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "08:00"_t),
-                                  type::RTLevel::Theoric);
+                                  type::RTLevel::Base);
 
     // We should find this solution, but...
     /*

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -50,7 +50,7 @@ BOOST_AUTO_TEST_CASE(direct){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0,8050-1000), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0,8050-1000), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(direct){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(change){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1000), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1000), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(change){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1000), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1000), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600 - 1000), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600 - 1000), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22*3600, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -320,7 +320,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"],  50*60, 1, DateTimeUtils::set(0, 23*3600 - 1000), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"],  50*60, 1, DateTimeUtils::set(0, 23*3600 - 1000), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600-1), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -344,7 +344,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50*60, 1, DateTimeUtils::set(0, 23*3600), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit4){
     type::PT_Data & d = *b.data->pt_data;
 
     auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"],
-            24*3600+15*60, 3, DateTimeUtils::min, nt::RTLevel::Theoric, false);
+            24*3600+15*60, 3, DateTimeUtils::min, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7000, 1, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7000, 1, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res.size(), 0);
 }
 
@@ -405,7 +405,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050 - 1000), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050 - 1000), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050-1), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu){
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050), type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(sn_fin) {
     RAPTOR raptor(*(b.data));
 
 
-    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 9*3600 + 20 * 60), nt::RTLevel::Theoric);
+    auto res1 = raptor.compute_all(departs, destinations, DateTimeUtils::set(0, 9*3600 + 20 * 60), nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].departure.time_of_day().total_seconds(), 8*3600);
@@ -467,7 +467,7 @@ BOOST_AUTO_TEST_CASE(stay_in_basic) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE(stay_in_and_one_earlier_with_connection) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 2);
     BOOST_CHECK(std::any_of(res1.begin(), res1.end(), [](Path path){
                           return path.items[2].arrival.time_of_day().total_seconds() == 8*3600 + 25*60;}));
@@ -513,7 +513,7 @@ BOOST_AUTO_TEST_CASE(stay_in_3_vj) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 35*60, 0, DateTimeUtils::min, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[4].arrival.time_of_day().total_seconds(), 8*3600 + 30*60);
 }
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE(stay_in_loop) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600 + 25*60, 0, DateTimeUtils::min, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[2].arrival.time_of_day().total_seconds(), 8*3600 + 20*60);
 }
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(stay_in_invalid_vp) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, nt::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -566,12 +566,12 @@ BOOST_AUTO_TEST_CASE(itl) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9*3600+15*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9*3600+15*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600+20*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 8*3600+20*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
     BOOST_CHECK_EQUAL(res1.back().items[0].departure.time_of_day().total_seconds(), 8*3600+10*60);
 
@@ -590,14 +590,14 @@ BOOST_AUTO_TEST_CASE(mdi) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop6"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_CHECK_EQUAL(res1.size(), 0);
-    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop5"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop4"], d.stop_areas_map["stop5"], 17*3600+30*60, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_CHECK_EQUAL(res1.size(), 1);
 }
 
@@ -611,13 +611,13 @@ BOOST_AUTO_TEST_CASE(max_duration){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::min, type::RTLevel::Theoric, false);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::min, type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8049), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8049), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8051), type::RTLevel::Theoric, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8200, 0, DateTimeUtils::set(0, 8051), type::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -636,7 +636,7 @@ BOOST_AUTO_TEST_CASE(max_transfers){
     type::PT_Data & d = *b.data->pt_data;
 
     for(uint32_t nb_transfers=0; nb_transfers<=2;++nb_transfers) {
-        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 86400, 0, DateTimeUtils::inf, nt::RTLevel::Theoric, true, type::AccessibiliteParams(), nb_transfers);
+        auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 86400, 0, DateTimeUtils::inf, nt::RTLevel::Base, true, type::AccessibiliteParams(), nb_transfers);
         BOOST_REQUIRE(res1.size()>=1);
         for(auto r : res1) {
             BOOST_REQUIRE(r.nb_changes <= nb_transfers);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(simple_journey) {
 
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
-                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             true, navitia::type::AccessibiliteParams()/*false*/, forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                              {ntest::to_posix_timestamp("20120614T021000")},
                                              true, navitia::type::AccessibiliteParams()/*false*/,
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     resp = make_response(raptor, origin, destination,
                          {ntest::to_posix_timestamp("20120614T021000")},
                          true, navitia::type::AccessibiliteParams()/*false*/,
-                         forbidden, sn_worker, nt::RTLevel::Theoric);
+                         forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(journey_stay_in) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                             {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(journey_stay_in_teleport) {
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE(journey_stay_in_shortteleport) {
     ng::StreetNetwork sn_worker(*data.geo_ref);
     pbnavitia::Response resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(journey_departure_from_a_stay_in) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                             {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE(journey_arrival_before_a_stay_in) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                              {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -583,7 +583,7 @@ BOOST_AUTO_TEST_CASE(journey_arrival_in_a_stay_in) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                             {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     dump_response(resp, "arrival_before");
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
@@ -650,7 +650,7 @@ BOOST_AUTO_TEST_CASE(journey_arrival_before_a_stay_in_without_teleport) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                              {ntest::to_posix_timestamp("20120614T165300")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -697,7 +697,7 @@ BOOST_AUTO_TEST_CASE(journey_stay_in_shortteleport_counterclockwise) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                             {ntest::to_posix_timestamp("20120614T174000")}, false,
                                              navitia::type::AccessibiliteParams(), forbidden,
-                                             sn_worker, nt::RTLevel::Theoric);
+                                             sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
@@ -757,7 +757,7 @@ BOOST_AUTO_TEST_CASE(journey_array){
     std::vector<uint64_t> datetimes({ntest::to_posix_timestamp("20120614T080000"), ntest::to_posix_timestamp("20120614T090000")});
     pbnavitia::Response resp = nr::make_response(raptor, origin, destination, datetimes, true,
                                                  navitia::type::AccessibiliteParams(),
-                                                 forbidden, sn_worker, nt::RTLevel::Theoric);
+                                                 forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2);
@@ -794,7 +794,7 @@ struct streetnetworkmode_fixture : public routing_api_data<speed_provider_trait>
         nr::RAPTOR raptor(*this->b.data);
         return nr::make_response(raptor, this->origin, this->destination, this->datetimes,
                                  true, navitia::type::AccessibiliteParams(),
-                                 this->forbidden, sn_worker, nt::RTLevel::Theoric);
+                                 this->forbidden, sn_worker, nt::RTLevel::Base);
     }
 };
 
@@ -1296,7 +1296,7 @@ BOOST_FIXTURE_TEST_CASE(bus_car_parking, streetnetworkmode_fixture<test_speed_pr
 
     ng::StreetNetwork sn_worker(*this->b.data->geo_ref);
     nr::RAPTOR raptor(*this->b.data);
-    auto resp = nr::make_response(raptor, this->destination, this->origin, this->datetimes, true, navitia::type::AccessibiliteParams(), this->forbidden, sn_worker, nt::RTLevel::Theoric);
+    auto resp = nr::make_response(raptor, this->destination, this->origin, this->datetimes, true, navitia::type::AccessibiliteParams(), this->forbidden, sn_worker, nt::RTLevel::Base);
 
     dump_response(resp, "bus_car_parking");
 
@@ -1650,7 +1650,7 @@ BOOST_AUTO_TEST_CASE(projection_on_one_way) {
     nr::RAPTOR raptor(*b.data);
     auto resp = nr::make_response(raptor, origin, destination,
                                   {navitia::test::to_posix_timestamp("20120614T080000")},
-                                  true, navitia::type::AccessibiliteParams(), {}, sn_worker, nt::RTLevel::Theoric, true);
+                                  true, navitia::type::AccessibiliteParams(), {}, sn_worker, nt::RTLevel::Base, true);
 
 
     dump_response(resp, "biking length test");
@@ -1772,7 +1772,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
                                      {},
                                      {},
                                      sn_worker,
-                                     nt::RTLevel::Theoric,
+                                     nt::RTLevel::Base,
                                      3 * 60 * 60);
 
     BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
@@ -1806,7 +1806,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
                                      {},
                                      {},
                                      sn_worker,
-                                     nt::RTLevel::Theoric,
+                                     nt::RTLevel::Base,
                                      3 * 60 * 60);
 
     BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
@@ -1833,7 +1833,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone_duration_limit, isochrone_fixture) {
                                      {},
                                      {},
                                      sn_worker,
-                                     nt::RTLevel::Theoric,
+                                     nt::RTLevel::Base,
                                      1 * 60 * 60);
 
     BOOST_REQUIRE_EQUAL(result.journeys_size(), 1);
@@ -1934,7 +1934,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                              {ntest::to_posix_timestamp("20150315T080000")},
                                              true, nt::AccessibiliteParams(),
-                                             {}, sn_worker, nt::RTLevel::Theoric);
+                                             {}, sn_worker, nt::RTLevel::Base);
 
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
@@ -2037,7 +2037,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                             {ntest::to_posix_timestamp("20150314T080000")},
                                             true, navitia::type::AccessibiliteParams(),
-                                            {}, sn_worker, nt::RTLevel::Theoric);
+                                            {}, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
 
@@ -2070,7 +2070,7 @@ BOOST_AUTO_TEST_CASE(journey_with_forbidden) {
     pbnavitia::Response resp = make_response(raptor, origin, destination,
                                                 {ntest::to_posix_timestamp("20120614T021000")},
                                              true, navitia::type::AccessibiliteParams(),
-                                             forbidden, sn_worker, nt::RTLevel::Theoric);
+                                             forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);
@@ -2079,7 +2079,7 @@ BOOST_AUTO_TEST_CASE(journey_with_forbidden) {
     forbidden.push_back("A");
     resp = make_response(raptor, origin, destination, {ntest::to_posix_timestamp("20120614T021000")},
                          true, navitia::type::AccessibiliteParams(),
-                         forbidden, sn_worker, nt::RTLevel::Theoric);
+                         forbidden, sn_worker, nt::RTLevel::Base);
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -406,7 +406,7 @@ struct routing_api_data {
         b.sa("stopB", B.lon(), B.lat());
         if (activate_pt) {
             //we add a very fast bus (2 seconds) to be faster than walking and biking
-            b.vj("A")("stop_point:stopB", "08:01"_t)("stop_point:stopA", "08:01:02"_t)
+            b.vj("A", "111111", "", true, "vjA")("stop_point:stopB", "08:01"_t)("stop_point:stopA", "08:01:02"_t)
                 .st_shape({B, I, A});
             b.lines["A"]->code = "1A";
             b.data->pt_data->headsign_handler.affect_headsign_to_stop_time(

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -114,7 +114,7 @@ struct data_set {
         b.data->build_uri();
 
         navitia::type::VehicleJourney* vj = b.data->pt_data->vehicle_journeys_map["vj1"];
-        vj->theoric_validity_pattern()->add(boost::gregorian::from_undelimited_string("20140101"),
+        vj->base_validity_pattern()->add(boost::gregorian::from_undelimited_string("20140101"),
                                   boost::gregorian::from_undelimited_string("20140111"), monday_cal->week_pattern);
 
         //we add some comments

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -154,7 +154,7 @@ get_all_stop_times(const type::JourneyPatternPoint* jpp,
             continue;
         }
         //we can get only the first theoric one, because BY CONSTRUCTION all theoric vj have the same local times
-        vjs.push_back(meta_vj->theoric_vj.front());
+        vjs.push_back(meta_vj->base_vj.front());
     }
     if (vjs.empty()) {
         return {};

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -58,15 +58,15 @@ struct calendar_fixture {
         vj->stop_time_list[0].set_date_time_estimated(true);
 
         vj_week = b.data->pt_data->vehicle_journeys_map["week"];
-        vj_week->theoric_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"1111100"});
+        vj_week->base_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"1111100"});
         vj_week_bis = b.data->pt_data->vehicle_journeys_map["week_bis"];
-        vj_week_bis->theoric_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"1111100"});
+        vj_week_bis->base_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"1111100"});
         vj_weekend = b.data->pt_data->vehicle_journeys_map["weekend"];
-        vj_weekend->theoric_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"0000011"});
+        vj_weekend->base_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"0000011"});
         vj_all = b.data->pt_data->vehicle_journeys_map["all"];
-        vj_all->theoric_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"1111111"});
+        vj_all->base_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"1111111"});
         vj_wednesday = b.data->pt_data->vehicle_journeys_map["wednesday"];
-        vj_wednesday->theoric_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"0010000"});
+        vj_wednesday->base_validity_pattern()->add(beg, end_of_year, std::bitset<7>{"0010000"});
 
         //we now add 2 similar calendars
         auto week_cal = new navitia::type::Calendar(b.data->meta->production_date.begin());

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -76,13 +76,13 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
 
     b.data->meta->production_date = boost::gregorian::date_period(begin, end);
     // normal departure board
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(),1);
 
     // no departure for route "A"
-    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(),1);
 
     // no departure for all routes
-    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 
     // no departure for route "B"
-    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 
     // Terminus for route "A"
-    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
     BOOST_CHECK_EQUAL(resp.stop_schedules(0).response_status(), pbnavitia::ResponseStatus::terminus);
@@ -117,12 +117,12 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).date_times_size(), 1);
 
     // Terminus for route "B"
-    resp = departure_board("stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    resp = departure_board("stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "B");
     BOOST_CHECK_EQUAL(resp.stop_schedules(0).response_status(), pbnavitia::ResponseStatus::terminus);
 
-    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    resp = departure_board("stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
 }
 
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
 
     b.data->meta->production_date = boost::gregorian::date_period(begin, end);
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     pbnavitia::StopSchedule stop_schedule = resp.stop_schedules(0);
     BOOST_CHECK(stop_schedule.date_times_size() == 2);
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
     //when asked on non existent calendar, we get an error
     const boost::optional<const std::string> calendar_id{"bob_the_calendar"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     BOOST_REQUIRE(resp.has_error());
     BOOST_REQUIRE(! resp.error().message().empty());
@@ -202,7 +202,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
     const boost::optional<const std::string> calendar_id{"weekend_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     BOOST_REQUIRE(! resp.has_error());
     BOOST_CHECK_EQUAL(resp.stop_schedules_size(), 1);
@@ -225,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
     boost::optional<const std::string> calendar_id{"week_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     BOOST_REQUIRE(! resp.has_error());
     BOOST_CHECK_EQUAL(resp.stop_schedules_size(), 1);
@@ -249,7 +249,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
     boost::optional<const std::string> calendar_id{"not_associated_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     BOOST_REQUIRE(! resp.has_error());
     BOOST_CHECK_EQUAL(resp.stop_schedules_size(), 1);
@@ -299,7 +299,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
 
     boost::optional<const std::string> calendar_id{"nearly_cal"};
 
-    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+    pbnavitia::Response resp = departure_board("stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     //it should match only the 'all' vj
     BOOST_REQUIRE(! resp.has_error());
@@ -376,7 +376,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time, small_cal_fixture) {
 
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
                                                 86400, 0, std::numeric_limits<int>::max(),
-                                                1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+                                                1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     //we should get a nice schedule, first stop at 08:10, last at 07:10
     BOOST_REQUIRE(! resp.has_error());
@@ -403,7 +403,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_matched_cal, small_cal_fixture) {
 
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("empty_cal"), {}, d("20120615T080000"),
                                                 86400, 0, std::numeric_limits<int>::max(),
-                                                1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+                                                1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     BOOST_REQUIRE(! resp.has_error());
     //no error but no results
@@ -422,7 +422,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period, small_cal_fixture) {
     auto duration = nb_hour*60*60;
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
                                                duration, 0, std::numeric_limits<int>::max(),
-                                               1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+                                               1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     //we should get a nice schedule, first stop at 08:10, last at 13:10
     BOOST_REQUIRE(! resp.has_error());
@@ -452,7 +452,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period_before, small_cal_fixtur
     auto duration = nb_hour*60*60;
     pbnavitia::Response resp = departure_board("stop_point.uri=stop1", std::string("cal"), {}, d("20120615T200000"),
                                                duration, 0, std::numeric_limits<int>::max(),
-                                               1, 10, 0, *(b.data), nt::RTLevel::Theoric);
+                                               1, 10, 0, *(b.data), nt::RTLevel::Base);
 
     //we should get a nice schedule, first stop at 20:10, last at 04:10
     BOOST_REQUIRE(! resp.has_error());
@@ -476,7 +476,7 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
     navitia::routing::RAPTOR raptor(*(b.data));
     navitia::type::PT_Data& d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8*60*60, 0, navitia::DateTimeUtils::inf, nt::RTLevel::Theoric, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 8*60*60, 0, navitia::DateTimeUtils::inf, nt::RTLevel::Base, true);
 
     //we must have a journey
     BOOST_REQUIRE_EQUAL(res1.size(), 1);

--- a/source/time_tables/tests/get_stop_times_test.cpp
+++ b/source/time_tables/tests/get_stop_times_test.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(test1){
         jpps.push_back(jpp->idx);
 
     auto result = get_stop_times(StopEvent::pick_up, jpps, navitia::DateTimeUtils::min,
-                                 navitia::DateTimeUtils::set(1, 0), 100, *b.data, nt::RTLevel::Theoric);
+                                 navitia::DateTimeUtils::set(1, 0), 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
                             [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 0;}));
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(test1){
                             [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 1;}));
 
     result = get_stop_times(StopEvent::drop_off, jpps, navitia::DateTimeUtils::set(0, 86399),
-                            navitia::DateTimeUtils::min, 100, *b.data, nt::RTLevel::Theoric, {});
+                            navitia::DateTimeUtils::min, 100, *b.data, nt::RTLevel::Base, {});
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
                             [](timetables::datetime_stop_time& dt_st) {return dt_st.second->journey_pattern_point->idx == 1;}));
@@ -382,47 +382,47 @@ BOOST_AUTO_TEST_CASE(test_discrete_next_arrivals_prev_departures){
     const navitia::DateTime today_8h45 = navitia::DateTimeUtils::set(1, 8*3600 + 45*60);
     const navitia::DateTime tomorrow = navitia::DateTimeUtils::set(2, 0);
     auto result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop1"),
-                                               today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
+                                               today, tomorrow, 100, *b.data, nt::RTLevel::Base);
     BOOST_CHECK_EQUAL(result_next_arrivals.size(), 0);
     auto result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop1"),
-                                                 today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
+                                                 today, yesterday, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 1);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "8:01"_t);
 
     result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop2"),
-                                          today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
+                                          today, tomorrow, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_next_arrivals.size(), 1);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(0).first, "24:00"_t + "9:00"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop2"),
-                                            today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
+                                            today, yesterday, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 2);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "9:01"_t);
     BOOST_CHECK_EQUAL(result_prev_departures.at(1).first, "8:31"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop2"),
-                                            today_8h45, today, 100, *b.data, nt::RTLevel::Theoric);
+                                            today_8h45, today, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 1);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "24:00"_t + "8:31"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop2"),
-                                            today_8h45, yesterday_8h45, 100, *b.data, nt::RTLevel::Theoric);
+                                            today_8h45, yesterday_8h45, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 2);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "24:00"_t + "8:31"_t);
     BOOST_CHECK_EQUAL(result_prev_departures.at(1).first, "9:01"_t);
 
     result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop3"),
-                                          today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
+                                          today, tomorrow, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_next_arrivals.size(), 2);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(0).first, "24:00"_t + "09:30"_t);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(1).first, "24:00"_t + "10:00"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop3"),
-                                            today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
+                                            today, yesterday, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_prev_departures.size(), 1);
     BOOST_CHECK_EQUAL(result_prev_departures.at(0).first, "9:31"_t);
 
     result_next_arrivals = get_stop_times(StopEvent::drop_off, get_jpp_idx("stop4"),
-                                          today, tomorrow, 100, *b.data, nt::RTLevel::Theoric);
+                                          today, tomorrow, 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result_next_arrivals.size(), 1);
     BOOST_CHECK_EQUAL(result_next_arrivals.at(0).first, "24:00"_t + "10:30"_t);
     result_prev_departures = get_stop_times(StopEvent::pick_up, get_jpp_idx("stop4"),
-                                            today, yesterday, 100, *b.data, nt::RTLevel::Theoric);
+                                            today, yesterday, 100, *b.data, nt::RTLevel::Base);
     BOOST_CHECK_EQUAL(result_prev_departures.size(), 0);
 }

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -118,7 +118,7 @@ struct route_schedule_fixture {
 BOOST_FIXTURE_TEST_CASE(test1, route_schedule_fixture) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=A", {}, {}, d("20120615T070000"), 86400, 100,
-                                                                   3, 10, 0, *(b.data), nt::RTLevel::Theoric, false);
+                                                                   3, 10, 0, *(b.data), nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -131,7 +131,7 @@ BOOST_FIXTURE_TEST_CASE(test1, route_schedule_fixture) {
 
 BOOST_FIXTURE_TEST_CASE(test_max_nb_stop_times, route_schedule_fixture) {
     pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=A", {}, {}, d("20120615T070000"), 86400, 0,
-                                                                   3, 10, 0, *(b.data), nt::RTLevel::Theoric, false);
+                                                                   3, 10, 0, *(b.data), nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -211,7 +211,7 @@ struct route_schedule_calendar_fixture {
 
     void check_calendar_results(boost::optional<const std::string> calendar, std::vector<std::string> expected_vjs) {
         pbnavitia::Response resp = navitia::timetables::route_schedule("line.uri=B", calendar, {}, d("20120615T070000"), 86400, 100,
-                                                                       3, 10, 0, *(b.data), nt::RTLevel::Theoric, false);
+                                                                       3, 10, 0, *(b.data), nt::RTLevel::Base, false);
         BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
         pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
         print_route_schedule(route_schedule);
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_1) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule(
         "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
-        3, 10, 0, *b.data, nt::RTLevel::Theoric, false);
+        3, 10, 0, *b.data, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_2) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule(
         "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
-        3, 10, 0, *b.data, nt::RTLevel::Theoric, false);
+        3, 10, 0, *b.data, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_3) {
 
     pbnavitia::Response resp = navitia::timetables::route_schedule(
         "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
-        3, 10, 0, *b.data, nt::RTLevel::Theoric, false);
+        3, 10, 0, *b.data, nt::RTLevel::Base, false);
     BOOST_REQUIRE_EQUAL(resp.route_schedules().size(), 1);
     pbnavitia::RouteSchedule route_schedule = resp.route_schedules(0);
     print_route_schedule(route_schedule);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -339,7 +339,7 @@ void Data::complete(){
 static ValidityPattern get_union_validity_pattern(const MetaVehicleJourney* meta_vj) {
     ValidityPattern validity;
 
-    for (auto* vj: meta_vj->theoric_vj) {
+    for (auto* vj: meta_vj->base_vj) {
         if (validity.beginning_date.is_not_a_date()) {
             validity.beginning_date = vj->base_validity_pattern()->beginning_date;
         } else {
@@ -360,7 +360,7 @@ void Data::build_associated_calendar() {
     for(auto meta_vj_pair : this->pt_data->meta_vj) {
         auto meta_vj = meta_vj_pair.second;
 
-        assert (! meta_vj->theoric_vj.empty());
+        assert (! meta_vj->base_vj.empty());
 
         // we check the theoric vj of a meta vj
         // because we start from the postulate that the theoric VJs are the same VJ
@@ -369,7 +369,7 @@ void Data::build_associated_calendar() {
         ValidityPattern meta_vj_validity_pattern = get_union_validity_pattern(meta_vj);
 
         //some check can be done on any theoric vj, we do them on the first
-        auto* first_vj = meta_vj->theoric_vj.front();
+        auto* first_vj = meta_vj->base_vj.front();
         const std::vector<Calendar*> calendar_list = first_vj->journey_pattern->route->line->calendar_list;
         if (calendar_list.empty()) {
             LOG4CPLUS_TRACE(log, "the line of the vj " << first_vj->uri << " is associated to no calendar");

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -341,13 +341,13 @@ static ValidityPattern get_union_validity_pattern(const MetaVehicleJourney* meta
 
     for (auto* vj: meta_vj->theoric_vj) {
         if (validity.beginning_date.is_not_a_date()) {
-            validity.beginning_date = vj->theoric_validity_pattern()->beginning_date;
+            validity.beginning_date = vj->base_validity_pattern()->beginning_date;
         } else {
-            if (validity.beginning_date != vj->theoric_validity_pattern()->beginning_date) {
+            if (validity.beginning_date != vj->base_validity_pattern()->beginning_date) {
                 throw navitia::exception("the beginning date of the meta_vj are not all the same");
             }
         }
-        validity.days |= vj->theoric_validity_pattern()->days;
+        validity.days |= vj->base_validity_pattern()->days;
     }
     return validity;
 }

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -133,7 +133,7 @@ HeadsignHandler::get_vj_from_headsign(const std::string& headsign) const {
     }
 
     for (const MetaVehicleJourney* mvj: it_vj_set->second) {
-        for (const auto& vect_vj: {mvj->theoric_vj, mvj->adapted_vj, mvj->real_time_vj}) {
+        for (const auto& vect_vj: {mvj->base_vj, mvj->adapted_vj, mvj->real_time_vj}) {
             for (const VehicleJourney* vj: vect_vj) {
                 if (has_headsign_or_name(*vj, headsign)) {
                     res.push_back(vj);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -675,17 +675,17 @@ void fill_pb_object(const nt::VehicleJourney* vj,
         fill_pb_object(vj->journey_pattern->physical_mode, data,
                        vehicle_journey->mutable_journey_pattern()->mutable_physical_mode(), depth-1,
                        now, action_period);
-        fill_pb_object(vj->theoric_validity_pattern(), data,
+        fill_pb_object(vj->base_validity_pattern(), data,
                        vehicle_journey->mutable_validity_pattern(),
                        depth-1);
         fill_pb_object(vj->adapted_validity_pattern(), data,
                        vehicle_journey->mutable_adapted_validity_pattern(),
                        depth-1);
-        fill_pb_object(vj->theoric_validity_pattern(), data,
+        fill_pb_object(vj->base_validity_pattern(), data,
                        vehicle_journey->mutable_validity_pattern(), max_depth-1);
         fill_pb_object(vj->adapted_validity_pattern(), data,
                        vehicle_journey->mutable_adapted_validity_pattern(), max_depth-1);
-        vptranslator::fill_pb_object(vptranslator::translate(*vj->theoric_validity_pattern()),
+        vptranslator::fill_pb_object(vptranslator::translate(*vj->base_validity_pattern()),
                                      data,
                                      vehicle_journey,
                                      max_depth - 1,

--- a/source/type/rt_level.h
+++ b/source/type/rt_level.h
@@ -35,8 +35,8 @@ namespace navitia {
 
 namespace type {
 enum class RTLevel : char {
-    Theoric = 0,
-    Adapted,
+    Base = 0, // base schedule (theoretical, from the GTFS)
+    Adapted, // adapted schedule (planned maintenance, strike, ...)
     RealTime
 };
 }
@@ -52,8 +52,8 @@ struct enum_size_trait<type::RTLevel> {
 
 inline std::ostream& operator<<(std::ostream& ss, navitia::type::RTLevel l) {
     switch (l) {
-    case navitia::type::RTLevel::Theoric:
-        return ss << "Theoric";
+    case navitia::type::RTLevel::Base:
+        return ss << "Base";
     case navitia::type::RTLevel::Adapted:
         return ss << "Adapted";
     case navitia::type::RTLevel::RealTime:

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -619,7 +619,7 @@ std::vector<idx_t> VehicleJourney::get(Type_e type, const PT_Data &) const {
     case Type_e::JourneyPattern: result.push_back(journey_pattern->idx); break;
     case Type_e::Company: result.push_back(company->idx); break;
     case Type_e::PhysicalMode: result.push_back(journey_pattern->physical_mode->idx); break;
-    case Type_e::ValidityPattern: result.push_back(theoric_validity_pattern()->idx); break;
+    case Type_e::ValidityPattern: result.push_back(base_validity_pattern()->idx); break;
     default: break;
     }
     return result;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -720,14 +720,14 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties, HasMessage
     // thus we store the shit needed to convert all stop times of the vehicle journey to local
     int16_t utc_to_local_offset = 0; //in seconds
 
-    RTLevel realtime_level = RTLevel::Theoric;
+    RTLevel realtime_level = RTLevel::Base;
 
     // validity pattern for all RTLevel
     flat_enum_map<RTLevel, ValidityPattern*> validity_patterns = {{{nullptr, nullptr, nullptr}}};
 
     VehicleJourney* theoric_vehicle_journey = nullptr;
 
-    ValidityPattern* theoric_validity_pattern() const { return validity_patterns[RTLevel::Theoric]; }
+    ValidityPattern* base_validity_pattern() const { return validity_patterns[RTLevel::Base]; }
     ValidityPattern* adapted_validity_pattern() const { return validity_patterns[RTLevel::Adapted]; }
     ValidityPattern* rt_validity_pattern() const { return validity_patterns[RTLevel::RealTime]; }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -1034,7 +1034,7 @@ struct Calendar : public Nameable, public Header {
 struct MetaVehicleJourney {
     //store the name ?
     //TODO if needed use a flat_enum_map
-    std::vector<VehicleJourney*> theoric_vj;
+    std::vector<VehicleJourney*> base_vj;
     std::vector<VehicleJourney*> adapted_vj;
     std::vector<VehicleJourney*> real_time_vj;
 
@@ -1043,7 +1043,7 @@ struct MetaVehicleJourney {
     std::map<std::string, AssociatedCalendar*> associated_calendars;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-        ar & theoric_vj & adapted_vj & real_time_vj & associated_calendars;
+        ar & base_vj & adapted_vj & real_time_vj & associated_calendars;
     }
 };
 


### PR DESCRIPTION
handle realtime message to cancel a train (VehicleJourney)

To query on realtime data a new `journeys` parameter has been added:
`data_freshess` (the name can be discussed) that can take 3 values:
- base_schedule 
- adapted_schedule
- realtime

The `disruption_active` parameter is thus now deprecated
