### PR TITLE
Georef: crowfly length with speed_factor bug fix

### DIFF
--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -67,8 +67,19 @@ using nt::hasVehicleProperties;
 
 using nt::ValidityPattern;
 
-#define FORWARD_CLASS_DECLARE(type_name, collection_name) struct type_name;
-ITERATE_NAVITIA_PT_TYPES(FORWARD_CLASS_DECLARE)
+struct Line;
+struct LineGroup;
+struct VehicleJourney;
+struct StopPoint;
+struct StopArea;
+struct Network;
+struct PhysicalMode;
+struct CommercialMode;
+struct Company;
+struct Route;
+struct Contributor;
+struct Calendar;
+
 struct StopTime;
 
 using nt::ConnectionType;

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -250,7 +250,8 @@ PathItem::TransportCaracteristic GeoRef::get_caracteristic(edge_t edge) const {
     throw navitia::exception("unhandled path item caracteristic");
 }
 
-double PathItem::get_length() const {
+double PathItem::get_length(double speed_factor) const {
+    double def_speed = default_speed[type::Mode_e::Walking];
     switch (transportation) {
     case TransportCaracteristic::BssPutBack:
     case TransportCaracteristic::BssTake:
@@ -258,15 +259,15 @@ double PathItem::get_length() const {
     case TransportCaracteristic::CarLeaveParking:
         return 0;
     case TransportCaracteristic::Walk:
-        //milliseconds to reduce rounding
-        return duration.total_milliseconds() * (default_speed[type::Mode_e::Walking]) / 1000;
+        def_speed = default_speed[type::Mode_e::Walking]; break;
     case TransportCaracteristic::Bike:
-        return duration.total_milliseconds() * (default_speed[type::Mode_e::Bike]) / 1000;
+        def_speed = default_speed[type::Mode_e::Bike]; break;
     case TransportCaracteristic::Car:
-        return duration.total_milliseconds() * (default_speed[type::Mode_e::Car]) / 1000;
+        def_speed = default_speed[type::Mode_e::Car]; break;
     default:
         throw navitia::exception("unhandled transportation case");
     }
+    return duration.total_milliseconds() * def_speed * speed_factor / 1000;
 }
 
 void GeoRef::add_way(const Way& w){

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -192,7 +192,7 @@ struct PathItem {
     };
     TransportCaracteristic transportation = TransportCaracteristic::Walk;
 
-    double get_length() const;
+    double get_length(double speed_factor) const;
 };
 
 /** Itinéraire complet */

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -97,8 +97,9 @@ Path StreetNetwork::get_path(type::idx_t idx, bool use_second) {
     if (! use_second) {
         result = departure_path_finder.get_path(idx);
 
-        if (! result.path_items.empty())
+        if (! result.path_items.empty()) {
             result.path_items.front().coordinates.push_front(departure_path_finder.starting_edge.projected);
+        }
     } else {
         result = arrival_path_finder.get_path(idx);
 
@@ -532,13 +533,14 @@ Path PathFinder::build_path(vertex_t best_destination) const {
     }
     reverse_path.push_back(best_destination);
 
-    return create_path(geo_ref, reverse_path, true);
+    return create_path(geo_ref, reverse_path, true, speed_factor);
 }
 
 
 Path create_path(const GeoRef& geo_ref,
                  const std::vector<vertex_t>& reverse_path,
-                 bool add_one_elt) {
+                 bool add_one_elt,
+                 double speed_factor) {
     Path p;
 
     // On reparcourt tout dans le bon ordre
@@ -573,8 +575,8 @@ Path create_path(const GeoRef& geo_ref,
         last_transport_carac = transport_carac;
         path_item.way_idx = edge.way_idx;
         path_item.transportation = transport_carac;
-        path_item.duration += edge.duration;
-        p.duration += edge.duration;
+        path_item.duration += edge.duration / speed_factor;
+        p.duration += path_item.duration;
         if (path_item_changed) {
             //we update the last path item
             path_item.angle = compute_directions(p, coord);

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -576,7 +576,7 @@ Path create_path(const GeoRef& geo_ref,
         path_item.way_idx = edge.way_idx;
         path_item.transportation = transport_carac;
         path_item.duration += edge.duration / speed_factor;
-        p.duration += path_item.duration;
+        p.duration += edge.duration / speed_factor;
         if (path_item_changed) {
             //we update the last path item
             path_item.angle = compute_directions(p, coord);

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -231,7 +231,8 @@ struct StreetNetwork {
 /// Build a path from a reverse path list
 Path create_path(const GeoRef& georef,
                  const std::vector<vertex_t>& reverse_path,
-                 bool add_one_elt);
+                 bool add_one_elt,
+                 double speed_factor);
 
 /// Compute the angle between the last segment of the path and the next point
 int compute_directions(const navitia::georef::Path& path, const nt::GeographicalCoord& c_coord);

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -292,20 +292,20 @@ class TestJourneys(AbstractTestFixture):
         assert(len(response['journeys']) == 2)
         #Note: we do not test order, because that can change depending on the scenario
         eq_(sorted(get_used_vj(response)), sorted([[], ['vj:B:1']]))
-        eq_(sorted(get_arrivals(response)), sorted(['20120614T080611', '20120614T180222']))
+        eq_(sorted(get_arrivals(response)), sorted(['20120614T080612', '20120614T180250']))
 
         # same response if we just give the wheelchair=True
         response = self.query_region(journey_basic_query + "&traveler_type=wheelchair&wheelchair=True")
         assert(len(response['journeys']) == 2)
         eq_(sorted(get_used_vj(response)), sorted([[], ['vj:B:1']]))
-        eq_(sorted(get_arrivals(response)), sorted(['20120614T080611', '20120614T180222']))
+        eq_(sorted(get_arrivals(response)), sorted(['20120614T080612', '20120614T180250']))
 
         # but with the wheelchair profile, if we explicitly accept non accessible solutions (not very
         # consistent, but anyway), we should take the non accessible bus that arrive at 08h
         response = self.query_region(journey_basic_query + "&traveler_type=wheelchair&wheelchair=False")
         assert(len(response['journeys']) == 2)
         eq_(sorted(get_used_vj(response)), sorted([['vjA'], []]))
-        eq_(sorted(get_arrivals(response)), sorted(['20120614T080222', '20120614T080611']))
+        eq_(sorted(get_arrivals(response)), sorted(['20120614T080250', '20120614T080612']))
 
 
 @dataset([])

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -41,7 +41,7 @@ namespace navitia{
     namespace type{
         struct EntryPoint;
         struct AccessibiliteParams;
-        struct Data;
+        class Data;
     }
     namespace georef{
         struct StreetNetwork;

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1595,7 +1595,7 @@ BOOST_FIXTURE_TEST_CASE(speed_factor_length_test, streetnetworkmode_fixture<norm
     dump_response(resp, "speed factor length test");
 
     std::vector<pbnavitia::PathItem> path_items;
-    for (int s = 0; s < journey.sections_size() ; s++) {
+    for (int s = 0; s < journey.sections_size(); ++s) {
         for (int i = 0; i < journey.sections(s).street_network().path_items_size(); ++i) {
             path_items.push_back(journey.sections(s).street_network().path_items(i));
         }

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -113,6 +113,12 @@ struct routing_api_data {
               S
 
                 We want to go from S to R:
+
+                    /journeys?from=coord:8.98311981954709e-05:8.98311981954709e-05
+                              &to=coord:0.0018864551621048887:0.0007186495855637672
+                              &datetime=20120614080000
+                              &debug=true
+
                     *) The bikeway is: A->G->H->I->J->K->B
                     *) The car way is: A->E->F->C->B
                     *) We can walk on A->B
@@ -121,21 +127,19 @@ struct routing_api_data {
                     *) A->R is a pedestrian street
 
                     Coordinates:
-                                A(120, 80)    0
-                                G(100, 80)    1
-                                H(100, 100)   2
-                                I(70, 100)    3
-                                J(70, 120)    4
-                                K(10, 120)    5
-                                B(10, 30)     6
-                                C(150, 30)    7
-                                F(150, 50)    8
-                                E(120, 50)    9
-                                R(210, 80)    10
-                                S(10, 10)     11
-
-
-
+                                A(120,  80)    0
+                                G(100,  80)    1
+                                H(100, 100)    2
+                                I( 70, 100)    3
+                                J( 70, 120)    4
+                                K( 10, 120)    5
+                                B( 10,  30)    6
+                                C(220,  30)    7
+                                F(220,  50)    8
+                                E(120,  50)    9
+                                R(210,  80)   10
+                                S( 10,  10)   11
+                                D(  0,  30)   12
         */
 
         boost::add_vertex(navitia::georef::Vertex(A),b.data->geo_ref->graph);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1271,7 +1271,7 @@ void fill_street_sections(EnhancedResponse& response, const type::EntryPoint& or
             finalize_section(section, last_item, item, data, session_departure, depth, now, action_period);
             session_departure += bt::seconds(section->duration());
 
-            //and be create a new one
+            //and we create a new one
             section = create_section(response, pb_journey, item, data, depth, now, action_period);
         }
 
@@ -1310,8 +1310,8 @@ void add_path_item(pbnavitia::StreetNetwork* sn, const navitia::georef::PathItem
 
     pbnavitia::PathItem* path_item = sn->add_path_items();
     path_item->set_name(data.geo_ref->ways[item.way_idx]->name);
-    path_item->set_length(item.get_length());
-    path_item->set_duration(item.duration.total_seconds() / ori_dest.streetnetwork_params.speed_factor);
+    path_item->set_length(item.get_length(ori_dest.streetnetwork_params.speed_factor));
+    path_item->set_duration(item.duration.total_seconds());
     path_item->set_direction(item.angle);
 
     //we add each path item coordinate to the global coordinate list

--- a/source/type/validity_pattern.cpp
+++ b/source/type/validity_pattern.cpp
@@ -89,7 +89,7 @@ std::string ValidityPattern::str() const {
 
 bool ValidityPattern::check(boost::gregorian::date day) const {
     long duration = slide(day);
-    if (duration < 0 || duration >= days.size()) {
+    if (duration < 0 || duration >= long(days.size())) {
         throw navitia::recoverable_exception("date " + boost::gregorian::to_iso_extended_string(day)
                                              + " out of bound, cannot check validity pattern");
     }


### PR DESCRIPTION
Duration stored in path_items now uses speed_factor, and everything is managed as crowfly path_items
JIRA: http://jira.canaltp.fr/browse/NAVITIAII-1995
