### PR TITLE
ed2nav: sort house number only one times

### DIFF
--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1141,7 +1141,7 @@ void EdReader::fill_ways(navitia::type::Data& data, pqxx::work& work){
     }
 }
 
-void EdReader::fill_house_numbers(navitia::type::Data& , pqxx::work& work){
+void EdReader::fill_house_numbers(navitia::type::Data& data, pqxx::work& work){
     std::string request = "SELECT way_id, ST_X(coord::geometry) as lon, ST_Y(coord::geometry) as lat, number, left_side FROM georef.house_number where way_id IS NOT NULL;";
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
@@ -1158,6 +1158,9 @@ void EdReader::fill_house_numbers(navitia::type::Data& , pqxx::work& work){
                 way->add_house_number(hn);
             }
         }
+    }
+    for(auto way: data.geo_ref->ways){
+        way->sort_house_numbers();
     }
 }
 

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -53,12 +53,15 @@ namespace navitia{ namespace georef{
 
 void Way::add_house_number(const HouseNumber& house_number){
     if (house_number.number % 2 == 0){
-            this->house_number_right.push_back(house_number);
-            std::sort(this->house_number_right.begin(),this->house_number_right.end());
+        this->house_number_right.push_back(house_number);
     } else{
         this->house_number_left.push_back(house_number);
-        std::sort(this->house_number_left.begin(),this->house_number_left.end());
     }
+}
+
+void Way::sort_house_numbers(){
+    std::sort(this->house_number_right.begin(),this->house_number_right.end());
+    std::sort(this->house_number_left.begin(),this->house_number_left.end());
 }
 
 std::string Way::get_label() const {

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -155,6 +155,8 @@ public:
     }
     std::string get_label() const;
 
+    void sort_house_numbers();
+
 #ifdef _DEBUG_DIJKSTRA_QUANTUM_
     template <typename Stream, typename G>
     void print(Stream& stream, const G& g){


### PR DESCRIPTION
On fr-npdc ed2nav(osm/bano) was taking 42 minutes, with this patch it take 1min 42sec.
It change almost nothing for fr-pdl(geopal) and fr-idf(osm).
