### PR TITLE
Jormugandr: load instance configuration as json

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -68,7 +68,7 @@ cache = Cache(app, config=app.config['CACHE_CONFIGURATION'])
 
 from jormungandr.instance_manager import InstanceManager
 
-i_manager = InstanceManager(ini_files=app.config.get('INI_FILE', None),
+i_manager = InstanceManager(conf_files=app.config.get('INI_FILE', None),
                             instances_dir=app.config.get('INSTANCES_DIR', None),
                             start_ping=app.config.get('START_MONITORING_THREAD', True))
 i_manager.initialisation()

--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -68,8 +68,7 @@ cache = Cache(app, config=app.config['CACHE_CONFIGURATION'])
 
 from jormungandr.instance_manager import InstanceManager
 
-i_manager = InstanceManager(conf_files=app.config.get('INI_FILE', None),
-                            instances_dir=app.config.get('INSTANCES_DIR', None),
+i_manager = InstanceManager(instances_dir=app.config.get('INSTANCES_DIR', None),
                             start_ping=app.config.get('START_MONITORING_THREAD', True))
 i_manager.initialisation()
 

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -50,26 +50,27 @@ import pybreaker
 from jormungandr import georef, planner, schedule, realtime_schedule
 
 type_to_pttype = {
-      "stop_area" : request_pb2.PlaceCodeRequest.StopArea,
-      "network" : request_pb2.PlaceCodeRequest.Network,
-      "company" : request_pb2.PlaceCodeRequest.Company,
-      "line" : request_pb2.PlaceCodeRequest.Line,
-      "route" : request_pb2.PlaceCodeRequest.Route,
-      "vehicle_journey" : request_pb2.PlaceCodeRequest.VehicleJourney,
-      "stop_point" : request_pb2.PlaceCodeRequest.StopPoint,
-      "calendar" : request_pb2.PlaceCodeRequest.Calendar
+      "stop_area": request_pb2.PlaceCodeRequest.StopArea,
+      "network": request_pb2.PlaceCodeRequest.Network,
+      "company": request_pb2.PlaceCodeRequest.Company,
+      "line": request_pb2.PlaceCodeRequest.Line,
+      "route": request_pb2.PlaceCodeRequest.Route,
+      "vehicle_journey": request_pb2.PlaceCodeRequest.VehicleJourney,
+      "stop_point": request_pb2.PlaceCodeRequest.StopPoint,
+      "calendar": request_pb2.PlaceCodeRequest.Calendar
 }
 
 @app.before_request
 def _init_g():
     g.instances_model = {}
 
+
 class Instance(object):
 
-    def __init__(self, context, name):
+    def __init__(self, context, name, zmq_socket, realtime_proxies_configuration=[]):
         self.geom = None
         self._sockets = Queue.Queue()
-        self.socket_path = None
+        self.socket_path = zmq_socket
         self._scenario = None
         self._scenario_name = None
         self.nb_created_socket = 0
@@ -85,7 +86,7 @@ class Instance(object):
         self.planner = planner.Kraken(self)
 
         self.schedule = schedule.MixedSchedule(self)
-        self.realtime_proxy_manager = realtime_schedule.RealtimeProxyManager()
+        self.realtime_proxy_manager = realtime_schedule.RealtimeProxyManager(realtime_proxies_configuration)
 
     def get_models(self):
         if self.name not in g.instances_model:

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
@@ -28,6 +28,8 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
+from importlib import import_module
+import logging
 
 
 class RealtimeProxyManager(object):
@@ -35,9 +37,34 @@ class RealtimeProxyManager(object):
     class managing real-time proxies
     """
 
-    def __init__(self):
+    def __init__(self, proxies_configuration):
+        """
+        Read the dict configuration to build realtime proxies
+        Each entry contains 3 values:
+            * id: the id of the system
+            * class: the class (the full python path) handling the proxy
+            * args: the argument to forward to the class contructor
+        """
         self.realtime_proxies = {}
-        #TODO read conf from file
+        log = logging.getLogger(__name__)
+        for configuration in proxies_configuration:
+            try:
+                cls = configuration['class']
+                proxy_id = configuration['id']
+            except ValueError:
+                log.warn('impossible to build a realtime proxy, missing mandatory field in configuration')
+                continue
+            args = configuration.get('args', {})
+
+            try:
+                module_path, name = cls.rsplit('.', 1)
+                module = import_module(module_path)
+                attr = getattr(module, name)
+            except ImportError:
+                log.warn('impossible to build rt proxy {}, cannot find class: {}'.format(proxy_id, cls))
+                continue
+            rt_proxy = attr(**args)
+            self.realtime_proxies[proxy_id] = rt_proxy
 
     def get(self, proxy_name):
         return self.realtime_proxies[proxy_name]

--- a/source/jormungandr/tests/test_jormungandr.ini
+++ b/source/jormungandr/tests/test_jormungandr.ini
@@ -1,4 +1,0 @@
-[instance]
-key={instance_name}
-socket=ipc:///tmp/{instance_name}
-

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -128,7 +128,7 @@ class AbstractTestFixture:
                      .format(cls.__name__))
         cls.launch_all_krakens()
         cls.create_dummy_ini()
-        i_manager.ini_files = app.config['INI_FILES']
+        i_manager.configuration_files = app.config['INI_FILES']
         i_manager.initialisation()
 
         #we block the stat manager not to send anything to rabbit mq


### PR DESCRIPTION
to be able to pass more instance configuration (like realtime proxies),
.ini files are a bit too tight.

change those to .json files

here is the proposed json format:

``` json
{
    "key": "default",
    "zmq_socket": "ipc:///tmp/default_kraken",
    "realtime_proxies": [
        {
            "id": "code_du_systeme",
            "class": "jormungandr.realtime_schedule.timeo.Timeo",
            "args": {
                "service_url": "http://bob.com"
            }
        }
    ]
}

```

if the format is OK I'll change the .ini generated in the tests

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1404)

<!-- Reviewable:end -->
