### PR TITLE
Tyr: update default value in a migration

### DIFF
--- a/source/tyr/migrations/versions/3011cf480291_add_stif_specific_params.py
+++ b/source/tyr/migrations/versions/3011cf480291_add_stif_specific_params.py
@@ -17,7 +17,7 @@ import sqlalchemy as sa
 def upgrade():
     op.add_column('instance', sa.Column('max_duration', sa.Integer(), server_default='14400', nullable=False))
     op.add_column('instance', sa.Column('night_bus_filter_base_factor', sa.Integer(), server_default='3600', nullable=False))
-    op.add_column('instance', sa.Column('night_bus_filter_max_factor', sa.Integer(), server_default='30', nullable=False))
+    op.add_column('instance', sa.Column('night_bus_filter_max_factor', sa.Integer(), server_default='3', nullable=False))
     op.add_column('instance', sa.Column('walking_transfer_penalty', sa.Integer(), server_default='2', nullable=False))
 
 


### PR DESCRIPTION
It won't change anything for us, but for other people it migth help
them.
The value will be changed manually on our plaform since a hotfix for this is way to much work, and it only affect only created instances
