### PR TITLE
Kraken: fix activation of full RT load

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -53,7 +53,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("GENERAL.nb_threads", po::value<int>()->default_value(1), "number of workers threads")
         ("GENERAL.is_realtime_enabled", po::value<bool>()->default_value(false),
                                         "enable loading of realtime data")
-        ("GENERAL.kirin_timeout", po::value<int>()->default_value(10000),
+        ("GENERAL.kirin_timeout", po::value<int>()->default_value(60000),
                                   "timeout in ms for loading realtime data from kirin")
 
         ("BROKER.host", po::value<std::string>()->default_value("localhost"), "host of rabbitmq")

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -58,6 +58,7 @@ void MaintenanceWorker::load(){
     LOG4CPLUS_INFO(logger, "Loading database from file: " + database);
     if(this->data_manager.load(database, chaos_database, contributors)){
         auto data = data_manager.get_data();
+        data->is_realtime_loaded = false;
         data->meta->instance_name = conf.instance_name();
     }
     load_realtime();

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -79,7 +79,7 @@ Data::Data(size_t data_identifier) :
 {
     loaded = false;
     is_connected_to_rabbitmq = false;
-    is_realtime_loaded = true;
+    is_realtime_loaded = false;
 }
 
 Data::~Data(){}


### PR DESCRIPTION
is_realtime_loaded=false by default, and timeout is set to 1 minute
