### PR TITLE
Kraken: fix label of admin

### DIFF
--- a/source/georef/adminref.cpp
+++ b/source/georef/adminref.cpp
@@ -36,21 +36,19 @@ std::string Admin::get_range_postal_codes(){
     std::string post_code;
     // the label is the range of the postcode
     // ex: Tours (37000;37100;37200) -> Tours (37000-37200)
+    //     Cosne-d'Allier (03430)    -> Cosne-d'Allier (03430)
     if (!this->postal_codes.empty()) {
-        int min_value = std::numeric_limits<int>::max();
-        int max_value = std::numeric_limits<int>::min();
         try {
+            std::vector<int> postal_codes_int;
             for (const std::string& str_post_code : this->postal_codes) {
-                int int_post_code;
-                int_post_code = boost::lexical_cast<int>(str_post_code);
-                min_value = std::min(min_value, int_post_code);
-                max_value = std::max(max_value, int_post_code);
+                postal_codes_int.push_back(boost::lexical_cast<int>(str_post_code));
             }
-            if (min_value == max_value){
-                post_code = boost::lexical_cast<std::string>(min_value);
+            auto result = std::minmax_element(postal_codes_int.begin(),postal_codes_int.end());
+            if (*result.first == *result.second){
+                post_code = this->postal_codes[result.first-postal_codes_int.begin()];
             }else{
-                post_code = boost::lexical_cast<std::string>(min_value)
-                        + "-" + boost::lexical_cast<std::string>(max_value);
+                post_code = this->postal_codes[result.first-postal_codes_int.begin()]
+                        + "-" + this->postal_codes[result.second-postal_codes_int.begin()];
             }
         }catch (boost::bad_lexical_cast) {
             post_code = this->postal_codes_to_string();

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -993,12 +993,34 @@ BOOST_AUTO_TEST_CASE(range_postal_codes) {
 
 }
 
+BOOST_AUTO_TEST_CASE(empty_postal_codes) {
+    navitia::georef::Admin* admin = new navitia::georef::Admin();
+    admin->postal_codes = {};
+    BOOST_CHECK_EQUAL(admin->get_range_postal_codes(), "");
+}
+
+BOOST_AUTO_TEST_CASE(one_postal_code) {
+    navitia::georef::Admin* admin = new navitia::georef::Admin();
+    admin->postal_codes = {"03430"};
+    BOOST_CHECK_EQUAL(admin->get_range_postal_codes(), "03430");
+}
+
+BOOST_AUTO_TEST_CASE(first_number_0) {
+    navitia::georef::Admin* admin = new navitia::georef::Admin();
+    admin->postal_codes = {"04400", "04410", "04420", "04430"};
+    BOOST_CHECK_EQUAL(admin->get_range_postal_codes(), "04400-04430");
+}
+
+BOOST_AUTO_TEST_CASE(string_and_int_post_codes) {
+    navitia::georef::Admin* admin = new navitia::georef::Admin();
+    admin->postal_codes = {"44000", "44100", "44200", "44300", "abcd"};
+    BOOST_CHECK_EQUAL(admin->get_range_postal_codes(), "44000;44100;44200;44300;abcd");
+}
 
 BOOST_AUTO_TEST_CASE(list_postal_codes) {
     navitia::georef::Admin* admin = new navitia::georef::Admin();
     admin->postal_codes = {"44000", "44100", "44200", "44300"};
     BOOST_CHECK_EQUAL(admin->postal_codes_to_string(), "44000;44100;44200;44300");
-
 }
 
 BOOST_AUTO_TEST_CASE(find_nearest_on_same_edge){

--- a/source/jormungandr/tests/places_test.py
+++ b/source/jormungandr/tests/places_test.py
@@ -51,6 +51,18 @@ class TestPlaces(AbstractTestFixture):
         is_valid_places(response['places'])
         assert(response['places'][0]['name'] == "42 rue kb (Condom)")
 
+    def test_label_of_admin(self):
+        '''
+        test label of admin "Condom (03430)"
+        '''
+
+
+        response = self.query_region("places?q=Condom&type[]=administrative_region")
+
+        assert(len(response['places']) == 1)
+        is_valid_places(response['places'])
+        assert(response['places'][0]['name'] == "Condom (03430)")
+
     def test_places_invalid_encoding(self):
         _, status = self.query_no_assert(b'/v1/coverage/main_routing_test/places/?q=ch\xe2teau')
         assert(status != 500)

--- a/source/jormungandr/tests/stats_tests.py
+++ b/source/jormungandr/tests/stats_tests.py
@@ -126,9 +126,9 @@ class MockWrapper:
 
         eq_(stat.journey_request.requested_date_time, 1339653600)
         eq_(stat.journey_request.clockwise, True)
-        eq_(stat.journey_request.departure_insee, '32107')
+        eq_(stat.journey_request.departure_insee, '03430')
         eq_(stat.journey_request.departure_admin, 'admin:74435')
-        eq_(stat.journey_request.arrival_insee, '32107')
+        eq_(stat.journey_request.arrival_insee, '03430')
         eq_(stat.journey_request.arrival_admin, 'admin:74435')
 
     def check_stat_places_to_publish(self, stat):

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -162,9 +162,9 @@ struct routing_api_data {
         auto admin = b.data->geo_ref->admins.back();
         admin->uri = "admin:74435";
         admin->name = "Condom";
-        admin->insee = "32107";
+        admin->insee = "03430";
         admin->level = 8;
-        admin->postal_codes.push_back("32100");
+        admin->postal_codes.push_back("03430");
         admin->coord = nt::GeographicalCoord(D.lon(), D.lat());
         admin->idx = 0;
 


### PR DESCRIPTION
Correction of label for administrative_region object.

Old json of administrative_region :

``` json
{
    "embedded_type": "administrative_region",
    "quality": 90,
    "administrative_region": 
{
    "insee": "03084",
    "name": "Cosne-d'Allier",
    "level": 8,
    "coord": 
       {
            "lat": "46.474174",
            "lon": "2.833047"
        },
        "label": "Cosne-d'Allier (3430)",
        "id": "admin:2213225",
        "zip_code": "03430"
    },
    "id": "admin:2213225",
    "name": "Cosne-d'Allier (03430)"
}
```

New json of administrative_region :

``` json
{
    "embedded_type": "administrative_region",
    "quality": 90,
    "administrative_region": 
{
    "insee": "03084",
    "name": "Cosne-d'Allier",
    "level": 8,
    "coord": 
       {
            "lat": "46.474174",
            "lon": "2.833047"
        },
        "label": "Cosne-d'Allier (03430)",
        "id": "admin:2213225",
        "zip_code": "03430"
    },
    "id": "admin:2213225",
    "name": "Cosne-d'Allier (03430)"
}
```

Jira: http://jira.canaltp.fr/browse/NAVITIAII-2075
