### PR TITLE
Type: fix circular reference on vj/datasets

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -63,7 +63,7 @@ namespace navitia { namespace type {
 
 wrong_version::~wrong_version() noexcept {}
 
-const unsigned int Data::data_version = 57; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 58; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     data_identifier(data_identifier),

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -902,8 +902,3 @@ void StreetNetworkParams::set_filter(const std::string &param_uri){
 }
 
 }} //namespace navitia::type
-#if BOOST_VERSION <= 105700
-BOOST_CLASS_EXPORT_IMPLEMENT(navitia::type::VehicleJourney)
-BOOST_CLASS_EXPORT_IMPLEMENT(navitia::type::DiscreteVehicleJourney)
-BOOST_CLASS_EXPORT_IMPLEMENT(navitia::type::FrequencyVehicleJourney)
-#endif

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -1005,7 +1005,3 @@ struct enum_size_trait<type::Mode_e> {
 };
 
 } //namespace navitia
-#if BOOST_VERSION <= 105700
-BOOST_CLASS_EXPORT_KEY(navitia::type::DiscreteVehicleJourney)
-BOOST_CLASS_EXPORT_KEY(navitia::type::FrequencyVehicleJourney)
-#endif


### PR DESCRIPTION
BOOST_CLASS_EXPORT_IMPLEMENT is brokne in boost 158, so we trick boost
serialize not to use it

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1438)

<!-- Reviewable:end -->
