### PR TITLE
RT proxies: better datetimes filter

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -119,7 +119,7 @@ class Cleverage(RealtimeProxy):
         else:
             return None
 
-    def next_passage_for_route_point(self, route_point):
+    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -119,7 +119,7 @@ class Cleverage(RealtimeProxy):
         else:
             return None
 
-    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -39,8 +39,39 @@ class RealtimeProxy(object):
     __metaclass__ = ABCMeta
 
     @abstractmethod
-    def next_passage_for_route_point(self, route_point):
+    def _get_next_passage_for_route_point(self, route_point, items_per_schedule, from_dt):
+        """
+        method that actually calls the external service to get the next passage for a given route_point
+        """
         pass
+
+    def _filter_passages(self, passages, items_per_schedule, from_dt):
+        """
+        after getting the next passages from the proxy, we might want to filter some
+
+        by default we filter:
+        * we keep at most 'items_per_schedule' items
+        * we don't want to display datetime after from_dt
+        """
+        if from_dt:
+            passages = filter(lambda p: p.datetime < from_dt, passages)
+
+        if items_per_schedule:
+            del passages[items_per_schedule:]
+
+        return passages
+
+    def next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
+        """
+        Main method for the proxy
+
+        returns the next realtime passages
+        """
+        next_passages = self._get_next_passage_for_route_point(route_point, items_per_schedule, from_dt)
+
+        filtered_passage = self._filter_passages(next_passages, items_per_schedule, from_dt)
+
+        return filtered_passage
 
     @abstractmethod
     def status(self):

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -118,7 +118,7 @@ class Synthese(RealtimeProxy):
             logging.getLogger(__name__).exception('Synthese RT error, using base schedule')
         return None
 
-    def next_passage_for_route_point(self, route_point):
+    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -118,7 +118,7 @@ class Synthese(RealtimeProxy):
             logging.getLogger(__name__).exception('Synthese RT error, using base schedule')
         return None
 
-    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -141,7 +141,7 @@ class Synthese(RealtimeProxy):
         m = self._get_synthese_passages(r.content)
         return m.get(route_point)# if there is nothing from synthese, we keep the base
 
-    def _make_url(self, route_point, count, from_dt):
+    def _make_url(self, route_point, count=None, from_dt=None):
         """
         The url returns something like a departure on a stop point
         """

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -45,7 +45,7 @@ class CustomProxy(RealtimeProxy):
     def status(self):
         return None
 
-    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None):
         return self.hard_coded_passages
 
 
@@ -65,7 +65,7 @@ def get_dt(p):
 def filter_items_test_under_the_limit():
     proxy = CustomProxy([passage("10:00"), passage("11:00")])
 
-    r = proxy.next_passage_for_route_point(None, items_per_schedule=3, from_dt=None)
+    r = proxy.next_passage_for_route_point(None, count=3)
 
     assert map(get_dt, r) == [dt("10:00"), dt("11:00")]
 
@@ -73,7 +73,7 @@ def filter_items_test_under_the_limit():
 def filter_items_test():
     proxy = CustomProxy([passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")])
 
-    r = proxy.next_passage_for_route_point(None, items_per_schedule=2, from_dt=None)
+    r = proxy.next_passage_for_route_point(None, count=2)
 
     assert map(get_dt, r) == [dt("10:00"), dt("11:00")]
 
@@ -82,7 +82,7 @@ def filter_no_filter():
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, items_per_schedule=None, from_dt=None)
+    r = proxy.next_passage_for_route_point(None)
     assert map(get_dt, r) == [dt("10:00"), dt("11:00"), dt("12:00"), dt("13:00")]
 
 
@@ -90,7 +90,7 @@ def filter_filter_dt():
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, items_per_schedule=None, from_dt=dt("12:00"))
+    r = proxy.next_passage_for_route_point(None, from_dt=dt("12:00"))
     assert map(get_dt, r) == [dt("12:00"), dt("13:00")]
 
 
@@ -98,7 +98,7 @@ def filter_filter_dt_over_all():
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, items_per_schedule=None, from_dt=dt("17:00"))
+    r = proxy.next_passage_for_route_point(None, from_dt=dt("17:00"))
     assert r == []
 
 
@@ -106,5 +106,5 @@ def filter_filter_dt_and_item():
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, items_per_schedule=1, from_dt=dt("11:59"))
+    r = proxy.next_passage_for_route_point(None, count=1, from_dt=dt("11:59"))
     assert map(get_dt, r) == [dt("12:00")]

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from datetime import datetime
+from nose.tools.trivial import eq_
+import pytz
+from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy
+from jormungandr.schedule import RealTimePassage
+
+
+class CustomProxy(RealtimeProxy):
+    """
+    mock proxy that return a fixed next passages
+    """
+    def __init__(self, passages):
+        self.hard_coded_passages = passages
+
+    def status(self):
+        return None
+
+    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
+        return self.hard_coded_passages
+
+
+def dt(dt_str):
+    t = datetime.strptime(dt_str, "%H:%M")
+    return datetime(year=2016, month=1, day=2, hour=t.hour, minute=t.minute, second=t.second, tzinfo=pytz.UTC)
+
+
+def passage(dt_str, **kwargs):
+    return RealTimePassage(dt(dt_str), **kwargs)
+
+
+def get_dt(p):
+    return p.datetime
+
+
+def filter_items_test_under_the_limit():
+    proxy = CustomProxy([passage("10:00"), passage("11:00")])
+
+    r = proxy.next_passage_for_route_point(None, items_per_schedule=3, from_dt=None)
+
+    assert map(get_dt, r) == [dt("10:00"), dt("11:00")]
+
+
+def filter_items_test():
+    proxy = CustomProxy([passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")])
+
+    r = proxy.next_passage_for_route_point(None, items_per_schedule=2, from_dt=None)
+
+    assert map(get_dt, r) == [dt("10:00"), dt("11:00")]
+
+
+def filter_no_filter():
+    passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
+    proxy = CustomProxy(passages)
+
+    r = proxy.next_passage_for_route_point(None, items_per_schedule=None, from_dt=None)
+    assert map(get_dt, r) == [dt("10:00"), dt("11:00"), dt("12:00"), dt("13:00")]
+
+
+def filter_filter_dt():
+    passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
+    proxy = CustomProxy(passages)
+
+    r = proxy.next_passage_for_route_point(None, items_per_schedule=None, from_dt=dt("12:00"))
+    assert map(get_dt, r) == [dt("12:00"), dt("13:00")]
+
+
+def filter_filter_dt_over_all():
+    passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
+    proxy = CustomProxy(passages)
+
+    r = proxy.next_passage_for_route_point(None, items_per_schedule=None, from_dt=dt("17:00"))
+    assert r == []
+
+
+def filter_filter_dt_and_item():
+    passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
+    proxy = CustomProxy(passages)
+
+    r = proxy.next_passage_for_route_point(None, items_per_schedule=1, from_dt=dt("11:59"))
+    assert map(get_dt, r) == [dt("12:00")]

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -52,6 +52,34 @@ def make_url_test():
     assert 'StopTimeoCode=stop_tutu' in url
     assert 'LineTimeoCode=line_toto' in url
     assert 'Way=route_tata' in url
+    # we did not provide a datetime, we should not have it in the url
+    assert 'NextStopReferenceTime' not in url
+    # we did not provide a count, we should have the default value
+    assert 'NextStopTimeNumber=5' in url
+
+
+def make_url_count_and_dt_test():
+    """
+    same as make_url_test but with a count and a from_dt
+    """
+    timeo = Timeo(id='tata', timezone='Europe/Paris', service_url='http://bob.com/tata',
+                  service_args={'a': 'bobette', 'b': '12'})
+
+    url = timeo._make_url(MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu'),
+                          count=2, from_dt=_dt("12:00"))
+
+    # it should be a valid url
+    assert validators.url(url)
+
+    assert url.startswith('http://bob.com')
+    assert 'a=bobette' in url
+    assert 'b=12' in url
+    assert 'StopTimeoCode=stop_tutu' in url
+    assert 'LineTimeoCode=line_toto' in url
+    assert 'Way=route_tata' in url
+    # we should have the param we provided
+    assert 'NextStopTimeNumber=2' in url
+    assert 'NextStopReferenceTime=2016-02-07T12:00:00' in url
 
 
 def make_url_invalid_code_test():

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -35,6 +35,7 @@ from time import sleep
 from jormungandr.realtime_schedule.timeo import Timeo
 import validators
 from jormungandr.realtime_schedule.tests.utils import MockRoutePoint
+from jormungandr.utils import date_to_timestamp
 
 
 def make_url_test():
@@ -62,11 +63,11 @@ def make_url_count_and_dt_test():
     """
     same as make_url_test but with a count and a from_dt
     """
-    timeo = Timeo(id='tata', timezone='Europe/Paris', service_url='http://bob.com/tata',
+    timeo = Timeo(id='tata', timezone='UTC', service_url='http://bob.com/tata',
                   service_args={'a': 'bobette', 'b': '12'})
 
     url = timeo._make_url(MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu'),
-                          count=2, from_dt=_dt("12:00"))
+                          count=2, from_dt=_timestamp("12:00"))
 
     # it should be a valid url
     assert validators.url(url)
@@ -127,6 +128,10 @@ def _dt(dt_to_parse="00:00", year=2016, month=2, day=7):
     pytz.UTC.localize(d)
 
     return d.replace(year=year, month=month, day=day, tzinfo=pytz.UTC)
+
+
+def _timestamp(str, **kwargs):
+    return date_to_timestamp(_dt(str, **kwargs))
 
 
 def mock_good_timeo_response():

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -167,8 +167,9 @@ class Timeo(RealtimeProxy):
         count = min(count, 5) or 5  # if no value defined we ask for 5 passages
 
         # if a custom datetime is provided we give it to timeo
-        dt_param = '&NextStopReferenceTime={dt}'.format(
-            dt=timestamp_to_datetime(from_dt).strftime('%Y-%m-%dT%H:%M:%S')) if from_dt else ''
+        dt_param = '&NextStopReferenceTime={dt}'\
+            .format(dt=self._timestamp_to_date(from_dt).strftime('%Y-%m-%dT%H:%M:%S')) \
+            if from_dt else ''
 
         stop_id_url = ("StopDescription=?"
                        "StopTimeoCode={stop}"
@@ -197,6 +198,11 @@ class Timeo(RealtimeProxy):
         utc_dt = self.timezone.normalize(self.timezone.localize(dt)).astimezone(pytz.utc)
 
         return utc_dt
+
+    def _timestamp_to_date(self, timestamp):
+        dt = datetime.utcfromtimestamp(timestamp)
+        dt = pytz.utc.localize(dt)
+        return dt.astimezone(self.timezone)
 
     def status(self):
         return {'id': self.rt_system_id,

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -96,7 +96,7 @@ class Timeo(RealtimeProxy):
             logging.getLogger(__name__).exception('Timeo RT error, using base schedule')
         return None
 
-    def next_passage_for_route_point(self, route_point):
+    def _get_next_passage_for_route_point(self, route_point, items_per_schedule=None, from_dt=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -147,7 +147,6 @@ class Scenario(object):
     def departure_boards(self, request, instance):
         return instance.schedule.departure_boards(request)
 
-
     def places_nearby(self, request, instance):
         req = request_pb2.Request()
         req.requested_api = type_pb2.places_nearby

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -67,7 +67,7 @@ class RealTimePassage(object):
         self.is_real_time = True
 
 
-def _update_stop_schedule(stop_schedule, next_realtime_passages):
+def _update_stop_schedule(stop_schedule, next_realtime_passages, items_per_schedule):
     """
     Update the stopschedule response with the new realtime passages
 
@@ -78,6 +78,9 @@ def _update_stop_schedule(stop_schedule, next_realtime_passages):
     """
     if next_realtime_passages is None:
         return
+
+    # we want to limit to at most 'items_per_schedule' items
+    del next_realtime_passages[items_per_schedule:]
 
     logging.getLogger(__name__).debug('next passages: : {}'
                                      .format(["dt: {}".format(d.datetime) for d in next_realtime_passages]))
@@ -312,5 +315,5 @@ class MixedSchedule(object):
         for stop_schedule in resp.stop_schedules:
             route_point = _get_route_point_from_stop_schedule(stop_schedule)
             next_rt_passages = self._get_next_realtime_passages(route_point)
-            _update_stop_schedule(stop_schedule, next_rt_passages)
+            _update_stop_schedule(stop_schedule, next_rt_passages, request['items_per_schedule'])
         return resp

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -67,7 +67,7 @@ class RealTimePassage(object):
         self.is_real_time = True
 
 
-def _update_stop_schedule(stop_schedule, next_realtime_passages, items_per_schedule):
+def _update_stop_schedule(stop_schedule, next_realtime_passages):
     """
     Update the stopschedule response with the new realtime passages
 
@@ -78,9 +78,6 @@ def _update_stop_schedule(stop_schedule, next_realtime_passages, items_per_sched
     """
     if next_realtime_passages is None:
         return
-
-    # we want to limit to at most 'items_per_schedule' items
-    del next_realtime_passages[items_per_schedule:]
 
     logging.getLogger(__name__).debug('next passages: : {}'
                                      .format(["dt: {}".format(d.datetime) for d in next_realtime_passages]))
@@ -210,7 +207,7 @@ class MixedSchedule(object):
     def __init__(self, instance):
         self.instance = instance
 
-    def _get_next_realtime_passages(self, route_point):
+    def _get_next_realtime_passages(self, route_point, request):
         log = logging.getLogger(__name__)
 
         if not route_point:
@@ -314,6 +311,6 @@ class MixedSchedule(object):
 
         for stop_schedule in resp.stop_schedules:
             route_point = _get_route_point_from_stop_schedule(stop_schedule)
-            next_rt_passages = self._get_next_realtime_passages(route_point)
-            _update_stop_schedule(stop_schedule, next_rt_passages, request['items_per_schedule'])
+            next_rt_passages = self._get_next_realtime_passages(route_point, request)
+            _update_stop_schedule(stop_schedule, next_rt_passages)
         return resp

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -222,7 +222,9 @@ class MixedSchedule(object):
             log.info('impossible to find {}, no realtime added'.format(rt_system_code))
             return None
 
-        next_rt_passages = rt_system.next_passage_for_route_point(route_point)
+        next_rt_passages = rt_system.next_passage_for_route_point(route_point,
+                                                                  request['items_per_schedule'],
+                                                                  request['from_datetime'])
         if next_rt_passages is None:
             log.debug('no next passages, using base schedule')
             return None
@@ -282,7 +284,7 @@ class MixedSchedule(object):
                             for rp in resp.route_points)
 
         for route_point, template in route_points.items():
-            next_rt_passages = self._get_next_realtime_passages(route_point)
+            next_rt_passages = self._get_next_realtime_passages(route_point, request)
             _update_passages(resp.next_departures, route_point, template, next_rt_passages)
 
         # sort

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -61,7 +61,7 @@ class MockedTestProxy(realtime_proxy.RealtimeProxy):
             next_passages.append(next_passage)
         return next_passages
 
-    def next_passage_for_route_point(self, route_point):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None):
         if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigital_C:S1":
             return []
 

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -205,6 +205,23 @@ class TestDepartures(AbstractTestFixture):
         get_not_null(d, "physical_mode")
         get_not_null(d, "headsign")
 
+    def test_stop_schedule_limit_per_items(self):
+        """
+        test the limit of item per stop_schedule with a realtime proxy
+        """
+        query = self.query_template.format(sp='C:S0', dt='20160102T1100', data_freshness='') + \
+                '&items_per_schedule=1'
+        response = self.query_region(query)
+        for stop_sched in response['stop_schedules']:
+            assert len(stop_sched['date_times']) == 1
+
+        # same with a big limit, we get only 2 items (because there are only 2)
+        query = self.query_template.format(sp='C:S0', dt='20160102T1100', data_freshness='') + \
+                '&items_per_schedule=42'
+        response = self.query_region(query)
+        for stop_sched in response['stop_schedules']:
+            assert len(stop_sched['date_times']) == 2
+
 
 MOCKED_PROXY_CONF = (' [{"id": "KisioDigital",\n'
                      ' "object_id_tag": "AnotherSource", \n'


### PR DESCRIPTION
it's now the proxy responsability to handle the pagination (`items_per_schedule`) and the
`from_datetime`.

for the moment only Timeo can ask realtime data in the futur

All the proxies post fitler the response to paginate and filter bad datetime

linked to http://jira.canaltp.fr/browse/NAVITIAII-2115
