### PR TITLE
jormun: filter short fallback on car and bike in new_default

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -591,6 +591,8 @@ class Journeys(ResourceUri, ResourceUtc):
         parser_get.add_argument("_walking_transfer_penalty", type=int)
         parser_get.add_argument("_night_bus_filter_base_factor", type=int)
         parser_get.add_argument("_night_bus_filter_max_factor", type=int)
+        parser_get.add_argument("_min_car", type=int)
+        parser_get.add_argument("_min_bike", type=int)
 
         self.method_decorators.append(complete_links(self))
 

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -69,6 +69,8 @@ def filter_journeys(response_list, instance, request, original_request):
     for j in journeys:
         _debug_journey(j)
 
+    _filter_too_short_heavy_journeys(journeys, request)
+
     _filter_similar_journeys(journeys, request)
 
     _filter_not_coherent_journeys(journeys, instance, request, original_request)
@@ -134,6 +136,33 @@ def _filter_similar_journeys(journeys, request):
 
             mark_as_dead(worst, 'duplicate_journey', 'similar_to_{other}'
                           .format(other=j1.internal_id if worst == j2 else j2.internal_id))
+
+def _filter_too_short_heavy_journeys(journeys, request):
+    """
+    we filter the journeys with use an "heavy" fallback mode if it's use only for a few minutes
+    Heavy fallback mode are Bike and Car, bss is not considered as one.
+    Typically you don't take your car for only 2 minutes
+    """
+    logger = logging.getLogger(__name__)
+    for journey in journeys:
+        if _to_be_deleted(journey):
+            continue
+        on_bss = False
+        for s in journey.sections:
+            if s.type == response_pb2.BSS_RENT:
+                on_bss = True
+            if s.type == response_pb2.BSS_PUT_BACK:
+                on_bss = False
+            if s.type != response_pb2.STREET_NETWORK:
+                continue
+            if s.street_network.mode == response_pb2.Car and s.duration < request['_min_car']:
+                logger.debug("the journey {} has not enough car, we delete it".format(journey.internal_id))
+                mark_as_dead(journey, "not_enough_car")
+                break
+            if not on_bss and s.street_network.mode == response_pb2.Bike and s.duration < request['_min_bike']:
+                logger.debug("the journey {} has not enough bike, we delete it".format(journey.internal_id))
+                mark_as_dead(journey, "not_enough_bike")
+                break
 
 def _filter_too_long_waiting(journeys, request):
     """

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -593,3 +593,96 @@ def test_arrival_sort():
     eq_(result[3], j4)
     eq_(result[4], j3)
 
+def test_heavy_journey_walking():
+    """
+    we don't filter any journey with walking
+    """
+    request = {'_min_bike': 10, '_min_car': 20}
+    journey = response_pb2.Journey()
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.STREET_NETWORK
+    journey.sections[-1].street_network.mode = response_pb2.Walking
+    journey.sections[-1].duration = 5
+
+
+    journey_filter._filter_too_short_heavy_journeys([journey], request)
+
+    assert 'to_delete' not in journey.tags
+
+def test_heavy_journey_bike():
+    """
+    the first time the duration of the biking section is superior to the min value, so we keep the journey
+    on the second test the duration is inferior to the min, so we delete the journey
+    """
+    request = {'_min_bike': 10, '_min_car': 20}
+    journey = response_pb2.Journey()
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.STREET_NETWORK
+    journey.sections[-1].street_network.mode = response_pb2.Bike
+    journey.sections[-1].duration = 15
+
+    journey_filter._filter_too_short_heavy_journeys([journey], request)
+
+    assert 'to_delete' not in journey.tags
+
+    journey.sections[-1].duration = 5
+
+    journey_filter._filter_too_short_heavy_journeys([journey], request)
+
+    assert 'to_delete' in journey.tags
+
+def test_heavy_journey_car():
+    """
+    the first time the duration of the car section is superior to the min value, so we keep the journey
+    on the second test the duration is inferior to the min, so we delete the journey
+    """
+    request = {'_min_bike': 10, '_min_car': 20}
+    journey = response_pb2.Journey()
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.STREET_NETWORK
+    journey.sections[-1].street_network.mode = response_pb2.Car
+    journey.sections[-1].duration = 25
+
+    journey_filter._filter_too_short_heavy_journeys([journey], request)
+
+    assert 'to_delete' not in journey.tags
+
+    journey.sections[-1].duration = 15
+
+    journey_filter._filter_too_short_heavy_journeys([journey], request)
+
+    assert 'to_delete' in journey.tags
+
+def test_heavy_journey_bss():
+    """
+    we should not remove any bss journey since it is already in concurrence with the walking
+    """
+    request = {'_min_bike': 10, '_min_car': 20}
+    journey = response_pb2.Journey()
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.STREET_NETWORK
+    journey.sections[-1].street_network.mode = response_pb2.Walking
+    journey.sections[-1].duration = 5
+
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.BSS_RENT
+    journey.sections[-1].duration = 5
+
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.STREET_NETWORK
+    journey.sections[-1].street_network.mode = response_pb2.Bike
+    journey.sections[-1].duration = 5
+
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.BSS_PUT_BACK
+    journey.sections[-1].duration = 5
+
+    journey.sections.add()
+    journey.sections[-1].type = response_pb2.STREET_NETWORK
+    journey.sections[-1].street_network.mode = response_pb2.Walking
+    journey.sections[-1].duration = 5
+
+    journey_filter._filter_too_short_heavy_journeys([journey], request)
+
+    assert 'to_delete' not in journey.tags
+

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -251,6 +251,12 @@ def updated_request_with_default(request, instance):
     if request['car_speed'] is None:
         request['car_speed'] = instance.car_speed
 
+    if request['_min_car'] is None:
+        request['_min_car'] = instance.min_car
+
+    if request['_min_bike'] is None:
+        request['_min_bike'] = instance.min_bike
+
 def change_ids(new_journeys, journey_count):
     """
     we have to change some id's on the response not to have id's collision between response


### PR DESCRIPTION
min_car and min_bike are back in business! We don't want to display very
short fallback in car or bike.
Almost nobody take it's car for 2 minutes.
This is a temporary solution we will hopefully find a better rule for
removing ugly journey.
Prior to this PR min_car and min_bike will be set to 0 on all instance
using new_default except fr-auv
Refer to: http://jira.canaltp.fr/browse/NAVITIAII-2020
