### PR TITLE
Raptor: add second passes

### DIFF
--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -147,8 +147,8 @@ int main(int argc, char** argv){
 
     desc.add_options()
             ("help", "Show this message")
-            ("interations,i", po::value<int>(&iterations)->default_value(100),
-                     "Number of iterations (10 calcuations par iteration)")
+            ("iterations,i", po::value<int>(&iterations)->default_value(100),
+                     "Number of iterations (10 requests by iteration)")
             ("file,f", po::value<std::string>(&file)->default_value("data.nav.lz4"),
                      "Path to data.nav.lz4")
             ("start,s", po::value<std::string>(&start),
@@ -156,9 +156,9 @@ int main(int argc, char** argv){
             ("target,t", po::value<std::string>(&target),
                     "Target of a particular journey")
             ("date,d", po::value<int>(&date)->default_value(-1),
-                    "Begginning date of a particular journey")
+                    "Beginning date of a particular journey")
             ("hour,h", po::value<int>(&hour)->default_value(-1),
-                    "Begginning hour of a particular journey")
+                    "Beginning hour of a particular journey")
             ("verbose,v", "Verbose debugging output")
             ("stop_files", po::value<std::string>(&stop_input_file), "File with list of start and target")
             ("output,o", po::value<std::string>(&output)->default_value("benchmark.csv"),
@@ -210,7 +210,7 @@ int main(int argc, char** argv){
         std::mt19937 rng(31442);
         std::uniform_int_distribution<> gen(0,data.pt_data->stop_areas.size()-1);
         std::vector<unsigned int> hours{0, 28800, 36000, 72000, 86000};
-        std::vector<unsigned int> days({date != 1 ? unsigned(date) : 7});
+        std::vector<unsigned int> days({date != -1 ? unsigned(date) : 7});
         if(data.pt_data->validity_patterns.front()->beginning_date.day_of_week().as_number() == 6)
             days.push_back(days.front() + 1);
         else
@@ -250,7 +250,7 @@ int main(int argc, char** argv){
     boost::progress_display show_progress(demands.size());
     Timer t("Calcul avec l'algorithme ");
     //ProfilerStart("bench.prof");
-    int nb_reponses = 0;
+    int nb_reponses = 0, nb_journeys = 0;
 #ifdef __BENCH_WITH_CALGRIND__
     CALLGRIND_START_INSTRUMENTATION;
 #endif
@@ -290,6 +290,7 @@ int main(int argc, char** argv){
 
         if(resp.journeys_size() > 0) {
             ++ nb_reponses;
+            nb_journeys += resp.journeys_size();
 
             Result result(resp.journeys(0));
             result.time = t2.ms();
@@ -303,4 +304,5 @@ int main(int argc, char** argv){
 
     std::cout << "Number of requests: " << demands.size() << std::endl;
     std::cout << "Number of results with solution: " << nb_reponses << std::endl;
+    std::cout << "Number of journey found: " << nb_journeys << std::endl;
 }

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -109,6 +109,13 @@ void dataRAPTOR::load(const type::PT_Data& data)
             }
         }
     }
+
+    min_connection_time = std::numeric_limits<uint32_t>::max();
+    for (const auto& conns : connections.forward_connections) {
+        for (const auto& conn : conns.second) {
+            min_connection_time = std::min(min_connection_time, conn.duration);
+        }
+    }
 }
 
 }}

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -58,6 +58,7 @@ struct dataRAPTOR {
         IdxMap<type::StopPoint, std::vector<Connection>> backward_connections;
     };
     Connections connections;
+    DateTime min_connection_time;
 
     // cache friendly access to JourneyPatternPoints from a StopPoint
     struct JppsFromSp {

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -258,7 +258,7 @@ static void init_best_pts_snd_pass(const routing::map_stop_point_duration& depar
 }
 
 std::vector<Path>
-RAPTOR::compute_all(const map_stop_point_duration& departures_,
+RAPTOR::compute_all(const map_stop_point_duration& departures,
                     const map_stop_point_duration& destinations,
                     const DateTime& departure_datetime,
                     const nt::RTLevel rt_level,
@@ -283,8 +283,8 @@ RAPTOR::compute_all(const map_stop_point_duration& departures_,
         solutions.add(j);
     }
 
-    const auto& calc_dep = clockwise ? departures_ : destinations;
-    const auto& calc_dest = clockwise ? destinations : departures_;
+    const auto& calc_dep = clockwise ? departures : destinations;
+    const auto& calc_dest = clockwise ? destinations : departures;
 
     first_raptor_loop(calc_dep, departure_datetime, rt_level,
                       bound, max_transfers, accessibilite_params, forbidden_uri, clockwise);
@@ -322,7 +322,7 @@ RAPTOR::compute_all(const map_stop_point_duration& departures_,
         const auto reader_results = read_solutions(*this,
                                                    !clockwise,
                                                    departure_datetime,
-                                                   departures_,
+                                                   departures,
                                                    destinations,
                                                    rt_level,
                                                    accessibilite_params);

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -453,7 +453,7 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
     }
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     LOG4CPLUS_DEBUG(logger, "[2nd pass] lower bound fallback duration = " << min_dur_to_sp
-            << ", lower bound connection duration = " << min_conn_dur);
+            << ", lower bound connection duration = " << data.dataRaptor->min_connection_time);
     LOG4CPLUS_DEBUG(logger, "[2nd pass] number of 2nd pass = " << nb_snd_pass << " / " << starting_points.size()
             << " (nb useless = " << nb_useless << ", last usefull try = " << last_usefull_2nd_pass << ")");
     auto end_raptor = std::chrono::system_clock::now();

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -418,11 +418,11 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
             continue;
         }
 
-        if (supplementary_2nd_pass > max_supplementary_2nd_pass) {
-            break;
-        }
         if (!start.has_priority) {
             ++supplementary_2nd_pass;
+        }
+        if (supplementary_2nd_pass > max_supplementary_2nd_pass) {
+            break;
         }
 
         const auto& working_labels = first_pass_labels[start.count];

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include <boost/range/adaptor/filtered.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/fill.hpp>
+#include <chrono>
 
 namespace bt = boost::posix_time;
 
@@ -193,24 +194,47 @@ struct StartingPointSndPhase {
     unsigned count;
     DateTime end_dt;
     unsigned fallback_dur;
+    bool has_priority;
 };
 struct Dom {
     Dom(bool c): clockwise(c) {}
     bool clockwise;
-    typedef StartingPointSndPhase Arg;
+    typedef std::pair<size_t, StartingPointSndPhase> Arg;
     inline bool operator()(const Arg& lhs, const Arg& rhs) const {
-        return lhs.count <= rhs.count
-            && (clockwise ? lhs.end_dt <= rhs.end_dt : lhs.end_dt >= rhs.end_dt)
-            && lhs.fallback_dur <= rhs.fallback_dur;
+        return lhs.second.count <= rhs.second.count
+            && (clockwise ? lhs.second.end_dt <= rhs.second.end_dt
+                          : lhs.second.end_dt >= rhs.second.end_dt)
+            && lhs.second.fallback_dur <= rhs.second.fallback_dur;
     }
 };
-ParetoFront<StartingPointSndPhase, Dom>
+struct CompSndPhase {
+    CompSndPhase(bool c): clockwise(c) {}
+    bool clockwise;
+    typedef StartingPointSndPhase Arg;
+    inline bool operator()(const Arg& lhs, const Arg& rhs) const {
+        if (lhs.has_priority != rhs.has_priority) {
+            return lhs.has_priority;
+        }
+        if (lhs.count != rhs.count) {
+            return lhs.count < rhs.count;
+        }
+        if (lhs.end_dt != rhs.end_dt) {
+            return (clockwise ? lhs.end_dt < rhs.end_dt : lhs.end_dt > rhs.end_dt);
+        }
+        if (lhs.fallback_dur != rhs.fallback_dur) {
+            return lhs.fallback_dur < rhs.fallback_dur;
+        }
+        return lhs.sp_idx < rhs.sp_idx; // just to avoid randomness
+    }
+};
+std::vector<StartingPointSndPhase>
 make_starting_points_snd_phase(const RAPTOR& raptor,
                                const routing::map_stop_point_duration& arrs,
                                const type::AccessibiliteParams& accessibilite_params,
                                const bool clockwise)
 {
-    auto res = ParetoFront<StartingPointSndPhase, Dom>(Dom(clockwise));
+    std::vector<StartingPointSndPhase> res;
+    auto overfilter = ParetoFront<std::pair<size_t, StartingPointSndPhase>, Dom>(Dom(clockwise));
 
     for (unsigned count = 1; count <= raptor.count; ++count) {
         const auto& working_labels = raptor.labels[count];
@@ -224,15 +248,81 @@ make_starting_points_snd_phase(const RAPTOR& raptor,
                 count,
                 (clockwise ? working_labels.dt_pt(a.first) + walking_t
                            : working_labels.dt_pt(a.first) - walking_t),
-                walking_t
+                walking_t,
+                false
             };
-            res.add(starting_point);
+            overfilter.add({res.size(), starting_point});
+            res.push_back(starting_point);
         }
     }
 
+    for (const auto& pair : overfilter) {
+        res[pair.first].has_priority = true;
+    }
+
+    std::sort(res.begin(), res.end(), CompSndPhase(clockwise)); // most interesting solutions first
+
     return res;
 }
+
+Journey convert_to_bound(const StartingPointSndPhase& sp,
+                         uint32_t lower_bound_fb,
+                         uint32_t lower_bound_conn,
+                         bool clockwise) {
+    Journey journey;
+    journey.sections.resize(sp.count);
+    journey.sn_dur = navitia::time_duration(0, 0, sp.fallback_dur + lower_bound_fb, 0);
+    uint32_t nb_conn = (sp.count >= 1 ? sp.count - 1 : 0);
+    if (clockwise) {
+        journey.arrival_dt = sp.end_dt;
+        journey.departure_dt = sp.end_dt - journey.sn_dur.seconds() - nb_conn * lower_bound_conn;
+    } else {
+        journey.arrival_dt = sp.end_dt + journey.sn_dur.seconds() + nb_conn * lower_bound_conn;
+        journey.departure_dt = sp.end_dt;
+    }
+
+    journey.transfer_dur = navitia::seconds(120 * sp.count + nb_conn * lower_bound_conn);
+    // provide best values on unknown criteria
+    journey.min_waiting_dur = navitia::time_duration(boost::date_time::pos_infin);
+    journey.nb_vj_extentions = 0;
+    return journey;
 }
+
+// To be used for debug purpose (see JourneyParetoFrontVisitor commented use in RAPTOR::compute_all)
+//
+//struct JourneyParetoFrontVisitor {
+//    JourneyParetoFrontVisitor() = default;
+//    JourneyParetoFrontVisitor(const JourneyParetoFrontVisitor&) = default;
+//    JourneyParetoFrontVisitor& operator=(const JourneyParetoFrontVisitor&) = default;
+//
+//    void is_dominated_by(const Journey& to_insert, const Journey& /*front_cur*/) {
+//        LOG4CPLUS_DEBUG(logger, "[  ]JourneyParetoFront " << to_insert);
+//        ++nb_is_dominated_by;
+//    }
+//    void dominates(const Journey& /*to_insert*/, const Journey& front_cur) {
+//        LOG4CPLUS_DEBUG(logger, "[--]JourneyParetoFront " << front_cur);
+//        ++nb_dominates;
+//    }
+//    void inserted(const Journey& to_insert) {
+//        LOG4CPLUS_DEBUG(logger, "[++]JourneyParetoFront " << to_insert);
+//        ++nb_inserted;
+//    }
+//
+//    ~JourneyParetoFrontVisitor() {
+//        LOG4CPLUS_DEBUG(logger, "JourneyParetoFront summary: nb_is_dominated_by = " << nb_is_dominated_by
+//                << ", nb_dominates = " << nb_dominates
+//                << ", nb_inserted = " << nb_inserted);
+//
+//    }
+//
+//private:
+//    size_t nb_is_dominated_by = 0;
+//    size_t nb_dominates = 0;
+//    size_t nb_inserted = 0;
+//    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+//};
+}
+
 // copy and do the off by one for strict comparison for the second pass.
 static IdxMap<type::StopPoint, DateTime>
 snd_pass_best_labels(const bool clockwise, IdxMap<type::StopPoint, DateTime> best_labels) {
@@ -267,9 +357,11 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
                     const type::AccessibiliteParams& accessibilite_params,
                     const std::vector<std::string>& forbidden_uri,
                     bool clockwise,
-                    const boost::optional<navitia::time_duration>& direct_path_dur) {
+                    const boost::optional<navitia::time_duration>& direct_path_dur,
+                    const size_t max_supplementary_2nd_pass) {
+    auto start_raptor = std::chrono::system_clock::now();
 
-    auto solutions = Solutions(Dominates(clockwise));
+    auto solutions = ParetoFront<Journey, Dominates/*, JourneyParetoFrontVisitor*/>(Dominates(clockwise));
     if (direct_path_dur) {
         Journey j;
         j.sn_dur = *direct_path_dur;
@@ -288,6 +380,8 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
 
     first_raptor_loop(calc_dep, departure_datetime, rt_level,
                       bound, max_transfers, accessibilite_params, forbidden_uri, clockwise);
+
+    auto end_first_pass = std::chrono::system_clock::now();
 
     // Now, we do the second pass.  In case of clockwise (resp
     // anticlockwise) search, the goal of the second pass is to find
@@ -308,7 +402,33 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
     init_best_pts_snd_pass(calc_dep, departure_datetime, clockwise, best_labels_pts_for_snd_pass);
     auto best_labels_transfers_for_snd_pass = snd_pass_best_labels(clockwise, best_labels_pts);
 
+    navitia::time_duration min_dur_to_sp(boost::date_time::pos_infin);
+    for (const auto& pair_sp_dt : calc_dep) {
+        min_dur_to_sp = std::min(min_dur_to_sp, pair_sp_dt.second);
+    }
+    unsigned lower_bound_fb = min_dur_to_sp.seconds();
+
+    navitia::DateTime min_conn_dur(std::numeric_limits<uint32_t>::max());
+    for (const auto& conns : data.dataRaptor->connections.forward_connections) {
+        for (const auto& conn : conns.second) {
+            min_conn_dur = std::min(min_conn_dur, conn.duration);
+        }
+    }
+
+    size_t nb_snd_pass, nb_useless, last_usefull_2nd_pass, supplementary_2nd_pass = 0;
     for (const auto& start: starting_points) {
+        Journey fake_journey = convert_to_bound(start, lower_bound_fb, min_conn_dur, clockwise);
+        if (solutions.is_dominated(fake_journey)) {
+            continue;
+        }
+
+        if (supplementary_2nd_pass > max_supplementary_2nd_pass) {
+            break;
+        }
+        if (!start.has_priority) {
+            ++supplementary_2nd_pass;
+        }
+
         const auto& working_labels = first_pass_labels[start.count];
 
         clear(!clockwise, departure_datetime + (clockwise ? -1 : 1));
@@ -326,8 +446,25 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
                                                    destinations,
                                                    rt_level,
                                                    accessibilite_params);
-        for (const auto& s: reader_results) { solutions.add(s); }
+        bool has_added = false;
+        for (const auto& s: reader_results) { has_added = (solutions.add(s) || has_added); }
+        ++nb_snd_pass;
+        if (!has_added) {
+            ++nb_useless;
+        } else {
+            last_usefull_2nd_pass = nb_snd_pass;
+        }
     }
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    LOG4CPLUS_DEBUG(logger, "[2nd pass] lower bound fallback duration = " << min_dur_to_sp
+            << ", lower bound connection duration = " << min_conn_dur);
+    LOG4CPLUS_DEBUG(logger, "[2nd pass] number of 2nd pass = " << nb_snd_pass << " / " << starting_points.size()
+            << " (nb useless = " << nb_useless << ", last usefull try = " << last_usefull_2nd_pass << ")");
+    auto end_raptor = std::chrono::system_clock::now();
+    LOG4CPLUS_DEBUG(logger, "[2nd pass] Run times: 1st pass = "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(end_first_pass - start_raptor).count()
+            << ", 2nd pass = "
+            << std::chrono::duration_cast<std::chrono::milliseconds>(end_raptor - end_first_pass).count());
 
     std::vector<Path> result;
     for (const auto& s: solutions) {

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -140,7 +140,7 @@ struct RAPTOR
                 const std::vector<std::string>& forbidden = std::vector<std::string>(),
                 bool clockwise = true,
                 const boost::optional<navitia::time_duration>& direct_path_dur = boost::none,
-                const size_t max_supplementary_2nd_pass = 10);
+                const size_t max_supplementary_2nd_pass = 0);
 
 
     /** Calcul d'itinéraires multiples dans le sens horaire à partir de plusieurs

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -139,7 +139,8 @@ struct RAPTOR
                 const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
                 const std::vector<std::string>& forbidden = std::vector<std::string>(),
                 bool clockwise = true,
-                const boost::optional<navitia::time_duration>& direct_path_dur = boost::none);
+                const boost::optional<navitia::time_duration>& direct_path_dur = boost::none,
+                const size_t max_supplementary_2nd_pass = 10);
 
 
     /** Calcul d'itinéraires multiples dans le sens horaire à partir de plusieurs

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -559,16 +559,26 @@ bool Journey::better_on_sn(const Journey& that, bool) const {
 }
 
 std::ostream& operator<<(std::ostream& os, const Journey& j) {
-    os << "([" << j.departure_dt << ", " << j.arrival_dt << ", "
+    os << "([" << navitia::str(j.departure_dt) << ", " << navitia::str(j.arrival_dt) << ", "
        << j.min_waiting_dur << ", " << j.transfer_dur << "], ["
        << j.sections.size() << ", " << unsigned(j.nb_vj_extentions) << "], "
        << j.sn_dur << ") ";
     for (const auto& s: j.sections) {
-        os << "("
-           << s.get_in_st->vehicle_journey->route->line->uri << ": "
-           << s.get_in_st->stop_point->uri << "@"
-           << s.get_in_dt << ", "
-           << s.get_out_st->stop_point->uri << "@"
+        if (s.get_in_st) {
+            os << "("
+               << s.get_in_st->vehicle_journey->route->line->uri << ": "
+               << s.get_in_st->stop_point->uri;
+        } else {
+            os << "(NULL";
+        }
+        os << "@"
+           << s.get_in_dt << ", ";
+        if (s.get_out_st) {
+           os << s.get_out_st->stop_point->uri;
+        } else {
+            os << "NULL";
+        }
+        os << "@"
            << s.get_out_dt << ")";
     }
     return os;

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -37,16 +37,17 @@ namespace navitia { namespace routing {
 
 struct Journey {
     struct Section {
+        Section() = default;
         Section(const type::StopTime& in,
                 const DateTime in_dt,
                 const type::StopTime& out,
                 const DateTime out_dt):
             get_in_st(&in), get_in_dt(in_dt), get_out_st(&out), get_out_dt(out_dt)
         {}
-        const type::StopTime* get_in_st;
-        DateTime get_in_dt;
-        const type::StopTime* get_out_st;
-        DateTime get_out_dt;
+        const type::StopTime* get_in_st = nullptr;
+        DateTime get_in_dt = 0;
+        const type::StopTime* get_out_st = nullptr;
+        DateTime get_out_dt = 0;
     };
 
     bool better_on_dt(const Journey& that, bool request_clockwise) const;

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2663,7 +2663,14 @@ BOOST_AUTO_TEST_CASE(exhaustive_second_pass) {
     auto res = raptor.compute_all(departures,
                                   arrivals,
                                   DateTimeUtils::set(2, "07:00"_t),
-                                  type::RTLevel::Base);
+                                  type::RTLevel::Base,
+                                  DateTimeUtils::inf,
+                                  10,
+                                  type::AccessibiliteParams(),
+                                  std::vector<std::string>(),
+                                  true,
+                                  boost::none,
+                                  10);
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     using boost::posix_time::time_from_string;

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2631,3 +2631,44 @@ BOOST_AUTO_TEST_CASE(begin_different_zone3) {
     // don't have a good solution and this case should not happen
     // often.
 }
+
+// test that raptor is able to find "hidden" pathes (improving sn, but only because of the departure)
+//
+//                                        9h10
+//       __________ A ===================> B ______________
+//      /   1 min            vj 1              3 min       \
+//     /                                               arrival
+// departure                                 9h00         /
+//    \_________________ C ==================> D ________/
+//           10 min              vj 2            1 min
+//
+BOOST_AUTO_TEST_CASE(exhaustive_second_pass) {
+    ed::builder b("20150101");
+    b.vj("1")("A", "8:00"_t, "8:00"_t)("B", "9:10"_t, "9:10"_t);
+    b.vj("2")("C", "8:00"_t, "8:01"_t)("D", "9:00"_t, "9:00"_t);
+
+    b.data->pt_data->index();
+    b.finish();
+    b.data->build_raptor();
+    b.data->build_uri();
+    RAPTOR raptor(*(b.data));
+    const type::PT_Data& d = *b.data->pt_data;
+
+    routing::map_stop_point_duration departures, arrivals;
+    departures[SpIdx(*d.stop_areas_map.at("A")->stop_point_list.front())] = 1_min;
+    departures[SpIdx(*d.stop_areas_map.at("C")->stop_point_list.front())] = 10_min;
+    arrivals[SpIdx(*d.stop_areas_map.at("B")->stop_point_list.front())] = 3_min;
+    arrivals[SpIdx(*d.stop_areas_map.at("D")->stop_point_list.front())] = 1_min;
+
+    auto res = raptor.compute_all(departures,
+                                  arrivals,
+                                  DateTimeUtils::set(2, "07:00"_t),
+                                  type::RTLevel::Base);
+
+    BOOST_CHECK_EQUAL(res.size(), 2);
+    using boost::posix_time::time_from_string;
+    BOOST_CHECK_EQUAL(res.at(0).items.front().departure, time_from_string("2015-01-03 08:01:00"));
+    BOOST_CHECK_EQUAL(res.at(0).items.back().arrival, time_from_string("2015-01-03 09:00:00"));
+    BOOST_CHECK_EQUAL(res.at(1).items.front().departure, time_from_string("2015-01-03 08:00:00"));
+    BOOST_CHECK_EQUAL(res.at(1).items.back().arrival, time_from_string("2015-01-03 09:10:00"));
+}

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2665,7 +2665,7 @@ BOOST_AUTO_TEST_CASE(exhaustive_second_pass) {
                                   DateTimeUtils::set(2, "07:00"_t),
                                   type::RTLevel::Base);
 
-    BOOST_CHECK_EQUAL(res.size(), 2);
+    BOOST_REQUIRE_EQUAL(res.size(), 2);
     using boost::posix_time::time_from_string;
     BOOST_CHECK_EQUAL(res.at(0).items.front().departure, time_from_string("2015-01-03 08:01:00"));
     BOOST_CHECK_EQUAL(res.at(0).items.back().arrival, time_from_string("2015-01-03 09:00:00"));

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2670,7 +2670,7 @@ BOOST_AUTO_TEST_CASE(exhaustive_second_pass) {
                                   std::vector<std::string>(),
                                   true,
                                   boost::none,
-                                  10);
+                                  10); // only extra second passes can find that A-B has less sn
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     using boost::posix_time::time_from_string;

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -259,7 +259,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_filter, route_schedule_calendar_fixture) {
 
 namespace ba = boost::adaptors;
 using vec_dt = std::vector<navitia::DateTime>;
-navitia::DateTime get_dt(const ntt::datetime_stop_time& p) { return p.first; }
+static navitia::DateTime get_dt(const ntt::datetime_stop_time& p) { return p.first; }
 
 /*
  * Test get_all_route_stop_times with a calendar

--- a/source/type/datetime.cpp
+++ b/source/type/datetime.cpp
@@ -49,11 +49,21 @@ std::ostream & operator<<(std::ostream & os, const DateTime & dt){
 */
 std::string str(const DateTime & dt){
     std::stringstream os;
-    os << "D=" << DateTimeUtils::date(dt) << " " << DateTimeUtils::hour(dt)/(3600) << ":";
+    os << "D=" << DateTimeUtils::date(dt) << " ";
+    if((DateTimeUtils::hour(dt)/3600) < 10)
+        os << "0" << (DateTimeUtils::hour(dt)/3600);
+    else
+        os << (DateTimeUtils::hour(dt)/3600);
+    os << ":";
     if((DateTimeUtils::hour(dt)%3600)/60 < 10)
         os << "0" << (DateTimeUtils::hour(dt)%3600)/60;
     else
         os << (DateTimeUtils::hour(dt)%3600)/60;
+    os << ":";
+    if((DateTimeUtils::hour(dt)%60) < 10)
+        os << "0" << (DateTimeUtils::hour(dt)%60);
+    else
+        os << (DateTimeUtils::hour(dt)%60);
     return os.str();
 }
 

--- a/source/type/datetime.cpp
+++ b/source/type/datetime.cpp
@@ -50,20 +50,9 @@ std::ostream & operator<<(std::ostream & os, const DateTime & dt){
 std::string str(const DateTime & dt){
     std::stringstream os;
     os << "D=" << DateTimeUtils::date(dt) << " ";
-    if((DateTimeUtils::hour(dt)/3600) < 10)
-        os << "0" << (DateTimeUtils::hour(dt)/3600);
-    else
-        os << (DateTimeUtils::hour(dt)/3600);
-    os << ":";
-    if((DateTimeUtils::hour(dt)%3600)/60 < 10)
-        os << "0" << (DateTimeUtils::hour(dt)%3600)/60;
-    else
-        os << (DateTimeUtils::hour(dt)%3600)/60;
-    os << ":";
-    if((DateTimeUtils::hour(dt)%60) < 10)
-        os << "0" << (DateTimeUtils::hour(dt)%60);
-    else
-        os << (DateTimeUtils::hour(dt)%60);
+    os << std::setfill('0') << std::setw(2) << DateTimeUtils::hour(dt)/3600 << ":";
+    os << std::setfill('0') << std::setw(2) << (DateTimeUtils::hour(dt)%3600)/60 << ":";
+    os << std::setfill('0') << std::setw(2) << DateTimeUtils::hour(dt)%60 << ":";
     return os.str();
 }
 


### PR DESCRIPTION
This PR adds second passes to currently overfiltered ones.

JIRA: http://jira.canaltp.fr/browse/NAVP-318

Bench when adding 11 second passes:
- stif: time \* 2.2, journeys \* 1.09
- fr-pdl: time \* 1.57, journeys \* 1.05

TODO (but in another PR to come):
- Currently adding 0 of them by default (but param management is to be changed)
- Managing the "2 minutes du peuple" on a more centralized way
