### PR TITLE
'block_until' column added for restriction access before this date

### DIFF
--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -467,8 +467,8 @@ class DataSet(db.Model):
 class BillingPlan(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False)
-    max_request_count = db.Column(db.Integer, nullable=False)
-    max_object_count = db.Column(db.Integer, nullable=False)
+    max_request_count = db.Column(db.Integer, default=0)
+    max_object_count = db.Column(db.Integer, default=0)
     default = db.Column(db.Boolean, nullable=False, default=False)
 
     end_point_id = db.Column(db.Integer, db.ForeignKey('end_point.id'), nullable=False)

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -105,6 +105,7 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     login = db.Column(db.Text, nullable=False)
     email = db.Column(db.Text, nullable=False)
+    block_until = db.Column(db.Date, nullable=True)
 
     end_point_id = db.Column(db.Integer, db.ForeignKey('end_point.id'), nullable=False)
     end_point = db.relationship('EndPoint', lazy='joined', cascade='save-update, merge')
@@ -120,9 +121,10 @@ class User(db.Model):
     type = db.Column(db.Enum('with_free_instances', 'without_free_instances', 'super_user', name='user_type'),
                              default='with_free', nullable=False)
 
-    def __init__(self, login=None, email=None, keys=None, authorizations=None):
+    def __init__(self, login=None, email=None, block_until=None, keys=None, authorizations=None):
         self.login = login
         self.email = email
+        self.block_until = block_until
         if keys:
             self.keys = keys
         if authorizations:

--- a/source/tyr/migrations/versions/2320ba18ce1_update_unlimited_billing_plans.py
+++ b/source/tyr/migrations/versions/2320ba18ce1_update_unlimited_billing_plans.py
@@ -1,0 +1,23 @@
+"""Update unlimited billing plans.
+
+Revision ID: 2320ba18ce1
+Revises: 962cfcce76f
+Create Date: 2015-12-17 11:58:42.675422
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2320ba18ce1'
+down_revision = '962cfcce76f'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.execute("update billing_plan set max_request_count=0 where max_request_count IS NULL")
+    op.execute("update billing_plan set max_object_count=0 where max_object_count IS NULL")
+
+def downgrade():
+    op.execute("update billing_plan set max_request_count=NULL where max_request_count=0")
+    op.execute("update billing_plan set max_object_count=NULL where max_object_count=0")

--- a/source/tyr/migrations/versions/2320ba18ce1_update_unlimited_billing_plans.py
+++ b/source/tyr/migrations/versions/2320ba18ce1_update_unlimited_billing_plans.py
@@ -17,7 +17,11 @@ import sqlalchemy as sa
 def upgrade():
     op.execute("update billing_plan set max_request_count=0 where max_request_count IS NULL")
     op.execute("update billing_plan set max_object_count=0 where max_object_count IS NULL")
+    op.alter_column('billing_plan', 'max_request_count', server_default='0')
+    op.alter_column('billing_plan', 'max_object_count', server_default='0')
 
 def downgrade():
     op.execute("update billing_plan set max_request_count=NULL where max_request_count=0")
     op.execute("update billing_plan set max_object_count=NULL where max_object_count=0")
+    op.alter_column('billing_plan', 'max_request_count')
+    op.alter_column('billing_plan', 'max_object_count')

--- a/source/tyr/migrations/versions/962cfcce76f_block_until_column_added_for_.py
+++ b/source/tyr/migrations/versions/962cfcce76f_block_until_column_added_for_.py
@@ -14,7 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 
 def upgrade():
-    op.add_column('user', sa.Column('block_until', sa.DateTime(), nullable=True))
+    op.add_column('user', sa.Column('block_until', sa.DateTime(timezone=True), nullable=True))
 
 
 def downgrade():

--- a/source/tyr/migrations/versions/962cfcce76f_block_until_column_added_for_.py
+++ b/source/tyr/migrations/versions/962cfcce76f_block_until_column_added_for_.py
@@ -1,0 +1,21 @@
+"""'block_until' column added for restriction access before this date.
+
+Revision ID: 962cfcce76f
+Revises: 11eae2b0e6b0
+Create Date: 2015-12-16 11:46:05.960382
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '962cfcce76f'
+down_revision = '11eae2b0e6b0'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('user', sa.Column('block_until', sa.Date(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'block_until')

--- a/source/tyr/migrations/versions/962cfcce76f_block_until_column_added_for_.py
+++ b/source/tyr/migrations/versions/962cfcce76f_block_until_column_added_for_.py
@@ -14,7 +14,7 @@ from alembic import op
 import sqlalchemy as sa
 
 def upgrade():
-    op.add_column('user', sa.Column('block_until', sa.Date(), nullable=True))
+    op.add_column('user', sa.Column('block_until', sa.DateTime(), nullable=True))
 
 
 def downgrade():

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -43,6 +43,7 @@ from navitiacommon.default_traveler_profile_params import default_traveler_profi
 from navitiacommon import models
 from navitiacommon.models import db
 from functools import wraps
+from validations import datetime_format
 
 __ALL__ = ['Api', 'Instance', 'User', 'Key']
 
@@ -414,7 +415,7 @@ class User(flask_restful.Resource):
             parser.add_argument('key', type=unicode, required=False,
                     case_sensitive=False, help='key')
             parser.add_argument('end_point_id', type=int)
-            parser.add_argument('block_until', type=types.date, required=False,
+            parser.add_argument('block_until', type=datetime_format, required=False,
                     case_sensitive=False)
             args = parser.parse_args()
 
@@ -439,7 +440,7 @@ class User(flask_restful.Resource):
                 case_sensitive=False, help='login is required', location=('json', 'values'))
         parser.add_argument('email', type=unicode, required=True,
                 case_sensitive=False, help='email is required', location=('json', 'values'))
-        parser.add_argument('block_until', type=types.date, required=False,
+        parser.add_argument('block_until', type=datetime_format, required=False,
                             help='end block date access', location=('json', 'values'))
         parser.add_argument('end_point_id', type=int, required=False,
                             help='id of the end_point', location=('json', 'values'))
@@ -491,8 +492,8 @@ class User(flask_restful.Resource):
                             choices=['with_free_instances', 'without_free_instances', 'super_user'])
         parser.add_argument('end_point_id', type=int, default=user.end_point_id,
                             help='id of the end_point', location=('json', 'values'))
-        parser.add_argument('block_until', type=types.date, required=False,
-                            help='end block date access', location=('json', 'values'))
+        parser.add_argument('block_until', type=datetime_format, required=False,
+                            help='block until argument is not correct', location=('json', 'values'))
         parser.add_argument('billing_plan_id', type=int, default=user.billing_plan_id,
                             help='billing id of the end_point', location=('json', 'values'))
         args = parser.parse_args()

--- a/source/tyr/tyr/validations.py
+++ b/source/tyr/tyr/validations.py
@@ -2,7 +2,4 @@ from datetime import datetime
 
 def datetime_format(value):
     """Parse a valid looking date in the format YYYYmmddTHHmmss"""
-    utc_dt = datetime.strptime(value, "%Y%m%dT%H%M%S")
-    if utc_dt.year < 1900:
-        raise ValueError(u"Year must be >= 1900")
-    return utc_dt
+    return datetime.strptime(value, "%Y%m%dT%H%M%S")

--- a/source/tyr/tyr/validations.py
+++ b/source/tyr/tyr/validations.py
@@ -1,5 +1,9 @@
 from datetime import datetime
+import pytz
 
 def datetime_format(value):
     """Parse a valid looking date in the format YYYYmmddTHHmmss"""
-    return datetime.strptime(value, "%Y%m%dT%H%M%S")
+    utc=pytz.UTC
+
+    return utc.localize(datetime.strptime(value, "%Y%m%dT%H%M%S"))
+

--- a/source/tyr/tyr/validations.py
+++ b/source/tyr/tyr/validations.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+def datetime_format(value):
+    """Parse a valid looking date in the format YYYYmmddTHHmmss"""
+    utc_dt = datetime.strptime(value, "%Y%m%dT%H%M%S")
+    if utc_dt.year < 1900:
+        raise ValueError(u"Year must be >= 1900")
+    return utc_dt


### PR DESCRIPTION
'block_until' field added. This field specify the end date restriction.

``` json
{
    "billing_plan": {
        "default": true,
        "max_request_count": null,
        "max_object_count": null,
        "id": 3,
        "name": "nav_ctp"
    },
    "authorizations": [],
    "keys": [],
    "end_point": {
        "default": true,
        "hostnames": [],
        "id": 1,
        "name": "navitia.io"
    },
    "login": "remy",
    "type": "with_free_instances",
    "id": 1,
    "block_until": "2015-12-24",
    "email": "remyabi@gmail.com"
}
```
