### PR TITLE
Pr route schedule over midnight

### DIFF
--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -109,12 +109,13 @@ get_all_route_stop_times(const nt::Route* route,
         // we add 24h for each vj's dt that starts before 'date_time' so the vj will be sorted
         // at the end (with the complex score of the route schedule)
         for (auto& vjs_stops: result) {
-            //by construction the vector cannot be empty
-            if (DateTimeUtils::hour(vjs_stops.front().first) >= DateTimeUtils::hour(date_time)) {
-                continue;
-            }
+            bool add_day = false;
             for (auto& dt_st: vjs_stops) {
-                dt_st.first += DateTimeUtils::SECONDS_PER_DAY;
+                // If a stop time is before limit then add a day from here to end of stops
+                if (add_day || (DateTimeUtils::hour(dt_st.first) < DateTimeUtils::hour(date_time))) {
+                    dt_st.first += DateTimeUtils::SECONDS_PER_DAY;
+                    add_day = true;
+                }
             }
         }
     }

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -448,6 +448,8 @@ BOOST_FIXTURE_TEST_CASE(test_get_all_route_stop_times_with_different_vp_and_hour
 // S1 23:30  23:50  00:10
 // S2 23:40  00:00  00:20
 // S3 23:50  00:10  00:30
+//
+// Detail in associated PR https://github.com/CanalTP/navitia/pull/1304
 BOOST_AUTO_TEST_CASE(test_route_schedule_with_different_vp_over_midnight) {
     ed::builder b = {"20151127"};
     navitia::type::Calendar *c1;

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -463,12 +463,12 @@ BOOST_AUTO_TEST_CASE(test_route_schedule_with_different_vp_over_midnight) {
         ("st3", "23:50"_t);
     b.vj("L", "111111", "", true, "B", "B")
         ("st1", "23:50"_t)
-        ("st2", "0:00"_t)
-        ("st3", "0:10"_t);
+        ("st2", "24:00"_t)
+        ("st3", "24:10"_t);
     b.vj("L", "111110", "", true, "C", "C")
-        ("st1", "0:10"_t)
-        ("st2", "0:20"_t)
-        ("st3", "0:30"_t);
+        ("st1", "24:10"_t)
+        ("st2", "24:20"_t)
+        ("st3", "24:30"_t);
 
     auto save_cal = [&](navitia::type::Calendar* cal) {
         b.data->pt_data->calendars.push_back(cal);


### PR DESCRIPTION
The previous PR #1218 correct only a part of the issue of services aver midnight.

It heavily depending on what you have in your data.
Hopefully, all tricky doomed data use case are present at Tisséo ;-)

I made a unit test to reproduce and provide code to solve the issue.

The test case is the following 

There is three services deserving three stops.
One integraly befor midnight, one integraly after midnight and on over midnight.

```
       A        B       C     
st1 |23:30   |23:50  |0:10   
st2 |23:40   |0:0    |0:20   
st3 |23:50   |0:10   |0:30   
```

and in seconds from midnight

```
       A        B       C     
st1 |86370   |86390  |10   
st2 |86380   |0      |20   
st3 |86390   |10     |30   
```

with a calendar switched by 1 for VJ C

We would like to display route_schedules with a calendar (TimeTable typical usecase).

Before this PR, the result was sorted like this 

```
      B       A      C     
st1 |23:50  |23:30  |0:10   
st2 |0:0    |23:40  |0:20   
st3 |0:10   |23:50  |0:30   
```

This is because the comparison used to sort column compare each cells and sort given the majority.

In PR #1218 we add 86400 to all VJ stop times of which the first VJ stop time is over midnight (or over a particular offset).

This is a good idea, but that does not save the sorting because the input is 

```
       A        B       C     
st1 |86370   |86390  |86410   
st2 |86380   |0      |86420
st3 |86390   |10     |86430
```

_This is a_ **return to the future** _sort of_

So I just change the code in order to add 86400 to all stop_times over midnight (or offset) for all cells and all cells after it.

The data before sort became

```
       A        B       C     
st1 |86370   |86390  |86410   
st2 |86380   |86400  |86420
st3 |86390   |86410  |86430
```

So after this correction the result is correctly sorted

```
       A        B       C     
st1 |23:30   |23:50  |0:10   
st2 |23:40   |0:0    |0:20   
st3 |23:50   |0:10   |0:30   
```

**I test it on a lot of real tricky use cases and with a lot of different offset . We are good !**
