### PR TITLE
Set favicon in meta tag in index.html

### DIFF
--- a/documentation/slate/source/layouts/layout.erb
+++ b/documentation/slate/source/layouts/layout.erb
@@ -22,6 +22,8 @@ under the License.
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <title><%= current_page.data.title || "API Documentation" %></title>
 
+    <link rel="icon" href="favicon.ico" />
+
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>
     <%= stylesheet_link_tag :navio, media: :all %>


### PR DESCRIPTION
Last PR which add a favicon.ico worked with middleman, but once deployed on `canaltp.github.io/navitia`, it is in a subfolder, so it needs a meta tag in index.html.
