### PR TITLE
Jormungandr: remove nose dependency from jormun unit tests

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/test/journey_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/journey_tests.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
-#     the software to build cool stuff with public transport.
+# the software to build cool stuff with public transport.
 #
 # Hope you'll enjoy and contribute to this project,
 #     powered by Canal TP (www.canaltp.fr).
@@ -27,9 +27,9 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
+import pytest
 from jormungandr import i_manager
 from jormungandr.exceptions import RegionNotFound
-from nose.tools import *
 from jormungandr.interfaces.v1.Journeys import compute_regions
 from navitiacommon import models
 
@@ -66,6 +66,7 @@ class TestMultiCoverage:
         """
         small helper, mock i_manager.get_region
         """
+
         def mock_get_instances(region_str=None, lon=None, lat=None, object_id=None, api='ALL', only_one=True):
             if object_id == 'paris':
                 if not paris_region:
@@ -82,6 +83,7 @@ class TestMultiCoverage:
             @classmethod
             def get_by_name(cls, i):
                 return i
+
         models.Instance.get_by_name = weNeedMock.get_by_name
 
     def test_multi_coverage_simple(self):
@@ -94,33 +96,33 @@ class TestMultiCoverage:
 
         assert regions[0] == self.regions['france'].name
 
-    @raises(RegionNotFound)
     def test_multi_coverage_diff_region(self):
         """orig and dest are in different region"""
         self._mock_function(['france'], ['peru'])
 
-        compute_regions(self.args)
+        with pytest.raises(RegionNotFound):
+            compute_regions(self.args)
 
-    @raises(RegionNotFound)
     def test_multi_coverage_no_region(self):
         """no orig """
         self._mock_function(None, ['peru'])
 
-        compute_regions(self.args)
+        with pytest.raises(RegionNotFound):
+            compute_regions(self.args)
 
-    @raises(RegionNotFound)
     def test_multi_coverage_no_region(self):
         """no orig not dest"""
         self._mock_function(None, None)
 
-        compute_regions(self.args)
+        with pytest.raises(RegionNotFound):
+            compute_regions(self.args)
 
-    @raises(RegionNotFound)
     def test_multi_coverage_diff_multiple_region(self):
         """orig and dest are in different multiple regions"""
         self._mock_function(['france', 'bolivia'], ['peru', 'equador'])
 
-        compute_regions(self.args)
+        with pytest.raises(RegionNotFound):
+            compute_regions(self.args)
 
     def test_multi_coverage_overlap(self):
         """orig as 2 possible region and dest one"""
@@ -149,7 +151,8 @@ class TestMultiCoverage:
         all regions are overlaping,
         we have to have the non free first then the free (but we don't know which one)
         """
-        self._mock_function(['france', 'equador', 'peru', 'bolivia'], ['france', 'equador', 'peru', 'bolivia'])
+        self._mock_function(['france', 'equador', 'peru', 'bolivia'],
+                            ['france', 'equador', 'peru', 'bolivia'])
 
         regions = compute_regions(self.args)
 
@@ -157,7 +160,8 @@ class TestMultiCoverage:
         print("regions ==> {}".format(regions))
 
         assert set([regions[0], regions[1]]) == set([self.regions['france'].name, self.regions['peru'].name])
-        assert set([regions[2], regions[3]]) == set([self.regions['equador'].name, self.regions['bolivia'].name])
+        assert set([regions[2], regions[3]]) == set(
+            [self.regions['equador'].name, self.regions['bolivia'].name])
 
     def test_multi_coverage_overlap_chose_with_non_free_and_priority(self):
         """
@@ -180,7 +184,8 @@ class TestMultiCoverage:
         4 regions are overlaping,
         regions are sorted by priority desc
         """
-        self._mock_function(['france', 'netherlands', 'brazil', 'bolivia', 'germany'], ['france', 'netherlands', 'brazil', 'bolivia'])
+        self._mock_function(['france', 'netherlands', 'brazil', 'bolivia', 'germany'],
+                            ['france', 'netherlands', 'brazil', 'bolivia'])
 
         regions = compute_regions(self.args)
 

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/atos_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/atos_test.py
@@ -28,10 +28,10 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
+import pytest
 from jormungandr.parking_space_availability.bss.atos import AtosProvider
 from jormungandr.parking_space_availability.bss.stands import Stands
 from mock import MagicMock
-from nose.tools import raises
 from urllib2 import URLError
 from suds import WebFault
 
@@ -101,10 +101,11 @@ def parking_space_availability_atos_get_all_stands_test():
     assert len(all_stands) == 2
     assert isinstance(all_stands.get('2'), Stands)
 
-@raises(URLError)
 def parking_space_availability_atos_get_all_stands_urlerror_test():
     """
     Atos webservice error should raise an URLError exception
     """
     provider = AtosProvider(u'10', u'Vélitul', u'https://error.fake.com?wsdl')
-    provider.get_all_stands()
+
+    with pytest.raises(URLError):
+        provider.get_all_stands()

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_provider_manager_test.py
@@ -28,9 +28,9 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
+import pytest
 from jormungandr.parking_space_availability.bss.bss_provider_manager import BssProviderManager
 from jormungandr import app
-from nose.tools import raises
 
 CONFIG = ([
     {
@@ -45,19 +45,20 @@ def realtime_place_creation_test():
     manager = BssProviderManager(CONFIG)
     assert len(manager.bss_providers) == 1
 
-@raises(Exception)
 def realtime_place_bad_creation_test():
     """
     simple bss provider bad creation
     """
-    manager = BssProviderManager((
-        {
-            'class': 'jormungandr.parking_space_availability.bss.tests.BssMockProvider'
-        },
-        {
-            'class': 'jormungandr.parking_space_availability.bss.BadProvider'
-        }
-    ))
+
+    with pytest.raises(Exception):
+        manager = BssProviderManager((
+            {
+                'class': 'jormungandr.parking_space_availability.bss.tests.BssMockProvider'
+            },
+            {
+                'class': 'jormungandr.parking_space_availability.bss.BadProvider'
+            }
+        ))
 
 def realtime_places_handle_test():
     """

--- a/source/jormungandr/jormungandr/pytest.ini
+++ b/source/jormungandr/jormungandr/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = --doctest-modules
+norecursedirs = .venv migrations
+python_functions=*test*
+python_files=*test*.py

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
@@ -26,7 +26,7 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
-from nose.tools.nontrivial import raises
+import pytest
 import pytz
 from jormungandr.realtime_schedule.realtime_proxy_manager import RealtimeProxyManager
 
@@ -106,7 +106,6 @@ def wrong_argument_test():
     assert manager.get('proxy_id') is None
 
 
-@raises(pytz.UnknownTimeZoneError)
 def wrong_timezone_test():
     """
     test with a timeo proxy, but with a wrong timezone
@@ -126,7 +125,8 @@ def wrong_timezone_test():
                   }
               }]
 
-    RealtimeProxyManager(config)  # should raise an Exception
+    with pytest.raises(pytz.UnknownTimeZoneError):
+        RealtimeProxyManager(config)  # should raise an Exception
 
 
 def multi_proxy_creation_test():

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -29,7 +29,6 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from datetime import datetime
-from nose.tools.trivial import eq_
 import pytz
 from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy
 from jormungandr.schedule import RealTimePassage

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/synthese_xml_reader_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/synthese_xml_reader_test.py
@@ -56,8 +56,8 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from nose.tools.nontrivial import raises
 import xml.etree.ElementTree as et
+import pytest
 from jormungandr.realtime_schedule.synthese import Synthese, SyntheseRoutePoint
 from jormungandr.interfaces.parsers import date_time_format
 import pytz
@@ -119,14 +119,17 @@ def xml_valid_test():
     assert result[route_point][1].is_real_time == True
     assert result[route_point][1].datetime == make_dt("2016-Mar-22 12:15:00")
 
-@raises(ValueError)
+
 def xml_date_time_invalid_test():
     builder = Synthese("id_synthese", "http://fake.url/", "Europe/Paris")
     xml = get_xml_parser().replace("2016-Mar-21 12:07:37", "2016-Mar-41 12:07:37", 1)
-    builder._get_synthese_passages(xml)
 
-@raises(et.ParseError)
+    with pytest.raises(ValueError):
+        builder._get_synthese_passages(xml)
+
+
 def xml_invalid_test():
     builder = Synthese("id_synthese", "http://fake.url/", "Europe/Paris")
     xml = get_xml_parser().replace("</journey>", "", 1)
-    builder._get_synthese_passages(xml)
+    with pytest.raises(et.ParseError):
+        builder._get_synthese_passages(xml)

--- a/source/jormungandr/jormungandr/scenarios/tests/default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/default_tests.py
@@ -28,7 +28,6 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 import datetime
-from nose.tools import eq_
 from jormungandr.scenarios import default
 from jormungandr.scenarios.tests.protobuf_builder import ResponseBuilder
 from jormungandr.utils import str_to_time_stamp
@@ -61,11 +60,11 @@ def find_max_duration_clockwise_test():
     response = resp_builder.response
 
     scenario = default.Scenario()
-    eq_(scenario._find_max_duration(response.journeys, Instance(), True), 580)
+    assert scenario._find_max_duration(response.journeys, Instance(), True) == 580
     scenario._delete_too_long_journey(response, Instance(), True)
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], resp_builder.get_journey('rapid'))
-    eq_(response.journeys[1], resp_builder.get_journey('non pt'))
+    assert len(response.journeys) == 2
+    assert response.journeys[0] == resp_builder.get_journey('rapid')
+    assert response.journeys[1] == resp_builder.get_journey('non pt')
 
 
 def find_max_duration__counterclockwise_test():
@@ -87,11 +86,11 @@ def find_max_duration__counterclockwise_test():
     response = resp_builder.response
 
     scenario = default.Scenario()
-    eq_(scenario._find_max_duration(response.journeys, Instance(), False), 580)
+    assert scenario._find_max_duration(response.journeys, Instance(), False) == 580
     scenario._delete_too_long_journey(response, Instance(), False)
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], resp_builder.get_journey('rapid'))
-    eq_(response.journeys[1], resp_builder.get_journey('non pt'))
+    assert len(response.journeys) == 2
+    assert response.journeys[0] == resp_builder.get_journey('rapid')
+    assert response.journeys[1] == resp_builder.get_journey('non pt')
 
 
 def find_max_duration_clockwise_no_walk_test():
@@ -112,11 +111,11 @@ def find_max_duration_clockwise_no_walk_test():
     response = resp_builder.response
 
     scenario = default.Scenario()
-    eq_(scenario._find_max_duration(response.journeys, Instance(), True), None)
+    assert scenario._find_max_duration(response.journeys, Instance(), True) == None
     scenario._delete_too_long_journey(response, Instance(), True)
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], resp_builder.get_journey('best'))
-    eq_(response.journeys[1], resp_builder.get_journey('rapid'))
+    assert len(response.journeys) == 2
+    assert response.journeys[0] == resp_builder.get_journey('best')
+    assert response.journeys[1] == resp_builder.get_journey('rapid')
 
 
 def next_journey_test():
@@ -128,7 +127,7 @@ def next_journey_test():
         .journey(type='car', departure='T1300', arrival='T1534')
 
     scenario = default.Scenario()
-    eq_(scenario.next_journey_datetime(builder.get_journeys()), str_to_time_stamp('20161010T120100'))
+    assert scenario.next_journey_datetime(builder.get_journeys()) == str_to_time_stamp('20161010T120100')
 
 
 def next_journey_test_no_rapid_test():
@@ -141,7 +140,7 @@ def next_journey_test_no_rapid_test():
         .journey(type='car', departure='T2000', arrival='T1534')
 
     scenario = default.Scenario()
-    eq_(scenario.next_journey_datetime(builder.get_journeys()), str_to_time_stamp('20161010T100100'))
+    assert scenario.next_journey_datetime(builder.get_journeys()) == str_to_time_stamp('20161010T100100')
 
 
 def previous_journey_test():
@@ -153,7 +152,7 @@ def previous_journey_test():
         .journey(type='car', departure='T1300', arrival='T1534')
 
     scenario = default.Scenario()
-    eq_(scenario.previous_journey_datetime(builder.get_journeys()), str_to_time_stamp('20161010T145900'))
+    assert scenario.previous_journey_datetime(builder.get_journeys()) == str_to_time_stamp('20161010T145900')
 
 
 def previous_journey_no_rapid_test():
@@ -166,4 +165,4 @@ def previous_journey_no_rapid_test():
         .journey(type='car', departure='T2000', arrival='T1534')
 
     scenario = default.Scenario()
-    eq_(scenario.previous_journey_datetime(builder.get_journeys()), str_to_time_stamp('20161010T165900'))
+    assert scenario.previous_journey_datetime(builder.get_journeys()) == str_to_time_stamp('20161010T165900')

--- a/source/jormungandr/jormungandr/scenarios/tests/destineo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/destineo_tests.py
@@ -28,9 +28,6 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 from copy import deepcopy
-
-from nose.tools import eq_
-
 from jormungandr.scenarios import destineo
 from jormungandr.scenarios.tests.protobuf_builder import ResponseBuilder
 import navitiacommon.response_pb2 as response_pb2
@@ -267,15 +264,15 @@ def sort_destineo_test():
     response = resp_builder.response
     scenario = destineo.Scenario()
     scenario._custom_sort_journeys(response, clockwise=True, timezone='Africa/Abidjan')
-    eq_(response.journeys[0], resp_builder.get_journey('journey_tc1'))
-    eq_(response.journeys[1], resp_builder.get_journey('journey_tc2'))
-    eq_(response.journeys[2], resp_builder.get_journey('journey_tc3'))
-    eq_(response.journeys[3], resp_builder.get_journey('journey_bss'))
-    eq_(response.journeys[4], resp_builder.get_journey('journey_bss_and_tc'))
-    eq_(response.journeys[5], resp_builder.get_journey('journey_bike_and_tc'))
-    eq_(response.journeys[6], resp_builder.get_journey('journey_car_and_tc'))
-    eq_(response.journeys[7], resp_builder.get_journey('journey_walk'))
-    eq_(response.journeys[8], resp_builder.get_journey('journey_bike'))
+    assert response.journeys[0] ==  resp_builder.get_journey('journey_tc1')
+    assert response.journeys[1] ==  resp_builder.get_journey('journey_tc2')
+    assert response.journeys[2] ==  resp_builder.get_journey('journey_tc3')
+    assert response.journeys[3] ==  resp_builder.get_journey('journey_bss')
+    assert response.journeys[4] ==  resp_builder.get_journey('journey_bss_and_tc')
+    assert response.journeys[5] ==  resp_builder.get_journey('journey_bike_and_tc')
+    assert response.journeys[6] ==  resp_builder.get_journey('journey_car_and_tc')
+    assert response.journeys[7] ==  resp_builder.get_journey('journey_walk')
+    assert response.journeys[8] ==  resp_builder.get_journey('journey_bike')
 
 
 def sort_destineo_date_test():
@@ -331,9 +328,9 @@ def sort_destineo_date_test():
 
     scenario = destineo.Scenario()
     scenario._custom_sort_journeys(response, clockwise=True, timezone='Africa/Abidjan')
-    eq_(response.journeys[0], journey_bss_and_tc)
-    eq_(response.journeys[1], journey_tc1)
-    eq_(response.journeys[2], journey_tc3)
+    assert response.journeys[0] ==  journey_bss_and_tc
+    assert response.journeys[1] ==  journey_tc1
+    assert response.journeys[2] ==  journey_tc3
 
 
 def sort_destineo_date_timezone_test():
@@ -386,9 +383,9 @@ def sort_destineo_date_timezone_test():
 
     scenario = destineo.Scenario()
     scenario._custom_sort_journeys(response, clockwise=True, timezone='Europe/Paris')
-    eq_(response.journeys[0], journey_tc1)
-    eq_(response.journeys[1], journey_tc3)
-    eq_(response.journeys[2], journey_bss_and_tc)
+    assert response.journeys[0] ==  journey_tc1
+    assert response.journeys[1] ==  journey_tc3
+    assert response.journeys[2] ==  journey_bss_and_tc
 
 
 class Instance(object):
@@ -441,9 +438,9 @@ def remove_not_long_enough_no_removal_test():
 
     scenario = destineo.Scenario()
     scenario._remove_not_long_enough_fallback(response, Instance())
-    eq_(len(response.journeys), 2)
+    assert len(response.journeys) ==  2
     scenario._remove_not_long_enough_tc_with_fallback(response, Instance())
-    eq_(len(response.journeys), 2)
+    assert len(response.journeys) ==  2
 
 def remove_not_long_enough_bss_test():
     response = response_pb2.Response()
@@ -532,14 +529,14 @@ def remove_not_long_enough_bss_test():
 
     scenario = destineo.Scenario()
     scenario._remove_not_long_enough_fallback(response, Instance())
-    eq_(len(response.journeys), 3)
-    eq_(response.journeys[0], journey1)
-    eq_(response.journeys[1], journey3)
-    eq_(response.journeys[2], journey4)
+    assert len(response.journeys) ==  3
+    assert response.journeys[0] ==  journey1
+    assert response.journeys[1] ==  journey3
+    assert response.journeys[2] ==  journey4
     scenario._remove_not_long_enough_tc_with_fallback(response, Instance())
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], journey1)
-    eq_(response.journeys[1], journey4)
+    assert len(response.journeys) ==  2
+    assert response.journeys[0] ==  journey1
+    assert response.journeys[1] ==  journey4
 
 
 def remove_not_long_enough_bike_test():
@@ -599,14 +596,14 @@ def remove_not_long_enough_bike_test():
 
     scenario = destineo.Scenario()
     scenario._remove_not_long_enough_fallback(response, Instance())
-    eq_(len(response.journeys), 3)
-    eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey3)
-    eq_(response.journeys[2], journey4)
+    assert len(response.journeys) ==  3
+    assert response.journeys[0] ==  journey
+    assert response.journeys[1] ==  journey3
+    assert response.journeys[2] ==  journey4
     scenario._remove_not_long_enough_tc_with_fallback(response, Instance())
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey4)
+    assert len(response.journeys) ==  2
+    assert response.journeys[0] ==  journey
+    assert response.journeys[1] ==  journey4
 
 
 def remove_not_long_enough_car_test():
@@ -666,14 +663,14 @@ def remove_not_long_enough_car_test():
 
     scenario = destineo.Scenario()
     scenario._remove_not_long_enough_fallback(response, Instance())
-    eq_(len(response.journeys), 3)
-    eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey3)
-    eq_(response.journeys[2], journey4)
+    assert len(response.journeys) ==  3
+    assert response.journeys[0] ==  journey
+    assert response.journeys[1] ==  journey3
+    assert response.journeys[2] ==  journey4
     scenario._remove_not_long_enough_tc_with_fallback(response, Instance())
-    eq_(len(response.journeys), 2)
-    eq_(response.journeys[0], journey)
-    eq_(response.journeys[1], journey4)
+    assert len(response.journeys) ==  2
+    assert response.journeys[0] ==  journey
+    assert response.journeys[1] ==  journey4
 
 
 def get_walking_walking_journey():
@@ -973,24 +970,24 @@ def choose_best_alternatives_simple_test():
     saved_journeys = deepcopy(journeys)
     scenario = destineo.Scenario()
     scenario._choose_best_alternatives(journeys)
-    eq_(len(journeys), 1)
-    eq_(journeys[0], saved_journeys[2])
+    assert len(journeys) ==  1
+    assert journeys[0] ==  saved_journeys[2]
 
 def choose_best_alternatives__bike_bss_test():
     journeys = [get_bike_bss_journey(), get_bike_car_journey()]
     saved_journeys = deepcopy(journeys)
     scenario = destineo.Scenario()
     scenario._choose_best_alternatives(journeys)
-    eq_(len(journeys), 1)
-    eq_(journeys[0], saved_journeys[0])
+    assert len(journeys) ==  1
+    assert journeys[0] ==  saved_journeys[0]
 
 def choose_best_alternatives__car_test():
     journeys = [get_bike_car_journey()]
     saved_journeys = deepcopy(journeys)
     scenario = destineo.Scenario()
     scenario._choose_best_alternatives(journeys)
-    eq_(len(journeys), 1)
-    eq_(journeys[0], saved_journeys[0])
+    assert len(journeys) ==  1
+    assert journeys[0] ==  saved_journeys[0]
 
 def choose_best_alternatives_non_pt_test():
     journeys = [get_bss_bss_journey(), get_bike_car_journey(), get_bss_walking_journey()]
@@ -1006,24 +1003,24 @@ def choose_best_alternatives_non_pt_test():
 
     scenario = destineo.Scenario()
     scenario._choose_best_alternatives(journeys)
-    eq_(len(journeys), 3)
-    eq_(journeys[0], saved_journeys[2])
-    eq_(journeys[1], j1)
-    eq_(journeys[2], j2)
+    assert len(journeys) ==  3
+    assert journeys[0] ==  saved_journeys[2]
+    assert journeys[1] ==  j1
+    assert journeys[2] ==  j2
 
 def remove_extra_journeys_less_test():
     journeys = [get_bss_bss_journey(), get_bike_car_journey()]
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, 3, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 2)
+    assert len(journeys) ==  2
 
 def remove_extra_journeys_enougth_test():
     journeys = [get_bss_bss_journey(), get_bike_car_journey()]
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, 2, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 2)
+    assert len(journeys) ==  2
 
 def remove_extra_journeys_more_test():
     journeys = [get_bss_bss_journey(), get_bike_car_journey(), get_bss_bike_journey()]
@@ -1031,13 +1028,13 @@ def remove_extra_journeys_more_test():
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, None, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 3)
+    assert len(journeys) ==  3
 
     scenario._remove_extra_journeys(journeys, 2, clockwise=True, timezone='UTC')
 
-    eq_(len(journeys), 2)
-    eq_(journeys[0], saved_journeys[0])
-    eq_(journeys[1], saved_journeys[1])
+    assert len(journeys) ==  2
+    assert journeys[0] ==  saved_journeys[0]
+    assert journeys[1] ==  saved_journeys[1]
 
 def remove_extra_journeys_more_with_walking_last_test():
     journeys = [get_bss_bss_journey(), get_bike_car_journey(), get_bss_bike_journey()]
@@ -1048,14 +1045,14 @@ def remove_extra_journeys_more_with_walking_last_test():
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, None, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 4)
+    assert len(journeys) ==  4
 
     scenario._remove_extra_journeys(journeys, 2, clockwise=True, timezone='UTC')
 
-    eq_(len(journeys), 3)
-    eq_(journeys[0], saved_journeys[0])
-    eq_(journeys[1], saved_journeys[1])
-    eq_(journeys[2], j1)
+    assert len(journeys) ==  3
+    assert journeys[0] ==  saved_journeys[0]
+    assert journeys[1] ==  saved_journeys[1]
+    assert journeys[2] ==  j1
 
 def remove_extra_journeys_more_with_walking_first_test():
     j1 = response_pb2.Journey()
@@ -1065,14 +1062,14 @@ def remove_extra_journeys_more_with_walking_first_test():
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, None, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 4)
+    assert len(journeys) ==  4
 
     scenario._remove_extra_journeys(journeys, 2, clockwise=True, timezone='UTC')
 
-    eq_(len(journeys), 3)
-    eq_(journeys[0], j1)
-    eq_(journeys[1], saved_journeys[1])
-    eq_(journeys[2], saved_journeys[2])
+    assert len(journeys) ==  3
+    assert journeys[0] ==  j1
+    assert journeys[1] ==  saved_journeys[1]
+    assert journeys[2] ==  saved_journeys[2]
 
 
 def remove_extra_journeys_similar_journey_latest_dep():
@@ -1093,8 +1090,8 @@ def remove_extra_journeys_similar_journey_latest_dep():
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, None, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 2)
-    eq_(journeys[1].type, 'bob')
+    assert len(journeys) ==  2
+    assert journeys[1].type ==  'bob'
 
 
 def remove_extra_journeys_not_similar_journeys():
@@ -1109,9 +1106,9 @@ def remove_extra_journeys_not_similar_journeys():
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, None, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 2) #nothing filtered, they are not equivalent
-    eq_(journeys[0].type, 'bobitto')
-    eq_(journeys[1].type, 'babitta')
+    assert len(journeys) ==  2 #nothing filtered, they are not equivalent
+    assert journeys[0].type ==  'bobitto'
+    assert journeys[1].type ==  'babitta'
 
 
 def remove_extra_journeys_max_and_similar():
@@ -1140,6 +1137,6 @@ def remove_extra_journeys_max_and_similar():
 
     scenario = destineo.Scenario()
     scenario._remove_extra_journeys(journeys, 1, clockwise=True, timezone='UTC')
-    eq_(len(journeys), 2)
-    eq_(journeys[0].type, 'bobitto1')
-    eq_(journeys[1].type, 'non_pt_walk')
+    assert len(journeys) ==  2
+    assert journeys[0].type ==  'bobitto1'
+    assert journeys[1].type ==  'non_pt_walk'

--- a/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
@@ -27,9 +27,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
-
 from navitiacommon import response_pb2
-from nose.tools import eq_
 from jormungandr.scenarios.helpers import *
 
 def get_walking_walking_journey():
@@ -563,54 +561,54 @@ def has_bike_first_and_bss_last__bike_car_test():
 
 
 def bike_duration_test():
-    eq_(bike_duration(get_walking_walking_journey()), 0)
+    assert bike_duration(get_walking_walking_journey()) ==  0
 
-    eq_(bike_duration(get_walking_bike_journey()), 40)
+    assert bike_duration(get_walking_bike_journey()) ==  40
 
-    eq_(bike_duration(get_walking_bss_journey()), 0)
+    assert bike_duration(get_walking_bss_journey()) ==  0
 
-    eq_(bike_duration(get_walking_car_journey()), 0)
+    assert bike_duration(get_walking_car_journey()) ==  0
 
-    eq_(bike_duration(get_bss_walking_journey()), 0)
+    assert bike_duration(get_bss_walking_journey()) ==  0
 
-    eq_(bike_duration(get_bss_bike_journey()), 200)
+    assert bike_duration(get_bss_bike_journey()) ==  200
 
-    eq_(bike_duration(get_bss_bss_journey()), 0)
+    assert bike_duration(get_bss_bss_journey()) ==  0
 
-    eq_(bike_duration(get_bss_car_journey()), 0)
+    assert bike_duration(get_bss_car_journey()) ==  0
 
-    eq_(bike_duration(get_bike_walking_journey()), 55)
+    assert bike_duration(get_bike_walking_journey()) ==  55
 
-    eq_(bike_duration(get_bike_bike_journey()), 30)
+    assert bike_duration(get_bike_bike_journey()) ==  30
 
-    eq_(bike_duration(get_bike_bss_journey()), 25)
+    assert bike_duration(get_bike_bss_journey()) ==  25
 
-    eq_(bike_duration(get_bike_car_journey()), 25)
+    assert bike_duration(get_bike_car_journey()) ==  25
 
 def car_duration_walking_test():
-    eq_(car_duration(get_walking_walking_journey()), 0)
+    assert car_duration(get_walking_walking_journey()) ==  0
 
-    eq_(car_duration(get_walking_bike_journey()), 0)
+    assert car_duration(get_walking_bike_journey()) ==  0
 
-    eq_(car_duration(get_walking_bss_journey()), 0)
+    assert car_duration(get_walking_bss_journey()) ==  0
 
-    eq_(car_duration(get_walking_car_journey()), 70)
+    assert car_duration(get_walking_car_journey()) ==  70
 
-    eq_(car_duration(get_bss_walking_journey()), 0)
+    assert car_duration(get_bss_walking_journey()) ==  0
 
-    eq_(car_duration(get_bss_bike_journey()), 0)
+    assert car_duration(get_bss_bike_journey()) ==  0
 
-    eq_(car_duration(get_bss_bss_journey()), 0)
+    assert car_duration(get_bss_bss_journey()) ==  0
 
-    eq_(car_duration(get_bss_car_journey()), 70)
+    assert car_duration(get_bss_car_journey()) ==  70
 
-    eq_(car_duration(get_bike_walking_journey()), 0)
+    assert car_duration(get_bike_walking_journey()) ==  0
 
-    eq_(car_duration(get_bike_bike_journey()), 0)
+    assert car_duration(get_bike_bike_journey()) ==  0
 
-    eq_(car_duration(get_bike_bss_journey()), 0)
+    assert car_duration(get_bike_bss_journey()) ==  0
 
-    eq_(car_duration(get_bike_car_journey()), 30)
+    assert car_duration(get_bike_car_journey()) ==  30
 
 
 def pt_duration_walking_test():
@@ -628,7 +626,7 @@ def pt_duration_walking_test():
     section.street_network.mode = response_pb2.Walking
     section.duration = 60
 
-    eq_(pt_duration(journey), 80)
+    assert pt_duration(journey) ==  80
 
 def pt_duration_bike_test():
     journey = response_pb2.Journey()
@@ -654,7 +652,7 @@ def pt_duration_bike_test():
     section.street_network.mode = response_pb2.Walking
     section.duration = 70
 
-    eq_(pt_duration(journey), 120)
+    assert pt_duration(journey) ==  120
 
 
 def pt_duration_bss_test():
@@ -686,67 +684,67 @@ def pt_duration_bss_test():
     section.street_network.mode = response_pb2.Bike
     section.duration = 5
 
-    eq_(pt_duration(journey), 80)
+    assert pt_duration(journey) ==  80
 
 def walking_duration_test():
-    eq_(walking_duration(get_walking_walking_journey()), 120)
+    assert walking_duration(get_walking_walking_journey()) ==  120
 
-    eq_(walking_duration(get_walking_bike_journey()), 30)
+    assert walking_duration(get_walking_bike_journey()) ==  30
 
-    eq_(walking_duration(get_walking_bss_journey()), 75)
+    assert walking_duration(get_walking_bss_journey()) ==  75
 
-    eq_(walking_duration(get_walking_car_journey()), 15)
+    assert walking_duration(get_walking_car_journey()) ==  15
 
-    eq_(walking_duration(get_bss_walking_journey()), 40)
+    assert walking_duration(get_bss_walking_journey()) ==  40
 
-    eq_(walking_duration(get_bss_bike_journey()), 40)
+    assert walking_duration(get_bss_bike_journey()) ==  40
 
-    eq_(walking_duration(get_bss_bss_journey()), 70)
+    assert walking_duration(get_bss_bss_journey()) ==  70
 
-    eq_(walking_duration(get_bss_car_journey()), 75)
+    assert walking_duration(get_bss_car_journey()) ==  75
 
-    eq_(walking_duration(get_bike_walking_journey()), 7)
+    assert walking_duration(get_bike_walking_journey()) ==  7
 
-    eq_(walking_duration(get_bike_bike_journey()), 0)
+    assert walking_duration(get_bike_bike_journey()) ==  0
 
-    eq_(walking_duration(get_bike_bss_journey()), 10)
+    assert walking_duration(get_bike_bss_journey()) ==  10
 
-    eq_(walking_duration(get_bike_car_journey()), 5)
+    assert walking_duration(get_bike_car_journey()) ==  5
 
 def bss_duration_test():
-    eq_(bss_duration(get_walking_walking_journey()), 0)
+    assert bss_duration(get_walking_walking_journey()) ==  0
 
-    eq_(bss_duration(get_walking_bike_journey()), 0)
+    assert bss_duration(get_walking_bike_journey()) ==  0
 
-    eq_(bss_duration(get_walking_bss_journey()), 85)
+    assert bss_duration(get_walking_bss_journey()) ==  85
 
-    eq_(bss_duration(get_walking_car_journey()), 0)
+    assert bss_duration(get_walking_car_journey()) ==  0
 
-    eq_(bss_duration(get_bss_walking_journey()), 45)
+    assert bss_duration(get_bss_walking_journey()) ==  45
 
-    eq_(bss_duration(get_bss_bike_journey()), 85)
+    assert bss_duration(get_bss_bike_journey()) ==  85
 
-    eq_(bss_duration(get_bss_bss_journey()), 100)
+    assert bss_duration(get_bss_bss_journey()) ==  100
 
-    eq_(bss_duration(get_bss_car_journey()), 25)
+    assert bss_duration(get_bss_car_journey()) ==  25
 
-    eq_(bss_duration(get_bike_walking_journey()), 0)
+    assert bss_duration(get_bike_walking_journey()) ==  0
 
-    eq_(bss_duration(get_bike_bike_journey()), 0)
+    assert bss_duration(get_bike_bike_journey()) ==  0
 
-    eq_(bss_duration(get_bike_bss_journey()), 70)
+    assert bss_duration(get_bike_bss_journey()) ==  70
 
-    eq_(bss_duration(get_bike_car_journey()), 0)
+    assert bss_duration(get_bike_car_journey()) ==  0
 
 def fallback_mode_sort_test():
     l = ['car', 'walking']
     l.sort(fallback_mode_comparator)
-    eq_(l[0], 'walking')
-    eq_(l[1], 'car')
+    assert l[0] ==  'walking'
+    assert l[1] ==  'car'
 
     l = ['bss', 'bike', 'car', 'walking']
     l.sort(fallback_mode_comparator)
-    eq_(l[0], 'walking')
-    eq_(l[1], 'bss')
-    eq_(l[2], 'bike')
-    eq_(l[3], 'car')
+    assert l[0] ==  'walking'
+    assert l[1] ==  'bss'
+    assert l[2] ==  'bike'
+    assert l[3] ==  'car'

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -34,7 +34,6 @@ import navitiacommon.response_pb2 as response_pb2
 from navitiacommon import default_values
 from jormungandr.scenarios.default import Scenario, are_equals
 from jormungandr.utils import str_to_time_stamp
-from nose.tools import eq_
 import random
 
 
@@ -65,8 +64,8 @@ def different_arrival_times_test():
     journey2.sections[0].duration = 2 * 60
 
     scenario.sort_journeys(response, 'arrival_time')
-    eq_(response.journeys[0].arrival_date_time, str_to_time_stamp("20140422T0758"))
-    eq_(response.journeys[1].arrival_date_time, str_to_time_stamp("20140422T0800"))
+    assert response.journeys[0].arrival_date_time ==  str_to_time_stamp("20140422T0758")
+    assert response.journeys[1].arrival_date_time ==  str_to_time_stamp("20140422T0800")
 
 
 def different_departure_times_test():
@@ -89,8 +88,8 @@ def different_departure_times_test():
     journey2.sections[0].duration = 2 * 60
 
     scenario.sort_journeys(response, 'departure_time')
-    eq_(response.journeys[0].departure_date_time, str_to_time_stamp("20140422T0758"))
-    eq_(response.journeys[1].departure_date_time, str_to_time_stamp("20140422T0800"))
+    assert response.journeys[0].departure_date_time ==  str_to_time_stamp("20140422T0758")
+    assert response.journeys[1].departure_date_time ==  str_to_time_stamp("20140422T0800")
 
 
 def different_duration_test():
@@ -594,11 +593,11 @@ def test_departure_sort():
 
     compartor = DepartureJourneySorter(True)
     result.sort(compartor)
-    eq_(result[0], j1)
-    eq_(result[1], j2)
-    eq_(result[2], j5)
-    eq_(result[3], j4)
-    eq_(result[4], j3)
+    assert result[0] ==  j1
+    assert result[1] ==  j2
+    assert result[2] ==  j5
+    assert result[3] ==  j4
+    assert result[4] ==  j3
 
 def test_arrival_sort():
     """
@@ -639,11 +638,11 @@ def test_arrival_sort():
 
     compartor = ArrivalJourneySorter(True)
     result.sort(compartor)
-    eq_(result[0], j1)
-    eq_(result[1], j2)
-    eq_(result[2], j5)
-    eq_(result[3], j4)
-    eq_(result[4], j3)
+    assert result[0] ==  j1
+    assert result[1] ==  j2
+    assert result[2] ==  j5
+    assert result[3] ==  j4
+    assert result[4] ==  j3
 
 def test_heavy_journey_walking():
     """

--- a/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
@@ -27,8 +27,6 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
-
-from nose.tools import eq_
 from jormungandr.scenarios import qualifier
 import navitiacommon.response_pb2 as response_pb2
 from jormungandr.utils import str_to_time_stamp
@@ -137,12 +135,12 @@ def qualifier_two_test():
 
     qualifier.qualifier_one(journeys, "departure")
 
-    eq_(journey_standard.type, "fastest")  # the standard should be the fastest
-    eq_(journey_rapid.type, "rapid")
+    assert journey_standard.type ==  "fastest"  # the standard should be the fastest
+    assert journey_rapid.type ==  "rapid"
 
     #TODO! refacto this test with custom rules not to depends on changing business rules
-#    eq_(journey_confort.type, "comfort")
-#    eq_(journey_health.type, "healthy")
+#    assert journey_confort.type ==  "comfort"
+#    assert journey_health.type ==  "healthy"
 
 
 def has_car_test():
@@ -214,7 +212,7 @@ def standard_choice_test():
 
     print(qualifier.has_car(standard))
     print("standard ", standard.arrival_date_time)
-    eq_(standard, journey_1)
+    assert standard ==  journey_1
 
 def standard_choice_with_pt_test():
     journeys = []
@@ -260,7 +258,7 @@ def standard_choice_with_pt_test():
 
     print(qualifier.has_car(standard))
     print("standard ", standard.arrival_date_time)
-    eq_(standard, journey_1)
+    assert standard ==  journey_1
 
 def choose_standard_pt_car():
     journeys = []
@@ -290,8 +288,8 @@ def tranfers_cri_test():
 
     #the transfert criterion is first, and then if 2 journeys have
     #the same nb_transfers, we compare the dates
-    eq_(best.nb_transfers, 1)
-    eq_(best.arrival_date_time, str_to_time_stamp("20131107T100000"))
+    assert best.nb_transfers ==  1
+    assert best.arrival_date_time ==  str_to_time_stamp("20131107T100000")
 
 def qualifier_crowfly_test():
     journeys = []
@@ -328,8 +326,8 @@ def qualifier_crowfly_test():
 
     qualifier.qualifier_one(journeys, "departure")
 
-    eq_(journey_standard.type, "rapid")  # the standard should be the fastest
-    eq_(journey_health.type, "less_fallback_walk")
+    assert journey_standard.type ==  "rapid"  # the standard should be the fastest
+    assert journey_health.type ==  "less_fallback_walk"
 
 
 def qualifier_nontransport_duration_only_walk_test():
@@ -350,7 +348,7 @@ def qualifier_nontransport_duration_only_walk_test():
     journey.sections[-1].type = response_pb2.STREET_NETWORK
     journey.sections[-1].duration = 864
 
-    eq_(qualifier.get_nontransport_duration(journey), 1988)
+    assert qualifier.get_nontransport_duration(journey) ==  1988
 
 
 def qualifier_nontransport_duration_with_tc_test():
@@ -383,4 +381,4 @@ def qualifier_nontransport_duration_with_tc_test():
     journey.sections[-1].type = response_pb2.STREET_NETWORK
     journey.sections[-1].duration = 864
 
-    eq_(qualifier.get_nontransport_duration(journey), 2797)
+    assert qualifier.get_nontransport_duration(journey) ==  2797


### PR DESCRIPTION
the migration to pytest was incomplete and lot's of tests were not run by jenkins.
