### PR TITLE
TimeTable: Fix /departures and /arrivals

### DIFF
--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -48,7 +48,7 @@ std::vector<datetime_stop_time> get_stop_times(const routing::StopEvent stop_eve
     std::vector<datetime_stop_time> result;
     routing::NextStopTime next_st = routing::NextStopTime(data);
 
-    // Next departure for the next stop: we store it to have to next departure for each jpp
+    // Next departure for the next stop: we store it to have the next departure for each jpp
     // We init it with the next_stop_time for each jpp
     JppStQueue next_requested_dt({clockwise});
     for (const auto& jpp_idx : journey_pattern_points) {

--- a/source/time_tables/get_stop_times.cpp
+++ b/source/time_tables/get_stop_times.cpp
@@ -110,7 +110,7 @@ get_stop_times(const std::vector<routing::JppIdx>& journey_pattern_points,
                                      accessibilite_params.vehicle_properties);
 
         //afterward we filter the datetime not in [dt, max_dt]
-        //the difficult part comes from the fact that for calendar dt are max_dt are not really datetime,
+        //the difficult part comes from the fact that, for calendar, 'dt' and 'max_dt' are not really datetime,
         //there are time but max_dt can be the day after like [today 4:00, tomorow 3:00]
         for (auto& res: st) {
             auto time = DateTimeUtils::hour(res.first);

--- a/source/time_tables/get_stop_times.h
+++ b/source/time_tables/get_stop_times.h
@@ -32,6 +32,7 @@ www.navitia.io
 #include "routing/stop_event.h"
 #include "routing/routing.h"
 #include "type/data.h"
+#include <queue>
 
 
 namespace navitia { namespace timetables {
@@ -74,4 +75,25 @@ get_all_stop_times(const routing::JourneyPattern& jp,
                    const std::string calendar_id,
                    const type::VehicleProperties& vehicle_properties = type::VehicleProperties());
 
+
+struct JppSt {
+    routing::JppIdx jpp;
+    const type::StopTime* st;
+    DateTime dt;
+};
+
+/*
+ * Comparator used in the heap
+ * for clockwise, we want the smallest first,
+ * for anticlockwise, we want the greatest first
+ */
+struct BestDTComp {
+    bool operator()(const JppSt& j1, const JppSt& j2) {
+        if (clockwise) { return j1.dt > j2.dt; }
+        return j1.dt < j2.dt;
+    }
+    const bool clockwise;
+};
+
+using JppStQueue = std::priority_queue<JppSt, std::vector<JppSt>, BestDTComp>;
 }}

--- a/source/time_tables/next_passages.cpp
+++ b/source/time_tables/next_passages.cpp
@@ -31,12 +31,12 @@ www.navitia.io
 #include "next_passages.h"
 #include "get_stop_times.h"
 #include "request_handle.h"
-#include "boost/date_time/posix_time/posix_time.hpp"
 #include "type/datetime.h"
 #include "ptreferential/ptreferential.h"
 #include "utils/paginate.h"
 #include "routing/dataraptor.h"
-
+#include <boost/range/algorithm_ext/erase.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace pt = boost::posix_time;
 using navitia::routing::StopEvent;
@@ -58,8 +58,7 @@ next_passages(const std::string &request,
         return handler.pb_response;
     }
 
-    std::remove_if(handler.journey_pattern_points.begin(),
-                   handler.journey_pattern_points.end(), vis.predicate);
+    boost::remove_erase_if(handler.journey_pattern_points, vis.predicate);
 
     const StopEvent stop_event = (vis.api_pb == pbnavitia::NEXT_DEPARTURES) ?
                                  StopEvent::pick_up : StopEvent::drop_off;

--- a/source/time_tables/next_passages.cpp
+++ b/source/time_tables/next_passages.cpp
@@ -69,9 +69,9 @@ next_passages(const std::string &request,
     size_t total_result = passages_dt_st.size();
     passages_dt_st = paginate(passages_dt_st, count, start_page);
 
-    for(auto dt_stop_time : passages_dt_st) {
-        pbnavitia::Passage * passage;
-        if(stop_event == StopEvent::pick_up) {
+    for (auto dt_stop_time : passages_dt_st) {
+        pbnavitia::Passage* passage;
+        if (vis.api_pb == pbnavitia::NEXT_DEPARTURES) {
             passage = handler.pb_response.add_next_departures();
         } else {
             passage = handler.pb_response.add_next_arrivals();

--- a/source/time_tables/next_passages.cpp
+++ b/source/time_tables/next_passages.cpp
@@ -70,7 +70,7 @@ next_passages(const std::string &request,
 
     for (auto dt_stop_time : passages_dt_st) {
         pbnavitia::Passage* passage;
-        if (vis.api_pb == pbnavitia::NEXT_DEPARTURES) {
+        if (stop_event == StopEvent::pick_up) {
             passage = handler.pb_response.add_next_departures();
         } else {
             passage = handler.pb_response.add_next_arrivals();

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -31,12 +31,12 @@ www.navitia.io
 #include "previous_passages.h"
 #include "get_stop_times.h"
 #include "request_handle.h"
-#include "boost/date_time/posix_time/posix_time.hpp"
 #include "type/datetime.h"
 #include "ptreferential/ptreferential.h"
 #include "utils/paginate.h"
 #include "routing/dataraptor.h"
-
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/range/algorithm_ext/erase.hpp>
 
 namespace pt = boost::posix_time;
 using navitia::routing::StopEvent;
@@ -58,8 +58,7 @@ previous_passages(const std::string &request,
         return handler.pb_response;
     }
 
-    std::remove_if(handler.journey_pattern_points.begin(),
-                   handler.journey_pattern_points.end(), vis.predicate);
+    boost::remove_erase_if(handler.journey_pattern_points, vis.predicate);
 
     const StopEvent stop_event = (vis.api_pb == pbnavitia::PREVIOUS_DEPARTURES) ?
                                  StopEvent::pick_up : StopEvent::drop_off;

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -68,9 +68,9 @@ previous_passages(const std::string &request,
     size_t total_result = passages_dt_st.size();
     passages_dt_st = paginate(passages_dt_st, count, start_page);
 
-    for(auto dt_stop_time : passages_dt_st) {
-        pbnavitia::Passage * passage;
-        if(vis.api_pb == pbnavitia::PREVIOUS_DEPARTURES) {
+    for (auto dt_stop_time : passages_dt_st) {
+        pbnavitia::Passage* passage;
+        if (stop_event == StopEvent::pick_up) {
             passage = handler.pb_response.add_next_departures();
         } else {
             passage = handler.pb_response.add_next_arrivals();

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -71,7 +71,7 @@ previous_passages(const std::string &request,
 
     for(auto dt_stop_time : passages_dt_st) {
         pbnavitia::Passage * passage;
-        if(stop_event == StopEvent::pick_up) {
+        if(vis.api_pb == pbnavitia::PREVIOUS_DEPARTURES) {
             passage = handler.pb_response.add_next_departures();
         } else {
             passage = handler.pb_response.add_next_arrivals();

--- a/source/time_tables/tests/get_stop_times_test.cpp
+++ b/source/time_tables/tests/get_stop_times_test.cpp
@@ -346,11 +346,11 @@ struct departure_helper {
     }
 
     ed::builder b;
-    const navitia::DateTime yesterday = navitia::DateTimeUtils::min;
-    const navitia::DateTime yesterday_8h45 = navitia::DateTimeUtils::set(0, 8*3600 + 45*60);
-    const navitia::DateTime today = navitia::DateTimeUtils::set(1, 0);
-    const navitia::DateTime today_8h45 = navitia::DateTimeUtils::set(1, 8*3600 + 45*60);
-    const navitia::DateTime tomorrow = navitia::DateTimeUtils::set(2, 0);
+    const navitia::DateTime yesterday = "00:00"_t;
+    const navitia::DateTime yesterday_8h45 = "8:45"_t;
+    const navitia::DateTime today = "24:00"_t;
+    const navitia::DateTime today_8h45 = "24:00"_t + "8:45"_t;
+    const navitia::DateTime tomorrow = "48:00"_t;
 };
 
 /**
@@ -428,9 +428,9 @@ BOOST_FIXTURE_TEST_CASE(test_discrete_next_arrivals_prev_departures, departure_h
  */
 BOOST_FIXTURE_TEST_CASE(test_discrete_lolipop, departure_helper) {
     b.vj("A")("s1", "8:00"_t, "8:01"_t)
-            ("s2", "9:00"_t, "9:01"_t)
-            ("s3", "10:00"_t, "10:01"_t)
-            ("s2", "11:00"_t, "11:01"_t);
+             ("s2", "9:00"_t, "9:01"_t)
+             ("s3", "10:00"_t, "10:01"_t)
+             ("s2", "11:00"_t, "11:01"_t);
 
     b.finish();
     b.data->pt_data->index();

--- a/source/time_tables/tests/get_stop_times_test.cpp
+++ b/source/time_tables/tests/get_stop_times_test.cpp
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(test_frequency_over_midnight_for_calendar) {
 }
 
 struct departure_helper {
-
+    departure_helper(): b("20150907") {}
     std::vector<navitia::routing::JppIdx> get_jpp_idx (const std::string& stop_point_id) {
         std::vector<navitia::routing::JppIdx>  jpp_stop;
         const auto sp_idx = routing::SpIdx(*b.data->pt_data->stop_points_map.at(stop_point_id));
@@ -345,8 +345,7 @@ struct departure_helper {
         return jpp_stop;
     }
 
-    ed::builder b = ed::builder("20150907");
-
+    ed::builder b;
     const navitia::DateTime yesterday = navitia::DateTimeUtils::min;
     const navitia::DateTime yesterday_8h45 = navitia::DateTimeUtils::set(0, 8*3600 + 45*60);
     const navitia::DateTime today = navitia::DateTimeUtils::set(1, 0);

--- a/source/time_tables/tests/get_stop_times_test.cpp
+++ b/source/time_tables/tests/get_stop_times_test.cpp
@@ -487,7 +487,7 @@ BOOST_AUTO_TEST_CASE(queue_comp_test_anti_clockwise) {
  *                                        Center
  *
  * A: A1   9H
- *    A2     9H15
+ *    A2                 10h30
  *    A3                      11h
  *
  * B: B1                                     19H


### PR DESCRIPTION
there was a problem on departure/arrival when multiple JourneyPattern were passing by the stoppoint (as show in test `dep_arr_filtering` in get_stop_time_tests.cpp)

fix http://jira.canaltp.fr/browse/NAVITIAII-1853
