### PR TITLE
Jormungandr: remove useless API routes

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -29,9 +29,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from flask import url_for, redirect
 from flask.ext.restful import fields, marshal_with, reqparse, abort
-from flask.globals import g
 from jormungandr import i_manager, authentication
 from converters_collection_type import collections_to_resource_type
 from fields import stop_point, stop_area, route, line, line_group, \
@@ -558,13 +556,3 @@ def coords(is_collection):
         """ Not implemented yet"""
         pass
     return Coords
-
-
-def Redirect(*args, **kwargs):
-    id_ = kwargs["id"]
-    collection = kwargs["collection"]
-    region = i_manager.get_region(object_id=id_)
-    if not region:
-        region = "{region.id}"
-    url = url_for("v1.uri", region=region, collection=collection, id=id_)
-    return redirect(url, 303)

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -260,25 +260,27 @@ class add_id_links(generate_links):
             self.get_objets(data)
             data = self.prepare_objetcs(objects, True)
             kwargs = self.prepare_kwargs(kwargs, data)
+
+            if 'region' not in kwargs and 'lon' not in kwargs:
+                # we don't know how to put links on this object, there is no coverage, we don't add links
+                return objects
+
             uri_id = None
-            if "id" in kwargs and\
-               "collection" in kwargs and \
-               kwargs["collection"] in data:
+            if "id" in kwargs and "collection" in kwargs and kwargs["collection"] in data:
                 uri_id = kwargs["id"]
             for obj in self.data:
                 kwargs["collection"] = resource_type_to_collection.get(obj, obj)
                 if kwargs["collection"] in collections_to_resource_type:
                     if not uri_id:
                         kwargs["id"] = "{" + obj + ".id}"
-                    endpoint = "v1." + kwargs["collection"] + "."
-                    endpoint += "id" if "region" in kwargs or\
-                        "lon" in kwargs\
-                                        else "redirect"
+
+                    endpoint = "v1." + kwargs["collection"] + ".id"
+
                     collection = kwargs["collection"]
-                    to_pass = {k:v for k,v in kwargs.iteritems() if k != "collection"}
+                    to_pass = {k: v for k, v in kwargs.iteritems() if k != "collection"}
                     data["links"].append(create_external_link(url=endpoint, rel=collection,
                                                               _type=obj, templated=True,
-                                                             **to_pass))
+                                                              **to_pass))
             if isinstance(objects, tuple):
                 return data, code, header
             else:

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -142,10 +142,6 @@ class V1Routing(AModule):
                               region + '<uri:uri>/' + collection + '/<id:id>',
                               coord + '<uri:uri>/' + collection + '/<id:id>',
                               endpoint=collection + '.id')
-            self.add_url_rule(
-                '/coverage/' + collection + '/<string:id>',
-                collection + '.redirect',
-                Uri.Redirect)
 
         collecs = ["routes", "lines", "line_groups", "networks", "stop_areas", "stop_points",
                    "vehicle_journeys"]

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -376,6 +376,10 @@ class TestPtRefRoutingAndPtrefCov(AbstractTestFixture):
         assert len(lines) == 1
         assert 'A' in [code['value'] for code in lines[0]['codes'] if code['type'] == 'external_code']
 
+    def test_invalid_url(self):
+        """the following bad url was causing internal errors, it should only be a 404"""
+        _, status = self.query_no_assert("v1/coverage/lines/bob")
+        eq_(status, 404)
 
 @dataset(["main_routing_test"])
 class TestPtRefRoutingCov(AbstractTestFixture):


### PR DESCRIPTION
`v1/coverage/{collection}/id` is not a valid url, we remove it in the routing

it was useful to create links for API that does not need a /coverage (/journeys for example) thought,
so for these API we do not create links

fix http://jira.canaltp.fr/browse/NAVITIAII-1896
