### PR TITLE
Ptref: add a period filter on /disruptions

### DIFF
--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -415,6 +415,8 @@ filter_impact_on_period(const std::vector<type::idx_t>& indexes,
     for (const idx_t idx: indexes) {
         auto impact = data.pt_data->disruption_holder.get_weak_impacts()[idx].lock();
 
+        if (! impact) { continue; }
+
         // to keep an impact, we want the intersection between its application periods
         // and the period to be non empy
         for (const auto& application_period: impact->application_periods) {

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(vj_filtering) {
 
     // we want the vj valid from 11pm the first day to 08:00 (excluded) the second, we still have no vj
     BOOST_CHECK_THROW(query(nt::Type_e::VehicleJourney, "", *(builder.data),
-                            {"20130311T1100"_dt}, {"20130312T0800"_dt}, true),
+                            {"20130311T1100"_dt}, {"20130312T0759"_dt}, true),
                       ptref_error);
 
     // we want the vj valid from 11pm the first day to 08::00 the second, we now have A in the results


### PR DESCRIPTION
now since and until filter in the impacts application_periods

you can thus do `api.navitia.io/disruptions?since=20160205T1615`

to get all disruptions that have an application period after the since

we return the disruptions that have a non null intersection between one of ther application period and the [since, until] period
