### PR TITLE
Ptref: use map for uri look up

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -150,9 +150,12 @@ nt::VehicleJourney* VJ::make() {
 
     //add physical mode
     if (!physical_mode.empty()) {
-        auto it = pt_data.physical_modes_map.find(physical_mode);
-        if (it != pt_data.physical_modes_map.end()){
-            vj->physical_mode = it->second;
+        // at this moment, the physical_modes_map might not be filled, we look up in the vector
+        auto it = boost::find_if(pt_data.physical_modes, [this](const nt::PhysicalMode* phy) {
+            return phy->uri == this->physical_mode;
+        });
+        if (it != std::end(pt_data.physical_modes)) {
+            vj->physical_mode = *it;
         }
     }
     if (!vj->physical_mode) {

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -425,19 +425,19 @@ void GeoRef::build_autocomplete_list(){
 }
 
 
-/** Chargement de la liste poitype_map : mappage entre codes externes et idx des POITypes*/
-void GeoRef::build_poitypes_map(){
+/** poitype_map load: mapping external codes -> POIType*/
+void GeoRef::build_poitypes_map() {
    this->poitype_map.clear();
-   for(const POIType* ptype : poitypes){
-       this->poitype_map[ptype->uri] = ptype->idx;
+   for (POIType* ptype : poitypes) {
+       this->poitype_map[ptype->uri] = ptype;
    }
 }
 
-/** Chargement de la liste poi_map : mappage entre codes externes et idx des POIs*/
-void GeoRef::build_pois_map(){
-    this->poi_map.clear();
-   for(const POI* poi : pois){
-       this->poi_map[poi->uri] = poi->idx;
+/** poi_map load: mapping external codes -> POI*/
+void GeoRef::build_pois_map() {
+   this->poi_map.clear();
+   for (POI* poi : pois) {
+       this->poi_map[poi->uri] = poi;
    }
 }
 

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -217,9 +217,9 @@ struct GeoRef {
     navitia::time_duration default_time_parking_park = seconds(5 * 60);
 
     std::vector<POIType*> poitypes;
-    std::map<std::string, nt::idx_t> poitype_map;
+    std::map<std::string, POIType*> poitype_map;
     std::vector<POI*> pois;
-    std::map<std::string, nt::idx_t> poi_map;
+    std::map<std::string, POI*> poi_map;
     proximitylist::ProximityList<type::idx_t> poi_proximity_list;
     std::vector<Way*> ways;
     std::map<std::string, nt::idx_t> way_map;
@@ -266,8 +266,8 @@ struct GeoRef {
 
     template<class Archive> void save(Archive & ar, const unsigned int) const {
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map &  pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & ghostwords & poi_proximity_list
-                & nb_vertex_by_mode;
+                & admins & admin_map &  pois & fl_poi & poitypes & poitype_map & poi_map & synonyms
+                & ghostwords & poi_proximity_list & nb_vertex_by_mode;
     }
 
     template<class Archive> void load(Archive & ar, const unsigned int) {
@@ -275,8 +275,8 @@ struct GeoRef {
         // On avait donc une fuite de mémoire
         graph.clear();
         ar & ways & way_map & graph & offsets & fl_admin & fl_way & pl & projected_stop_points
-                & admins & admin_map & pois & fl_poi & poitypes &poitype_map & poi_map & synonyms & ghostwords & poi_proximity_list
-                & nb_vertex_by_mode;
+                & admins & admin_map & pois & fl_poi & poitypes & poitype_map & poi_map & synonyms
+                & ghostwords & poi_proximity_list & nb_vertex_by_mode;
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -334,7 +334,7 @@ class TestPtRef(AbstractTestFixture):
 
         is_valid_stop_area(stops[0], depth_check=2)
         modes = get_not_null(stops[0], 'physical_modes')
-        assert len(modes) == 2
+        assert len(modes) == 1
         modes = get_not_null(stops[0], 'commercial_modes')
         assert len(modes) == 1
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -383,8 +383,7 @@ type::GeographicalCoord Worker::coord_of_entry_point(
     } else if(entry_point.type == Type_e::POI){
         auto poi = data->geo_ref->poi_map.find(entry_point.uri);
         if (poi != data->geo_ref->poi_map.end()){
-            const auto geo_poi = data->geo_ref->pois[poi->second];
-            result = geo_poi->coord;
+            result = poi->second->coord;
         }
     }
     return result;
@@ -462,7 +461,7 @@ pbnavitia::Response Worker::place_uri(const pbnavitia::PlaceUriRequest &request)
         } else {
             auto it_poi = data->geo_ref->poi_map.find(request.uri());
             if(it_poi != data->geo_ref->poi_map.end()) {
-                pb_creator.fill(data->geo_ref->pois[it_poi->second], pb_creator.add_places(), 1);
+                pb_creator.fill(it_poi->second, pb_creator.add_places(), 1);
             } else {
                 auto it_admin = data->geo_ref->admin_map.find(request.uri());
                 if(it_admin != data->geo_ref->admin_map.end()) {

--- a/source/proximity_list/tests/test.cpp
+++ b/source/proximity_list/tests/test.cpp
@@ -325,6 +325,7 @@ BOOST_AUTO_TEST_CASE(test_poi_filter) {
     }
     data.geo_ref->init();
     data.build_proximity_list();
+    data.build_uri();
     navitia::type::GeographicalCoord c;
     c.set_lon(-1.554514);
     c.set_lat(47.218515);

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -202,7 +202,7 @@ inline constexpr std::false_type has_string_lookup(const Container&, ...) {
 
 template<typename T, typename Container>
 std::vector<idx_t> filter_by_uri(const Container& data, const std::string& uri, std::false_type) {
-    // by refault, we loop over all element to find the one
+    // by default, we loop over all element to find the one
     return filtered_indexes(data, WHERE(ptr_uri<T>(), Operator_e::EQ, uri));
 }
 

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -213,6 +213,7 @@ BOOST_AUTO_TEST_CASE(sans_filtre) {
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
     b.finish();
+    b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::Line, "", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 2);
@@ -262,6 +263,7 @@ BOOST_AUTO_TEST_CASE(physical_modes) {
     b.connection("stop3", "stop2", 10*60);
     b.data->build_relations();
     b.finish();
+    b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::Line, "line.uri=A", *(b.data));
     BOOST_REQUIRE_EQUAL(indexes.size(), 1);
@@ -284,6 +286,7 @@ BOOST_AUTO_TEST_CASE(get_indexes_test){
     b.connection("stop3", "stop2", 10*60);
     b.finish();
     b.data->pt_data->index();
+    b.data->pt_data->build_uri();
 
     // On cherche à retrouver la ligne 1, en passant le stoparea en filtre
     Filter filter;
@@ -364,6 +367,7 @@ BOOST_AUTO_TEST_CASE(make_query_filtre_direct) {
     b.connection("stop2", "stop3", 10*60);
     b.connection("stop3", "stop2", 10*60);
     b.finish();
+    b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::Line, "line.uri=A", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 1);
@@ -406,6 +410,7 @@ BOOST_AUTO_TEST_CASE(line_code) {
     b.lines["C"]->code = "line C";
     b.data->build_relations();
     b.finish();
+    b.data->pt_data->build_uri();
 
     //find line by code
     auto indexes = make_query(nt::Type_e::Line, "line.code=line_A", *(b.data));
@@ -451,6 +456,7 @@ BOOST_AUTO_TEST_CASE(after_filter) {
     b.vj("C")("stop6", 9000,9050)("stop2", 9200,9250)("stop7", 10000);
     b.vj("D")("stop5", 9000,9050)("stop2", 9200,9250)("stop3", 10000);
     b.finish();
+    b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::StopArea, "AFTER(stop_area.uri=stop2)", *(b.data));
     BOOST_REQUIRE_EQUAL(indexes.size(), 3);
@@ -523,6 +529,7 @@ BOOST_AUTO_TEST_CASE(mvj_filtering) {
     builder.vj("B", "1011")("stop3", "10:00"_t);
     builder.vj("C", "1000")("stop3", "10:00"_t);
     builder.finish();
+    builder.data->pt_data->build_uri();
     nt::idx_t a = 0;
     nt::idx_t b = 1;
     nt::idx_t c = 2;
@@ -760,6 +767,7 @@ BOOST_AUTO_TEST_CASE(contributor_and_frame) {
 
     b.data->build_relations();
     b.finish();
+    b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::Contributor, "contributor.uri=c1", *(b.data));
     BOOST_REQUIRE_EQUAL(indexes.size(), 1);

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -108,8 +108,7 @@ static type::GeographicalCoord coord_of_entry_point(const type::EntryPoint& entr
     case type::Type_e::POI: {
             auto poi = data.geo_ref->poi_map.find(entry_point.uri);
             if (poi != data.geo_ref->poi_map.end()){
-                const auto geo_poi = data.geo_ref->pois[poi->second];
-                return geo_poi->coord;
+                return poi->second->coord;
             }
         }
         break;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -796,8 +796,7 @@ std::vector<georef::Admin*> find_admins(const type::EntryPoint& ep, const type::
         if (it_poi == data.geo_ref->poi_map.end()) {
             return {};
         }
-        const auto poi = data.geo_ref->pois[it_poi->second];
-        return poi->admin_list;
+        return it_poi->second->admin_list;
     }
     //else we look for the coordinate's admin
     return data.geo_ref->find_admins(ep.coordinates);

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -70,6 +70,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
+    b.data->pt_data->build_uri();
 
     boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20150615");
     boost::gregorian::date end = boost::gregorian::date_from_iso_string("20150630");
@@ -178,6 +179,7 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
+    b.data->pt_data->build_uri();
 
     boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20150615");
     boost::gregorian::date end = boost::gregorian::date_from_iso_string("20150630");

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -111,6 +111,7 @@ struct route_schedule_fixture {
         b.finish();
         b.data->pt_data->index();
         b.data->build_raptor();
+        b.data->pt_data->build_uri();
 
         boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20120613");
         boost::gregorian::date end = boost::gregorian::date_from_iso_string("20120630");
@@ -230,6 +231,7 @@ struct route_schedule_calendar_fixture {
         b.finish();
         b.data->pt_data->index();
         b.data->build_raptor();
+        b.data->pt_data->build_uri();
 
         b.data->meta->production_date = boost::gregorian::date_period(begin, end);
     }
@@ -495,6 +497,7 @@ BOOST_AUTO_TEST_CASE(test_route_schedule_with_different_vp_over_midnight) {
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
+    b.data->pt_data->build_uri();
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period, false);
 
@@ -539,6 +542,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_1) {
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
+    b.data->pt_data->build_uri();
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period, false);
     navitia::timetables::route_schedule(pb_creator, "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
@@ -589,6 +593,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_2) {
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
+    b.data->pt_data->build_uri();
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period, false);
     navitia::timetables::route_schedule(pb_creator, "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,
@@ -634,6 +639,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_3) {
     b.finish();
     b.data->pt_data->index();
     b.data->build_raptor();
+    b.data->pt_data->build_uri();
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period, false);
     navitia::timetables::route_schedule(pb_creator, "line.uri=L", {}, {}, d("20120615T000000"), 86400, 100,

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -508,6 +508,7 @@ Data::get_data<type_name>() const {\
     return this->pt_data->collection_name;\
 }
 ITERATE_NAVITIA_PT_TYPES(GET_DATA)
+#undef GET_DATA
 
 template<> const std::vector<georef::POI*>&
 Data::get_data<georef::POI>() const {
@@ -540,6 +541,48 @@ Data::get_data<routing::JourneyPatternPoint>() const {
 
 template<> const std::vector<boost::weak_ptr<type::disruption::Impact>>&
 Data::get_data<type::disruption::Impact>() const {
+    return pt_data->disruption_holder.get_weak_impacts();
+}
+
+#define GET_ASSOCIATIVE_DATA(type_name, collection_name)\
+template<> const ContainerTrait<type_name>::associative_type& \
+Data::get_assoc_data<type_name>() const {\
+    return this->pt_data->collection_name##_map;\
+}
+ITERATE_NAVITIA_PT_TYPES(GET_ASSOCIATIVE_DATA)
+#undef GET_ASSOCIATIVE_DATA
+
+template<> const ContainerTrait<georef::POI>::associative_type&
+Data::get_assoc_data<georef::POI>() const {
+    return this->geo_ref->poi_map;
+}
+template<> const ContainerTrait<georef::POIType>::associative_type&
+Data::get_assoc_data<georef::POIType>() const {
+    return this->geo_ref->poitype_map;
+}
+template<> const ContainerTrait<StopPointConnection>::associative_type&
+Data::get_assoc_data<StopPointConnection>() const {
+    return this->pt_data->stop_point_connections;
+}
+template<> const ContainerTrait<MetaVehicleJourney>::associative_type&
+Data::get_assoc_data<MetaVehicleJourney>() const {
+    return this->pt_data->meta_vjs;
+}
+
+// JP and JPP can't work with automatic build clause
+template<> const ContainerTrait<routing::JourneyPattern>::associative_type&
+Data::get_assoc_data<routing::JourneyPattern>() const {
+    static const ContainerTrait<routing::JourneyPattern>::associative_type res;
+    return res;
+}
+template<> const ContainerTrait<routing::JourneyPatternPoint>::associative_type&
+Data::get_assoc_data<routing::JourneyPatternPoint>() const {
+    static const ContainerTrait<routing::JourneyPatternPoint>::associative_type res;
+    return res;
+}
+
+template<> const ContainerTrait<type::disruption::Impact>::associative_type&
+Data::get_assoc_data<type::disruption::Impact>() const {
     return pt_data->disruption_holder.get_weak_impacts();
 }
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -42,17 +42,21 @@ www.navitia.io
 #include "utils/obj_factory.h"
 
 //forward declare
-namespace navitia{
-    namespace georef{
+namespace navitia {
+    namespace georef {
         struct GeoRef;
+        struct POI;
+        struct POIType;
     }
-    namespace fare{
+    namespace fare {
         struct Fare;
     }
-    namespace routing{
+    namespace routing {
         struct dataRAPTOR;
+        struct JourneyPattern;
+        struct JourneyPatternPoint;
     }
-    namespace type{
+    namespace type {
         struct MetaData;
     }
 }
@@ -67,22 +71,53 @@ struct wrong_version : public navitia::exception {
 };
 
 template<typename T>
-struct DataTraitHelper {
-  typedef std::vector<T*> type;
+struct ContainerTrait {
+    typedef std::vector<T*> vect_type;
+    typedef std::unordered_map<std::string, T*> associative_type;
 };
 
 // specialization for impact
 // Instead of pure pointer, we can only get a weak_ptr when requesting impacts 
 template<>
-struct DataTraitHelper<type::disruption::Impact> {
-  typedef std::vector<boost::weak_ptr<type::disruption::Impact>> type;
+struct ContainerTrait<type::disruption::Impact> {
+    typedef std::vector<boost::weak_ptr<type::disruption::Impact>> vect_type;
+    // for impacts, we don't want to have a map, we use the vector as the associative_type
+    typedef vect_type associative_type;
 };
 
+// specialization for StopPointConnection, there is no map too
+template<>
+struct ContainerTrait<type::StopPointConnection> {
+    typedef std::vector<type::StopPointConnection*> vect_type;
+    typedef vect_type associative_type;
+};
+
+template<>
+struct ContainerTrait<navitia::georef::POIType> {
+    typedef std::vector<navitia::georef::POIType*> vect_type;
+    typedef std::map<std::string, navitia::georef::POIType*> associative_type;
+};
+template<>
+struct ContainerTrait<navitia::georef::POI> {
+    typedef std::vector<navitia::georef::POI*> vect_type;
+    typedef std::map<std::string, navitia::georef::POI*> associative_type;
+};
+template<>
+struct ContainerTrait<navitia::routing::JourneyPattern> {
+    typedef std::vector<navitia::routing::JourneyPattern*> vect_type;
+    typedef vect_type associative_type;
+};
+template<>
+struct ContainerTrait<navitia::routing::JourneyPatternPoint> {
+    typedef std::vector<navitia::routing::JourneyPatternPoint*> vect_type;
+    typedef vect_type associative_type;
+};
 // specialization for meta-vj
 // Instead of vector, we can only get an objFactory when requesting meta-vj
 template<>
-struct DataTraitHelper<type::MetaVehicleJourney> {
-  typedef ObjFactory<MetaVehicleJourney> type;
+struct ContainerTrait<type::MetaVehicleJourney> {
+    typedef ObjFactory<MetaVehicleJourney> vect_type;
+    typedef vect_type associative_type;
 };
 
 /** Contient toutes les données théoriques du référentiel transport en communs
@@ -118,12 +153,14 @@ public:
     // functor to find admins
     std::function<std::vector<georef::Admin*>(const GeographicalCoord&)> find_admins;
 
-    /** Retourne la structure de données associée au type */
-    template<typename T> const typename DataTraitHelper<T>::type& get_data() const;
+    /** Return the vector containing all the objects of type T*/
+    template<typename T> const typename ContainerTrait<T>::vect_type& get_data() const;
 
-    template<typename T> typename DataTraitHelper<T>::type
+    template<typename T> const typename ContainerTrait<T>::associative_type& get_assoc_data() const;
+
+    template<typename T> typename ContainerTrait<T>::vect_type
     get_data(const std::vector<idx_t>& indexes) const {
-        typename DataTraitHelper<T>::type res;
+        typename ContainerTrait<T>::vect_type res;
         const auto& objs = get_data<T>();
         for (const auto& idx: indexes) { res.push_back(objs[idx]); }
         return res;

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1266,20 +1266,19 @@ void PbCreator::Filler::fill_pb_object(const nt::EntryPoint* point, pbnavitia::P
     } else if (point->type == nt::Type_e::POI) {
         const auto it = pb_creator.data.geo_ref->poi_map.find(point->uri);
         if (it != pb_creator.data.geo_ref->poi_map.end()) {
-            fill_with_creator(pb_creator.data.geo_ref->pois[it->second], [&](){return place;});
+            fill_with_creator(it->second, [&](){return place;});
         }
     } else if (point->type == nt::Type_e::Admin) {
         const auto it = pb_creator.data.geo_ref->admin_map.find(point->uri);
         if (it != pb_creator.data.geo_ref->admin_map.end()) {
             fill_with_creator(pb_creator.data.geo_ref->admins[it->second], [&](){return place;});
         }
-    } else if (point->type == nt::Type_e::Coord){
-        try{
+    } else if (point->type == nt::Type_e::Coord) {
+        try {
             auto address = pb_creator.data.geo_ref->nearest_addr(point->coordinates);
             const auto& way_coord = WayCoord(address.second, point->coordinates, address.first);
             fill_pb_object(&way_coord, place);
-
-        }catch(navitia::proximitylist::NotFound){
+        } catch(navitia::proximitylist::NotFound) {
             //we didn't find a address at this coordinate, we fill the address manually with the coord, so we have a valid output
             place->set_name("");
             place->set_uri(point->coordinates.uri());
@@ -1289,7 +1288,6 @@ void PbCreator::Filler::fill_pb_object(const nt::EntryPoint* point, pbnavitia::P
             c->set_lon(point->coordinates.lon());
             c->set_lat(point->coordinates.lat());
         }
-
     }
 }
 
@@ -1532,9 +1530,8 @@ void PbCreator::fill_street_sections(const type::EntryPoint& ori_dest, const geo
 }
 
 const ng::POI* PbCreator::get_nearest_bss_station(const nt::GeographicalCoord& coord){
-    nt::idx_t poi_type_idx = data.geo_ref->poitype_map["poi_type:amenity:bicycle_rental"];
-    const ng::POIType poi_type = *data.geo_ref->poitypes[poi_type_idx];
-    return this->get_nearest_poi(coord, poi_type);
+    const auto* poi_type = data.geo_ref->poitype_map["poi_type:amenity:bicycle_rental"];
+    return this->get_nearest_poi(coord, *poi_type);
 }
 
 const ng::POI* PbCreator::get_nearest_poi(const nt::GeographicalCoord& coord, const ng::POIType& poi_type) {
@@ -1550,9 +1547,8 @@ const ng::POI* PbCreator::get_nearest_poi(const nt::GeographicalCoord& coord, co
 }
 
 const ng::POI* PbCreator::get_nearest_parking(const nt::GeographicalCoord& coord){
-    nt::idx_t poi_type_idx = data.geo_ref->poitype_map["poi_type:amenity:parking"];
-    const ng::POIType poi_type = *data.geo_ref->poitypes[poi_type_idx];
-    return get_nearest_poi(coord, poi_type);
+    const auto* poi_type = data.geo_ref->poitype_map["poi_type:amenity:parking"];
+    return get_nearest_poi(coord, *poi_type);
 }
 
 pbnavitia::RouteSchedule* PbCreator::add_route_schedules(){

--- a/source/type/tests/fill_pb_object_tests.cpp
+++ b/source/type/tests/fill_pb_object_tests.cpp
@@ -118,6 +118,7 @@ BOOST_AUTO_TEST_CASE(physical_and_commercial_modes_stop_area) {
 
     b.data->build_relations();
     b.finish();
+    b.data->pt_data->build_uri();
 
     auto stop_area = new pbnavitia::StopArea();
     boost::gregorian::date d1(2014,06,14);


### PR DESCRIPTION
for uri look up we don't use the vector anymore, we use the associated maps.

This should speed up 'a bit' the ptref look up

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1435)

<!-- Reviewable:end -->
