### PR TITLE
Timezone format for block until in tyr api updated.

### DIFF
--- a/source/tyr/migrations/versions/64854ef94b3_block_until_column_updated_for_date_.py
+++ b/source/tyr/migrations/versions/64854ef94b3_block_until_column_updated_for_date_.py
@@ -1,0 +1,24 @@
+"""'block_until' column updated for date format.
+
+Revision ID: 64854ef94b3
+Revises: 2320ba18ce1
+Create Date: 2015-12-22 15:15:21.597541
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '64854ef94b3'
+down_revision = '2320ba18ce1'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('user', 'block_until')
+    op.add_column('user', sa.Column('block_until', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'block_until')
+    op.add_column('user', sa.Column('block_until', sa.DateTime(timezone=True), nullable=True))

--- a/source/tyr/tyr/validations.py
+++ b/source/tyr/tyr/validations.py
@@ -3,7 +3,6 @@ import pytz
 
 def datetime_format(value):
     """Parse a valid looking date in the format YYYYmmddTHHmmss"""
-    utc=pytz.UTC
 
-    return utc.localize(datetime.strptime(value, "%Y%m%dT%H%M%S"))
+    return datetime.strptime(value, "%Y%m%dT%H%M%SZ")
 


### PR DESCRIPTION
See with @kinnou02 
"user" table need to be without timezone to save UTC datetime.
