### PR TITLE
kraken: fix journey pattern auto generation with multiple utc offset on vjs

### DIFF
--- a/source/routing/journey_pattern_container.cpp
+++ b/source/routing/journey_pattern_container.cpp
@@ -120,7 +120,9 @@ static bool st_are_equals(const nt::VehicleJourney& vj1, const nt::VehicleJourne
     for (auto it1 = vj1.stop_time_list.begin(), it2 = vj2.stop_time_list.begin();
          it1 !=  vj1.stop_time_list.end() && it2 !=  vj2.stop_time_list.end();
          ++it1, ++it2) {
-        if (it1->arrival_time != it2->arrival_time || it1->departure_time != it2->departure_time) {
+        // Comparaison is done on local time
+        if (it1->arrival_time + vj1.utc_to_local_offset != it2->arrival_time + vj2.utc_to_local_offset ||
+            it1->departure_time + vj1.utc_to_local_offset != it2->departure_time + vj2.utc_to_local_offset) {
             return false;
         }
     }
@@ -145,15 +147,17 @@ overtake(const VJ& vj, const std::vector<const VJ*>& vjs) {
         // if the stop times are the same, they don't overtake
         if (st_are_equals(vj, *cur_vj)) { continue; }
 
+        // Comparaisons are done on local time
         const bool vj_is_first =
-            vj.stop_time_list.front().departure_time < cur_vj->stop_time_list.front().departure_time;
+            vj.stop_time_list.front().departure_time + vj.utc_to_local_offset 
+            < cur_vj->stop_time_list.front().departure_time + cur_vj->utc_to_local_offset;
         const VJ& vj1 = vj_is_first ? vj : *cur_vj;
         const VJ& vj2 = vj_is_first ? *cur_vj : vj;
         for (auto it1 = vj1.stop_time_list.begin(), it2 = vj2.stop_time_list.begin();
              it1 !=  vj1.stop_time_list.end() && it2 !=  vj2.stop_time_list.end();
              ++it1, ++it2) {
-            if (it1->arrival_time >= it2->arrival_time ||
-                it1->departure_time >= it2->departure_time) {
+            if (it1->arrival_time + vj1.utc_to_local_offset >= it2->arrival_time + vj2.utc_to_local_offset ||
+                it1->departure_time + vj1.utc_to_local_offset >= it2->departure_time + vj2.utc_to_local_offset) {
                 return true;
             }            
         }


### PR DESCRIPTION
I push this without test because I would like be sure that you won't fix the same issue at the same time.
Unit tests will follow if you don't already solve it yourself.

**So please tell me if you are already working on it or if I could continue**

The issue is quite simple to understand.

When there is different time offset on vehicule journey on a unique route, the journey pattern auto generation (overtake function) is wrong because it compares times off different offset.

Imagine you have a VJ starting at 15h with an offset of 3600 and a VJ starting at 16h with a 7200 offset (with different speeds).
Then overtake function will detect an overtake and create a journey pattern.

This additionnal JP creates very bad things in services like route_schedules.
