### PR TITLE
RT: connect apply disruption to the new VJs methods

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -99,8 +99,7 @@ public:
     void add_disruption(DisruptionCreator disrupt, nt::PT_Data& pt_data) {
         nt::disruption::DisruptionHolder& holder = pt_data.disruption_holder;
 
-        auto disruption = std::make_unique<Disruption>();
-        disruption->uri = disrupt.uri;
+        auto disruption = std::make_unique<Disruption>(disrupt.uri, nt::RTLevel::Adapted);
         disruption->publication_period = disrupt.publication_period;
 
         auto impact = boost::make_shared<Impact>();

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -180,9 +180,9 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
         }
         const auto& impact = this->impact;
         boost::range::remove_erase_if(mvj->impacted_by,
-                                      [&impact](const boost::weak_ptr<nt::disruption::Impact>& i) {
-            auto spt = i.lock();
-            return (spt) ? spt == impact : true;
+            [&impact](const boost::weak_ptr<nt::disruption::Impact>& i) {
+                auto spt = i.lock();
+                return (spt) ? spt == impact : true;
         });
 
         for (auto i: mvj->impacted_by) {

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -262,8 +262,7 @@ make_disruption(const chaos::Disruption& chaos_disruption, nt::PT_Data& pt_data)
     auto from_posix = navitia::from_posix_timestamp;
     nt::disruption::DisruptionHolder& holder = pt_data.disruption_holder;
 
-    auto disruption = std::make_unique<nt::disruption::Disruption>();
-    disruption->uri = chaos_disruption.id();
+    auto disruption = std::make_unique<nt::disruption::Disruption>(chaos_disruption.id(), nt::RTLevel::Adapted);
 
     if (chaos_disruption.has_contributor()) {
         disruption->contributor = chaos_disruption.contributor();

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -71,24 +71,6 @@ make_cause(const chaos::Cause& chaos_cause, nt::disruption::DisruptionHolder& ho
 
 }
 
-
-//return the time period of circulation of a vj for one day
-boost::posix_time::time_period execution_period(const boost::gregorian::date& date,
-                                                const nt::VehicleJourney& vj) {
-    uint32_t first_departure = std::numeric_limits<uint32_t>::max();
-    uint32_t last_arrival = 0;
-    for(const auto& st: vj.stop_time_list){
-        if(st.pick_up_allowed() && first_departure > st.departure_time){
-            first_departure = st.departure_time;
-        }
-        if(st.drop_off_allowed() && last_arrival < st.arrival_time){
-            last_arrival = st.arrival_time;
-        }
-    }
-    return bt::time_period(bt::ptime(date, bt::seconds(first_departure)),
-            bt::ptime(date, bt::seconds(last_arrival)));
-}
-
 static boost::shared_ptr<nt::disruption::Severity>
 make_severity(const chaos::Severity& chaos_severity, nt::disruption::DisruptionHolder& holder) {
     namespace tr = transit_realtime;
@@ -146,7 +128,7 @@ make_line_section(const chaos::PtObject& chaos_section,
                        << pb_section.line().uri() << " in LineSection invalid!");
         return boost::none;
     }
-    if (const auto* start = find_or_default(pb_section.start_point().uri(), pt_data.stop_areas_map)) {
+    if (auto* start = find_or_default(pb_section.start_point().uri(), pt_data.stop_areas_map)) {
         line_section.start_point = start;
     } else {
         LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
@@ -154,7 +136,7 @@ make_line_section(const chaos::PtObject& chaos_section,
                        << pb_section.start_point().uri() << " in LineSection invalid!");
         return boost::none;
     }
-    if (const auto* end = find_or_default(pb_section.end_point().uri(), pt_data.stop_areas_map)) {
+    if (auto* end = find_or_default(pb_section.end_point().uri(), pt_data.stop_areas_map)) {
         line_section.end_point = end;
     } else {
         LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
@@ -283,7 +265,7 @@ make_disruption(const chaos::Disruption& chaos_disruption, nt::PT_Data& pt_data)
     auto disruption = std::make_unique<nt::disruption::Disruption>();
     disruption->uri = chaos_disruption.id();
 
-    if (chaos_disruption.has_contributor()){
+    if (chaos_disruption.has_contributor()) {
         disruption->contributor = chaos_disruption.contributor();
     }
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -83,8 +83,7 @@ create_disruption(const std::string& id,
     const auto& mvj = *data.pt_data->meta_vjs.get_mut(trip_update.trip().trip_id());
 
     delete_disruption(id, *data.pt_data, *data.meta);
-    auto disruption = std::make_unique<nt::disruption::Disruption>();
-    disruption->uri = id;
+    auto disruption = std::make_unique<nt::disruption::Disruption>(id, type::RTLevel::RealTime);
     disruption->reference = disruption->uri;
     disruption->publication_period = data.meta->production_period();
     disruption->created_at = timestamp;

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -65,7 +65,7 @@ static boost::posix_time::time_period
 execution_period(const boost::gregorian::date& date, const nt::MetaVehicleJourney& mvj) {
     auto running_vj = mvj.get_vj_at_date(type::RTLevel::Base, date);
     if (running_vj) {
-        return execution_period(date, *running_vj);
+        return running_vj->execution_period(date);
     }
     // If there is no running vj at this date, we return a null period (begin == end)
     return {boost::posix_time::ptime{date}, boost::posix_time::ptime{date}};

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1878,8 +1878,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
 
     {
         //we create one disruption on stop A
-        auto disruption = std::make_unique<Disruption>();
-        disruption->uri = "info_on_stop_A";
+        auto disruption = std::make_unique<Disruption>("info_on_stop_A", nt::RTLevel::Adapted);
         disruption->publication_period = default_period;
         auto tag = boost::make_shared<Tag>();
         tag->uri = "tag";
@@ -1902,8 +1901,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
     }
     {
         //we create one disruption on line 2
-        auto disruption = std::make_unique<Disruption>();
-        disruption->uri = "detour_on_line_2";
+        auto disruption = std::make_unique<Disruption>("detour_on_line_2", nt::RTLevel::Adapted);
         disruption->publication_period = default_period;
         auto tag = boost::make_shared<Tag>();
         tag->uri = "tag";
@@ -1982,8 +1980,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
 
     {
         //we create one disruption on stop A
-        auto disruption = std::make_unique<Disruption>();
-        disruption->uri = "info_on_stop_A";
+        auto disruption = std::make_unique<Disruption>("info_on_stop_A", nt::RTLevel::Adapted);
         disruption->publication_period = default_period;
         auto tag = boost::make_shared<Tag>();
         tag->uri = "tag";
@@ -2006,8 +2003,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
     }
     {
         //we create one disruption on line 2
-        auto disruption = std::make_unique<Disruption>();
-        disruption->uri = "detour_on_line_2";
+        auto disruption = std::make_unique<Disruption>("detour_on_line_2", nt::RTLevel::Adapted);
         disruption->publication_period = default_period;
         auto tag = boost::make_shared<Tag>();
         tag->uri = "tag";

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -63,7 +63,7 @@ namespace navitia { namespace type {
 
 wrong_version::~wrong_version() noexcept {}
 
-const unsigned int Data::data_version = 48; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 49; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     data_identifier(data_identifier),

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -228,11 +228,15 @@ struct Tag {
 };
 
 struct Disruption {
+    Disruption() {}
+    Disruption(const std::string u, RTLevel lvl): uri(u), rt_level(lvl) {}
+
     std::string uri;
     // Provider of the disruption
     std::string contributor;
     // it's the title of the disruption as shown in the backoffice
     std::string reference;
+    RTLevel rt_level = RTLevel::Adapted;
 
     // the publication period specify when an information can be displayed to
     // the customer, if a request is made before or after this period the
@@ -256,7 +260,7 @@ struct Disruption {
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
-        ar & uri & reference & publication_period
+        ar & uri & reference & rt_level & publication_period
            & created_at & updated_at & cause & impacts & localization & tags & note & contributor;
     }
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -142,9 +142,9 @@ struct UnknownPtObj {
     void serialize(Archive&, const unsigned int) {}
 };
 struct LineSection {
-    const Line* line = nullptr;
-    const StopArea* start_point = nullptr;
-    const StopArea* end_point = nullptr;
+    Line* line = nullptr;
+    StopArea* start_point = nullptr;
+    StopArea* end_point = nullptr;
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar & line & start_point & end_point;
@@ -152,13 +152,13 @@ struct LineSection {
 };
 typedef boost::variant<
     UnknownPtObj,
-    const Network *,
-    const StopArea *,
-    const StopPoint *,
+    Network*,
+    StopArea*,
+    StopPoint*,
     LineSection,
-    const Line *,
-    const Route *,
-    const MetaVehicleJourney *
+    Line*,
+    Route*,
+    MetaVehicleJourney*
     > PtObj;
 
 PtObj make_pt_obj(Type_e type,

--- a/source/type/tests/test.cpp
+++ b/source/type/tests/test.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(projection) {
 
 
 struct disruption_fixture {
-    disruption_fixture() : disruption(std::make_unique<Disruption>()) {
+    disruption_fixture() : disruption(std::make_unique<Disruption>("bob", navitia::type::RTLevel::Adapted)) {
         disruption->add_impact(boost::make_shared<Impact>());
 
         disruption->publication_period = pt::time_period(

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -351,9 +351,11 @@ static bool intersect(const VehicleJourney* vj, const std::vector<boost::posix_t
 
 void MetaVehicleJourney::cancel_vj(RTLevel level,
         const std::vector<boost::posix_time::time_period>& periods,
-        nt::PT_Data& pt_data, const nt::MetaData& meta) {
+        nt::PT_Data& pt_data, const nt::MetaData& meta, const Route* filtering_route) {
     for (auto l: reverse_enum_range_from<RTLevel>(level)) {
         for (auto* vj: rtlevel_to_vjs_map[l]) {
+            // note: we might want to cancel only the vj of certain routes
+            if (filtering_route && vj->route != filtering_route) { continue; }
             nt::ValidityPattern tmp_vp(*vj->get_validity_pattern_at(l));
             auto vp_modifier = [&tmp_vp] (const unsigned day) {
                 tmp_vp.remove(day);
@@ -382,10 +384,12 @@ MetaVehicleJourney::get_vj_at_date(RTLevel level, const boost::gregorian::date& 
 std::vector<VehicleJourney*>
 MetaVehicleJourney::get_vjs_in_period(RTLevel level,
                                       const std::vector<boost::posix_time::time_period>& periods,
-                                      const MetaData& meta) const {
+                                      const MetaData& meta,
+                                      const Route* filtering_route) const {
     std::vector<VehicleJourney*> res;
     for (auto l: reverse_enum_range_from<RTLevel>(level)) {
         for (auto* vj: rtlevel_to_vjs_map[l]) {
+            if (filtering_route && vj->route != filtering_route) { continue; }
             auto func = [] (const unsigned /*day*/) {
                 return false; // we want to stop as soon as we know the vj intersec the period
             };

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -324,23 +324,6 @@ bool ValidityPattern::uncheck2(unsigned int day) const {
         return !days[day-1] && !days[day] && !days[day+1];
 }
 
-void MetaVehicleJourney::cancel_vj(RTLevel level,
-        const std::vector<boost::gregorian::date>& dates,
-        const type::Data& data) {
-    for (auto l : reverse_enum_range_from<RTLevel>(level)) {
-        for (auto* vj: rtlevel_to_vjs_map[l]) {
-            for (const auto& date: dates){
-                if (! vj->get_validity_pattern_at(level)->check(date)) { continue; }
-                LOG4CPLUS_INFO(log4cplus::Logger::getInstance("realtime"),
-                        "canceling the vj " << vj->uri << " on " << date);
-                nt::ValidityPattern tmp_vp(*vj->get_validity_pattern_at(l));
-                tmp_vp.remove(date);
-                vj->validity_patterns[level] = data.pt_data->get_or_create_validity_pattern(tmp_vp);
-            }
-        }
-    }
-}
-
 template <typename F>
 static bool intersect(const VehicleJourney* vj, const std::vector<boost::posix_time::time_period>& periods,
                       RTLevel lvl, const nt::MetaData& meta, const F& fun) {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -1017,10 +1017,6 @@ struct MetaVehicleJourney: public Header, HasMessages {
     }
 
     void cancel_vj(RTLevel level,
-            const std::vector<boost::gregorian::date>& dates,
-            const type::Data& data);
-
-    void cancel_vj(RTLevel level,
             const std::vector<boost::posix_time::time_period>& periods,
             PT_Data& pt_data, const MetaData& meta);
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -135,6 +135,8 @@ enum class OdtLevel_e {
 std::ostream& operator<<(std::ostream& os, const Mode_e& mode);
 
 struct PT_Data;
+struct MetaData;
+
 template<class T> std::string T::* name_getter(){return &T::name;}
 template<class T> int T::* idx_getter(){return &T::idx;}
 
@@ -684,13 +686,8 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties {
     VehicleJourney* next_vj = nullptr;
     VehicleJourney* prev_vj = nullptr;
     //associated meta vj
-    const MetaVehicleJourney* meta_vj = nullptr;
+    MetaVehicleJourney* meta_vj = nullptr;
     std::string odt_message; //TODO It seems a VJ can have either a comment or an odt_message but never both, so we could use only the 'comment' to store the odt_message
-
-
-    // impacts not directly on this vj, by example an impact on a line will impact the vj, so we add the impact here
-    // because it's not really on the vj
-    std::vector<boost::weak_ptr<disruption::Impact>> impacted_by;
 
     // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1
     VehicleJourneyType vehicle_journey_type = VehicleJourneyType::regular;
@@ -711,6 +708,8 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties {
     ValidityPattern* adapted_validity_pattern() const { return get_validity_pattern_at(RTLevel::Adapted); }
     ValidityPattern* rt_validity_pattern() const { return get_validity_pattern_at(RTLevel::RealTime); }
 
+    //return the time period of circulation of the vj for one day
+    boost::posix_time::time_period execution_period(const boost::gregorian::date& date) const;
 
     std::string get_direction() const;
     bool has_datetime_estimated() const;
@@ -728,8 +727,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties {
             & vehicle_journey_type
             & odt_message & _vehicle_properties
             & next_vj & prev_vj
-            & meta_vj & utc_to_local_offset
-            & impacted_by;
+            & meta_vj & utc_to_local_offset;
     }
 
     virtual ~VehicleJourney();
@@ -984,13 +982,18 @@ struct Calendar : public Nameable, public Header {
  */
 struct MetaVehicleJourney: public Header, HasMessages {
 
+    // impacts not directly on this vj, by example an impact on a line will impact the vj, so we add the impact here
+    // because it's not really on the vj
+    std::vector<boost::weak_ptr<disruption::Impact>> impacted_by;
 
     /// map of the calendars that nearly match union of the validity pattern
     /// of the theoric vj, key is the calendar name
     std::map<std::string, AssociatedCalendar*> associated_calendars;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
-        ar & idx & uri & rtlevel_to_vjs_map & associated_calendars & impacts;
+        ar & idx & uri & rtlevel_to_vjs_map
+           & associated_calendars & impacts
+           & impacted_by;
     }
 
     // TODO XL: this function should be called in places where add_vj is called, because MetaVehicleJourney will
@@ -1017,10 +1020,16 @@ struct MetaVehicleJourney: public Header, HasMessages {
             const std::vector<boost::gregorian::date>& dates,
             const type::Data& data);
 
+    void cancel_vj(RTLevel level,
+            const std::vector<boost::posix_time::time_period>& periods,
+            PT_Data& pt_data, const MetaData& meta);
+
     VehicleJourney*
     get_vj_at_date(RTLevel level, const boost::gregorian::date& date) const;
     std::vector<VehicleJourney*>
-    get_vjs_in_period(RTLevel level, const boost::gregorian::date_period& period) const;
+    get_vjs_in_period(RTLevel level,
+                      const std::vector<boost::posix_time::time_period>& period,
+                      const MetaData& meta) const;
 
 private:
     navitia::flat_enum_map<RTLevel, std::vector<VehicleJourney*>> rtlevel_to_vjs_map;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -1018,14 +1018,14 @@ struct MetaVehicleJourney: public Header, HasMessages {
 
     void cancel_vj(RTLevel level,
             const std::vector<boost::posix_time::time_period>& periods,
-            PT_Data& pt_data, const MetaData& meta);
+            PT_Data& pt_data, const MetaData& meta, const Route* filtering_route = nullptr);
 
     VehicleJourney*
     get_vj_at_date(RTLevel level, const boost::gregorian::date& date) const;
     std::vector<VehicleJourney*>
     get_vjs_in_period(RTLevel level,
                       const std::vector<boost::posix_time::time_period>& period,
-                      const MetaData& meta) const;
+                      const MetaData& meta, const Route* filtering_route = nullptr) const;
 
 private:
     navitia::flat_enum_map<RTLevel, std::vector<VehicleJourney*>> rtlevel_to_vjs_map;


### PR DESCRIPTION
we want apply_disruption to handle chaos and kirin messages, so refactoring of apply_disruption to make it a bit more generic
