### PR TITLE
eitri: changing pyscopg connection string to enable old psql client

### DIFF
--- a/source/eitri/docker_wrapper.py
+++ b/source/eitri/docker_wrapper.py
@@ -117,4 +117,9 @@ class PostgresDocker(object):
     @retry(stop_max_delay=10000, wait_fixed=100,
            retry_on_exception=lambda e: isinstance(e, Exception))
     def test_db_cnx(self):
-        psycopg2.connect(self.get_db_params().cnx_string())
+        psycopg2.connect(
+            database=self.get_db_params().dbname,
+            user=self.get_db_params().user,
+            password=self.get_db_params().password,
+            host=self.get_db_params().host
+        )

--- a/source/eitri/ed_handler.py
+++ b/source/eitri/ed_handler.py
@@ -109,7 +109,12 @@ def update_db(db_params):
     cnx_string = db_params.cnx_string()
 
     #we need to enable postgis on the db
-    cnx = psycopg2.connect(cnx_string)
+    cnx = psycopg2.connect(
+        database=db_params.dbname,
+        user=db_params.user,
+        password=db_params.password,
+        host=db_params.host
+    )
     c = cnx.cursor()
     c.execute("create extension postgis;")
     c.close()


### PR DESCRIPTION
changing pyscopg connection string to enable old psql client (<9.2) to connect to postgres database.
