### PR TITLE
Osm: fix crash on debug and way merge

### DIFF
--- a/source/cities/cities.cpp
+++ b/source/cities/cities.cpp
@@ -136,7 +136,7 @@ void OSMCache::build_postal_codes(){
         if(relation.second.level != 9){
             continue;
         }
-        auto rel = this->match_coord_admin(relation.second.centre.get<0>(), relation.second.centre.get<1>());
+        auto rel = match_coord_admin(relation.second.centre.get<0>(), relation.second.centre.get<1>());
         if(rel){
             rel->postal_codes.insert(relation.second.postal_codes.begin(), relation.second.postal_codes.end());
         }
@@ -146,13 +146,12 @@ void OSMCache::build_postal_codes(){
 OSMRelation* OSMCache::match_coord_admin(const double lon, const double lat) {
     Rect search_rect(lon, lat);
     const auto p = point(lon, lat);
-    typedef std::vector<OSMRelation*> relations;
+    using relations = std::vector<OSMRelation*>;
 
     relations result;
     auto callback = [](OSMRelation* rel, void* c)->bool{
-        relations* context;
-        context = reinterpret_cast<relations*>(c);
         if (rel->level == 8) { // we want to match only cities
+            relations* context = reinterpret_cast<relations*>(c);
             context->push_back(rel);
         }
         return true;

--- a/source/cities/cities.cpp
+++ b/source/cities/cities.cpp
@@ -122,6 +122,7 @@ void ReadNodesVisitor::node_callback(uint64_t osm_id, double lon, double lat,
 void OSMCache::build_relations_geometries() {
     for (auto& relation : relations) {
         relation.second.build_geometry(*this);
+        if (relation.second.polygon.empty()) { continue; }
         boost::geometry::model::box<point> box;
         boost::geometry::envelope(relation.second.polygon, box);
         Rect r(box.min_corner().get<0>(), box.min_corner().get<1>(),

--- a/source/cities/cities.h
+++ b/source/cities/cities.h
@@ -166,7 +166,7 @@ struct OSMCache {
     OSMCache(const std::string& connection_string) : lotus(connection_string) {}
 
     void build_relations_geometries();
-    OSMRelation* match_coord_admin(const double lon, const double lat, uint32_t level);
+    OSMRelation* match_coord_admin(const double lon, const double lat);
     void match_nodes_admin();
     void insert_relations();
     void build_postal_codes();

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -205,13 +205,12 @@ void OSMCache::build_relations_geometries() {
 const OSMRelation* OSMCache::match_coord_admin(const double lon, const double lat) {
     Rect search_rect(lon, lat);
     const auto p = point(lon, lat);
-    typedef std::vector<const OSMRelation*> relations;
+    using relations = std::vector<const OSMRelation*>;
 
     relations result;
     auto callback = [](const OSMRelation* rel, void* c)->bool{
-        relations* context;
-        context = reinterpret_cast<relations*>(c);
         if (rel->level == 8) { // we want to match only cities
+            relations* context = reinterpret_cast<relations*>(c);
             context->push_back(rel);
         }
         return true;

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -190,6 +190,7 @@ void ReadNodesVisitor::node_callback(uint64_t osm_id, double lon, double lat,
 void OSMCache::build_relations_geometries() {
     for (const auto& relation : relations) {
         relation.build_geometry(*this);
+        if (relation.polygon.empty()) { continue; }
         boost::geometry::model::box<point> box;
         boost::geometry::envelope(relation.polygon, box);
         Rect r(box.min_corner().get<0>(), box.min_corner().get<1>(),

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -202,16 +202,22 @@ void OSMCache::build_relations_geometries() {
 /*
  * Find the admin of coordinates
  */
-const OSMRelation* OSMCache::match_coord_admin(const double lon, const double lat) {
+const OSMRelation* OSMCache::match_coord_admin(const double lon, const double lat, uint32_t level) {
     Rect search_rect(lon, lat);
     const auto p = point(lon, lat);
+    typedef std::pair<uint32_t, std::vector<const OSMRelation*>*> level_relations;
 
-    std::vector<OSMRelation*> result;
-    auto callback = [](const OSMRelation* rel, void* vec)->bool{
-        reinterpret_cast<std::vector<const OSMRelation*>*>(vec)->push_back(rel);
+    std::vector<const OSMRelation*> result;
+    auto callback = [](const OSMRelation* rel, void* c)->bool{
+        level_relations* context;
+        context = reinterpret_cast<level_relations*>(c);
+        if(rel->level == context->first){
+            context->second->push_back(rel);
+        }
         return true;
     };
-    admin_tree.Search(search_rect.min, search_rect.max, callback, &result);
+    level_relations context = std::make_pair(level, &result);
+    admin_tree.Search(search_rect.min, search_rect.max, callback, &context);
     for(auto rel : result) {
         if (boost::geometry::within(p, rel->polygon)){
             return rel;
@@ -230,7 +236,7 @@ void OSMCache::match_nodes_admin() {
         if (!node.is_defined() || node.admin) {
             continue;
         }
-        node.admin = match_coord_admin(node.lon(), node.lat());
+        node.admin = match_coord_admin(node.lon(), node.lat(), 8);
         if (node.admin != nullptr) {
             ++ count_matches;
         }
@@ -720,7 +726,7 @@ void PoiHouseNumberVisitor::insert_house_numbers() {
  */
 const OSMWay* PoiHouseNumberVisitor::find_way_without_name(const double lon, const double lat) {
     const OSMWay* result = nullptr;
-    const auto admin = cache.match_coord_admin(lon, lat);
+    const auto admin = cache.match_coord_admin(lon, lat, 8);
     if (!admin) {
         return result;
     }
@@ -786,7 +792,7 @@ const OSMWay* PoiHouseNumberVisitor::find_way(const CanalTP::Tags& tags, const d
         }
     }
     // Otherwize we try to match coords with an admin
-    const auto admin = cache.match_coord_admin(lon, lat);
+    const auto admin = cache.match_coord_admin(lon, lat, 8);
     if (admin) {
         auto it_admin = it_ways->second.find({admin});
         if (it_admin != it_ways->second.end()) {

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -287,7 +287,7 @@ struct OSMCache {
     OSMCache(const std::string& connection_string) : lotus(connection_string) {}
 
     void build_relations_geometries();
-    const OSMRelation* match_coord_admin(const double lon, const double lat);
+    const OSMRelation* match_coord_admin(const double lon, const double lat, uint32_t level);
     void match_nodes_admin();
     void insert_nodes();
     void insert_ways();

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -287,7 +287,7 @@ struct OSMCache {
     OSMCache(const std::string& connection_string) : lotus(connection_string) {}
 
     void build_relations_geometries();
-    const OSMRelation* match_coord_admin(const double lon, const double lat, uint32_t level);
+    const OSMRelation* match_coord_admin(const double lon, const double lat);
     void match_nodes_admin();
     void insert_nodes();
     void insert_ways();


### PR DESCRIPTION
- do not insert empty geometry in rtree
- merge way if they share the same city (we created separate way between the city's district)

Fix #1115 , thanks @frodrigo and @eturck for the bug report!
