### PR TITLE
ed: Use cache for building shape

### DIFF
--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -164,6 +164,8 @@ public:
 
     size_t count_too_long_connections = 0,
            count_empty_connections = 0;
+
+
     /**
          * trie les différentes donnée et affecte l'idx
          *


### PR DESCRIPTION
The shape of vjs has to be split between each stop points. This
operation is really heavy moslty because of a lot of comparaison of
distance between coord.

Most vehicle journeys of a line will have the same shape and almost all
of these vj will serve the same stop_point in the same order (In
most case a line have a small set of journey patterns).
So we cache the resulting geometry by shape_id, starting stop point id
and ending stop_point id.

On the NL dataset the improvement is phenomenal: before fusio2ed was
taking a little more than 1H10, after we are down to 12min!!!
