### PR TITLE
Isochrone: catch boost exception

### DIFF
--- a/source/routing/isochron.cpp
+++ b/source/routing/isochron.cpp
@@ -122,8 +122,15 @@ static type::MultiPolygon merge_poly(const type::MultiPolygon& multi_poly, type:
     for(const type::Polygon& p: multi_poly) {
         if (boost::geometry::intersects(p, poly)) {
            type::MultiPolygon poly_union;
-           boost::geometry::union_(poly, p, poly_union);
-           poly = poly_union[0];
+           try {
+               boost::geometry::union_(poly, p, poly_union);
+               poly = poly_union[0];
+           } catch (const boost::geometry::exception& e) {
+               //We don't merge the polygons
+               multi_polys_merged.push_back(p);
+               log4cplus::Logger logger = log4cplus::Logger::getInstance("logger");
+               LOG4CPLUS_WARN(logger, "impossible to merge polygon: " << e.what());
+           }
         } else {
             multi_polys_merged.push_back(p);
         }

--- a/source/routing/isochron.h
+++ b/source/routing/isochron.h
@@ -31,10 +31,19 @@ www.navitia.io
 #pragma once
 
 #include "type/geographical_coord.h"
+#include "utils/exception.h"
 #include "raptor.h"
 #include <set>
 
 namespace navitia { namespace routing {
+
+struct IsochronException: public recoverable_exception {
+    IsochronException(const std::string& msg): recoverable_exception(msg) {}
+    IsochronException() = default;
+    IsochronException(const IsochronException&) = default;
+    IsochronException& operator=(const IsochronException&) = default;
+    virtual ~IsochronException() noexcept = default;
+};
 
 constexpr static double N_RAD_TO_DEG = 57.295779513;
 


### PR DESCRIPTION
Catch boost exception when we merge polygon and add a warning
