### PR TITLE
[TYR]: TyrUserEvent and RabbitMqHandler implemented (and refactoring)

### DIFF
--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -28,3 +28,4 @@ redis==2.9.1
 six>=1.10.0
 validate-email==1.1
 wsgiref==0.1.2
+retrying==1.3.3

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -1,4 +1,4 @@
 docker-py==1.6.0
 pytest==2.8.7
 python-dateutil==2.4.2
-retrying==1.3.3
+mock==1.0.1

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -420,7 +420,7 @@ def reload_data(self, instance_config, job_id):
         task = navitiacommon.task_pb2.Task()
         task.action = navitiacommon.task_pb2.RELOAD
 
-        rabbit_mq_handler = RabbitMqHandler(instance_config.exchange, "topic")
+        rabbit_mq_handler = RabbitMqHandler(current_app.config['CELERY_BROKER_URL'], instance_config.exchange, "topic")
 
         logger.info("reload kraken")
         rabbit_mq_handler.publish(task.SerializeToString(), instance.name + '.task.reload')

--- a/source/tyr/tyr/rabbit_mq_handler.py
+++ b/source/tyr/tyr/rabbit_mq_handler.py
@@ -28,5 +28,4 @@ class RabbitMqHandler(object):
                 declare=[self._task_exchange],
                 routing_key=routing_key)
 
-        logging.info("Sent: %s" % payload)
         self._connection.release()

--- a/source/tyr/tyr/rabbit_mq_handler.py
+++ b/source/tyr/tyr/rabbit_mq_handler.py
@@ -1,0 +1,32 @@
+# encoding=utf-8
+
+from kombu import Exchange, Connection, Producer
+import logging
+
+from flask import current_app
+
+class RabbitMqHandler(object):
+
+    def __init__(self, exchange_name, type='direct', durable=True):
+        try:
+            self._connection = Connection(current_app.config['CELERY_BROKER_URL'])
+            self._producer = Producer(self._connection)
+            self._task_exchange = Exchange(name=exchange_name, type=type, durable=durable)
+        except Exception:
+            logging.exception('Unable to activate the producer')
+            raise
+
+    def errback(exc, interval):
+        logging.info('Error: %r', exc, exc_info=1)
+        logging.info('Retry in %s seconds.', interval)
+
+    def publish(self, payload, routing_key=None, serializer='json'):
+        publish = self._connection.ensure(self._producer, self._producer.publish, errback = self.errback, max_retries=3)
+        publish(payload,
+                serializer=serializer,
+                exchange=self._task_exchange,
+                declare=[self._task_exchange],
+                routing_key=routing_key)
+
+        logging.info("Sent: %s" % payload)
+        self._connection.release()

--- a/source/tyr/tyr/rabbit_mq_handler.py
+++ b/source/tyr/tyr/rabbit_mq_handler.py
@@ -3,24 +3,23 @@
 from kombu import Exchange, Connection, Producer
 import logging
 
-from flask import current_app
-
 class RabbitMqHandler(object):
 
-    def __init__(self, exchange_name, type='direct', durable=True):
+    def __init__(self, connection, exchange_name, type='direct', durable=True):
+        self._logger = logging.getLogger(__name__)
         try:
-            self._connection = Connection(current_app.config['CELERY_BROKER_URL'])
+            self._connection = Connection(connection)
             self._producer = Producer(self._connection)
             self._task_exchange = Exchange(name=exchange_name, type=type, durable=durable)
         except Exception:
-            logging.exception('Unable to activate the producer')
+            self._logger.info('badly formated token %s', auth).exception('Unable to activate the producer')
             raise
 
     def errback(exc, interval):
-        logging.info('Error: %r', exc, exc_info=1)
-        logging.info('Retry in %s seconds.', interval)
+        self._logger.info('Error: %r', exc, exc_info=1)
+        self._logger.info('Retry in %s seconds.', interval)
 
-    def publish(self, payload, routing_key=None, serializer='json'):
+    def publish(self, payload, routing_key=None, serializer=None):
         publish = self._connection.ensure(self._producer, self._producer.publish, errback = self.errback, max_retries=3)
         publish(payload,
                 serializer=serializer,

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -548,6 +548,7 @@ class User(flask_restful.Resource):
             return ({'error': 'billing_plan doesn\'t exist'}, 400)
 
         try:
+            last_login = user.login
             user.email = args['email']
             user.login = args['login']
             user.type = args['type']
@@ -557,7 +558,7 @@ class User(flask_restful.Resource):
             db.session.commit()
 
             tyr_user_event = TyrUserEvent()
-            tyr_user_event.request(user, "update_user")
+            tyr_user_event.request(user, "update_user", last_login)
 
             return marshal(user, user_fields_full)
         except (sqlalchemy.exc.IntegrityError, sqlalchemy.orm.exc.FlushError):

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -36,6 +36,7 @@ import sqlalchemy
 from validate_email import validate_email
 from datetime import datetime
 from itertools import combinations, chain
+from tyr_user_event import TyrUserEvent
 import logging
 
 from navitiacommon import models, parser_args_type
@@ -503,6 +504,10 @@ class User(flask_restful.Resource):
             user.billing_plan = billing_plan
             db.session.add(user)
             db.session.commit()
+
+            tyr_user_event = TyrUserEvent()
+            tyr_user_event.request(user, "create_user")
+
             return marshal(user, user_fields_full)
         except (sqlalchemy.exc.IntegrityError, sqlalchemy.orm.exc.FlushError):
             return ({'error': 'duplicate user'}, 409)
@@ -550,6 +555,10 @@ class User(flask_restful.Resource):
             user.end_point = end_point
             user.billing_plan = billing_plan
             db.session.commit()
+
+            tyr_user_event = TyrUserEvent()
+            tyr_user_event.request(user, "update_user")
+
             return marshal(user, user_fields_full)
         except (sqlalchemy.exc.IntegrityError, sqlalchemy.orm.exc.FlushError):
             return ({'error': 'duplicate user'}, 409)  # Conflict
@@ -562,6 +571,10 @@ class User(flask_restful.Resource):
         try:
             db.session.delete(user)
             db.session.commit()
+
+            tyr_user_event = TyrUserEvent()
+            tyr_user_event.request(user, "delete_user")
+
         except Exception:
             logging.exception("fail")
             raise

--- a/source/tyr/tyr/tyr_user_event.py
+++ b/source/tyr/tyr/tyr_user_event.py
@@ -1,0 +1,71 @@
+# encoding=utf-8
+
+from rabbit_mq_handler import RabbitMqHandler
+
+class RabbitMqMessage:
+
+    def __init__(self):
+        self._event_name = None
+        self._billing_plan_name = None
+        self._billing_plan_max_object_count = None
+        self._billing_plan_max_request_count = None
+        self._billing_plan_default = None
+        self._end_point_name = None
+        self._end_point_default = None
+        self._login = None
+        self._email = None
+        self._block_until = None
+        self._type = None
+
+    def get_message(self):
+        return {
+            'data': {
+                'billing_plan': self.get_billing_plan(),
+                'origin': self.get_end_point(),
+                'username': self._login,
+                'block_until': self._block_until,
+                'email': self._email,
+                'type': self._type
+            },
+            'event': self._event_name
+        }
+
+    def get_end_point(self):
+        return {
+            'name': self._end_point_name,
+            'default': self._end_point_default
+        }
+
+    def get_billing_plan(self):
+        return {
+            'name': self._billing_plan_name,
+            'max_object_count': self._billing_plan_max_object_count,
+            'max_request_count': self._billing_plan_max_request_count,
+            'max_default_count': self._billing_plan_default
+        }
+
+    def set_event_name(self, event_name):
+        self._event_name = event_name
+
+    def set_user(self, user):
+        self._email = user.email
+        self._login = user.login
+        self._block_until = user.block_until
+        self._type = user.type
+        self._billing_plan_name = user.billing_plan.name
+        self._billing_plan_default = user.billing_plan.default
+        self._billing_plan_max_request_count = user.billing_plan.max_request_count
+        self._billing_plan_max_object_count = user.billing_plan.max_object_count
+        self._end_point_name = user.end_point.name
+        self._end_point_default = user.end_point.default
+
+class TyrUserEvent(object):
+
+    def __init__(self):
+        self._rabbit_mq_handler = RabbitMqHandler("tyr_event_exchange")
+        self._rabbit_mq_message = RabbitMqMessage()
+
+    def request(self, user, event_name):
+        self._rabbit_mq_message.set_user(user)
+        self._rabbit_mq_message.set_event_name(event_name)
+        self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message())

--- a/source/tyr/tyr/tyr_user_event.py
+++ b/source/tyr/tyr/tyr_user_event.py
@@ -16,6 +16,7 @@ class RabbitMqMessage:
         self._email = None
         self._block_until = None
         self._type = None
+        self._last_login = None
 
     def get_message(self):
         return {
@@ -29,6 +30,12 @@ class RabbitMqMessage:
             },
             'event': self._event_name
         }
+
+    def get_message_with_last_login(self):
+        message = self.get_message()
+        message['data']['last_username'] = self._last_login
+
+        return message
 
     def get_end_point(self):
         return {
@@ -46,6 +53,9 @@ class RabbitMqMessage:
 
     def set_event_name(self, event_name):
         self._event_name = event_name
+
+    def set_last_login(self, last_login):
+        self._last_login = last_login
 
     def set_user(self, user):
         self._email = user.email
@@ -66,7 +76,12 @@ class TyrUserEvent(object):
         self._rabbit_mq_handler = RabbitMqHandler("tyr_event_exchange")
         self._rabbit_mq_message = RabbitMqMessage()
 
-    def request(self, user, event_name):
+    def request(self, user, event_name, last_login=None):
         self._rabbit_mq_message.set_user(user)
         self._rabbit_mq_message.set_event_name(event_name)
-        self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message())
+
+        if last_login is not None:
+            self._rabbit_mq_message.set_last_login(last_login)
+            self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message_with_last_login())
+        else:
+            self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message())

--- a/source/tyr/tyr/tyr_user_event.py
+++ b/source/tyr/tyr/tyr_user_event.py
@@ -1,6 +1,7 @@
 # encoding=utf-8
 
 from rabbit_mq_handler import RabbitMqHandler
+from flask import current_app
 
 class RabbitMqMessage:
 
@@ -73,7 +74,7 @@ class RabbitMqMessage:
 class TyrUserEvent(object):
 
     def __init__(self):
-        self._rabbit_mq_handler = RabbitMqHandler("tyr_event_exchange")
+        self._rabbit_mq_handler = RabbitMqHandler(current_app.config['CELERY_BROKER_URL'], "tyr_event_exchange")
         self._rabbit_mq_message = RabbitMqMessage()
 
     def request(self, user, event_name, last_login=None):
@@ -82,6 +83,6 @@ class TyrUserEvent(object):
 
         if last_login is not None:
             self._rabbit_mq_message.set_last_login(last_login)
-            self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message_with_last_login())
+            self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message_with_last_login(), None, 'json')
         else:
-            self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message())
+            self._rabbit_mq_handler.publish(self._rabbit_mq_message.get_message(), None, 'json')

--- a/source/tyr/tyr/tyr_user_event.py
+++ b/source/tyr/tyr/tyr_user_event.py
@@ -50,7 +50,8 @@ class RabbitMqMessage:
     def set_user(self, user):
         self._email = user.email
         self._login = user.login
-        self._block_until = user.block_until
+        if user.block_until:
+            self._block_until = user.block_until.isoformat()
         self._type = user.type
         self._billing_plan_name = user.billing_plan.name
         self._billing_plan_default = user.billing_plan.default


### PR DESCRIPTION
# Introduction
- TyrUserEvent and RabbitMqHandler implemented: able to publish events through RabbitMQ. This will synchronize FenrirApi which manage users (https://github.com/CanalTP/FenrirApi). For now, only the methods "put", "post" and "delete" are considered.
- Refactoring "source/tyr/tyr/binarisation.py" file

Related to:
https://github.com/CanalTP/FenrirApi/pull/14

![screenshot from 2016-05-18 18 25 48](https://cloud.githubusercontent.com/assets/1167753/15366736/fad4f4ac-1d25-11e6-9d25-b17c5cbcd77f.png)

cc @Netmisa ;)
