### PR TITLE
TimeTable: Fix route schedule with calendar

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -126,7 +126,10 @@ class Schedules(ResourceUri, ResourceUtc):
 
         if not args["from_datetime"] and not args["until_datetime"]:
             args['from_datetime'] = datetime.datetime.now()
-            args['from_datetime'] = args['from_datetime'].replace(hour=13, minute=37)
+            if args["calendar"]:  # if we have a calendar 00:00 is fine
+                args['from_datetime'] = args['from_datetime'].replace(hour=0, minute=0)
+            else:
+                args['from_datetime'] = args['from_datetime'].replace(hour=13, minute=37)
 
         # we save the original datetime for debuging purpose
         args['original_datetime'] = args['from_datetime']

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -60,7 +60,7 @@ def check_departure_board(schedules, tester, only_time=False):
     check_links(schedule, tester, href_mandatory=False)
 
 
-def is_valid_route_schedule(schedules):
+def is_valid_route_schedule(schedules, only_time=False):
     assert len(schedules) == 1, "there should be only one elt"
     schedule = schedules[0]
     d = get_not_null(schedule, 'display_informations')
@@ -78,10 +78,14 @@ def is_valid_route_schedule(schedules):
 
     rows = get_not_null(table, 'rows')
     for row in rows:
-        for dt in get_not_null(row, 'date_times'):
-            assert "additional_informations" in dt
-            assert "links" in dt
-            get_valid_datetime(get_not_null(dt, "date_time"))
+        for dt_obj in get_not_null(row, 'date_times'):
+            assert "additional_informations" in dt_obj
+            assert "links" in dt_obj
+            dt = get_not_null(dt_obj, "date_time")
+            if only_time:
+                get_valid_time(dt)
+            else:
+                get_valid_datetime(dt)
 
         is_valid_stop_point(get_not_null(row, 'stop_point'), depth_check=1)
 
@@ -217,6 +221,16 @@ class TestDepartureBoard(AbstractTestFixture):
 
         assert "route_schedules" in response
         is_valid_route_schedule(response["route_schedules"])
+
+    def test_routes_schedule_with_calendar(self):
+        """
+        departure board for a given calendar
+        """
+        response = self.query_region("routes/line:A:0/route_schedules?calendar=week_cal")
+
+        assert "route_schedules" in response
+        # the route_schedule with calendar should not have avec date (only time)
+        is_valid_route_schedule(response["route_schedules"], only_time=True)
 
     def test_with_wrong_type(self):
         """

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -229,7 +229,7 @@ class TestDepartureBoard(AbstractTestFixture):
         response = self.query_region("routes/line:A:0/route_schedules?calendar=week_cal")
 
         assert "route_schedules" in response
-        # the route_schedule with calendar should not have avec date (only time)
+        # the route_schedule with calendar should not have with date (only time)
         is_valid_route_schedule(response["route_schedules"], only_time=True)
 
     def test_with_wrong_type(self):

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -61,3 +61,14 @@ std::ostream& operator<<(std::ostream& os, const std::map<K, V>& m) {
     return os << "}";
 }
 }
+
+/*
+ * BOOST_CHECK_EQUAL_COLLECTIONS does not work well with a temporary collection, thus this macro
+ * (and it's easier to use)
+ */
+#define BOOST_CHECK_EQUAL_RANGE(range1, range2) \
+    { \
+        const auto& r1 = range1; \
+        const auto& r2 = range2; \
+        BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(r1), std::end(r1), std::begin(r2), std::end(r2)); \
+    }

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -193,19 +193,8 @@ departure_board(const std::string& request,
         if ( ! calendar_id) {
             std::sort(stop_times.begin(), stop_times.end(), sort_predicate);
         } else {
-            // for calendar we want to sort the result a quite a strange way
-            // we want the first stop time to start from handler.date_time
-            std::sort(stop_times.begin(), stop_times.end(),
-                      [&handler](datetime_stop_time dst1, datetime_stop_time dst2) {
-                auto is_before_start1 = (DateTimeUtils::hour(dst1.first) < DateTimeUtils::hour(handler.date_time));
-                auto is_before_start2 = (DateTimeUtils::hour(dst2.first) < DateTimeUtils::hour(handler.date_time));
-
-                if (is_before_start1 != is_before_start2) {
-                    //if one is before and one is after, we want the one after first
-                    return ! is_before_start1;
-                }
-                return DateTimeUtils::hour(dst1.first) < DateTimeUtils::hour(dst2.first);
-                });
+            // for calendar we want the first stop time to start from handler.date_time
+            std::sort(stop_times.begin(), stop_times.end(), CalendarScheduleSort(handler.date_time));
             if (stop_times.size() > max_date_times) {
                 stop_times.resize(max_date_times);
             }

--- a/source/time_tables/get_stop_times.h
+++ b/source/time_tables/get_stop_times.h
@@ -96,4 +96,25 @@ struct BestDTComp {
 };
 
 using JppStQueue = std::priority_queue<JppSt, std::vector<JppSt>, BestDTComp>;
+
+
+/*
+ * for schedule with calendar, we want to sort the result a quite a strange way
+ * we want the first stop time to start from a given dt and loop through the day after
+ * */
+struct CalendarScheduleSort {
+    CalendarScheduleSort(DateTime d): pivot(d) {}
+    DateTime pivot;
+    bool operator()(datetime_stop_time dst1, datetime_stop_time dst2) const {
+        auto is_before_start1 = (DateTimeUtils::hour(dst1.first) < DateTimeUtils::hour(pivot));
+        auto is_before_start2 = (DateTimeUtils::hour(dst2.first) < DateTimeUtils::hour(pivot));
+
+        if (is_before_start1 != is_before_start2) {
+            //if one is before and one is after, we want the one after first
+            return ! is_before_start1;
+        }
+        return DateTimeUtils::hour(dst1.first) < DateTimeUtils::hour(dst2.first);
+    }
+};
+
 }}

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -90,8 +90,8 @@ get_all_route_stop_times(const nt::Route* route,
                 } else {
                     // for calendar, we need to shift the time to local time
                     const auto utc_to_local_offset = stop_time.vehicle_journey->utc_to_local_offset;
-                    dt = DateTimeUtils::hour(dt);
-                    dt = DateTimeUtils::shift(dt, DateTimeUtils::hour(stop_time.departure_time + utc_to_local_offset));
+                    // we don't care about the date and about the overmidnight cases
+                    dt = DateTimeUtils::hour(stop_time.departure_time + utc_to_local_offset);
                 }
             } else {
                 // for frequencies, we only need to add the stoptime offset to the first stoptime

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -48,12 +48,12 @@ namespace navitia { namespace timetables {
 
 std::vector<std::vector<datetime_stop_time> >
 get_all_route_stop_times(const nt::Route* route,
-                   const DateTime& date_time,
-                   const DateTime& max_datetime,
-                   const size_t max_stop_date_times,
-                   const type::Data& d,
-                   const type::RTLevel rt_level,
-                   const boost::optional<const std::string> calendar_id) {
+                         const DateTime& date_time,
+                         const DateTime& max_datetime,
+                         const size_t max_stop_date_times,
+                         const type::Data& d,
+                         const type::RTLevel rt_level,
+                         const boost::optional<const std::string> calendar_id) {
     std::vector<std::vector<datetime_stop_time> > result;
 
     const auto& journey_patterns =  d.dataRaptor->jp_container.get_jps_from_route()[routing::RouteIdx(*route)];
@@ -278,8 +278,8 @@ route_schedule(const std::string& filter,
     for (const auto& route_idx: routes_idx) {
         auto route = d.pt_data->routes[route_idx];
         auto stop_times = get_all_route_stop_times(route, handler.date_time,
-                                             handler.max_datetime, max_stop_date_times,
-                                             d, rt_level, calendar_id);
+                                                   handler.max_datetime, max_stop_date_times,
+                                                   d, rt_level, calendar_id);
         const auto& jps =  d.dataRaptor->jp_container.get_jps_from_route()[routing::RouteIdx(*route)];
         std::vector<vector_idx> stop_points;
         for (const auto& jp_idx : jps) {

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -46,15 +46,17 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace timetables {
 
-static std::vector<std::vector<datetime_stop_time> >
-get_all_stop_times(const std::vector<routing::JpIdx>& journey_patterns,
-                   const DateTime& dateTime,
+std::vector<std::vector<datetime_stop_time> >
+get_all_route_stop_times(const nt::Route* route,
+                   const DateTime& date_time,
                    const DateTime& max_datetime,
                    const size_t max_stop_date_times,
                    const type::Data& d,
                    const type::RTLevel rt_level,
                    const boost::optional<const std::string> calendar_id) {
     std::vector<std::vector<datetime_stop_time> > result;
+
+    const auto& journey_patterns =  d.dataRaptor->jp_container.get_jps_from_route()[routing::RouteIdx(*route)];
 
     // We take the first journey pattern points from every journey_pattern
     std::vector<routing::JppIdx> first_journey_pattern_points;
@@ -65,31 +67,46 @@ get_all_stop_times(const std::vector<routing::JpIdx>& journey_patterns,
     }
 
     std::vector<datetime_stop_time> first_dt_st;
-    if(!calendar_id) {
+    if (! calendar_id) {
         // If there is no calendar we get all stop times in
         // the desired timeframe
         first_dt_st = get_stop_times(routing::StopEvent::pick_up, first_journey_pattern_points,
-                                     dateTime, max_datetime, max_stop_date_times, d, rt_level);
-    }
-    else {
+                                     date_time, max_datetime, max_stop_date_times, d, rt_level);
+    } else {
         // Otherwise we only take stop_times in a vehicle_journey associated to
         // the desired calendar and in the timeframe
-        first_dt_st = get_stop_times(first_journey_pattern_points, DateTimeUtils::hour(dateTime),
+        first_dt_st = get_stop_times(first_journey_pattern_points, DateTimeUtils::hour(date_time),
                                      DateTimeUtils::hour(max_datetime), d, *calendar_id);
     }
 
-    //On va chercher tous les prochains horaires
-    for(auto ho : first_dt_st) {
+    // we need to load the next datetimes for each jp
+    for (const auto& ho : first_dt_st) {
         result.push_back(std::vector<datetime_stop_time>());
         DateTime dt = ho.first;
-        for(const type::StopTime& stop_time : ho.second->vehicle_journey->stop_time_list) {
-            if(!stop_time.is_frequency()) {
-                dt = DateTimeUtils::shift(dt, stop_time.departure_time);
+        for (const type::StopTime& stop_time : ho.second->vehicle_journey->stop_time_list) {
+            if (! stop_time.is_frequency()) {
+                if (! calendar_id) {
+                    dt = DateTimeUtils::shift(dt, stop_time.departure_time);
+                } else {
+                    // for calendar, we need to shift the time to local time
+                    const auto utc_to_local_offset = stop_time.vehicle_journey->utc_to_local_offset;
+                    dt = DateTimeUtils::shift(dt, stop_time.departure_time + utc_to_local_offset);
+                }
             } else {
                 // for frequencies, we only need to add the stoptime offset to the first stoptime
                 dt = ho.first + stop_time.departure_time;
+                // NOTE: for calendar, we don't need to add again the utc offset, since for frequency
+                // vj all stop_times are relative to the start of the vj (and the UTC offset has  already
+                // been included in the first stop time)
             }
             result.back().push_back(std::make_pair(dt, &stop_time));
+        }
+    }
+
+    // for calendar's schedule we need to sort the datetimes
+    if (calendar_id) {
+        for (auto& vec_dt_st: result) {
+            boost::sort(vec_dt_st, CalendarScheduleSort(date_time));
         }
     }
     return result;
@@ -251,10 +268,10 @@ route_schedule(const std::string& filter,
     routes_idx = paginate(routes_idx, count, start_page);
     for (const auto& route_idx: routes_idx) {
         auto route = d.pt_data->routes[route_idx];
-        const auto& jps =  d.dataRaptor->jp_container.get_jps_from_route()[routing::RouteIdx(*route)];
-        auto stop_times = get_all_stop_times(jps, handler.date_time,
+        auto stop_times = get_all_route_stop_times(route, handler.date_time,
                                              handler.max_datetime, max_stop_date_times,
                                              d, rt_level, calendar_id);
+        const auto& jps =  d.dataRaptor->jp_container.get_jps_from_route()[routing::RouteIdx(*route)];
         std::vector<vector_idx> stop_points;
         for (const auto& jp_idx : jps) {
             const auto& jp = d.dataRaptor->jp_container.get(jp_idx);
@@ -303,7 +320,7 @@ route_schedule(const std::string& filter,
 
                 auto pb_dt = row->add_date_times();
                 fill_pb_object(dt_stop_time.second, d, pb_dt, max_depth,
-                               now, action_period, dt_stop_time.first);
+                               now, action_period, dt_stop_time.first, calendar_id);
             }
         }
         fill_pb_object(route->shape, schedule->mutable_geojson());

--- a/source/time_tables/route_schedules.h
+++ b/source/time_tables/route_schedules.h
@@ -39,6 +39,15 @@ namespace navitia { namespace timetables {
 typedef std::vector<std::string> vector_string;
 typedef std::pair<DateTime, const type::StopTime*> vector_date_time;
 
+std::vector<std::vector<datetime_stop_time> >
+get_all_route_stop_times(const navitia::type::Route* route,
+                   const DateTime& dateTime,
+                   const DateTime& max_datetime,
+                   const size_t max_stop_date_times,
+                   const type::Data& d,
+                   const type::RTLevel rt_level,
+                   const boost::optional<const std::string> calendar_id);
+
 pbnavitia::Response route_schedule(const std::string & line_externalcode,
         const boost::optional<const std::string> calendar_id,
         const std::vector<std::string>& forbidden_uris,

--- a/source/time_tables/route_schedules.h
+++ b/source/time_tables/route_schedules.h
@@ -41,18 +41,20 @@ typedef std::pair<DateTime, const type::StopTime*> vector_date_time;
 
 std::vector<std::vector<datetime_stop_time> >
 get_all_route_stop_times(const navitia::type::Route* route,
-                   const DateTime& dateTime,
-                   const DateTime& max_datetime,
-                   const size_t max_stop_date_times,
-                   const type::Data& d,
-                   const type::RTLevel rt_level,
-                   const boost::optional<const std::string> calendar_id);
+                         const DateTime& dateTime,
+                         const DateTime& max_datetime,
+                         const size_t max_stop_date_times,
+                         const type::Data& d,
+                         const type::RTLevel rt_level,
+                         const boost::optional<const std::string> calendar_id);
 
 pbnavitia::Response route_schedule(const std::string & line_externalcode,
-        const boost::optional<const std::string> calendar_id,
-        const std::vector<std::string>& forbidden_uris,
-        const boost::posix_time::ptime datetime, uint32_t duration, size_t max_stop_date_times,
-        const uint32_t max_depth, int count, int start_page, const type::Data &d, const type::RTLevel rt_level,
-        const bool show_codes);
+                                   const boost::optional<const std::string> calendar_id,
+                                   const std::vector<std::string>& forbidden_uris,
+                                   const boost::posix_time::ptime datetime,
+                                   uint32_t duration, size_t max_stop_date_times,
+                                   const uint32_t max_depth, int count, int start_page,
+                                   const type::Data &d, const type::RTLevel rt_level,
+                                   const bool show_codes);
 
 }}

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -362,16 +362,16 @@ BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_time, route_schedule_
  * The dataset in LOCAL TIME (france) is:
  *
  *      vj1    vj2    vj3
- * S1  00:50  01:05  01:15
- * S2  01:50  02:05  02:15
- * S3  02:50  03:05  03:15
+ * S1  00:50  01:50  02:50
+ * S2  01:05  02:05  03:05
+ * S3  01:15  02:15  03:15
  *
  * The small catch is that there is 2 hours UTC shift, thus vj1 and vj2 validity pattern's are shifted the day before:
  *
  *      vj1    vj2    vj3
- * S1  22:50  23:05  23:15
- * S2  23:50  00:05  00:15
- * S3  00:50  01:05  01:15
+ * S1  22:50  23:50  00:50
+ * S2  23:05  00:05  01:05
+ * S3  23:15  00:15  01:15
  *
  */
 struct CalWithDSTFixture {
@@ -380,11 +380,11 @@ struct CalWithDSTFixture {
     CalWithDSTFixture() {
         auto normal_vp = "111111";
         auto shifted_vp = "111110";
-        b.vj("B", shifted_vp)("S1", "22:50"_t)("S2", "23:50"_t)("S3", "00:50"_t)
+        b.vj("B", shifted_vp)("S1", "22:50"_t)("S2", "23:05"_t)("S3", "23:15"_t)
                 .vj->utc_to_local_offset = "02:00"_t;
-        b.vj("B", shifted_vp)("S1", "23:05"_t)("S2", "00:05"_t)("S3", "01:05"_t)
+        b.vj("B", shifted_vp)("S1", "23:50"_t)("S2", "00:05"_t)("S3", "00:15"_t)
                 .vj->utc_to_local_offset = "02:00"_t;
-        b.vj("B", normal_vp)("S1", "23:15"_t)("S2", "00:15"_t)("S3", "01:15"_t)
+        b.vj("B", normal_vp)("S1", "00:50"_t)("S2", "01:05"_t)("S3", "01:15"_t)
                 .vj->utc_to_local_offset = "02:00"_t;
 
         auto cal = new navitia::type::Calendar();
@@ -418,9 +418,9 @@ BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_different_vp, CalWith
     BOOST_REQUIRE_EQUAL(res.size(), 3);
 
     boost::sort(res);
-    BOOST_CHECK_EQUAL_RANGE(res[0] | ba::transformed(get_dt), vec_dt({"00:50"_t, "01:50"_t, "02:50"_t}));
-    BOOST_CHECK_EQUAL_RANGE(res[1] | ba::transformed(get_dt), vec_dt({"01:05"_t, "02:05"_t, "03:05"_t}));
-    BOOST_CHECK_EQUAL_RANGE(res[2] | ba::transformed(get_dt), vec_dt({"01:15"_t, "02:15"_t, "03:15"_t}));
+    BOOST_CHECK_EQUAL_RANGE(res[0] | ba::transformed(get_dt), vec_dt({"00:50"_t, "01:05"_t, "01:15"_t}));
+    BOOST_CHECK_EQUAL_RANGE(res[1] | ba::transformed(get_dt), vec_dt({"01:50"_t, "02:05"_t, "02:15"_t}));
+    BOOST_CHECK_EQUAL_RANGE(res[2] | ba::transformed(get_dt), vec_dt({"02:50"_t, "03:05"_t, "03:15"_t}));
 }
 
 BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_different_vp_and_hour, CalWithDSTFixture) {
@@ -437,10 +437,10 @@ BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_different_vp_and_hour
     auto one_day = "24:00"_t;
     boost::sort(res);
     //both are after the asked time (1h), so they are on the following day
-    BOOST_CHECK_EQUAL_RANGE(res[0] | ba::transformed(get_dt), vec_dt({"01:05"_t, "02:05"_t, "03:05"_t}));
-    BOOST_CHECK_EQUAL_RANGE(res[1] | ba::transformed(get_dt), vec_dt({"01:15"_t, "02:15"_t, "03:15"_t}));
+    BOOST_CHECK_EQUAL_RANGE(res[0] | ba::transformed(get_dt), vec_dt({"01:50"_t, "02:05"_t, "02:15"_t}));
+    BOOST_CHECK_EQUAL_RANGE(res[1] | ba::transformed(get_dt), vec_dt({"02:50"_t, "03:05"_t, "03:15"_t}));
     BOOST_CHECK_EQUAL_RANGE(res[2] | ba::transformed(get_dt),
-            vec_dt({"00:50"_t + one_day, "01:50"_t + one_day, "02:50"_t + one_day}));
+            vec_dt({"00:50"_t + one_day, "01:05"_t + one_day, "01:15"_t + one_day}));
 }
 
 


### PR DESCRIPTION
fixes #1161 (and http://jira.canaltp.fr/browse/NAVITIAII-1872)

/route_schedules with calendar are now without date and the sort have been corrected.

On the dataset given in #1161 the behaviour is now:

 classical route_schedules with a calendar:

`/routes/route:1_A/route_schedules?calendar=Y2FsZW5kYXI6OA`

```
{
  "schedule": [
    {
      "vj": "vehicle_journey:2",
      "dt": "005000"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "015000"
    },
    {
      "vj": "vehicle_journey:4",
      "dt": "025000"
    }
  ],
  "stop": "stop_point:1"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:2",
      "dt": "010500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "020500"
    },
    {
      "vj": "vehicle_journey:4",
      "dt": "030500"
    }
  ],
  "stop": "stop_point:2"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:2",
      "dt": "011500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "021500"
    },
    {
      "vj": "vehicle_journey:4",
      "dt": "031500"
    }
  ],
  "stop": "stop_point:3"
}


```

/route_schedules with a calendar, and sorted with a pivot time at midnight (same as above)
`/routes/route:1_A/route_schedules?calendar=Y2FsZW5kYXI6OA&from_datetime=20160704T000000`

```
{
  "schedule": [
    {
      "vj": "vehicle_journey:2",
      "dt": "005000"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "015000"
    },
    {
      "vj": "vehicle_journey:4",
      "dt": "025000"
    }
  ],
  "stop": "stop_point:1"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:2",
      "dt": "010500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "020500"
    },
    {
      "vj": "vehicle_journey:4",
      "dt": "030500"
    }
  ],
  "stop": "stop_point:2"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:2",
      "dt": "011500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "021500"
    },
    {
      "vj": "vehicle_journey:4",
      "dt": "031500"
    }
  ],
  "stop": "stop_point:3"
}
```

sort with pivot time at 2h00
`/routes/route:1_A/route_schedules?calendar=Y2FsZW5kYXI6OA&from_datetime=20160704T020000`

```
{
  "schedule": [
    {
      "vj": "vehicle_journey:4",
      "dt": "025000" <-- first datetime after 02h00
    },
    {
      "vj": "vehicle_journey:2",
      "dt": "005000"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "015000"
    }
  ],
  "stop": "stop_point:1"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:4",
      "dt": "030500"
    },
    {
      "vj": "vehicle_journey:2",
      "dt": "010500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "020500"
    }
  ],
  "stop": "stop_point:2"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:4",
      "dt": "031500"
    },
    {
      "vj": "vehicle_journey:2",
      "dt": "011500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "021500"
    }
  ],
  "stop": "stop_point:3"
}
```

route schedule without a calendar, just a datetime:
`/route:1_A/route_schedules?from_datetime=20160709T020000`

```
{
  "schedule": [
    {
      "vj": "vehicle_journey:4",
      "dt": "20160709T025000"
    },
    {
      "vj": "vehicle_journey:2",
      "dt": "20160710T005000"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "20160710T015000"
    }
  ],
  "stop": "stop_point:1"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:4",
      "dt": "20160709T030500"
    },
    {
      "vj": "vehicle_journey:2",
      "dt": "20160710T010500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "20160710T020500"
    }
  ],
  "stop": "stop_point:2"
}
{
  "schedule": [
    {
      "vj": "vehicle_journey:4",
      "dt": "20160709T031500"
    },
    {
      "vj": "vehicle_journey:2",
      "dt": "20160710T011500"
    },
    {
      "vj": "vehicle_journey:3",
      "dt": "20160710T021500"
    }
  ],
  "stop": "stop_point:3"
}

```

**Note:** on the examples I used [jq](https://stedolan.github.io/jq/) to make them a bit more readable.

the JQ command was `jq '.route_schedules[].table.rows[] | {stop: .stop_point.id, schedule: [.date_times[] | {dt : .date_time ,  vj: .links[].id}]}'`
