### PR TITLE
Ed: normalize physical_modes uri

### DIFF
--- a/fixtures/ed/ntfs/trips.txt
+++ b/fixtures/ed/ntfs/trips.txt
@@ -1,5 +1,5 @@
 route_id,service_id,trip_id,trip_headsign,block_id,company_id,odt_condition_id,physical_mode_id,trip_property_id,contributor_id,geometry_id
-route_1,1,trip_1,"vehiclejourney1",,,0_test1,,0,C1,
-route_2,1,trip_2,"vehiclejourney2",,,0_test1,,0,C1,
-route_3,1,trip_3,"vehiclejourney3",,,0_test1,,0,C1,
+route_1,1,trip_1,"vehiclejourney1",,,0_test1,BUS,0,C1,
+route_2,1,trip_2,"vehiclejourney2",,,0_test1,BUS,0,C1,
+route_3,1,trip_3,"vehiclejourney3",,,0_test1,BUS,0,C1,
 route_3,1,trip_4,"vehiclejourney3",,,0_test1,,0,C1,

--- a/fixtures/ed/ntfs_v5/trips.txt
+++ b/fixtures/ed/ntfs_v5/trips.txt
@@ -1,5 +1,5 @@
 route_id,service_id,trip_id,trip_headsign,block_id,company_id,odt_condition_id,physical_mode_id,trip_property_id,contributor_id,geometry_id
-route_1,1,trip_1,"vehiclejourney1",,,0_test1,,0,C1,
-route_2,1,trip_2,"vehiclejourney2",,,0_test1,,0,C1,
-route_3,1,trip_3,"vehiclejourney3",,,0_test1,,0,C1,
+route_1,1,trip_1,"vehiclejourney1",,,0_test1,BUS,0,C1,
+route_2,1,trip_2,"vehiclejourney2",,,0_test1,BUS,0,C1,
+route_3,1,trip_3,"vehiclejourney3",,,0_test1,BUS,0,C1,
 route_3,1,trip_4,"vehiclejourney3",,,0_test1,,0,C1,

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -1198,60 +1198,63 @@ void GenericGtfsParser::fill(Data& data, const std::string& beginning_date) {
 
 void GenericGtfsParser::fill_default_modes(Data& data){
 
-    // commercial_mode et physical_mode : par défaut
+    // default commercial_mode and physical_modes
+    // all modes are represented by a number in GTFS
+    // see route_type in https://developers.google.com/transit/gtfs/reference?hl=fr-FR#routestxt
     ed::types::CommercialMode* commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Tram";
-    commercial_mode->uri = "0";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["0"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Metro";
-    commercial_mode->uri = "1";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["1"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Rail";
-    commercial_mode->uri = "2";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["2"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Bus";
-    commercial_mode->uri = "3";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["3"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Ferry";
-    commercial_mode->uri = "4";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["4"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Cable car";
-    commercial_mode->uri = "5";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["5"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Gondola";
-    commercial_mode->uri = "6";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["6"] = commercial_mode;
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Funicular";
-    commercial_mode->uri = "7";
+    commercial_mode->uri = commercial_mode->name;
     data.commercial_modes.push_back(commercial_mode);
-    gtfs_data.commercial_mode_map[commercial_mode->uri] = commercial_mode;
+    gtfs_data.commercial_mode_map["7"] = commercial_mode;
 
     for(ed::types::CommercialMode *mt : data.commercial_modes) {
         ed::types::PhysicalMode* mode = new ed::types::PhysicalMode();
         mode->name = mt->name;
         mode->uri = mt->uri;
         data.physical_modes.push_back(mode);
+        //NOTE: physical mode don't need to be indexed by the GTFS code, since they don't exist in GTFS
         gtfs_data.physical_mode_map[mode->uri] = mode;
     }
 }

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -1233,7 +1233,7 @@ void GenericGtfsParser::fill_default_modes(Data& data){
 
     commercial_mode = new ed::types::CommercialMode();
     commercial_mode->name = "Cable car";
-    commercial_mode->uri = commercial_mode->name;
+    commercial_mode->uri = "Cable_car";
     data.commercial_modes.push_back(commercial_mode);
     gtfs_data.commercial_mode_map["5"] = commercial_mode;
 
@@ -1249,7 +1249,12 @@ void GenericGtfsParser::fill_default_modes(Data& data){
     data.commercial_modes.push_back(commercial_mode);
     gtfs_data.commercial_mode_map["7"] = commercial_mode;
 
-    for(ed::types::CommercialMode *mt : data.commercial_modes) {
+    for (ed::types::CommercialMode* mt : data.commercial_modes) {
+        // we aggregate some GTFS modes
+        if (in(mt->uri, {"Cable_car", "Gondola"})) {
+            continue;
+        }
+
         ed::types::PhysicalMode* mode = new ed::types::PhysicalMode();
         mode->name = mt->name;
         mode->uri = mt->uri;
@@ -1257,6 +1262,9 @@ void GenericGtfsParser::fill_default_modes(Data& data){
         //NOTE: physical mode don't need to be indexed by the GTFS code, since they don't exist in GTFS
         gtfs_data.physical_mode_map[mode->uri] = mode;
     }
+    //for physical mode, cable car is tramway, gondola is funicular
+    gtfs_data.physical_mode_map["Cable_car"] = gtfs_data.physical_mode_map.at("Tram");
+    gtfs_data.physical_mode_map["Gondola"] = gtfs_data.physical_mode_map.at("Funicular");
 }
 
 void normalize_extcodes(Data & data) {

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -225,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(gtfs_test, ArgsFixture) {
 
     // check physical/commercial modes
     // for GTFS we got all the default ones
-    BOOST_REQUIRE_EQUAL(pt_data.physical_modes.size(), 8);
+    BOOST_REQUIRE_EQUAL(pt_data.physical_modes.size(), 6); // less physical mode, some are aggregated
     BOOST_REQUIRE_EQUAL(pt_data.commercial_modes.size(), 8);
     // we check one of each
     const auto* physical_bus = pt_data.physical_modes_map.at("physical_mode:Bus");

--- a/source/ed/tests/gtfsparser_test.cpp
+++ b/source/ed/tests/gtfsparser_test.cpp
@@ -274,14 +274,14 @@ BOOST_AUTO_TEST_CASE(parse_gtfs_no_dst){
     BOOST_REQUIRE(data.lines[0]->network != nullptr);
     BOOST_CHECK_EQUAL(data.lines[0]->network->uri, "DTA");
     BOOST_REQUIRE(data.lines[0]->commercial_mode != nullptr);
-    BOOST_CHECK_EQUAL(data.lines[0]->commercial_mode->uri, "3");
+    BOOST_CHECK_EQUAL(data.lines[0]->commercial_mode->uri, "Bus");
 
     BOOST_CHECK_EQUAL(data.lines[4]->uri, "AAMV");
     BOOST_CHECK_EQUAL(data.lines[4]->name, "Airport - Amargosa Valley");
     BOOST_REQUIRE(data.lines[4]->network != nullptr);
     BOOST_CHECK_EQUAL(data.lines[4]->network->uri, "DTA");
     BOOST_REQUIRE(data.lines[4]->commercial_mode != nullptr);
-    BOOST_CHECK_EQUAL(data.lines[4]->commercial_mode->uri, "3");
+    BOOST_CHECK_EQUAL(data.lines[4]->commercial_mode->uri, "Bus");
 
     //Trips
     BOOST_REQUIRE_EQUAL(data.vehicle_journeys.size(), 11);
@@ -372,14 +372,14 @@ static void check_gtfs_google_example(const ed::Data& data) {
     BOOST_REQUIRE(data.lines[0]->network != nullptr);
     BOOST_CHECK_EQUAL(data.lines[0]->network->uri, "DTA");
     BOOST_REQUIRE(data.lines[0]->commercial_mode != nullptr);
-    BOOST_CHECK_EQUAL(data.lines[0]->commercial_mode->uri, "3");
+    BOOST_CHECK_EQUAL(data.lines[0]->commercial_mode->uri, "Bus");
 
     BOOST_CHECK_EQUAL(data.lines[4]->uri, "AAMV");
     BOOST_CHECK_EQUAL(data.lines[4]->name, "Airport - Amargosa Valley");
     BOOST_REQUIRE(data.lines[4]->network != nullptr);
     BOOST_CHECK_EQUAL(data.lines[4]->network->uri, "DTA");
     BOOST_REQUIRE(data.lines[4]->commercial_mode != nullptr);
-    BOOST_CHECK_EQUAL(data.lines[4]->commercial_mode->uri, "3");
+    BOOST_CHECK_EQUAL(data.lines[4]->commercial_mode->uri, "Bus");
 
     // we need to also check the number of routes created (since they are implicit in GTFS)
     // we create one by line/direction id


### PR DESCRIPTION
Now the physical_modes uris are the same whenever they are from a GTFS or a NTFS

ie. the uri of the bus imported from the GTFS is no more `physical_mode:3` but `physical_mode:Bus`

**WARNING** this can break some API compatibility for navitia's instances loaded with GTFS (no dataset from api.navitia.io should be impacted)

Thanx @grote for the bug issue
