### PR TITLE
jormun: prevent error in stat if pagination item is empty

### DIFF
--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -166,7 +166,8 @@ class StatManager(object):
         """
         store data from response of all requests
         """
-        if 'pagination' in call_result[0] and 'items_on_page' in call_result[0]['pagination']:
+        if 'pagination' in call_result[0] and call_result[0]['pagination'] \
+                and 'items_on_page' in call_result[0]['pagination']:
             stat_info_response.object_count = call_result[0]['pagination']['items_on_page']
 
     def fill_result(self, stat_request, call_result):

--- a/source/jormungandr/tests/stats_tests.py
+++ b/source/jormungandr/tests/stats_tests.py
@@ -227,3 +227,11 @@ class TestError(object):
                 stat_manager._manage_stat(time.time(), response)
             assert mock.called
 
+        @mock.patch.object(stat_manager, 'publish_request')
+        def test_pagination(self, mock):
+            response = ({"places_nearby": [], "pagination": None}, 200)
+            #should not raise any exception
+            with app.test_request_context('/v1/places'):
+                stat_manager._manage_stat(time.time(), response)
+            assert mock.called
+


### PR DESCRIPTION
For some strange reason place_nearby seem to behave differently that all the others API...
