### PR TITLE
jormun: serve challenge on 401

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -64,7 +64,7 @@ got_request_exception.connect(log_exception, app)
 #we want the old behavior for reqparse
 compat.patch_reqparse()
 
-rest_api = Api(app, catch_all_404s=True)
+rest_api = Api(app, catch_all_404s=True, serve_challenge_on_401=True)
 
 from navitiacommon.models import db
 db.init_app(app)

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -179,6 +179,14 @@ class TestBasicAuthentication(AbstractTestAuthentication):
             assert(len(response['regions']) == 1)
             assert(response['regions'][0]['id'] == "main_routing_test")
 
+    def test_auth_required(self):
+        """
+        if no token is given we are asked to log in (code 401) and a chalenge is sent (header WWW-Authenticate)
+        """
+        response_obj = self.app.get('/v1/coverage')
+        assert response_obj.status_code == 401
+        assert 'WWW-Authenticate' in response_obj.headers
+
     def test_status_code(self):
         """
         We query the api with user 1 who have access to the main routintg test and not to the departure board


### PR DESCRIPTION
The new version of flask didn't automatically serve challenge on 401, causing
the browser to don't show "the authentication box"
