### PR TITLE
jormun: refacto instance_manager

### DIFF
--- a/source/jormungandr/CMakeLists.txt
+++ b/source/jormungandr/CMakeLists.txt
@@ -4,7 +4,7 @@ configure_file("${CMAKE_SOURCE_DIR}/navitia_version.py.cmake" "${CMAKE_CURRENT_S
 
 #tests 
 set(JORMUN_PATH "${CMAKE_CURRENT_SOURCE_DIR}/jormungandr")
-add_test(jormungandr nosetests --with-doctest -v --with-xunit  --xunit-file=${CMAKE_BINARY_DIR}/nosetest_jormungandr.xml "--where=${JORMUN_PATH}")
+add_test(jormungandr py.test --doctest-modules --junit-xml=${CMAKE_BINARY_DIR}/nosetest_jormungandr.xml ${JORMUN_PATH})
 SET_PROPERTY(TEST jormungandr PROPERTY
     ENVIRONMENT "PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}:${CMAKE_SOURCE_DIR}/navitiacommon")
 

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -239,8 +239,9 @@ class InstanceManager(object):
 
     def get_instances(self, name=None, lon=None, lat=None, object_id=None, api='ALL'):
         available_instances = []
-        if name and name in self.instances:
-            available_instances = [self.instances[name]]
+        if name:
+            if name in self.instances:
+                available_instances = [self.instances[name]]
         elif lon and lat:
             available_instances = [self.instances[k] for k in self._all_keys_of_coord(lon, lat)]
         elif object_id:

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -84,12 +84,14 @@ class InstanceManager(object):
     def __init__(self, instances_dir=None, start_ping=False):
         # if a configuration file is defined in the settings we take it
         # else we load all .ini/.json files found in the INSTANCES_DIR
-        if instances_dir is None:
-            raise ValueError("conf_files or instance_dir has to be set")
-
-        self.configuration_files = glob.glob(instances_dir + '/*.ini') +\
-                                   glob.glob(instances_dir + '/*.json')
+        if instances_dir:
+            self.configuration_files = glob.glob(instances_dir + '/*.ini') +\
+                                       glob.glob(instances_dir + '/*.json')
+        else:
+            self.configuration_files = []
         self.start_ping = start_ping
+        self.instances = {}
+        self.context = zmq.Context()
 
     def initialisation(self):
         """ Charge la configuration à partir d'un fichier ini indiquant
@@ -98,10 +100,7 @@ class InstanceManager(object):
             - la socket pour chaque identifiant navitia
         """
 
-        self.instances = {}
-        self.context = zmq.Context()
-        self.default_socket = None
-
+        self.instances.clear()
         for file_name in self.configuration_files:
             logging.getLogger(__name__).info("Initialisation, reading file : " + file_name)
             if file_name.endswith('.ini'):
@@ -218,12 +217,6 @@ class InstanceManager(object):
         if not instances:
             raise RegionNotFound(lon=lon, lat=lat)
         return instances
-
-    def region_exists(self, region_str):
-        if region_str in self.instances:
-            return True
-        else:
-            raise RegionNotFound(region=region_str)
 
     def get_region(self, region_str=None, lon=None, lat=None, object_id=None, api='ALL'):
         return self.get_regions(region_str, lon, lat, object_id, api, only_one=True)

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -360,11 +360,11 @@ def compute_regions(args):
     from_regions = set()
     to_regions = set()
     if args['origin']:
-        from_regions = set(i_manager.get_regions(object_id=args['origin']))
+        from_regions = set(i_manager.get_instances(object_id=args['origin']))
         #Note: if get_regions does not find any region, it raises a RegionNotFoundException
 
     if args['destination']:
-        to_regions = set(i_manager.get_regions(object_id=args['destination']))
+        to_regions = set(i_manager.get_instances(object_id=args['destination']))
 
     if not from_regions:
         #we didn't get any origin, the region is in the destination's list
@@ -386,7 +386,7 @@ def compute_regions(args):
 
     regions = sorted(sorted_regions, key=cmp_to_key(instances_comparator))
 
-    return regions
+    return [r.name for r in regions]
 
 class Journeys(ResourceUri, ResourceUtc):
 

--- a/source/jormungandr/jormungandr/interfaces/v1/test/journey_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/journey_tests.py
@@ -42,8 +42,8 @@ class MockInstance:
 
 
 class TestMultiCoverage:
-    #TODO change that with real mock and change nose to py.test to be able to use test generator
-    def __init__(self):
+    #TODO change that with real mock
+    def setup_method(self, method):
         #we mock a query
         self.args = {
             'origin': 'paris',

--- a/source/jormungandr/jormungandr/interfaces/v1/test/journey_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/journey_tests.py
@@ -66,8 +66,7 @@ class TestMultiCoverage:
         """
         small helper, mock i_manager.get_region
         """
-        def mock_get_regions(region_str=None, lon=None, lat=None,
-                object_id=None, api='ALL', only_one=True):
+        def mock_get_instances(region_str=None, lon=None, lat=None, object_id=None, api='ALL', only_one=True):
             if object_id == 'paris':
                 if not paris_region:
                     raise RegionNotFound('paris')
@@ -77,7 +76,7 @@ class TestMultiCoverage:
                     raise RegionNotFound('lima')
                 return [self.regions[r] for r in lima_region]
 
-        i_manager.get_regions = mock_get_regions
+        i_manager.get_instances = mock_get_instances
         #we also need to mock the ptmodel cache
         class weNeedMock:
             @classmethod
@@ -93,7 +92,7 @@ class TestMultiCoverage:
 
         assert len(regions) == 1
 
-        assert regions[0].name == self.regions['france'].name
+        assert regions[0] == self.regions['france'].name
 
     @raises(RegionNotFound)
     def test_multi_coverage_diff_region(self):
@@ -131,7 +130,7 @@ class TestMultiCoverage:
 
         assert len(regions) == 1
 
-        assert regions[0].name == self.regions['peru'].name
+        assert regions[0] == self.regions['peru'].name
 
     def test_multi_coverage_overlap_chose_non_free(self):
         """orig as 2 possible region and destination 3, we want to have france first because equador is free"""
@@ -142,8 +141,8 @@ class TestMultiCoverage:
         assert len(regions) == 2
         print("regions ==> {}".format(regions))
 
-        assert regions[0].name == self.regions['france'].name
-        assert regions[1].name == self.regions['equador'].name
+        assert regions[0] == self.regions['france'].name
+        assert regions[1] == self.regions['equador'].name
 
     def test_multi_coverage_overlap_chose_non_free2_with_priority_zero(self):
         """
@@ -157,8 +156,8 @@ class TestMultiCoverage:
         assert len(regions) == 4
         print("regions ==> {}".format(regions))
 
-        assert set([regions[0].name, regions[1].name]) == set([self.regions['france'].name, self.regions['peru'].name])
-        assert set([regions[2].name, regions[3].name]) == set([self.regions['equador'].name, self.regions['bolivia'].name])
+        assert set([regions[0], regions[1]]) == set([self.regions['france'].name, self.regions['peru'].name])
+        assert set([regions[2], regions[3]]) == set([self.regions['equador'].name, self.regions['bolivia'].name])
 
     def test_multi_coverage_overlap_chose_with_non_free_and_priority(self):
         """
@@ -172,9 +171,9 @@ class TestMultiCoverage:
         assert len(regions) == 3
         print("regions ==> {}".format(regions))
 
-        assert regions[0].name == self.regions['germany'].name
-        assert regions[1].name == self.regions['netherlands'].name
-        assert regions[2].name == self.regions['france'].name
+        assert regions[0] == self.regions['germany'].name
+        assert regions[1] == self.regions['netherlands'].name
+        assert regions[2] == self.regions['france'].name
 
     def test_multi_coverage_overlap_chose_with_priority(self):
         """
@@ -188,7 +187,7 @@ class TestMultiCoverage:
         assert len(regions) == 4
         print("regions ==> {}".format(regions))
 
-        assert regions[0].name == self.regions['brazil'].name
-        assert regions[1].name == self.regions['netherlands'].name
-        assert regions[2].name == self.regions['france'].name
-        assert regions[3].name == self.regions['bolivia'].name
+        assert regions[0] == self.regions['brazil'].name
+        assert regions[1] == self.regions['netherlands'].name
+        assert regions[2] == self.regions['france'].name
+        assert regions[3] == self.regions['bolivia'].name

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/jcdecaux_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/jcdecaux_test.py
@@ -72,7 +72,7 @@ def parking_space_availability_jcdecaux_get_informations_test():
     provider._call_webservice = MagicMock(return_value=None)
     assert provider.get_informations(poi) is None
 
-def parking_space_availability_jcdecaux_get_informations_test_unauthorized():
+def parking_space_availability_jcdecaux_get_informations_unauthorized_test():
     """
     Jcdecaux validate return None if not authorized
     """

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -31,7 +31,6 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from abc import abstractmethod, ABCMeta
 from jormungandr.utils import timestamp_to_datetime
-from pytest_mock import mocker
 
 
 class RealtimeProxy(object):

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -31,6 +31,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from abc import abstractmethod, ABCMeta
 from jormungandr.utils import timestamp_to_datetime
+from pytest_mock import mocker
 
 
 class RealtimeProxy(object):

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -33,6 +33,7 @@ from nose.tools.trivial import eq_
 import pytz
 from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy
 from jormungandr.schedule import RealTimePassage
+from jormungandr.utils import date_to_timestamp as d2t
 
 
 class CustomProxy(RealtimeProxy):
@@ -62,7 +63,7 @@ def get_dt(p):
     return p.datetime
 
 
-def filter_items_test_under_the_limit():
+def test_filter_items_under_the_limit():
     proxy = CustomProxy([passage("10:00"), passage("11:00")])
 
     r = proxy.next_passage_for_route_point(None, count=3)
@@ -78,7 +79,7 @@ def filter_items_test():
     assert map(get_dt, r) == [dt("10:00"), dt("11:00")]
 
 
-def filter_no_filter():
+def filter_no_filter_test():
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
@@ -86,34 +87,38 @@ def filter_no_filter():
     assert map(get_dt, r) == [dt("10:00"), dt("11:00"), dt("12:00"), dt("13:00")]
 
 
-def filter_filter_dt():
+def filter_filter_dt_test(mocker):
+    mocker.patch('jormungandr.utils.get_timezone', return_value=pytz.timezone('UTC'))
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, from_dt=dt("12:00"))
+    r = proxy.next_passage_for_route_point(None, from_dt=d2t(dt("12:00")))
     assert map(get_dt, r) == [dt("12:00"), dt("13:00")]
 
 
-def filter_filter_dt_over_all():
+def filter_filter_dt_over_all_test(mocker):
+    mocker.patch('jormungandr.utils.get_timezone', return_value=pytz.timezone('UTC'))
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, from_dt=dt("17:00"))
-    assert r == []
+    r = proxy.next_passage_for_route_point(None, from_dt=d2t(dt("17:00")))
+    assert r is None
 
 
-def filter_filter_dt_and_item():
+def filter_filter_dt_and_item_test(mocker):
+    mocker.patch('jormungandr.utils.get_timezone', return_value=pytz.timezone('UTC'))
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, count=1, from_dt=dt("11:59"))
+    r = proxy.next_passage_for_route_point(None, count=1, from_dt=d2t(dt("11:59")))
     assert map(get_dt, r) == [dt("12:00")]
 
 
-def filter_filter_dt_all():
+def filter_filter_dt_all_test(mocker):
+    mocker.patch('jormungandr.utils.get_timezone', return_value=pytz.timezone('UTC'))
     """the filter will filter all, so we should not get an empty list but None"""
     passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
     proxy = CustomProxy(passages)
 
-    r = proxy.next_passage_for_route_point(None, count=1, from_dt=dt("15:00"))
+    r = proxy.next_passage_for_route_point(None, count=1, from_dt=d2t(dt("15:00")))
     assert r is None

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -176,7 +176,7 @@ def get_passages_test():
         assert passages[2].datetime == _dt('16:10:04')
 
 
-def get_passages_test_no_passages():
+def get_passages_no_passages_test():
     """
     test that if timeo returns 0 response, we return an empty list
     """
@@ -213,7 +213,7 @@ def get_passages_test_no_passages():
         assert len(passages) == 0
 
 
-def get_passages_test_wrong_response():
+def get_passages_wrong_response_test():
     """
     test that if timeo returns a not valid response, we get None (and not an empty list)
     """

--- a/source/jormungandr/jormungandr/scenarios/tests/default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/default_tests.py
@@ -94,7 +94,7 @@ def find_max_duration__counterclockwise_test():
     eq_(response.journeys[1], resp_builder.get_journey('non pt'))
 
 
-def find_max_duration_clockwise_test_no_walk():
+def find_max_duration_clockwise_no_walk_test():
     """
     we don't have a journey with walking so max_duration is None, and we keep all journeys
     """
@@ -131,7 +131,7 @@ def next_journey_test():
     eq_(scenario.next_journey_datetime(builder.get_journeys()), str_to_time_stamp('20161010T120100'))
 
 
-def next_journey_test_no_rapid():
+def next_journey_test_no_rapid_test():
     """ In the default scenario, if we don't get a rapid,
     the next journey is one minute after the earliest journey
     """
@@ -156,7 +156,7 @@ def previous_journey_test():
     eq_(scenario.previous_journey_datetime(builder.get_journeys()), str_to_time_stamp('20161010T145900'))
 
 
-def previous_journey_test_no_rapid():
+def previous_journey_no_rapid_test():
     """ In the default scenario, if we don't get a rapid,
     the previous journey is one minute before the tardiest journey
     """

--- a/source/jormungandr/jormungandr/tests/instance_manager_tests.py
+++ b/source/jormungandr/jormungandr/tests/instance_manager_tests.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from jormungandr import InstanceManager
+from pytest import fixture
+from pytest_mock import mocker
+
+from jormungandr import app
+
+class FakeInstance():
+    def __init__(self, name):
+        self.name = name
+
+@fixture
+def manager():
+    instance_manager = InstanceManager()
+    instance_manager.instances['paris'] = FakeInstance('paris')
+    instance_manager.instances['pdl'] = FakeInstance('pdl')
+    return instance_manager
+
+
+def get_instances_test(manager):
+    with app.test_request_context('/'):
+        instances = manager.get_instances()
+        assert len(instances) == 2
+        assert {'paris', 'pdl'} == {i.name for i in instances}
+
+        instances = manager.get_instances('paris')
+        assert len(instances) == 1
+        assert 'paris' == instances[0].name
+
+        assert manager.get_instances('foo') is None
+
+def get_instances_by_coord_test(manager, mocker):
+    mock = mocker.patch.object(manager, '_all_keys_of_coord', return_value=['paris'])
+    with app.test_request_context('/'):
+        instances = manager.get_instances(lon=4, lat=3)
+        assert len(instances) == 1
+        assert 'paris' == instances[0].name
+        assert mock.called
+
+def get_instances_by_object_id_test(manager, mocker):
+    mock = mocker.patch.object(manager, '_all_keys_of_id', return_value=['pdl'])
+    with app.test_request_context('/'):
+        instances = manager.get_instances(object_id='sa:pdl')
+        assert len(instances) == 1
+        assert 'pdl' == instances[0].name
+        assert mock.called
+
+

--- a/source/jormungandr/requirements_dev.txt
+++ b/source/jormungandr/requirements_dev.txt
@@ -1,3 +1,5 @@
 mock==1.0.1
 nose==1.3.1
 validators==0.10
+pytest==2.8.7
+pytest-mock==1.0

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -384,7 +384,8 @@ class TestOverlappingAuthentication(AbstractTestAuthentication):
 
             response, status = self.query_no_assert('/v1/journeys?from={from_coord}&to={to_coord}&datetime={d}'
                                                     .format(from_coord=s_coord, to_coord=r_coord, d='20120614T08'))
-            assert 'error' in response and response['error']['id'] == "no_origin_nor_destination"
+            assert 'error' in response
+            eq_(response['error']['id'], "no_origin_nor_destination")
             assert status == 404
 
     def test_places_for_bobitto(self):

--- a/source/jormungandr/tests/overlapping_routing_tests.py
+++ b/source/jormungandr/tests/overlapping_routing_tests.py
@@ -84,7 +84,7 @@ class TestOverlappingCoverage(AbstractTestFixture):
         debug_query = "/v1/{q}&debug=true".format(q=journey_basic_query)
         response = self.query(debug_query)
         self.is_valid_journey_response(response, debug_query)
-        assert set(response['debug']['regions_called']) == {"main_routing_test", "empty_routing_test"}
+        eq_(set(response['debug']['regions_called']), {"main_routing_test", "empty_routing_test"})
 
     def test_journeys_on_empty(self):
         """

--- a/source/jormungandr/tests/overlapping_routing_tests.py
+++ b/source/jormungandr/tests/overlapping_routing_tests.py
@@ -41,7 +41,7 @@ class MockKraken:
         self.priority = priority
 
 
-@dataset({"main_routing_test": {}, "empty_routing_test": {}})
+@dataset({"main_routing_test": {}, "empty_routing_test": {'priority': 5}})
 class TestOverlappingCoverage(AbstractTestFixture):
     """
     Test the answer if 2 coverages are overlapping

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -577,21 +577,9 @@ class TestWithoutPt(AbstractTestFixture):
     def setup(self):
         from jormungandr import i_manager
         self.instance_map = {
-            'main_routing_without_pt_test': MockKraken(i_manager.instances['main_routing_without_pt_test'], True, 0),
-            'main_routing_test': MockKraken(i_manager.instances['main_routing_test'], True, 0),
+            'main_routing_without_pt_test': MockKraken(i_manager.instances['main_routing_without_pt_test'], True, 5),
+            'main_routing_test': MockKraken(i_manager.instances['main_routing_test'], True, 10),
         }
-        self.real_method = models.Instance.get_by_name
-        self.real_comparator = instance_manager.instances_comparator
-
-        models.Instance.get_by_name = self.mock_get_by_name
-        instance_manager.instances_comparator = lambda a, b: a.name == "main_routing_without_pt_test"
-
-    def mock_get_by_name(self, name):
-        return self.instance_map[name]
-
-    def teardown(self):
-        models.Instance.get_by_name = self.real_method
-        instance_manager.instances_comparator = self.real_comparator
 
     def test_one_region_wihout_pt(self):
         response = self.query("v1/"+journey_basic_query+"&debug=true",


### PR DESCRIPTION
A little refacto of instance_manager:
- we don't want to do sql request on call to v1/journeys

Unittest has been migrate to py.test too
