### PR TITLE
experimental stuff on /journeys: splitting of pt and georef 

### DIFF
--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -1,0 +1,63 @@
+#  Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from navitiacommon import request_pb2, type_pb2
+
+class Kraken(object):
+
+    def __init__(self, instance):
+        self.instance = instance
+
+    def get_stop_points(self, place, mode, max_duration, reverse=False):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.nearest_stop_points
+        req.nearest_stop_points.place = place
+        req.nearest_stop_points.mode = mode
+        req.nearest_stop_points.reverse = reverse
+        req.nearest_stop_points.max_duration = max_duration
+
+        req.nearest_stop_points.walking_speed = self.instance.walking_speed
+        req.nearest_stop_points.bike_speed = self.instance.bike_speed
+        req.nearest_stop_points.bss_speed = self.instance.bss_speed
+        req.nearest_stop_points.car_speed = self.instance.car_speed
+
+        result = self.instance.send_and_receive(req)
+        nsp = {}
+        for item in result.nearest_stop_points:
+            nsp[item.stop_point.uri] = item.access_duration
+        return nsp
+
+    def place(self, place):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.place_uri
+        req.place_uri.uri = place
+        response = self.instance.send_and_receive(req)
+        return response.places[0]
+
+

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -48,6 +48,7 @@ from flask import g
 import json
 import flask
 import pybreaker
+from jormungandr import georef, planner
 
 type_to_pttype = {
       "stop_area" : request_pb2.PlaceCodeRequest.StopArea,
@@ -80,6 +81,8 @@ class Instance(object):
         self.publication_date = -1
         self.is_up = True
         self.breaker = pybreaker.CircuitBreaker(fail_max=4, reset_timeout=60)
+        self.georef = georef.Kraken(self)
+        self.planner = planner.Kraken(self)
 
     def get_models(self):
         if self.name not in g.instances_model:

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -108,6 +108,7 @@ class Instance(object):
             try:
                 module = import_module('jormungandr.scenarios.{}'.format(override_scenario))
             except ImportError:
+                logger.exception('sceneario not found')
                 abort(404, message='invalid scenario: {}'.format(override_scenario))
             scenario = module.Scenario()
             g.scenario = scenario

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -190,7 +190,7 @@ class InstanceManager(object):
             authentication.abort_request(user)
         return valid_regions
 
-    @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_PTOBJECTS',None))
+    @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_PTOBJECTS', None))
     def _all_keys_of_id(self, object_id):
         if object_id.count(";") == 1 or object_id[:6] == "coord:":
             if object_id.count(";") == 1:

--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -38,7 +38,8 @@ class JourneyParameters(object):
                  forbidden_uris=None,
                  show_codes=False,
                  realtime_level='base_schedule',
-                 max_extra_second_pass=0):
+                 max_extra_second_pass=None,
+                 walking_transfer_penalty=120):
         self.max_duration = max_duration
         self.max_transfers = max_transfers
         self.wheelchair = wheelchair
@@ -72,7 +73,8 @@ class Kraken(object):
         req.journeys.max_duration = journey_parameters.max_duration
         req.journeys.max_transfers = journey_parameters.max_transfers
         req.journeys.wheelchair = journey_parameters.wheelchair
-        req.journeys.max_extra_second_pass = journey_parameters.max_extra_second_pass
+        if journey_parameters.max_extra_second_pass:
+            req.journeys.max_extra_second_pass = journey_parameters.max_extra_second_pass
         req.journeys.show_codes = journey_parameters.show_codes
 
         for uri in journey_parameters.forbidden_uris:

--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -1,0 +1,81 @@
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from navitiacommon import request_pb2, type_pb2
+
+def realtime_level_to_pbf(level):
+    if level == 'base_schedule':
+        return type_pb2.BASE
+    elif level == 'adapted_schedule':
+        return type_pb2.ADAPTED
+    elif level == 'realtime':
+        return type_pb2.REAL_TIME
+    else:
+        raise ValueError('Impossible to convert in pbf')
+
+
+class JourneyParameters(object):
+    def __init__(self,
+                 max_duration=86400,
+                 max_transfers=10,
+                 wheelchair=False,
+                 forbidden_uris=None,
+                 show_codes=False,
+                 realtime_level='base_schedule',
+                 max_extra_second_pass=0):
+        self.max_duration = max_duration
+        self.max_transfers = max_transfers
+        self.wheelchair = wheelchair
+        self.forbidden_uris = set(forbidden_uris) if forbidden_uris else set()
+        self.show_codes = show_codes
+        self.realtime_level = realtime_level
+        self.max_extra_second_pass = max_extra_second_pass
+
+
+class Kraken(object):
+
+    def __init__(self, instance):
+        self.instance = instance
+
+    def journeys(self, origins, destinations, datetime, clockwise, journey_parameters):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.pt_planner
+        for stop_point_id, access_duration in origins.iteritems():
+            location = req.journeys.origin.add()
+            location.place = stop_point_id
+            location.access_duration = access_duration
+
+        for stop_point_id, access_duration in destinations.iteritems():
+            location = req.journeys.destination.add()
+            location.place = stop_point_id
+            location.access_duration = access_duration
+
+        req.journeys.datetimes.append(datetime)
+        req.journeys.clockwise = clockwise
+        req.journeys.realtime_level = realtime_level_to_pbf(journey_parameters.realtime_level)
+        req.journeys.max_duration = journey_parameters.max_duration
+        req.journeys.max_transfers = journey_parameters.max_transfers
+        req.journeys.wheelchair = journey_parameters.wheelchair
+        req.journeys.max_extra_second_pass = journey_parameters.max_extra_second_pass
+        req.journeys.show_codes = journey_parameters.show_codes
+
+        for uri in journey_parameters.forbidden_uris:
+            req.journeys.forbidden_uris.append(uri)
+
+        return self.instance.send_and_receive(req)

--- a/source/jormungandr/jormungandr/scenarios/experimental.py
+++ b/source/jormungandr/jormungandr/scenarios/experimental.py
@@ -66,7 +66,7 @@ def get_max_fallback_duration(request, mode):
         return request['max_bike_duration_to_pt']
     if mode == 'car':
         return request['max_car_duration_to_pt']
-    raise ValueError('unknow mode: {}'.format(mode))
+    raise ValueError('unknown mode: {}'.format(mode))
 
 def build_journey(journey, _from, to, origins, destinations):
     departure = journey.sections[0].origin
@@ -92,6 +92,17 @@ def _init_g():
     g.destinations_fallback = {}
     g.requested_origin = None
     g.requested_destination = None
+
+def create_parameters(request):
+    return JourneyParameters(max_duration=request['max_duration'],
+                             max_transfers=request['max_transfers'],
+                             wheelchair=request['wheelchair'] or False,
+                             show_codes=request['show_codes'],
+                             realtime_level=request['data_freshness'],
+                             max_extra_second_pass=request['max_extra_second_pass'],
+                             walking_transfer_penalty=request['_walking_transfer_penalty'],
+                             forbidden_uris=request['forbidden_uris[]'])
+
 
 class Scenario(new_default.Scenario):
 
@@ -126,7 +137,7 @@ class Scenario(new_default.Scenario):
             g.requested_destination = instance.georef.place(request['destination'])
 
         resp = []
-        journey_parameters = JourneyParameters()
+        journey_parameters = create_parameters(request)
         for dep_mode, arr_mode in krakens_call:
             #todo: this is probably shared between multiple thread
             self.nb_kraken_calls += 1

--- a/source/jormungandr/jormungandr/scenarios/experimental.py
+++ b/source/jormungandr/jormungandr/scenarios/experimental.py
@@ -35,6 +35,7 @@ from copy import deepcopy
 import uuid
 from jormungandr.scenarios.utils import fill_uris
 from jormungandr.planner import JourneyParameters
+from jormungandr.scenarios import journey_filter
 
 from jormungandr.scenarios.new_default import sort_journeys, type_journeys, tag_journeys, culling_journeys
 
@@ -89,6 +90,7 @@ class Scenario(new_default.Scenario):
             journey.sections.extend([create_crowfly(arrival, requested_destination, sections[-1].end_date_time, journey.arrival_date_time)])
 
 
+        journey_filter.filter_journeys([response], instance, request=request, original_request=request)
         #sort_journeys(response, instance.journey_order, request['clockwise'])
         tag_journeys(response)
         type_journeys(response, request)

--- a/source/jormungandr/jormungandr/scenarios/experimental.py
+++ b/source/jormungandr/jormungandr/scenarios/experimental.py
@@ -128,7 +128,7 @@ class Scenario(new_default.Scenario):
             if arr_mode not in g.destinations_fallback:
                 g.destinations_fallback[arr_mode] = instance.georef.get_stop_points(request['destination'],
                         arr_mode,
-                        get_max_fallback_duration(request, arr_mode))#TODO add reverse
+                        get_max_fallback_duration(request, arr_mode), reverse=True)
                 #logger.debug('destinations %s: %s', arr_mode, g.destinations_fallback[arr_mode])
 
         if not g.requested_origin:

--- a/source/jormungandr/jormungandr/scenarios/experimental.py
+++ b/source/jormungandr/jormungandr/scenarios/experimental.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import logging
+from flask.ext.restful import abort
+from jormungandr.scenarios import new_default
+from navitiacommon import type_pb2, response_pb2, request_pb2
+from copy import deepcopy
+import uuid
+from jormungandr.scenarios.utils import fill_uris
+from jormungandr.planner import JourneyParameters
+
+from jormungandr.scenarios.new_default import sort_journeys, type_journeys, tag_journeys, culling_journeys
+
+def create_crowfly(_from, to, begin, end, mode='walking'):
+    section = response_pb2.Section()
+    section.type = response_pb2.CROW_FLY
+    section.origin.CopyFrom(_from)
+    section.destination.CopyFrom(to)
+    section.duration = end-begin;
+    section.begin_date_time = begin
+    section.end_date_time = end
+    section.street_network.mode = response_pb2.Walking
+    section.id = str(uuid.uuid4())
+    return section
+
+
+class Scenario(new_default.Scenario):
+
+    def __init__(self):
+        super(Scenario, self).__init__()
+
+
+
+    def journeys(self, request, instance):
+        logger = logging.getLogger(__name__)
+        logger.warn('using experimental scenario!!!')
+        origins = instance.georef.get_stop_points(request['origin'], 'walking', 1800)
+        logging.debug('origins: %s', origins)
+        destinations = instance.georef.get_stop_points(request['destination'], 'walking', 1800)
+        logging.debug('destinations: %s', destinations)
+
+        journey_parameters = JourneyParameters()
+        response = instance.planner.journeys(origins, destinations, request['datetime'], request['clockwise'], journey_parameters)
+        if not response.journeys:
+            return response
+
+        requested_origin = instance.georef.place(request['origin'])
+        requested_destination = instance.georef.place(request['destination'])
+
+        for journey in response.journeys:
+            departure = journey.sections[0].origin
+            arrival = journey.sections[-1].destination
+
+            sections = deepcopy(journey.sections)
+            del journey.sections[:]
+            journey.duration = journey.duration + origins[departure.uri] + destinations[arrival.uri]
+            journey.departure_date_time = journey.departure_date_time - origins[departure.uri]
+            journey.arrival_date_time = journey.arrival_date_time + destinations[arrival.uri]
+
+            journey.sections.extend([create_crowfly(requested_origin, departure, journey.departure_date_time, sections[0].begin_date_time)])
+            journey.sections.extend(sections)
+            journey.sections.extend([create_crowfly(arrival, requested_destination, sections[-1].end_date_time, journey.arrival_date_time)])
+
+
+        #sort_journeys(response, instance.journey_order, request['clockwise'])
+        tag_journeys(response)
+        type_journeys(response, request)
+        culling_journeys(response, request)
+        fill_uris(response)
+        return response
+
+
+
+    def nm_journeys(self, request, instance):
+        return self.__on_journeys(type_pb2.NMPLANNER, request, instance)
+
+    def isochrone(self, request, instance):
+        return self.__on_journeys(type_pb2.ISOCHRONE, request, instance)

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+import logging
+from tests.tests_mechanism import AbstractTestFixture
+
+from tests_mechanism import dataset
+from check_utils import *
+from nose.tools import eq_
+import jormungandr.scenarios.experimental
+from jormungandr.instance import Instance
+
+
+def check_journeys(resp):
+    assert not resp.get('journeys') or sum([1 for j in resp['journeys'] if j['type'] == "best"]) == 1
+
+
+@dataset(["main_routing_test"])
+class TestJourneysExperimental(AbstractTestFixture):
+    """
+    Test the experiental scenario
+    All the tests are defined in "TestJourneys" class, we only change the scenario
+
+
+    NOTE: for the moment we cannot import all routing tests, so we only get 2, but we need to add some more
+    """
+
+    def setup(self):
+        logging.debug('setup for experimental')
+        from jormungandr import i_manager
+        dest_instance = i_manager.instances['main_routing_test']
+        self.old_scenario = dest_instance._scenario
+        dest_instance._scenario = jormungandr.scenarios.experimental.Scenario()
+
+    def teardown(self):
+        from jormungandr import i_manager
+        i_manager.instances['main_routing_test']._scenario = self.old_scenario
+
+    def test_journeys(self):
+        #NOTE: we query /v1/coverage/main_routing_test/journeys and not directly /v1/journeys
+        #not to use the jormungandr database
+        response = self.query_region(journey_basic_query, display=True)
+
+        check_journeys(response)
+        is_valid_journey_response(response, self.tester, journey_basic_query)
+
+    def test_error_on_journeys(self):
+        """ if we got an error with kraken, an error should be returned"""
+
+        query_out_of_production_bound = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}"\
+            .format(from_coord="0.0000898312;0.0000898312",  # coordinate of S in the dataset
+            to_coord="0.00188646;0.00071865",  # coordinate of R in the dataset
+            datetime="20110614T080000")  # 2011 should not be in the production period
+
+        response, status = self.query_no_assert("v1/coverage/main_routing_test/" + query_out_of_production_bound)
+
+        assert status != 200, "the response should not be valid"
+
+        check_journeys(response)
+        assert response['error']['id'] == "date_out_of_bounds"
+        assert response['error']['message'] == "date is not in data production period"
+
+        #and no journey is to be provided
+        assert 'journeys' not in response or len(response['journeys']) == 0
+
+
+@dataset(["main_ptref_test"])
+class TestJourneysExperimentalWithPtref(AbstractTestFixture):
+    """Test the experimental scenario with ptref_test data"""
+
+    def setup(self):
+        logging.debug('setup for experimental')
+        from jormungandr import i_manager
+        dest_instance = i_manager.instances['main_ptref_test']
+        self.old_scenario = dest_instance._scenario
+        dest_instance._scenario = jormungandr.scenarios.experimental.Scenario()
+
+    def teardown(self):
+        from jormungandr import i_manager
+        i_manager.instances['main_ptref_test']._scenario = self.old_scenario
+
+    def test_strange_line_name(self):
+        response = self.query("v1/coverage/main_ptref_test/journeys"
+                              "?from=stop_area:stop2&to=stop_area:stop1"
+                              "&datetime=20140107T100000", display=True)
+        check_journeys(response)
+        eq_(len(response['journeys']), 1)

--- a/source/jormungandr/tests/stats_tests.py
+++ b/source/jormungandr/tests/stats_tests.py
@@ -84,7 +84,7 @@ class MockWrapper:
         assert len(stat.journeys) == 2
 
         assert stat.journeys[0].requested_date_time == str_to_time_stamp("20120614T080000") #1339653600
-        assert stat.journeys[0].departure_date_time == str_to_time_stamp("20120614T080042") #1339653642
+        assert stat.journeys[0].departure_date_time == str_to_time_stamp("20120614T080043") #1339653643
         assert stat.journeys[0].arrival_date_time == str_to_time_stamp("20120614T080222") #1339653742
         assert stat.journeys[0].duration == 99
         assert stat.journeys[0].type == "best"

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -440,7 +440,7 @@ pbnavitia::Response Worker::place_uri(const pbnavitia::PlaceUriRequest &request)
                 auto it_admin = data->geo_ref->admin_map.find(request.uri());
                 if(it_admin != data->geo_ref->admin_map.end()) {
                     pbnavitia::PtObject* place = pb_response.add_places();
-                    fill_pb_placemark(data->geo_ref->admins[it_admin->second],*data, place, 1);
+                    fill_pb_placemark(data->geo_ref->admins[it_admin->second], *data, place, 1);
 
                 }else{
                     fill_pb_error(pbnavitia::Error::unable_to_parse, "Unable to parse : "+request.uri(),  pb_response.mutable_error());
@@ -625,6 +625,12 @@ pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, 
                 forbidden, *street_network_worker,
                 rt_level, request.max_duration(),
                 request.max_transfers(), request.show_codes());
+
+    case pbnavitia::pt_planner:
+        return routing::make_pt_response(*planner, origins, destinations, datetimes[0],
+                request.clockwise(), accessibilite_params,
+                forbidden, rt_level, seconds{request.walking_transfer_penalty()}, request.max_duration(),
+                request.max_transfers(), request.show_codes(), request.max_extra_second_pass());
     default:
         return routing::make_response(*planner, origins[0], destinations[0], datetimes,
                 request.clockwise(), accessibilite_params,
@@ -688,12 +694,14 @@ pbnavitia::Response Worker::dispatch(const pbnavitia::Request& request) {
             response = next_stop_times(request.next_stop_times(), request.requested_api()); break;
         case pbnavitia::ISOCHRONE:
         case pbnavitia::NMPLANNER:
+        case pbnavitia::pt_planner:
         case pbnavitia::PLANNER: response = journeys(request.journeys(), request.requested_api()); break;
         case pbnavitia::places_nearby: response = proximity_list(request.places_nearby()); break;
         case pbnavitia::PTREFERENTIAL: response = pt_ref(request.ptref()); break;
         case pbnavitia::traffic_reports : response = traffic_reports(request.traffic_reports()); break;
         case pbnavitia::calendars : response = calendars(request.calendars()); break;
         case pbnavitia::place_code : response = place_code(request.place_code()); break;
+        case pbnavitia::nearest_stop_points : response = nearest_stop_points(request.nearest_stop_points()); break;
         default:
             LOG4CPLUS_WARN(logger, "Unknown API : " + API_Name(request.requested_api()));
             fill_pb_error(pbnavitia::Error::unknown_api, "Unknown API", response.mutable_error());
@@ -701,6 +709,61 @@ pbnavitia::Response Worker::dispatch(const pbnavitia::Request& request) {
     }
     metadatas(response);//we add the metadatas for each response
     feed_publisher(response);
+    return response;
+}
+
+pbnavitia::Response Worker::nearest_stop_points(const pbnavitia::NearestStopPointsRequest& request) {
+    const auto data = data_manager.get_data();
+    this->init_worker_data(data);
+
+    //todo check the request
+
+    type::EntryPoint entry_point;
+    Type_e origin_type = data->get_type_of_id(request.place());
+    entry_point = type::EntryPoint(origin_type, request.place(), 0);
+
+    if (entry_point.type == type::Type_e::Address || entry_point.type == type::Type_e::Admin
+            || entry_point.type == type::Type_e::StopArea || entry_point.type == type::Type_e::StopPoint
+            || entry_point.type == type::Type_e::POI) {
+        entry_point.coordinates = this->coord_of_entry_point(entry_point, data);
+    }
+    if ((entry_point.type == type::Type_e::Address)
+            || (entry_point.type == type::Type_e::Coord) || (entry_point.type == type::Type_e::Admin)
+            || (entry_point.type == type::Type_e::POI) || (entry_point.type == type::Type_e::StopArea)) {
+
+        entry_point.streetnetwork_params.mode = type::static_data::get()->modeByCaption(request.mode());
+        entry_point.streetnetwork_params.set_filter(request.filter());
+    }
+    switch(entry_point.streetnetwork_params.mode){
+        case type::Mode_e::Bike:
+            entry_point.streetnetwork_params.offset = data->geo_ref->offsets[type::Mode_e::Bike];
+            entry_point.streetnetwork_params.speed_factor = request.bike_speed() / georef::default_speed[type::Mode_e::Bike];
+            break;
+        case type::Mode_e::Car:
+            entry_point.streetnetwork_params.offset = data->geo_ref->offsets[type::Mode_e::Car];
+            entry_point.streetnetwork_params.speed_factor = request.car_speed() / georef::default_speed[type::Mode_e::Car];
+            break;
+        case type::Mode_e::Bss:
+            entry_point.streetnetwork_params.offset = data->geo_ref->offsets[type::Mode_e::Bss];
+            entry_point.streetnetwork_params.speed_factor = request.bss_speed() / georef::default_speed[type::Mode_e::Bss];
+            break;
+        default:
+            entry_point.streetnetwork_params.offset = data->geo_ref->offsets[type::Mode_e::Walking];
+            entry_point.streetnetwork_params.speed_factor = request.walking_speed() / georef::default_speed[type::Mode_e::Walking];
+            break;
+    }
+    if (entry_point.streetnetwork_params.speed_factor <= 0) {
+        throw navitia::recoverable_exception("invalid speed factor");
+    }
+    entry_point.streetnetwork_params.max_duration = navitia::seconds(request.max_duration());
+    street_network_worker->init(entry_point, {});
+    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, request.reverse());
+    pbnavitia::Response response;
+    for(const auto& item: result){
+        auto* nsp = response.add_nearest_stop_points();
+        fill_pb_object(planner->get_sp(item.first), *data, nsp->mutable_stop_point(), 0);
+        nsp->set_access_duration(item.second.total_seconds());
+    }
     return response;
 }
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -757,7 +757,8 @@ pbnavitia::Response Worker::nearest_stop_points(const pbnavitia::NearestStopPoin
     }
     entry_point.streetnetwork_params.max_duration = navitia::seconds(request.max_duration());
     street_network_worker->init(entry_point, {});
-    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, request.reverse());
+    //kraken don't handle reverse isochrone
+    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, false);
     pbnavitia::Response response;
     for(const auto& item: result){
         auto* nsp = response.add_nearest_stop_points();

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -89,6 +89,7 @@ class Worker {
         pbnavitia::Response calendars(const pbnavitia::CalendarsRequest &request);
         pbnavitia::Response pt_object(const pbnavitia::PtobjectRequest &request);
         pbnavitia::Response place_code(const pbnavitia::PlaceCodeRequest &request);
+        pbnavitia::Response nearest_stop_points(const pbnavitia::NearestStopPointsRequest& request);
 };
 
 }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -936,12 +936,22 @@ pbnavitia::Response make_pt_response(RAPTOR &raptor,
     routing::map_stop_point_duration arrivals;
 
     for(const auto& origin: origins){
-        //todo check uri is valid
-        departures[SpIdx{*raptor.data.pt_data->stop_points_map[origin.uri]}] = navitia::seconds(origin.access_duration);
+        auto it = raptor.data.pt_data->stop_points_map.find(origin.uri);
+        if(it != raptor.data.pt_data->stop_points_map.end()){
+            departures[SpIdx{*it->second}] = navitia::seconds(origin.access_duration);
+        }else{
+            //for now we throw, maybe we should ignore them
+            throw navitia::recoverable_exception("stop_point " + origin.uri + " not found");
+        }
     }
     for(const auto& destination: destinations){
-        //todo check uri is valid
-        arrivals[SpIdx{*raptor.data.pt_data->stop_points_map[destination.uri]}] = navitia::seconds(destination.access_duration);
+        auto it = raptor.data.pt_data->stop_points_map.find(destination.uri);
+        if(it != raptor.data.pt_data->stop_points_map.end()){
+            arrivals[SpIdx{*it->second}] = navitia::seconds(destination.access_duration);
+        }else{
+            //for now we throw, maybe we should ignore them
+            throw navitia::recoverable_exception("stop_point " + destination.uri + " not found");
+        }
     }
 
     DateTime bound = clockwise ? DateTimeUtils::inf : DateTimeUtils::min;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -547,8 +547,8 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             // last is 'taxi like' ODT, there is no walking nor crow fly section,
             // but we have to update the end of the journey
             auto* section = pb_journey->mutable_sections(pb_journey->sections_size() - 1);
-            section->mutable_origin()->Clear();
-            //TODO: the perido can probably be better (-1 min shift)
+            section->mutable_destination()->Clear();
+            //TODO: the period can probably be better (-1 min shift)
             auto action_period = bt::time_period(navitia::from_posix_timestamp(section->end_date_time()), bt::minutes(1));
             fill_pb_placemark(destination, d, section->mutable_destination(), 1, now, action_period, show_codes);
         } else if (!path.items.empty() && !path.items.back().stop_points.empty()) {

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -261,6 +261,182 @@ static void add_direct_path(EnhancedResponse& enhanced_response,
     }
 }
 
+static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
+        EnhancedResponse& enhanced_response,
+        const navitia::routing::Path& path,
+        const nt::Data& d,
+        bt::ptime now,
+        const bool show_codes){
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    pb_journey->set_nb_transfers(path.nb_changes);
+    pb_journey->set_requested_date_time(navitia::to_posix_timestamp(path.request_time));
+    bt::ptime arrival_time;
+
+    pb_journey->set_sn_dur(path.sn_dur.total_seconds());
+    pb_journey->set_transfer_dur(path.transfer_dur.total_seconds());
+    pb_journey->set_min_waiting_dur(path.min_waiting_dur.total_seconds());
+    pb_journey->set_nb_vj_extentions(path.nb_vj_extentions);
+    pb_journey->set_nb_sections(path.nb_sections);
+
+    size_t item_idx(0);
+    boost::optional<navitia::type::ValidityPattern> vp;
+
+    for(auto path_i = path.items.begin(); path_i < path.items.end(); ++path_i) {
+        const auto& item = *path_i;
+
+        pbnavitia::Section* pb_section = pb_journey->add_sections();
+        pb_section->set_id(enhanced_response.register_section(pb_journey, item, item_idx++));
+
+        if(item.type == ItemType::public_transport) {
+            pb_section->set_type(pbnavitia::PUBLIC_TRANSPORT);
+            bt::ptime departure_ptime, arrival_ptime;
+            type::VehicleJourney const *const vj = item.get_vj();
+
+            if (!vp) {
+                vp = *vj->base_validity_pattern();
+            } else {
+                assert(vp->beginning_date == vj->base_validity_pattern()->beginning_date);
+                vp->days &= vj->base_validity_pattern()->days;
+            }
+
+            const size_t nb_sps = item.stop_points.size();
+            for (size_t i = 0; i < nb_sps; ++i) {
+                if (vj->has_boarding() || vj->has_landing()) {
+                    continue;
+                }
+                // skipping estimated stop points
+                if (i != 0 && i != nb_sps - 1 && item.stop_times[i]->date_time_estimated()) {
+                    continue;
+                }
+                pbnavitia::StopDateTime* stop_time = pb_section->add_stop_date_times();
+                auto arr_time = navitia::to_posix_timestamp(item.arrivals[i]);
+                stop_time->set_arrival_date_time(arr_time);
+                auto dep_time = navitia::to_posix_timestamp(item.departures[i]);
+                stop_time->set_departure_date_time(dep_time);
+                const auto p_deptime = item.departures[i];
+                const auto p_arrtime = item.arrivals[i];
+                bt::time_period action_period(p_deptime, p_arrtime);
+                fill_pb_object(item.stop_points[i], d, stop_time->mutable_stop_point(),
+                        0, now, action_period, show_codes);
+                fill_pb_object(item.stop_times[i], d, stop_time, 1, now, action_period);
+
+                // L'heure de départ du véhicule au premier stop point
+                if(departure_ptime.is_not_a_date_time())
+                    departure_ptime = p_deptime;
+                // L'heure d'arrivée au dernier stop point
+                arrival_ptime = p_arrtime;
+            }
+            if (! item.stop_points.empty()) {
+                //some time there is only one stop points, typically in case of "extension of services"
+                //if the passenger as to board on the last stop_point of a VJ (yes, it's possible...)
+                //in this case we want to display this only point as the departure and the destination of this section
+                auto arr_time = item.arrivals[0];
+                auto dep_time = item.departures[0];
+                bt::time_period action_period(dep_time, arr_time + bt::seconds(1));
+
+                fill_pb_placemark(item.stop_points.front(), d,
+                        pb_section->mutable_origin(), 1, now, action_period,
+                        show_codes);
+
+                fill_pb_placemark(item.stop_points.back(), d,
+                        pb_section->mutable_destination(), 1, now,
+                        action_period, show_codes);
+
+            }
+            bt::time_period action_period(departure_ptime, arrival_ptime);
+            fill_section(pb_section, vj, item.stop_times, d, now, action_period);
+
+            // setting additional_informations
+            const bool has_datetime_estimated = ! item.stop_times.empty()
+                && (item.stop_times.front()->date_time_estimated()
+                        || item.stop_times.back()->date_time_estimated());
+            const bool has_odt = ! item.stop_times.empty()
+                && (item.stop_times.front()->odt() || item.stop_times.back()->odt());
+            const bool is_zonal = ! item.stop_points.empty()
+                && (item.stop_points.front()->is_zonal || item.stop_points.back()->is_zonal);
+            fill_additional_informations(pb_section->mutable_additional_informations(),
+                    has_datetime_estimated,
+                    has_odt,
+                    is_zonal);
+
+            // If this section has estimated stop times,
+            // if the previous section is a waiting section, we also
+            // want to set it to estimated.
+            if (has_datetime_estimated && pb_journey->sections_size() >= 2) {
+                auto previous_section = pb_journey->mutable_sections(pb_journey->sections_size()-2);
+                if (previous_section->type() == pbnavitia::WAITING) {
+                    previous_section->add_additional_informations(pbnavitia::HAS_DATETIME_ESTIMATED);
+                }
+            }
+        } else {
+            pb_section->set_type(pbnavitia::TRANSFER);
+            switch(item.type) {
+                case ItemType::stay_in :{
+                                            pb_section->set_transfer_type(pbnavitia::stay_in);
+                                            //We "stay in" the precedent section, this one is only a transfer
+                                            int section_idx = pb_journey->sections_size() - 2;
+                                            if(section_idx >= 0 && pb_journey->sections(section_idx).type() == pbnavitia::PUBLIC_TRANSPORT){
+                                                auto* prec_section = pb_journey->mutable_sections(section_idx);
+                                                prec_section->add_additional_informations(pbnavitia::STAY_IN);
+                                            }
+                                            break;
+                                        }
+                case ItemType::waiting : pb_section->set_type(pbnavitia::WAITING); break;
+                default : pb_section->set_transfer_type(pbnavitia::walking); break;
+            }
+            // For a waiting section, if the previous public transport section,
+            // has estimated datetime we need to set it has estimated too.
+            const auto& sections = pb_journey->sections();
+            for (auto it = sections.rbegin(); it != sections.rend(); ++it) {
+                if (it->type() != pbnavitia::PUBLIC_TRANSPORT) { continue; }
+                if (boost::count(it->additional_informations(), pbnavitia::HAS_DATETIME_ESTIMATED)) {
+                    pb_section->add_additional_informations(pbnavitia::HAS_DATETIME_ESTIMATED);
+                }
+                break;
+            }
+
+            bt::time_period action_period(item.departure, item.arrival);
+            const auto origin_sp = item.stop_points.front();
+            const auto destination_sp = item.stop_points.back();
+            fill_pb_placemark(origin_sp, d, pb_section->mutable_origin(), 1, now, action_period, show_codes);
+            fill_pb_placemark(destination_sp, d, pb_section->mutable_destination(), 1, now, action_period,
+                    show_codes);
+            pb_section->set_length(origin_sp->coord.distance_to(destination_sp->coord));
+        }
+        uint64_t dep_time, arr_time;
+        if(item.stop_points.size() == 1 && item.type == ItemType::public_transport){
+            //after a stay it's possible to have only one point,
+            //so we take the arrival hour as arrival and departure
+            dep_time = navitia::to_posix_timestamp(item.arrival);
+            arr_time = navitia::to_posix_timestamp(item.arrival);
+        }else{
+            dep_time = navitia::to_posix_timestamp(item.departure);
+            arr_time = navitia::to_posix_timestamp(item.arrival);
+        }
+        pb_section->set_begin_date_time(dep_time);
+        pb_section->set_end_date_time(arr_time);
+
+        arrival_time = item.arrival;
+        pb_section->set_duration(arr_time - dep_time);
+    }
+
+    if (vp) {
+        vptranslator::fill_pb_object(vptranslator::translate(*vp), d, pb_journey, 1);
+    }
+
+    compute_most_serious_disruption(pb_journey);
+
+    //fare computation, done at the end for the journey to be complete
+    auto fare = d.fare->compute_fare(path);
+    try {
+        fill_fare_section(enhanced_response, pb_journey, fare);
+    } catch(const navitia::exception& e) {
+        pb_journey->clear_fare();
+        LOG4CPLUS_WARN(logger, "Unable to compute fare, error : " << e.what());
+    }
+    return arrival_time;
+}
+
 static void add_pathes(EnhancedResponse& enhanced_response,
                        const std::vector<navitia::routing::Path>& paths,
                        const nt::Data& d,
@@ -276,23 +452,13 @@ static void add_pathes(EnhancedResponse& enhanced_response,
     bt::ptime now = bt::second_clock::universal_time();
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
-    for(Path path : paths) {
-        bt::ptime departure_time = bt::pos_infin,
-                          arrival_time = bt::pos_infin;
-        pbnavitia::Journey* pb_journey = pb_response.add_journeys();
-
-        pb_journey->set_nb_transfers(path.nb_changes);
-        pb_journey->set_requested_date_time(navitia::to_posix_timestamp(path.request_time));
-
-        pb_journey->set_sn_dur(path.sn_dur.total_seconds());
-        pb_journey->set_transfer_dur(path.transfer_dur.total_seconds());
-        pb_journey->set_min_waiting_dur(path.min_waiting_dur.total_seconds());
-        pb_journey->set_nb_vj_extentions(path.nb_vj_extentions);
-        pb_journey->set_nb_sections(path.nb_sections);
-
+    for(const Path& path : paths) {
+        bt::ptime arrival_time = bt::pos_infin;
         if (path.items.empty()) {
             continue;
         }
+        pbnavitia::Journey* pb_journey = pb_response.add_journeys();
+
         /*
          * For the first section, we can distinguish 4 cases
          * 1) We start from an area(stop_area or admin), we will add a crow fly section from the centroid of the area
@@ -331,7 +497,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                                               path.items.front().departures.front() + bt::minutes(1));
                 const time_duration& crow_fly_duration = find_or_default(SpIdx(*departure_stop_point),
                                             worker.departure_path_finder.distance_to_entry_point);
-                departure_time = path.items.front().departures.front()- crow_fly_duration.to_posix();
+                auto departure_time = path.items.front().departures.front() - pt::seconds(crow_fly_duration.to_posix().total_seconds());
                 fill_crowfly_section(origin, destination_tmp, crow_fly_duration,
                                      get_crowfly_mode(sn_departure_path),
                                      departure_time, d, enhanced_response,
@@ -346,8 +512,9 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                     sn_departure_path.path_items.back().coordinates.push_back(routing_first_coord);
                 }
 
+                //todo: better way to round this: fractionnal second are evil
                 const auto walking_time = sn_departure_path.duration;
-                departure_time = path.items.front().departure - walking_time.to_posix();
+                auto departure_time = path.items.front().departure - pt::seconds(walking_time.to_posix().total_seconds());
                 fill_street_sections(enhanced_response, origin, sn_departure_path, d, pb_journey,
                     departure_time);
                 if (pb_journey->sections_size() > 0) {
@@ -367,167 +534,30 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             }
         }
 
-        size_t item_idx(0);
-        // La partie TC et correspondances
-        boost::optional<navitia::type::ValidityPattern> vp;
-        for(auto path_i = path.items.begin(); path_i < path.items.end(); ++path_i) {
-            const auto& item = *path_i;
-
-            pbnavitia::Section* pb_section = pb_journey->add_sections();
-            pb_section->set_id(enhanced_response.register_section(pb_journey, item, item_idx++));
-
-            if(item.type == ItemType::public_transport) {
-                pb_section->set_type(pbnavitia::PUBLIC_TRANSPORT);
-                bt::ptime departure_ptime, arrival_ptime;
-                type::VehicleJourney const *const vj = item.get_vj();
-
-                if (!vp) {
-                    vp = *vj->base_validity_pattern();
+        arrival_time = handle_pt_sections(pb_journey, enhanced_response, path, d, now, show_codes);
+                // TODO:
+                // for 'taxi like' odt, we want to start from the address, not the 1 stop point
+        /*        if (item_idx == 1 && journey_begin_with_address_odt) {
+                    fill_pb_placemark(origin, d,
+                            pb_section->mutable_origin(), 1, now, action_period,
+                            show_codes);
                 } else {
-                    assert(vp->beginning_date == vj->base_validity_pattern()->beginning_date);
-                    vp->days &= vj->base_validity_pattern()->days;
+                    fill_pb_placemark(item.stop_points.front(), d,
+                            pb_section->mutable_origin(), 1, now, action_period,
+                            show_codes);
                 }
 
-                const size_t nb_sps = item.stop_points.size();
-                for (size_t i = 0; i < nb_sps; ++i) {
-                    if (vj->has_boarding() || vj->has_landing()) {
-                        continue;
-                    }
-                    // skipping estimated stop points
-                    if (i != 0 && i != nb_sps - 1 && item.stop_times[i]->date_time_estimated()) {
-                        continue;
-                    }
-                    pbnavitia::StopDateTime* stop_time = pb_section->add_stop_date_times();
-                    auto arr_time = navitia::to_posix_timestamp(item.arrivals[i]);
-                    stop_time->set_arrival_date_time(arr_time);
-                    auto dep_time = navitia::to_posix_timestamp(item.departures[i]);
-                    stop_time->set_departure_date_time(dep_time);
-                    const auto p_deptime = item.departures[i];
-                    const auto p_arrtime = item.arrivals[i];
-                    bt::time_period action_period(p_deptime, p_arrtime);
-                    fill_pb_object(item.stop_points[i], d, stop_time->mutable_stop_point(),
-                            0, now, action_period, show_codes);
-                    fill_pb_object(item.stop_times[i], d, stop_time, 1, now, action_period);
-
-                    // L'heure de départ du véhicule au premier stop point
-                    if(departure_ptime.is_not_a_date_time())
-                        departure_ptime = p_deptime;
-                    // L'heure d'arrivée au dernier stop point
-                    arrival_ptime = p_arrtime;
+                // same for the end
+                if (item_idx == path.items.size() && journey_end_with_address_odt) {
+                    fill_pb_placemark(destination, d,
+                            pb_section->mutable_destination(), 1, now,
+                            action_period, show_codes);
+                } else {
+                    fill_pb_placemark(item.stop_points.back(), d,
+                            pb_section->mutable_destination(), 1, now,
+                            action_period, show_codes);
                 }
-                if (! item.stop_points.empty()) {
-                    //some time there is only one stop points, typically in case of "extension of services"
-                    //if the passenger as to board on the last stop_point of a VJ (yes, it's possible...)
-                    //in this case we want to display this only point as the departure and the destination of this section
-                    auto arr_time = item.arrivals[0];
-                    auto dep_time = item.departures[0];
-                    bt::time_period action_period(dep_time, arr_time + bt::seconds(1));
-
-                    // for 'taxi like' odt, we want to start from the address, not the 1 stop point
-                    if (item_idx == 1 && journey_begin_with_address_odt) {
-                        fill_pb_placemark(origin, d,
-                                    pb_section->mutable_origin(), 1, now, action_period,
-                                    show_codes);
-                    } else {
-                        fill_pb_placemark(item.stop_points.front(), d,
-                                    pb_section->mutable_origin(), 1, now, action_period,
-                                    show_codes);
-                    }
-
-                    // same for the end
-                    if (item_idx == path.items.size() && journey_end_with_address_odt) {
-                        fill_pb_placemark(destination, d,
-                                    pb_section->mutable_destination(), 1, now,
-                                    action_period, show_codes);
-                    } else {
-                        fill_pb_placemark(item.stop_points.back(), d,
-                                    pb_section->mutable_destination(), 1, now,
-                                    action_period, show_codes);
-                    }
-
-                }
-                bt::time_period action_period(departure_ptime, arrival_ptime);
-                fill_section(pb_section, vj, item.stop_times, d, now, action_period);
-
-                // setting additional_informations
-                const bool has_datetime_estimated = ! item.stop_times.empty()
-                    && (item.stop_times.front()->date_time_estimated()
-                        || item.stop_times.back()->date_time_estimated());
-                const bool has_odt = ! item.stop_times.empty()
-                    && (item.stop_times.front()->odt() || item.stop_times.back()->odt());
-                const bool is_zonal = ! item.stop_points.empty()
-                    && (item.stop_points.front()->is_zonal || item.stop_points.back()->is_zonal);
-                fill_additional_informations(pb_section->mutable_additional_informations(),
-                                             has_datetime_estimated,
-                                             has_odt,
-                                             is_zonal);
-
-                // If this section has estimated stop times,
-                // if the previous section is a waiting section, we also
-                // want to set it to estimated.
-                if (has_datetime_estimated && pb_journey->sections_size() >= 2) {
-                    auto previous_section = pb_journey->mutable_sections(pb_journey->sections_size()-2);
-                    if (previous_section->type() == pbnavitia::WAITING) {
-                        previous_section->add_additional_informations(pbnavitia::HAS_DATETIME_ESTIMATED);
-                    }
-                }
-            } else {
-                pb_section->set_type(pbnavitia::TRANSFER);
-                switch(item.type) {
-                    case ItemType::stay_in :{
-                        pb_section->set_transfer_type(pbnavitia::stay_in);
-                        //We "stay in" the precedent section, this one is only a transfer
-                        int section_idx = pb_journey->sections_size() - 2;
-                        if(section_idx >= 0 && pb_journey->sections(section_idx).type() == pbnavitia::PUBLIC_TRANSPORT){
-                            auto* prec_section = pb_journey->mutable_sections(section_idx);
-                            prec_section->add_additional_informations(pbnavitia::STAY_IN);
-                        }
-                        break;
-                    }
-                    case ItemType::waiting : pb_section->set_type(pbnavitia::WAITING); break;
-                    default : pb_section->set_transfer_type(pbnavitia::walking); break;
-                }
-                // For a waiting section, if the previous public transport section,
-                // has estimated datetime we need to set it has estimated too.
-                const auto& sections = pb_journey->sections();
-                for (auto it = sections.rbegin(); it != sections.rend(); ++it) {
-                    if (it->type() != pbnavitia::PUBLIC_TRANSPORT) { continue; }
-                    if (boost::count(it->additional_informations(), pbnavitia::HAS_DATETIME_ESTIMATED)) {
-                        pb_section->add_additional_informations(pbnavitia::HAS_DATETIME_ESTIMATED);
-                    }
-                    break;
-                }
-
-                bt::time_period action_period(item.departure, item.arrival);
-                const auto origin_sp = item.stop_points.front();
-                const auto destination_sp = item.stop_points.back();
-                fill_pb_placemark(origin_sp, d, pb_section->mutable_origin(), 1, now, action_period, show_codes);
-                fill_pb_placemark(destination_sp, d, pb_section->mutable_destination(), 1, now, action_period,
-                        show_codes);
-                pb_section->set_length(origin_sp->coord.distance_to(destination_sp->coord));
-            }
-            uint64_t dep_time, arr_time;
-            if(item.stop_points.size() == 1 && item.type == ItemType::public_transport){
-                //after a stay it's possible to have only one point,
-                //so we take the arrival hour as arrival and departure
-                dep_time = navitia::to_posix_timestamp(item.arrival);
-                arr_time = navitia::to_posix_timestamp(item.arrival);
-            }else{
-                dep_time = navitia::to_posix_timestamp(item.departure);
-                arr_time = navitia::to_posix_timestamp(item.arrival);
-            }
-            pb_section->set_begin_date_time(dep_time);
-            pb_section->set_end_date_time(arr_time);
-
-            if(departure_time == bt::pos_infin)
-                departure_time = item.departure;
-            arrival_time = item.arrival;
-            pb_section->set_duration(arr_time - dep_time);
-        }
-
-        if (vp) {
-            vptranslator::fill_pb_object(vptranslator::translate(*vp), d, pb_journey, 1);
-        }
+                */
 
         if (journey_end_with_address_odt) {
             // last is 'taxi like' ODT, we do nothing, there is no walking nor crow fly section,
@@ -543,7 +573,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                                               path.items.back().departures.back()+bt::minutes(1));
                 const time_duration& crow_fly_duration = find_or_default(SpIdx(*arrival_stop_point),
                                                 worker.arrival_path_finder.distance_to_entry_point);
-                arrival_time = arrival_time + crow_fly_duration.to_posix();
+                arrival_time = arrival_time + pt::seconds(crow_fly_duration.to_posix().total_seconds());
                 fill_crowfly_section(origin_tmp, destination, crow_fly_duration,
                                      get_crowfly_mode(sn_arrival_path),
                                      path.items.back().departures.back(), d, enhanced_response,
@@ -562,7 +592,7 @@ static void add_pathes(EnhancedResponse& enhanced_response,
                 int nb_section = pb_journey->mutable_sections()->size();
                 fill_street_sections(enhanced_response, destination, sn_arrival_path, d, pb_journey,
                         begin_section_time);
-                arrival_time = arrival_time + sn_arrival_path.duration.to_posix();
+                arrival_time = arrival_time + pt::seconds(sn_arrival_path.duration.to_posix().total_seconds());
                 if (pb_journey->mutable_sections()->size() > nb_section) {
                     //We add coherence between the destination of the PT part of the journey
                     //and the origin of the street network part
@@ -584,23 +614,13 @@ static void add_pathes(EnhancedResponse& enhanced_response,
             }
         }
 
-        const auto str_departure = navitia::to_posix_timestamp(departure_time);
-        const auto str_arrival = navitia::to_posix_timestamp(arrival_time);
-        pb_journey->set_departure_date_time(str_departure);
-        pb_journey->set_arrival_date_time(str_arrival);
-        pb_journey->set_duration((arrival_time - departure_time).total_seconds());
-
-        compute_most_serious_disruption(pb_journey);
-
-        //fare computation, done at the end for the journey to be complete
-        auto fare = d.fare->compute_fare(path);
-        try {
-            fill_fare_section(enhanced_response, pb_journey, fare);
-        } catch(const navitia::exception& e) {
-            pb_journey->clear_fare();
-            LOG4CPLUS_WARN(logger, "Unable to compute fare, error : " << e.what());
-        }
+        const auto departure = pb_journey->sections(0).begin_date_time();
+        const auto arrival = navitia::to_posix_timestamp(arrival_time);
+        pb_journey->set_departure_date_time(departure);
+        pb_journey->set_arrival_date_time(arrival);
+        pb_journey->set_duration(arrival - departure);
         co2_emission_aggregator(pb_journey);
+
     }
 
     add_direct_path(enhanced_response, d, direct_path, origin, destination, datetimes, clockwise);
@@ -623,6 +643,53 @@ make_pathes(const std::vector<navitia::routing::Path>& paths,
 
     add_pathes(enhanced_response, paths, d, worker, direct_path,
                origin, destination, datetimes, clockwise, show_codes);
+
+    if (pb_response.journeys().size() == 0) {
+        fill_pb_error(pbnavitia::Error::no_solution, "no solution found for this journey",
+        pb_response.mutable_error());
+        pb_response.set_response_type(pbnavitia::NO_SOLUTION);
+    }
+    return pb_response;
+}
+
+
+static void add_pt_pathes(EnhancedResponse& enhanced_response,
+                       const std::vector<navitia::routing::Path>& paths,
+                       const nt::Data& d,
+                       const bool show_codes) {
+    pbnavitia::Response& pb_response = enhanced_response.response;
+
+    bt::ptime now = bt::second_clock::universal_time();
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+
+    for(const Path& path : paths) {
+        //TODO: what do we want to do in this case?
+        if (path.items.empty()) {
+            continue;
+        }
+        bt::ptime departure_time = path.items.front().departures.front();
+        pbnavitia::Journey* pb_journey = pb_response.add_journeys();
+        bt::ptime arrival_time = handle_pt_sections(pb_journey, enhanced_response, path, d, now, show_codes);
+
+
+        pb_journey->set_departure_date_time(navitia::to_posix_timestamp(departure_time));
+        pb_journey->set_arrival_date_time(navitia::to_posix_timestamp(arrival_time));
+        pb_journey->set_duration((arrival_time - departure_time).total_seconds());
+
+        co2_emission_aggregator(pb_journey);
+    }
+}
+
+static pbnavitia::Response make_pt_pathes(
+        const std::vector<navitia::routing::Path>& paths,
+        const nt::Data& d,
+        const bool show_codes) {
+    EnhancedResponse enhanced_response; //wrapper around raw protobuff response to handle ids
+    pbnavitia::Response& pb_response = enhanced_response.response;
+
+    pb_response.set_response_type(pbnavitia::ITINERARY_FOUND);
+
+    add_pt_pathes(enhanced_response, paths, d, show_codes);
 
     if (pb_response.journeys().size() == 0) {
         fill_pb_error(pbnavitia::Error::no_solution, "no solution found for this journey",
@@ -731,10 +798,9 @@ std::vector<georef::Admin*> find_admins(const type::EntryPoint& ep, const type::
     return data.geo_ref->find_admins(ep.coordinates);
 }
 
-static
 routing::map_stop_point_duration
 get_stop_points( const type::EntryPoint &ep, const type::Data& data,
-        georef::StreetNetwork & worker, bool use_second = false){
+        georef::StreetNetwork & worker, bool use_second){
     routing::map_stop_point_duration result;
     georef::PathFinder& concerned_path_finder = use_second ? worker.arrival_path_finder :
                                                             worker.departure_path_finder;
@@ -854,6 +920,59 @@ parse_datetimes(RAPTOR& raptor,
         std::sort(datetimes.begin(), datetimes.end());
 
     return datetimes;
+}
+
+pbnavitia::Response make_pt_response(RAPTOR &raptor,
+                                  const std::vector<type::EntryPoint> &origins,
+                                  const std::vector<type::EntryPoint> &destinations,
+                                  const uint64_t timestamp,
+                                  bool clockwise,
+                                  const type::AccessibiliteParams& accessibilite_params,
+                                  const std::vector<std::string>& forbidden,
+                                  const type::RTLevel rt_level,
+                                  const navitia::time_duration& transfer_penalty,
+                                  uint32_t max_duration,
+                                  uint32_t max_transfers,
+                                  bool show_codes,
+                                  uint32_t max_extra_second_pass){
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    pbnavitia::Response response;
+    std::vector<bt::ptime> datetimes;
+    datetimes = parse_datetimes(raptor, {timestamp}, response, clockwise);
+    if(response.has_error() || response.response_type() == pbnavitia::DATE_OUT_OF_BOUNDS) {
+        return response;
+    }
+    auto datetime = datetimes.front();
+
+    routing::map_stop_point_duration departures;
+    routing::map_stop_point_duration arrivals;
+
+    for(const auto& origin: origins){
+        //todo check uri is valid
+        departures[SpIdx{*raptor.data.pt_data->stop_points_map[origin.uri]}] = navitia::seconds(origin.access_duration);
+    }
+    for(const auto& destination: destinations){
+        //todo check uri is valid
+        arrivals[SpIdx{*raptor.data.pt_data->stop_points_map[destination.uri]}] = navitia::seconds(destination.access_duration);
+    }
+
+    DateTime bound = clockwise ? DateTimeUtils::inf : DateTimeUtils::min;
+    int day = (datetime.date() - raptor.data.meta->production_date.begin()).days();
+    int time = datetime.time_of_day().total_seconds();
+    DateTime init_dt = DateTimeUtils::set(day, time);
+
+    if(max_duration != std::numeric_limits<uint32_t>::max()) {
+        bound = clockwise ? init_dt + max_duration : init_dt - max_duration;
+    }
+    std::vector<Path> pathes = raptor.compute_all(
+            departures, arrivals, init_dt, rt_level, transfer_penalty, bound, max_transfers,
+            accessibilite_params, forbidden, clockwise, {}, max_extra_second_pass);
+    LOG4CPLUS_DEBUG(logger, "raptor found " << pathes.size() << " solutions");
+    if(clockwise){
+        std::reverse(pathes.begin(), pathes.end());
+    }
+    return make_pt_pathes(pathes, raptor.data, show_codes);
+
 }
 
 pbnavitia::Response
@@ -1120,5 +1239,6 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
 
     return response;
 }
+
 
 }}

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -35,11 +35,13 @@ www.navitia.io
 #include "utils/flat_enum_map.h"
 #include "type/rt_level.h"
 #include <limits>
+#include "routing/routing.h"
 
 namespace navitia{
     namespace type{
         struct EntryPoint;
         struct AccessibiliteParams;
+        struct Data;
     }
     namespace georef{
         struct StreetNetwork;
@@ -86,6 +88,24 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
                                    int max_duration = 3600,
                                    uint32_t max_transfers=std::numeric_limits<uint32_t>::max(),
                                    bool show_codes = false);
+
+pbnavitia::Response make_pt_response(RAPTOR &raptor,
+                                  const std::vector<type::EntryPoint> &origins,
+                                  const std::vector<type::EntryPoint> &destinations,
+                                  const uint64_t timestamps,
+                                  bool clockwise,
+                                  const type::AccessibiliteParams& accessibilite_params,
+                                  const std::vector<std::string>& forbidden,
+                                  const type::RTLevel rt_level,
+                                  const navitia::time_duration& transfer_penalty,
+                                  uint32_t max_duration=std::numeric_limits<uint32_t>::max(),
+                                  uint32_t max_transfers=std::numeric_limits<uint32_t>::max(),
+                                  bool show_codes = false,
+                                  uint32_t max_extra_second_pass = 0);
+
+routing::map_stop_point_duration
+get_stop_points( const type::EntryPoint &ep, const type::Data& data,
+        georef::StreetNetwork & worker, bool use_second = false);
 
 
 }}


### PR DESCRIPTION
For not breaking anything we add a new scenario, this way it's possible
to enable this new comportment at the request level.
In jormungandr every instance have two "adaptor" classes:
- planner: it will handle interaction with the PT journey planner. At this
  time only kraken is done and there is no plan for another one.
- georef: Handle all interaction with the street network system. A
  this time only kraken exist, but there is plan to replace it with a
  better routing system in a near future

Currently the experimental scenario has a lot of limitation:
- zonal TAD is not handle
- ~~only walking fallback is use~~
- ~~a lot of parameters are ignored~~
- direct path are not activated
- only crowfly are used: there is no streetnetwork section

Refactoring has be done in raptor_api, for limiting code duplication.

:warning: require https://github.com/CanalTP/navitia-proto/pull/31 to be merge before
