### PR TITLE
jormun: handle bad format of date

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/parsers.py
+++ b/source/jormungandr/jormungandr/interfaces/parsers.py
@@ -55,6 +55,10 @@ def date_time_format(value):
     we want to valid the date format
     """
     try:
-        return parse_input_date(value)
+        d = parse_input_date(value)
+        if d.year < 1970:
+            raise ValueError('date is too early!')
+
+        return d
     except ValueError as e:
         raise ValueError("Unable to parse datetime, {}".format(e.message))

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -226,6 +226,18 @@ class TestJourneys(AbstractTestFixture):
         assert 'message' in response
         assert response['message'] == "Unable to parse datetime, hour must be in 0..23"
 
+    def test_journeys_date_valid_invalid(self):
+        """some format of date are bizarrely interpreted, and can result in date in 800"""
+
+        query = "journeys?from={from_coord}&to={to_coord}&datetime={d}"\
+            .format(from_coord=s_coord, to_coord=r_coord, d="T0800")
+
+        response, status_code = self.query_no_assert("v1/coverage/main_routing_test/" + query)
+
+        assert not 'journeys' in response
+        assert 'message' in response
+        assert response['message'] == "Unable to parse datetime, date is too early!"
+
     def test_journeys_bad_speed(self):
         """speed <= 0 is invalid"""
 


### PR DESCRIPTION
"T0800" seems to be a valid iso date, but the year is set to 800, we
won't be able to convert it to a timestamp.
