### PR TITLE
Add the possibility to choose what type of poi import from osm

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -37,6 +37,7 @@ www.navitia.io
 #include <boost/geometry.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/dynamic_bitset.hpp>
+#include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/range/algorithm/reverse.hpp>
 
@@ -52,6 +53,21 @@ namespace po = boost::program_options;
 namespace pt = boost::posix_time;
 
 namespace ed { namespace connectors {
+
+bool poi_type_comp::operator()(const std::string& a, const std::string& b){
+    auto it_a = boost::range::find(order, a);
+    auto it_b = boost::range::find(order, b);
+    if(it_a != order.end() && it_b != order.end()){
+        return it_a < it_b;
+    }
+    if(it_a == order.end() && it_b != order.end()){
+        return false;
+    }
+    if(it_b == order.end() && it_a != order.end()){
+        return true;
+    }
+    return a < b;
+}
 
 /*
  * Read relations
@@ -845,7 +861,7 @@ void PoiHouseNumberVisitor::fill_poi(const u_int64_t osm_id, const CanalTP::Tags
         return;
 
     std::string ref_tag = "";
-    for(auto tags_type: tags_types){
+    for(const auto& tags_type: tags_types){
         if(tags.find(tags_type) != tags.end()){
             ref_tag = tags_type;
             break;

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -378,25 +378,23 @@ struct PoiHouseNumberVisitor {
     std::set<std::string> properties_to_ignore;
     size_t n_inserted_pois = 0;
     size_t n_inserted_house_numbers = 0;
+    std::set<std::string> tags_types;
 
     PoiHouseNumberVisitor(EdPersistor& persistor, /*const*/ OSMCache& cache,
-            Georef& data, const bool parse_pois) :
+            Georef& data, const bool parse_pois, const std::map<std::string, std::string>& poi_types) :
         persistor(persistor), cache(cache), data(data), parse_pois(parse_pois)  {
-        data.poi_types =
-         {
-            {"amenity:college" , new ed::types::PoiType(0,  "école")},
-            {"amenity:university" , new ed::types::PoiType(1, "université")},
-            {"amenity:theatre" , new ed::types::PoiType(2, "théâtre")},
-            {"amenity:hospital" , new ed::types::PoiType(3, "hôpital")},
-            {"amenity:post_office" , new ed::types::PoiType(4, "bureau de poste")},
-            {"amenity:bicycle_rental" , new ed::types::PoiType(5, "station vls")},
-            {"amenity:bicycle_parking" , new ed::types::PoiType(6, "Parking vélo")},
-            {"amenity:parking" , new ed::types::PoiType(7, "Parking")},
-            {"amenity:police" , new ed::types::PoiType(8, "Police, Gendarmerie")},
-            {"amenity:townhall" , new ed::types::PoiType(9, "Mairie")},
-            {"leisure:garden" , new ed::types::PoiType(10, "Jardin")},
-            {"leisure:park" , new ed::types::PoiType(11, "Zone Parc. Zone verte ouverte, pour déambuler. habituellement municipale")}
-        };
+        uint32_t idx = 0;
+        for(auto type: poi_types){
+            data.poi_types[type.first] = new ed::types::PoiType(idx, type.second);
+            ++idx;
+        }
+        for(auto tag: data.poi_types){
+            std::vector<std::string> strs;
+            boost::algorithm::split(strs, tag.first, boost::is_any_of(":"));
+            if(strs.size() > 1){
+                tags_types.insert(strs[0]);
+            }
+        }
         properties_to_ignore.insert("name");
         properties_to_ignore.insert("amenity");
         properties_to_ignore.insert("leisure");

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -368,6 +368,11 @@ inline std::string to_string(OsmObjectType t) {
     }
 }
 
+struct poi_type_comp{
+    std::vector<std::string> order = {"amenity", "tourism", "leisure", "aeroway", "railway", "shop"};
+    bool operator()(const std::string& a, const std::string& b);
+};
+
 struct PoiHouseNumberVisitor {
     const size_t max_inserts_without_bulk = 20000;
     ed::EdPersistor& persistor;
@@ -378,7 +383,7 @@ struct PoiHouseNumberVisitor {
     std::set<std::string> properties_to_ignore;
     size_t n_inserted_pois = 0;
     size_t n_inserted_house_numbers = 0;
-    std::set<std::string> tags_types;
+    std::set<std::string, poi_type_comp> tags_types;
 
     PoiHouseNumberVisitor(EdPersistor& persistor, /*const*/ OSMCache& cache,
             Georef& data, const bool parse_pois, const std::map<std::string, std::string>& poi_types) :

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -192,6 +192,14 @@ class Key(db.Model):
     def get_by_token(cls, token):
         return cls.query.filter_by(token=token).first()
 
+class PoiType(db.Model):
+    uri = db.Column(db.Text, nullable=False)
+    name = db.Column(db.Text, nullable=True)
+    instance_id = db.Column(db.Integer, db.ForeignKey('instance.id'), nullable=False)
+
+    __tablename__ = 'poi_type'
+    __table_args__ = (db.PrimaryKeyConstraint('instance_id', 'uri'), )
+
 
 class Instance(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -202,6 +210,9 @@ class Instance(db.Model):
             lazy='dynamic', cascade='save-update, merge, delete')
 
     jobs = db.relationship('Job', backref='instance', lazy='dynamic', cascade='save-update, merge, delete')
+
+    poi_types = db.relationship('PoiType', backref=backref('instance'),
+                               lazy='dynamic', cascade='save-update, merge, delete')
     # ============================================================
     # params for jormungandr
     # ============================================================

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -200,6 +200,11 @@ class PoiType(db.Model):
     __tablename__ = 'poi_type'
     __table_args__ = (db.PrimaryKeyConstraint('instance_id', 'uri'), )
 
+    def __init__(self, uri, name=None, instance=None):
+        self.uri = uri
+        self.name = name
+        self.instance = instance
+
 
 class Instance(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/source/tyr/migrations/versions/3fde52b5e132_add_poi_type.py
+++ b/source/tyr/migrations/versions/3fde52b5e132_add_poi_type.py
@@ -1,0 +1,29 @@
+"""add poi_type for an instance
+they are used only for osm import
+
+Revision ID: 3fde52b5e132
+Revises: 3e56c7e0a4a4
+Create Date: 2015-11-26 08:50:13.923059
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3fde52b5e132'
+down_revision = '3e56c7e0a4a4'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('poi_type',
+        sa.Column('uri', sa.Text(), nullable=False),
+        sa.Column('name', sa.Text(), nullable=True),
+        sa.Column('instance_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['instance_id'], ['instance.id'], ),
+        sa.PrimaryKeyConstraint('instance_id', 'uri')
+    )
+
+
+def downgrade():
+    op.drop_table('poi_type')

--- a/source/tyr/readme.md
+++ b/source/tyr/readme.md
@@ -448,3 +448,56 @@ Use the id in the next query
 }
 
 ```
+
+#### PoiTypes
+It is possible to define what type of POI should be extracted from OSM for a specific instance.
+
+A type of poi is characterised by an uri and a name.
+
+If nothing if configured, default POI are extracted, at this time the list is as follow:
+     - uri: "amenity:college" name: "école"
+     - uri: "amenity:university" name: "université"
+     - uri: "amenity:theatre" name: "théâtre"
+     - uri: "amenity:hospital" name: "hôpital"
+     - uri: "amenity:post_office" name: "bureau de poste"
+     - uri: "amenity:bicycle_rental" name: "station vls"
+     - uri: "amenity:bicycle_parking" name: "Parking vélo"
+     - uri: "amenity:parking" name: "Parking"
+     - uri: "amenity:police" name: "Police, Gendarmerie"
+     - uri: "amenity:townhall" name: "Mairie"
+     - uri: "leisure:garden" name: "Jardin"
+     - uri: "leisure:park" name: "Zone Parc. Zone verte ouverte, pour déambuler. habituellement municipale"
+
+Let say you want to see all type of poi for the instance fr-bre, you have to call the PoiTypes endpoint for this
+instance:
+
+    curl -X POST "http://localhost:5000/v0/instances/fr-bre/poi_types"
+```json
+{
+    "poi_types": [
+        {
+            "name": "foo",
+            "uri": "foo:ba"
+        },
+        {
+            "name": "foo\u00e9",
+            "uri": "foo:baff"
+        }
+    ]
+}
+
+```
+
+If you want to add a poi type for an instance you have to POST it:
+
+    curl 'http://localhost:5000/v0/instances/fr-bre/poi_types/foo:baff?name=foo' -X POST
+
+The name of a poi type is optional and can also be pass in a json like this:
+
+    curl 'http://localhost:5000/v0/instances/fr-bre/poi_types/foo:json' -X POST -H 'content-type: application/json' -d '{"name": "json"}'
+
+For updating a poi_type (only the name can be change) you have to do the same thing with a PUT.
+
+Finally if you want to delete a poi_type you just have to use the DELETE action:
+
+    curl 'http://localhost:5000/v0/instances/fr-bre/poi_types/foo:bar' -X DELETE

--- a/source/tyr/readme.md
+++ b/source/tyr/readme.md
@@ -501,3 +501,20 @@ For updating a poi_type (only the name can be change) you have to do the same th
 Finally if you want to delete a poi_type you just have to use the DELETE action:
 
     curl 'http://localhost:5000/v0/instances/fr-bre/poi_types/foo:bar' -X DELETE
+
+
+A little help if you want to add a new POI type and keep all the default ones:
+
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:college?name=école' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:university?name=université' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:theatre?name=théâtre' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:hospital?name=hôpital' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:post_office?name=bureau+de+poste' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:bicycle_rental?name=station+vls' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:bicycle_parking?name=Parking+vélo' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:parking?name=Parking' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:police?name=Police,+Gendarmerie' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:townhall?name=Mairie' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/leisure:garden?name=Jardin' -X POST
+    curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/leisure:park?name=Zone+Parc.+Zone+verte+ouverte,+pour+déambuler.+habituellement+municipale' -X POST
+

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -62,6 +62,10 @@ api.add_resource(resources.BillingPlan,
                  '/v0/billing_plans/',
                  '/v0/billing_plans/<int:billing_plan_id>')
 
+api.add_resource(resources.PoiType,
+            '/v0/instances/<string:instance_name>/poi_types',
+            '/v0/instances/<string:instance_name>/poi_types/<string:uri>')
+
 @app.errorhandler(Exception)
 def error_handler(exception):
     """

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -207,9 +207,17 @@ def osm2ed(self, instance_config, osm_filename, job_id, dataset_uid):
     try:
         connection_string = make_connection_string(instance_config)
         res = None
+        args = ["-i", osm_filename, "--connection-string", connection_string]
+        for poi_type in instance.poi_types:
+            args.append('-p')
+            if poi_type.name:
+                args.append(u'{}={}'.format(poi_type.uri, poi_type.name))
+            else:
+                args.append(poi_type.uri)
+
         with collect_metric('osm2ed', job, dataset_uid):
             res = launch_exec('osm2ed',
-                    ["-i", osm_filename, "--connection-string", connection_string],
+                    args,
                     logger)
         if res != 0:
             #@TODO: exception


### PR DESCRIPTION
close: http://jira.canaltp.fr/browse/NAVP-64

Osm2ed can now take in parameters what type of poi to import. 
It also force an order for poi with multiple type:
amenity > tourism > leisure > aeroway > railway > shop > others

It's possible to choose the type of poi for an instance in tyr with the api.

By default nothing change!
