### PR TITLE
Ed: for the GTFS create one route by line and direction_id

### DIFF
--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -450,7 +450,6 @@ std::vector<ed::types::VehicleJourney*> TripsFusioHandler::get_split_vj(Data& da
         vj->validity_pattern = vp_xx;
         vj->adapted_validity_pattern = vp_xx;
         vj->route = route;
-        vj->tmp_line = vj->route->line;
         if(is_valid(block_id_c, row))
             vj->block_id = row[block_id_c];
         else

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -893,6 +893,7 @@ void TripsGtfsHandler::init(Data& data) {
     wheelchair_c = csv.get_pos_col("wheelchair_accessible");
     bikes_c = csv.get_pos_col("bikes_allowed");
     shape_id_c = csv.get_pos_col("shape_id");
+    direction_id_c = csv.get_pos_col("direction_id");
 }
 
 void TripsGtfsHandler::finish(Data& data) {
@@ -902,18 +903,42 @@ void TripsGtfsHandler::finish(Data& data) {
     LOG4CPLUS_TRACE(logger, ignored_vj << " duplicated vehicule journey have been ignored");
 }
 
+/*
+ * We create one route by line and direction_id
+ * the direction_id field is usually a boolean, but can be used as a string
+ * to create as many routes as wanted
+ */
+types::Route* TripsGtfsHandler::get_or_create_route(Data& data, const RouteId& route_id) {
+    const auto it = routes.find(route_id);
+    if (it != std::end(routes)) {
+        return it->second;
+    } else {
+        types::Route* route = new types::Route();
+        route->line = route_id.first;
+        //uri is {line}:{direction}
+        route->uri = route->line->uri + ":" + route_id.second;
+        route->name = route->line->name;
+        route->idx = data.routes.size();
+        data.routes.push_back(route);
+        routes[route_id] = route;
+        return route;
+    }
+}
+
 void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
     auto it = gtfs_data.line_map.find(row[id_c]);
     if (it == gtfs_data.line_map.end()) {
-        LOG4CPLUS_WARN(logger, "Impossible to find the Gtfs route " + row[id_c]
-                       + " referenced by trip " + row[trip_c]);
+        LOG4CPLUS_WARN(logger, "Impossible to find the Gtfs line " << row[id_c]
+                       << " referenced by trip " << row[trip_c]);
         ignored++;
         return;
     }
 
     nm::Line* line = it->second;
 
-    auto vp_range= gtfs_data.tz.vp_by_name.equal_range(row[service_c]);
+    nm::Route* route = get_or_create_route(data, {line, row[direction_id_c]});
+
+    auto vp_range = gtfs_data.tz.vp_by_name.equal_range(row[service_c]);
     if(empty(vp_range)) {
         LOG4CPLUS_WARN(logger, "Impossible to find the Gtfs service " + row[service_c]
                        + " referenced by trip " + row[trip_c]);
@@ -922,7 +947,7 @@ void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
     }
 
     //we look in the meta vj table to see if we already have one such vj
-    if(data.meta_vj_map.find(row[trip_c]) != data.meta_vj_map.end()) {
+    if (data.meta_vj_map.find(row[trip_c]) != data.meta_vj_map.end()) {
         LOG4CPLUS_DEBUG(logger, "vj " << row[trip_c] << " already read, we skip the second one");
         ignored_vj++;
         return;
@@ -957,7 +982,7 @@ void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
 
         vj->validity_pattern = vp_xx;
         vj->adapted_validity_pattern = vp_xx;
-        vj->tmp_line = line;
+        vj->route = route;
         if(has_col(block_id_c, row))
             vj->block_id = row[block_id_c];
         else

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -340,7 +340,8 @@ struct TripsGtfsHandler : public GenericHandler {
     int id_c, service_c,
             trip_c, headsign_c,
             block_id_c, wheelchair_c,
-            bikes_c, shape_id_c;
+            bikes_c, shape_id_c,
+            direction_id_c;
 
     int ignored = 0;
     int ignored_vj = 0;
@@ -351,6 +352,11 @@ struct TripsGtfsHandler : public GenericHandler {
     const std::vector<std::string> required_headers() const {
         return {"route_id", "service_id", "trip_id"};
     }
+
+    using RouteId = std::pair<types::Line*, const std::string>;
+    std::map<RouteId, types::Route*> routes;
+
+    types::Route* get_or_create_route(Data& data, const RouteId&);
 };
 struct StopTimeGtfsHandler : public GenericHandler {
     StopTimeGtfsHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}

--- a/source/ed/tests/gtfsparser_test.cpp
+++ b/source/ed/tests/gtfsparser_test.cpp
@@ -281,20 +281,20 @@ BOOST_AUTO_TEST_CASE(parse_gtfs_no_dst){
     //Trips
     BOOST_REQUIRE_EQUAL(data.vehicle_journeys.size(), 11);
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->uri, "AB1");
-    BOOST_REQUIRE(data.vehicle_journeys[0]->tmp_line != nullptr);
-    BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->tmp_line->uri, "AB");
     BOOST_REQUIRE(data.vehicle_journeys[0]->validity_pattern != nullptr);
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->validity_pattern->uri, "FULLW");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->name, "to Bullfrog");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->block_id, "1");
+    BOOST_REQUIRE(data.vehicle_journeys[0]->route != nullptr);
+    BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->route->uri, "AB:0");
 
     BOOST_CHECK_EQUAL(data.vehicle_journeys[10]->uri, "AAMV4");
-    BOOST_REQUIRE(data.vehicle_journeys[10]->tmp_line != nullptr);
-    BOOST_CHECK_EQUAL(data.vehicle_journeys[10]->tmp_line->uri, "AAMV");
     BOOST_REQUIRE(data.vehicle_journeys[10]->validity_pattern != nullptr);
     BOOST_CHECK_EQUAL(data.vehicle_journeys[10]->validity_pattern->uri, "WE");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[10]->name, "to Airport");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[10]->block_id, "");
+    BOOST_REQUIRE(data.vehicle_journeys[10]->route != nullptr);
+    BOOST_CHECK_EQUAL(data.vehicle_journeys[10]->route->uri, "AAMV:1");
 
     //Calendar
     BOOST_REQUIRE_EQUAL(data.validity_patterns.size(), 2);
@@ -368,6 +368,24 @@ static void check_gtfs_google_example(const ed::Data& data, const ed::connectors
     BOOST_REQUIRE(data.lines[4]->commercial_mode != nullptr);
     BOOST_CHECK_EQUAL(data.lines[4]->commercial_mode->uri, "3");
 
+    // we need to also check the number of routes created (since they are implicit in GTFS)
+    // we create one by line/direction id
+    BOOST_REQUIRE_EQUAL(data.routes.size(), 9);
+    BOOST_CHECK_EQUAL(data.routes[0]->uri, "AB:0"); //NOTE: order is not important
+    BOOST_CHECK_EQUAL(data.routes[1]->uri, "AB:1");
+    BOOST_CHECK_EQUAL(data.routes[2]->uri, "STBA:");
+    BOOST_CHECK_EQUAL(data.routes[3]->uri, "CITY:0");
+    BOOST_CHECK_EQUAL(data.routes[4]->uri, "CITY:1");
+    BOOST_CHECK_EQUAL(data.routes[5]->uri, "BFC:0");
+    BOOST_CHECK_EQUAL(data.routes[6]->uri, "BFC:1");
+    BOOST_CHECK_EQUAL(data.routes[7]->uri, "AAMV:0");
+    BOOST_CHECK_EQUAL(data.routes[8]->uri, "AAMV:1");
+    for (const auto& r: data.routes) {
+        BOOST_CHECK_NE(r->idx, navitia::invalid_idx);
+        BOOST_REQUIRE(r->line);
+        BOOST_CHECK_EQUAL(r->name, r->line->name);//route's name is it's line's name
+    }
+
     //Calendar, Trips and stop times are another matters
     //we have to split the trip validity period in such a fashion that the period does not overlap a dst
 
@@ -399,17 +417,18 @@ static void check_gtfs_google_example(const ed::Data& data, const ed::connectors
     // same for the vj, all have been split in 9
     BOOST_REQUIRE_EQUAL(data.vehicle_journeys.size(), 11 * 3);
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->uri, "AB1_dst_1");
-    BOOST_REQUIRE(data.vehicle_journeys[0]->tmp_line != nullptr);
-    BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->tmp_line->uri, "AB");
     BOOST_REQUIRE(data.vehicle_journeys[0]->validity_pattern != nullptr);
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->validity_pattern->uri, "FULLW_1");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->name, "to Bullfrog");
     BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->block_id, "1");
+    BOOST_REQUIRE(data.vehicle_journeys[0]->route != nullptr);
+    BOOST_CHECK_EQUAL(data.vehicle_journeys[0]->route->uri, "AB:0");
 
     for (int i = 1; i <= 3; ++i) {
         BOOST_CHECK_EQUAL(data.vehicle_journeys[i-1]->uri, "AB1_dst_" + std::to_string(i));
         BOOST_REQUIRE(data.vehicle_journeys[i-1]->validity_pattern != nullptr);
         BOOST_CHECK_EQUAL(data.vehicle_journeys[i-1]->validity_pattern->uri, "FULLW_" + std::to_string(i));
+        BOOST_REQUIRE(data.vehicle_journeys[i-1]->route != nullptr);
     }
 
     //Stop time

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -251,7 +251,6 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties{
     Route* route = nullptr;
     Company* company = nullptr;
     PhysicalMode* physical_mode = nullptr;
-    Line * tmp_line = nullptr; // May be empty
     //Vehicle* vehicle;
     bool wheelchair_boarding = false;
     navitia::type::VehicleJourneyType vehicle_journey_type = navitia::type::VehicleJourneyType::regular;


### PR DESCRIPTION
with the journey pattern refactoring, we missed that the routes were not
associated with the VJ on the GTFS parser, thus gtfs2ed was crashing
during database insertion.

For the GTFS (since the route are explicitly given in the NTFS), we now
create one route by line and direction_id

NEEDS to be hotfixed
jira: http://jira.canaltp.fr/browse/NAVITIAII-1901
