### PR TITLE
Kraken: Kraken can now compute direct path on car

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -147,9 +147,14 @@ Path StreetNetwork::get_path(type::idx_t idx, bool use_second) {
 
 Path
 StreetNetwork::get_direct_path(const type::EntryPoint& origin, const type::EntryPoint& destination) {
+    auto dest_mode = origin.streetnetwork_params.mode;
+    if(dest_mode == type::Mode_e::Car){
+        //on direct path with car we want to arrive on the walking graph
+        dest_mode = type::Mode_e::Walking;
+    }
     const auto dest_edge = ProjectionData(destination.coordinates,
                                           geo_ref,
-                                          geo_ref.offsets[origin.streetnetwork_params.mode],
+                                          geo_ref.offsets[dest_mode],
                                           geo_ref.pl);
     if (! dest_edge.found) { return Path(); }
     const auto max_dur = origin.streetnetwork_params.max_duration

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -48,6 +48,9 @@ from jormungandr.scenarios.helpers import fallback_mode_comparator
 
 non_pt_types = ['non_pt_walk', 'non_pt_bike', 'non_pt_bss']
 
+def is_admin(entrypoint):
+    return entrypoint.startswith('admin:')
+
 class Scenario(simple.Scenario):
 
     def parse_journey_request(self, requested_type, request):
@@ -150,6 +153,11 @@ class Scenario(simple.Scenario):
         for o_mode, d_mode in itertools.product(self.origin_modes, self.destination_modes):
             req.journeys.streetnetwork_params.origin_mode = o_mode
             req.journeys.streetnetwork_params.destination_mode = d_mode
+            if o_mode == 'car' or (is_admin(req.journeys.origin[0].place) and is_admin(req.journeys.destination[0].place)):
+                # we don't want direct path for car or for admin to admin journeys
+                req.journeys.streetnetwork_params.enable_direct_path = False
+            else:
+                req.journeys.streetnetwork_params.enable_direct_path = True
             local_resp = instance.send_and_receive(req)
             if local_resp.response_type == response_pb2.ITINERARY_FOUND:
 

--- a/source/jormungandr/jormungandr/scenarios/destineo.py
+++ b/source/jormungandr/jormungandr/scenarios/destineo.py
@@ -27,6 +27,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from jormungandr.scenarios import default, helpers
+from jormungandr.scenarios.default import is_admin
 import copy
 import logging
 from jormungandr.scenarios.utils import JourneySorter, are_equals, compare
@@ -202,9 +203,6 @@ class DestineoJourneySorter(JourneySorter):
             return 1
 
         return 0
-
-def is_admin(entrypoint):
-    return entrypoint.startswith('admin:')
 
 
 class Scenario(default.Scenario):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -118,6 +118,8 @@ def create_pb_request(requested_type, request, dep_mode, arr_mode):
     sn_params.bss_speed = request["bss_speed"]
     sn_params.origin_filter = request.get("origin_filter", "")
     sn_params.destination_filter = request.get("destination_filter", "")
+    #we always want direct path, even for car
+    sn_params.enable_direct_path = True
 
     #settings fallback modes
     sn_params.origin_mode = dep_mode
@@ -517,6 +519,12 @@ def type_journeys(resp, req):
             non_pt_journey,
             has_no_car,
             has_bss,
+        ], [
+            best_crit
+        ])),
+        ("non_pt_car", trip_carac([
+            non_pt_journey,
+            has_car,
         ], [
             best_crit
         ])),

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -409,6 +409,7 @@ type::StreetNetworkParams Worker::streetnetwork_params_of_entry_point(const pbna
     }
     if (result.speed_factor <= 0) { throw navitia::recoverable_exception("invalid speed factor"); }
     result.max_duration = navitia::seconds(max_non_pt);
+    result.enable_direct_path = request.enable_direct_path();
     return result;
 }
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -202,15 +202,9 @@ static void co2_emission_aggregator(pbnavitia::Journey* pb_journey){
 static georef::Path get_direct_path(georef::StreetNetwork& worker,
                             const type::EntryPoint& origin,
                             const type::EntryPoint& destination) {
-    if ((origin.type == nt::Type_e::Admin && destination.type == nt::Type_e::Admin)
-        || origin.streetnetwork_params.mode == nt::Mode_e::Car) { //(direct path use only origin mode)
-        // we don't want direct path for admin to admin (it has no meaning)
-        // and we do not compute direct path for car because:
-        //  * our car pathes are not very realistic
-        //  * we do not want to promote car solution
+    if (! origin.streetnetwork_params.enable_direct_path) { //(direct path use only origin mode)
         return georef::Path();
     }
-
     return worker.get_direct_path(origin, destination);
 }
 

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -2113,7 +2113,7 @@ BOOST_FIXTURE_TEST_CASE(direct_path_car, streetnetworkmode_fixture<test_speed_pr
     nr::RAPTOR raptor(*this->b.data);
     auto resp = nr::make_response(raptor, this->origin, this->destination, this->datetimes, true, navitia::type::AccessibiliteParams(), this->forbidden, sn_worker, type::RTLevel::Base, 2_min);
 
-    dump_response(resp, "direct_path_car", true);
+    dump_response(resp, "direct_path_car");
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2); //1 direct car + 1 car->bus->walk

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -872,6 +872,7 @@ struct StreetNetworkParams{
     void set_filter(const std::string & param_uri);
 
     navitia::time_duration max_duration = 1_s;
+    bool enable_direct_path = true;
 };
 /**
   Gestion de l'accessibilié


### PR DESCRIPTION
In kraken, when we compute a direct path for car, we want an arrival on
the walking graph, so we will park the car at a parking and finish walking.

Jormungandr has the responsability to choose if a direct path has to be
computed. For the default scenario, direct path are always computed except
for car and for journey of admin-to-admin type.
New default always ask for a direct path.
