### PR TITLE
Doc: Departures example added in navitia.io documentation

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1030,11 +1030,11 @@ nop      | data_freshness   | enum                           | Define the freshn
 
 ``` shell
 
-#using "headers"
+#Request
 $ curl 'https://api.navitia.io/v1/coverage/sandbox/lines/line:RAT:M1/departures?from_datetime=20160615T1337' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
 
+#Response
 HTTP/1.1 200 OK
-
 {
    "departures":[
         {

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1028,6 +1028,60 @@ nop      | data_freshness   | enum                           | Define the freshn
 <a name="departures"></a>Departures
 -----------------------------------
 
+``` shell
+
+#using "headers"
+$ curl 'https://api.navitia.io/v1/coverage/sandbox/lines/line:RAT:M1/departures?from_datetime=20160615T1337' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
+
+HTTP/1.1 200 OK
+
+{
+   "departures":[
+        {
+            "display_informations":{
+                "direction":"Ch\u00e2teau de Vincennes (Saint-Mand\u00e9)",
+                "color":"F2C931",
+                "physical_mode":"M?tro",
+                "headsign":"Ch\u00e2teau de Vincennes",
+                "commercial_mode":"Metro",
+                "network":"RATP",
+                "..."
+            },
+            "stop_point":{
+                "name":"Esplanade de la D\u00e9fense",
+                "physical_modes":[
+                   {
+                      "name":"M?tro",
+                      "id":"physical_mode:Metro"
+                   }
+                ],
+                "coord":{
+                   "lat":"48.887843",
+                   "lon":"2.250442"
+                },
+                "label":"Esplanade de la D\u00e9fense (Puteaux)",
+                "id":"stop_point:RAT:SP:ESDEN2",
+                "..."
+            },
+            "route":{
+                "id":"route:RAT:M1_R",
+                "name":"Ch\u00e2teau de Vincennes - La D\u00e9fense",
+                "..."
+            },
+            "stop_date_time":{
+                "arrival_date_time":"20160615T133700",
+                "departure_date_time":"20160615T133700",
+                "base_arrival_date_time":"20160615T133700",
+                "base_departure_date_time":"20160615T133700"
+            }
+        },
+        {"...":"..."},
+        {"...":"..."},
+        {"...":"..."}
+   ]
+}
+```
+
 Also known as `/departures` service.
 
 This endpoint retrieves a list of departures from a specific datetime of a selected


### PR DESCRIPTION
- Navitia.io documentation updated (curl requests added in departures section)

Result:
![screen-departures-example-3](https://cloud.githubusercontent.com/assets/10560073/16117329/d75fd68c-33d1-11e6-8b87-4bc3e001cd58.png)
