### PR TITLE
route_schedule: Improve ranked pairs implementation

### DIFF
--- a/source/time_tables/tests/thermometer.cpp
+++ b/source/time_tables/tests/thermometer.cpp
@@ -281,8 +281,8 @@ BOOST_AUTO_TEST_CASE(t10) {
         }
     }
 
-    BOOST_REQUIRE_EQUAL(t.get_thermometer().size(), 97);
-    BOOST_REQUIRE_EQUAL(error, false);
+    BOOST_CHECK_EQUAL(t.get_thermometer().size(), 96);
+    BOOST_CHECK_EQUAL(error, false);
 }
 
 
@@ -338,10 +338,11 @@ BOOST_AUTO_TEST_CASE(t13) {
     t.generate_thermometer(req);
     auto result = t.get_thermometer();
 
-    BOOST_REQUIRE_EQUAL(result[0], 0);
-    BOOST_REQUIRE_EQUAL(result[1], 3);
-    BOOST_REQUIRE_EQUAL(result[2], 1);
-    BOOST_REQUIRE_EQUAL(result[3], 2);
+    BOOST_REQUIRE_EQUAL(result.size(), 4);
+    BOOST_CHECK_EQUAL(result[0], 0);
+    BOOST_CHECK_EQUAL(result[1], 1);
+    BOOST_CHECK_EQUAL(result[2], 3);
+    BOOST_CHECK_EQUAL(result[3], 2);
 }
 
 BOOST_AUTO_TEST_CASE(t14) {

--- a/source/time_tables/thermometer.cpp
+++ b/source/time_tables/thermometer.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 #include "time.h"
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/topological_sort.hpp>
+#include <boost/range/algorithm/sort.hpp>
 
 namespace navitia { namespace timetables {
 
@@ -188,7 +189,11 @@ bool Thermometer::generate_topological_thermometer(const std::vector<vector_idx>
     return true;
 }
 
-void Thermometer::generate_thermometer(const std::vector<vector_idx> &stop_point_lists) {
+void Thermometer::generate_thermometer(const std::vector<vector_idx> &sps) {
+    // We prefere to have the biggest jp first, because the heuristic
+    // has less chance to do bad choice if critical jp are used first.
+    std::vector<vector_idx> stop_point_lists = sps;
+    boost::range::sort(stop_point_lists, [](const vector_idx& a, const vector_idx&b) { return a.size() > b.size(); });
 
     if (stop_point_lists.size() > 1) {
         // Try a topological_sort first


### PR DESCRIPTION
http://jira.canaltp.fr/browse/NAVITIAII-1988

Bench for RER and Transilien on fr-idf (kraken only):

| Line | removed | topo before | time before | topo after | time after |
| --- | --- | --- | --- | --- | --- |
| A | 1314 | 149644 | 24.1 | 19601 | 6.0 |
| B | 692 | 105984 | 14.1 | 9939 | 2.4 |
| C | 364 | 99623 | 11.8 | 5308 | 1.5 |
| D | 1453 | 94221 | 10.3 | 21426 | 4.8 |
| E | 677 | 77381 | 8.5 | 9570 | 1.8 |
| H | 1849 | 98187 | 10.8 | 28425 | 4.8 |
| J | 712 | 107003 | 13.5 | 11383 | 2.3 |
| K | 0 | 1 | 0.0 | 1 | 0.0 |
| L | 159 | 179827 | 33.0 | 2555 | 1.0 |
| N | 47 | 57244 | 4.2 | 672 | 0.2 |
| P | 46 | 27357 | 1.9 | 638 | 0.1 |
| R | 36 | 6653 | 0.2 | 405 | 0.0 |
| U | 0 | 1 | 0.0 | 1 | 0.0 |

nb edges = topo before - 2 (except when topo before = 1)

tldr: always faster, really faster on L
