### PR TITLE
routing: optimize memory of CachedNextStopTime

### DIFF
--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -431,7 +431,7 @@ bool CachedNextStopTimeKey::operator<(const CachedNextStopTimeKey& other) const 
 }
 
 CachedNextStopTime CachedNextStopTimeManager::CacheCreator::operator()(const CachedNextStopTimeKey& key) const {
-    CachedNextStopTime::JppIdxMap departure, arrival;
+    CachedNextStopTime::vDtStByJpp departure, arrival;
     const auto& jp_container = dataRaptor.jp_container;
 
     departure.assign(jp_container.get_jpps_values());
@@ -457,7 +457,7 @@ CachedNextStopTime CachedNextStopTimeManager::CacheCreator::operator()(const Cac
     return {departure, arrival};
 }
 
-CachedNextStopTime::DtStFromJpp::DtStFromJpp(const JppIdxMap& map) {
+CachedNextStopTime::DtStFromJpp::DtStFromJpp(const vDtStByJpp& map) {
     until.assign(map, 0);
     for (const auto& elt: map) {
         boost::push_back(dtsts, elt.second);

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -230,10 +230,18 @@ struct CachedNextStopTime {
 
 private:
     struct DtStFromJpp {
+        DtStFromJpp(const JppIdxMap& jpp_idx_map);
+        // Returns the range corresponding to jpp_idx_map[jpp_idx],
+        // i.e. from dtsts[until[prev(jpp_idx)]] to
+        // dtsts[until[jpp_idx]] (excluded).
+        boost::iterator_range<vDtSt::const_iterator> operator[](const JppIdx& jpp_idx) const;
+    private:
+        // Every vectors of jpp_idx_map concatenated in order
+        // (flatten(jpp_idx_map.values())).
         vDtSt dtsts;
+        // dtsts[until[jpp_idx]] correspond to the end of
+        // jpp_idx_map[jpp_idx], and to the begin of jpp_idx_map[next(jpp_idx)]
         IdxMap<JourneyPatternPoint, uint32_t> until;
-        DtStFromJpp(const JppIdxMap&);
-        boost::iterator_range<vDtSt::const_iterator> operator[](const JppIdx&) const;
     };
     DtStFromJpp departure;
     DtStFromJpp arrival;

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -216,9 +216,9 @@ struct CachedNextStopTimeKey {
 struct CachedNextStopTime {
     using DtSt = std::pair<DateTime, const type::StopTime*>;
     using vDtSt = std::vector<DtSt>;
-    using JppIdxMap = IdxMap<JourneyPatternPoint, vDtSt>;
+    using vDtStByJpp = IdxMap<JourneyPatternPoint, vDtSt>;
 
-    CachedNextStopTime(const JppIdxMap& d, const JppIdxMap& a): departure(d), arrival(a) {}
+    CachedNextStopTime(const vDtStByJpp& d, const vDtStByJpp& a): departure(d), arrival(a) {}
     // Returns the next stop time at given journey pattern point
     // either a vehicle that leaves or that arrives depending on
     // clockwise.
@@ -229,18 +229,37 @@ struct CachedNextStopTime {
                    const bool clockwise) const;
 
 private:
+    // This structure provide the same interface as a vDtStByJpp, but
+    // in a condensed and read only view.
     struct DtStFromJpp {
-        DtStFromJpp(const JppIdxMap& jpp_idx_map);
-        // Returns the range corresponding to jpp_idx_map[jpp_idx],
-        // i.e. from dtsts[until[prev(jpp_idx)]] to
-        // dtsts[until[jpp_idx]] (excluded).
+        DtStFromJpp(const vDtStByJpp& map);
+
+        // Returns the range corresponding to map[jpp_idx], i.e. from
+        // dtsts[until[prev(jpp_idx)]] to dtsts[until[jpp_idx]]
+        // (excluded).
         boost::iterator_range<vDtSt::const_iterator> operator[](const JppIdx& jpp_idx) const;
+
     private:
-        // Every vectors of jpp_idx_map concatenated in order
-        // (flatten(jpp_idx_map.values())).
+        // let map[JppIdx(40)] == []
+        //     map[JppIdx(41)] == [a, l]
+        //     map[JppIdx(42)] == [x, y, z]
+        //
+        // until: [..., JppIdx(39), JppIdx(40), JppIdx(41), JppIdx(42), ...]
+        //                  |           |            |        |
+        //                  ------------+------,     |        |
+        //                                     V     V        V
+        // dtsts: [...................... , o, a, l, x, y, z, p, q, ...]
+        //                                           ^^^^^^^
+        //                                      range of values
+        //                                      corresponding to
+        //                                      map[JppIdx(42)]
+        //
+        // Every vectors of map concatenated in order
+        // (flatten(map.values())).
         vDtSt dtsts;
+
         // dtsts[until[jpp_idx]] correspond to the end of
-        // jpp_idx_map[jpp_idx], and to the begin of jpp_idx_map[next(jpp_idx)]
+        // map[jpp_idx], and to the begin of map[next(jpp_idx)]
         IdxMap<JourneyPatternPoint, uint32_t> until;
     };
     DtStFromJpp departure;

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -215,9 +215,10 @@ struct CachedNextStopTimeKey {
 
 struct CachedNextStopTime {
     using DtSt = std::pair<DateTime, const type::StopTime*>;
-    IdxMap<JourneyPatternPoint, std::vector<DtSt>> departure;
-    IdxMap<JourneyPatternPoint, std::vector<DtSt>> arrival;
+    using vDtSt = std::vector<DtSt>;
+    using JppIdxMap = IdxMap<JourneyPatternPoint, vDtSt>;
 
+    CachedNextStopTime(const JppIdxMap& d, const JppIdxMap& a): departure(d), arrival(a) {}
     // Returns the next stop time at given journey pattern point
     // either a vehicle that leaves or that arrives depending on
     // clockwise.
@@ -226,6 +227,16 @@ struct CachedNextStopTime {
                    const JppIdx jpp_idx,
                    const DateTime dt,
                    const bool clockwise) const;
+
+private:
+    struct DtStFromJpp {
+        vDtSt dtsts;
+        IdxMap<JourneyPatternPoint, uint32_t> until;
+        DtStFromJpp(const JppIdxMap&);
+        boost::iterator_range<vDtSt::const_iterator> operator[](const JppIdx&) const;
+    };
+    DtStFromJpp departure;
+    DtStFromJpp arrival;
 };
 
 struct CachedNextStopTimeManager {


### PR DESCRIPTION
Performance:
- time: (small gain) (ms/request)
  - stif: 99 -> 94
  - ch: 490 -> 440
- memory: (improve 1.5 for stif, 1.9 for ch) (Mo/cache)
  - stif: [147-254], avg 202 -> [47-212], avg 130
  - ch: [362-396], avg 389 -> [129-368], avg 209

http://jira.canaltp.fr/browse/NAVP-511
