### PR TITLE
raptor: bound before launching the reader

### DIFF
--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -274,11 +274,11 @@ int main(int argc, char** argv){
 
         origin.streetnetwork_params.mode = demand.start_mode;
         origin.streetnetwork_params.offset = data.geo_ref->offsets[demand.start_mode];
-        origin.streetnetwork_params.max_duration = navitia::seconds(15*60);
+        origin.streetnetwork_params.max_duration = navitia::seconds(30*60);
         origin.streetnetwork_params.speed_factor = 1;
         destination.streetnetwork_params.mode = demand.target_mode;
         destination.streetnetwork_params.offset = data.geo_ref->offsets[demand.target_mode];
-        destination.streetnetwork_params.max_duration = navitia::seconds(15*60);
+        destination.streetnetwork_params.max_duration = navitia::seconds(30*60);
         destination.streetnetwork_params.speed_factor = 1;
         type::AccessibiliteParams accessibilite_params;
         auto resp = make_response(router, origin, destination,

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -140,7 +140,7 @@ int main(int argc, char** argv){
     navitia::init_app();
     po::options_description desc("Options de l'outil de benchmark");
     std::string file, output, stop_input_file, start, target;
-    int iterations, date, hour;
+    int iterations, date, hour, nb_second_pass;
 
     auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     logger.setLogLevel(log4cplus::WARN_LOG_LEVEL);
@@ -160,6 +160,7 @@ int main(int argc, char** argv){
             ("hour,h", po::value<int>(&hour)->default_value(-1),
                     "Beginning hour of a particular journey")
             ("verbose,v", "Verbose debugging output")
+            ("nb_second_pass", po::value<int>(&nb_second_pass)->default_value(0), "nb second pass")
             ("stop_files", po::value<std::string>(&stop_input_file), "File with list of start and target")
             ("output,o", po::value<std::string>(&output)->default_value("benchmark.csv"),
                      "Output file");
@@ -254,11 +255,11 @@ int main(int argc, char** argv){
 #ifdef __BENCH_WITH_CALGRIND__
     CALLGRIND_START_INSTRUMENTATION;
 #endif
-    for(auto demand : demands){
+    for (auto demand: demands) {
         ++show_progress;
         Timer t2;
         auto date = data.pt_data->validity_patterns.front()->beginning_date + boost::gregorian::days(demand.date + 1) - boost::gregorian::date(1970, 1, 1);
-        if (verbose){
+        if (verbose) {
             std::cout << demand.start
                       << ", " << demand.start
                       << ", " << demand.target
@@ -286,9 +287,12 @@ int main(int argc, char** argv){
               {},
               georef_worker,
               type::RTLevel::Base,
-              std::numeric_limits<int>::max(), 10, false);
+              std::numeric_limits<int>::max(),
+              10,
+              false,
+              nb_second_pass);
 
-        if(resp.journeys_size() > 0) {
+        if (resp.journeys_size() > 0) {
             ++ nb_reponses;
             nb_journeys += resp.journeys_size();
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -189,13 +189,6 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
 }
 
 namespace {
-struct StartingPointSndPhase {
-    SpIdx sp_idx;
-    unsigned count;
-    DateTime end_dt;
-    unsigned fallback_dur;
-    bool has_priority;
-};
 struct Dom {
     Dom(bool c): clockwise(c) {}
     bool clockwise;
@@ -227,6 +220,7 @@ struct CompSndPhase {
         return lhs.sp_idx < rhs.sp_idx; // just to avoid randomness
     }
 };
+
 std::vector<StartingPointSndPhase>
 make_starting_points_snd_phase(const RAPTOR& raptor,
                                const routing::map_stop_point_duration& arrs,
@@ -366,6 +360,7 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
     auto start_raptor = std::chrono::system_clock::now();
 
     auto solutions = ParetoFront<Journey, Dominates/*, JourneyParetoFrontVisitor*/>(Dominates(clockwise));
+
     if (direct_path_dur) {
         Journey j;
         j.sn_dur = *direct_path_dur;
@@ -439,25 +434,18 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
         best_labels_pts = best_labels_pts_for_snd_pass;
         best_labels_transfers = best_labels_transfers_for_snd_pass;
         boucleRAPTOR(accessibilite_params, !clockwise, rt_level, max_transfers);
-        const auto reader_results = read_solutions(*this,
-                                                   !clockwise,
-                                                   departure_datetime,
-                                                   departures,
-                                                   destinations,
-                                                   rt_level,
-                                                   accessibilite_params,
-                                                   transfer_penalty);
-        bool has_added = false;
-        for (const auto& s: reader_results) {
-            const bool cur_added = solutions.add(s);
-            has_added = has_added || cur_added;
-        }
+        read_solutions(*this,
+                       solutions,
+                       !clockwise,
+                       departure_datetime,
+                       departures,
+                       destinations,
+                       rt_level,
+                       accessibilite_params,
+                       transfer_penalty,
+                       start);
+
         ++nb_snd_pass;
-        if (!has_added) {
-            ++nb_useless;
-        } else {
-            last_usefull_2nd_pass = nb_snd_pass;
-        }
     }
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     LOG4CPLUS_DEBUG(logger, "[2nd pass] lower bound fallback duration = " << lower_bound_fb

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -158,6 +158,7 @@ void RAPTOR::init(const map_stop_point_duration& dep,
         const DateTime sn_dur = sp_dt.second.total_seconds();
         const DateTime begin_dt = bound + (clockwise ? sn_dur : -sn_dur);
         labels[0].mut_dt_transfer(sp_dt.first) = begin_dt;
+        best_labels_transfers[sp_dt.first] = begin_dt;
         for (const auto jpp: jpps_from_sp[sp_dt.first]) {
             if (clockwise && Q[jpp.jp_idx] > jpp.order) {
                 Q[jpp.jp_idx] = jpp.order;
@@ -429,10 +430,10 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
         clear(!clockwise, departure_datetime + (clockwise ? -1 : 1));
         map_stop_point_duration init_map;
         init_map[start.sp_idx] = 0_s;
-        init(init_map, working_labels.dt_pt(start.sp_idx),
-             !clockwise, accessibilite_params.properties);
         best_labels_pts = best_labels_pts_for_snd_pass;
         best_labels_transfers = best_labels_transfers_for_snd_pass;
+        init(init_map, working_labels.dt_pt(start.sp_idx),
+             !clockwise, accessibilite_params.properties);
         boucleRAPTOR(accessibilite_params, !clockwise, rt_level, max_transfers);
         read_solutions(*this,
                        solutions,

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -45,6 +45,14 @@ www.navitia.io
 
 namespace navitia { namespace routing {
 
+struct StartingPointSndPhase {
+    SpIdx sp_idx;
+    unsigned count;
+    DateTime end_dt;
+    unsigned fallback_dur;
+    bool has_priority;
+};
+
 /*
  * Use to save routing test to launch stay_in
  */

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -297,10 +297,10 @@ Journey make_bound_journey(DateTime beg,
                            navitia::time_duration beg_sn_dur,
                            DateTime end,
                            navitia::time_duration end_sn_dur,
-                         unsigned count,
-                         uint32_t lower_bound_conn,
-                         navitia::time_duration transfer_penalty,
-                         bool clockwise) {
+                           unsigned count,
+                           uint32_t lower_bound_conn,
+                           navitia::time_duration transfer_penalty,
+                           bool clockwise) {
     Journey journey;
     journey.sections.resize(count); // only the number of sections is part of the dominance function
     journey.sn_dur = beg_sn_dur + end_sn_dur;
@@ -572,7 +572,8 @@ void read_solutions(const RAPTOR& raptor,
                          const StartingPointSndPhase& end_point)
 {
     auto reader = RaptorSolutionReader<Visitor>(
-        raptor, solutions, v, departure_datetime, deps, arrs, rt_level, accessibilite_params, transfer_penalty, end_point);
+        raptor, solutions, v, departure_datetime, deps, arrs, rt_level,
+        accessibilite_params, transfer_penalty, end_point);
 
     for (unsigned count = 1; count <= raptor.count; ++count) {
         auto& working_labels = raptor.labels[count];

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -293,6 +293,32 @@ std::vector<VehicleSection> get_vjs(const Journey::Section& section) {
     throw navitia::recoverable_exception("impossible to rebuild path");
 }
 
+Journey make_bound_journey(DateTime beg,
+                           navitia::time_duration beg_sn_dur,
+                           DateTime end,
+                           navitia::time_duration end_sn_dur,
+                         unsigned count,
+                         uint32_t lower_bound_conn,
+                         navitia::time_duration transfer_penalty,
+                         bool clockwise) {
+    Journey journey;
+    journey.sections.resize(count); // only the number of sections is part of the dominance function
+    journey.sn_dur = beg_sn_dur + end_sn_dur;
+    if (clockwise) {
+        journey.departure_dt = beg - beg_sn_dur.total_seconds();
+        journey.arrival_dt = end + end_sn_dur.total_seconds();
+    } else {
+        journey.departure_dt = end + end_sn_dur.total_seconds();
+        journey.arrival_dt = beg - beg_sn_dur.total_seconds();
+    }
+
+    // for the rest KPI, we don't know yet the accurate values, so we'll provide the best lb possible
+    journey.transfer_dur = transfer_penalty * count + navitia::seconds((count - 1) * lower_bound_conn);
+    journey.min_waiting_dur = navitia::time_duration(boost::date_time::pos_infin);
+    journey.nb_vj_extentions = 0;
+    return journey;
+}
+
 struct stop_search {};
 
 template<typename Visitor>
@@ -339,13 +365,15 @@ struct RaptorSolutionReader {
     Cache<Journey> journey_cache;
 
     RaptorSolutionReader(const RAPTOR& r,
+                         Solutions& solutions,
                          const Visitor& vis,// 3rd pass visitor
                          const DateTime& departure_dt,
                          const routing::map_stop_point_duration& deps,
                          const routing::map_stop_point_duration& arrs,
                          const type::RTLevel rt_level,
                          const type::AccessibiliteParams& access,
-                         const navitia::time_duration& transfer_penalty):
+                         const navitia::time_duration& transfer_penalty,
+                         const StartingPointSndPhase& end_point):
         raptor(r),
         v(vis),
         departure_datetime(departure_dt),
@@ -354,8 +382,8 @@ struct RaptorSolutionReader {
         rt_level(rt_level),
         accessibilite_params(access),
         transfer_penalty(transfer_penalty),
-        // Dominates need request_clockwise (the same as reader's visitor)
-        solutions(Dominates(v.clockwise()))
+        end_point(end_point),
+        solutions(solutions)
     {}
     const RAPTOR& raptor;
     const Visitor& v;
@@ -365,7 +393,8 @@ struct RaptorSolutionReader {
     const type::RTLevel rt_level;
     const type::AccessibiliteParams& accessibilite_params;
     const navitia::time_duration transfer_penalty;
-    Solutions solutions;
+    const StartingPointSndPhase& end_point;
+    Solutions& solutions; //raptor's solutions pool
 
     size_t nb_sol_added = 0;
     void handle_solution(const PathElt& path) {
@@ -529,18 +558,21 @@ struct RaptorSolutionReader {
     }
 };
 
+
 template <typename Visitor>
-Solutions read_solutions(const RAPTOR& raptor,
+void read_solutions(const RAPTOR& raptor,
+                         Solutions& solutions,
                          const Visitor& v,
                          const DateTime& departure_datetime,
                          const routing::map_stop_point_duration& deps,
                          const routing::map_stop_point_duration& arrs,
                          const type::RTLevel rt_level,
                          const type::AccessibiliteParams& accessibilite_params,
-                         const navitia::time_duration& transfer_penalty)
+                         const navitia::time_duration& transfer_penalty,
+                         const StartingPointSndPhase& end_point)
 {
     auto reader = RaptorSolutionReader<Visitor>(
-        raptor, v, departure_datetime, deps, arrs, rt_level, accessibilite_params, transfer_penalty);
+        raptor, solutions, v, departure_datetime, deps, arrs, rt_level, accessibilite_params, transfer_penalty, end_point);
 
     for (unsigned count = 1; count <= raptor.count; ++count) {
         auto& working_labels = raptor.labels[count];
@@ -548,12 +580,21 @@ Solutions read_solutions(const RAPTOR& raptor,
             if (! working_labels.pt_is_initialized(a.first)) { continue; }
             if (! raptor.get_sp(a.first)->accessible(accessibilite_params.properties)) { continue; }
             reader.nb_sol_added = 0;
+            // we check that it's worth to explore this possible journey
+            auto j = make_bound_journey(working_labels.dt_pt(a.first),
+                                        a.second,
+                                        raptor.labels[0].dt_transfer(end_point.sp_idx),
+                                        navitia::seconds(end_point.fallback_dur),
+                                        count,
+                                        raptor.data.dataRaptor->min_connection_time,
+                                        transfer_penalty,
+                                        v.clockwise());
+            if (reader.solutions.contains_better_than(j)) { continue; }
             try {
                 reader.begin_pt(count, a.first, working_labels.dt_pt(a.first));
             } catch (stop_search&) {}
         }
     }
-    return std::move(reader.solutions);
 }
 
 } // anonymous namespace
@@ -598,34 +639,34 @@ std::ostream& operator<<(std::ostream& os, const Journey& j) {
         } else {
             os << "(NULL";
         }
-        os << "@"
-           << s.get_in_dt << ", ";
+        os << "@" << navitia::str(s.get_in_dt) << ", ";
         if (s.get_out_st) {
            os << s.get_out_st->stop_point->uri;
         } else {
             os << "NULL";
         }
-        os << "@"
-           << s.get_out_dt << ")";
+        os << "@" << navitia::str(s.get_out_dt) << ")";
     }
     return os;
 }
 
-Solutions read_solutions(const RAPTOR& raptor,
+void read_solutions(const RAPTOR& raptor,
+                         Solutions& solutions,
                          const bool clockwise,
                          const DateTime& departure_datetime,
                          const routing::map_stop_point_duration& deps,
                          const routing::map_stop_point_duration& arrs,
                          const type::RTLevel rt_level,
                          const type::AccessibiliteParams& accessibilite_params,
-                         const navitia::time_duration& transfer_penalty)
+                         const navitia::time_duration& transfer_penalty,
+                         const StartingPointSndPhase& end_point)
 {
     if (clockwise) {
-        return read_solutions(raptor, raptor_reverse_visitor(), departure_datetime, deps, arrs,
-                              rt_level, accessibilite_params, transfer_penalty);
+        return read_solutions(raptor, solutions, raptor_reverse_visitor(), departure_datetime, deps, arrs,
+                              rt_level, accessibilite_params, transfer_penalty, end_point);
     } else {
-        return read_solutions(raptor, raptor_visitor(), departure_datetime, deps, arrs,
-                              rt_level, accessibilite_params, transfer_penalty);
+        return read_solutions(raptor, solutions, raptor_visitor(), departure_datetime, deps, arrs,
+                              rt_level, accessibilite_params, transfer_penalty, end_point);
     }
 }
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -81,15 +81,17 @@ typedef ParetoFront<Journey, Dominates> Solutions;
 
 // deps (resp. arrs) are departure (resp. arrival) stop points and
 // durations (not clockwise dependent).
-Solutions
+void
 read_solutions(const RAPTOR& raptor,
+               Solutions& solutions, //all raptor solutions, modified by side effects
                const bool clockwise,
                const DateTime& departure_datetime,
                const routing::map_stop_point_duration& deps,
                const routing::map_stop_point_duration& arrs,
                const type::RTLevel rt_level,
                const type::AccessibiliteParams& accessibilite_params,
-               const navitia::time_duration& transfer_penalty);
+               const navitia::time_duration& transfer_penalty,
+               const StartingPointSndPhase& end_point);
 
 Path make_path(const Journey& journey, const type::Data& data);
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -81,17 +81,16 @@ typedef ParetoFront<Journey, Dominates> Solutions;
 
 // deps (resp. arrs) are departure (resp. arrival) stop points and
 // durations (not clockwise dependent).
-void
-read_solutions(const RAPTOR& raptor,
-               Solutions& solutions, //all raptor solutions, modified by side effects
-               const bool clockwise,
-               const DateTime& departure_datetime,
-               const routing::map_stop_point_duration& deps,
-               const routing::map_stop_point_duration& arrs,
-               const type::RTLevel rt_level,
-               const type::AccessibiliteParams& accessibilite_params,
-               const navitia::time_duration& transfer_penalty,
-               const StartingPointSndPhase& end_point);
+void read_solutions(const RAPTOR& raptor,
+                    Solutions& solutions, //all raptor solutions, modified by side effects
+                    const bool clockwise,
+                    const DateTime& departure_datetime,
+                    const routing::map_stop_point_duration& deps,
+                    const routing::map_stop_point_duration& arrs,
+                    const type::RTLevel rt_level,
+                    const type::AccessibiliteParams& accessibilite_params,
+                    const navitia::time_duration& transfer_penalty,
+                    const StartingPointSndPhase& end_point);
 
 Path make_path(const Journey& journey, const type::Data& data);
 


### PR DESCRIPTION
This is a corrected version of @antoine-de's PR

benchmark_full, unlimited snd pass, -i 10:
- without : 197s
- with : 147s

Still 10 seconds on the very problematic journey.

4s -> 900ms to go to la fourche (journey in jira's ticket)
