### PR TITLE
Kraken: Implementation of cached next_stop_time

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -63,6 +63,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("GENERAL.display_contributors", display_contributors ?
              po::value<bool>()->default_value(*display_contributors) : po::value<bool>()->default_value(false),
          "display all contributors in feed publishers")
+        ("GENERAL.raptor_cache_size", po::value<int>()->default_value(10), "maximum number of stored raptor caches")
 
         ("BROKER.host", po::value<std::string>()->default_value("localhost"), "host of rabbitmq")
         ("BROKER.port", po::value<int>()->default_value(5672), "port of rabbitmq")
@@ -118,8 +119,12 @@ boost::optional<std::string> Configuration::chaos_database() const{
     }
     return result;
 }
-int Configuration::nb_thread() const{
-    return this->vm["GENERAL.nb_threads"].as<int>();
+int Configuration::nb_threads() const{
+    int nb_threads = vm["GENERAL.nb_threads"].as<int>();
+    if (nb_threads < 0) {
+        throw std::invalid_argument("nb_threads cannot be negative");
+    }
+    return size_t(nb_threads);
 }
 
 bool Configuration::is_realtime_enabled() const{
@@ -173,5 +178,16 @@ bool Configuration::display_contributors() const{
         return false;
     }
     return vm["GENERAL.display_contributors"].as<bool>();
+}
+
+size_t Configuration::raptor_cache_size() const{
+    if (! vm.count("GENERAL.raptor_cache_size")) {
+        return 10;
+    }
+    int raptor_cache_size = vm["GENERAL.raptor_cache_size"].as<int>();
+    if (raptor_cache_size < 0) {
+        throw std::invalid_argument("raptor_cache_size cannot be negative");
+    }
+    return size_t(raptor_cache_size);
 }
 }}//namespace

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -45,7 +45,7 @@ namespace navitia { namespace kraken{
             std::string zmq_socket_path() const;
             std::string instance_name() const;
             boost::optional<std::string> chaos_database() const;
-            int nb_thread() const;
+            int nb_threads() const;
 
             std::string broker_host() const;
             int broker_port() const;
@@ -59,6 +59,7 @@ namespace navitia { namespace kraken{
             int kirin_timeout() const;
             int kirin_retry_timeout() const;
             bool display_contributors() const;
+            size_t raptor_cache_size() const;
 
             std::vector<std::string> rt_topics() const;
     };

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -86,7 +86,7 @@ int main(int argn, char** argv){
 
     threads.create_thread(navitia::MaintenanceWorker(data_manager, conf));
 
-    int nb_threads = conf.nb_thread();
+    int nb_threads = conf.nb_threads();
     // Launch pool of worker threads
     LOG4CPLUS_INFO(logger, "starting workers threads");
     for(int thread_nbr = 0; thread_nbr < nb_threads; ++thread_nbr) {

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -144,7 +144,7 @@ pbnavitia::Response Worker::status() {
     status->set_last_load_status(d->last_load);
     status->set_last_load_at(pt::to_iso_string(d->last_load_at));
     status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded));
-    status->set_nb_threads(conf.nb_thread());
+    status->set_nb_threads(conf.nb_threads());
     status->set_is_connected_to_rabbitmq(d->is_connected_to_rabbitmq);
     status->set_status(get_string_status(d));
     status->set_is_realtime_loaded(d->is_realtime_loaded);
@@ -213,7 +213,7 @@ void Worker::feed_publisher(pbnavitia::Response& response){
 void Worker::init_worker_data(const boost::shared_ptr<const navitia::type::Data> data){
     //@TODO should be done in data_manager
     if(data->data_identifier != this->last_data_identifier || !planner){
-        planner = std::unique_ptr<routing::RAPTOR>(new routing::RAPTOR(*data));
+        planner = std::unique_ptr<routing::RAPTOR>(new routing::RAPTOR(*data, conf.raptor_cache_size()));
         street_network_worker = std::unique_ptr<georef::StreetNetwork>(new georef::StreetNetwork(*data->geo_ref));
         this->last_data_identifier = data->data_identifier;
 

--- a/source/routing/CMakeLists.txt
+++ b/source/routing/CMakeLists.txt
@@ -4,7 +4,7 @@ SET(BOOST_LIBS
 
 SET(ROUTING_SRC
   routing.cpp raptor_solution_reader.cpp raptor.cpp raptor_api.cpp
-  next_stop_time.cpp dataraptor.cpp journey_pattern_container.cpp)
+  next_stop_time.cpp dataraptor.cpp journey_pattern_container.cpp get_stop_times.cpp)
 
 add_library(routing ${ROUTING_SRC})
 target_link_libraries(routing types fare georef utils autocomplete ${BOOST_LIBS})

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -181,7 +181,7 @@ int main(int argc, char** argv){
     // Calculs des itinéraires
     std::vector<Result> results;
     data.build_raptor();
-    RAPTOR router(data);
+    RAPTOR router(data, 10);
 
     std::cout << "On lance le benchmark de l'algo " << std::endl;
     boost::progress_display show_progress(demands.size());

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -244,7 +244,7 @@ int main(int argc, char** argv){
     // Calculs des itinéraires
     std::vector<Result> results;
     data.build_raptor();
-    RAPTOR router(data);
+    RAPTOR router(data, 10);
     auto georef_worker = georef::StreetNetwork(*data.geo_ref);
 
     std::cout << "On lance le benchmark de l'algo " << std::endl;

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -125,7 +125,7 @@ static type::EntryPoint make_entry_point(const std::string& entry_id, const type
     try {
         type::idx_t idx = boost::lexical_cast<type::idx_t>(entry_id);
 
-        //if it is a idx, we consider it to be a stop area idx
+        //if it iCached s a idx, we consider it to be a stop area idx
         entry = type::EntryPoint(type::Type_e::StopArea, data.pt_data->stop_areas.at(idx)->uri, 0);
     } catch (boost::bad_lexical_cast) {
         // else we use the same way to identify an entry point as the api
@@ -290,7 +290,7 @@ int main(int argc, char** argv){
               georef_worker,
               type::RTLevel::Base,
               2_min,
-              departure_datetime + DateTimeUtils::SECONDS_PER_DAY,
+              DateTimeUtils::SECONDS_PER_DAY,
               10,
               false,
               nb_second_pass);

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -263,7 +263,8 @@ int main(int argc, char** argv){
             std::cout << demand.start
                       << ", " << demand.start
                       << ", " << demand.target
-                      << ", " << demand.target
+                      << ", " << static_cast<int>(demand.start_mode)
+                      << ", " << static_cast<int>(demand.target_mode)
                       << ", " << date
                       << ", " << demand.hour
                       << "\n";

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -125,7 +125,7 @@ static type::EntryPoint make_entry_point(const std::string& entry_id, const type
     try {
         type::idx_t idx = boost::lexical_cast<type::idx_t>(entry_id);
 
-        //if it iCached s a idx, we consider it to be a stop area idx
+        //if it is a cached idx, we consider it to be a stop area idx
         entry = type::EntryPoint(type::Type_e::StopArea, data.pt_data->stop_areas.at(idx)->uri, 0);
     } catch (boost::bad_lexical_cast) {
         // else we use the same way to identify an entry point as the api

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -281,14 +281,15 @@ int main(int argc, char** argv){
         destination.streetnetwork_params.max_duration = navitia::seconds(30*60);
         destination.streetnetwork_params.speed_factor = 1;
         type::AccessibiliteParams accessibilite_params;
+        const auto departure_datetime = DateTimeUtils::set(date.days(), demand.hour);
         auto resp = make_response(router, origin, destination,
-              {DateTimeUtils::set(date.days(), demand.hour)}, true,
+              {departure_datetime}, true,
               accessibilite_params,
               {},
               georef_worker,
               type::RTLevel::Base,
               2_min,
-              std::numeric_limits<int>::max(),
+              departure_datetime + DateTimeUtils::SECONDS_PER_DAY,
               10,
               false,
               nb_second_pass);

--- a/source/routing/get_stop_times.cpp
+++ b/source/routing/get_stop_times.cpp
@@ -34,7 +34,7 @@ www.navitia.io
 #include "type/pb_converter.h"
 #include <functional>
 
-namespace navitia { namespace timetables {
+namespace navitia { namespace routing {
 
 std::vector<datetime_stop_time> get_stop_times(const routing::StopEvent stop_event,
                                                const std::vector<routing::JppIdx>& journey_pattern_points,

--- a/source/routing/get_stop_times.h
+++ b/source/routing/get_stop_times.h
@@ -35,7 +35,7 @@ www.navitia.io
 #include <queue>
 
 
-namespace navitia { namespace timetables {
+namespace navitia { namespace routing {
 typedef std::pair<DateTime, const type::StopTime*> datetime_stop_time;
 
 /**

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -1,32 +1,32 @@
 /* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
 twitter @navitia 
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
-*/
+ */
 
 #include "next_stop_time.h"
 
@@ -55,8 +55,8 @@ bool NextStopTimeData::Arrival::is_valid(const type::StopTime& st) const {
 
 template<typename Getter>
 void NextStopTimeData::TimesStopTimes<Getter>::init(const JourneyPattern& jp,
-                                                    const JourneyPatternPoint& jpp)
-{
+        const JourneyPatternPoint& jpp)
+        {
     // collect the stop times at the given jpp
     const size_t jpp_order = jpp.order;
     stop_times.reserve(jp.discrete_vjs.size());
@@ -68,16 +68,16 @@ void NextStopTimeData::TimesStopTimes<Getter>::init(const JourneyPattern& jp,
 
     // sort the stop times in ascending order
     boost::sort(stop_times, [&](const type::StopTime* st1, const type::StopTime* st2) {
-            const auto time1 = DateTimeUtils::hour(getter.get_time(*st1));
-            const auto time2 = DateTimeUtils::hour(getter.get_time(*st2));
-            if (time1 != time2) { return time1 < time2; }
-            const auto& st1_first = st1->vehicle_journey->stop_time_list.front();
-            const auto& st2_first = st2->vehicle_journey->stop_time_list.front();
-            if (getter.get_time(st1_first) != getter.get_time(st2_first)) {
-                return getter.get_time(st1_first) < getter.get_time(st2_first);
-            }
-            return st1_first.vehicle_journey->idx < st2_first.vehicle_journey->idx;
-        });
+        const auto time1 = DateTimeUtils::hour(getter.get_time(*st1));
+        const auto time2 = DateTimeUtils::hour(getter.get_time(*st2));
+        if (time1 != time2) { return time1 < time2; }
+        const auto& st1_first = st1->vehicle_journey->stop_time_list.front();
+        const auto& st2_first = st2->vehicle_journey->stop_time_list.front();
+        if (getter.get_time(st1_first) != getter.get_time(st2_first)) {
+            return getter.get_time(st1_first) < getter.get_time(st2_first);
+        }
+        return st1_first.vehicle_journey->idx < st2_first.vehicle_journey->idx;
+    });
 
     // collect the corresponding times
     times.reserve(stop_times.size());
@@ -101,13 +101,13 @@ void NextStopTimeData::load(const JourneyPatternContainer& jp_container) {
 
 inline static bool
 is_valid(const type::StopTime* st,
-         const DateTime date,
-         const bool clockwise,
-         const type::RTLevel rt_level,
-         const type::VehicleProperties& vehicle_props)
+        const DateTime date,
+        const bool clockwise,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties& vehicle_props)
 {
     return st->is_valid_day(date, !clockwise, rt_level) &&
-        st->vehicle_journey->accessible(vehicle_props);
+            st->vehicle_journey->accessible(vehicle_props);
 }
 
 /** Which is the first valid stop_time in this range ?
@@ -115,12 +115,12 @@ is_valid(const type::StopTime* st,
  */
 static std::pair<const type::StopTime*, DateTime>
 next_valid_discrete(const StopEvent stop_event,
-                    const dataRAPTOR& dataRaptor,
-                    const JppIdx jpp_idx,
-                    const DateTime dt,
-                    const type::RTLevel rt_level,
-                    const type::VehicleProperties& vehicle_props,
-                    const DateTime bound) {
+        const dataRAPTOR& dataRaptor,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties& vehicle_props,
+        const DateTime bound) {
     auto date = DateTimeUtils::date(dt);
     for (const auto* st: dataRaptor.next_stop_time_data.stop_time_range_after(jpp_idx, dt, stop_event)) {
         assert(dataRaptor.jp_container.get_jpp(*st) == jpp_idx);
@@ -150,11 +150,11 @@ next_valid_discrete(const StopEvent stop_event,
 
 static std::pair<const type::StopTime*, DateTime>
 next_valid_frequency(const StopEvent stop_event,
-                     const dataRAPTOR& dataRaptor,
-                     const JppIdx jpp_idx,
-                     const DateTime dt,
-                     const type::RTLevel rt_level,
-                     const type::VehicleProperties &vehicle_props) {
+        const dataRAPTOR& dataRaptor,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties &vehicle_props) {
     // to find the next frequency VJ, for the moment we loop through all frequency VJ of the JP
     // and for each jp, get compute the datetime on the jpp
     const auto& jpp = dataRaptor.jp_container.get(jpp_idx);
@@ -195,11 +195,11 @@ next_valid_frequency(const StopEvent stop_event,
 
 static std::pair<const type::StopTime*, DateTime>
 previous_valid_frequency(const StopEvent stop_event,
-                         const dataRAPTOR& dataRaptor,
-                         const JppIdx jpp_idx,
-                         const DateTime dt,
-                         const type::RTLevel rt_level,
-                         const type::VehicleProperties &vehicle_props) {
+        const dataRAPTOR& dataRaptor,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties &vehicle_props) {
     const auto& jpp = dataRaptor.jp_container.get(jpp_idx);
     const auto& jp = dataRaptor.jp_container.get(jpp.jp_idx);
     std::pair<const type::StopTime*, DateTime> best = {nullptr, DateTimeUtils::not_valid};
@@ -234,7 +234,7 @@ previous_valid_frequency(const StopEvent stop_event,
             if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
             const auto previous_dt = get_previous_stop_time(stop_event, previous_date, *freq_vj,
-                                                            st, rt_level);
+                    st, rt_level);
 
             if (previous_dt == DateTimeUtils::not_valid) {
                 continue;
@@ -249,12 +249,12 @@ previous_valid_frequency(const StopEvent stop_event,
 
 static std::pair<const type::StopTime*, DateTime>
 previous_valid_discrete(const StopEvent stop_event,
-                        const dataRAPTOR& dataRaptor,
-                        const JppIdx jpp_idx,
-                        const DateTime dt,
-                        const type::RTLevel rt_level,
-                        const type::VehicleProperties& vehicle_props,
-                        const DateTime bound) {
+        const dataRAPTOR& dataRaptor,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties& vehicle_props,
+        const DateTime bound) {
     auto date = DateTimeUtils::date(dt);
     for (const auto* st: dataRaptor.next_stop_time_data.stop_time_range_before(jpp_idx, dt, stop_event)) {
         assert(dataRaptor.jp_container.get_jpp(*st) == jpp_idx);
@@ -286,19 +286,19 @@ previous_valid_discrete(const StopEvent stop_event,
 
 std::pair<const type::StopTime*, DateTime>
 NextStopTime::earliest_stop_time(const StopEvent stop_event,
-                                 const JppIdx jpp_idx,
-                                 const DateTime dt,
-                                 const type::RTLevel rt_level,
-                                 const type::VehicleProperties& vehicle_props,
-                                 const bool check_freq,
-                                 const DateTime bound) const
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties& vehicle_props,
+        const bool check_freq,
+        const DateTime bound) const
 {
     const auto first_discrete_st_pair =
-        next_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
+            next_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
 
     if (check_freq) {
         const auto first_frequency_st_pair =
-            next_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props);
+                next_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props);
 
         if (first_frequency_st_pair.second < first_discrete_st_pair.second) {
             return first_frequency_st_pair;
@@ -310,19 +310,19 @@ NextStopTime::earliest_stop_time(const StopEvent stop_event,
 
 std::pair<const type::StopTime*, DateTime>
 NextStopTime::tardiest_stop_time(const StopEvent stop_event,
-                                 const JppIdx jpp_idx,
-                                 const DateTime dt,
-                                 const type::RTLevel rt_level,
-                                 const type::VehicleProperties& vehicle_props,
-                                 const bool check_freq,
-                                 const DateTime bound) const
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties& vehicle_props,
+        const bool check_freq,
+        const DateTime bound) const
 {
     const auto first_discrete_st_pair =
-        previous_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
+            previous_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
 
     if (check_freq) {
         const auto first_frequency_st_pair =
-            previous_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props);
+                previous_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props);
 
         // since the default value is DateTimeUtils::not_valid (== DateTimeUtils::max)
         // we need to check first that they are
@@ -341,174 +341,103 @@ NextStopTime::tardiest_stop_time(const StopEvent stop_event,
     return first_discrete_st_pair;
 }
 
+
+template<typename F>
+static void vj_loop(const nt::DiscreteVehicleJourney*, F f) {
+    // Discrete Vehicle Journey doesn't need to loop
+    f(0);
+}
+
+template<typename F>
+static void vj_loop(const nt::FrequencyVehicleJourney* vj, F f) {
+    for (auto freq_shift = vj->start_time; freq_shift <= vj->end_time; freq_shift+= vj->headway_secs) {
+        f(freq_shift);
+    }
+}
+
+using DtSt = std::pair<DateTime, const type::StopTime*>;
+template<typename VJ_T>
+static void fill_cache(const DateTime from,
+        const DateTime to,
+        const type::RTLevel rt_level,
+        const type::AccessibiliteParams& accessibilite_params,
+        const JourneyPattern& jp,
+        const std::vector<const VJ_T*>& vjs,
+        IdxMap<JourneyPatternPoint, std::vector<DtSt>>& arrival,
+        IdxMap<JourneyPatternPoint, std::vector<DtSt>>& departure){
+
+    const int to_int = static_cast<int>(DateTimeUtils::date(to));
+    int from_int = static_cast<int>(DateTimeUtils::date(from)) - 1;
+    from_int = from_int > 0 ? from_int : 0;
+
+    for (const auto* vj :  vjs) {
+        if (! vj->accessible(accessibilite_params.vehicle_properties)) {
+            continue;
+        }
+        // test validity pattern of vj
+        const auto* vp = vj->validity_patterns[rt_level];
+        for (int day = from_int; day <=  to_int ; ++day) {
+            if (! vp->check(day)) {
+                continue;
+            }
+            const auto shift = navitia::DateTimeUtils::SECONDS_PER_DAY * day;
+            size_t i= 0;
+            for (const auto& st : vj->stop_time_list) {
+                auto jpp_idx = jp.jpps[i];
+                auto loop_impl = [&](DateTime freq_shift){
+                    if (st.drop_off_allowed()) {
+                        auto arrival_time = st.arrival_time + shift + freq_shift;
+                        if (from <= arrival_time && arrival_time <= to) {
+                            arrival[jpp_idx].emplace_back(arrival_time,&st);
+                        }
+                    }
+                    if (st.pick_up_allowed()) {
+                        auto departure_time = st.departure_time + shift + freq_shift;
+                        if (departure_time <= to && from <= departure_time ) {
+                            departure[jpp_idx].emplace_back(departure_time,&st);
+                        }
+                    }
+                };
+                // loop is done differently according to the type of Vehicle Journey
+                vj_loop(vj, loop_impl);
+                ++i;
+            }
+        }
+    }
+}
+
 void CachedNextStopTime::load(const type::Data& data,
-                              //const boost::dynamic_bitset<>& valid_jpps,
-                              const DateTime from,
-                              const DateTime to,
-                              const type::RTLevel rt_level,
-                              const type::AccessibiliteParams& accessibilite_params) {
+        const DateTime from,
+        const DateTime to,
+        const type::RTLevel rt_level,
+        const type::AccessibiliteParams& accessibilite_params) {
     const auto& jp_container = data.dataRaptor->jp_container;
+
     departure.assign(jp_container.get_jpps_values());
     arrival.assign(jp_container.get_jpps_values());
 
-    std::cout << str(from) << std::endl;
-    std::cout << str(to)<< std::endl;
-
-    namespace bpt =  boost::posix_time;
-    namespace bg  = boost::gregorian;
-
-    const auto from_ptime = to_posix_time(from, data);
-    const auto to_ptime = to_posix_time(to + 1, data); //
-    const auto from_to_period = bpt::time_period{from_ptime, to_ptime};
-
     for( const auto& jp : jp_container.get_jps_values() ) {
-         for (const auto* vj :  jp.discrete_vjs) {
-             std::cout << vj->uri << std::endl;
-
-             // test accessibility
-             if (! vj->accessible(accessibilite_params.vehicle_properties)) {
-                 continue;
-             }
-             // test validity pattern of vj
-             const auto& vp = vj->validity_patterns[rt_level];
-             int day = static_cast<int>(DateTimeUtils::date(from)) - 1;
-             day = day > 0 ? day : 0;
-             for (;day <= static_cast<int>(DateTimeUtils::date(to)) ; ++day) {
-
-                 std::cout << day << std::endl;
-
-                 std::cout << vp->days.to_string()<< std::endl;
-                 if (vp->check(day)) {
-                     for (const auto& st : vj->stop_time_list) {
-
-                         if (st.drop_off_allowed()) {
-                             std::cout << "drop_off_allowed" << std::endl;
-
-                             auto arrival_time_ptime = bpt::ptime{data.meta->production_date.begin()}
-                             + bpt::seconds(st.arrival_time + navitia::DateTimeUtils::SECONDS_PER_DAY * day);
-                             std::cout << st.stop_point->uri << std::endl;
-                             std::cout << str(to_datetime(arrival_time_ptime, data)) << std::endl;
-
-                             if (from_to_period.contains(arrival_time_ptime)) {
-                                 auto jpp_idx = jp.jpps[st.order()];
-                                 std::cout << "adding arrival_time" << std::endl;
-
-                                 arrival[jpp_idx].push_back(
-                                         {to_datetime(arrival_time_ptime, data),
-                                         &st});
-                             }
-                         }
-
-                         if (st.pick_up_allowed()) {
-                             std::cout << "pick up allowed" << std::endl;
-
-                             auto departure_time_ptime = bpt::ptime{data.meta->production_date.begin()}
-                             + bpt::seconds(st.departure_time + navitia::DateTimeUtils::SECONDS_PER_DAY * day);
-                             std::cout << st.stop_point->uri << std::endl;
-                             std::cout << str(to_datetime(departure_time_ptime, data)) << std::endl;
-                             if (from_to_period.contains(departure_time_ptime)) {
-                                 auto jpp_idx = jp.jpps[st.order()];
-                                 std::cout << "adding departure_time" << std::endl;
-
-                                 departure[jpp_idx].push_back(
-                                         {to_datetime(departure_time_ptime, data),
-                                         &st});
-                             }
-                         }
-
-                     }
-                 }
-             }
-         }
-         for (const auto* vj :  jp.freq_vjs) {
-             std::cout << vj->uri << std::endl;
-
-             // test validity pattern of vj
-             const auto& vp = vj->validity_patterns[rt_level];
-             int day = static_cast<int>(DateTimeUtils::date(from)) - 1;
-             day = day > 0 ? day : 0;
-             for (;day <= static_cast<int>(DateTimeUtils::date(to)) ; ++day) {
-
-                 std::cout << day << std::endl;
-
-                 std::cout << vp->days.to_string()<< std::endl;
-                 if (vp->check(day)) {
-
-                     for (const auto& st : vj->stop_time_list) {
-                         for (DateTime shift = vj->start_time;
-                                 shift <= vj->end_time; shift+= vj->headway_secs) {
-
-                             if (st.drop_off_allowed()) {
-                                 auto arrival_time_ptime = bpt::ptime{data.meta->production_date.begin()}
-                                 + bpt::seconds(st.arrival_time + shift + navitia::DateTimeUtils::SECONDS_PER_DAY * day);
-
-                                 std::cout << st.stop_point->uri << std::endl;
-                                 std::cout << str(to_datetime(arrival_time_ptime, data)) << std::endl;
-
-                                 if (from_to_period.contains(arrival_time_ptime)) {
-                                     auto jpp_idx = jp.jpps[st.order()];
-                                     std::cout << "adding arrival_time" << std::endl;
-
-                                     arrival[jpp_idx].push_back(
-                                             {to_datetime(arrival_time_ptime, data),
-                                             &st});
-                                 }
-                             }
-                             if (st.pick_up_allowed()) {
-                                 auto departure_time_ptime = bpt::ptime{data.meta->production_date.begin()}
-                                 + bpt::seconds(st.departure_time + shift + navitia::DateTimeUtils::SECONDS_PER_DAY * day);
-                                 std::cout << st.stop_point->uri << std::endl;
-                                 std::cout << str(to_datetime(departure_time_ptime, data)) << std::endl;
-                                 if (from_to_period.contains(departure_time_ptime)) {
-                                     auto jpp_idx = jp.jpps[st.order()];
-                                     std::cout << "adding departure_time" << std::endl;
-                                     departure[jpp_idx].push_back(
-                                             {to_datetime(departure_time_ptime, data),
-                                             &st});
-                                 }
-                             }
-                         }
-                     }
-                 }
-             }
-         }
-         auto compare = [](const DtSt& lhs, const DtSt& rhs){
-             return lhs.first < rhs.first;
-         };
-         for (const auto& jpp_dtst : arrival) {
-             boost::sort(jpp_dtst.second, compare);
-         }
-         for (const auto& jpp_dtst : departure) {
-             boost::sort(jpp_dtst.second, compare);
-         }
+        fill_cache(from, to, rt_level, accessibilite_params, jp,
+                jp.discrete_vjs, arrival, departure);
+        fill_cache(from, to, rt_level, accessibilite_params, jp,
+                jp.freq_vjs, arrival, departure);
     }
-
-//    for (auto idx = valid_jpps.find_first(); idx != boost::dynamic_bitset<>::npos; idx = valid_jpps.find_next(idx)) {
-//        const auto jpp_idx = JppIdx(idx);
-//        departure[jpp_idx] = get_stop_times(StopEvent::pick_up,
-//                {jpp_idx},
-//                from,
-//                to,
-//                std::numeric_limits<size_t>::max(),
-//                data,
-//                rt_level,
-//                accessibilite_params);
-//        arrival[jpp_idx] = get_stop_times(StopEvent::drop_off,
-//                {jpp_idx},
-//                from,
-//                to,
-//                std::numeric_limits<size_t>::max(),
-//                data,
-//                rt_level,
-//                accessibilite_params);
-//    }
+    auto compare = [](const DtSt& lhs, const DtSt& rhs) noexcept{
+        return lhs.first < rhs.first;
+    };
+    for (const auto& jpp_dtst : arrival) {
+        boost::sort(jpp_dtst.second, compare);
+    }
+    for (const auto& jpp_dtst : departure) {
+        boost::sort(jpp_dtst.second, compare);
+    }
 }
 
 std::pair<const type::StopTime*, DateTime>
 CachedNextStopTime::next_stop_time(const StopEvent stop_event,
-                                   const JppIdx jpp_idx,
-                                   const DateTime dt,
-                                   const bool clockwise) const {
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const bool clockwise) const {
     const auto& v = stop_event == StopEvent::pick_up ? departure[jpp_idx] : arrival[jpp_idx];
     const type::StopTime* null_st = nullptr;
     decltype(v.begin()) search;
@@ -561,10 +490,10 @@ inline static bool within(u_int32_t val, std::pair<u_int32_t, u_int32_t> bound) 
 * Note: If hour in [0, end] we have to check the previous day's validity pattern
 **/
 DateTime get_next_stop_time(const StopEvent stop_event,
-                            DateTime dt,
-                            const type::FrequencyVehicleJourney& freq_vj,
-                            const type::StopTime& st,
-                            const type::RTLevel rt_level) {
+        DateTime dt,
+        const type::FrequencyVehicleJourney& freq_vj,
+        const type::StopTime& st,
+        const type::RTLevel rt_level) {
     const u_int32_t considered_time = (stop_event == StopEvent::pick_up) ? st.departure_time : st.arrival_time;
     const u_int32_t lower_bound = DateTimeUtils::hour(freq_vj.start_time + considered_time);
     const u_int32_t upper_bound = DateTimeUtils::hour(freq_vj.end_time + considered_time);
@@ -596,9 +525,9 @@ DateTime get_next_stop_time(const StopEvent stop_event,
             return DateTimeUtils::inf;
         }
 
-         double diff = hour - lower_bound;
-         const uint32_t x = std::ceil(diff / double(freq_vj.headway_secs));
-         return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
+        double diff = hour - lower_bound;
+        const uint32_t x = std::ceil(diff / double(freq_vj.headway_secs));
+        return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
     }
 
     // overnight case and hour > midnight
@@ -621,12 +550,12 @@ DateTime get_next_stop_time(const StopEvent stop_event,
 }
 
 DateTime get_previous_stop_time(const StopEvent stop_event,
-                                DateTime dt,
-                                const type::FrequencyVehicleJourney& freq_vj,
-                                const type::StopTime& st,
-                                const type::RTLevel rt_level) {
+        DateTime dt,
+        const type::FrequencyVehicleJourney& freq_vj,
+        const type::StopTime& st,
+        const type::RTLevel rt_level) {
     const u_int32_t considered_time = (stop_event == StopEvent::pick_up) ?
-                                      st.departure_time : st.arrival_time;
+            st.departure_time : st.arrival_time;
     const u_int32_t lower_bound = DateTimeUtils::hour(freq_vj.start_time + considered_time);
     const u_int32_t upper_bound = DateTimeUtils::hour(freq_vj.end_time + considered_time);
 
@@ -657,9 +586,9 @@ DateTime get_previous_stop_time(const StopEvent stop_event,
             return DateTimeUtils::not_valid;
         }
 
-         double diff = hour - lower_bound;
-         const uint32_t x = std::floor(diff / double(freq_vj.headway_secs));
-         return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
+        double diff = hour - lower_bound;
+        const uint32_t x = std::floor(diff / double(freq_vj.headway_secs));
+        return DateTimeUtils::set(date, lower_bound + x * freq_vj.headway_secs);
     }
 
     // overnight case and hour > midnight

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -429,7 +429,7 @@ CachedNextStopTime CachedNextStopTimeManager::CacheCreator::operator()(const Cac
     result.departure.assign(jp_container.get_jpps_values());
     result.arrival.assign(jp_container.get_jpps_values());
     DateTime dt_from = DateTimeUtils::set(key.from, 0);
-    DateTime dt_to = DateTimeUtils::set(key.from + 2, 0);
+    DateTime dt_to = DateTimeUtils::set(key.from + 2, 0); //cache window is 2-days wide (journeys : 24h max)
 
     for( const auto& jp : jp_container.get_jps_values() ) {
         fill_cache(dt_from, dt_to, key.rt_level, key.accessibilite_params, jp,

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -160,9 +160,9 @@ next_valid_frequency(const StopEvent stop_event,
     for (const auto& freq_vj: jp.freq_vjs) {
         const auto& st = freq_vj->stop_time_list[jpp.order];
 
-        if (! st.valid_begin(true) || ! freq_vj->accessible(vehicle_props)) {
-            continue;
-        }
+        if (! freq_vj->accessible(vehicle_props)) { continue; }
+        if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
+        if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
         const auto next_dt = get_next_stop_time(stop_event, dt, *freq_vj, st, rt_level);
 
@@ -176,9 +176,9 @@ next_valid_frequency(const StopEvent stop_event,
         for (const auto& freq_vj: jp.freq_vjs) {
             const auto& st = freq_vj->stop_time_list[jpp.order];
 
-            if (! st.valid_begin(true) || ! freq_vj->accessible(vehicle_props)) {
-                continue;
-            }
+            if (! freq_vj->accessible(vehicle_props)) { continue; }
+            if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
+            if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
             const auto next_dt = get_next_stop_time(stop_event, next_date, *freq_vj, st, rt_level);
 
@@ -203,9 +203,9 @@ previous_valid_frequency(const StopEvent stop_event,
     for (const auto& freq_vj: jp.freq_vjs) {
         const auto& st = freq_vj->stop_time_list[jpp.order];
 
-        if (! st.valid_begin(false) || ! freq_vj->accessible(vehicle_props)) {
-            continue;
-        }
+        if (! freq_vj->accessible(vehicle_props)) { continue; }
+        if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
+        if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
         const auto previous_dt = get_previous_stop_time(stop_event, dt, *freq_vj, st, rt_level);
 
@@ -226,9 +226,9 @@ previous_valid_frequency(const StopEvent stop_event,
         for (const auto& freq_vj: jp.freq_vjs) {
             const auto& st = freq_vj->stop_time_list[jpp.order];
 
-            if (! st.valid_begin(false) || ! freq_vj->accessible(vehicle_props)) {
-                continue;
-            }
+            if (! freq_vj->accessible(vehicle_props)) { continue; }
+            if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
+            if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
             const auto previous_dt = get_previous_stop_time(stop_event, previous_date, *freq_vj,
                                                             st, rt_level);

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -364,10 +364,7 @@ static void vj_loop(const nt::FrequencyVehicleJourney* vj, F f, nt::RTLevel rt_l
     // end_time may be smaller than start_time because of the UTC conversion
     if (vj->start_time > vj->end_time ) {
         // In this case, the vj passes midnight, it begins actually on yesterday
-        if (! vj->is_valid(start_date - 1, rt_level)) {
-            return;
-        }
-        start_time -= DateTimeUtils::SECONDS_PER_DAY;
+        end_time += DateTimeUtils::SECONDS_PER_DAY;
     }
     for (auto freq_shift = start_time; freq_shift <= end_time; freq_shift+= vj->headway_secs) {
         f(freq_shift);

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -31,7 +31,6 @@ www.navitia.io
 #include "next_stop_time.h"
 
 #include "dataraptor.h"
-#include "get_stop_times.h"
 #include "type/data.h"
 #include "type/pt_data.h"
 #include "type/meta_data.h"
@@ -351,20 +350,19 @@ NextStopTime::tardiest_stop_time(const StopEvent stop_event,
  *
  * */
 template<typename F>
-static void vj_loop(const nt::DiscreteVehicleJourney*, F f, nt::RTLevel) {
+static void vj_loop(const nt::DiscreteVehicleJourney*, F f) {
     f(0);
 }
 
 template<typename F>
-static void vj_loop(const nt::FrequencyVehicleJourney* vj, F f, nt::RTLevel rt_level) {
+static void vj_loop(const nt::FrequencyVehicleJourney* vj, F f) {
     int start_time = vj->start_time;
     int end_time = vj->end_time;
     // start date is relative to the production begin date
-    auto start_date = DateTimeUtils::date(start_time);
     // end_time may be smaller than start_time because of the UTC conversion
     if (vj->start_time > vj->end_time ) {
-        // In this case, the vj passes midnight, it begins actually on yesterday
-        end_time += DateTimeUtils::SECONDS_PER_DAY;
+        // In this case, the vj passes midnight
+        end_time += static_cast<int>(DateTimeUtils::SECONDS_PER_DAY);
     }
     for (auto freq_shift = start_time; freq_shift <= end_time; freq_shift+= vj->headway_secs) {
         f(freq_shift);
@@ -415,7 +413,7 @@ static void fill_cache(const DateTime from,
                     }
                 };
                 // loop is done differently according to the type of Vehicle Journey
-                vj_loop(vj, loop_impl, rt_level);
+                vj_loop(vj, loop_impl);
                 ++i;
             }
         }

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -367,7 +367,7 @@ static void vj_loop(const nt::FrequencyVehicleJourney* vj, F f, nt::RTLevel rt_l
         if (! vj->is_valid(start_date - 1, rt_level)) {
             return;
         }
-        start_time -= 86400;
+        start_time -= DateTimeUtils::SECONDS_PER_DAY;
     }
     for (auto freq_shift = start_time; freq_shift <= end_time; freq_shift+= vj->headway_secs) {
         f(freq_shift);

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -201,7 +201,6 @@ struct CachedNextStopTime {
     explicit CachedNextStopTime() {}
 
     void load(const type::Data& d,
-              //const boost::dynamic_bitset<>& valid_jpps,
               const DateTime from,
               const DateTime to,
               const type::RTLevel rt_level,

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -38,6 +38,7 @@ www.navitia.io
 #include <boost/range/algorithm/lower_bound.hpp>
 #include <boost/range/algorithm/upper_bound.hpp>
 #include <boost/optional.hpp>
+#include <boost/dynamic_bitset.hpp>
 
 namespace navitia {
 
@@ -200,6 +201,7 @@ struct CachedNextStopTime {
     explicit CachedNextStopTime() {}
 
     void load(const type::Data& d,
+              const boost::dynamic_bitset<>& valid_jpps,
               const DateTime from,
               const DateTime to,
               const type::RTLevel rt_level,

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -216,6 +216,15 @@ struct CachedNextStopTime {
     using DtSt = std::pair<DateTime, const type::StopTime*>;
     IdxMap<JourneyPatternPoint, std::vector<DtSt>> departure;
     IdxMap<JourneyPatternPoint, std::vector<DtSt>> arrival;
+
+    // Returns the next stop time at given journey pattern point
+    // either a vehicle that leaves or that arrives depending on
+    // clockwise.
+    std::pair<const type::StopTime*, DateTime>
+    next_stop_time(const StopEvent stop_event,
+                   const JppIdx jpp_idx,
+                   const DateTime dt,
+                   const bool clockwise) const;
 };
 
 struct CachedNextStopTimeManager {
@@ -238,7 +247,6 @@ private:
     };
 
     Lru<CacheCreator> lru;
-    const CachedNextStopTime* cache;
 };
 
 DateTime get_next_stop_time(const StopEvent stop_event,

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -46,6 +46,7 @@ struct PT_Data;
 class Data;
 struct FrequencyVehicleJourney;
 typedef std::bitset<8> VehicleProperties;
+struct AccessibiliteParams;
 }
 
 namespace routing {
@@ -193,6 +194,30 @@ struct NextStopTime {
 
 private:
     const type::Data& data;
+};
+
+struct CachedNextStopTime {
+    explicit CachedNextStopTime() {}
+
+    void load(const type::Data& d,
+              const DateTime from,
+              const DateTime to,
+              const type::RTLevel rt_level,
+              const type::AccessibiliteParams& accessibilite_params);
+
+    // Returns the next stop time at given journey pattern point
+    // either a vehicle that leaves or that arrives depending on
+    // clockwise.
+    std::pair<const type::StopTime*, DateTime>
+    next_stop_time(const StopEvent stop_event,
+                   const JppIdx jpp_idx,
+                   const DateTime dt,
+                   const bool clockwise) const;
+
+private:
+    using DtSt = std::pair<DateTime, const type::StopTime*>;
+    IdxMap<JourneyPatternPoint, std::vector<DtSt>> departure;
+    IdxMap<JourneyPatternPoint, std::vector<DtSt>> arrival;
 };
 
 DateTime get_next_stop_time(const StopEvent stop_event,

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -201,7 +201,7 @@ struct CachedNextStopTime {
     explicit CachedNextStopTime() {}
 
     void load(const type::Data& d,
-              const boost::dynamic_bitset<>& valid_jpps,
+              //const boost::dynamic_bitset<>& valid_jpps,
               const DateTime from,
               const DateTime to,
               const type::RTLevel rt_level,

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -228,11 +228,12 @@ struct CachedNextStopTime {
 };
 
 struct CachedNextStopTimeManager {
-    explicit CachedNextStopTimeManager(const type::Data& d, size_t max_cache = 10) :
-            lru({d}, max_cache) {}
+    explicit CachedNextStopTimeManager(const type::Data& data, size_t max_cache) :
+            lru({data}, max_cache) {}
 
     ~CachedNextStopTimeManager();
 
+    // WARNING: returned pointer is invalidated by next load() call
     const CachedNextStopTime* load(const DateTime from,
                                    const type::RTLevel rt_level,
                                    const type::AccessibiliteParams& accessibilite_params);

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -194,7 +194,7 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
             forbidden_uri,
             rt_level);
 
-    current_cache = cached_next_st_manager.load(clockwise ? departure_datetime : bound,
+    next_st = cached_next_st_manager.load(clockwise ? departure_datetime : bound,
                                         rt_level,
                                         accessibilite_params);
 
@@ -496,7 +496,7 @@ RAPTOR::isochrone(const map_stop_point_duration& departures,
                                                  accessibilite_params,
                                                  forbidden,
                                                  rt_level);
-    current_cache = cached_next_st_manager.load(clockwise ? departure_datetime : bound,
+    next_st = cached_next_st_manager.load(clockwise ? departure_datetime : bound,
                                         rt_level,
                                         accessibilite_params);
 
@@ -682,7 +682,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
                     const DateTime previous_dt = prec_labels.dt_transfer(jpp.sp_idx);
                     if (prec_labels.transfer_is_initialized(jpp.sp_idx) &&
                         (!is_onboard || visitor.better_or_equal(previous_dt, workingDt, *it_st))) {
-                        const auto tmp_st_dt = current_cache->next_stop_time(
+                        const auto tmp_st_dt = next_st->next_stop_time(
                             visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise());
 
                         if (tmp_st_dt.first != nullptr) {

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -178,6 +178,34 @@ void RAPTOR::init(const map_stop_point_duration& dep,
     }
 }
 
+std::pair<const type::StopTime*, DateTime>
+RAPTOR::next_stop_time(const StopEvent stop_event,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const bool clockwise) const {
+    const auto& v = (stop_event == StopEvent::pick_up ? current_cache->departure[jpp_idx]
+                                                      : current_cache->arrival[jpp_idx]);
+    const type::StopTime* null_st = nullptr;
+    decltype(v.begin()) search;
+    auto cmp = [](const CachedNextStopTime::DtSt& a, const CachedNextStopTime::DtSt& b) noexcept {
+        return a.first < b.first;
+    };
+    if (clockwise) {
+        search = boost::lower_bound(v, std::make_pair(dt, null_st), cmp);
+    } else {
+        search = boost::upper_bound(v, std::make_pair(dt, null_st), cmp);
+        if (search == v.begin()) {
+            search = v.end();
+        } else if (!v.empty()) {
+            --search;
+        }
+    }
+    if (search != v.end()) {
+        return {search->second, search->first};
+    }
+    return {nullptr, 0};
+}
+
 void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
                                const DateTime& departure_datetime,
                                const nt::RTLevel rt_level,
@@ -194,9 +222,9 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
             forbidden_uri,
             rt_level);
 
-    cached_next_st.load(clockwise ? departure_datetime : bound,
-                        rt_level,
-                        accessibilite_params);
+    current_cache = cached_next_st.load(clockwise ? departure_datetime : bound,
+                                        rt_level,
+                                        accessibilite_params);
 
     clear(clockwise, bound);
     init(dep, departure_datetime, clockwise, accessibilite_params.properties);
@@ -496,9 +524,9 @@ RAPTOR::isochrone(const map_stop_point_duration& departures,
                                                  accessibilite_params,
                                                  forbidden,
                                                  rt_level);
-    cached_next_st.load(clockwise ? departure_datetime : bound,
-                        rt_level,
-                        accessibilite_params);
+    current_cache = cached_next_st.load(clockwise ? departure_datetime : bound,
+                                        rt_level,
+                                        accessibilite_params);
 
     clear(clockwise, bound);
     init(departures, departure_datetime, clockwise, accessibilite_params.properties);
@@ -682,7 +710,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
                     const DateTime previous_dt = prec_labels.dt_transfer(jpp.sp_idx);
                     if (prec_labels.transfer_is_initialized(jpp.sp_idx) &&
                         (!is_onboard || visitor.better_or_equal(previous_dt, workingDt, *it_st))) {
-                        const auto tmp_st_dt = cached_next_st.next_stop_time(
+                        const auto tmp_st_dt = next_stop_time(
                             visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise());
 
                         if (tmp_st_dt.first != nullptr) {

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -41,6 +41,15 @@ namespace bt = boost::posix_time;
 
 namespace navitia { namespace routing {
 
+static DateTime limit_bound(const bool clockwise, const DateTime departure_datetime, const DateTime bound) {
+    return clockwise ?
+        std::min(departure_datetime + DateTimeUtils::SECONDS_PER_DAY, bound) :
+        std::max(departure_datetime > DateTimeUtils::SECONDS_PER_DAY ?
+                 departure_datetime - DateTimeUtils::SECONDS_PER_DAY :
+                 0,
+                 bound);
+}
+
 /*
  * Check if the given vj is valid for the given datetime,
  * If it is for every stoptime of the vj,
@@ -172,21 +181,27 @@ void RAPTOR::init(const map_stop_point_duration& dep,
 void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
                                const DateTime& departure_datetime,
                                const nt::RTLevel rt_level,
-                               const DateTime& bound,
+                               const DateTime& b,
                                const uint32_t max_transfers,
                                const type::AccessibiliteParams& accessibilite_params,
                                const std::vector<std::string>& forbidden_uri,
                                bool clockwise) {
 
+    const DateTime bound = limit_bound(clockwise, departure_datetime, b);
     set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
                          accessibilite_params,
                          forbidden_uri,
                          rt_level);
+    next_st.load(data,
+                 clockwise ? departure_datetime : bound,
+                 clockwise ? bound : departure_datetime,
+                 rt_level,
+                 accessibilite_params);
 
     clear(clockwise, bound);
     init(dep, departure_datetime, clockwise, accessibilite_params.properties);
 
-    boucleRAPTOR(accessibilite_params, clockwise, rt_level, max_transfers);
+    boucleRAPTOR(clockwise, rt_level, max_transfers);
 }
 
 namespace {
@@ -434,7 +449,7 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
         best_labels_transfers = best_labels_transfers_for_snd_pass;
         init(init_map, working_labels.dt_pt(start.sp_idx),
              !clockwise, accessibilite_params.properties);
-        boucleRAPTOR(accessibilite_params, !clockwise, rt_level, max_transfers);
+        boucleRAPTOR(!clockwise, rt_level, max_transfers);
         read_solutions(*this,
                        solutions,
                        !clockwise,
@@ -470,20 +485,27 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
 void
 RAPTOR::isochrone(const map_stop_point_duration& departures,
                   const DateTime& departure_datetime,
-                  const DateTime& bound,
+                  const DateTime& b,
                   uint32_t max_transfers,
                   const type::AccessibiliteParams& accessibilite_params,
                   const std::vector<std::string>& forbidden,
                   bool clockwise,
                   const nt::RTLevel rt_level) {
+    const DateTime bound = limit_bound(clockwise, departure_datetime, b);
     set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
                          accessibilite_params,
                          forbidden,
                          rt_level);
+    next_st.load(data,
+                 clockwise ? departure_datetime : bound,
+                 clockwise ? bound : departure_datetime,
+                 rt_level,
+                 accessibilite_params);
+
     clear(clockwise, bound);
     init(departures, departure_datetime, clockwise, accessibilite_params.properties);
 
-    boucleRAPTOR(accessibilite_params, clockwise, rt_level, max_transfers);
+    boucleRAPTOR(clockwise, rt_level, max_transfers);
 }
 
 
@@ -599,7 +621,6 @@ void RAPTOR::set_valid_jp_and_jpp(
 
 template<typename Visitor>
 void RAPTOR::raptor_loop(Visitor visitor,
-                         const type::AccessibiliteParams& accessibilite_params,
                          const nt::RTLevel rt_level,
                          uint32_t max_transfers) {
     bool continue_algorithm = true;
@@ -662,8 +683,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
                     if (prec_labels.transfer_is_initialized(jpp.sp_idx) &&
                         (!is_onboard || visitor.better_or_equal(previous_dt, workingDt, *it_st))) {
                         const auto tmp_st_dt = next_st.next_stop_time(
-                            visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise(),
-                            rt_level, accessibilite_params.vehicle_properties, jpp.has_freq);
+                            visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise());
 
                         if (tmp_st_dt.first != nullptr) {
                             if (! is_onboard || &*it_st != tmp_st_dt.first) {
@@ -714,14 +734,13 @@ void RAPTOR::raptor_loop(Visitor visitor,
 }
 
 
-void RAPTOR::boucleRAPTOR(const type::AccessibiliteParams& accessibilite_params,
-                          bool clockwise,
+void RAPTOR::boucleRAPTOR(bool clockwise,
                           const nt::RTLevel rt_level,
                           uint32_t max_transfers) {
     if(clockwise) {
-        raptor_loop(raptor_visitor(), accessibilite_params, rt_level, max_transfers);
+        raptor_loop(raptor_visitor(), rt_level, max_transfers);
     } else {
-        raptor_loop(raptor_reverse_visitor(), accessibilite_params, rt_level, max_transfers);
+        raptor_loop(raptor_reverse_visitor(), rt_level, max_transfers);
     }
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -188,11 +188,12 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
                                bool clockwise) {
 
     const DateTime bound = limit_bound(clockwise, departure_datetime, b);
-    set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
-                         accessibilite_params,
-                         forbidden_uri,
-                         rt_level);
+    const auto valid_jpps = set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
+                                                 accessibilite_params,
+                                                 forbidden_uri,
+                                                 rt_level);
     next_st.load(data,
+                 valid_jpps,
                  clockwise ? departure_datetime : bound,
                  clockwise ? bound : departure_datetime,
                  rt_level,
@@ -492,11 +493,12 @@ RAPTOR::isochrone(const map_stop_point_duration& departures,
                   bool clockwise,
                   const nt::RTLevel rt_level) {
     const DateTime bound = limit_bound(clockwise, departure_datetime, b);
-    set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
-                         accessibilite_params,
-                         forbidden,
-                         rt_level);
+    const auto valid_jpps = set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
+                                                 accessibilite_params,
+                                                 forbidden,
+                                                 rt_level);
     next_st.load(data,
+                 valid_jpps,
                  clockwise ? departure_datetime : bound,
                  clockwise ? bound : departure_datetime,
                  rt_level,
@@ -508,8 +510,8 @@ RAPTOR::isochrone(const map_stop_point_duration& departures,
     boucleRAPTOR(clockwise, rt_level, max_transfers);
 }
 
-
-void RAPTOR::set_valid_jp_and_jpp(
+// Returns valid_jpps
+boost::dynamic_bitset<> RAPTOR::set_valid_jp_and_jpp(
     uint32_t date,
     const type::AccessibiliteParams& accessibilite_params,
     const std::vector<std::string>& forbidden,
@@ -617,6 +619,8 @@ void RAPTOR::set_valid_jp_and_jpp(
     // feasible ones.
     jpps_from_sp = data.dataRaptor->jpps_from_sp;
     jpps_from_sp.filter_jpps(valid_journey_pattern_points);
+
+    return std::move(valid_journey_pattern_points);
 }
 
 template<typename Visitor>

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -194,11 +194,9 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
             forbidden_uri,
             rt_level);
 
-    cached_next_st.load(data,
-                 clockwise ? departure_datetime : bound,
-                 clockwise ? bound : departure_datetime,
-                 rt_level,
-                 accessibilite_params);
+    cached_next_st.load(clockwise ? departure_datetime : bound,
+                        rt_level,
+                        accessibilite_params);
 
     clear(clockwise, bound);
     init(dep, departure_datetime, clockwise, accessibilite_params.properties);
@@ -498,11 +496,9 @@ RAPTOR::isochrone(const map_stop_point_duration& departures,
                                                  accessibilite_params,
                                                  forbidden,
                                                  rt_level);
-    cached_next_st.load(data,
-                 clockwise ? departure_datetime : bound,
-                 clockwise ? bound : departure_datetime,
-                 rt_level,
-                 accessibilite_params);
+    cached_next_st.load(clockwise ? departure_datetime : bound,
+                        rt_level,
+                        accessibilite_params);
 
     clear(clockwise, bound);
     init(departures, departure_datetime, clockwise, accessibilite_params.properties);

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -188,12 +188,13 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& dep,
                                bool clockwise) {
 
     const DateTime bound = limit_bound(clockwise, departure_datetime, b);
-    const auto valid_jpps = set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
-                                                 accessibilite_params,
-                                                 forbidden_uri,
-                                                 rt_level);
-    next_st.load(data,
-                 valid_jpps,
+
+    set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
+            accessibilite_params,
+            forbidden_uri,
+            rt_level);
+
+    cached_next_st.load(data,
                  clockwise ? departure_datetime : bound,
                  clockwise ? bound : departure_datetime,
                  rt_level,
@@ -497,8 +498,7 @@ RAPTOR::isochrone(const map_stop_point_duration& departures,
                                                  accessibilite_params,
                                                  forbidden,
                                                  rt_level);
-    next_st.load(data,
-                 valid_jpps,
+    cached_next_st.load(data,
                  clockwise ? departure_datetime : bound,
                  clockwise ? bound : departure_datetime,
                  rt_level,
@@ -686,7 +686,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
                     const DateTime previous_dt = prec_labels.dt_transfer(jpp.sp_idx);
                     if (prec_labels.transfer_is_initialized(jpp.sp_idx) &&
                         (!is_onboard || visitor.better_or_equal(previous_dt, workingDt, *it_st))) {
-                        const auto tmp_st_dt = next_st.next_stop_time(
+                        const auto tmp_st_dt = cached_next_st.next_stop_time(
                             visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise());
 
                         if (tmp_st_dt.first != nullptr) {

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -70,7 +70,7 @@ struct RAPTOR
 {
     const navitia::type::Data& data;
 
-    CachedNextStopTime next_st;
+    CachedNextStopTime cached_next_st;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -71,7 +71,7 @@ struct RAPTOR
     const navitia::type::Data& data;
 
     CachedNextStopTimeManager cached_next_st_manager;
-    const CachedNextStopTime* current_cache;
+    const CachedNextStopTime* next_st = nullptr;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers
@@ -92,9 +92,9 @@ struct RAPTOR
     // set to store if the stop_point is valid
     boost::dynamic_bitset<> valid_stop_points;
 
-    explicit RAPTOR(const navitia::type::Data& data) :
+    explicit RAPTOR(const navitia::type::Data& data, size_t cache_size = 10) :
         data(data),
-        cached_next_st_manager(data),
+        cached_next_st_manager(data, cache_size),
         best_labels_pts(data.pt_data->stop_points),
         best_labels_transfers(data.pt_data->stop_points),
         count(0),

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -71,6 +71,7 @@ struct RAPTOR
     const navitia::type::Data& data;
 
     CachedNextStopTimeManager cached_next_st;
+    const CachedNextStopTime* current_cache;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers
@@ -117,6 +118,15 @@ struct RAPTOR
     const type::StopPoint* get_sp(SpIdx idx) const {
         return data.pt_data->stop_points[idx.val];
     }
+
+    // Returns the next stop time at given journey pattern point
+    // either a vehicle that leaves or that arrives depending on
+    // clockwise.
+    std::pair<const type::StopTime*, DateTime>
+    next_stop_time(const StopEvent stop_event,
+                   const JppIdx jpp_idx,
+                   const DateTime dt,
+                   const bool clockwise) const;
 
     ///Lance un calcul d'itinéraire entre deux stop areas avec aussi une borne
     std::vector<Path>

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -70,7 +70,7 @@ struct RAPTOR
 {
     const navitia::type::Data& data;
 
-    CachedNextStopTimeManager cached_next_st;
+    CachedNextStopTimeManager cached_next_st_manager;
     const CachedNextStopTime* current_cache;
 
     /// Contains the different labels used by raptor.
@@ -94,7 +94,7 @@ struct RAPTOR
 
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
-        cached_next_st(data),
+        cached_next_st_manager(data),
         best_labels_pts(data.pt_data->stop_points),
         best_labels_transfers(data.pt_data->stop_points),
         count(0),
@@ -118,15 +118,6 @@ struct RAPTOR
     const type::StopPoint* get_sp(SpIdx idx) const {
         return data.pt_data->stop_points[idx.val];
     }
-
-    // Returns the next stop time at given journey pattern point
-    // either a vehicle that leaves or that arrives depending on
-    // clockwise.
-    std::pair<const type::StopTime*, DateTime>
-    next_stop_time(const StopEvent stop_event,
-                   const JppIdx jpp_idx,
-                   const DateTime dt,
-                   const bool clockwise) const;
 
     ///Lance un calcul d'itinéraire entre deux stop areas avec aussi une borne
     std::vector<Path>

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -70,7 +70,7 @@ struct RAPTOR
 {
     const navitia::type::Data& data;
 
-    CachedNextStopTime cached_next_st;
+    CachedNextStopTimeManager cached_next_st;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers
@@ -93,6 +93,7 @@ struct RAPTOR
 
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
+        cached_next_st(data),
         best_labels_pts(data.pt_data->stop_points),
         best_labels_transfers(data.pt_data->stop_points),
         count(0),
@@ -210,7 +211,7 @@ struct RAPTOR
                            const std::vector<std::string>& forbidden_uri,
                            bool clockwise);
 
-    ~RAPTOR() {}
+    ~RAPTOR() = default;
 };
 
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -70,7 +70,7 @@ struct RAPTOR
 {
     const navitia::type::Data& data;
 
-    NextStopTime next_st;
+    CachedNextStopTime next_st;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers
@@ -93,7 +93,6 @@ struct RAPTOR
 
     explicit RAPTOR(const navitia::type::Data& data) :
         data(data),
-        next_st(data),
         best_labels_pts(data.pt_data->stop_points),
         best_labels_transfers(data.pt_data->stop_points),
         count(0),
@@ -176,8 +175,7 @@ struct RAPTOR
                               const nt::RTLevel rt_level);
 
     ///Boucle principale, parcourt les journey_patterns,
-    void boucleRAPTOR(const type::AccessibiliteParams& accessibilite_params,
-                      bool clockwise,
+    void boucleRAPTOR(bool clockwise,
                       const nt::RTLevel rt_level,
                       const uint32_t max_transfers);
 
@@ -194,7 +192,6 @@ struct RAPTOR
     ///Main loop
     template<typename Visitor>
     void raptor_loop(Visitor visitor,
-                     const type::AccessibiliteParams& accessibilite_params,
                      const nt::RTLevel rt_level,
                      uint32_t max_transfers=std::numeric_limits<uint32_t>::max());
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -169,10 +169,10 @@ struct RAPTOR
 
     /// Désactive les journey_patterns qui n'ont pas de vj valides la veille, le jour, et le lendemain du calcul
     /// Gère également les lignes, modes, journey_patterns et VJ interdits
-    void set_valid_jp_and_jpp(uint32_t date,
-                              const type::AccessibiliteParams& accessibilite_params,
-                              const std::vector<std::string>& forbidden,
-                              const nt::RTLevel rt_level);
+    boost::dynamic_bitset<> set_valid_jp_and_jpp(uint32_t date,
+                                                 const type::AccessibiliteParams&,
+                                                 const std::vector<std::string>& forbidden,
+                                                 const nt::RTLevel rt_level);
 
     ///Boucle principale, parcourt les journey_patterns,
     void boucleRAPTOR(bool clockwise,

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -171,10 +171,10 @@ struct RAPTOR
 
     /// Désactive les journey_patterns qui n'ont pas de vj valides la veille, le jour, et le lendemain du calcul
     /// Gère également les lignes, modes, journey_patterns et VJ interdits
-    boost::dynamic_bitset<> set_valid_jp_and_jpp(uint32_t date,
-                                                 const type::AccessibiliteParams&,
-                                                 const std::vector<std::string>& forbidden,
-                                                 const nt::RTLevel rt_level);
+    void set_valid_jp_and_jpp(uint32_t date,
+                              const type::AccessibiliteParams&,
+                              const std::vector<std::string>& forbidden,
+                              const nt::RTLevel rt_level);
 
     ///Boucle principale, parcourt les journey_patterns,
     void boucleRAPTOR(bool clockwise,

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -125,7 +125,7 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
             *prev_s->get_out_st->stop_point,
             *cur_s.get_in_st->stop_point);
         assert(conn != nullptr);
-        const auto new_st_dt = reader.raptor.cached_next_st.next_stop_time(
+        const auto new_st_dt = reader.raptor.next_stop_time(
             StopEvent::pick_up,
             cur_jpp_idx,
             prev_s->get_out_dt + conn->duration,
@@ -507,7 +507,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.cached_next_st.next_stop_time(
+            const auto begin_st_dt = raptor.next_stop_time(
                         v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
@@ -544,7 +544,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.cached_next_st.next_stop_time(
+            const auto begin_st_dt = raptor.next_stop_time(
                                 v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -125,7 +125,7 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
             *prev_s->get_out_st->stop_point,
             *cur_s.get_in_st->stop_point);
         assert(conn != nullptr);
-        const auto new_st_dt = reader.raptor.next_st.next_stop_time(
+        const auto new_st_dt = reader.raptor.cached_next_st.next_stop_time(
             StopEvent::pick_up,
             cur_jpp_idx,
             prev_s->get_out_dt + conn->duration,
@@ -507,7 +507,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.next_st.next_stop_time(
+            const auto begin_st_dt = raptor.cached_next_st.next_stop_time(
                         v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
@@ -544,7 +544,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.next_st.next_stop_time(
+            const auto begin_st_dt = raptor.cached_next_st.next_stop_time(
                                 v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -125,7 +125,7 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
             *prev_s->get_out_st->stop_point,
             *cur_s.get_in_st->stop_point);
         assert(conn != nullptr);
-        const auto new_st_dt = reader.raptor.current_cache->next_stop_time(
+        const auto new_st_dt = reader.raptor.next_st->next_stop_time(
             StopEvent::pick_up,
             cur_jpp_idx,
             prev_s->get_out_dt + conn->duration,
@@ -507,7 +507,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.current_cache->next_stop_time(
+            const auto begin_st_dt = raptor.next_st->next_stop_time(
                         v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
@@ -544,7 +544,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.current_cache->next_stop_time(
+            const auto begin_st_dt = raptor.next_st->next_stop_time(
                                 v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -125,7 +125,7 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
             *prev_s->get_out_st->stop_point,
             *cur_s.get_in_st->stop_point);
         assert(conn != nullptr);
-        const auto new_st_dt = reader.raptor.next_stop_time(
+        const auto new_st_dt = reader.raptor.current_cache->next_stop_time(
             StopEvent::pick_up,
             cur_jpp_idx,
             prev_s->get_out_dt + conn->duration,
@@ -507,7 +507,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.next_stop_time(
+            const auto begin_st_dt = raptor.current_cache->next_stop_time(
                         v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
@@ -544,7 +544,7 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count].dt_pt(begin_sp_idx);
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.next_stop_time(
+            const auto begin_st_dt = raptor.current_cache->next_stop_time(
                                 v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -125,12 +125,11 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
             *prev_s->get_out_st->stop_point,
             *cur_s.get_in_st->stop_point);
         assert(conn != nullptr);
-        const auto new_st_dt = reader.raptor.next_st.earliest_stop_time(
+        const auto new_st_dt = reader.raptor.next_st.next_stop_time(
             StopEvent::pick_up,
             cur_jpp_idx,
             prev_s->get_out_dt + conn->duration,
-            reader.rt_level,
-            reader.accessibilite_params.vehicle_properties);
+            true);
         if (new_st_dt.second < cur_s.get_in_dt) {
             const auto out_st_dt = get_out_st_dt(new_st_dt,
                                                  jp_container.get_jpp(*cur_s.get_out_st),
@@ -509,8 +508,7 @@ struct RaptorSolutionReader {
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
             const auto begin_st_dt = raptor.next_st.next_stop_time(
-                        v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
-                        accessibilite_params.vehicle_properties, /*jpp.has_freq*/ true, begin_limit);
+                        v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
 
@@ -547,8 +545,7 @@ struct RaptorSolutionReader {
         for (const auto jpp: raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
             const auto begin_st_dt = raptor.next_st.next_stop_time(
-                                v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
-                                accessibilite_params.vehicle_properties/*, jpp.has_freq*/);
+                                v.stop_event(), jpp.idx, begin_dt, v.clockwise());
             if (begin_st_dt.first == nullptr) { continue; }
             if (v.comp(begin_limit, begin_st_dt.second)) { continue; }
 

--- a/source/routing/tests/CMakeLists.txt
+++ b/source/routing/tests/CMakeLists.txt
@@ -40,3 +40,7 @@ ADD_BOOST_TEST(co2_emission_test)
 add_executable(journey_pattern_container_test journey_pattern_container_test.cpp)
 target_link_libraries(journey_pattern_container_test ${BOOST_LIBS} routing ed data)
 ADD_BOOST_TEST(journey_pattern_container_test)
+
+add_executable(get_stop_times_test get_stop_times_test.cpp)
+target_link_libraries(get_stop_times_test ed data fare georef routing types utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+ADD_BOOST_TEST(get_stop_times_test)

--- a/source/routing/tests/get_stop_times_test.cpp
+++ b/source/routing/tests/get_stop_times_test.cpp
@@ -32,17 +32,17 @@ www.navitia.io
 #define BOOST_TEST_MODULE test_ed
 #include <boost/test/unit_test.hpp>
 #include "tests/utils_test.h"
-#include "time_tables/get_stop_times.h"
+#include "routing/get_stop_times.h"
 #include "ed/build_helper.h"
 #include "routing/dataraptor.h"
 
 using namespace navitia;
-using namespace navitia::timetables;
+using namespace navitia::routing;
 using navitia::routing::StopEvent;
 
-static std::pair<const routing::JourneyPattern&, const routing::JourneyPatternPoint&>
+static std::pair<const JourneyPattern&, const JourneyPatternPoint&>
 get_first_jp_jpp(const ed::builder &b, const std::string& sa) {
-    const auto sp_idx = routing::SpIdx(*b.data->pt_data->stop_areas_map[sa]->stop_point_list.front());
+    const auto sp_idx = SpIdx(*b.data->pt_data->stop_areas_map[sa]->stop_point_list.front());
     const auto& jpp = b.data->dataRaptor->jpps_from_sp[sp_idx].front();
     return {b.data->dataRaptor->jp_container.get(jpp.jp_idx),
             b.data->dataRaptor->jp_container.get(jpp.idx)};
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test1){
     b.data->pt_data->index();
     b.data->build_raptor();
 
-    std::vector<navitia::routing::JppIdx> jpps;
+    std::vector<JppIdx> jpps;
     for (const auto& jpp: b.data->dataRaptor->jp_container.get_jpps())
         jpps.push_back(jpp.first);
 
@@ -63,17 +63,17 @@ BOOST_AUTO_TEST_CASE(test1){
                                  navitia::DateTimeUtils::set(1, 0), 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->order() == 0;}));
+                            [](datetime_stop_time& dt_st) {return dt_st.second->order() == 0;}));
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->order() == 1;}));
+                            [](datetime_stop_time& dt_st) {return dt_st.second->order() == 1;}));
 
     result = get_stop_times(StopEvent::drop_off, jpps, navitia::DateTimeUtils::set(0, 86399),
                             navitia::DateTimeUtils::min, 100, *b.data, nt::RTLevel::Base, {});
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->order() == 1;}));
+                            [](datetime_stop_time& dt_st) {return dt_st.second->order() == 1;}));
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](timetables::datetime_stop_time& dt_st) {return dt_st.second->order() == 2;}));
+                            [](datetime_stop_time& dt_st) {return dt_st.second->order() == 2;}));
 
 
 }
@@ -335,9 +335,9 @@ BOOST_AUTO_TEST_CASE(test_frequency_over_midnight_for_calendar) {
 
 struct departure_helper {
     departure_helper(): b("20150907") {}
-    std::vector<navitia::routing::JppIdx> get_jpp_idx (const std::string& stop_point_id) {
-        std::vector<navitia::routing::JppIdx>  jpp_stop;
-        const auto sp_idx = routing::SpIdx(*b.data->pt_data->stop_points_map.at(stop_point_id));
+    std::vector<JppIdx> get_jpp_idx (const std::string& stop_point_id) {
+        std::vector<JppIdx>  jpp_stop;
+        const auto sp_idx = SpIdx(*b.data->pt_data->stop_points_map.at(stop_point_id));
         const auto& vec_jpp_stop = b.data->dataRaptor->jpps_from_sp[sp_idx];
         for (const auto& jpp : vec_jpp_stop) {
             jpp_stop.push_back(jpp.idx);
@@ -456,10 +456,10 @@ BOOST_FIXTURE_TEST_CASE(test_discrete_lolipop, departure_helper) {
  */
 BOOST_AUTO_TEST_CASE(queue_comp_test_clockwise) {
     bool clockwise{true};
-    navitia::timetables::JppStQueue q({clockwise});
-    q.push({routing::JppIdx(0), nullptr, 12});
-    q.push({routing::JppIdx(1), nullptr, 42});
-    q.push({routing::JppIdx(2), nullptr, 6});
+    JppStQueue q({clockwise});
+    q.push({JppIdx(0), nullptr, 12});
+    q.push({JppIdx(1), nullptr, 42});
+    q.push({JppIdx(2), nullptr, 6});
 
     //for clockwise, we want the smallest first
     BOOST_CHECK_EQUAL(q.top().dt, 6);
@@ -469,10 +469,10 @@ BOOST_AUTO_TEST_CASE(queue_comp_test_clockwise) {
 
 BOOST_AUTO_TEST_CASE(queue_comp_test_anti_clockwise) {
     bool clockwise{false};
-    navitia::timetables::JppStQueue q({clockwise});
-    q.push({routing::JppIdx(0), nullptr, 12});
-    q.push({routing::JppIdx(1), nullptr, 42});
-    q.push({routing::JppIdx(2), nullptr, 6});
+    JppStQueue q({clockwise});
+    q.push({JppIdx(0), nullptr, 12});
+    q.push({JppIdx(1), nullptr, 42});
+    q.push({JppIdx(2), nullptr, 6});
 
     //for clockwise, we want the greatest first
     BOOST_CHECK_EQUAL(q.top().dt, 42);

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -267,8 +267,8 @@ BOOST_AUTO_TEST_CASE(different_connection_time) {
 
 BOOST_AUTO_TEST_CASE(over_midnight){
     ed::builder b("20120614");
-    b.vj("A")("stop1", 23*3600)("stop2", 24*3600 + 5*60);
-    b.vj("B")("stop2", 10*60)("stop3", 20*60);
+    b.vj("A")("stop1", "23:00"_t)("stop2", "24:05"_t);
+    b.vj("B")("stop2", "00:10"_t)("stop3", "00:20"_t);
     b.connection("stop1", "stop1", 120);
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::inf,
+    auto res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], "22:00"_t, 0, DateTimeUtils::inf,
             type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
@@ -293,8 +293,10 @@ BOOST_AUTO_TEST_CASE(over_midnight){
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22*3600, 0, DateTimeUtils::set(1, 8500),
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], "22:00"_t, 0, DateTimeUtils::set(1, 8500),
             type::RTLevel::Base, 2_min, true);
+    std::cout << d.stop_areas[0]->uri << std::endl;
+    std::cout << d.stop_areas[2]->uri << std::endl;
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -467,7 +469,7 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), type::RTLevel::Base, 2_min, true);
-    BOOST_REQUIRE_EQUAL(res1.size(), 1);
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);//?
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
@@ -1189,9 +1191,9 @@ BOOST_AUTO_TEST_CASE(destination_over_writing) {
 
 BOOST_AUTO_TEST_CASE(over_midnight_special) {
     ed::builder b("20120614");
-    b.vj("A")("stop1", 8*3600)("stop2", 8*3600+10*60);
-    b.vj("B")("stop1", 7*3600)("stop3", 7*3600+5*60);
-    b.vj("C")("stop2", 7*3600+10*60)("stop3", 7*3600+15*60)("stop4", 7*3600+20*60);
+    b.vj("A")("stop1", "08:00"_t)("stop2", "08:10"_t);
+    b.vj("B")("stop1", "07:00"_t)("stop3", "07:05"_t);
+    b.vj("C")("stop2", "07:10"_t)("stop3", "07:15"_t)("stop4", "07:20"_t);
     b.connection("stop1", "stop1", 120);
     b.connection("stop2", "stop2", 120);
     b.connection("stop3", "stop3", 120);
@@ -1205,7 +1207,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_special) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 6*3600, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], "06:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     auto res = res1.back();
@@ -1951,7 +1953,7 @@ BOOST_AUTO_TEST_CASE(good_connection_when_walking_as_fast_as_bus) {
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
                                "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min, true);
     test_good_connection_when_walking_as_fast_as_bus(res1);
-
+    std::cout << "-----------------ok-----------------" << std::endl;
     // non clockwise test
     auto res2 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
                                "12:00"_t, 0, 0, type::RTLevel::Base, 2_min, false);

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -728,7 +728,7 @@ BOOST_AUTO_TEST_CASE(pam_veille) {
     RAPTOR raptor(*(b.data));
     type::PT_Data & d = *b.data->pt_data;
 
-    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 5*60, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min, true);
+    auto res1 = raptor.compute(d.stop_areas_map["stop2"], d.stop_areas_map["stop3"], 50*60, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 }
@@ -2044,7 +2044,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
     // reverse clockwise
     res = raptor.compute_all(departures,
                              arrivals,
-                             DateTimeUtils::set(2, "08:03"_t),
+                             DateTimeUtils::set(2, "08:05"_t),
                              type::RTLevel::Base,
                              2_min,
                              0,
@@ -2057,7 +2057,7 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
 
     res = raptor.compute_all(departures,
                              arrivals,
-                             DateTimeUtils::set(2, "08:03"_t),
+                             DateTimeUtils::set(2, "08:05"_t),
                              type::RTLevel::Base,
                              2_min,
                              0,

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(validity_pattern){
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 10000), type::RTLevel::Base, 2_min, true);
-    BOOST_REQUIRE_EQUAL(res1.size(), 1);//?
+    BOOST_REQUIRE_EQUAL(res1.size(), 1);
     res = res1.back();
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
@@ -1953,7 +1953,6 @@ BOOST_AUTO_TEST_CASE(good_connection_when_walking_as_fast_as_bus) {
     auto res1 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
                                "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min, true);
     test_good_connection_when_walking_as_fast_as_bus(res1);
-    std::cout << "-----------------ok-----------------" << std::endl;
     // non clockwise test
     auto res2 = raptor.compute(d.stop_areas_map.at("A"), d.stop_areas_map.at("E"),
                                "12:00"_t, 0, 0, type::RTLevel::Base, 2_min, false);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1293,6 +1293,7 @@ BOOST_FIXTURE_TEST_CASE(bus_car_parking, streetnetworkmode_fixture<test_speed_pr
         seconds(distance_ar / get_default_speed()[Mode_e::Walking] / speed_factor)
         + seconds(1);
     destination.streetnetwork_params.speed_factor = speed_factor;
+    datetimes = {navitia::test::to_posix_timestamp("20120614T070000")};
 
     ng::StreetNetwork sn_worker(*this->b.data->geo_ref);
     nr::RAPTOR raptor(*this->b.data);

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -2,6 +2,8 @@
 
 #include "type/datetime.h"
 #include "type/kirin.pb.h"
+#include "routing/raptor.h"
+#include "kraken/realtime.h"
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <set>
@@ -13,6 +15,15 @@
  */
 namespace navitia {
 namespace test {
+
+inline void handle_realtime_test(const std::string& id,
+                                 const boost::posix_time::ptime& timestamp,
+                                 const transit_realtime::TripUpdate& trip_update,
+                                 const type::Data& data,
+                                 std::unique_ptr<navitia::routing::RAPTOR>& raptor) {
+    navitia::handle_realtime(id, timestamp, trip_update, data);
+    raptor = std::move(std::make_unique<navitia::routing::RAPTOR>(data));
+}
 
 inline uint64_t to_posix_timestamp(const std::string& str) {
     return navitia::to_posix_timestamp(boost::posix_time::from_iso_string(str));

--- a/source/time_tables/CMakeLists.txt
+++ b/source/time_tables/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(thermometer thermometer.cpp)
 target_link_libraries(thermometer types)    
 
-SET(TIME_TABLES_SRC get_stop_times.cpp next_passages.cpp route_schedules.cpp departure_boards.cpp request_handle.cpp previous_passages.cpp)
+SET(TIME_TABLES_SRC next_passages.cpp route_schedules.cpp departure_boards.cpp request_handle.cpp previous_passages.cpp)
 add_library(time_tables ${TIME_TABLES_SRC})
 #TODO: a static lib doesn't need to be linked with is dependency
 target_link_libraries(time_tables utils types routing autocomplete proximitylist ptreferential georef thermometer)

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -138,7 +138,7 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
     size_t total_result = sps_routes.size();
     sps_routes = paginate(sps_routes, count, start_page);
     //Trie des vecteurs de date_times stop_times
-    auto sort_predicate = [](datetime_stop_time dt1, datetime_stop_time dt2) {
+    auto sort_predicate = [](routing::datetime_stop_time dt1, routing::datetime_stop_time dt2) {
                     return dt1.first < dt2.first;
                 };
     // On regroupe entre eux les stop_times appartenant
@@ -161,10 +161,10 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
             std::vector<routing::datetime_stop_time> tmp;
             if (! calendar_id) {
                 tmp = routing::get_stop_times(routing::StopEvent::pick_up, {jpp_idx}, handler.date_time,
-                                     handler.max_datetime, max_date_times, data, rt_level);
+                        handler.max_datetime, max_date_times, pb_creator.data, rt_level);
             } else {
                 tmp = routing::get_stop_times({jpp_idx}, DateTimeUtils::hour(handler.date_time),
-                                     DateTimeUtils::hour(handler.max_datetime), data, *calendar_id);
+                        DateTimeUtils::hour(handler.max_datetime), pb_creator.data, *calendar_id);
             }
             if (! tmp.empty()) {
                 stop_times.insert(stop_times.end(), tmp.begin(), tmp.end());

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -31,13 +31,13 @@ www.navitia.io
 #pragma once
 #include "type/pb_converter.h"
 #include "routing/routing.h"
-#include "get_stop_times.h"
+#include "routing/get_stop_times.h"
 
 
 namespace navitia { namespace timetables {
 typedef std::vector<DateTime> vector_datetime;
 typedef std::pair<uint32_t, uint32_t> stop_point_line;
-typedef std::vector<datetime_stop_time> vector_dt_st;
+typedef std::vector<routing::datetime_stop_time> vector_dt_st;
 
 void departure_board(PbCreator& pb_creator, const std::string &filter,
                      boost::optional<const std::string> calendar_id,

--- a/source/time_tables/next_passages.cpp
+++ b/source/time_tables/next_passages.cpp
@@ -29,7 +29,7 @@ www.navitia.io
 */
 
 #include "next_passages.h"
-#include "get_stop_times.h"
+#include "routing/get_stop_times.h"
 #include "request_handle.h"
 #include "type/datetime.h"
 #include "ptreferential/ptreferential.h"

--- a/source/time_tables/previous_passages.cpp
+++ b/source/time_tables/previous_passages.cpp
@@ -29,7 +29,7 @@ www.navitia.io
 */
 
 #include "previous_passages.h"
-#include "get_stop_times.h"
+#include "routing/get_stop_times.h"
 #include "request_handle.h"
 #include "type/datetime.h"
 #include "ptreferential/ptreferential.h"

--- a/source/time_tables/route_schedules.h
+++ b/source/time_tables/route_schedules.h
@@ -31,7 +31,7 @@ www.navitia.io
 #pragma once
 #include "type/type.h"
 #include "routing/routing.h"
-#include "get_stop_times.h"
+#include "routing/get_stop_times.h"
 #include "type/pb_converter.h"
 
 namespace navitia { namespace timetables {
@@ -39,7 +39,7 @@ namespace navitia { namespace timetables {
 typedef std::vector<std::string> vector_string;
 typedef std::pair<DateTime, const type::StopTime*> vector_date_time;
 
-std::vector<std::vector<datetime_stop_time> >
+std::vector<std::vector<routing::datetime_stop_time> >
 get_all_route_stop_times(const navitia::type::Route* route,
                          const DateTime& dateTime,
                          const DateTime& max_datetime,

--- a/source/time_tables/tests/CMakeLists.txt
+++ b/source/time_tables/tests/CMakeLists.txt
@@ -3,10 +3,6 @@ SET(BOOST_LIBS ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_REGEX_LIBRARY}
     ${Boost_IOSTREAMS_LIBRARY})
 
-add_executable(get_stop_times_test get_stop_times_test.cpp)
-target_link_libraries(get_stop_times_test time_tables ed data fare georef routing types utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
-ADD_BOOST_TEST(get_stop_times_test)
-
 
 add_executable(thermometer_test thermometer.cpp)
 target_link_libraries(thermometer_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus protobuf)

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -265,7 +265,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_filter, route_schedule_calendar_fixture) {
 
 namespace ba = boost::adaptors;
 using vec_dt = std::vector<navitia::DateTime>;
-static navitia::DateTime get_dt(const ntt::datetime_stop_time& p) { return p.first; }
+static navitia::DateTime get_dt(const navitia::routing::datetime_stop_time& p) { return p.first; }
 
 /*
  * Test get_all_route_stop_times with a calendar

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -914,13 +914,22 @@ struct StreetNetworkParams{
     bool enable_direct_path = true;
 };
 /**
-  Gestion de l'accessibilié
+  Accessibility management
   */
 struct AccessibiliteParams{
-    Properties properties;  // Accissibilié StopPoint, Correspondance, ..
-    VehicleProperties vehicle_properties; // Accissibilié VehicleJourney
+    Properties properties;  // Accessibility StopPoint, Connection, ...
+    VehicleProperties vehicle_properties; // Accessibility VehicleJourney
 
     AccessibiliteParams(){}
+
+    bool operator<(const AccessibiliteParams& other) const {
+        if (properties.to_ulong() != other.properties.to_ulong()) {
+            return properties.to_ulong() < other.properties.to_ulong();
+        } else if (vehicle_properties.to_ulong() != other.vehicle_properties.to_ulong()) {
+            return vehicle_properties.to_ulong() < other.vehicle_properties.to_ulong();
+        }
+        return false;
+    }
 };
 
 /** Type pour gérer le polymorphisme en entrée de l'API


### PR DESCRIPTION
http://jira.canaltp.fr/browse/NAVP-422 (+ http://jira.canaltp.fr/browse/NAVP-480)
- Implementation of Load cache
- NOT implemented LRU

Benchmarked on Stif
- 180ms per request without cache init
-  250ms per request with cache init (for each request)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1406)

<!-- Reviewable:end -->

Result of bench:
- 100 requests, every request is repeated for 10 times
- Benched on BackupStif, fr-pdl, SNCF
- Benched on `dev` (right before this PR, contributor is only activated on VJ), `Cache`, `LRU`(to do)

**Backup STIF** : 943 solutions / 1000 requests

| (nb 2nd pass) | 0 | 10 | 25 | 100 | 1000 | 10000 |
| --- | --- | --- | --- | --- | --- | --- |
| nb journeys found | 6682 | 6930 | 7098 | 7603 | 7715 | 7715 |
| dev | 125.76s | 226.98s | 354.58 | 715.26s | 885.6s | 873s |
| Cache | 219.41s | 260s | 311.56s | 461.82s | 517.49s | 552.78s |
| LRU | 78.88s | 138.88s | 189.54s | 399s | 482s | 475s |

**fr-pdl**:  863 solutions / 1000 requests

| (nb 2nd pass) | 0 | 10 | 100 | 1000 | 10000 |
| --- | --- | --- | --- | --- | --- |
| dev | 78.8s | 128s | 251s | 280s | 281s |
| Cache | 120s | 126.13s | 193.09s | 203s | 204s |
| LRU | 60s | 90s | 162s | 180s | 181s |

**SNCF**:  1000 solutions / 1000 requests

| (nb 2nd pass) | 0 | 10 | 100 | 1000 | 10000 |
| --- | --- | --- | --- | --- | --- |
| dev | 11.62s | 12.37s | 13.17s | 12.36s | 12.38s |
| Cache | 15.7s | 16.01 | 16.17s | 16.73s | 16.69s |
| LRU | 7.28s | 7.48s | 7.51s | 7.56s | 8.2s |
