### PR TITLE
jormun: fix a bug in multithread context

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -130,10 +130,10 @@ ww_places = {
 
 
 class Places(ResourceUri):
-    parsers = {}
 
     def __init__(self, *args, **kwargs):
         ResourceUri.__init__(self, authentication=False, *args, **kwargs)
+        self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
         self.parsers["get"].add_argument("q", type=unicode, required=True,
@@ -285,10 +285,10 @@ places_types = {'stop_areas', 'stop_points', 'pois',
                 'addresses', 'coords', 'places'}  # add admins when possible
 
 class PlacesNearby(ResourceUri):
-    parsers = {}
 
     def __init__(self, *args, **kwargs):
         ResourceUri.__init__(self, *args, **kwargs)
+        self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
         parser_get = self.parsers["get"]

--- a/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
@@ -54,10 +54,10 @@ pt_object_type_values = ["network", "commercial_mode", "line", "line_group", "ro
 
 
 class Ptobjects(ResourceUri):
-    parsers = {}
 
     def __init__(self, *args, **kwargs):
         ResourceUri.__init__(self, *args, **kwargs)
+        self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
         self.parsers["get"].add_argument("q", type=unicode, required=True,

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -53,12 +53,12 @@ from navitiacommon import response_pb2
 
 
 class Schedules(ResourceUri, ResourceUtc):
-    parsers = {}
 
     def __init__(self, endpoint):
         ResourceUri.__init__(self)
         ResourceUtc.__init__(self)
         self.endpoint = endpoint
+        self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
         parser_get = self.parsers["get"]

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -54,12 +54,12 @@ from datetime import datetime
 
 
 class Uri(ResourceUri, ResourceUtc):
-    parsers = {}
 
     def __init__(self, is_collection, collection, *args, **kwargs):
         kwargs['authentication'] = False
         ResourceUri.__init__(self, *args, **kwargs)
         ResourceUtc.__init__(self)
+        self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
         parser = self.parsers["get"]


### PR DESCRIPTION
Some resources had their parser at the class level and not at the
instance level, so multiple request can used the same parser at the same
time. As you can guess it didn't do any good!
