### PR TITLE
jormungandr: fix a bug depending of the order of the parameter

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -44,6 +44,7 @@ from jormungandr.scenarios import simple
 import logging
 from jormungandr.scenarios.helpers import walking_duration, bss_duration, bike_duration, car_duration, pt_duration
 from jormungandr.scenarios.helpers import select_best_journey_by_time, select_best_journey_by_duration, max_duration_fallback_modes
+from jormungandr.scenarios.helpers import fallback_mode_comparator
 
 non_pt_types = ['non_pt_walk', 'non_pt_bike', 'non_pt_bss']
 
@@ -142,7 +143,6 @@ class Scenario(simple.Scenario):
             for all combinaison of departure and arrival mode we call kraken
         """
         logger = logging.getLogger(__name__)
-        # filter walking if bss in mode ?
         for o_mode, d_mode in itertools.product(self.origin_modes, self.destination_modes):
             req.journeys.streetnetwork_params.origin_mode = o_mode
             req.journeys.streetnetwork_params.destination_mode = d_mode
@@ -209,6 +209,14 @@ class Scenario(simple.Scenario):
         max_attempts = 2 if not request["min_nb_journeys"] else request["min_nb_journeys"]*2
         at_least_one_journey_found = False
         forbidden_uris = []
+
+        #call to kraken must be done with fallback mode in the right order:
+        #walking, then bss, then bike, and finally car
+        #in some case a car journey can be equivalent to a walking journey, typically when crowfly are used
+        #and only the first one is kept, and we want the walking one to be kept!
+        self.origin_modes.sort(fallback_mode_comparator)
+        self.destination_modes.sort(fallback_mode_comparator)
+
         while ((request["min_nb_journeys"] and request["min_nb_journeys"] > nb_typed_journeys) or\
             (not request["min_nb_journeys"] and nb_typed_journeys == 0)) and cpt_attempt < max_attempts:
             tmp_resp = self.call_kraken(next_request, instance)

--- a/source/jormungandr/jormungandr/scenarios/helpers.py
+++ b/source/jormungandr/jormungandr/scenarios/helpers.py
@@ -213,3 +213,7 @@ def select_best_journey_by_duration(journeys, clockwise, fallback_modes):
     if not list_journeys:
         return None
     return min(list_journeys, key=attrgetter('duration'))
+
+fallback_mode_order = ['walking', 'bss', 'bike', 'car']
+def fallback_mode_comparator(a, b):
+    return fallback_mode_order.index(a) -  fallback_mode_order.index(b)

--- a/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
@@ -736,3 +736,16 @@ def bss_duration_test():
     eq_(bss_duration(get_bike_bss_journey()), 70)
 
     eq_(bss_duration(get_bike_car_journey()), 0)
+
+def fallback_mode_sort_test():
+    l = ['car', 'walking']
+    l.sort(fallback_mode_comparator)
+    eq_(l[0], 'walking')
+    eq_(l[1], 'car')
+
+    l = ['bss', 'bike', 'car', 'walking']
+    l.sort(fallback_mode_comparator)
+    eq_(l[0], 'walking')
+    eq_(l[1], 'bss')
+    eq_(l[2], 'bike')
+    eq_(l[3], 'car')


### PR DESCRIPTION
Typically on admin to admin journeys we can get a journey like this:
Crowfly > PT > Crowfly
The mode of the crowfly is the one asked to kraken, so kraken will give
the exact same response for all fallback mode except for the mode used
(but we don't care since it's a teleportation)
And since all journeys are the same, jormungandr only keep the first
one, eventually the one with car fallback. Not cool but why not, except
that we only want one car journey so we remove a few journeys.
Paradoxically enabling car fallback was reducing the number of solution
found.

With this patch fallback modes are used in a logical order:
Walking > bss > bike > car

Refer to: http://jira.canaltp.fr/browse/NAVITIAII-1909
