### PR TITLE
Fix pre-filter of vjs for impact on stop_points

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -210,10 +210,9 @@ struct add_impacts_visitor : public apply_impacts_visitor {
         // Computing a validity_pattern of impact used to pre-filter concerned vjs later
         type::ValidityPattern impact_vp{meta.production_date.begin()}; // bitset are all initialised to 0
         for (const auto& period: impact->application_periods) {
-            auto one_day = boost::posix_time::time_duration{24, 0, 0};
-            for (time_iterator it(period.begin() - one_day, one_day); it < period.end(); ++it) {
-                if (! meta.production_date.contains((*it).date())) { continue; }
-                auto day = ((*it).date() - meta.production_date.begin()).days();
+            for (bg::day_iterator it(period.begin().date() - bg::days(1)) ; it <= period.end().date() ; ++it) {
+                if (! meta.production_date.contains(*it)) { continue; }
+                auto day = (*it - meta.production_date.begin()).days();
                 impact_vp.add(day);
             }
         }


### PR DESCRIPTION
While discussing about the PR #1558 @antoine-de told me I had indeed found a bug.
The use case is : 
- your production date starts on the 1st,
- your impact starts on the 2nd at 9am,
- your impact ends on the 3rd at 8:30am.

The code using time_iterator was missing the last day because we had : 
1. "it" was initialized at  period.begin() - one_day => 1st at 9am,
2. second loop, we increment of one_day => it = 2st at 9am,
3. third loop, we increment of one day => it = 3rd at 9am.

And on the third loop it < period.end() is false, since it = 3rd at 9am and period.end() = 3rd at 8:30am.
We were never adding the 3rd to the impact_vp, causing some vj to be ignored when they should not.

I added a little unit test failing before the fix, and working afterwards.
Let me know if there is something to change. I'll rebase the code of the PR #1558 afterwards and move this code in the impact since I'm using it when applying disruption on line_sections.
