### PR TITLE
Kraken: enable RVO to avoid another response copy

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -671,7 +671,8 @@ pbnavitia::Response Worker::dispatch(const pbnavitia::Request& request) {
     pbnavitia::Response response ;
     // These api can respond even if the data isn't loaded
     if (request.requested_api() == pbnavitia::STATUS) {
-        return status();
+        response = status();
+        return response;
     }
     if (request.requested_api() ==  pbnavitia::METADATAS) {
         metadatas(response);


### PR DESCRIPTION
there are still lot's of Response useless copy, but it's a start

on /vehicle_journeys?depth=3, it gives 10% faster response

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1457)

<!-- Reviewable:end -->
