### PR TITLE
RT: change delay enum

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -103,21 +103,21 @@ public:
                 .uri("mess1")
                 .publish(btp("20131219T123200"_dt, "20131221T123201"_dt))
                 .application_periods(btp("20131220T123200"_dt, "20131221T123201"_dt))
-                .severity(nt::disruption::Effect::MODIFIED_SERVICE)
+                .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
                 .on(nt::Type_e::Line, "line:A");
 
         b.impact(nt::RTLevel::Adapted)
                 .uri("mess0")
                 .publish(btp("20131221T083200"_dt, "20131221T123201"_dt))
                 .application_periods(btp("20131221T083200"_dt, "20131221T123201"_dt))
-                .severity(nt::disruption::Effect::MODIFIED_SERVICE)
+                .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
                 .on(nt::Type_e::Line, "line:S");
 
         b.impact(nt::RTLevel::Adapted)
                 .uri("mess2")
                 .application_periods(btp("20131223T123200"_dt, "20131225T123201"_dt))
                 .publish(btp("20131224T123200"_dt, "20131226T123201"_dt))
-                .severity(nt::disruption::Effect::MODIFIED_SERVICE)
+                .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
                 .on(nt::Type_e::Network, "network:K");
     }
 };

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -153,7 +153,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             LOG4CPLUS_TRACE(log, "canceling " << mvj->uri);
             mvj->cancel_vj(rt_level, impact->application_periods, pt_data, meta, r);
             mvj->impacted_by.push_back(impact);
-        } else if (impact->severity->effect == nt::disruption::Effect::MODIFIED_SERVICE) {
+        } else if (impact->severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS) {
             LOG4CPLUS_TRACE(log, "modifying " << mvj->uri);
             auto vp = compute_vp(impact->application_periods, meta.production_date);
             if (! r && ! mvj->get_base_vj().empty()) {
@@ -199,7 +199,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
 static bool is_modifying_effect(nt::disruption::Effect e) {
     // check is the effect needs to modify the model
     return in(e, {nt::disruption::Effect::NO_SERVICE,
-                  nt::disruption::Effect::MODIFIED_SERVICE});
+                  nt::disruption::Effect::SIGNIFICANT_DELAYS});
 }
 
 void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact,

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -171,10 +171,10 @@ create_disruption(const std::string& id,
         }
         else if (trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED
                 && trip_update.stop_time_update_size()) {
-            LOG4CPLUS_TRACE(log, "Disruption has MODIFIED_SERVICE effect");
+            LOG4CPLUS_TRACE(log, "Disruption has SIGNIFICANT_DELAYS effect");
             // Yeah, that's quite hardcodded...
-            wording = "trip modified!";
-            effect = nt::disruption::Effect::MODIFIED_SERVICE;
+            wording = "trip delayed";
+            effect = nt::disruption::Effect::SIGNIFICANT_DELAYS;
             LOG4CPLUS_TRACE(log, "Adding stop time into impact");
             for (const auto& st: trip_update.stop_time_update()) {
                 auto* stop_point_ptr = data.pt_data->stop_points_map[st.stop_id()];

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1861,7 +1861,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
             .uri("too_bad")
             .publish(default_period)
             .application_periods(default_period)
-            .severity(nt::disruption::Effect::MODIFIED_SERVICE)
+            .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
             .on(nt::Type_e::StopArea, "A")
             .msg("no luck");
 
@@ -1892,7 +1892,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
     const auto& j = resp.journeys(0);
-    BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(), "DETOUR");
+    BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(), "SIGNIFICANT_DELAYS");
 
     BOOST_REQUIRE_EQUAL(j.sections_size(), 1);
 }
@@ -1916,7 +1916,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
             .uri("too_bad")
             .publish(default_period)
             .application_periods(default_period)
-            .severity(nt::disruption::Effect::MODIFIED_SERVICE)
+            .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
             .on(nt::Type_e::StopArea, "A")
             .msg("no luck");
 
@@ -1944,7 +1944,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
     const auto& j = resp.journeys(0);
-    BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(), "DETOUR"); //we should have the network's disruption's effect
+    BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(), "SIGNIFICANT_DELAYS"); //we should have the network's disruption's effect
 }
 
 BOOST_AUTO_TEST_CASE(journey_with_forbidden) {


### PR DESCRIPTION
this enum should be computed by kirin, but it is not the case, so for
the moment all TripDescriptor_ScheduleRelationship_SCHEDULED are delayed
train
