### PR TITLE
Jormungandr: add impacted stops in /disruptions

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -763,7 +763,7 @@ impacted_stop = {
     "amended_arrival_time": SplitDateTime(date=None, time='amended_stop_time.arrival_time'),
     "amended_departure_time": SplitDateTime(date=None, time='amended_stop_time.departure_time'),
     "cause": fields.String(),
-    "stop_timeeffect": enum_type()
+    "stop_time_effect": enum_type()
 }
 
 impacted_object = {

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -757,7 +757,13 @@ instance_status_with_parameters['traveler_profiles'] = fields.List(fields.Nested
                                                                                  allow_null=True))
 
 impacted_stop = {
-
+    "stop_point": NonNullNested(stop_point),
+    "base_arrival_time": SplitDateTime(date=None, time='base_stop_time.arrival_time'),
+    "base_departure_time": SplitDateTime(date=None, time='base_stop_time.departure_time'),
+    "amended_arrival_time": SplitDateTime(date=None, time='amended_stop_time.arrival_time'),
+    "amended_departure_time": SplitDateTime(date=None, time='amended_stop_time.departure_time'),
+    "cause": fields.String(),
+    "stop_timeeffect": enum_type()
 }
 
 impacted_object = {

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -930,7 +930,7 @@ def is_valid_disruption(disruption):
                 is_valid_stop_point(get_not_null(impacted_stop, 'stop_point'), depth_check=0)
 
                 get_not_null(impacted_stop, "cause")
-                get_not_null(impacted_stop, "stoptime_effect") in ('ADDED', 'DELETED', 'DELAYED')
+                assert(get_not_null(impacted_stop, "stoptime_effect") in ('ADDED', 'DELETED', 'DELAYED'))
 
                 if 'base_arrival_time' in impacted_stop:
                     get_valid_time(impacted_stop['base_arrival_time'])

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -930,7 +930,7 @@ def is_valid_disruption(disruption):
                 is_valid_stop_point(get_not_null(impacted_stop, 'stop_point'), depth_check=0)
 
                 get_not_null(impacted_stop, "cause")
-                assert(get_not_null(impacted_stop, "stoptime_effect") in ('ADDED', 'DELETED', 'DELAYED'))
+                assert(get_not_null(impacted_stop, "stop_time_effect") in ('ADDED', 'DELETED', 'DELAYED'))
 
                 if 'base_arrival_time' in impacted_stop:
                     get_valid_time(impacted_stop['base_arrival_time'])

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -922,10 +922,28 @@ def is_valid_disruption(disruption):
         is_valid_pt_object(pt_obj, depth_check=0)
 
         # for the vj, if it's not a cancellation we need to have the list of impacted stoptimes
-        if get_not_null(pt_obj, 'embedded_type') == 'vehicle_journey' and effect != 'NO_SERVICE':
+        if get_not_null(pt_obj, 'embedded_type') == 'trip' and effect != 'NO_SERVICE':
             impacted_stops = get_not_null(impacted_obj, 'impacted_stops')
 
-            #TODO
+            assert len(impacted_stops) > 0
+            for impacted_stop in impacted_stops:
+                is_valid_stop_point(get_not_null(impacted_stop, 'stop_point'), depth_check=0)
+
+                get_not_null(impacted_stop, "cause")
+                get_not_null(impacted_stop, "stoptime_effect") in ('ADDED', 'DELETED', 'DELAYED')
+
+                if 'base_arrival_time' in impacted_stop:
+                    get_valid_time(impacted_stop['base_arrival_time'])
+                if 'base_departure_time' in impacted_stop:
+                    get_valid_time(impacted_stop['base_departure_time'])
+                if 'amended_arrival_time' in impacted_stop:
+                    get_valid_time(impacted_stop['amended_arrival_time'])
+                if 'amended_departure_time' in impacted_stop:
+                    get_valid_time(impacted_stop['amended_departure_time'])
+
+                # we need at least either the base or the departure information
+                assert 'base_arrival_time' in impacted_stop and 'base_departure_time' in impacted_stop or \
+                       'amended_arrival_time' in impacted_stop and 'amended_arrival_time' in impacted_stop
 
 
 

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -177,7 +177,10 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 vj->physical_mode = pt_data.physical_modes[0];
                 vj->physical_mode->vehicle_journey_list.push_back(vj);
                 vj->name = new_vj_uri;
-
+            }
+            // we need to associate the stoptimes to the created vj
+            for (auto& stu: impact->aux_info.stop_times) {
+                stu.stop_time.vehicle_journey = vj;
             }
             mvj->impacted_by.push_back(impact);
         } else {

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -169,4 +169,22 @@ void DisruptionHolder::add_weak_impact(boost::weak_ptr<Impact> weak_impact) {
 void DisruptionHolder::clean_weak_impacts(){
     clean_up_weak_ptr(weak_impacts);
 }
+
+const StopTime* StopTimeUpdate::get_base_stop_time() const {
+    return nullptr;
+//    //TODO check effect when available, we can do this only for UPDATED
+//    auto* vj = stop_time.vehicle_journey;
+//    if (! vj) {
+//        //TODO log
+//        return nullptr;
+//    }
+
+//    const auto* base_vj = vj->meta_vj->get_base_vj_circulating_at_date();
+
+//    if (! base_vj) {
+//        return nullptr;
+//    }
+
+}
+
 }}}//namespace

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -206,6 +206,9 @@ struct StopTimeUpdate {
     StopTime stop_time;
     std::string cause; //TODO factorize this cause with a pool
     // enum ADDED/DELETED/UPDATE
+
+    // get the corresponding stoptime in the base vj. return null if nothing found
+    const StopTime* get_base_stop_time() const;
 };
 
 namespace detail {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -176,7 +176,8 @@ struct PtObjVisitor: public boost::static_visitor<> {
     }
 };
 
-void fill_pb_object(const nt::disruption::PtObj& ptobj,
+
+static void fill_pb_object(const nt::disruption::PtObj& ptobj,
                     const nt::disruption::Impact& impact,
                     const nt::Data& data,
                     pbnavitia::Impact* pb_impact, int max_depth,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -129,9 +129,12 @@ void fill_pb_object(const navitia::type::GeographicalCoord& coord, const type::D
         int max_depth = 0, const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
         const boost::posix_time::time_period& action_period = null_time_period);
 
-void fill_pb_object(const navitia::type::StopTime* st, const type::Data &data, pbnavitia::StopTime *stop_time, int max_depth = 0,
-        const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
-        const boost::posix_time::time_period& action_period = null_time_period, const bool show_codes = false);
+void fill_pb_object(const navitia::type::StopTime& st, const type::Data &data,
+                    pbnavitia::StopTime *stop_time, int max_depth = 0,
+                    const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,
+                    const boost::posix_time::time_period& action_period = null_time_period,
+                    const bool show_codes = false,
+                    const DumpMessage = DumpMessage::Yes);
 
 void fill_pb_object(const navitia::type::StopTime* st, const type::Data &data, pbnavitia::StopDateTime * stop_date_time, int max_depth = 0,
         const boost::posix_time::ptime& now = boost::posix_time::not_a_date_time,


### PR DESCRIPTION
Enhance the disruption object with data on the impacted stoptimes

TODO: for the moment no information on the base schedule is outputed

``` json
{
    "disruptions": 
    [
        {
            "status": "past",
            "application_periods": 
            [
                {
                    "begin": "20151201T060400",
                    "end": "20151201T082259"
                }
            ],
            "updated_at": "20151202T090248",
            "uri": "3eabf0a6-2bd6-472f-94c4-3aedd83caaa5",
            "contributor": "ire sncf",
            "severity": 
            {
                "color": "#000000",
                "priority": 42,
                "name": "trip delayed",
                "effect": "DETOUR"
            },
            "cause": "a problem",
            "impacted_objects": [
                {
                    "pt_object": {
                        "vehicle_journey": {
                            "uri": "bob"
                            ...
                        }
                    },
                    "impacted_stops": [
                        {
                            "stop_point": { "uri": "B", ... },
                            "base_departure": 171500,
                            "base_arrival": 170000,
                            "cause": "cochon sur les voies",
                            "stoptime_effect": "DELETED"
                        },
                        {
                            "stop_point": { "uri": "E", ... },
                            "amended_departure": 171500,
                            "amended_arrival": 170000,
                            "cause": "cochon sur les voies",
                            "stoptime_effect": "ADDED"
                        },
                        {
                            "stop_point": { "uri": "C", ... },
                            "amended_departure": 181700,
                            "amended_arrival": 181700,
                            "base_departure": 180000,
                            "base_arrival": 180000,
                            "cause": "vache sur les voies",
                            "stoptime_effect": "SIGNIFICANT_DELAYS"
                        },
                        {
                            "stop_point": { "uri": "D", ... },
                            "amended_departure": 192300,
                            "amended_arrival": 192300,
                            "base_departure": 190000,
                            "base_arrival": 190000,
                            "cause": "vache sur les voies",
                            "stoptime_effect": "SIGNIFICANT_DELAYS"
                        }
                    ]
                }
            ]
        },
        {
            "status": "past",
            "application_periods": 
            [
                {
                    "begin": "20151201T060400",
                    "end": "20151201T082259"
                }
            ],
            "updated_at": "20151202T090248",
            "uri": "3eabf0a6-2bd6-472f-94c4-3aedd83caaa6",
            "contributor": "transilien",
            "severity": 
            {
                "color": "#000000",
                "priority": 42,
                "name": "trip delayed",
                "effect": "NO_SERVICE"
            },
            "cause": "another problem",
            "impacted_objects": [
                {
                    "pt_object": {
                        "line": {
                            "uri": "bobette",
                            ...
                        }
                    }
                },
                {
                    "pt_object": {
                        "stop_area": {
                            "uri": "bobitto",
                            ...
                        }
                    }
                }
            ],
            "messages": [
                {
                    "text": "<p>_pas_de_filtre<br></p>",
                    "channel": 
                    {
                        "content_type": "text/html",
                        "types": ["web"],
                        "name": "we"
                    }
                }
            ]
        }
    ]
}
```
