### PR TITLE
All: Improvement of isochrone and remove nm api

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -287,23 +287,18 @@ class add_journey_href(object):
         @wraps(f)
         def wrapper(*args, **kwargs):
             objects = f(*args, **kwargs)
-            if objects[1] != 200:
+            if objects[1] != 200 or 'journeys' not in objects[0]:
                 return objects
-            if "journeys" not in objects[0]:
-                return objects
-            if "uri" in kwargs:
-                del kwargs["uri"]
-            if "lon" in kwargs and "lat" in kwargs:
-                del kwargs["lon"]
-                del kwargs["lat"]
             for journey in objects[0]['journeys']:
                 if "sections" not in journey:#this mean it's an isochrone...
-                    kwargs["datetime"] = journey["requested_date_time"]
-                    kwargs["to"] = journey["to"]["id"]
-                    kwargs["from"] = journey["from"]["id"]
-                    if 'datetime_represents' in request.args:
-                        kwargs['datetime_represents'] = request.args['datetime_represents']
-                    journey['links'] = [create_external_link("v1.journeys", rel="journeys", **kwargs)]
+                    args = dict(request.args)
+                    if 'to' not in args:
+                        args['to'] = journey['to']['id']
+                    if 'from' not in args:
+                        args['from'] = journey['from']['id']
+                    if 'region' in kwargs:
+                        args['region'] = kwargs['region']
+                    journey['links'] = [create_external_link('v1.journeys', rel='journeys', **args)]
             return objects
         return wrapper
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -294,17 +294,17 @@ class add_journey_href(object):
             if "region" in kwargs:
                 del kwargs["region"]
             if "uri" in kwargs:
-                kwargs["from"] = kwargs["uri"].split("/")[-1]
                 del kwargs["uri"]
             if "lon" in kwargs and "lat" in kwargs:
-                if not "from" in kwargs:
-                    kwargs["from"] = kwargs["lon"] + ';' + kwargs["lat"]
                 del kwargs["lon"]
                 del kwargs["lat"]
             for journey in objects[0]['journeys']:
-                if "sections" not in journey:
+                if "sections" not in journey:#this mean it's an isochrone...
                     kwargs["datetime"] = journey["requested_date_time"]
                     kwargs["to"] = journey["to"]["id"]
+                    kwargs["from"] = journey["from"]["id"]
+                    if 'datetime_represents' in request.args:
+                        kwargs['datetime_represents'] = request.args['datetime_represents']
                     journey['links'] = [create_external_link("v1.journeys", rel="journeys", **kwargs)]
             return objects
         return wrapper

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -291,8 +291,6 @@ class add_journey_href(object):
                 return objects
             if "journeys" not in objects[0]:
                 return objects
-            if "region" in kwargs:
-                del kwargs["region"]
             if "uri" in kwargs:
                 del kwargs["uri"]
             if "lon" in kwargs and "lat" in kwargs:

--- a/source/jormungandr/jormungandr/scenarios/default.py
+++ b/source/jormungandr/jormungandr/scenarios/default.py
@@ -450,18 +450,6 @@ class Scenario(simple.Scenario):
     def journeys(self, request, instance):
         return self.__on_journeys(type_pb2.PLANNER, request, instance)
 
-    def nm_journeys(self, request, instance):
-        updated_request_with_default(request, instance)
-        req = self.parse_journey_request(type_pb2.NMPLANNER, request)
-
-        # call to kraken
-        # TODO: check mode size
-        req.journeys.streetnetwork_params.origin_mode = self.origin_modes[0]
-        req.journeys.streetnetwork_params.destination_mode = self.destination_modes[0]
-        resp = instance.send_and_receive(req)
-
-        return resp
-
     def isochrone(self, request, instance):
         updated_request_with_default(request, instance)
         req = self.parse_journey_request(type_pb2.ISOCHRONE, request)

--- a/source/jormungandr/jormungandr/scenarios/experimental.py
+++ b/source/jormungandr/jormungandr/scenarios/experimental.py
@@ -168,9 +168,6 @@ class Scenario(new_default.Scenario):
 
 
 
-    def nm_journeys(self, request, instance):
-        return self.__on_journeys(type_pb2.NMPLANNER, request, instance)
-
     def isochrone(self, request, instance):
         return self.__on_journeys(type_pb2.ISOCHRONE, request, instance)
 

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -682,9 +682,6 @@ class Scenario(simple.Scenario):
     def journeys(self, request, instance):
         return self.__on_journeys(type_pb2.PLANNER, request, instance)
 
-    def nm_journeys(self, request, instance):
-        return self.__on_journeys(type_pb2.NMPLANNER, request, instance)
-
     def isochrone(self, request, instance):
         updated_request_with_default(request, instance)
         #we don't want to filter anything!

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -267,8 +267,5 @@ class Scenario(object):
     def journeys(self, request, instance):
         raise NotImplementedError()
 
-    def nm_journeys(self, request, instance):
-        raise NotImplementedError()
-
     def isochrone(self, request, instance):
         raise NotImplementedError()

--- a/source/jormungandr/tests/isochrone_tests.py
+++ b/source/jormungandr/tests/isochrone_tests.py
@@ -49,17 +49,22 @@ class TestIsochrone(AbstractTestFixture):
         #NOTE: we query /v1/coverage/basic_routing_test/journeys and not directly /v1/journeys
         #not to use the jormungandr database
         query = "v1/coverage/basic_routing_test/stop_points/A/journeys?max_duration=400&datetime=20120614T080000"
-        response = self.query(query)
+        response = self.query(query, display=True)
+        is_valid_isochrone_response(response, self.tester, query)
         assert len(response["journeys"]) == 1
         assert response["journeys"][0]["duration"] == 300
         assert response["journeys"][0]["to"]["stop_point"]["id"] == "B"
+        assert response["journeys"][0]["from"]["id"] == "A"
         query = "v1/coverage/basic_routing_test/stop_points/A/journeys?max_duration=25500&datetime=20120614T080000"
         response = self.query(query)
+        is_valid_isochrone_response(response, self.tester, query)
         assert len(response["journeys"]) == 2
         assert response["journeys"][0]["duration"] == 300
         assert response["journeys"][0]["to"]["stop_point"]["id"] == "B"
+        assert response["journeys"][0]["from"]["id"] == "A"
         assert response["journeys"][1]["duration"] == 25200
         assert response["journeys"][1]["to"]["stop_point"]["id"] == "D"
+        assert response["journeys"][1]["from"]["id"] == "A"
 
     def test_stop_point_isochrone_coord_no_transfers(self):
         #same query as the test_stop_point_isochrone_coord test, but this time we forbid to do a transfers
@@ -68,29 +73,32 @@ class TestIsochrone(AbstractTestFixture):
                 "max_duration=25500&datetime=20120614T080000" \
                 "&max_nb_transfers=0"
         response = self.query(query)
+        is_valid_isochrone_response(response, self.tester, query)
         assert len(response["journeys"]) == 1
         assert response["journeys"][0]["duration"] == 300
         assert response["journeys"][0]["to"]["stop_point"]["id"] == "B"
+        assert response["journeys"][0]["from"]["id"] == "A"
 
     def test_to_isochrone_coord(self):
         query = "v1/coverage/basic_routing_test/journeys?from={}&datetime={}"
         query = query.format(s_coord, "20120614T080000")
-        self.query(query)
+        response = self.query(query)
 
     def test_from_isochrone_sa(self):
         query = "v1/coverage/basic_routing_test/journeys?from={}&datetime={}"
         query = query.format("stopA", "20120614T080000")
-        self.query(query)
+        response = self.query(query)
 
     def test_to_isochrone_sa(self):
         query = "v1/coverage/basic_routing_test/journeys?to={}&datetime={}&datetime_represents=arrival"
         query = query.format("stopA", "20120614T080000")
-        self.query(query)
+        response = self.query(query)
 
     def test_reverse_isochrone_coord(self):
         q = "v1/coverage/basic_routing_test/journeys?max_duration=100000" \
             "&datetime=20120615T200000&datetime_represents=arrival&to=D"
         normal_response = self.query(q, display=True)
+        is_valid_isochrone_response(normal_response, self.tester, q)
         assert len(normal_response["journeys"]) == 2
 
     def test_reverse_isochrone_coord_clockwise(self):
@@ -111,6 +119,8 @@ class TestIsochrone(AbstractTestFixture):
         query = "v1/coverage/basic_routing_test/stop_points/A/journeys?max_duration=25500&datetime=20120614T080000"
         response = self.query(query)
         assert len(response["journeys"]) == 2
+        is_valid_isochrone_response(response, self.tester, query)
         query += "&count=1"
         response = self.query(query)
         assert len(response["journeys"]) == 1
+        is_valid_isochrone_response(response, self.tester, query)

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -626,12 +626,6 @@ pbnavitia::Response Worker::journeys(const pbnavitia::JourneysRequest &request, 
                                                 rt_level, request.max_duration(),
                                                 request.max_transfers(), request.show_codes());
     }
-    case pbnavitia::NMPLANNER:
-        return routing::make_nm_response(*planner, origins, destinations, datetimes[0],
-                request.clockwise(), accessibilite_params,
-                forbidden, *street_network_worker,
-                rt_level, request.max_duration(),
-                request.max_transfers(), request.show_codes());
 
     case pbnavitia::pt_planner:
         return routing::make_pt_response(*planner, origins, destinations, datetimes[0],

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -467,55 +467,6 @@ RAPTOR::compute_all(const map_stop_point_duration& departures,
     return result;
 }
 
-std::vector<std::pair<type::EntryPoint, std::vector<Path>>>
-RAPTOR::compute_nm_all(const std::vector<std::pair<type::EntryPoint, map_stop_point_duration>>& departures,
-                       const std::vector<std::pair<type::EntryPoint, map_stop_point_duration>>& arrivals,
-                       const DateTime& departure_datetime,
-                       const nt::RTLevel rt_level,
-                       const DateTime& bound,
-                       const uint32_t max_transfers,
-                       const type::AccessibiliteParams& accessibilite_params,
-                       const std::vector<std::string>& forbidden_uri,
-                       bool clockwise) {
-    std::vector<std::pair<type::EntryPoint, std::vector<Path>>> result;
-    set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime),
-                         accessibilite_params,
-                         forbidden_uri,
-                         rt_level);
-
-    map_stop_point_duration calc_dep_map;
-    for (const auto& n_point : (clockwise ? departures : arrivals)) {
-        calc_dep_map.insert(n_point.second.begin(), n_point.second.end());
-    }
-
-    clear(clockwise, bound);
-    init(calc_dep_map, departure_datetime, clockwise, accessibilite_params.properties);
-
-    boucleRAPTOR(accessibilite_params, clockwise, rt_level, max_transfers);
-
-    for(const auto& m_point : (clockwise ? arrivals : departures)) {
-        const type::EntryPoint& m_entry_point = m_point.first;
-
-        std::vector<Path> paths;
-
-        // just returns destination stop points
-        for (auto& m_stop_point : m_point.second) {
-            Path path;
-            path.nb_changes = 0;
-            PathItem path_item;
-            const navitia::type::StopPoint* sp = get_sp(m_stop_point.first);
-            path_item.stop_points.push_back(sp);
-            path_item.type = ItemType::public_transport;
-            path.items.push_back(path_item);
-            paths.push_back(path);
-        }
-
-        result.push_back(std::make_pair(m_entry_point, paths));
-    }
-
-    return result;
-}
-
 void
 RAPTOR::isochrone(const map_stop_point_duration& departures,
                   const DateTime& departure_datetime,

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -153,22 +153,6 @@ struct RAPTOR
                 const size_t max_extra_second_pass = 0);
 
 
-    /** Calcul d'itinéraires multiples dans le sens horaire à partir de plusieurs
-     * stop points de départs, vers plusieurs stoppoints d'arrivée,
-     * à une heure donnée.
-     */
-    std::vector<std::pair<type::EntryPoint, std::vector<Path>>>
-    compute_nm_all(const std::vector<std::pair<type::EntryPoint, map_stop_point_duration>>& departures,
-                   const std::vector<std::pair<type::EntryPoint, map_stop_point_duration>>& arrivals,
-                   const DateTime& departure_datetime,
-                   const nt::RTLevel rt_level,
-                   const DateTime& bound,
-                   const uint32_t max_transfers,
-                   const type::AccessibiliteParams& accessibilite_params,
-                   const std::vector<std::string>& forbidden_uri,
-                   bool clockwise);
-
-
     /** Calcul l'isochrone à partir de tous les points contenus dans departs,
      *  vers tous les autres points.
      *  Renvoie toutes les arrivées vers tous les stop points.

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -649,8 +649,7 @@ static void add_isochrone_response(RAPTOR& raptor,
                                    bool clockwise,
                                    DateTime init_dt,
                                    DateTime bound,
-                                   int max_duration,
-                                   bool show_stop_area) {
+                                   int max_duration) {
     pb_creator.now = bt::second_clock::universal_time();
     for(const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
@@ -690,10 +689,7 @@ static void add_isochrone_response(RAPTOR& raptor,
             pb_journey->set_nb_transfers(round - 1);
             pb_creator.action_period = bt::time_period(navitia::to_posix_time(best_lbl-duration, raptor.data),
                                                        navitia::to_posix_time(best_lbl, raptor.data));
-            if (show_stop_area)
-                pb_creator.fill(sp->stop_area, pb_journey->mutable_destination(), 0);
-            else
-                pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
+            pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
         }
     }
 }
@@ -1029,105 +1025,6 @@ make_response(RAPTOR &raptor,
     return pb_creator.get_response();
 }
 
-pbnavitia::Response
-make_nm_response(RAPTOR &raptor, const std::vector<type::EntryPoint> &origins,
-                 const std::vector<type::EntryPoint> &destinations,
-                 const uint64_t &datetimes_str, bool clockwise,
-                 const type::AccessibiliteParams & accessibilite_params,
-                 std::vector<std::string> forbidden,
-                 georef::StreetNetwork & worker,
-                 const type::RTLevel rt_level,
-                 uint32_t max_duration, uint32_t max_transfers,
-                 bool show_codes) {
-    PbCreator pb_creator(raptor.data, pt::not_a_date_time, null_time_period, show_codes);
-    pb_creator.set_response_type(pbnavitia::ITINERARY_FOUND);
-    std::vector<bt::ptime> datetimes;
-    datetimes = parse_datetimes(raptor, {datetimes_str}, pb_creator, clockwise);
-    if(pb_creator.has_error() || pb_creator.has_response_type(pbnavitia::DATE_OUT_OF_BOUNDS)) {
-        return pb_creator.get_response();
-    }
-
-    std::vector<std::pair<type::EntryPoint, routing::map_stop_point_duration > > departures;
-    std::vector<std::pair<type::EntryPoint, routing::map_stop_point_duration > > arrivals;
-
-    for(const type::EntryPoint& org : origins) {
-        worker.init(org);
-        auto org_stop_points = get_stop_points(org, raptor.data, worker);
-        for (auto& org_stop_point: org_stop_points) {
-            org_stop_point.second += navitia::seconds(org.access_duration);
-        }
-        departures.push_back(std::make_pair(org, org_stop_points));
-    }
-
-    for(const type::EntryPoint& dst : destinations) {
-        worker.init(dst);
-        auto dst_stop_points = get_stop_points(dst, raptor.data, worker);
-        for (auto& dst_stop_point: dst_stop_points) {
-            dst_stop_point.second += navitia::seconds(dst.access_duration);
-        }
-        arrivals.push_back(std::make_pair(dst, dst_stop_points));
-    }
-
-    if(departures.empty() && arrivals.empty()) {
-        pb_creator.fill_pb_error(pbnavitia::Error::no_origin_nor_destination,
-                                 pbnavitia::NO_ORIGIN_NOR_DESTINATION_POINT,
-                                 "no origin point nor destination point");
-        return pb_creator.get_response();
-    }
-
-    if(departures.empty()) {
-        pb_creator.fill_pb_error(pbnavitia::Error::no_origin, pbnavitia::NO_ORIGIN_POINT, "no origin point");
-        return pb_creator.get_response();
-    }
-
-    if(arrivals.empty()) {
-        pb_creator.fill_pb_error(pbnavitia::Error::no_destination, pbnavitia::NO_DESTINATION_POINT,
-                                 "no destination point");
-        return pb_creator.get_response();
-    }
-
-    DateTime bound = clockwise ? DateTimeUtils::inf : DateTimeUtils::min;
-
-    for(bt::ptime datetime : datetimes) {
-        int day = (datetime.date() - raptor.data.meta->production_date.begin()).days();
-        int time = datetime.time_of_day().total_seconds();
-        DateTime init_dt = DateTimeUtils::set(day, time);
-
-        if(max_duration!=std::numeric_limits<uint32_t>::max()) {
-            bound = clockwise ? init_dt + max_duration : init_dt - max_duration;
-        }
-
-        // compute m trip in one call
-        auto paths_by_entrypoint = raptor.
-                compute_nm_all(departures, arrivals, init_dt, rt_level, bound, max_transfers,
-                               accessibilite_params, forbidden, clockwise);
-
-        // compute isochron style result at "m point"
-        for (const auto& paths_for_m_point : paths_by_entrypoint) {
-            const std::vector<Path>& paths = paths_for_m_point.second;
-            if(paths.empty())
-                continue;
-
-            std::vector<type::StopPoint*> stop_points;
-            for (const auto& path : paths) {
-                const type::StopPoint* sp = clockwise ? path.items.front().stop_points.front() :
-                    path.items.back().stop_points.back();
-                stop_points.push_back(const_cast<type::StopPoint*>(sp));
-            }
-
-            const type::EntryPoint& m_point = paths_for_m_point.first;
-
-            add_isochrone_response(raptor, pb_creator, stop_points, clockwise,
-                                   init_dt, bound, max_duration, (m_point.type == nt::Type_e::StopArea));
-        }
-    }
-
-    if (pb_creator.empty_journeys()) {
-        pb_creator.fill_pb_error(pbnavitia::Error::no_solution,
-                                 pbnavitia::NO_SOLUTION, "no solution found for this journey");
-    }
-    return pb_creator.get_response();
-}
 
 pbnavitia::Response make_isochrone(RAPTOR &raptor,
                                    type::EntryPoint origin,
@@ -1163,8 +1060,8 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
     raptor.isochrone(departures, init_dt, bound, max_transfers,
                            accessibilite_params, forbidden, clockwise, rt_level);
 
-    add_isochrone_response(raptor, pb_creator, raptor.data.pt_data->stop_points, clockwise,
-                           init_dt, bound, max_duration, false);
+    add_isochrone_response(raptor, /*origin, clockwise,*/ pb_creator, raptor.data.pt_data->stop_points, clockwise,
+                           init_dt, bound, max_duration);
     pb_creator.sort_journeys();
     if(pb_creator.empty_journeys()){
          pb_creator.fill_pb_error(pbnavitia::Error::no_solution, pbnavitia::NO_SOLUTION,

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -644,6 +644,7 @@ static pbnavitia::Response make_pt_pathes(PbCreator& pb_creator,
 }
 
 static void add_isochrone_response(RAPTOR& raptor,
+                                   type::EntryPoint origin,
                                    PbCreator& pb_creator,
                                    const std::vector<type::StopPoint*> stop_points,
                                    bool clockwise,
@@ -689,7 +690,14 @@ static void add_isochrone_response(RAPTOR& raptor,
             pb_journey->set_nb_transfers(round - 1);
             pb_creator.action_period = bt::time_period(navitia::to_posix_time(best_lbl-duration, raptor.data),
                                                        navitia::to_posix_time(best_lbl, raptor.data));
-            pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
+            if(clockwise){
+                pb_creator.fill(&origin, pb_journey->mutable_origin(), 0);
+                pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
+            }else{
+                pb_creator.fill(sp, pb_journey->mutable_origin(), 0);
+                pb_creator.fill(&origin, pb_journey->mutable_destination(), 0);
+
+            }
         }
     }
 }
@@ -1060,7 +1068,7 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
     raptor.isochrone(departures, init_dt, bound, max_transfers,
                            accessibilite_params, forbidden, clockwise, rt_level);
 
-    add_isochrone_response(raptor, /*origin, clockwise,*/ pb_creator, raptor.data.pt_data->stop_points, clockwise,
+    add_isochrone_response(raptor, origin, pb_creator, raptor.data.pt_data->stop_points, clockwise,
                            init_dt, bound, max_duration);
     pb_creator.sort_journeys();
     if(pb_creator.empty_journeys()){

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -68,16 +68,6 @@ pbnavitia::Response make_response(RAPTOR &raptor,
                                   bool show_codes = false,
                                   uint32_t max_extra_second_pass = 0);
 
-pbnavitia::Response make_nm_response(RAPTOR &raptor, const std::vector<type::EntryPoint> &origins,
-                                     const std::vector<type::EntryPoint> &destinations,
-                                     const uint64_t& datetimes, bool clockwise,
-                                     const type::AccessibiliteParams & accessibilite_params,
-                                     std::vector<std::string> forbidden,
-                                     georef::StreetNetwork & worker,
-                                     const type::RTLevel rt_level,
-                                     uint32_t max_duration, uint32_t max_transfers,
-                                     bool show_codes);
-
 pbnavitia::Response make_isochrone(RAPTOR &raptor,
                                    type::EntryPoint origin,
                                    const uint64_t datetime, bool clockwise,


### PR DESCRIPTION
Remove the NM journey api, it's not used, not tested and probably not even work as expected.

Each journey in the isochrone response has a link to the detail of the journey (that will compute a usual journey), most of the time this link didn't include the `from` parameter, resulting to a link to another isochrone. `datetime_represents` has also been added to the link.

The link was created without any reference to the coverage used even if it was specifically requested in the request, I also added it if it was in the original request, it will ensure that you get a similar response since the same coverage will be used.

In the isochrone response only the field to was filled, even with a reverse isochrone.... With this change there always a `from` and a `to` sections, the drawback is that the response is bigger.

Since isochrone only used stop_points the journey link make you compute a journey to a specified stop_point, it would be nice to used stop_area in the response, it will provide better response and allow us to make journey link directly to the stop_area.
