### PR TITLE
Add isochron and lines JsFiddle exemples

### DIFF
--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.css
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.css
@@ -1,0 +1,6 @@
+body {
+    margin: 0;
+}
+#map {
+    height: 600px;
+}

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.details
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.details
@@ -24,7 +24,6 @@ description: |
 authors:
    - CanalTP
 resources:
-   - https://code.jquery.com/jquery-2.2.3.min.js
    - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js
    - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css
 wrap: I

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.details
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.details
@@ -23,5 +23,9 @@ description: |
   www.navitia.io
 authors:
    - CanalTP
+resources:
+   - https://code.jquery.com/jquery-2.2.3.min.js
+   - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js
+   - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css
 normalize_css: no
 ...

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.details
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.details
@@ -1,0 +1,27 @@
+---
+name: Isochron API - jsFiddle/Github
+description: |
+  Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+  Hope you'll enjoy and contribute to this project,
+      powered by Canal TP (www.canaltp.fr).
+  Help us simplify mobility and open public transport:
+      a non ending quest to the responsive locomotion way of traveling!
+  LICENCE: This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+  Stay tuned using
+  twitter @navitia
+  IRC #navitia on freenode
+  https://groups.google.com/d/forum/navitia
+  www.navitia.io
+authors:
+   - CanalTP
+normalize_css: no
+...

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.details
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.details
@@ -27,5 +27,6 @@ resources:
    - https://code.jquery.com/jquery-2.2.3.min.js
    - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js
    - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css
+wrap: I
 normalize_css: no
 ...

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.details
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.details
@@ -26,6 +26,6 @@ authors:
 resources:
    - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js
    - https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css
-wrap: I
+wrap: b
 normalize_css: no
 ...

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.html
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.html
@@ -1,0 +1,1 @@
+<div id="map"></div>

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.html
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.html
@@ -1,1 +1,3 @@
-<div id="map"></div>
+<div id="map">
+    <h2 style="font-family: sans-serif">Click RUN on JsFiddle navbar if the exemple is not autorun in your browser.</h2>
+</div>

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.js
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.js
@@ -1,0 +1,172 @@
+var sandboxToken = 'a61f4cd8-3007-4557-9f4c-214969369cca';
+
+// Isochron starting point
+var from = [48.846905, 2.377097];
+
+// Limit isochron duration (required, or may trigger timeout when there is more data)
+var maxDuration = 2000;
+
+// Navitia query for this isochron
+var isochronUrl = 'https://api.navitia.io/v1/coverage/sandbox/journeys?from='+from[1]+';'+from[0]+'&max_duration='+maxDuration;
+
+// Call navitia api
+$.ajax({
+    type: 'GET',
+    url: isochronUrl,
+    dataType: 'json',
+    headers: {
+        Authorization: 'Basic ' + btoa(sandboxToken)
+    },
+    success: drawIsochron,
+    error: function(xhr, textStatus, errorThrown) {
+        alert('Error when trying to process isochron: "'+textStatus+'", "'+errorThrown+'"');
+    }
+});
+
+/*
+ * Drawing isochron result on a map.
+ *
+ * Isochron result contains many points with their duration from starting point.
+ * So here using Leaflet and OSM tiles, each point will be represented with a color
+ * showing its duration from starting point.
+ */
+
+var osm = {
+    url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    attrib: 'Navitia Isochron example © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
+};
+
+// Create a drawable map using Leaflet
+var map = L.map('map')
+    .setView(from, 13)
+    .addLayer(new L.TileLayer(osm.url, {minZoom: 0, maxZoom: 16, attribution: osm.attrib}))
+;
+
+// Add marker to show isochron starting point
+L.marker(from).addTo(map);
+
+var geojsonLayer = null;
+
+/**
+ * Display points returned by navitia isochron, and colored red/green depending on journey duration.
+ *
+ * @param {Object} result
+ */
+function drawIsochron(result) {
+    var isochron = [];
+
+    $.each(result.journeys, function (i, journey) {
+        isochron.push({
+            to: [
+                parseFloat(journey.to.stop_point.coord.lat),
+                parseFloat(journey.to.stop_point.coord.lon)
+            ],
+            duration: journey.duration,
+            data: journey
+        });
+    });
+
+    var geojson = createGeoJsonFromIsochron(isochron);
+
+    drawGeoJson(map, geojson);
+
+    map.on('zoomend', function () {
+        drawGeoJson(map, geojson);
+    });
+}
+
+/**
+ * Create a geoJson object contening all points and their colors.
+ *
+ * @param {Array} isochron
+ *
+ * @returns {Object} GeoJson object
+ */
+function createGeoJsonFromIsochron(isochron) {
+    var geojson = {
+        name: 'Points',
+        type: 'FeatureCollection',
+        features: []
+    };
+
+    $.each(isochron, function (i, point) {
+        geojson.features.push({
+            type: 'Feature',
+            geometry: {
+                type: 'Point',
+                coordinates: point.to.reverse()
+            },
+            properties: {
+                color: colorFromDuration(point.duration),
+                journey: point.data
+            }
+        });
+    });
+
+    return geojson;
+}
+
+/**
+ * Create a Leaflet GeoJson layer and append it to the map.
+ * (Remove the last layer if there is any.)
+ *
+ * @param {L.Map} map
+ * @param {Object} geojson
+ */
+function drawGeoJson(map, geojson) {
+    if (null !== geojsonLayer) {
+        map.removeLayer(geojsonLayer);
+    }
+
+    geojsonLayer = L.geoJson(geojson, {
+        style: function(feature) {
+            return {
+                color: feature.properties.color
+            };
+        },
+        pointToLayer: function(feature, latlng) {
+            var raduis = Math.pow(2, map.getZoom()) / 1000;
+
+            return new L.CircleMarker(latlng, {radius: raduis, fillOpacity: 0.6});
+        },
+        onEachFeature: function (feature, layer) {
+            var journey = feature.properties.journey;
+            var duration = Math.floor(journey.duration / 60)+'min'+(journey.duration % 60)+'s ('+journey.duration+'s)';
+            var journeyLink = journey.links[0].href.replace('://', '://'+sandboxToken+'@');
+
+            layer.bindPopup([
+                '<b>'+journey.to.name+'</b>',
+                duration,
+                '<a href="'+journeyLink+'" target="_blank">Journeys to this point</a>'
+            ].join('<br>'));
+        }
+    });
+
+    map.addLayer(geojsonLayer);
+}
+
+/**
+ * Calculate a color from a duration, from green to red when duration is small/long.
+ *
+ * @param {Integer} duration
+ *
+ * @returns {String}
+ */
+function colorFromDuration(duration) {
+    var color1 = 'FF0000';
+    var color2 = '00FF00';
+    var ratio = duration / maxDuration;
+    ratio *= ratio; // Apply ratio^2 to have more green.
+    var hex = function(x) {
+        x = x.toString(16);
+        return (x.length === 1) ? '0' + x : x;
+    };
+
+    var r = Math.ceil(parseInt(color1.substring(0,2), 16) * ratio + parseInt(color2.substring(0,2), 16) * (1-ratio));
+    var g = Math.ceil(parseInt(color1.substring(2,4), 16) * ratio + parseInt(color2.substring(2,4), 16) * (1-ratio));
+    var b = Math.ceil(parseInt(color1.substring(4,6), 16) * ratio + parseInt(color2.substring(4,6), 16) * (1-ratio));
+
+    var middle = hex(r) + hex(g) + hex(b);
+
+    return '#' + middle;
+}

--- a/documentation/slate/source/examples/jsFiddle/isochron/demo.js
+++ b/documentation/slate/source/examples/jsFiddle/isochron/demo.js
@@ -27,19 +27,19 @@ $.ajax({
  * Drawing isochron result on a map.
  *
  * Isochron result contains many points with their duration from starting point.
- * So here using Leaflet and OSM tiles, each point will be represented with a color
+ * So here using Leaflet, each point will be represented with a color
  * showing its duration from starting point.
  */
 
-var osm = {
-    url: 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+var tiles = {
+    url: 'http://www.toolserver.org/tiles/bw-mapnik/{z}/{x}/{y}.png',
     attrib: 'Navitia Isochron example © <a href="http://openstreetmap.org">OpenStreetMap</a> contributors'
 };
 
 // Create a drawable map using Leaflet
 var map = L.map('map')
     .setView(from, 13)
-    .addLayer(new L.TileLayer(osm.url, {minZoom: 0, maxZoom: 16, attribution: osm.attrib}))
+    .addLayer(new L.TileLayer(tiles.url, {minZoom: 0, maxZoom: 16, attribution: tiles.attrib}))
 ;
 
 // Add marker to show isochron starting point

--- a/documentation/slate/source/examples/jsFiddle/lines/demo.css
+++ b/documentation/slate/source/examples/jsFiddle/lines/demo.css
@@ -1,0 +1,24 @@
+.line-circle {
+  display: inline-block;
+  border-radius: 100px;
+  width: 32px;
+  height: 32px;
+  color: white;
+  font-family: sans-serif;
+  font-weight: bold;
+  font-size: 1.25em;
+  text-align: center;
+  margin-right: 0.5em;
+  line-height: 1.5em;
+  text-shadow: 0 2px 1px rgba(0, 0, 0, 0.25);
+}
+
+li {
+  margin-bottom: 0.5em;
+}
+
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}

--- a/documentation/slate/source/examples/jsFiddle/lines/demo.details
+++ b/documentation/slate/source/examples/jsFiddle/lines/demo.details
@@ -1,0 +1,27 @@
+---
+name: Lines API - jsFiddle/Github
+description: |
+  Copyright (c) 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+  Hope you'll enjoy and contribute to this project,
+      powered by Canal TP (www.canaltp.fr).
+  Help us simplify mobility and open public transport:
+      a non ending quest to the responsive locomotion way of traveling!
+  LICENCE: This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+  You should have received a copy of the GNU Affero General Public License
+  along with this program. If not, see <http://www.gnu.org/licenses/>.
+  Stay tuned using
+  twitter @navitia
+  IRC #navitia on freenode
+  https://groups.google.com/d/forum/navitia
+  www.navitia.io
+authors:
+   - CanalTP
+normalize_css: no
+...

--- a/documentation/slate/source/examples/jsFiddle/lines/demo.html
+++ b/documentation/slate/source/examples/jsFiddle/lines/demo.html
@@ -1,0 +1,3 @@
+<pre></pre>
+<h2>Lines available:</h2>
+<ul id="lines"></ul>

--- a/documentation/slate/source/examples/jsFiddle/lines/demo.js
+++ b/documentation/slate/source/examples/jsFiddle/lines/demo.js
@@ -1,0 +1,41 @@
+// Url to retrieve lines available on the coverage
+var linesUrl = 'https://api.navitia.io/v1/coverage/sandbox/lines';
+
+// Call Navitia API
+$.ajax({
+  type: 'GET',
+  url: linesUrl,
+  dataType: 'json',
+  headers: {
+    Authorization: 'Basic ' + btoa('a61f4cd8-3007-4557-9f4c-214969369cca')
+  },
+  success: displayLines,
+  error: function(xhr, textStatus, errorThrown) {
+    alert('Error: ' + textStatus + ' ' + errorThrown);
+  }
+});
+
+$('pre').html(linesUrl);
+
+/**
+ * Displays lines with their colors and names.
+ *
+ * @param {Object} navitiaResult
+ */
+function displayLines(navitiaResult) {
+  var $ul = $('ul#lines');
+
+  $.each(navitiaResult.lines, function (i, line) {
+  	var $li = $('<li>');
+
+    var $lineCircle = $('<span>')
+      .html(line.code)
+      .addClass('line-circle')
+      .css({backgroundColor: '#'+line.color})
+    ;
+
+    $li.html('('+line.network.name+' '+line.commercial_mode.name+') '+line.name).prepend($lineCircle);
+
+    $ul.append($li);
+  });
+}

--- a/documentation/slate/source/includes/examples.md
+++ b/documentation/slate/source/includes/examples.md
@@ -45,6 +45,15 @@ To query for the public transport lines of New York we thus have to call: <https
 
 Easy isn't it?
 
+
+<a
+    href="http://jsfiddle.net/gh/get/jquery/2.2.2/CanalTP/navitia/tree/documentation/slate/source/examples/jsFiddle/lines/"
+    target="_blank"
+    class="button button-blue">
+    Code it yourself on JSFiddle
+</a>
+
+
 We could push the exploration further and:
 
 - Where am I? (WGS 84 coordinates)

--- a/documentation/slate/source/includes/isochrones.md
+++ b/documentation/slate/source/includes/isochrones.md
@@ -6,7 +6,14 @@ your reach and their corresponding travel times, using a variety of transportati
 You can even specify the maximum amount of time you want to spare on travel and find 
 the quickest way to reach your destination. 
 The Isochrone function provides information in the form of a table with all the possible stops 
-from a potential destination with their respective arrival times, travel times and number of matches. 
+from a potential destination with their respective arrival times, travel times and number of matches.
+
+<a
+    href="http://jsfiddle.net/gh/get/jquery/2.2.2/CanalTP/navitia/tree/documentation/slate/source/examples/jsFiddle/isochron/"
+    target="_blank"
+    class="button button-blue">
+    Code it yourself on JSFiddle
+</a>
 
 You have to use these APIs (click on them for details):
 

--- a/documentation/slate/source/includes/isochrones.md
+++ b/documentation/slate/source/includes/isochrones.md
@@ -9,7 +9,7 @@ The Isochrone function provides information in the form of a table with all the 
 from a potential destination with their respective arrival times, travel times and number of matches.
 
 <a
-    href="http://jsfiddle.net/gh/get/library/pure/CanalTP/navitia/tree/documentation/slate/source/examples/jsFiddle/isochron/"
+    href="http://jsfiddle.net/gh/get/jquery/2.2.2/CanalTP/navitia/tree/documentation/slate/source/examples/jsFiddle/isochron/"
     target="_blank"
     class="button button-blue">
     Code it yourself on JSFiddle

--- a/documentation/slate/source/includes/isochrones.md
+++ b/documentation/slate/source/includes/isochrones.md
@@ -9,7 +9,7 @@ The Isochrone function provides information in the form of a table with all the 
 from a potential destination with their respective arrival times, travel times and number of matches.
 
 <a
-    href="http://jsfiddle.net/gh/get/jquery/2.2.2/CanalTP/navitia/tree/documentation/slate/source/examples/jsFiddle/isochron/"
+    href="http://jsfiddle.net/gh/get/library/pure/CanalTP/navitia/tree/documentation/slate/source/examples/jsFiddle/isochron/"
     target="_blank"
     class="button button-blue">
     Code it yourself on JSFiddle


### PR DESCRIPTION
This PR adds a "Try it yourself" button in Isochrone section and another one in "A quick exploration".

To preview JsFiddle exemple on my repo:
**Isochron** - http://jsfiddle.net/gh/get/jquery/2.2.2/alcalyn/navitia/tree/documentation/slate/source/examples/jsFiddle/isochron/
**Lines** - http://jsfiddle.net/gh/get/jquery/2.2.2/alcalyn/navitia/tree/documentation/slate/source/examples/jsFiddle/lines/

_Note for isochron_: We need to Run exemple as resources loading seems to be broken in jsfiddle
