### PR TITLE
kraken: fix a regression in the association of stop_point to admins

### DIFF
--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -42,6 +42,7 @@ www.navitia.io
 #include <boost/serialization/set.hpp>
 #include <map>
 #include <set>
+#include <functional>
 
 
 namespace nt = navitia::type;
@@ -326,6 +327,8 @@ struct GeoRef {
         return nearest_edge(coordinates, pl, offsets[mode]);
     }
     std::pair<int, const Way*> nearest_addr(const type::GeographicalCoord&) const;
+    std::pair<int, const Way*> nearest_addr(const type::GeographicalCoord& coord,
+                                            const std::function<bool(const Way&)>& filter) const;
 
     void add_way(const Way& w);
 


### PR DESCRIPTION
We were excluding way without name, but they can have an admin.
nearest_addr can now take a lambda for custom filtering of the way

Refer to: http://jira.canaltp.fr/browse/NAVITIAII-2045
require: https://github.com/CanalTP/artemis_references/pull/11
