### PR TITLE
Jormungandr: add items_per_schedule param to /stop_schedules

### DIFF
--- a/documentation/slate/source/includes/integration.md
+++ b/documentation/slate/source/includes/integration.md
@@ -793,13 +793,13 @@ access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource
 
 #### Parameters
 
-Required | Name             | Type      | Description                                                                              | Default Value
----------|------------------|-----------|------------------------------------------------------------------------------------------|--------------
-yep      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                    |
-nop      | duration         | int       | Maximum duration in seconds between from_datetime and the retrieved datetimes.           | 86400
-nop      | max_date_times   | int       | Maximum number of columns per schedule.                                                  |
-nop      | forbidden_uris[] | id        | If you want to avoid lines, modes, networks, etc.                                        | 
-nop      | data_freshness   | enum      | Define the freshness of data to use<br><ul><li>realtime</li><li>base_schedule</li></ul>  | base_schedule
+Required | Name               | Type      | Description                                                                              | Default Value
+---------|--------------------|-----------|------------------------------------------------------------------------------------------|--------------
+yep      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                    |
+nop      | duration           | int       | Maximum duration in seconds between from_datetime and the retrieved datetimes.           | 86400
+nop      | items_per_schedule | int       | Maximum number of columns per schedule.                                                  |
+nop      | forbidden_uris[]   | id        | If you want to avoid lines, modes, networks, etc.                                        | 
+nop      | data_freshness     | enum      | Define the freshness of data to use<br><ul><li>realtime</li><li>base_schedule</li></ul>  | base_schedule
 
 
 #### Objects
@@ -846,6 +846,7 @@ Required | Name           | Type                    | Description        | Defau
 yep      | from_datetime  | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules |
 nop      | duration         | int                            | Maximum duration in seconds between from_datetime and the retrieved datetimes.                            | 86400
 nop      | forbidden_uris[] | id                             | If you want to avoid lines, modes, networks, etc.    | 
+nop      | items_per_schedule | int       | Maximum number of datetimes per schedule.                                                  |
 nop      | data_freshness   | enum                           | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul> | base_schedule
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -78,9 +78,8 @@ class Schedules(ResourceUri, ResourceUtc):
                                 description="Number of schedules per page")
         parser_get.add_argument("start_page", type=int, default=0,
                                 description="The current page")
-        parser_get.add_argument("max_date_times", type=natural, default=10000,
-                                description="Maximum number of schedule per\
-                                stop_point/route")
+        parser_get.add_argument("max_date_times", type=natural,
+                                description="DEPRECATED, use items_per_schedule")
         parser_get.add_argument("forbidden_id[]", type=unicode,
                                 description="DEPRECATED, replaced by forbidden_uris[]",
                                 dest="__temporary_forbidden_id[]",
@@ -122,7 +121,10 @@ class Schedules(ResourceUri, ResourceUtc):
             args['forbidden_uris[]'].append(forbid_id)
 
         args["nb_stoptimes"] = args["count"]
-        args["interface_version"] = 1
+
+        # retrocompatibility
+        if args['max_date_times'] is not None:
+            args['items_per_schedule'] = args['max_date_times']
 
         if uri is None:
             if not args['filter']:
@@ -254,8 +256,6 @@ class StopSchedules(Schedules):
 
     def __init__(self):
         super(StopSchedules, self).__init__("departure_boards")
-        self.parsers["get"].add_argument("interface_version", type=int,
-                                         default=1, hidden=True)
 
     @marshal_with(stop_schedules)
     @ManageError()

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -109,6 +109,8 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument("_current_datetime", type=date_time_format, default=datetime.datetime.utcnow(),
                                 description="The datetime we want to publish the disruptions from."
                                             " Default is the current date and it is mainly used for debug.")
+        parser_get.add_argument("items_per_schedule", type=natural, default=10000,
+                                description="maximum number of date_times per schedule")
 
         self.method_decorators.append(complete_links(self))
 

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -242,14 +242,11 @@ class MixedSchedule(object):
             st.nb_stoptimes = 0
         else:
             st.nb_stoptimes = request["nb_stoptimes"]
-        st.interface_version = 1
         st.count = request.get("count", 10)
         if "start_page" not in request:
             st.start_page = 0
         else:
             st.start_page = request["start_page"]
-        if request["max_date_times"]:
-            st.max_date_times = request["max_date_times"]
         if request["items_per_schedule"]:
             st.items_per_schedule = request["items_per_schedule"]
         if request["forbidden_uris[]"]:

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -250,6 +250,8 @@ class MixedSchedule(object):
             st.start_page = request["start_page"]
         if request["max_date_times"]:
             st.max_date_times = request["max_date_times"]
+        if request["items_per_schedule"]:
+            st.items_per_schedule = request["items_per_schedule"]
         if request["forbidden_uris[]"]:
             for forbidden_uri in request["forbidden_uris[]"]:
                 st.forbidden_uri.append(forbidden_uri)

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -417,7 +417,7 @@ def check_stop_schedule(response, reference):
                    if r.sp == get_not_null(get_not_null(resp, 'stop_point'), 'id')
                    and r.route == get_not_null(get_not_null(resp, 'route'), 'id'))
 
-        for (resp_dt, ref_st) in itertools.izip_longest(get_not_null(resp, 'date_times'), ref.date_times):
+        for (resp_dt, ref_st) in itertools.izip_longest(resp['date_times'], ref.date_times):
             eq_(get_not_null(resp_dt, 'date_time'), ref_st.dt)
             eq_(get_not_null(resp_dt, 'links')[0]['id'], ref_st.vj)
 
@@ -516,6 +516,36 @@ class TestSchedules(AbstractTestFixture):
         is_valid_stop_schedule(stop_sched, self.tester)
 
         self.check_stop_schedule_rt_sol(stop_sched)
+
+    def test_stop_schedule_realtime_limit_per_schedule(self):
+        """
+        same as test_stop_schedule_realtime, but we limit the number of item per schedule
+        """
+        response = self.query_region("stop_points/S1/stop_schedules?from_datetime=20160101T080000"
+                                     "&data_freshness=realtime&items_per_schedule=1")
+
+        stop_sched = response["stop_schedules"]
+        is_valid_stop_schedule(stop_sched, self.tester)
+
+        check_stop_schedule(stop_sched,
+                            [StopSchedule(sp='S1', route='A:0',
+                                          date_times=[SchedDT(dt='20160101T090700',
+                                                              vj='A:vj1:modified:0:delay_vj1')]),
+                             StopSchedule(sp='S1', route='B:1',
+                                          date_times=[SchedDT(dt='20160101T113000', vj='B:vj1')])])
+
+        # and test with a limit at 0
+        response = self.query_region("stop_points/S1/stop_schedules?from_datetime=20160101T080000"
+                                     "&data_freshness=realtime&items_per_schedule=0")
+
+        stop_sched = response["stop_schedules"]
+        # is_valid_stop_schedule(stop_sched, self.tester)
+
+        check_stop_schedule(stop_sched,
+                            [StopSchedule(sp='S1', route='A:0',
+                                          date_times=[]),
+                             StopSchedule(sp='S1', route='B:1',
+                                          date_times=[])])
 
     def test_stop_schedule_no_dt(self):
         """

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -539,7 +539,18 @@ class TestSchedules(AbstractTestFixture):
                                      "&data_freshness=realtime&items_per_schedule=0")
 
         stop_sched = response["stop_schedules"]
-        # is_valid_stop_schedule(stop_sched, self.tester)
+
+        check_stop_schedule(stop_sched,
+                            [StopSchedule(sp='S1', route='A:0',
+                                          date_times=[]),
+                             StopSchedule(sp='S1', route='B:1',
+                                          date_times=[])])
+
+        # test retrocompat'
+        response = self.query_region("stop_points/S1/stop_schedules?from_datetime=20160101T080000"
+                                     "&data_freshness=realtime&max_date_times=0")
+
+        stop_sched = response["stop_schedules"]
 
         check_stop_schedule(stop_sched,
                             [StopSchedule(sp='S1', route='A:0',

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -316,13 +316,14 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                                  rt_level, api, request.count(), request.start_page());
             break;
         case pbnavitia::DEPARTURE_BOARDS:
+
             timetables::departure_board(pb_creator, request.departure_filter(),
                     request.has_calendar() ? boost::optional<const std::string>(request.calendar()) :
                                              boost::optional<const std::string>(),
                     forbidden_uri, from_datetime,
                     request.duration(),
                     request.depth(), max_date_times,
-                    request.count(), request.start_page(), rt_level);
+                    request.count(), request.start_page(), rt_level, request.items_per_schedule());
             break;
         case pbnavitia::ROUTE_SCHEDULES:
             timetables::route_schedule(pb_creator, request.departure_filter(),

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -321,7 +321,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                                              boost::optional<const std::string>(),
                     forbidden_uri, from_datetime,
                     request.duration(),
-                    request.depth(), max_date_times, request.interface_version(),
+                    request.depth(), max_date_times,
                     request.count(), request.start_page(), rt_level);
             break;
         case pbnavitia::ROUTE_SCHEDULES:

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -274,7 +274,6 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                                             const boost::posix_time::ptime& current_datetime) {
 
     const auto data = data_manager.get_data();
-    int32_t max_date_times = request.has_max_date_times() ? request.max_date_times() : std::numeric_limits<int>::max();
     std::vector<std::string> forbidden_uri;
     for(int i = 0; i < request.forbidden_uri_size(); ++i)
         forbidden_uri.push_back(request.forbidden_uri(i));
@@ -316,13 +315,12 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                                  rt_level, api, request.count(), request.start_page());
             break;
         case pbnavitia::DEPARTURE_BOARDS:
-
             timetables::departure_board(pb_creator, request.departure_filter(),
                     request.has_calendar() ? boost::optional<const std::string>(request.calendar()) :
                                              boost::optional<const std::string>(),
                     forbidden_uri, from_datetime,
                     request.duration(),
-                    request.depth(), max_date_times,
+                    request.depth(),
                     request.count(), request.start_page(), rt_level, request.items_per_schedule());
             break;
         case pbnavitia::ROUTE_SCHEDULES:
@@ -331,7 +329,7 @@ pbnavitia::Response Worker::next_stop_times(const pbnavitia::NextStopTimeRequest
                     boost::optional<const std::string>(),
                     forbidden_uri,
                     from_datetime,
-                    request.duration(), max_date_times, request.depth(),
+                    request.duration(), request.items_per_schedule(), request.depth(),
                     request.count(), request.start_page(), rt_level);
             break;
         default:

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -96,7 +96,6 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
                 const std::vector<std::string>& forbidden_uris,
                 const pt::ptime date,
                 uint32_t duration, uint32_t depth,
-                uint32_t max_date_times,
                 int count, int start_page, const type::RTLevel rt_level, const size_t items_per_route_point) {
 
     RequestHandle handler(pb_creator, request, forbidden_uris, date, duration, calendar_id);
@@ -146,49 +145,52 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
         const type::StopPoint* stop_point = pb_creator.data.pt_data->stop_points[sp_route.first.val];
         const type::Route* route = pb_creator.data.pt_data->routes[sp_route.second.val];
         const auto& jpps = pb_creator.data.dataRaptor->jpps_from_sp[sp_route.first];
+        std::vector<routing::JppIdx> routepoint_jpps;
         for (const auto& jpp_from_sp: jpps) {
             const routing::JppIdx& jpp_idx = jpp_from_sp.idx;
             const auto& jpp = pb_creator.data.dataRaptor->jp_container.get(jpp_idx);
             const auto& jp = pb_creator.data.dataRaptor->jp_container.get(jpp.jp_idx);
             if (jp.route_idx != sp_route.second) { continue; }
 
-            std::vector<routing::datetime_stop_time> tmp;
-            if (! calendar_id) {
-                tmp = routing::get_stop_times(routing::StopEvent::pick_up, {jpp_idx}, handler.date_time,
-                        handler.max_datetime, max_date_times, pb_creator.data, rt_level);
-            } else {
-                tmp = routing::get_stop_times({jpp_idx}, DateTimeUtils::hour(handler.date_time),
-                        DateTimeUtils::hour(handler.max_datetime), pb_creator.data, *calendar_id);
-            }
-            if (! tmp.empty()) {
-                stop_times.insert(stop_times.end(), tmp.begin(), tmp.end());
-            } else {
-                const auto& last_jpp = pb_creator.data.dataRaptor->jp_container.get(jp.jpps.back());
-                if (sp_route.first == last_jpp.sp_idx) {
-                    if (stop_point->stop_area == route->destination){
-                        response_status[route->idx] = pbnavitia::ResponseStatus::terminus;
-                    }else{
-                        response_status[route->idx] = pbnavitia::ResponseStatus::partial_terminus;
-                    }
-                }
-            }
+            routepoint_jpps.push_back(jpp_idx);
+        }
+
+        std::vector<routing::datetime_stop_time> tmp;
+        if (! calendar_id) {
+            stop_times = routing::get_stop_times(routing::StopEvent::pick_up, routepoint_jpps, handler.date_time,
+                    handler.max_datetime, items_per_route_point, pb_creator.data, rt_level);
+        } else {
+            stop_times = routing::get_stop_times(routepoint_jpps, DateTimeUtils::hour(handler.date_time),
+                    DateTimeUtils::hour(handler.max_datetime), pb_creator.data, *calendar_id);
         }
         if ( ! calendar_id) {
             std::sort(stop_times.begin(), stop_times.end(), sort_predicate);
         } else {
             // for calendar we want the first stop time to start from handler.date_time
             std::sort(stop_times.begin(), stop_times.end(), routing::CalendarScheduleSort(handler.date_time));
-            if (stop_times.size() > max_date_times) {
-                stop_times.resize(max_date_times);
+            if (stop_times.size() > items_per_route_point) {
+                stop_times.resize(items_per_route_point);
             }
         }
-        if(stop_times.empty() && (response_status.find(route->idx) == response_status.end())){
+
+        //we compute the route status
+        for (const auto& jpp_from_sp: jpps) {
+            const routing::JppIdx& jpp_idx = jpp_from_sp.idx;
+            const auto& jpp = pb_creator.data.dataRaptor->jp_container.get(jpp_idx);
+            const auto& jp = pb_creator.data.dataRaptor->jp_container.get(jpp.jp_idx);
+            const auto& last_jpp = pb_creator.data.dataRaptor->jp_container.get(jp.jpps.back());
+            if (sp_route.first == last_jpp.sp_idx) {
+                if (stop_point->stop_area == route->destination) {
+                    response_status[route->idx] = pbnavitia::ResponseStatus::terminus;
+                } else {
+                    response_status[route->idx] = pbnavitia::ResponseStatus::partial_terminus;
+                }
+            }
+        }
+        if (stop_times.empty() && (response_status.find(route->idx) == response_status.end())) {
             response_status[route->idx] = pbnavitia::ResponseStatus::no_departure_this_day;
         }
 
-        if (stop_times.size() > items_per_route_point) {
-            stop_times.resize(items_per_route_point);
-        }
         map_route_stop_point[sp_route] = stop_times;
     }
 

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -43,7 +43,7 @@ namespace pt = boost::posix_time;
 namespace navitia { namespace timetables {
 
 static void
-render_v1(PbCreator& pb_creator,
+render(PbCreator& pb_creator,
           const std::map<uint32_t, pbnavitia::ResponseStatus>& response_status,
           const std::map<stop_point_route, vector_dt_st>& map_route_stop_point,
           DateTime datetime,
@@ -98,7 +98,6 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
                 const pt::ptime date,
                 uint32_t duration, uint32_t depth,
                 uint32_t max_date_times,
-                int interface_version,
                 int count, int start_page, const type::RTLevel rt_level) {
 
     RequestHandle handler(pb_creator, request, forbidden_uris, date,  duration, calendar_id);

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -36,7 +36,7 @@ www.navitia.io
 
 namespace navitia { namespace timetables {
 typedef std::vector<DateTime> vector_datetime;
-typedef std::pair<uint32_t, uint32_t> stop_point_line;
+typedef std::pair<routing::SpIdx, routing::RouteIdx> stop_point_route;
 typedef std::vector<routing::datetime_stop_time> vector_dt_st;
 
 void departure_board(PbCreator& pb_creator, const std::string &filter,

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -43,7 +43,7 @@ void departure_board(PbCreator& pb_creator, const std::string &filter,
                      boost::optional<const std::string> calendar_id,
                      const std::vector<std::string>& forbidden_uris,
                      const boost::posix_time::ptime datetime,
-                     uint32_t duration, uint32_t depth, uint32_t max_date_times,
+                     uint32_t duration, uint32_t depth,
                      int count, int start_page,
                      const type::RTLevel rt_level,
                      const size_t items_per_route_point);

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -45,7 +45,8 @@ void departure_board(PbCreator& pb_creator, const std::string &filter,
                      const boost::posix_time::ptime datetime,
                      uint32_t duration, uint32_t depth, uint32_t max_date_times,
                      int count, int start_page,
-                     const type::RTLevel rt_level);
+                     const type::RTLevel rt_level,
+                     const size_t items_per_route_point);
 }
 
 }

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -44,7 +44,7 @@ void departure_board(PbCreator& pb_creator, const std::string &filter,
                      const std::vector<std::string>& forbidden_uris,
                      const boost::posix_time::ptime datetime,
                      uint32_t duration, uint32_t depth, uint32_t max_date_times,
-                     int interface_version, int count, int start_page,
+                     int count, int start_page,
                      const type::RTLevel rt_level);
 }
 

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
 
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "B");
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
     }
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
@@ -267,7 +267,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(resp.has_error());
     BOOST_REQUIRE(! resp.error().message().empty());
@@ -282,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -308,7 +308,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -335,7 +335,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -391,7 +391,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //it should match only the 'all' vj
@@ -469,7 +469,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time, small_cal_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 08:10, last at 07:10
@@ -497,7 +497,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_matched_cal, small_cal_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("empty_cal"), {}, d("20120615T080000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    86400, 0, 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -517,7 +517,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period, small_cal_fixture) {
     auto duration = nb_hour*60*60;
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
-                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    duration, 0, 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 08:10, last at 13:10
@@ -548,7 +548,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period_before, small_cal_fixtur
     auto duration = nb_hour*60*60;
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T200000"),
-                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    duration, 0, 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 20:10, last at 04:10
@@ -586,7 +586,7 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                    86400, 0, 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     pbnavitia::Response resp = pb_creator.get_response();
 
     auto find_sched = [](const std::string& route) {
@@ -617,7 +617,7 @@ BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
 BOOST_FIXTURE_TEST_CASE(rt_stop_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::RealTime,
+                    86400, 0, 10, 0, nt::RTLevel::RealTime,
                     std::numeric_limits<size_t>::max());
     pbnavitia::Response resp = pb_creator.get_response();
 
@@ -650,7 +650,7 @@ BOOST_FIXTURE_TEST_CASE(rt_stop_schedule, departure_board_fixture) {
 BOOST_FIXTURE_TEST_CASE(base_stop_schedule_limit_per_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, 2);
+                    86400, 0, 10, 0, nt::RTLevel::Base, 2);
     pbnavitia::Response resp = pb_creator.get_response();
 
     auto find_sched = [](const std::string& route) {

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -80,8 +80,9 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     // normal departure board
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
+
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
@@ -92,7 +93,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
@@ -105,7 +106,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
@@ -119,7 +120,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
@@ -131,7 +132,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -143,7 +144,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "B");
@@ -152,7 +153,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
     }
@@ -226,7 +227,7 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
@@ -266,7 +267,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(resp.has_error());
     BOOST_REQUIRE(! resp.error().message().empty());
@@ -281,7 +282,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -307,7 +308,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -334,7 +335,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -390,7 +391,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //it should match only the 'all' vj
@@ -468,7 +469,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time, small_cal_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 08:10, last at 07:10
@@ -496,7 +497,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_matched_cal, small_cal_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("empty_cal"), {}, d("20120615T080000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -516,7 +517,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period, small_cal_fixture) {
     auto duration = nb_hour*60*60;
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
-                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 08:10, last at 13:10
@@ -547,7 +548,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period_before, small_cal_fixtur
     auto duration = nb_hour*60*60;
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T200000"),
-                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 20:10, last at 04:10
@@ -585,7 +586,7 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
     pbnavitia::Response resp = pb_creator.get_response();
 
     auto find_sched = [](const std::string& route) {
@@ -616,7 +617,8 @@ BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
 BOOST_FIXTURE_TEST_CASE(rt_stop_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::RealTime);
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::RealTime,
+                    std::numeric_limits<size_t>::max());
     pbnavitia::Response resp = pb_creator.get_response();
 
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
@@ -641,3 +643,36 @@ BOOST_FIXTURE_TEST_CASE(rt_stop_schedule, departure_board_fixture) {
     BOOST_REQUIRE_EQUAL(sc2.date_times_size(), 1);
     BOOST_CHECK_EQUAL(sc2.date_times(0).time(), "11:30"_t);
 }
+
+/*
+ * same as base_stop_schedule but we limit the number of results per schedule
+ */
+BOOST_FIXTURE_TEST_CASE(base_stop_schedule_limit_per_schedule, departure_board_fixture) {
+    navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
+    departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base, 2);
+    pbnavitia::Response resp = pb_creator.get_response();
+
+    auto find_sched = [](const std::string& route) {
+        return [&route](const pbnavitia::StopSchedule& s) { return s.route().uri() == route; };
+    };
+    BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
+    auto it_sc1 = boost::find_if(resp.stop_schedules(), find_sched("A:0"));
+    BOOST_CHECK(it_sc1 != std::end(resp.stop_schedules()));
+    const auto& sc1 = *it_sc1;
+    BOOST_CHECK_EQUAL(sc1.stop_point().uri(), "S1");
+    BOOST_CHECK_EQUAL(sc1.route().uri(), "A:0");
+    BOOST_REQUIRE_EQUAL(sc1.date_times_size(), 2);
+    BOOST_CHECK_EQUAL(sc1.date_times(0).time(), "09:00"_t);
+    BOOST_CHECK_EQUAL(sc1.date_times(1).time(), "10:00"_t);
+
+    // does not change anything the B:1
+    auto it_sc2 = boost::find_if(resp.stop_schedules(), find_sched("B:1"));
+    BOOST_CHECK(it_sc2 != std::end(resp.stop_schedules()));
+    const auto& sc2 = *it_sc2;
+    BOOST_CHECK_EQUAL(sc2.stop_point().uri(), "S1");
+    BOOST_CHECK_EQUAL(sc2.route().uri(), "B:1");
+    BOOST_REQUIRE_EQUAL(sc2.date_times_size(), 1);
+    BOOST_CHECK_EQUAL(sc2.date_times(0).time(), "11:30"_t);
+}
+

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
 
     navitia::PbCreator pb_creator(*(b.data), "20150616T080000"_dt, null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
@@ -186,7 +186,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     navitia::PbCreator pb_creator1(*(b.data), "20150626T110000"_dt, null_time_period);
     pb_creator.now = "20150626T110000"_dt;
     departure_board(pb_creator1, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
     resp = pb_creator1.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150616T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),0);
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(),1);
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "A");
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
     BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "B");
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
     }
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
@@ -266,7 +266,7 @@ BOOST_FIXTURE_TEST_CASE(test_no_weekend, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(resp.has_error());
     BOOST_REQUIRE(! resp.error().message().empty());
@@ -281,7 +281,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_weekend, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -307,7 +307,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_week, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -334,7 +334,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -390,7 +390,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_exception, calendar_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     //it should match only the 'all' vj
@@ -468,7 +468,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time, small_cal_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"), 86400, 0,
-                    std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 08:10, last at 07:10
@@ -496,7 +496,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_matched_cal, small_cal_fixture) {
 
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("empty_cal"), {}, d("20120615T080000"),
-                    86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE(! resp.has_error());
@@ -516,7 +516,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period, small_cal_fixture) {
     auto duration = nb_hour*60*60;
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T080000"),
-                    duration, 0, std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 08:10, last at 13:10
@@ -547,7 +547,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_start_time_period_before, small_cal_fixtur
     auto duration = nb_hour*60*60;
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=stop1", std::string("cal"), {}, d("20120615T200000"),
-                    duration, 0, std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    duration, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
 
     pbnavitia::Response resp = pb_creator.get_response();
     //we should get a nice schedule, first stop at 20:10, last at 04:10
@@ -585,7 +585,7 @@ BOOST_FIXTURE_TEST_CASE(test_journey, calendar_fixture) {
 BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::Base);
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::Base);
     pbnavitia::Response resp = pb_creator.get_response();
 
     auto find_sched = [](const std::string& route) {
@@ -616,7 +616,7 @@ BOOST_FIXTURE_TEST_CASE(base_stop_schedule, departure_board_fixture) {
 BOOST_FIXTURE_TEST_CASE(rt_stop_schedule, departure_board_fixture) {
     navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator, "stop_point.uri=S1", {}, {}, d("20160101T070000"),
-                    86400, 0, std::numeric_limits<int>::max(), 1, 10, 0, nt::RTLevel::RealTime);
+                    86400, 0, std::numeric_limits<int>::max(), 10, 0, nt::RTLevel::RealTime);
     pbnavitia::Response resp = pb_creator.get_response();
 
     BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);


### PR DESCRIPTION
This param sets a maximum number of date_times per route/point in /stop_schedules

linked to http://jira.canaltp.fr/browse/NAVP-490

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/canaltp/navitia/1480)

<!-- Reviewable:end -->
