### PR TITLE
Build: patches for Ubuntu 15.10

### DIFF
--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -406,14 +406,12 @@ BOOST_AUTO_TEST_CASE(Faute_de_frappe_One){
 
         auto res1 = ac.find_partial_with_pattern("gare patea", word_weight, nbmax, [](int){return true;}, ghostwords);
         BOOST_REQUIRE_EQUAL(res1.size(), 3);
-        BOOST_CHECK_EQUAL(res1.at(0).idx, 4);
-        BOOST_CHECK_EQUAL(res1.at(1).idx, 1);
+        std::initializer_list<unsigned> best_res = {1, 4}; // they are equivalent
+        BOOST_CHECK(in(res1.at(0).idx, best_res));
+        BOOST_CHECK(in(res1.at(1).idx, best_res));
         BOOST_CHECK_EQUAL(res1.at(2).idx, 0);
         BOOST_CHECK_EQUAL(res1.at(0).quality, 94);
-
-
     }
-
 
 /*
     > Le fonctionnement normal :> On prends que les autocomplete si tous les mots dans la recherche existent

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -409,6 +409,7 @@ BOOST_AUTO_TEST_CASE(Faute_de_frappe_One){
         std::initializer_list<unsigned> best_res = {1, 4}; // they are equivalent
         BOOST_CHECK(in(res1.at(0).idx, best_res));
         BOOST_CHECK(in(res1.at(1).idx, best_res));
+        BOOST_CHECK_NE(res1.at(0).idx, res1.at(1).idx);
         BOOST_CHECK_EQUAL(res1.at(2).idx, 0);
         BOOST_CHECK_EQUAL(res1.at(0).quality, 94);
     }

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -827,6 +827,11 @@ void CommercialModeFusioHandler::handle_line(Data& data, const csv_row& row, boo
                         "  file has more than one commercial mode and no commercial_mode_id column");
         throw InvalidHeaders(csv.filename);
     }
+    if (! has_col(name_c, row)) {
+        LOG4CPLUS_WARN(logger, "invalid line on " << csv.filename <<
+                        "  commercial mode " << row[id_c] << " is missing a name");
+        return;
+    }
     ed::types::CommercialMode* commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = row[name_c];
     commercial_mode->uri = row[id_c];

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -37,7 +37,7 @@ www.navitia.io
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/date_time/gregorian/greg_serialize.hpp>
-#include <boost/serialization/vector.hpp>
+#include "utils/serialization_vector.h"
 #include <boost/serialization/utility.hpp>
 
 namespace navitia { namespace fare {

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -37,7 +37,7 @@ www.navitia.io
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/adj_list_serialize.hpp>
 #include <boost/serialization/serialization.hpp>
-#include <boost/serialization/vector.hpp>
+#include "utils/serialization_vector.h"
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/set.hpp>
 #include <map>

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -45,7 +45,7 @@ www.navitia.io
 #include <boost/spirit/include/phoenix1_binders.hpp>
 #include <boost/spirit/include/phoenix_stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
-#include <boost/spirit/home/phoenix/object/construct.hpp>
+#include <boost/phoenix/object/construct.hpp>
 #include <boost/date_time/time_duration.hpp>
 #include "type/pt_data.h"
 #include "type/meta_data.h"

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -45,7 +45,12 @@ www.navitia.io
 #include <boost/spirit/include/phoenix1_binders.hpp>
 #include <boost/spirit/include/phoenix_stl.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 105700
 #include <boost/phoenix/object/construct.hpp>
+#else
+#include <boost/spirit/home/phoenix/object/construct.hpp>
+#endif
 #include <boost/date_time/time_duration.hpp>
 #include "type/pt_data.h"
 #include "type/meta_data.h"

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -68,7 +68,8 @@ get_out_st_dt(const std::pair<const type::StopTime*, DateTime>& in_st_dt,
               const JourneyPatternContainer& jp_container)
 {
     DateTime cur_dt = in_st_dt.second;
-    for (const auto& st: raptor_visitor().st_range(*in_st_dt.first).advance_begin(1)) {
+    auto st_range = raptor_visitor().st_range(*in_st_dt.first);
+    for (const auto& st: st_range.advance_begin(1)) {
         cur_dt = st.section_end(cur_dt, true);
         if (jp_container.get_jpp(st) == target_jpp) {
             // check if the get_out is valid?
@@ -440,9 +441,13 @@ struct RaptorSolutionReader {
             //for frequency, we need cur_dt to be the begin in the stoptime
             cur_dt = begin_st_dt.first->begin_from_end(cur_dt, v.clockwise());
         }
-        for (const auto& end_st: v.st_range(*begin_st_dt.first).advance_begin(1)) {
+        // Note: We keep a ref on the range because the advance_begin return a ref on the object
+        // and some gcc version optimize out the inner range
+        auto r = v.st_range(*begin_st_dt.first);
+        for (const auto& end_st: r.advance_begin(1)) {
             cur_dt = end_st.section_end(cur_dt, v.clockwise());
         }
+
         return cur_dt;
     }
 

--- a/source/third_party/eos_portable_archive/portable_iarchive.hpp
+++ b/source/third_party/eos_portable_archive/portable_iarchive.hpp
@@ -63,7 +63,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and ï¿½kos Marï¿½y.
+ *       Contributions we made by Johan Rade and Ákos Maróy.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -186,11 +186,12 @@ namespace eos {
 
 		// the example derives from common_oarchive but that lacks the
 		// load_override functions so we chose to stay one level higher
-                , public boost::archive::basic_binary_iarchive<portable_iarchive>
-        #if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
-                // mix-in helper class for serializing shared_ptr
-                , public boost::archive::detail::shared_ptr_helper
-        #endif
+		, public boost::archive::basic_binary_iarchive<portable_iarchive>
+
+	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
+		// mix-in helper class for serializing shared_ptr
+		, public boost::archive::detail::shared_ptr_helper
+	#endif
 	{
 		// only needed for Robert's hack in basic_binary_iarchive::init
 		friend class boost::archive::basic_binary_iarchive<portable_iarchive>;

--- a/source/third_party/eos_portable_archive/portable_iarchive.hpp
+++ b/source/third_party/eos_portable_archive/portable_iarchive.hpp
@@ -63,7 +63,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and Ákos Maróy.
+ *       Contributions we made by Johan Rade and ï¿½kos Marï¿½y.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -89,7 +89,7 @@
 #include <boost/archive/basic_binary_iprimitive.hpp>
 #include <boost/archive/basic_binary_iarchive.hpp>
 
-#if BOOST_VERSION >= 103500
+#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
 #include <boost/archive/shared_ptr_helper.hpp>
 #endif
 
@@ -186,12 +186,11 @@ namespace eos {
 
 		// the example derives from common_oarchive but that lacks the
 		// load_override functions so we chose to stay one level higher
-		, public boost::archive::basic_binary_iarchive<portable_iarchive>
-
-	#if BOOST_VERSION >= 103500
-		// mix-in helper class for serializing shared_ptr
-		, public boost::archive::detail::shared_ptr_helper
-	#endif
+                , public boost::archive::basic_binary_iarchive<portable_iarchive>
+        #if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
+                // mix-in helper class for serializing shared_ptr
+                , public boost::archive::detail::shared_ptr_helper
+        #endif
 	{
 		// only needed for Robert's hack in basic_binary_iarchive::init
 		friend class boost::archive::basic_binary_iarchive<portable_iarchive>;

--- a/source/third_party/eos_portable_archive/portable_oarchive.hpp
+++ b/source/third_party/eos_portable_archive/portable_oarchive.hpp
@@ -66,7 +66,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and Ákos Maróy.
+ *       Contributions we made by Johan Rade and ï¿½kos Marï¿½y.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -92,7 +92,7 @@
 #include <boost/archive/basic_binary_oprimitive.hpp>
 #include <boost/archive/basic_binary_oarchive.hpp>
 
-#if BOOST_VERSION >= 103500
+#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
 #include <boost/archive/shared_ptr_helper.hpp>
 #endif
 
@@ -161,6 +161,7 @@ namespace endian = boost::spirit::detail;
 #error "VAX floating point format is not supported!"
 #endif
 
+
 namespace eos {
 
 	// forward declaration
@@ -192,12 +193,11 @@ namespace eos {
 
 		// the example derives from common_oarchive but that lacks the
 		// save_override functions so we chose to stay one level higher
-		, public boost::archive::basic_binary_oarchive<portable_oarchive>
-
-	#if BOOST_VERSION >= 103500
-		// mix-in helper class for serializing shared_ptr
-		, public boost::archive::detail::shared_ptr_helper
-	#endif
+                , public boost::archive::basic_binary_oarchive<portable_oarchive>
+        #if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
+                // mix-in helper class for serializing shared_ptr
+                , public boost::archive::detail::shared_ptr_helper
+        #endif
 	{
 		// workaround for gcc: use a dummy struct
 		// as additional argument type for overloading
@@ -391,7 +391,7 @@ namespace eos {
 			case FP_NAN: bits = traits::exponent | traits::mantissa; break;
 			case FP_INFINITE: bits = traits::exponent | (t<0) * traits::sign; break;
 			case FP_SUBNORMAL: assert(std::numeric_limits<T>::has_denorm); // pass
-			case FP_ZERO: // note that floats can be ±0.0
+			case FP_ZERO: // note that floats can be ï¿½0.0
 			case FP_NORMAL: traits::get_bits(t, bits); break;
 			default: throw portable_archive_exception(t);
 			}

--- a/source/third_party/eos_portable_archive/portable_oarchive.hpp
+++ b/source/third_party/eos_portable_archive/portable_oarchive.hpp
@@ -66,7 +66,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and ï¿½kos Marï¿½y.
+ *       Contributions we made by Johan Rade and Ákos Maróy.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -161,7 +161,6 @@ namespace endian = boost::spirit::detail;
 #error "VAX floating point format is not supported!"
 #endif
 
-
 namespace eos {
 
 	// forward declaration
@@ -193,11 +192,12 @@ namespace eos {
 
 		// the example derives from common_oarchive but that lacks the
 		// save_override functions so we chose to stay one level higher
-                , public boost::archive::basic_binary_oarchive<portable_oarchive>
-        #if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
-                // mix-in helper class for serializing shared_ptr
-                , public boost::archive::detail::shared_ptr_helper
-        #endif
+		, public boost::archive::basic_binary_oarchive<portable_oarchive>
+
+	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
+		// mix-in helper class for serializing shared_ptr
+		, public boost::archive::detail::shared_ptr_helper
+	#endif
 	{
 		// workaround for gcc: use a dummy struct
 		// as additional argument type for overloading
@@ -391,7 +391,7 @@ namespace eos {
 			case FP_NAN: bits = traits::exponent | traits::mantissa; break;
 			case FP_INFINITE: bits = traits::exponent | (t<0) * traits::sign; break;
 			case FP_SUBNORMAL: assert(std::numeric_limits<T>::has_denorm); // pass
-			case FP_ZERO: // note that floats can be ï¿½0.0
+			case FP_ZERO: // note that floats can be ±0.0
 			case FP_NORMAL: traits::get_bits(t, bits); break;
 			default: throw portable_archive_exception(t);
 			}

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -284,7 +284,7 @@ BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_cal, route_schedule_c
                                                              "00:00"_t + "24:00"_t,
                                                              std::numeric_limits<size_t>::max(),
                                                              *b.data, nt::RTLevel::Base,
-                                                             {c2->uri});
+                                                             boost::optional<const std::string>(c2->uri));
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
     boost::sort(res);
@@ -310,7 +310,7 @@ BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_cal_and_time, route_s
                                                              "12:37"_t + "24:00"_t,
                                                              std::numeric_limits<size_t>::max(),
                                                              *b.data, nt::RTLevel::Base,
-                                                             {c2->uri});
+                                                             boost::optional<const std::string>(c2->uri));
 
     BOOST_REQUIRE_EQUAL(res.size(), 2);
 

--- a/source/type/geographical_coord.h
+++ b/source/type/geographical_coord.h
@@ -40,7 +40,7 @@ www.navitia.io
 #include <boost/geometry/multi/geometries/multi_linestring.hpp>
 #include <boost/geometry/multi/geometries/register/multi_linestring.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/serialization/vector.hpp>
+#include "utils/serialization_vector.h"
 
 namespace navitia { namespace type {
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -38,7 +38,7 @@ www.navitia.io
 #include <boost/date_time/gregorian/greg_serialize.hpp>
 #include <boost/date_time/posix_time/time_serialize.hpp>
 #include <boost/serialization/bitset.hpp>
-#include <boost/serialization/vector.hpp>
+#include "utils/serialization_vector.h"
 #include <boost/serialization/map.hpp>
 #include <boost/variant.hpp>
 #include <boost/serialization/variant.hpp>

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -761,4 +761,4 @@ std::ostream& operator<<(std::ostream& os, const Mode_e& mode) {
 #if BOOST_VERSION <= 105700
 BOOST_CLASS_EXPORT_GUID(navitia::type::DiscreteVehicleJourney, "DiscreteVehicleJourney")
 BOOST_CLASS_EXPORT_GUID(navitia::type::FrequencyVehicleJourney, "FrequencyVehicleJourney")
-##endif
+#endif

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -758,5 +758,7 @@ std::ostream& operator<<(std::ostream& os, const Mode_e& mode) {
 
 }} //namespace navitia::type
 
+#if BOOST_VERSION <= 105700
 BOOST_CLASS_EXPORT_GUID(navitia::type::DiscreteVehicleJourney, "DiscreteVehicleJourney")
 BOOST_CLASS_EXPORT_GUID(navitia::type::FrequencyVehicleJourney, "FrequencyVehicleJourney")
+##endif

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -47,7 +47,7 @@ www.navitia.io
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/bitset.hpp>
-#include <boost/serialization/vector.hpp>
+#include "utils/serialization_vector.h"
 #include <boost/serialization/export.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/bimap.hpp>


### PR DESCRIPTION
ubuntu 1.510 uses gcc 5.2 and boost 1.58 are there were several problems with the change.
- Boost
  - boost vector serialization is buggy (and has been patched in boost 1.59)
  - some deprecated includes were moved
  - eos_portable_archive was using deprecated stuff
  - BOOST_CLASS_EXPORT_GUID does not seems to work anymore, but at the same time does not seems to be mandatory anymore :sweat_smile: 
- GCC 5.2
  - gcc 5.2 seems to be quite aggresive with the optimization and when doing:
    `for (auto bob: make_a_range().advance_begin(1)) {...}`
    it optimize out the inner range, so the advance begin returns a reference on a deleted object
  - some tests on sorted vector for equivalent entry
  - some explicit constructor calls
  - a fixture file was containing a windows return line (\r), and was creating problems in the gtfs_parser

Compiled, unit-tested and docker-tested with:
- Ubuntu 15.04, clang 3.6.0 / gcc 4.9.2, boost 1.54, release
- Ubuntu 15.10, gcc 5.2, boost 1.58, release
- debian 7, gcc 4.7, boost 1.49, release
- Ubuntu 14.04,  gcc 4.8.4, boost 1.54, release
