### PR TITLE
Ptref: do not build ptref graph at request, and use of flat_enum_map

### DIFF
--- a/source/ptreferential/ptref_graph.h
+++ b/source/ptreferential/ptref_graph.h
@@ -32,6 +32,7 @@ www.navitia.io
 
 #include "type/type.h"
 #include <boost/graph/adjacency_list.hpp>
+#include "utils/flat_enum_map.h"
 
 namespace navitia { namespace ptref {
 
@@ -46,7 +47,7 @@ struct Jointures {
     typedef boost::graph_traits<Graph>::vertex_descriptor vertex_t;
     typedef boost::graph_traits<Graph>::edge_descriptor edge_t;
 
-    std::map<type::Type_e, vertex_t> vertex_map;
+    navitia::flat_enum_map<type::Type_e, vertex_t> vertex_map;
     Graph g;
     Jointures();
 };

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -337,7 +337,8 @@ std::vector<idx_t> get_indexes(Filter filter,  Type_e requested_type, const Data
 std::vector<Filter> parse(std::string request){
     std::string::iterator begin = request.begin();
     std::vector<Filter> filters;
-    select_r<std::string::iterator> s;
+    // the spirit parser does not depend of the data, it can be static
+    static const select_r<std::string::iterator> s;
     if (qi::phrase_parse(begin, request.end(), s, qi::space, filters)) {
         if(begin != request.end()) {
             std::string unparsed(begin, request.end());

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -84,7 +84,8 @@ enum class Type_e {
     LineGroup                       = 25,
     MetaVehicleJourney              = 26,
     Impact                          = 27,
-    Dataset                         = 28
+    Dataset                         = 28,
+    size                            = 29
 };
 
 enum class Mode_e {


### PR DESCRIPTION
use of flat_enum_map for better look up
