### PR TITLE
eitri: adding future module in requirements.txt

### DIFF
--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,3 +1,4 @@
+future==0.13.1
 docker-py==0.4.0
 retrying==1.2.3
 psycopg2==2.4.5


### PR DESCRIPTION
Adding future module in eitri requirements.txt in order to be able to launch docker_test.
