### PR TITLE
Type: use flat_set instead of vector in ptref

### DIFF
--- a/source/calendar/calendar.cpp
+++ b/source/calendar/calendar.cpp
@@ -34,29 +34,29 @@ www.navitia.io
 
 namespace navitia { namespace calendar {
 
-std::vector<type::idx_t> Calendar::get_calendars(const std::string& filter,
+type::Indexes Calendar::get_calendars(const std::string& filter,
                 const std::vector<std::string>& forbidden_uris,
                 const type::Data &d,
                 const boost::gregorian::date_period filter_period,
                 const boost::posix_time::ptime){
 
-    std::vector<type::idx_t> to_return;
+    type::Indexes to_return;
     to_return  = ptref::make_query(type::Type_e::Calendar, filter, forbidden_uris, d);
-    if(to_return.empty() || (filter_period.begin().is_not_a_date())){
+    if (to_return.empty() || (filter_period.begin().is_not_a_date())) {
         return to_return;
     }
-    std::vector<type::idx_t> indexes;
-    for(type::idx_t idx : to_return){
+    type::Indexes indexes;
+    for (type::idx_t idx : to_return) {
         navitia::type::Calendar* cal = d.pt_data->calendars[idx];
-        for(const boost::gregorian::date_period per : cal->active_periods){
-            if(filter_period.begin() == filter_period.end()){
-                if (per.contains(filter_period.begin())){
-                    indexes.push_back(cal->idx);
+        for (const boost::gregorian::date_period per : cal->active_periods) {
+            if (filter_period.begin() == filter_period.end()) {
+                if (per.contains(filter_period.begin())) {
+                    indexes.insert(cal->idx);
                     break;
                 }
-            }else{
-                if (filter_period.intersects(per)){
-                    indexes.push_back(cal->idx);
+            } else {
+                if (filter_period.intersects(per)) {
+                    indexes.insert(cal->idx);
                     break;
                 }
             }

--- a/source/calendar/calendar.h
+++ b/source/calendar/calendar.h
@@ -39,7 +39,7 @@ class Calendar{
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 public:
     // Return idx calendars list
-    std::vector<type::idx_t> get_calendars(const std::string& filter,
+    type::Indexes get_calendars(const std::string& filter,
                     const std::vector<std::string>& forbidden_uris,
                     const type::Data &d,
                     const boost::gregorian::date_period filter_period,

--- a/source/calendar/calendar_api.cpp
+++ b/source/calendar/calendar_api.cpp
@@ -44,7 +44,7 @@ pbnavitia::Response calendars(const navitia::type::Data &d,
     const std::string &filter,
     const std::vector<std::string>& forbidden_uris) {
 
-    std::vector<type::idx_t> calendar_list;
+    navitia::type::Indexes calendar_list;
     boost::gregorian::date start_period(boost::gregorian::not_a_date_time);
     boost::gregorian::date end_period(boost::gregorian::not_a_date_time);
     PbCreator pb_creator(d, boost::posix_time::second_clock::universal_time(), null_time_period, false);

--- a/source/disruption/traffic_reports_api.cpp
+++ b/source/disruption/traffic_reports_api.cpp
@@ -57,20 +57,20 @@ private:
     log4cplus::Logger logger;
 
     NetworkDisrupt& find_or_create(const type::Network* network);
-    void add_stop_areas(const std::vector<type::idx_t>& network_idx,
+    void add_stop_areas(const type::Indexes& network_idx,
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
                       const boost::posix_time::ptime now);
 
-    void add_networks(const std::vector<type::idx_t>& network_idx,
+    void add_networks(const type::Indexes& network_idx,
                       const type::Data &d,
                       const boost::posix_time::ptime now);
     void add_lines(const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data &d,
                       const boost::posix_time::ptime now);
-    void add_vehicle_journeys(const std::vector<type::idx_t>& network_idx,
+    void add_vehicle_journeys(const type::Indexes& network_idx,
                               const std::string& filter,
                               const std::vector<std::string>& forbidden_uris,
                               const type::Data &d,
@@ -120,7 +120,7 @@ NetworkDisrupt& TrafficReport::find_or_create(const type::Network* network){
     return *it;
 }
 
-void TrafficReport::add_stop_areas(const std::vector<type::idx_t>& network_idx,
+void TrafficReport::add_stop_areas(const type::Indexes& network_idx,
                       const std::string& filter,
                       const std::vector<std::string>& forbidden_uris,
                       const type::Data& d,
@@ -132,7 +132,7 @@ void TrafficReport::add_stop_areas(const std::vector<type::idx_t>& network_idx,
         if (!filter.empty()) {
             new_filter += " and " + filter;
         }
-        std::vector<type::idx_t> stop_areas;
+        type::Indexes stop_areas;
 
        try {
             stop_areas = ptref::make_query(type::Type_e::StopArea, new_filter, forbidden_uris, d);
@@ -167,7 +167,7 @@ void TrafficReport::add_stop_areas(const std::vector<type::idx_t>& network_idx,
     }
 }
 
-void TrafficReport::add_vehicle_journeys(const std::vector<type::idx_t>& network_idx,
+void TrafficReport::add_vehicle_journeys(const type::Indexes& network_idx,
                                          const std::string& filter,
                                          const std::vector<std::string>& forbidden_uris,
                                          const type::Data& d,
@@ -179,7 +179,7 @@ void TrafficReport::add_vehicle_journeys(const std::vector<type::idx_t>& network
         if (!filter.empty()) {
             new_filter += " and " + filter;
         }
-        std::vector<type::idx_t> vehicle_journeys;
+        type::Indexes vehicle_journeys;
 
         try {
             vehicle_journeys =
@@ -213,7 +213,7 @@ void TrafficReport::add_vehicle_journeys(const std::vector<type::idx_t>& network
     }
 }
 
-void TrafficReport::add_networks(const std::vector<type::idx_t>& network_idx,
+void TrafficReport::add_networks(const type::Indexes& network_idx,
                       const type::Data &d,
                       const boost::posix_time::ptime now){
 
@@ -232,7 +232,7 @@ void TrafficReport::add_lines(const std::string& filter,
                       const type::Data& d,
                       const boost::posix_time::ptime now){
 
-    std::vector<type::idx_t> line_list;
+    type::Indexes line_list;
     try {
         line_list  = ptref::make_query(type::Type_e::Line, filter, forbidden_uris, d);
     } catch(const ptref::parsing_error &parse_error) {
@@ -292,7 +292,7 @@ void TrafficReport::disruptions_list(const std::string& filter,
                         const type::Data& d,
                         const boost::posix_time::ptime now){
 
-    std::vector<type::idx_t> network_idx = ptref::make_query(type::Type_e::Network, filter,
+    type::Indexes network_idx = ptref::make_query(type::Type_e::Network, filter,
                                                              forbidden_uris, d);
     add_networks(network_idx, d, now);
     add_lines(filter, forbidden_uris, d, now);

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -791,7 +791,7 @@ GeoRef::~GeoRef() {
 
 type::Indexes POI::get(type::Type_e type, const GeoRef &) const {
     switch(type) {
-    case type::Type_e::POIType : return {poitype_idx};
+    case type::Type_e::POIType : return type::make_indexes({poitype_idx});
     default : return type::Indexes{};
     }
 }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -789,20 +789,20 @@ GeoRef::~GeoRef() {
 }
 
 
-std::vector<type::idx_t> POI::get(type::Type_e type, const GeoRef &) const {
+type::Indexes POI::get(type::Type_e type, const GeoRef &) const {
     switch(type) {
     case type::Type_e::POIType : return {poitype_idx};
-    default : return {};
+    default : return type::Indexes{};
     }
 }
 
-std::vector<type::idx_t> POIType::get(type::Type_e type, const GeoRef & data) const {
-    std::vector<type::idx_t> result;
+type::Indexes POIType::get(type::Type_e type, const GeoRef & data) const {
+    type::Indexes result;
     switch(type) {
     case type::Type_e::POI:
         for(const POI* elem : data.pois) {
             if(elem->poitype_idx == idx) {
-                result.push_back(elem->idx);
+                result.insert(elem->idx);
             }
         }
         break;

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -402,7 +402,7 @@ struct POIType : public nt::Nameable, nt::Header{
         ar &idx &uri &name;
     }
 
-    std::vector<type::idx_t> get(type::Type_e type, const GeoRef & data) const;
+    type::Indexes get(type::Type_e type, const GeoRef & data) const;
 };
 
 
@@ -424,7 +424,7 @@ struct POI : public nt::Nameable, nt::Header{
         ar &idx & uri & name & weight & coord & admin_list & properties & poitype_idx & visible & address_number & address_name & label;
     }
 
-    std::vector<type::idx_t> get(type::Type_e type, const GeoRef &) const;
+    type::Indexes get(type::Type_e type, const GeoRef &) const;
 
     private:
 };

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -108,7 +108,7 @@ pbnavitia::Response find(const type::GeographicalCoord& coord, const double dist
         }
 
         vector_idx_coord list;
-        std::vector<type::idx_t> indexes;
+        type::Indexes indexes;
         if(! filter.empty()) {
             try {
                 indexes = ptref::make_query(type, filter, pb_creator.data);

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -175,8 +175,8 @@ struct GetterType<ObjFactory<T>> {
 };
 
 template<typename T, typename C>
-boost::container::flat_set<idx_t> filtered_indexes(const T& data, const C& clause) {
-    boost::container::flat_set<idx_t> result;
+Indexes filtered_indexes(const T& data, const C& clause) {
+    Indexes result;
     for (size_t i = 0; i < data.size(); ++i) {
         if (ClauseType<T, C>::is_clause_tested(GetterType<T>::get(data, i), clause)) {
             result.insert(i);
@@ -209,7 +209,7 @@ template<typename T, typename Container>
 Indexes filter_by_uri(const Container& c, const std::string& uri, std::true_type) {
     // for associative containers we can do a better search
     auto elt = find_or_default(uri, c);
-    if (elt) { return Indexes({elt->idx}); }
+    if (elt) { return make_indexes({elt->idx}); }
     return Indexes{};
 }
 }
@@ -349,14 +349,14 @@ std::vector<Filter> parse(std::string request){
     return filters;
 }
 
-Indexes get_difference(Indexes& idxs1, Indexes& idxs2) {
+Indexes get_difference(const Indexes& idxs1, const Indexes& idxs2) {
     Indexes tmp_indexes;
     std::insert_iterator<Indexes> it(tmp_indexes, std::begin(tmp_indexes));
     std::set_difference(std::begin(idxs1), std::end(idxs1), std::begin(idxs2), std::end(idxs2), it);
     return tmp_indexes;
 }
 
-Indexes get_intersection(Indexes& idxs1, Indexes& idxs2) {
+Indexes get_intersection(const Indexes& idxs1, const Indexes& idxs2) {
    Indexes tmp_indexes;
    std::insert_iterator<Indexes> it(tmp_indexes, std::begin(tmp_indexes));
    std::set_intersection(std::begin(idxs1), std::end(idxs1), std::begin(idxs2), std::end(idxs2), it);
@@ -364,9 +364,9 @@ Indexes get_intersection(Indexes& idxs1, Indexes& idxs2) {
 }
 
 Indexes manage_odt_level(const Indexes& final_indexes,
-                                          const navitia::type::Type_e requested_type,
-                                          const navitia::type::OdtLevel_e odt_level,
-                                          const type::Data & data){
+                         const navitia::type::Type_e requested_type,
+                         const navitia::type::OdtLevel_e odt_level,
+                         const type::Data & data) {
     if ((!final_indexes.empty()) && (requested_type == navitia::type::Type_e::Line)) {
         Indexes odt_level_idx;
         for(const idx_t idx : final_indexes){

--- a/source/ptreferential/ptreferential.h
+++ b/source/ptreferential/ptreferential.h
@@ -101,7 +101,7 @@ struct parsing_error : public ptref_error{
 };
 
 /// Exécute une requête sur les données Data : retourne les idx des objets demandés
-std::vector<type::idx_t> make_query(const type::Type_e requested_type,
+type::Indexes make_query(const type::Type_e requested_type,
                                     const std::string& request,
                                     const std::vector<std::string>& forbidden_uris,
                                     const type::OdtLevel_e odt_level,
@@ -109,12 +109,12 @@ std::vector<type::idx_t> make_query(const type::Type_e requested_type,
                                     const boost::optional<boost::posix_time::ptime>& until,
                                     const type::Data& data);
 
-std::vector<type::idx_t> make_query(const type::Type_e requested_type,
+type::Indexes make_query(const type::Type_e requested_type,
                                     const std::string& request,
                                     const std::vector<std::string>& forbidden_uris,
                                     const type::Data& data);
 
-std::vector<type::idx_t> make_query(const type::Type_e requested_type,
+type::Indexes make_query(const type::Type_e requested_type,
                                     const std::string& request,
                                     const type::Data& data);
 
@@ -124,19 +124,19 @@ std::vector<type::idx_t> make_query(const type::Type_e requested_type,
 std::map<Type_e,Type_e> find_path(Type_e source);
 
 /// À parti d'un élément, on veut retrouver tous ceux de destination
-std::vector<type::idx_t> get(Type_e source, Type_e destination, type::idx_t source_idx, type::PT_Data & data);
+navitia::type::Indexes get(Type_e source, Type_e destination, type::idx_t source_idx, type::PT_Data & data);
 
 
 std::vector<Filter> parse(std::string request);
 
-std::vector<type::idx_t>::iterator sort_and_get_new_end(std::vector<type::idx_t>& list_idx);
+type::Indexes::iterator sort_and_get_new_end(type::Indexes& list_idx);
 
-std::vector<type::idx_t> get_difference(std::vector<type::idx_t>& list_idx1,
-                                        std::vector<type::idx_t>& list_idx2);
+type::Indexes get_difference(type::Indexes& list_idx1,
+                                        type::Indexes& list_idx2);
 
-std::vector<type::idx_t> get_intersection(std::vector<type::idx_t>& list_idx1,
-                                        std::vector<type::idx_t>& list_idx2);
-std::vector<type::idx_t> manage_odt_level(const std::vector<type::idx_t>& final_indexes,
+type::Indexes get_intersection(type::Indexes& list_idx1,
+                                        type::Indexes& list_idx2);
+type::Indexes manage_odt_level(const type::Indexes& final_indexes,
                                           const navitia::type::Type_e requested_type,
                                           const navitia::type::OdtLevel_e,
                                           const type::Data & data);

--- a/source/ptreferential/ptreferential.h
+++ b/source/ptreferential/ptreferential.h
@@ -129,13 +129,9 @@ navitia::type::Indexes get(Type_e source, Type_e destination, type::idx_t source
 
 std::vector<Filter> parse(std::string request);
 
-type::Indexes::iterator sort_and_get_new_end(type::Indexes& list_idx);
+type::Indexes get_difference(const type::Indexes&, const type::Indexes&);
+type::Indexes get_intersection(const type::Indexes&, const type::Indexes&);
 
-type::Indexes get_difference(type::Indexes& list_idx1,
-                                        type::Indexes& list_idx2);
-
-type::Indexes get_intersection(type::Indexes& list_idx1,
-                                        type::Indexes& list_idx2);
 type::Indexes manage_odt_level(const type::Indexes& final_indexes,
                                           const navitia::type::Type_e requested_type,
                                           const navitia::type::OdtLevel_e,

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -42,7 +42,7 @@ namespace navitia{ namespace ptref{
 
 static pbnavitia::Response extract_data(const type::Data& data,
                                         const type::Type_e requested_type,
-                                        const std::vector<type::idx_t>& rows,
+                                        const type::Indexes& rows,
                                         const int depth,
                                         const bool show_codes,
                                         const boost::posix_time::ptime& current_time) {
@@ -152,7 +152,7 @@ pbnavitia::Response query_pb(const type::Type_e requested_type,
                              const boost::optional<boost::posix_time::ptime>& until,
                              const type::Data& data,
                              const boost::posix_time::ptime& current_time) {
-    std::vector<type::idx_t> final_indexes;
+    type::Indexes final_indexes;
     pbnavitia::Response pb_response;
     int total_result;
     try {

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -36,7 +36,7 @@ namespace navitia{ namespace ptref{
 /// build the protobuf response of a pt ref query
 pbnavitia::Response extract_data(const type::Data& data,
                                  const type::Type_e requested_type,
-                                 const std::vector<type::idx_t> & rows,
+                                 const type::Indexes & rows,
                                  const int depth,
                                  const boost::posix_time::ptime& current_time); //this date is used to filter the disruptions
 

--- a/source/ptreferential/tests/ptref_companies_test.cpp
+++ b/source/ptreferential/tests/ptref_companies_test.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "ptreferential/reflexion.h"
 #include "ptreferential/ptref_graph.h"
 #include "ed/build_helper.h"
+#include "tests/utils_test.h"
 
 #include <boost/graph/strong_components.hpp>
 #include <boost/graph/connected_components.hpp>
@@ -138,55 +139,42 @@ BOOST_FIXTURE_TEST_SUITE(companies_test, Params)
 
 BOOST_AUTO_TEST_CASE(comanies_list) {
     auto indexes = make_query(navitia::type::Type_e::Company, "", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 2);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C1");
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[1]]->uri, "C2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C1", "C2"}));
 }
 
 
 BOOST_AUTO_TEST_CASE(comany_by_uri) {
     auto indexes = make_query(navitia::type::Type_e::Company, "company.uri=C1", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C1"}));
 }
 
 BOOST_AUTO_TEST_CASE(lines_by_company) {
     auto indexes = make_query(navitia::type::Type_e::Line, "company.uri=C1", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 2);
-    BOOST_CHECK_EQUAL(data.pt_data->lines[indexes[0]]->uri, "C1-L1");
-    BOOST_CHECK_EQUAL(data.pt_data->lines[indexes[1]]->uri, "C1-L2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Line>(indexes, data), std::set<std::string>({"C1-L1", "C1-L2"}));
 
     indexes = make_query(navitia::type::Type_e::Line, "company.uri=C2", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 3);
-    BOOST_CHECK_EQUAL(data.pt_data->lines[indexes[0]]->uri, "C2-L1");
-    BOOST_CHECK_EQUAL(data.pt_data->lines[indexes[1]]->uri, "C2-L2");
-    BOOST_CHECK_EQUAL(data.pt_data->lines[indexes[2]]->uri, "C2-L3");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Line>(indexes, data), std::set<std::string>({"C2-L1", "C2-L2", "C2-L3"}));
 }
 
 BOOST_AUTO_TEST_CASE(comanies_by_line) {
     auto indexes = make_query(navitia::type::Type_e::Company, "line.uri=C1-L1", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C1"}));
 }
 
 BOOST_AUTO_TEST_CASE(networks_by_company) {
     auto indexes = make_query(navitia::type::Type_e::Network, "company.uri=C1", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->networks[indexes.front()]->uri, "N1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Network>(indexes, data), std::set<std::string>({"N1"}));
 
     indexes = make_query(navitia::type::Type_e::Network, "company.uri=C2", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->networks[indexes.front()]->uri, "N2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Network>(indexes, data), std::set<std::string>({"N2"}));
 }
 
 BOOST_AUTO_TEST_CASE(companies_by_network) {
     auto indexes = make_query(navitia::type::Type_e::Company, "network.uri=N1", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C1"}));
 
     indexes = make_query(navitia::type::Type_e::Company, "network.uri=N2", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C2"}));
 
     BOOST_CHECK_THROW(make_query(navitia::type::Type_e::Company, "network.uri=N3", data), ptref_error);
 }
@@ -195,19 +183,15 @@ BOOST_AUTO_TEST_CASE(routes_by_company) {
     BOOST_CHECK_THROW(make_query(navitia::type::Type_e::Route, "company.uri=C1", data), ptref_error);
 
     auto indexes = make_query(navitia::type::Type_e::Route, "company.uri=C2", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 2);
-    BOOST_CHECK_EQUAL(data.pt_data->routes[indexes[0]]->uri, "C2-L1-R1");
-    BOOST_CHECK_EQUAL(data.pt_data->routes[indexes[1]]->uri, "C2-L1-R2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Route>(indexes, data), std::set<std::string>({"C2-L1-R1", "C2-L1-R2"}));
 }
 
 BOOST_AUTO_TEST_CASE(companies_by_route) {
     auto indexes = make_query(navitia::type::Type_e::Company, "route.uri=C2-L1-R1", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C2"}));
 
     indexes = make_query(navitia::type::Type_e::Company, "route.uri=C2-L1-R2", data);
-    BOOST_CHECK_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(data.pt_data->companies[indexes[0]]->uri, "C2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Company>(indexes, data), std::set<std::string>({"C2"}));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -328,13 +328,13 @@ BOOST_AUTO_TEST_CASE(get_indexes_test){
     filter.op = EQ;
     filter.value = "stop1";
     auto indexes = get_indexes<nt::StopArea>(filter, Type_e::Line, *(b.data));
-    BOOST_CHECK_EQUAL_RANGE(indexes, nt::Indexes({0}));
+    BOOST_CHECK_EQUAL_RANGE(indexes, nt::make_indexes({0}));
 
     // On cherche les stopareas de la ligneA
     filter.navitia_type = Type_e::Line;
     filter.value = "A";
     indexes = get_indexes<nt::Line>(filter, Type_e::StopArea, *(b.data));
-    BOOST_CHECK_EQUAL_RANGE(indexes, nt::Indexes({0, 1}));
+    BOOST_CHECK_EQUAL_RANGE(indexes, nt::make_indexes({0, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line){
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line){
 
     navitia::apply_disruption(disrup_3, *b.data->pt_data, *b.data->meta);
     indexes = get_indexes<nt::Line>(filter, Type_e::Impact, *(b.data));
-    BOOST_CHECK_EQUAL_RANGE(indexes, nt::Indexes({0, 1}));
+    BOOST_CHECK_EQUAL_RANGE(indexes, nt::make_indexes({0, 1}));
 }
 
 
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(headsign_request) {
     const auto res = make_query(nt::Type_e::VehicleJourney,
                                 R"(vehicle_journey.has_headsign("vehicle_journey 1"))",
                                 *(b.data));
-    BOOST_CHECK_EQUAL_RANGE(res, nt::Indexes({1}));
+    BOOST_CHECK_EQUAL_RANGE(res, nt::make_indexes({1}));
 }
 
 BOOST_AUTO_TEST_CASE(headsign_sa_request) {

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -40,11 +40,11 @@ www.navitia.io
 #include <boost/graph/connected_components.hpp>
 #include "type/pt_data.h"
 #include "tests/utils_test.h"
-
 #include "kraken/apply_disruption.h"
+#include <boost/range/adaptors.hpp>
 
 namespace navitia{namespace ptref {
-template<typename T> std::vector<type::idx_t> get_indexes(Filter filter,  Type_e requested_type, const type::Data & d);
+template<typename T> nt::Indexes get_indexes(Filter filter,  Type_e requested_type, const type::Data & d);
 }}
 
 namespace nt = navitia::type;
@@ -282,36 +282,32 @@ BOOST_AUTO_TEST_CASE(physical_modes) {
     b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::Line, "line.uri=A", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.at(indexes.front())->physical_mode_list.size(), 2);
-    BOOST_CHECK_EQUAL(b.data->pt_data->lines.at(indexes.front())->physical_mode_list.at(0)->name, "Car");
-    BOOST_CHECK_EQUAL(b.data->pt_data->lines.at(indexes.front())->physical_mode_list.at(1)->name, "Metro");
+    auto objects = get_objects<nt::Line>(indexes, *b.data);
+    BOOST_REQUIRE_EQUAL(objects.size(), 1);
+    BOOST_REQUIRE_EQUAL((*objects.begin())->physical_mode_list.size(), 2);
+    BOOST_CHECK_EQUAL((*objects.begin())->physical_mode_list.at(0)->name, "Car");
+    BOOST_CHECK_EQUAL((*objects.begin())->physical_mode_list.at(1)->name, "Metro");
 
     indexes = make_query(nt::Type_e::Line, "line.uri=C", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.at(indexes.front())->physical_mode_list.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->lines.at(indexes.front())->physical_mode_list.at(0)->name, "Tram");
+    objects = get_objects<nt::Line>(indexes, *b.data);
+    BOOST_REQUIRE_EQUAL(objects.size(), 1);
+    BOOST_REQUIRE_EQUAL((*objects.begin())->physical_mode_list.size(), 1);
+    BOOST_CHECK_EQUAL((*objects.begin())->physical_mode_list.at(0)->name, "Tram");
 
     indexes = make_query(nt::Type_e::Dataset, "stop_point.uri=stop1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->datasets.at(indexes.front())->uri, "default:dataset");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"default:dataset"}));
 
     indexes = make_query(nt::Type_e::Dataset, "stop_point.uri=stop2", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->datasets.at(indexes.front())->uri, "default:dataset");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"default:dataset"}));
 
     indexes = make_query(nt::Type_e::Dataset, "stop_point.uri=stop3", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 2);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->datasets.at(indexes.front())->uri, "default:dataset");
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->datasets.at(indexes.back())->uri, "f1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"default:dataset", "f1"}));
 
     indexes = make_query(nt::Type_e::Contributor, "dataset.uri=default:dataset", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->contributors.at(indexes.front())->uri, "default:contributor");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"default:dataset"}));
 
     indexes = make_query(nt::Type_e::Contributor, "dataset.uri=f1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->contributors.at(indexes.front())->uri, "c1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Contributor>(indexes, *b.data), std::set<std::string>({"c1"}));
 }
 
 BOOST_AUTO_TEST_CASE(get_indexes_test){
@@ -332,16 +328,13 @@ BOOST_AUTO_TEST_CASE(get_indexes_test){
     filter.op = EQ;
     filter.value = "stop1";
     auto indexes = get_indexes<nt::StopArea>(filter, Type_e::Line, *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(indexes[0], 0);
+    BOOST_CHECK_EQUAL_RANGE(indexes, nt::Indexes({0}));
 
     // On cherche les stopareas de la ligneA
     filter.navitia_type = Type_e::Line;
     filter.value = "A";
     indexes = get_indexes<nt::Line>(filter, Type_e::StopArea, *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 2);
-    BOOST_CHECK_EQUAL(indexes[0], 0);
-    BOOST_CHECK_EQUAL(indexes[1], 1);
+    BOOST_CHECK_EQUAL_RANGE(indexes, nt::Indexes({0, 1}));
 }
 
 BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line){
@@ -391,7 +384,7 @@ BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line){
 
     navitia::apply_disruption(disrup_3, *b.data->pt_data, *b.data->meta);
     indexes = get_indexes<nt::Line>(filter, Type_e::Impact, *(b.data));
-    BOOST_CHECK_EQUAL_RANGE(indexes, std::vector<size_t>({0, 1}));
+    BOOST_CHECK_EQUAL_RANGE(indexes, nt::Indexes({0, 1}));
 }
 
 
@@ -451,12 +444,14 @@ BOOST_AUTO_TEST_CASE(line_code) {
 
     //find line by code
     auto indexes = make_query(nt::Type_e::Line, "line.code=line_A", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line_A");
+    auto objects = get_objects<nt::Line>(indexes, *b.data);
+    BOOST_REQUIRE_EQUAL(objects.size(), 1);
+    BOOST_CHECK_EQUAL((*objects.begin())->code, "line_A");
 
     indexes = make_query(nt::Type_e::Line, "line.code=\"line C\"", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line C");
+    objects = get_objects<nt::Line>(indexes, *b.data);
+    BOOST_REQUIRE_EQUAL(objects.size(), 1);
+    BOOST_CHECK_EQUAL((*objects.begin())->code, "line C");
 
     //no line B
     BOOST_CHECK_THROW(make_query(nt::Type_e::Line, "line.code=\"line B\"", *(b.data)),
@@ -464,8 +459,9 @@ BOOST_AUTO_TEST_CASE(line_code) {
 
     //find route by line code
     indexes = make_query(nt::Type_e::Route, "line.code=line_A", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->routes[indexes.front()]->line->code, "line_A");
+    auto routes = get_objects<nt::Route>(indexes, *b.data);
+    BOOST_REQUIRE_EQUAL(routes.size(), 1);
+    BOOST_CHECK_EQUAL((*routes.begin())->line->code, "line_A");
 
     //route has no code attribute, no filter can be used
     indexes = make_query(nt::Type_e::Line, "route.code=test", *(b.data));
@@ -535,20 +531,19 @@ BOOST_AUTO_TEST_CASE(find_path_test){
 }
 
 //helper to get default values
-static std::vector<nt::idx_t> query(nt::Type_e requested_type, std::string request,
+static nt::Indexes query(nt::Type_e requested_type, std::string request,
                                     const nt::Data& data,
                                     const boost::optional<boost::posix_time::ptime>& since = boost::none,
                                     const boost::optional<boost::posix_time::ptime>& until = boost::none,
                                     bool fail = false) {
     try {
-       return navitia::ptref::make_query(
-                   requested_type, request, {}, nt::OdtLevel_e::all, since, until, data);
+       return navitia::ptref::make_query(requested_type, request, {}, nt::OdtLevel_e::all, since, until, data);
     } catch (const navitia::ptref::ptref_error& e) {
         if (fail) {
             throw e;
         }
         BOOST_CHECK_MESSAGE(false, " error on ptref request " + std::string(e.what()));
-        return {};
+        return nt::Indexes{};
     }
 }
 
@@ -580,7 +575,7 @@ BOOST_AUTO_TEST_CASE(mvj_filtering) {
                          R"(trip.uri="vehicle_journey 0")",
                          *(builder.data));
     BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    const auto mvj_idx = navitia::Idx<nt::MetaVehicleJourney>(indexes.front());
+    const auto mvj_idx = navitia::Idx<nt::MetaVehicleJourney>(*indexes.begin());
     BOOST_CHECK_EQUAL(builder.data->pt_data->meta_vjs[mvj_idx]->uri, "vehicle_journey 0");
 
     // looking for MetaVJ 0 another way
@@ -703,8 +698,7 @@ BOOST_AUTO_TEST_CASE(headsign_request) {
     const auto res = make_query(nt::Type_e::VehicleJourney,
                                 R"(vehicle_journey.has_headsign("vehicle_journey 1"))",
                                 *(b.data));
-    BOOST_REQUIRE_EQUAL(res.size(), 1);
-    BOOST_CHECK_EQUAL(res.at(0), 1);
+    BOOST_CHECK_EQUAL_RANGE(res, nt::Indexes({1}));
 }
 
 BOOST_AUTO_TEST_CASE(headsign_sa_request) {
@@ -739,8 +733,8 @@ BOOST_AUTO_TEST_CASE(code_request) {
     const auto res = make_query(nt::Type_e::StopArea,
                                 R"(stop_area.has_code(UIC, 8727100))",
                                 *(b.data));
-    BOOST_REQUIRE_EQUAL(res.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->stop_areas.at(res.at(0))->uri, "A");
+
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::StopArea>(res, *b.data), std::set<std::string>({"A"}));
 }
 
 BOOST_AUTO_TEST_CASE(contributor_and_dataset) {
@@ -803,42 +797,31 @@ BOOST_AUTO_TEST_CASE(contributor_and_dataset) {
     b.data->pt_data->build_uri();
 
     auto indexes = make_query(nt::Type_e::Contributor, "contributor.uri=c1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->contributors[indexes.front()]->uri, "c1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Contributor>(indexes, *b.data), std::set<std::string>({"c1"}));
 
     indexes = make_query(nt::Type_e::Dataset, "dataset.uri=d1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->datasets[indexes.front()]->uri, "d1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"d1"}));
 
     indexes = make_query(nt::Type_e::Dataset, "contributor.uri=c1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 2);
-    BOOST_CHECK_EQUAL(b.data->pt_data->datasets[indexes.front()]->uri, "d1");
-    BOOST_CHECK_EQUAL(b.data->pt_data->datasets[indexes.back()]->uri, "d2");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"d1", "d2"}));
 
     indexes = make_query(nt::Type_e::VehicleJourney, "contributor.uri=c1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 2);
-    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys[indexes.front()]->uri, "vj:A:0");
-    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys[indexes.back()]->uri, "vj:C:1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::VehicleJourney>(indexes, *b.data), std::set<std::string>({"vj:A:0", "vj:C:1"}));
 
     indexes = make_query(nt::Type_e::VehicleJourney, "dataset.uri=d1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys[indexes.front()]->uri, "vj:A:0");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::VehicleJourney>(indexes, *b.data), std::set<std::string>({"vj:A:0"}));
 
     indexes = make_query(nt::Type_e::VehicleJourney, "dataset.uri=d2", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys[indexes.front()]->uri, "vj:C:1");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::VehicleJourney>(indexes, *b.data), std::set<std::string>({"vj:C:1"}));
 
     indexes = make_query(nt::Type_e::Route, "dataset.uri=d1", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->routes[indexes.front()]->line->code, "line_A");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Route>(indexes, *b.data), std::set<std::string>({"A:0"}));
 
     indexes = make_query(nt::Type_e::Line, "dataset.uri=d2", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->lines[indexes.front()]->code, "line C");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Route>(indexes, *b.data), std::set<std::string>({"C:1"}));
 
     indexes = make_query(nt::Type_e::Dataset, "contributor.uri=c2", *(b.data));
-    BOOST_REQUIRE_EQUAL(indexes.size(), 1);
-    BOOST_CHECK_EQUAL(b.data->pt_data->datasets[indexes.front()]->uri, "d3");
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Dataset>(indexes, *b.data), std::set<std::string>({"d3"}));
 
     //no vehicle_journey for dataset "d3"
     BOOST_CHECK_THROW(make_query(nt::Type_e::VehicleJourney, "dataset.uri=d3", *(b.data)),

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -100,6 +100,30 @@ std::ostream& operator<<(std::ostream& os, const std::map<K, V>& m) {
 }
 }
 
+// small helper especially usefull for ptref tests
+// get list of pointers from indexes
+template <typename T>
+std::set<const T*> get_objects(const nt::Indexes& indexes, const nt::Data& data) {
+    const auto& obj_col = data.get_data<T>();
+    std::set<const T*> objs;
+    for (const auto idx: indexes) {
+        objs.insert(obj_col[idx]);
+    }
+    return objs;
+}
+
+// get uris from indexes
+template <typename T>
+std::set<std::string> get_uris(const nt::Indexes& indexes, const nt::Data& data) {
+    const auto& objs = get_objects<T>(indexes, data);
+    std::set<std::string> uris;
+    for (const auto* obj: objs) {
+        uris.insert(obj->uri);
+    }
+    return uris;
+}
+
+
 /*
  * BOOST_CHECK_EQUAL_COLLECTIONS does not work well with a temporary collection, thus this macro
  * (and it's easier to use)

--- a/source/time_tables/thermometer.cpp
+++ b/source/time_tables/thermometer.cpp
@@ -63,10 +63,10 @@ std::pair<vector_idx, bool> Thermometer::recc(std::vector<vector_idx> &journey_p
     ++depth;
     ++nb_branches;
     uint32_t lower_bound = lower_bound_, upper_bound = upper_bound_;
-    std::vector<type::idx_t> result;
+    vector_idx result;
 
 
-    std::vector<type::idx_t> possibilities = generate_possibilities(journey_patterns, pre_computed_lb);
+    vector_idx possibilities = generate_possibilities(journey_patterns, pre_computed_lb);
     bool res_bool = possibilities.empty();
     for (auto poss_spidx : possibilities) {
         if (nb_branches > 5000 && !result.empty())
@@ -232,7 +232,7 @@ vector_idx Thermometer::get_thermometer() const {
 
 
 std::vector<uint32_t> Thermometer::stop_times_order(const type::VehicleJourney& vj) const {
-    std::vector<type::idx_t> tmp;
+    vector_idx tmp;
     for (const auto& st: vj.stop_time_list) {
         tmp.push_back(st.stop_point->idx);
     }

--- a/source/time_tables/thermometer.h
+++ b/source/time_tables/thermometer.h
@@ -33,7 +33,7 @@ www.navitia.io
 #include "boost/functional/hash.hpp"
 namespace navitia { namespace timetables {
 
-typedef std::vector<type::idx_t> vector_idx;
+typedef std::vector<idx_t> vector_idx;
 typedef std::vector<uint16_t> vector_size;
 
 struct Thermometer {

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -637,17 +637,17 @@ Indexes Data::get_all_index(Type_e type) const {
     return indexes;
 }
 
-
-
 Indexes
 Data::get_target_by_source(Type_e source, Type_e target,
                            Indexes source_idx) const {
     Indexes result;
     result.reserve(source_idx.size());
     for(idx_t idx : source_idx) {
-        Indexes tmp;
-        tmp = get_target_by_one_source(source, target, idx);
-        result.insert(boost::container::ordered_unique_range_t(), tmp.begin(), tmp.end());
+        Indexes tmp = get_target_by_one_source(source, target, idx);
+        result.insert(/*boost::container::ordered_unique_range_t(),
+                        // Note the tag does not work on old boost version,
+                        //   put it back when we stop boost 1.49 support*/
+                        tmp.begin(), tmp.end());
     }
     return result;
 }

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -159,7 +159,7 @@ public:
     template<typename T> const typename ContainerTrait<T>::associative_type& get_assoc_data() const;
 
     template<typename T> typename ContainerTrait<T>::vect_type
-    get_data(const std::vector<idx_t>& indexes) const {
+    get_data(const Indexes& indexes) const {
         typename ContainerTrait<T>::vect_type res;
         const auto& objs = get_data<T>();
         for (const auto& idx: indexes) { res.push_back(objs[idx]); }
@@ -170,18 +170,19 @@ public:
       *
       * Concrètement, on a un tableau avec des éléments allant de 0 à (n-1) où n est le nombre d'éléments
       */
-    std::vector<idx_t> get_all_index(Type_e type) const;
+    Indexes get_all_index(Type_e type) const;
 
+    size_t get_nb_obj(Type_e type) const;
 
     /** Étant donné une liste d'indexes pointant vers source,
       * retourne une liste d'indexes pointant vers target
       */
-    std::vector<idx_t> get_target_by_source(Type_e source, Type_e target, std::vector<idx_t> source_idx) const;
+    Indexes get_target_by_source(Type_e source, Type_e target, Indexes source_idx) const;
 
     /** Étant donné un index pointant vers source,
       * retourne une liste d'indexes pointant vers target
       */
-    std::vector<idx_t> get_target_by_one_source(Type_e source, Type_e target, idx_t source_idx) const ;
+    Indexes get_target_by_one_source(Type_e source, Type_e target, idx_t source_idx) const ;
 
 
     bool last_load = true;

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -314,7 +314,7 @@ template<> pbnavitia::NavitiaType get_pb_type<nt::MetaVehicleJourney>(){ return 
 template <typename Target, typename Source>
 std::vector<Target*> PbCreator::Filler::ptref_indexes(const Source* nav_obj) {
     const nt::Type_e type_e = get_type_e<Target>();
-    std::vector<nt::idx_t> indexes;
+    nt::Indexes indexes;
     std::string request;
     try{
         request = nt::static_data::get()->captionByType(nav_obj->type) +

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -201,16 +201,16 @@ void PT_Data::index(){
     ITERATE_NAVITIA_PT_TYPES(INDEX)
 }
 
-std::vector<idx_t>
+Indexes
 PT_Data::get_impacts_idx(const std::vector<boost::shared_ptr<disruption::Impact>>& impacts) const {
-    std::vector<idx_t> result;
+    Indexes result;
     idx_t i = 0;
     const auto & impacts_pool = disruption_holder.get_weak_impacts();
     for (const auto& impact: impacts_pool) {
         auto impact_sptr = impact.lock();
         assert(impact_sptr);
         if (navitia::contains(impacts, impact_sptr)){
-            result.push_back(i);
+            result.insert(i); //TODO use bulk insert ?
         }
         ++i;
     }

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -173,7 +173,7 @@ struct PT_Data : boost::noncopyable{
     /** Définis les idx des différents objets */
     void index();
 
-    std::vector<idx_t>
+    Indexes
     get_impacts_idx(const std::vector<boost::shared_ptr<disruption::Impact>>& impacts) const;
 
     const StopPointConnection*

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -492,12 +492,12 @@ const VehicleJourney* VehicleJourney::get_corresponding_base() const {
     return nullptr;
 }
 
-std::vector<idx_t> MetaVehicleJourney::get(Type_e type, const PT_Data& data) const {
-    std::vector<idx_t> result;
+Indexes MetaVehicleJourney::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
     switch(type) {
     case Type_e::VehicleJourney:
         for_all_vjs([&](const VehicleJourney& vj) {
-            result.push_back(vj.idx);
+            result.insert(vj.idx); //TODO use bulk insert ?
         });
     break;
     case Type_e::Impact: return data.get_impacts_idx(get_impacts());
@@ -574,10 +574,10 @@ Mode_e static_data::modeByCaption(const std::string & mode_str) {
     return instance->modes_string.right.at(mode_str);
 }
 
-template<typename T> std::vector<idx_t> indexes(const std::vector<T*>& elements){
-    std::vector<idx_t> result;
+template<typename T> Indexes indexes(const std::vector<T*>& elements){
+    Indexes result;
     for(T* element : elements){
-        result.push_back(element->idx);
+        result.insert(element->idx);
     }
     return result;
 }
@@ -612,15 +612,15 @@ bool VehicleJourney::operator<(const VehicleJourney& other) const {
     return this->uri < other.uri;
 }
 
-std::vector<idx_t> Calendar::get(Type_e type, const PT_Data & data) const{
-    std::vector<idx_t> result;
+Indexes Calendar::get(Type_e type, const PT_Data & data) const{
+    Indexes result;
     switch(type) {
     case Type_e::Line:{
         // if the method is slow, adding a list of lines in calendar
         for(Line* line: data.lines) {
             for(Calendar* cal : line->calendar_list) {
                 if(cal == this) {
-                    result.push_back(line->idx);
+                    result.insert(line->idx);
                     break;
                 }
             }
@@ -631,8 +631,8 @@ std::vector<idx_t> Calendar::get(Type_e type, const PT_Data & data) const{
     }
     return result;
 }
-std::vector<idx_t> StopArea::get(Type_e type, const PT_Data & data) const {
-    std::vector<idx_t> result;
+Indexes StopArea::get(Type_e type, const PT_Data & data) const {
+    Indexes result;
     switch(type) {
     case Type_e::StopPoint: return indexes(this->stop_point_list);
     case Type_e::Impact: return data.get_impacts_idx(get_impacts());
@@ -642,8 +642,8 @@ std::vector<idx_t> StopArea::get(Type_e type, const PT_Data & data) const {
     return result;
 }
 
-std::vector<idx_t> Network::get(Type_e type, const PT_Data& data) const {
-    std::vector<idx_t> result;
+Indexes Network::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
     switch(type) {
     case Type_e::Line: return indexes(line_list);
     case Type_e::Impact: return data.get_impacts_idx(get_impacts());
@@ -653,8 +653,8 @@ std::vector<idx_t> Network::get(Type_e type, const PT_Data& data) const {
 }
 
 
-std::vector<idx_t> Company::get(Type_e type, const PT_Data &) const {
-    std::vector<idx_t> result;
+Indexes Company::get(Type_e type, const PT_Data &) const {
+    Indexes result;
     switch(type) {
     case Type_e::Line: return indexes(line_list);
     default: break;
@@ -662,8 +662,8 @@ std::vector<idx_t> Company::get(Type_e type, const PT_Data &) const {
     return result;
 }
 
-std::vector<idx_t> CommercialMode::get(Type_e type, const PT_Data &) const {
-    std::vector<idx_t> result;
+Indexes CommercialMode::get(Type_e type, const PT_Data &) const {
+    Indexes result;
     switch(type) {
     case Type_e::Line: return indexes(line_list);
     default: break;
@@ -671,13 +671,13 @@ std::vector<idx_t> CommercialMode::get(Type_e type, const PT_Data &) const {
     return result;
 }
 
-std::vector<idx_t> PhysicalMode::get(Type_e type, const PT_Data & data) const {
-    std::vector<idx_t> result;
+Indexes PhysicalMode::get(Type_e type, const PT_Data & data) const {
+    Indexes result;
     switch(type) {
     case Type_e::VehicleJourney:
         for (const auto* vj: data.vehicle_journeys) {
             if (vj->physical_mode != this) { continue; }
-            result.push_back(vj->idx);
+            result.insert(vj->idx);
         }
         break;
     default: break;
@@ -685,17 +685,17 @@ std::vector<idx_t> PhysicalMode::get(Type_e type, const PT_Data & data) const {
     return result;
 }
 
-std::vector<idx_t> Line::get(Type_e type, const PT_Data& data) const {
-    std::vector<idx_t> result;
+Indexes Line::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
     switch(type) {
     case Type_e::CommercialMode:
         if (this->commercial_mode){
-            result.push_back(commercial_mode->idx);
+            result.insert(commercial_mode->idx);
         }
         break;
     case Type_e::PhysicalMode: return indexes(physical_mode_list);
     case Type_e::Company: return indexes(company_list);
-    case Type_e::Network: result.push_back(network->idx); break;
+    case Type_e::Network: result.insert(network->idx); break;
     case Type_e::Route: return indexes(route_list);
     case Type_e::Calendar: return indexes(calendar_list);
     case Type_e::LineGroup: return indexes(line_group_list);
@@ -733,8 +733,8 @@ std::string Route::get_label() const {
     return s.str();
 }
 
-std::vector<idx_t> LineGroup::get(Type_e type, const PT_Data&) const {
-    std::vector<idx_t> result;
+Indexes LineGroup::get(Type_e type, const PT_Data&) const {
+    Indexes result;
     switch(type) {
     case Type_e::Line: return indexes(line_list);
     default: break;
@@ -742,13 +742,13 @@ std::vector<idx_t> LineGroup::get(Type_e type, const PT_Data&) const {
     return result;
 }
 
-std::vector<idx_t> Route::get(Type_e type, const PT_Data& data) const {
-    std::vector<idx_t> result;
+Indexes Route::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
     switch(type) {
-    case Type_e::Line: result.push_back(line->idx); break;
+    case Type_e::Line: result.insert(line->idx); break;
     case Type_e::VehicleJourney:
         for_each_vehicle_journey([&](const VehicleJourney& vj) {
-                result.push_back(vj.idx);
+                result.insert(vj.idx); //TODO use bulk insert ?
                 return true;
             });
         break;
@@ -787,15 +787,15 @@ VehicleJourney::get_impacts() const {
     return result;
 }
 
-std::vector<idx_t> VehicleJourney::get(Type_e type, const PT_Data& data) const {
-    std::vector<idx_t> result;
+Indexes VehicleJourney::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
     switch(type) {
-    case Type_e::Route: result.push_back(route->idx); break;
-    case Type_e::Company: result.push_back(company->idx); break;
-    case Type_e::PhysicalMode: result.push_back(physical_mode->idx); break;
-    case Type_e::ValidityPattern: result.push_back(base_validity_pattern()->idx); break;
-    case Type_e::MetaVehicleJourney: result.push_back(meta_vj->idx); break;
-    case Type_e::Dataset: if (dataset) { result.push_back(dataset->idx); } break;
+    case Type_e::Route: result.insert(route->idx); break;
+    case Type_e::Company: result.insert(company->idx); break;
+    case Type_e::PhysicalMode: result.insert(physical_mode->idx); break;
+    case Type_e::ValidityPattern: result.insert(base_validity_pattern()->idx); break;
+    case Type_e::MetaVehicleJourney: result.insert(meta_vj->idx); break;
+    case Type_e::Dataset: if (dataset) { result.insert(dataset->idx); } break;
     case Type_e::Impact: return data.get_impacts_idx(get_impacts());
     default: break;
     }
@@ -806,14 +806,14 @@ VehicleJourney::~VehicleJourney() {}
 FrequencyVehicleJourney::~FrequencyVehicleJourney() {}
 DiscreteVehicleJourney::~DiscreteVehicleJourney() {}
 
-std::vector<idx_t> StopPoint::get(Type_e type, const PT_Data& data) const {
-    std::vector<idx_t> result;
+Indexes StopPoint::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
     switch(type) {
-    case Type_e::StopArea: result.push_back(stop_area->idx); break;
+    case Type_e::StopArea: result.insert(stop_area->idx); break;
     case Type_e::Connection:
     case Type_e::StopPointConnection:
         for (const StopPointConnection* stop_cnx : stop_point_connection_list)
-            result.push_back(stop_cnx->idx);
+            result.insert(stop_cnx->idx); //TODO use bulk insert ?
         break;
     case Type_e::Impact: return data.get_impacts_idx(get_impacts());
     case Type_e::Dataset: return indexes(dataset_list);
@@ -822,12 +822,12 @@ std::vector<idx_t> StopPoint::get(Type_e type, const PT_Data& data) const {
     return result;
 }
 
-std::vector<idx_t> StopPointConnection::get(Type_e type, const PT_Data & ) const {
-    std::vector<idx_t> result;
+Indexes StopPointConnection::get(Type_e type, const PT_Data & ) const {
+    Indexes result;
     switch(type) {
     case Type_e::StopPoint:
-        result.push_back(this->departure->idx);
-        result.push_back(this->destination->idx);
+        result.insert(this->departure->idx);
+        result.insert(this->destination->idx);
         break;
     default: break;
     }
@@ -835,18 +835,18 @@ std::vector<idx_t> StopPointConnection::get(Type_e type, const PT_Data & ) const
 }
 bool StopPointConnection::operator<(const StopPointConnection& other) const { return this < &other; }
 
-std::vector<idx_t> Dataset::get(Type_e type, const PT_Data&) const {
-    std::vector<idx_t> result;
+Indexes Dataset::get(Type_e type, const PT_Data&) const {
+    Indexes result;
     switch(type) {
-    case Type_e::Contributor: result.push_back(contributor->idx); break;
+    case Type_e::Contributor: result.insert(contributor->idx); break;
     case Type_e::VehicleJourney: return indexes(vehiclejourney_list);
     default: break;
     }
     return result;
 }
 
-std::vector<idx_t> Contributor::get(Type_e type, const PT_Data&) const {
-    std::vector<idx_t> result;
+Indexes Contributor::get(Type_e type, const PT_Data&) const {
+    Indexes result;
     switch(type) {
     case Type_e::Dataset: return indexes(dataset_list);
     default: break;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -166,7 +166,7 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages {
 
     StopPoint(): fare_zone(0),  stop_area(nullptr), network(nullptr) {}
 
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const StopPoint & other) const { return this < &other; }
 
 };
@@ -196,7 +196,7 @@ struct StopPointConnection: public Header, hasProperties{
         destination->stop_point_connection_list.push_back(this);
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
 
     bool operator<(const StopPointConnection &other) const;
 
@@ -260,7 +260,7 @@ struct StopArea : public Header, Nameable, hasProperties, HasMessages {
     }
 
     std::vector<StopPoint*> stop_point_list;
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const StopArea & other) const { return this < &other; }
 };
 
@@ -283,7 +283,7 @@ struct Network : public Header, HasMessages {
             & mail & website & fax & sort & line_list & impacts;
     }
 
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const Network & other) const {
         if(this->sort != other.sort) {
             return this->sort < other.sort;
@@ -305,7 +305,7 @@ struct Contributor : public Header, Nameable{
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & website & license & dataset_list;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const Contributor & other) const { return this < &other; }
 };
 
@@ -321,7 +321,7 @@ struct Dataset : public Header, Nameable{
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & uri & contributor & realtime_level & validation_period & desc & system;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const Dataset & other) const { return this < &other; }
 };
 
@@ -341,7 +341,7 @@ struct Company : public Header, Nameable {
         ar & idx & name & uri & address_name & address_number &
         address_type_name & phone_number & mail & website & fax & line_list;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const Company & other) const { return this < &other; }
 };
 
@@ -351,7 +351,7 @@ struct CommercialMode : public Header, Nameable{
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & line_list;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const CommercialMode & other) const { return this < &other; }
 
 };
@@ -364,7 +364,7 @@ struct PhysicalMode : public Header, Nameable{
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & co2_emission & vehicle_journey_list;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
 
     PhysicalMode() {}
     bool operator<(const PhysicalMode & other) const { return this < &other; }
@@ -436,7 +436,7 @@ struct Line : public Header, Nameable, HasMessages {
                 & impacts & calendar_list & shape & closing_time
                 & opening_time & properties & line_group_list;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
 
     bool operator<(const Line & other) const {
         if(this->network != other.network){
@@ -467,7 +467,7 @@ struct LineGroup : public Header, Nameable{
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & main_line & line_list;
     }
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const LineGroup & other) const { return this < &other; }
 };
 
@@ -559,7 +559,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties {
 
     bool has_boarding() const;
     bool has_landing() const;
-    std::vector<idx_t> get(Type_e type, const PT_Data& data) const;
+    Indexes get(Type_e type, const PT_Data& data) const;
     std::vector<boost::shared_ptr<disruption::Impact>> get_impacts() const;
 
     bool operator<(const VehicleJourney& other) const;
@@ -652,7 +652,7 @@ struct Route : public Header, Nameable, HasMessages {
             & frequency_vehicle_journey_list & impacts & shape & direction_type & dataset_list;
     }
 
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     bool operator<(const Route & other) const { return this < &other; }
 
     std::string get_label() const;
@@ -796,7 +796,7 @@ struct Calendar : public Nameable, public Header {
 
     bool operator<(const Calendar & other) const { return this < &other; }
 
-    std::vector<idx_t> get(Type_e type, const PT_Data & data) const;
+    Indexes get(Type_e type, const PT_Data & data) const;
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & name & idx & uri & week_pattern & active_periods & exceptions & validity_pattern;
     }
@@ -883,7 +883,7 @@ struct MetaVehicleJourney: public Header, HasMessages {
 
     const std::string& get_label() const { return uri; } // for the moment the label is just the uri
 
-    std::vector<idx_t> get(Type_e type, const PT_Data& data) const;
+    Indexes get(Type_e type, const PT_Data& data) const;
 
     void push_unique_impact(const boost::shared_ptr<disruption::Impact>& impact);
 

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -31,6 +31,7 @@ www.navitia.io
 #include <bitset>
 #include <iostream>
 #include "utils/idx_map.h"
+#include <boost/container/flat_set.hpp>
 
 namespace navitia {
 namespace type {
@@ -121,10 +122,12 @@ struct Nameable {
 
 struct PT_Data;
 
+using Indexes = boost::container::flat_set<idx_t>;
+
 struct Header {
     idx_t idx = invalid_idx; // Index of the object in the main structure
     std::string uri; // unique indentifier of the object
-    std::vector<idx_t> get(Type_e, const PT_Data &) const {return std::vector<idx_t>();}
+    Indexes get(Type_e, const PT_Data&) const {return Indexes{};}
 };
 
 typedef std::bitset<10> Properties;

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -124,6 +124,15 @@ struct PT_Data;
 
 using Indexes = boost::container::flat_set<idx_t>;
 
+inline Indexes make_indexes(std::initializer_list<idx_t> l) {
+    Indexes indexes;
+    indexes.reserve(l.size());
+    for (const auto& v: l) {
+        indexes.insert(v);
+    }
+    return indexes;
+}
+
 struct Header {
     idx_t idx = invalid_idx; // Index of the object in the main structure
     std::string uri; // unique indentifier of the object


### PR DESCRIPTION
since the vector<idx> were implicitly sorted, we use a better container
for this

We need to check all `TODO: use bulk insert` to be sure that were doing the right stuff

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1448)

<!-- Reviewable:end -->
