### PR TITLE
Jormun: no from_datetime => current datetime and realtime

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -624,9 +624,23 @@ void builder::build_blocks() {
     }
 }
 
- void builder::finish() {
+/*
+ * assign the last stop point a the first vj as the route's destination if none given
+ */
+void builder::fill_missing_destinations() {
+    for (auto r: data->pt_data->routes) {
+        if (r->destination) { continue; }
+        r->for_each_vehicle_journey([&r](nt::VehicleJourney& vj) {
+            if (vj.stop_time_list.empty()) { return true; }
+            r->destination = vj.stop_time_list.back().stop_point->stop_area;
+            return false; // we stop at the first
+        });
+    }
+}
 
+void builder::finish() {
      build_blocks();
+     fill_missing_destinations();
      for(navitia::type::VehicleJourney* vj : this->data->pt_data->vehicle_journeys) {
          if (vj->stop_time_list.empty()) {
              continue;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -248,6 +248,7 @@ struct builder {
     void generate_dummy_basis();
     void manage_admin();
     void build_autocomplete();
+    void fill_missing_destinations();
 };
 
 }

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -146,10 +146,10 @@ class Schedules(ResourceUri, ResourceUtc):
 
         if not args['data_freshness']:
             # The data freshness depends on the API
-            # for route/stop schedule, by default we want the base schedule
-            if self.endpoint in ('route_schedules', 'departure_boards'):
+            # for route_schedule, by default we want the base schedule
+            if self.endpoint == 'route_schedules':
                 args['data_freshness'] = 'base_schedule'
-            # for previous/next departure/arrival, we want the freshest data by default
+            # for stop_schedule and previous/next departure/arrival, we want the freshest data by default
             else:
                 args['data_freshness'] = 'realtime'
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -89,6 +89,14 @@ class Schedules(ResourceUri, ResourceUtc):
                                 description="Distance range of the query. Used only if a coord is in the query")
         parser_get.add_argument("show_codes", type=boolean, default=False,
                             description="show more identification codes")
+        #Note: no default param for data freshness, the default depends on the API
+        parser_get.add_argument("data_freshness",
+                                description='freshness of the data. '
+                                            'base_schedule is the long term planned schedule. '
+                                            'adapted_schedule is for planned ahead disruptions (strikes, '
+                                            'maintenances, ...). '
+                                            'realtime is to have the freshest possible data',
+                                type=option_value(['base_schedule', 'adapted_schedule', 'realtime']))
         parser_get.add_argument("_current_datetime", type=date_time_format, default=datetime.datetime.utcnow(),
                                 description="The datetime we want to publish the disruptions from."
                                             " Default is the current date and it is mainly used for debug.")
@@ -115,25 +123,35 @@ class Schedules(ResourceUri, ResourceUtc):
         timezone.set_request_timezone(self.region)
 
         if not args["from_datetime"] and not args["until_datetime"]:
-            args['from_datetime'] = datetime.datetime.now()
-            if args["calendar"]:  # if we have a calendar 00:00 is fine
+            # no datetime given, default is the current time, and we activate the realtime
+            args['from_datetime'] = datetime.datetime.utcnow()
+            if args["calendar"]:  # if we have a calendar, the dt is only used for sorting, so 00:00 is fine
                 args['from_datetime'] = args['from_datetime'].replace(hour=0, minute=0)
-            else:
-                args['from_datetime'] = args['from_datetime'].replace(hour=13, minute=37)
+
+            if not args['data_freshness']:
+                args['data_freshness'] = 'realtime'
+        elif not args.get('calendar'):
+            #if a calendar is given all times will be given in local (because the calendar might span over dst)
+            if args['from_datetime']:
+                args['from_datetime'] = self.convert_to_utc(args['from_datetime'])
+            if args['until_datetime']:
+                args['until_datetime'] = self.convert_to_utc(args['until_datetime'])
 
         # we save the original datetime for debuging purpose
         args['original_datetime'] = args['from_datetime']
-
-        if not args.get('calendar'):
-            #if a calendar is given all times will be given in local (because it might span over dst)
-            if args['from_datetime']:
-                new_datetime = self.convert_to_utc(args['from_datetime'])
-                args['from_datetime'] = utils.date_to_timestamp(new_datetime)
-            if args['until_datetime']:
-                new_datetime = self.convert_to_utc(args['until_datetime'])
-                args['until_datetime'] = utils.date_to_timestamp(new_datetime)
-        else:
+        if args['from_datetime']:
             args['from_datetime'] = utils.date_to_timestamp(args['from_datetime'])
+        if args['until_datetime']:
+            args['until_datetime'] = utils.date_to_timestamp(args['until_datetime'])
+
+        if not args['data_freshness']:
+            # The data freshness depends on the API
+            # for route/stop schedule, by default we want the base schedule
+            if self.endpoint in ('route_schedules', 'departure_boards'):
+                args['data_freshness'] = 'base_schedule'
+            # for previous/next departure/arrival, we want the freshest data by default
+            else:
+                args['data_freshness'] = 'realtime'
 
         if not args["from_datetime"] and args["until_datetime"]\
                 and self.endpoint[:4] == "next":

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -124,7 +124,7 @@ class Schedules(ResourceUri, ResourceUtc):
 
         if not args["from_datetime"] and not args["until_datetime"]:
             # no datetime given, default is the current time, and we activate the realtime
-            args['from_datetime'] = datetime.datetime.utcnow()
+            args['from_datetime'] = args['_current_datetime']
             if args["calendar"]:  # if we have a calendar, the dt is only used for sorting, so 00:00 is fine
                 args['from_datetime'] = args['from_datetime'].replace(hour=0, minute=0)
 

--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -16,18 +16,8 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
-
+from jormungandr import utils
 from navitiacommon import request_pb2, type_pb2
-
-def realtime_level_to_pbf(level):
-    if level == 'base_schedule':
-        return type_pb2.BASE
-    elif level == 'adapted_schedule':
-        return type_pb2.ADAPTED
-    elif level == 'realtime':
-        return type_pb2.REAL_TIME
-    else:
-        raise ValueError('Impossible to convert in pbf')
 
 
 class JourneyParameters(object):
@@ -69,7 +59,7 @@ class Kraken(object):
 
         req.journeys.datetimes.append(datetime)
         req.journeys.clockwise = clockwise
-        req.journeys.realtime_level = realtime_level_to_pbf(journey_parameters.realtime_level)
+        req.journeys.realtime_level = utils.realtime_level_to_pbf(journey_parameters.realtime_level)
         req.journeys.max_duration = journey_parameters.max_duration
         req.journeys.max_transfers = journey_parameters.max_transfers
         req.journeys.wheelchair = journey_parameters.wheelchair

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -28,6 +28,7 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
+from jormungandr import utils
 
 from navitiacommon import type_pb2, request_pb2
 from jormungandr.utils import date_to_timestamp
@@ -87,6 +88,7 @@ class MixedSchedule(object):
                 st.forbidden_uri.append(forbidden_uri)
         if request.get("calendar"):
             st.calendar = request["calendar"]
+        st.realtime_level = utils.realtime_level_to_pbf(request['data_freshness'])
         st._current_datetime = date_to_timestamp(request['_current_datetime'])
         resp = self.instance.send_and_receive(req)
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -31,7 +31,7 @@ import calendar
 from collections import deque
 from datetime import datetime
 from google.protobuf.descriptor import FieldDescriptor
-from navitiacommon import response_pb2
+from navitiacommon import response_pb2, type_pb2
 
 
 def str_to_time_stamp(str):
@@ -176,3 +176,15 @@ def walk_protobuf(pb_object, visitor):
         visitor(elem[0], elem[1])
 
         add_elt(elem[0], elem[1])
+
+
+def realtime_level_to_pbf(level):
+    if level == 'base_schedule':
+        return type_pb2.BASE
+    elif level == 'adapted_schedule':
+        return type_pb2.ADAPTED
+    elif level == 'realtime':
+        return type_pb2.REAL_TIME
+    else:
+        raise ValueError('Impossible to convert in pbf')
+

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -568,7 +568,6 @@ def is_valid_stop_point(stop_point, depth_check=1):
     """
     check the structure of a stop point
     """
-
     get_not_null(stop_point, "name")
     is_valid_label(get_not_null(stop_point, "label"))
     coord = get_not_null(stop_point, "coord")

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -439,11 +439,8 @@ class TestSchedules(AbstractTestFixture):
 
     def test_stop_schedule_realtime(self):
         """
-        test a stop schedule without a from_datetime parameter
-
-        we should have the current datetime used and the realtime activated
-
-        Note: for test purpose we override the current_datetime
+        we give a from_datetime and a data_freshness, we should get the schedule
+        from this datetime and with realtime data
         """
         response = self.query_region("stop_points/S1/stop_schedules?from_datetime=20160101T080000"
                                      "&data_freshness=realtime")

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -367,10 +367,14 @@ def check_stop_schedule(response, reference):
     """
     check the values in a stopschedule
     check the id of the stoppoint, the id of the routes, the datetimes and the vj used
+
+    Note: the stop_schedule are not sorted, we just must find all reference StopSchedule
     """
-    for (resp, ref) in itertools.izip_longest(response, reference):
-        assert get_not_null(get_not_null(resp, 'stop_point'), 'id') == ref.sp
-        assert get_not_null(get_not_null(resp, 'route'), 'id') == ref.route
+    eq_(len(response), len(reference))
+    for resp in response:
+        ref = next(r for r in reference
+                   if r.sp == get_not_null(get_not_null(resp, 'stop_point'), 'id')
+                   and r.route == get_not_null(get_not_null(resp, 'route'), 'id'))
 
         for (resp_dt, ref_st) in itertools.izip_longest(get_not_null(resp, 'date_times'), ref.date_times):
             eq_(get_not_null(resp_dt, 'date_time'), ref_st.dt)

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -401,7 +401,17 @@ def check_departures(response, reference):
 class TestSchedules(AbstractTestFixture):
 
     def test_classic_stop_schedule(self):
+        """default is Realtime stopschedule"""
         response = self.query_region("stop_points/S1/stop_schedules?from_datetime=20160101T080000")
+
+        stop_sched = response["stop_schedules"]
+        is_valid_stop_schedule(stop_sched, self.tester)
+
+        self.check_stop_schedule_rt_sol(stop_sched)
+
+    def test_stop_schedule_base_schedule(self):
+        response = self.query_region("stop_points/S1/stop_schedules?from_datetime=20160101T080000"
+                                     "&data_freshness=base_schedule")
 
         stop_sched = response["stop_schedules"]
         is_valid_stop_schedule(stop_sched, self.tester)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(main_ptref_test main_ptref_test.cpp)
 
 add_executable(basic_routing_test basic_routing_test.cpp)
 
+add_executable(basic_schedule_test basic_schedule_test.cpp)
+
 add_executable(departure_board_test departure_board_test.cpp)
 
 add_executable(empty_routing_test empty_routing_test.cpp)
@@ -24,6 +26,7 @@ add_executable(main_routing_without_pt_test main_routing_without_pt_test.cpp)
 target_link_libraries(main_routing_test ${ALL_LIBS})
 target_link_libraries(main_ptref_test ${ALL_LIBS})
 target_link_libraries(basic_routing_test ${ALL_LIBS})
+target_link_libraries(basic_schedule_test ${ALL_LIBS})
 target_link_libraries(departure_board_test ${ALL_LIBS})
 target_link_libraries(empty_routing_test ${ALL_LIBS})
 target_link_libraries(main_autocomplete_test ${ALL_LIBS})

--- a/source/tests/basic_schedule_test.cpp
+++ b/source/tests/basic_schedule_test.cpp
@@ -1,0 +1,67 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "utils/init.h"
+#include "utils_test.h"
+#include "mock_kraken.h"
+#include "time_tables/tests/departure_board_test_data.h"
+
+/*
+ * tests for departure board
+ *
+ * Also used with realtime proxy
+ *
+ *          A:s
+ *           v RouteA
+ *           v
+ *           v
+ *         |-----------|      RouteB
+ *B:s > > >| S1> > > > |> > > > B:e
+ *         | v         |
+ *         | v         |
+ *         | S2        |
+ *         |-----------|
+ *           v         SA1
+ *           v
+ *           v
+ *          A:e
+ *
+ *
+ */
+int main(int argc, const char* const argv[]) {
+    navitia::init_app();
+
+    departure_board_fixture data_set;
+
+    mock_kraken kraken(data_set.b, "basic_schedule_test", argc, argv);
+
+    return 0;
+}
+

--- a/source/time_tables/tests/CMakeLists.txt
+++ b/source/time_tables/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ ADD_BOOST_TEST(thermometer_test)
 
 
 add_executable(departure_boards_test departure_boards_test.cpp)
-target_link_libraries(departure_boards_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
+target_link_libraries(departure_boards_test rt_handling time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
 ADD_BOOST_TEST(departure_boards_test)
 
 

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -485,6 +485,9 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
 
+/*
+ *  Calling a stop_schedule asking only for base schedule data should return base schedule data 
+ */
 BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
     pbnavitia::Response resp = departure_board("stop_point.uri=S1", {}, {}, d("20160101T070000"),
                                                86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, *(b.data),


### PR DESCRIPTION
linked to http://jira.canaltp.fr/browse/NAVP-275
- add a data_freshness parameter to the schedules API
- when no from_datetime is provided to those API, the current time is used (not 13h37 anymore), and the datafreshness (if not given) is set to realtime
- pass the realtime_level to kraken (it was hard coded before)

DO NOT merge, tests are coming
