### PR TITLE
Jormungandr: add impacted objects to disruptions

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -636,6 +636,7 @@ pt_object = {
     "line": PbField(line),
     "route": PbField(route),
     "stop_area": PbField(stop_area),
+    "trip": PbField(trip),
     "embedded_type": enum_type(),
     "name": fields.String(),
     "quality": fields.Integer(),

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -442,45 +442,6 @@ disruption_severity = {
     "priority": fields.Integer(),
 }
 
-disruption_marshaller = {
-    "id": fields.String(attribute="uri"),
-    "disruption_id": fields.String(attribute="disruption_uri"),
-    "impact_id": fields.String(attribute="uri"),
-    "title": fields.String(),
-    "application_periods": NonNullList(NonNullNested(period)),
-    "status": disruption_status,
-    "updated_at": DateTime(),
-    "tags": NonNullList(fields.String()),
-    "cause": fields.String(),
-    "severity": NonNullNested(disruption_severity),
-    "messages": NonNullList(NonNullNested(disruption_message)),
-    "uri": fields.String(),
-    "disruption_uri": fields.String(),
-    "contributor": fields.String()
-}
-
-
-class DisruptionsField(fields.Raw):
-    """
-    Dump the real disruptions (and there will be link to them)
-    """
-
-    def output(self, key, obj):
-        all_impacts = {}
-
-        def get_all_impacts(_, val):
-            if not hasattr(val, 'impacts'):
-                return
-            impacts = val.impacts
-            if not impacts or not hasattr(impacts[0], 'uri'):
-                return
-
-            for impact in impacts:
-                all_impacts[impact.uri] = impact
-
-        utils.walk_protobuf(obj, get_all_impacts)
-
-        return [marshal(d, disruption_marshaller, display_null=False) for d in all_impacts.values()]
 
 display_informations_route = {
     "network": fields.String(attribute="network"),
@@ -793,3 +754,53 @@ instance_traveler_types = {
 
 instance_status_with_parameters['traveler_profiles'] = fields.List(fields.Nested(instance_traveler_types,
                                                                                  allow_null=True))
+
+impacted_stop = {
+
+}
+
+impacted_object = {
+    'pt_object': NonNullNested(pt_object),
+    'impacted_stops': NonNullList(NonNullNested(impacted_stop))
+}
+
+disruption_marshaller = {
+    "id": fields.String(attribute="uri"),
+    "disruption_id": fields.String(attribute="disruption_uri"),
+    "impact_id": fields.String(attribute="uri"),
+    "title": fields.String(),
+    "application_periods": NonNullList(NonNullNested(period)),
+    "status": disruption_status,
+    "updated_at": DateTime(),
+    "tags": NonNullList(fields.String()),
+    "cause": fields.String(),
+    "severity": NonNullNested(disruption_severity),
+    "messages": NonNullList(NonNullNested(disruption_message)),
+    "impacted_objects": NonNullList(NonNullNested(impacted_object)),
+    "uri": fields.String(),
+    "disruption_uri": fields.String(),
+    "contributor": fields.String()
+}
+
+
+class DisruptionsField(fields.Raw):
+    """
+    Dump the real disruptions (and there will be link to them)
+    """
+
+    def output(self, key, obj):
+        all_impacts = {}
+
+        def get_all_impacts(_, val):
+            if not hasattr(val, 'impacts'):
+                return
+            impacts = val.impacts
+            if not impacts or not hasattr(impacts[0], 'uri'):
+                return
+
+            for impact in impacts:
+                all_impacts[impact.uri] = impact
+
+        utils.walk_protobuf(obj, get_all_impacts)
+
+        return [marshal(d, disruption_marshaller, display_null=False) for d in all_impacts.values()]

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -746,10 +746,10 @@ def is_valid_pt_object(pt_object, depth_check=1):
         assert get_not_null(pt_object, pt_obj_type)['label'] == n
     if pt_obj_type == 'line':
         # the line network, commercial_mode, code and name should be in the label
-        check_embedded_line_label(n, pt_obj_type['line'], depth_check)
+        check_embedded_line_label(n, pt_object['line'], depth_check)
     if pt_obj_type == 'route':
         # the line network, commercial_mode, code and name should be in the label
-        check_embedded_route_label(n, pt_obj_type['route'], depth_check)
+        check_embedded_route_label(n, pt_object['route'], depth_check)
 
 
 def check_embedded_line_label(label, line, depth_check):
@@ -903,7 +903,7 @@ def is_valid_disruption(disruption):
     s = get_not_null(disruption, 'severity')
     get_not_null(s, 'name')
     get_not_null(s, 'color')
-    get_not_null(s, 'effect')
+    effect = get_not_null(s, 'effect')
     msg = get_not_null(disruption, 'messages')
     assert len(msg) > 0
     for m in msg:
@@ -912,6 +912,18 @@ def is_valid_disruption(disruption):
         get_not_null(channel, "content_type")
         get_not_null(channel, "id")
         get_not_null(channel, "name")
+
+    for impacted_obj in get_not_null(disruption, 'impacted_objects'):
+        pt_obj = get_not_null(impacted_obj, 'pt_object')
+        is_valid_pt_object(pt_obj, depth_check=0)
+
+        # for the vj, if it's not a cancellation we need to have the list of impacted stoptimes
+        # if get_not_null(pt_obj, 'embedded_type') == 'vehicle_journey' and effect != 'NO_SERVICE':
+        #     impacted_stops = get_not_null(impacted_obj, 'impacted_stops')
+        #
+        #     #TODO
+
+
 
 s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
 r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -730,10 +730,11 @@ def is_valid_pt_object(pt_object, depth_check=1):
                            'vehicle_journey',
                            'calendar',
                            'company',
-                           "stop_area",
-                           "stop_point",
-                           "poi",
-                           "address")
+                           'stop_area',
+                           'stop_point',
+                           'poi',
+                           'address',
+                           'trip')
 
     # if it's a line, it should pass the 'is_valid_line' test,
     # if it's a stop_area, it should pass the 'is_valid_stop_area' test ...
@@ -816,8 +817,7 @@ def is_valid_vehicle_journey(vj, depth_check=1):
         is_valid_comment(c)
 
     if depth_check > 0:
-        get_not_null(vj, "trip")
-        get_not_null(vj["trip"], "id")
+        is_valid_trip(get_not_null(vj, "trip"), depth_check=depth_check-1)
 
         is_valid_journey_pattern(get_not_null(vj, 'journey_pattern'), depth_check=depth_check-1)
         is_valid_validity_pattern(get_not_null(vj, 'validity_pattern'), depth_check=depth_check-1)
@@ -840,6 +840,10 @@ def is_valid_vehicle_journey(vj, depth_check=1):
         assert 'stop_times' not in vj
         assert 'journey_pattern' not in vj
         assert 'validity_pattern' not in vj
+
+
+def is_valid_trip(trip, depth_check=1):
+    get_not_null(trip, "id")
 
 
 def is_valid_journey_pattern(jp, depth_check=1):
@@ -918,10 +922,10 @@ def is_valid_disruption(disruption):
         is_valid_pt_object(pt_obj, depth_check=0)
 
         # for the vj, if it's not a cancellation we need to have the list of impacted stoptimes
-        # if get_not_null(pt_obj, 'embedded_type') == 'vehicle_journey' and effect != 'NO_SERVICE':
-        #     impacted_stops = get_not_null(impacted_obj, 'impacted_stops')
-        #
-        #     #TODO
+        if get_not_null(pt_obj, 'embedded_type') == 'vehicle_journey' and effect != 'NO_SERVICE':
+            impacted_stops = get_not_null(impacted_obj, 'impacted_stops')
+
+            #TODO
 
 
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -66,14 +66,23 @@ class TestKirinOnVJDeletion(MockKirinDisruptionsFixture):
         self.send_mock("vjA", "20120614", 'canceled')
 
         # we should see the disruption
+        def _check_train_delay_disruption(dis):
+            eq_(dis['disruption_id'], '96231_2015-07-28_0')
+            eq_(dis['severity']['effect'], 'NO_SERVICE')
+            eq_(len(dis['impacted_objects']), 1)
+            ptobj = dis['impacted_objects'][0]['pt_object']
+            eq_(ptobj['embedded_type'], 'trip')
+            eq_(ptobj['id'], 'vjA')
+            eq_(ptobj['name'], 'vjA')
+
         pt_response = self.query_region('vehicle_journeys/vjA?_current_datetime=20120614T1337')
         eq_(len(pt_response['disruptions']), 1)
-        eq_(pt_response['disruptions'][0]['disruption_id'], '96231_2015-07-28_0')
+        _check_train_delay_disruption(pt_response['disruptions'][0])
 
         # and we should be able to query for the vj's disruption
         disrup_response = self.query_region('vehicle_journeys/vjA/disruptions')
         eq_(len(disrup_response['disruptions']), 1)
-        eq_(disrup_response['disruptions'][0]['disruption_id'], '96231_2015-07-28_0')
+        _check_train_delay_disruption(disrup_response['disruptions'][0])
 
         new_response = self.query_region(journey_basic_query + "&data_freshness=realtime")
         eq_(get_arrivals(new_response), ['20120614T080435', '20120614T180222'])

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -143,7 +143,6 @@ struct PtObjVisitor: public boost::static_visitor<> {
         fill_pb_placemark(line_section.line, data, pb_pt_pbj, 0, now, action_period, show_codes, DumpMessage::No);
     }
     void operator()(const nt::disruption::UnknownPtObj&) const {}
-    void operator()(const nt::MetaVehicleJourney*) const { }
 };
 
 void fill_pb_object(const nt::disruption::PtObj& ptobj,
@@ -231,8 +230,7 @@ void fill_message(const type::disruption::Impact& impact,
     pb_impact->set_status(compute_disruption_status(impact, action_period));
 
     for (const auto& informed_entity: impact.informed_entities) {
-        if (boost::get<nt::disruption::UnknownPtObj>(&informed_entity) != nullptr ||
-                boost::get<nt::MetaVehicleJourney*>(&informed_entity) != nullptr) { continue; }
+        if (boost::get<nt::disruption::UnknownPtObj>(&informed_entity) != nullptr) { continue; }
         auto* pb_impacted_obj = pb_impact->add_impacted_objects();
         fill_pb_object(informed_entity, data, pb_impacted_obj->mutable_pt_object(),
                        depth, now, action_period, show_codes);
@@ -714,6 +712,7 @@ void fill_pb_object(const nt::ValidityPattern* vp, const nt::Data&,
 }
 
 void fill_pb_object(const nt::MetaVehicleJourney* nav_mvj,
+                    const nt::Data&,
                     pbnavitia::Trip* pb_trip,
                     int /*max_depth*/,
                     const pt::ptime& /*now*/,
@@ -761,7 +760,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
             fill_pb_object(&stop_time, data, vehicle_journey->add_stop_times(),
                            depth-1, now, action_period, show_codes);
         }
-        fill_pb_object(vj->meta_vj, vehicle_journey->mutable_trip(), depth-1, now,
+        fill_pb_object(vj->meta_vj, data, vehicle_journey->mutable_trip(), depth-1, now,
                        action_period, show_codes);
         fill_pb_object(vj->physical_mode, data,
                        vehicle_journey->mutable_journey_pattern()->mutable_physical_mode(), depth-1,

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -136,7 +136,6 @@ struct PtObjVisitor: public boost::static_visitor<> {
                  now(now), action_period(action_period), show_codes(show_codes) {}
     template <typename NavitiaPTObject>
     void operator()(const NavitiaPTObject* bo) const {
-        std::cout << "hop objet bo" << std::endl;
         fill_pb_placemark(bo, data, pb_pt_pbj, 0, now, action_period, show_codes, DumpMessage::No);
     }
     void operator()(const nt::disruption::LineSection& line_section) const {
@@ -232,8 +231,8 @@ void fill_message(const type::disruption::Impact& impact,
     pb_impact->set_status(compute_disruption_status(impact, action_period));
 
     for (const auto& informed_entity: impact.informed_entities) {
-        if (boost::get<nt::disruption::UnknownPtObj>(&informed_entity) == nullptr ||
-                boost::get<nt::MetaVehicleJourney*>(&informed_entity) == nullptr) { continue; }
+        if (boost::get<nt::disruption::UnknownPtObj>(&informed_entity) != nullptr ||
+                boost::get<nt::MetaVehicleJourney*>(&informed_entity) != nullptr) { continue; }
         auto* pb_impacted_obj = pb_impact->add_impacted_objects();
         fill_pb_object(informed_entity, data, pb_impacted_obj->mutable_pt_object(),
                        depth, now, action_period, show_codes);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -47,7 +47,7 @@ www.navitia.io
 namespace nt = navitia::type;
 namespace pt = boost::posix_time;
 
-namespace navitia{
+namespace navitia {
 
 template<typename NT, typename PB>
 static void fill_codes(const NT* nt, const nt::Data& data, PB* pb) {
@@ -121,15 +121,50 @@ static void fill_property(const std::string& name,
     property->set_value(value);
 }
 
+struct PtObjVisitor: public boost::static_visitor<> {
+    const nt::Data& data;
+    pbnavitia::PtObject* pb_pt_pbj;
+    const pt::ptime& now;
+    const pt::time_period& action_period;
+    const bool show_codes;
+    PtObjVisitor(const nt::Data& data,
+                 pbnavitia::PtObject* pb_pt_pbj,
+                 const pt::ptime& now,
+                 const pt::time_period& action_period,
+                 const bool show_codes):
+                 data(data), pb_pt_pbj(pb_pt_pbj),
+                 now(now), action_period(action_period), show_codes(show_codes) {}
+    template <typename NavitiaPTObject>
+    void operator()(const NavitiaPTObject* bo) const {
+        std::cout << "hop objet bo" << std::endl;
+        fill_pb_placemark(bo, data, pb_pt_pbj, 0, now, action_period, show_codes, DumpMessage::No);
+    }
+    void operator()(const nt::disruption::LineSection& line_section) const {
+        //TODO: for the moment a line section is only a line, but later we might want to output more stuff
+        fill_pb_placemark(line_section.line, data, pb_pt_pbj, 0, now, action_period, show_codes, DumpMessage::No);
+    }
+    void operator()(const nt::disruption::UnknownPtObj&) const {}
+    void operator()(const nt::MetaVehicleJourney*) const { }
+};
+
+void fill_pb_object(const nt::disruption::PtObj& ptobj,
+                    const nt::Data& data,
+                    pbnavitia::PtObject* pb_pt_pbj, int max_depth,
+                    const pt::ptime& now, const pt::time_period& action_period,
+                    const bool show_codes) {
+    boost::apply_visitor(PtObjVisitor(data, pb_pt_pbj, now, action_period, show_codes), ptobj);
+}
+
 template <typename T>
 void fill_message(const type::disruption::Impact& impact,
-        const type::Data&, T pb_object, int,
-        const boost::posix_time::ptime&, const boost::posix_time::time_period& action_period) {
+        const type::Data& data, T pb_object, int depth,
+        const boost::posix_time::ptime& now, const boost::posix_time::time_period& action_period,
+        const bool show_codes) {
     auto pb_impact = pb_object->add_impacts();
 
     pb_impact->set_disruption_uri(impact.disruption->uri);
 
-    if (!impact.disruption->contributor.empty()){
+    if (!impact.disruption->contributor.empty()) {
         pb_impact->set_contributor(impact.disruption->contributor);
     }
 
@@ -195,6 +230,14 @@ void fill_message(const type::disruption::Impact& impact,
 
     //we need to compute the active status
     pb_impact->set_status(compute_disruption_status(impact, action_period));
+
+    for (const auto& informed_entity: impact.informed_entities) {
+        if (boost::get<nt::disruption::UnknownPtObj>(&informed_entity) == nullptr ||
+                boost::get<nt::MetaVehicleJourney*>(&informed_entity) == nullptr) { continue; }
+        auto* pb_impacted_obj = pb_impact->add_impacted_objects();
+        fill_pb_object(informed_entity, data, pb_impacted_obj->mutable_pt_object(),
+                       depth, now, action_period, show_codes);
+    }
 }
 
 void fill_pb_object(const type::disruption::Impact* impact,
@@ -232,7 +275,7 @@ void fill_pb_object(const navitia::type::StopTime* stop_time, const type::Data&,
 void fill_pb_object(const georef::Admin* adm, const nt::Data&,
                     pbnavitia::AdministrativeRegion* admin, int,
                     const pt::ptime&, const pt::time_period&,
-                    const bool){
+                    const bool, const DumpMessage) {
     if(adm == nullptr)
         return ;
     admin->set_name(adm->name);
@@ -249,16 +292,16 @@ void fill_pb_object(const georef::Admin* adm, const nt::Data&,
     }
 }
 
-
 void fill_pb_object(const nt::Contributor*,
                     const nt::Data& , pbnavitia::Contributor* ,
                     int , const pt::ptime& ,
-                    const pt::time_period& , const bool){}
+                    const pt::time_period& , const bool, const DumpMessage) {}
 
 void fill_pb_object(const nt::StopArea* sa,
                     const nt::Data& data, pbnavitia::StopArea* stop_area,
                     int max_depth, const pt::ptime& now,
-                    const pt::time_period& action_period, const bool show_codes){
+                    const pt::time_period& action_period, const bool show_codes,
+                    const DumpMessage dump_message) {
     if(sa == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -297,8 +340,10 @@ void fill_pb_object(const nt::StopArea* sa,
         }
     }
 
-    for (const auto& message : sa->get_applicable_messages(now, action_period)){
-        fill_message(*message, data, stop_area, max_depth-1, now, action_period);
+    if (dump_message == DumpMessage::Yes) {
+        for (const auto& message : sa->get_applicable_messages(now, action_period)){
+            fill_message(*message, data, stop_area, max_depth-1, now, action_period, show_codes);
+        }
     }
     if (show_codes) { fill_codes(sa, data, stop_area); }
 }
@@ -306,7 +351,8 @@ void fill_pb_object(const nt::StopArea* sa,
 
 void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
                     pbnavitia::StopPoint* stop_point, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+                    const pt::ptime& now, const pt::time_period& action_period,
+                    const bool show_codes, const DumpMessage dump_message) {
     if(sp == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -371,9 +417,10 @@ void fill_pb_object(const nt::StopPoint* sp, const nt::Data& data,
         fill_pb_object(sp->stop_area, data, stop_point->mutable_stop_area(),
                        depth-1, now, action_period, show_codes);
 
-
-    for(const auto message : sp->get_applicable_messages(now, action_period)){
-        fill_message(*message, data, stop_point, max_depth-1, now, action_period);
+    if (dump_message == DumpMessage::Yes) {
+        for(const auto message : sp->get_applicable_messages(now, action_period)){
+            fill_message(*message, data, stop_point, max_depth-1, now, action_period, show_codes);
+        }
     }
     if (show_codes) { fill_codes(sp, data, stop_point); }
 }
@@ -403,8 +450,9 @@ void fill_pb_object(const navitia::type::GeographicalCoord& coord, const type::D
 }
 
 void fill_pb_object(nt::Line const* l, const nt::Data& data,
-        pbnavitia::Line * line, int max_depth, const pt::ptime& now,
-        const pt::time_period& action_period, const bool show_codes){
+                    pbnavitia::Line* line, int max_depth, const pt::ptime& now,
+                    const pt::time_period& action_period, const bool show_codes,
+                    const DumpMessage dump_message) {
     if(l == nullptr)
         return ;
 
@@ -452,8 +500,10 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
         }
     }
 
-    for(const auto message : l->get_applicable_messages(now, action_period)){
-        fill_message(*message, data, line, depth-1, now, action_period);
+    if (dump_message == DumpMessage::Yes) {
+        for(const auto message : l->get_applicable_messages(now, action_period)){
+            fill_message(*message, data, line, depth-1, now, action_period, show_codes);
+        }
     }
 
     if (show_codes) { fill_codes(l, data, line); }
@@ -465,7 +515,8 @@ void fill_pb_object(nt::Line const* l, const nt::Data& data,
 
 void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
         pbnavitia::LineGroup* line_group, int max_depth,
-        const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+        const pt::ptime& now, const pt::time_period& action_period
+                    , const bool show_codes, const DumpMessage dump_message) {
     if(lg == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -475,9 +526,11 @@ void fill_pb_object(const nt::LineGroup* lg, const nt::Data& data,
 
     if(depth > 0) {
         for(const auto& line : lg->line_list) {
-            fill_pb_object(line, data, line_group->add_lines(), depth-1, now, action_period, show_codes);
+            fill_pb_object(line, data, line_group->add_lines(), depth-1,
+                           now, action_period, show_codes, dump_message);
         }
-        fill_pb_object(lg->main_line, data, line_group->mutable_main_line(), 0, now, action_period, show_codes);
+        fill_pb_object(lg->main_line, data, line_group->mutable_main_line(), 0,
+                       now, action_period, show_codes, dump_message);
 
         for (const auto& comment: data.pt_data->comments.get(lg)) {
             auto com = line_group->add_comments();
@@ -520,7 +573,8 @@ void fill_pb_object(const nt::MultiLineString& shape, pbnavitia::MultiLineString
 
 void fill_pb_object(const nt::Route* r, const nt::Data& data,
                     pbnavitia::Route* route, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+                    const pt::ptime& now, const pt::time_period& action_period,
+                    const bool show_codes, const DumpMessage dump_message) {
     if(r == nullptr)
         return ;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -539,8 +593,11 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
     }
 
     route->set_uri(r->uri);
-    for(const auto& message : r->get_applicable_messages(now, action_period)){
-        fill_message(*message, data, route, max_depth-1, now, action_period);
+
+    if (dump_message == DumpMessage::Yes) {
+        for(const auto& message : r->get_applicable_messages(now, action_period)){
+            fill_message(*message, data, route, max_depth-1, now, action_period, show_codes);
+        }
     }
 
     if (show_codes) { fill_codes(r, data, route); }
@@ -577,15 +634,18 @@ void fill_pb_object(const nt::Route* r, const nt::Data& data,
 
 void fill_pb_object(const nt::Network* n, const nt::Data& data,
                     pbnavitia::Network* network, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool show_codes){
+                    const pt::ptime& now, const pt::time_period& action_period,
+                    const bool show_codes, const DumpMessage dump_message) {
     if(n == nullptr)
         return ;
 
     network->set_name(n->name);
     network->set_uri(n->uri);
 
-    for(const auto& message : n->get_applicable_messages(now, action_period)){
-        fill_message(*message, data, network, max_depth-1, now, action_period);
+    if (dump_message == DumpMessage::Yes) {
+        for(const auto& message : n->get_applicable_messages(now, action_period)){
+            fill_message(*message, data, network, max_depth-1, now, action_period, show_codes);
+        }
     }
     if (show_codes) { fill_codes(n, data, network); }
 }
@@ -593,7 +653,7 @@ void fill_pb_object(const nt::Network* n, const nt::Data& data,
 
 void fill_pb_object(const nt::CommercialMode* m, const nt::Data&,
                     pbnavitia::CommercialMode* commercial_mode,
-                    int, const pt::ptime&, const pt::time_period&, const bool){
+                    int, const pt::ptime&, const pt::time_period&, const bool, const DumpMessage){
     if(m == nullptr)
         return ;
 
@@ -604,7 +664,7 @@ void fill_pb_object(const nt::CommercialMode* m, const nt::Data&,
 
 void fill_pb_object(const nt::PhysicalMode* m, const nt::Data&,
                     pbnavitia::PhysicalMode* physical_mode, int,
-                    const pt::ptime&, const pt::time_period&, const bool){
+                    const pt::ptime&, const pt::time_period&, const bool, const DumpMessage){
     if(m == nullptr)
         return ;
 
@@ -615,7 +675,7 @@ void fill_pb_object(const nt::PhysicalMode* m, const nt::Data&,
 
 void fill_pb_object(const nt::Company* c, const nt::Data& data,
                     pbnavitia::Company* company, int, const pt::ptime&,
-                    const pt::time_period&, const bool show_codes){
+                    const pt::time_period&, const bool show_codes, const DumpMessage){
     if(c == nullptr)
         return ;
 
@@ -644,11 +704,9 @@ void fill_pb_object(const nt::StopPointConnection* c, const nt::Data& data,
     }
 }
 
-
-
 void fill_pb_object(const nt::ValidityPattern* vp, const nt::Data&,
                     pbnavitia::ValidityPattern* validity_pattern, int,
-                    const pt::ptime&, const pt::time_period&, const bool){
+                    const pt::ptime&, const pt::time_period&, const bool, const DumpMessage) {
     if(vp == nullptr)
         return;
     auto vp_string = boost::gregorian::to_iso_string(vp->beginning_date);
@@ -661,7 +719,8 @@ void fill_pb_object(const nt::MetaVehicleJourney* nav_mvj,
                     int /*max_depth*/,
                     const pt::ptime& /*now*/,
                     const pt::time_period& /*action_period*/,
-                    const bool /*show_codes*/) {
+                    const bool /*show_codes*/,
+                    const DumpMessage) {
     pb_trip->set_uri(nav_mvj->uri);
 }
 
@@ -671,7 +730,8 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     int max_depth,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
-                    const bool show_codes){
+                    const bool show_codes,
+                    const DumpMessage dump_message){
     if (vj == nullptr) { return; }
     int depth = (max_depth <= 3) ? max_depth : 3;
 
@@ -725,8 +785,10 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                                      action_period);
     }
 
-    for (const auto& message: vj->meta_vj->get_applicable_messages(now, action_period)) {
-        fill_message(*message, data, vehicle_journey, max_depth-1, now, action_period);
+    if (dump_message == DumpMessage::Yes) {
+        for (const auto& message: vj->meta_vj->get_applicable_messages(now, action_period)) {
+            fill_message(*message, data, vehicle_journey, max_depth-1, now, action_period, show_codes);
+        }
     }
 
     if (show_codes) { fill_codes(vj, data, vehicle_journey); }
@@ -1250,7 +1312,7 @@ void fill_pb_object(const georef::POIType* geo_poi_type, const type::Data &,
 void fill_pb_object(const georef::POI* geopoi, const type::Data &data,
                     pbnavitia::Poi* poi, int max_depth,
                     const pt::ptime& now, const pt::time_period& action_period,
-                    const bool){
+                    const bool, const DumpMessage){
     if(geopoi == nullptr)
         return;
     int depth = (max_depth <= 3) ? max_depth : 3;
@@ -1545,7 +1607,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
 
 void fill_pb_object(const nt::Calendar* cal, const nt::Data& data,
                     pbnavitia::Calendar* pb_cal, int max_depth,
-                    const pt::ptime& now, const pt::time_period& action_period, const bool)
+                    const pt::ptime& now, const pt::time_period& action_period, const bool, const DumpMessage)
 {
     pb_cal->set_uri(cal->uri);
     pb_cal->set_name(cal->name);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -60,6 +60,12 @@ namespace navitia {
 }
 namespace pt = boost::posix_time;
 
+// we don't use a boolean to have a more type checks
+enum class DumpMessage {
+    Yes,
+    No
+};
+
 #define null_time_period boost::posix_time::time_period(boost::posix_time::not_a_date_time, boost::posix_time::seconds(0))
 
 namespace navitia {
@@ -94,7 +100,8 @@ struct EnhancedResponse {
 #define FILL_PB_CONSTRUCTOR(type_name, collection_name)\
     void fill_pb_object(const navitia::type::type_name* item, const navitia::type::Data& data, pbnavitia::type_name *, int max_depth = 0,\
             const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,\
-            const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes=false);
+            const boost::posix_time::time_period& action_period = null_time_period, \
+            const bool show_codes = false, const DumpMessage = DumpMessage::Yes);
     ITERATE_NAVITIA_PT_TYPES(FILL_PB_CONSTRUCTOR)
 #undef FILL_PB_CONSTRUCTOR
 void fill_pb_object(const std::pair<const routing::JpIdx, const routing::JourneyPattern&>& item,
@@ -135,7 +142,7 @@ void fill_pb_object(const navitia::type::MetaVehicleJourney* nav_mvj,
                     int max_depth,
                     const boost::posix_time::ptime& now,
                     const boost::posix_time::time_period& action_period,
-                    const bool show_codes);
+                    const bool show_codes, const DumpMessage = DumpMessage::Yes);
 
 void fill_co2_emission(pbnavitia::Section *pb_section, const nt::Data& data, const type::VehicleJourney* vehicle_journey);
 void fill_co2_emission_by_mode(pbnavitia::Section *pb_section, const nt::Data& data, const std::string& mode_uri);
@@ -191,7 +198,7 @@ void fill_street_sections(EnhancedResponse& response, const type::EntryPoint &or
 template <typename T>
 void fill_message(const type::disruption::Impact& impact, const type::Data &data, T pb_object, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
-        const boost::posix_time::time_period& action_period = null_time_period);
+        const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes = false);
 
 void add_path_item(pbnavitia::StreetNetwork* sn, const navitia::georef::PathItem& item, const type::EntryPoint &ori_dest,
                    const navitia::type::Data& data);
@@ -199,7 +206,7 @@ void add_path_item(pbnavitia::StreetNetwork* sn, const navitia::georef::PathItem
 void fill_pb_object(const georef::POI*, const type::Data &data, pbnavitia::Poi* poi, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period,
-        const bool show_codes=false);
+        const bool show_codes = false, const DumpMessage = DumpMessage::Yes);
 
 void fill_pb_object(const georef::POIType*, const type::Data &data, pbnavitia::PoiType* poi_type, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
@@ -208,7 +215,7 @@ void fill_pb_object(const georef::POIType*, const type::Data &data, pbnavitia::P
 void fill_pb_object(const georef::Admin* adm, const type::Data& data, pbnavitia::AdministrativeRegion* admin, int max_depth = 0,
                     const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
                     const boost::posix_time::time_period& action_period = null_time_period,
-                    const bool show_codes=false);
+                    const bool show_codes = false, const DumpMessage = DumpMessage::Yes);
 
 void fill_pb_object(const navitia::type::StopTime* st, const type::Data& data, pbnavitia::ScheduleStopTime* row, int max_depth = 0,
                     const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
@@ -232,7 +239,7 @@ void fill_pb_object(const nt::VehicleJourney* vj,
                     int max_depth,
                     const pt::ptime& now,
                     const pt::time_period& action_period,
-                    const bool show_codes);
+                    const bool show_codes, const DumpMessage);
 
 void fill_pb_object(const type::VehicleJourney* vj,
                     const type::Data& data,
@@ -331,12 +338,12 @@ template<typename T>
 void fill_pb_placemark(const T* value, const type::Data &data, pbnavitia::PtObject* pt_object, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period,
-        const bool show_codes=false) {
+        const bool show_codes = false, const DumpMessage dump_message = DumpMessage::Yes) {
     if(value == nullptr)
         return;
     int depth = (max_depth <= 3) ? max_depth : 3;
     fill_pb_object(value, data, get_sub_object(value, pt_object), depth,
-                   now, action_period, show_codes);
+                   now, action_period, show_codes, dump_message);
     pt_object->set_name(get_label(value));
     pt_object->set_uri(value->uri);
     pt_object->set_embedded_type(get_embedded_type(value));

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -205,6 +205,12 @@ void fill_message(const type::disruption::Impact& impact, const type::Data &data
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes = false);
 
+template <typename HasMessage, typename PbObj>
+void fill_messages(const HasMessage*, const type::Data& data, PbObj, int max_depth = 0,
+                   const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
+                   const boost::posix_time::time_period& action_period = null_time_period,
+                   const bool show_codes = false, const DumpMessage = DumpMessage::Yes);
+
 void add_path_item(pbnavitia::StreetNetwork* sn, const navitia::georef::PathItem& item, const type::EntryPoint &ori_dest,
                    const navitia::type::Data& data);
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -138,11 +138,13 @@ void fill_pb_object(const navitia::type::StopTime* st, const type::Data &data, p
         const boost::posix_time::time_period& action_period = null_time_period);
 
 void fill_pb_object(const navitia::type::MetaVehicleJourney* nav_mvj,
+                    const nt::Data&,
                     pbnavitia::Trip* pb_trip,
-                    int max_depth,
-                    const boost::posix_time::ptime& now,
-                    const boost::posix_time::time_period& action_period,
-                    const bool show_codes, const DumpMessage = DumpMessage::Yes);
+                    int max_depth = 0,
+                    const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
+                    const boost::posix_time::time_period& action_period = null_time_period,
+                    const bool show_codes = false,
+                    const DumpMessage = DumpMessage::Yes);
 
 void fill_co2_emission(pbnavitia::Section *pb_section, const nt::Data& data, const type::VehicleJourney* vehicle_journey);
 void fill_co2_emission_by_mode(pbnavitia::Section *pb_section, const nt::Data& data, const std::string& mode_uri);
@@ -170,6 +172,7 @@ inline pbnavitia::NavitiaType get_embedded_type(const georef::Admin*) { return p
 inline pbnavitia::NavitiaType get_embedded_type(const type::StopArea*) { return pbnavitia::STOP_AREA; }
 inline pbnavitia::NavitiaType get_embedded_type(const type::StopPoint*) { return pbnavitia::STOP_POINT; }
 inline pbnavitia::NavitiaType get_embedded_type(const type::CommercialMode*) { return pbnavitia::COMMERCIAL_MODE; }
+inline pbnavitia::NavitiaType get_embedded_type(const type::MetaVehicleJourney*) { return pbnavitia::TRIP; }
 
 inline pbnavitia::Calendar* get_sub_object(const type::Calendar*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_calendar(); }
 inline pbnavitia::VehicleJourney* get_sub_object(const type::VehicleJourney*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_vehicle_journey(); }
@@ -182,6 +185,7 @@ inline pbnavitia::AdministrativeRegion* get_sub_object(const georef::Admin*, pbn
 inline pbnavitia::StopArea* get_sub_object(const type::StopArea*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_stop_area(); }
 inline pbnavitia::StopPoint* get_sub_object(const type::StopPoint*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_stop_point(); }
 inline pbnavitia::CommercialMode* get_sub_object(const type::CommercialMode*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_commercial_mode(); }
+inline pbnavitia::Trip* get_sub_object(const type::MetaVehicleJourney*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_trip(); }
 
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
                           const time_duration& crow_fly_duration, type::Mode_e mode,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -169,6 +169,7 @@ inline pbnavitia::NavitiaType get_embedded_type(const georef::POI*) { return pbn
 inline pbnavitia::NavitiaType get_embedded_type(const georef::Admin*) { return pbnavitia::ADMINISTRATIVE_REGION; }
 inline pbnavitia::NavitiaType get_embedded_type(const type::StopArea*) { return pbnavitia::STOP_AREA; }
 inline pbnavitia::NavitiaType get_embedded_type(const type::StopPoint*) { return pbnavitia::STOP_POINT; }
+inline pbnavitia::NavitiaType get_embedded_type(const type::CommercialMode*) { return pbnavitia::COMMERCIAL_MODE; }
 
 inline pbnavitia::Calendar* get_sub_object(const type::Calendar*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_calendar(); }
 inline pbnavitia::VehicleJourney* get_sub_object(const type::VehicleJourney*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_vehicle_journey(); }
@@ -180,7 +181,7 @@ inline pbnavitia::Poi* get_sub_object(const georef::POI*, pbnavitia::PtObject* p
 inline pbnavitia::AdministrativeRegion* get_sub_object(const georef::Admin*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_administrative_region(); }
 inline pbnavitia::StopArea* get_sub_object(const type::StopArea*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_stop_area(); }
 inline pbnavitia::StopPoint* get_sub_object(const type::StopPoint*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_stop_point(); }
-
+inline pbnavitia::CommercialMode* get_sub_object(const type::CommercialMode*, pbnavitia::PtObject* pt_object) { return pt_object->mutable_commercial_mode(); }
 
 void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
                           const time_duration& crow_fly_duration, type::Mode_e mode,

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -715,6 +715,24 @@ type::hasOdtProperties Line::get_odt_properties() const{
     return result;
 }
 
+std::string Line::get_label() const {
+    //LineName = NetworkName + ModeName + LineCode + (LineName)
+    std::stringstream s;
+    if (network) { s << network->name << " "; }
+    if (commercial_mode) { s << commercial_mode->name << " "; }
+    s << code << " (" << name << ")";
+    return s.str();
+}
+
+std::string Route::get_label() const {
+    //RouteName = NetworkName + ModeName + LineCode + (RouteName)
+    std::stringstream s;
+    if (line->network) { s << line->network->name << " "; }
+    if (line->commercial_mode) { s << line->commercial_mode->name << " "; }
+    s << line->code << " (" << name << ")";
+    return s.str();
+}
+
 std::vector<idx_t> LineGroup::get(Type_e type, const PT_Data&) const {
     std::vector<idx_t> result;
     switch(type) {

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -1049,6 +1049,7 @@ struct MetaVehicleJourney: public Header, HasMessages {
     VehicleJourney*
     get_base_vj_circulating_at_date(const boost::gregorian::date& date) const;
 
+    const std::string& get_label() const { return uri; } // for the moment the label is just the uri
 private:
     template<typename VJ>
     VJ* impl_create_vj(const std::string& uri,

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -645,6 +645,8 @@ struct Line : public Header, Nameable, HasMessages {
         return this < &other;
     }
     type::hasOdtProperties get_odt_properties() const;
+
+    std::string get_label() const;
 };
 
 struct LineGroup : public Header, Nameable{
@@ -800,6 +802,7 @@ struct Route : public Header, Nameable, HasMessages {
     std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
     bool operator<(const Route & other) const { return this < &other; }
 
+    std::string get_label() const;
 };
 
 struct AssociatedCalendar {


### PR DESCRIPTION
Add impacted_objects to the /disruptions API.

the goal is to have:

``` json
{
    "disruptions": 
    [
        {
            "status": "past",
            "application_periods": 
            [
                {
                    "begin": "20151201T060400",
                    "end": "20151201T082259"
                }
            ],
            "updated_at": "20151202T090248",
            "uri": "3eabf0a6-2bd6-472f-94c4-3aedd83caaa5",
            "contributor": "ire sncf",
            "severity": 
            {
                "color": "#000000",
                "priority": 42,
                "name": "trip delayed",
                "effect": "DETOUR"
            },
            "cause": "a problem",
            "impacted_objects": [
                {
                    "pt_object": {
                        "vehicle_journey": {
                            "uri": "bob"
                            ...
                        }
                    },
                    "impacted_stops": [
                        {
                            "stop_point": { "uri": "B", ... },
                            "base_departure": 171500,
                            "base_arrival": 170000,
                            "cause": "cochon sur les voies",
                            "stoptime_effect": "DELETED"
                        },
                        {
                            "stop_point": { "uri": "E", ... },
                            "departure": 171500,
                            "arrival": 170000,
                            "cause": "cochon sur les voies",
                            "stop_timeeffect": "ADDED"
                        },
                        {
                            "stop_point": { "uri": "C", ... },
                            "departure": 181700,
                            "arrival": 181700,
                            "base_departure": 180000,
                            "base_arrival": 180000,
                            "cause": "vache sur les voies",
                            "stop_timeeffect": "SIGNIFICANT_DELAYS"
                        },
                        {
                            "stop_point": { "uri": "D", ... },
                            "departure": 192300,
                            "arrival": 192300,
                            "base_departure": 190000,
                            "base_arrival": 190000,
                            "cause": "vache sur les voies",
                            "stop_timeeffect": "SIGNIFICANT_DELAYS"
                        }
                    ]
                }
            ]
        },
        {
            "status": "past",
            "application_periods": 
            [
                {
                    "begin": "20151201T060400",
                    "end": "20151201T082259"
                }
            ],
            "updated_at": "20151202T090248",
            "uri": "3eabf0a6-2bd6-472f-94c4-3aedd83caaa6",
            "contributor": "transilien",
            "severity": 
            {
                "color": "#000000",
                "priority": 42,
                "name": "trip delayed",
                "effect": "NO_SERVICE"
            },
            "cause": "another problem",
            "impacted_objects": [
                {
                    "pt_object": {
                        "line": {
                            "uri": "bobette",
                            ...
                        }
                    }
                },
                {
                    "pt_object": {
                        "stop_area": {
                            "uri": "bobitto",
                            ...
                        }
                    }
                }
            ],
            "messages": [
                {
                    "text": "<p>_pas_de_filtre<br></p>",
                    "channel": 
                    {
                        "content_type": "text/html",
                        "types": ["web"],
                        "name": "we"
                    }
                },
                {
                    "text": "_pas_de_filtre",
                    "channel": 
                    {
                        "content_type": "text/plain",
                        "types": ["email"],
                        "name": "email"
                    }
                }
            ]
        }
    ]
}
```

but for the moment the 'impacted_stops' are not outputed
