### PR TITLE
Jormungandr: fix /places_nearby

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -281,6 +281,8 @@ places_nearby = {
     "disruptions": DisruptionsField,
 }
 
+places_types = {'stop_areas', 'stop_points', 'pois',
+                'addresses', 'coords', 'places'}  # add admins when possible
 
 class PlacesNearby(ResourceUri):
     parsers = {}
@@ -320,8 +322,12 @@ class PlacesNearby(ResourceUri):
             if uri[-1] == '/':
                 uri = uri[:-1]
             uris = uri.split("/")
-            if len(uris) > 1:
+            if len(uris) >= 2:
                 args["uri"] = transform_id(uris[-1])
+                # for coherence we check the type of the object
+                obj_type = uris[-2]
+                if obj_type not in places_types:
+                    abort(404, message='places_nearby api not available for {}'.format(obj_type))
             else:
                 abort(404)
         elif lon and lat:

--- a/source/jormungandr/tests/places_test.py
+++ b/source/jormungandr/tests/places_test.py
@@ -75,3 +75,21 @@ class TestPlaces(AbstractTestFixture):
 
         assert(len(response['places_nearby']) > 0)
         is_valid_places(response['places_nearby'])
+
+    def test_wrong_places_nearby(self):
+        """test that a wrongly formated query do not work on places_neaby"""
+
+        lon = 10. / 111319.9
+        lat = 100. / 111319.9
+        response, status = self.query_region("bob/{};{}/places_nearby".format(lon, lat), check=False)
+
+        eq_(status, 404)
+        #Note: it's not a canonical Navitia error with an Id and a message, but it don't seems to be
+        # possible to do this with 404 (handled by flask)
+        assert(get_not_null(response, 'message'))
+
+        # same with a line (it has no meaning)
+        response, status = self.query_region("lines/A/places_nearby".format(lon, lat), check=False)
+
+        eq_(status, 404)
+        assert(get_not_null(response, 'message'))


### PR DESCRIPTION
the url

coverage/fr_idf/bob/{a coords}/places_nearby was working and we don't
want that.

linked to http://jira.canaltp.fr/browse/NAVITIAII-1738

Note: The error returned is not a canonical Navitia error with an Id and a message, but it don't seems to be possible to do this with 404 (handled by flask)

error:

```
 ❯ http http://localhost:5000/v1/coverage/main_routing_test/routes/A:0/places_nearby
HTTP/1.0 404 NOT FOUND
{
    "message": "places_nearby api not available for routes"
}

```
