### PR TITLE
kraken: add a timeout to the rabbitmq connection

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -65,6 +65,8 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
         ("BROKER.timeout", po::value<int>()->default_value(100), "timeout for maintenance worker in millisecond")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
+        ("BROKER.keepalive_timeout", po::value<int>()->default_value(10), "timeout of the rabbitmq connection "
+            "in minutes. After this time without receiving message we open a new connection")
 
         ("CHAOS.database", po::value<std::string>(), "Chaos database connection string");
 
@@ -147,6 +149,10 @@ int Configuration::broker_timeout() const {
 
 int Configuration::broker_sleeptime() const {
     return vm["BROKER.sleeptime"].as<int>();
+}
+
+int Configuration::broker_keepalive_timeout() const {
+    return vm["BROKER.keepalive_timeout"].as<int>();
 }
 
 std::vector<std::string> Configuration::rt_topics() const{

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -58,6 +58,8 @@ namespace navitia { namespace kraken{
             bool is_realtime_enabled() const;
             int kirin_timeout() const;
 
+            int broker_keepalive_timeout() const;
+
             std::vector<std::string> rt_topics() const;
     };
 

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -252,6 +252,14 @@ void MaintenanceWorker::listen_rabbitmq(){
 
         auto task_envelopes = consume_in_batch(task_tag, 1, timeout_ms, no_ack);
         handle_task_in_batch(task_envelopes);
+        if(rt_envelopes.size() + task_envelopes.size() > 0){
+            this->last_message_received_at = boost::posix_time::second_clock::universal_time();
+        }else if(boost::posix_time::second_clock::universal_time()
+                > (this->last_message_received_at + boost::posix_time::minutes(conf.broker_keepalive_timeout()))){
+            throw std::runtime_error(
+                    (boost::format("no messages for more than %s minutes, we force a new connection")
+                        % conf.broker_keepalive_timeout()).str());
+        }
 
         // Since consume_in_batch is non blocking, we don't want that the worker loops for nothing, when the
         // queue is empty.
@@ -302,6 +310,7 @@ void MaintenanceWorker::init_rabbitmq(){
         }
         is_initialized = true;
     }
+    this->last_message_received_at = boost::posix_time::second_clock::universal_time();
     LOG4CPLUS_DEBUG(logger, "connected to rabbitmq");
 }
 

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -50,6 +50,7 @@ class MaintenanceWorker{
         //nom de la queue créer pour ce worker
         std::string queue_name_task;
         std::string queue_name_rt;
+        boost::posix_time::ptime last_message_received_at;
 
         void init_rabbitmq();
         void listen_rabbitmq();

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -106,7 +106,7 @@ CELERYBEAT_SCHEDULE = {
     },
     'heartbeat-kraken': {
         'task': 'tyr.tasks.heartbeat',
-        'schedule': timedelta(minutes=30),
+        'schedule': timedelta(minutes=5),
         'options': {'expires': 50}
     },
 }


### PR DESCRIPTION
Our beloved loadbalancer/firewall can choose to drop a session from
their table and never say anything to anyone.
Kraken don't know it, but he is already dead!
With this PR we will create a new connection if there is no message for
a period of time.

There is a small problem to solve before being able to merge this PR:
Actually the keep alive is handled by tyr, but when we deploy we stop
tyr_beat, so there is no more keep alive coming and all instances will
restart their connection periodically and more importantly reload all
realtime information: we don't want that to happen...
