### PR TITLE
Isochrone : Improve processing time

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -40,6 +40,7 @@ from jormungandr.interfaces.v1.make_links import create_internal_link, create_ex
 from jormungandr.timezone import get_timezone
 from jormungandr.utils import timestamp_to_str
 from navitiacommon import response_pb2, type_pb2
+import ujson
 
 
 class PbField(fields.Nested):
@@ -404,20 +405,8 @@ class MultiPolyGeoJson(fields.Raw):
 
     def format(self, value):
 
-        polys = []
-
-        for poly in value.polygons:
-            p = []
-            outer = [[c.lon, c.lat] for c in poly.outer.coordinates]
-            p.append(outer)
-            for inners in poly.inners:
-                inner = [[c.lon, c.lat] for c in inners.coordinates]
-                p.append(inner)
-            polys.append(p)
-        response = {
-            "type": "MultiPolygon",
-            "coordinates": polys,
-        }
+        geojson = str(value)
+        response = ujson.loads(geojson)
 
         return response
 

--- a/source/routing/isochrone.cpp
+++ b/source/routing/isochrone.cpp
@@ -148,10 +148,10 @@ struct InfoCircle {
     double distance;
     int duration_left;
     InfoCircle(const type::GeographicalCoord& center,
-           const double& distance,
-           const int& duration_left): center(center),
-                                      distance(distance),
-                                      duration_left(duration_left) {}
+               const double& distance,
+               const int& duration_left): center(center),
+        distance(distance),
+        duration_left(duration_left) {}
 };
 
 template<typename T>
@@ -195,9 +195,9 @@ type::MultiPolygon build_single_isochrone(RAPTOR& raptor,
             circles_classed.push_back(to_add);
         }
     }
-    boost::sort(circles_classed, [](const InfoCircle& a, const InfoCircle& b) {
-        return a.distance < b.distance;
-    });
+    boost::sort(circles_classed,
+                [](const InfoCircle& a, const InfoCircle& b) {return a.distance < b.distance;});
+
     for (const auto& c: circles_classed) {
         type::Polygon circle_to_add = circle(c.center, c.duration_left * speed);
         circles = merge_poly(circles, circle_to_add);

--- a/source/routing/isochrone.cpp
+++ b/source/routing/isochrone.cpp
@@ -42,6 +42,7 @@ www.navitia.io
 #include <cmath>
 #include <string>
 #include <algorithm>
+#include <boost/range/algorithm.hpp>
 
 namespace navitia { namespace routing {
 
@@ -153,13 +154,6 @@ struct InfoCircle {
                                       duration_left(duration_left) {}
 };
 
-struct {
-  bool operator()(const InfoCircle& a, const InfoCircle& b) const {
-    return a.distance < b.distance;
-  }
-} furtherthan;
-
-
 template<typename T>
 static bool in_bound(const T & begin, const T & end, bool clockwise) {
     return (clockwise && begin < end) ||
@@ -201,9 +195,11 @@ type::MultiPolygon build_single_isochrone(RAPTOR& raptor,
             circles_classed.push_back(to_add);
         }
     }
-    std::sort(circles_classed.begin(), circles_classed.end(), furtherthan);
-    for (auto it = circles_classed.begin(); it != circles_classed.end(); ++it) {
-        type::Polygon circle_to_add = circle(it->center, it->duration_left * speed);
+    boost::sort(circles_classed, [](const InfoCircle& a, const InfoCircle& b) {
+        return a.distance < b.distance;
+    });
+    for (const auto& c: circles_classed) {
+        type::Polygon circle_to_add = circle(c.center, c.duration_left * speed);
         circles = merge_poly(circles, circle_to_add);
     }
     return circles;
@@ -233,4 +229,3 @@ type::MultiPolygon build_isochrones(RAPTOR& raptor,
 }
 
 }} //namespace navitia::routing
-

--- a/source/routing/isochrone.h
+++ b/source/routing/isochrone.h
@@ -63,17 +63,20 @@ type::Polygon circle(const type::GeographicalCoord& center,
 type::MultiPolygon build_single_isochrone(RAPTOR& raptor,
                                 const std::vector<type::StopPoint*>& stop_points,
                                 const bool clockwise,
+                                const type::GeographicalCoord& coord_origin,
                                 const DateTime& bound,
                                 const map_stop_point_duration &origine,
                                 const double& speed,
                                 const int& duration);
 
 type::MultiPolygon build_isochrones(RAPTOR& raptor,
-                                   const bool clockwise,
-                                   const DateTime& bound_max,
-                                   const DateTime& bound_min,
-                                   const map_stop_point_duration& origin,
-                                   const double& speed,
-                                   const int& max_duration,
-                                   const int& min_duration);
+                                    const bool clockwise,
+                                    const type::GeographicalCoord& coord_origin,
+                                    const DateTime& bound_max,
+                                    const DateTime& bound_min,
+                                    const map_stop_point_duration& origin,
+                                    const double& speed,
+                                    const int& max_duration,
+                                    const int& min_duration);
+
 }}

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1149,8 +1149,8 @@ pbnavitia::Response make_isochrone(RAPTOR &raptor,
 static void coord_to_string(std::stringstream& ss,
                             const double& lon,
                             const double& lat) {
-    ss << "[" << boost::lexical_cast<std::string>(lon) << ","
-       << boost::lexical_cast<std::string>(lat) << "]";
+    ss << std::setprecision(15) << "[" << lon << ","
+       << lat << "]";
 }
 
 static void add_graphical_isochrone(const type::MultiPolygon& shape, PbCreator& pb_creator) {
@@ -1158,20 +1158,22 @@ static void add_graphical_isochrone(const type::MultiPolygon& shape, PbCreator& 
     geojson << R"({"type":"MultiPolygon","coordinates":[)";
     for (unsigned i = 0; i < shape.size(); i++) {
         geojson << "[[";
-        for(unsigned j = 0; j < shape[i].outer().size(); j++) {
-            auto outer = shape[i].outer()[j];
-            coord_to_string(geojson, outer.lon(), outer.lat());
-            if (j == shape[i].outer().size() - 1) { continue; }
+        auto it = shape[i].outer().begin();
+        const auto end = shape[i].outer().end();
+        if (it != end) { coord_to_string(geojson, it->lon(), it->lat()); ++it; }
+        for (; it != end; ++it) {
             geojson << ",";
+            coord_to_string(geojson, it->lon(), it->lat());
         }
         geojson << "]";
-        for(unsigned k = 0; k < shape[i].inners().size(); k++) {
+        for(unsigned j = 0; j < shape[i].inners().size(); j++) {
             geojson << ",[";
-            for (unsigned l = 0; l < shape[i].inners()[k].size(); l++) {
-                auto inner = shape[i].inners()[k][l];
-                coord_to_string(geojson, inner.lon(), inner.lat());
-                if (l == shape[i].inners()[k].size() - 1) { continue; }
+            auto it = shape[i].inners()[j].begin();
+            const auto end = shape[i].inners()[j].end();
+            if (it != end) { coord_to_string(geojson, it->lon(), it->lat()); ++it; }
+            for (; it != end; ++it) {
                 geojson << ",";
+                coord_to_string(geojson, it->lon(), it->lat());
             }
             geojson << "]";
         }

--- a/source/routing/tests/isochrone_test.cpp
+++ b/source/routing/tests/isochrone_test.cpp
@@ -140,8 +140,9 @@ BOOST_AUTO_TEST_CASE(build_single_ischron_test) {
     raptor.isochrone(d, navitia::DateTimeUtils::set(0, "08:00"_t), navitia::DateTimeUtils::set(0, "09:12"_t));
     double speed = 0.8;
     navitia::type::MultiPolygon isochrone = build_single_isochrone(raptor, b.data->pt_data->stop_points, true,
-                                                           navitia::DateTimeUtils::set(0, "09:12"_t),
-                                                           d, speed, 3600 + 60*12);
+                                                                   coord_Paris,
+                                                                   navitia::DateTimeUtils::set(0, "09:12"_t),
+                                                                   d, speed, 3600 + 60*12);
 #if BOOST_VERSION >= 105600
     BOOST_CHECK(boost::geometry::within(coord_Paris, isochrone));
     BOOST_CHECK(boost::geometry::within(coord_Notre_Dame, isochrone));
@@ -185,15 +186,15 @@ BOOST_AUTO_TEST_CASE(build_ischrons_test) {
     raptor.isochrone(d, navitia::DateTimeUtils::set(0, "08:00"_t), navitia::DateTimeUtils::set(0, "09:00"_t));
     double speed = 0.8;
 
-    navitia::type::MultiPolygon isochrone_9h = build_isochrones(raptor, true,
+    navitia::type::MultiPolygon isochrone_9h = build_isochrones(raptor, true, coord_Paris,
                                                                     navitia::DateTimeUtils::set(0, "09:00"_t),
                                                                     navitia::DateTimeUtils::set(0, "08:00"_t),
                                                                     d, speed, 3600, 0);
-    navitia::type::MultiPolygon isochrone_8h30 = build_isochrones(raptor, true,
+    navitia::type::MultiPolygon isochrone_8h30 = build_isochrones(raptor, true, coord_Paris,
                                                                     navitia::DateTimeUtils::set(0, "08:30"_t),
                                                                     navitia::DateTimeUtils::set(0, "08:00"_t),
                                                                     d, speed, 60 * 30, 0);
-    navitia::type::MultiPolygon isochrone_8h30_9h = build_isochrones(raptor, true,
+    navitia::type::MultiPolygon isochrone_8h30_9h = build_isochrones(raptor, true, coord_Paris,
                                                            navitia::DateTimeUtils::set(0, "09:00"_t),
                                                            navitia::DateTimeUtils::set(0, "08:30"_t),
                                                            d, speed, 3600, 60 * 30);


### PR DESCRIPTION
needs PR  in https://github.com/CanalTP/navitia-proto/pull/60

Kraken returns a string instead of a multipolygon and does not spend too much time in the marshall.

The circles are sorted with their distance to the origin, then they are merged.
It minimizes the number of polygons in the multipolygon during the merge.
