### PR TITLE
kraken: use a set in place of a vector of dataset

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -637,7 +637,7 @@ void builder::connection(const std::string & name1, const std::string & name2, f
     dataset->uri = "default:dataset";
     dataset->name = "default dataset";
     dataset->contributor = contributor;
-    contributor->dataset_list.push_back(dataset);
+    contributor->dataset_list.insert(dataset);
     this->data->pt_data->datasets.push_back(dataset);
     this->data->pt_data->datasets_map[dataset->uri] = dataset;
  }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -417,7 +417,7 @@ void EdReader::fill_datasets(nt::Data& data, pqxx::work& work){
         dataset->contributor = contributor_it->second;
         dataset->idx = data.pt_data->datasets.size();
 
-        dataset->contributor->dataset_list.push_back(dataset);
+        dataset->contributor->dataset_list.insert(dataset);
         data.pt_data->datasets.push_back(dataset);
         this->dataset_map[const_it["id"].as<idx_t>()] = dataset;
     }
@@ -895,7 +895,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work){
             auto dataset_it = this->dataset_map.find(const_it["dataset_id"].as<idx_t>());
             if(dataset_it != this->dataset_map.end()) {
                 vj->dataset = dataset_it->second;
-                vj->dataset->vehiclejourney_list.push_back(vj);
+                vj->dataset->vehiclejourney_list.insert(vj);
             }
         }
     }

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(physical_modes) {
     dataset->uri = "f1";
     dataset->name = "name-f1";
     dataset->contributor = contributor;
-    contributor->dataset_list.push_back(dataset);
+    contributor->dataset_list.insert(dataset);
     b.data->pt_data->datasets.push_back(dataset);
     vj_c->dataset = dataset;
 
@@ -824,14 +824,14 @@ BOOST_AUTO_TEST_CASE(contributor_and_dataset) {
 
     auto* dataset = b.add<nt::Dataset>("d1", "name-d1");
     dataset->contributor = contributor;
-    contributor->dataset_list.push_back(dataset);
+    contributor->dataset_list.insert(dataset);
 
     //dataset "d1" is assigned to vehicle_journey "vj:A:0"
     vj_a->dataset = dataset;
 
     dataset = b.add<nt::Dataset>("d2", "name-d2");
     dataset->contributor = contributor;
-    contributor->dataset_list.push_back(dataset);
+    contributor->dataset_list.insert(dataset);
 
     //dataset "d2" is assigned to vehicle_journey "vj:C:1"
     vj_c->dataset = dataset;
@@ -841,7 +841,7 @@ BOOST_AUTO_TEST_CASE(contributor_and_dataset) {
 
     dataset = b.add<nt::Dataset>("d3", "name-d3");
     dataset->contributor = contributor;
-    contributor->dataset_list.push_back(dataset);
+    contributor->dataset_list.insert(dataset);
 
     b.data->build_relations();
     b.finish();

--- a/source/tests/basic_routing_test.cpp
+++ b/source/tests/basic_routing_test.cpp
@@ -82,7 +82,7 @@ int main(int argc, const char* const argv[]) {
     ds->uri = "base_dataset";
     ds->name = "base dataset";
     ds->validation_period = period("20160101", "20161230");
-    ds->vehiclejourney_list.push_back(vj);
+    ds->vehiclejourney_list.insert(vj);
     vj->dataset = ds;
 
     navitia::type::Contributor* cr = new navitia::type::Contributor();
@@ -91,7 +91,7 @@ int main(int argc, const char* const argv[]) {
     cr->name = "base contributor";
     cr->license = "L-contributor";
     cr->website = "www.canaltp.fr";
-    cr->dataset_list.push_back(ds);
+    cr->dataset_list.insert(ds);
     ds->contributor = cr;
 
     b.data->pt_data->datasets.push_back(ds);

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -189,13 +189,13 @@ struct data_set {
         dataset->validation_period = period("20160101", "20161230");
 
         dataset->contributor = contributor;
-        contributor->dataset_list.push_back(dataset);
+        contributor->dataset_list.insert(dataset);
         b.data->pt_data->datasets.push_back(dataset);
 
         //Link between dataset and vehicle_journey
         vj = b.data->pt_data->vehicle_journeys.back();
         vj->dataset = dataset;
-        dataset->vehiclejourney_list.push_back(vj);
+        dataset->vehiclejourney_list.insert(vj);
 
         b.data->complete();
         b.data->build_raptor();

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -434,15 +434,11 @@ void Data::build_associated_calendar() {
 */
 static void build_datasets(navitia::type::VehicleJourney* vj){
     if(!vj->dataset) { return; }
-    if (vj->route && (!navitia::contains(vj->route->dataset_list, vj->dataset))){
-        vj->route->dataset_list.push_back(vj->dataset);
-    }
-    if (!navitia::contains(vj->dataset->vehiclejourney_list, vj)){
-        vj->dataset->vehiclejourney_list.push_back(vj);
-    }
+    vj->route->dataset_list.insert(vj->dataset);
+    vj->dataset->vehiclejourney_list.insert(vj);
     for(navitia::type::StopTime& st : vj->stop_time_list){
-        if(st.stop_point && (!navitia::contains(st.stop_point->dataset_list, vj->dataset))){
-            st.stop_point->dataset_list.push_back(vj->dataset);
+        if(st.stop_point){
+            st.stop_point->dataset_list.insert(vj->dataset);
         }
     }
 }

--- a/source/type/tests/fill_pb_object_tests.cpp
+++ b/source/type/tests/fill_pb_object_tests.cpp
@@ -168,16 +168,16 @@ BOOST_AUTO_TEST_CASE(ptref_indexes_test) {
     auto* c1 = b.add<nt::Contributor>("c1", "name-c1");
     auto* d1 = b.add<nt::Dataset>("d1", "name-d1");
     d1->contributor = c1;
-    c1->dataset_list.push_back(d1);
+    c1->dataset_list.insert(d1);
 
     auto* d2 = b.add<nt::Dataset>("d2", "name-d2");
     d2->contributor = c1;
-    c1->dataset_list.push_back(d2);
+    c1->dataset_list.insert(d2);
 
     auto* c2 = b.add<nt::Contributor>("c2", "name-c2");
     auto* d3 = b.add<nt::Dataset>("d3", "name-d3");
     d3->contributor = c2;
-    c2->dataset_list.push_back(d3);
+    c2->dataset_list.insert(d3);
 
     auto* vj_a = b.vj("A")("stop1", 8000, 8050).make();
     vj_a->dataset = d1;

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -654,6 +654,14 @@ template<typename T> Indexes indexes(const std::vector<T*>& elements){
     return result;
 }
 
+template<typename T> Indexes indexes(const std::set<T*>& elements){
+    Indexes result;
+    for(T* element : elements){
+        result.insert(element->idx);
+    }
+    return result;
+}
+
 Calendar::Calendar(boost::gregorian::date beginning_date) : validity_pattern(beginning_date) {}
 
 void Calendar::build_validity_pattern(boost::gregorian::date_period production_period) {
@@ -920,7 +928,7 @@ Indexes Dataset::get(Type_e type, const PT_Data&) const {
 Indexes Contributor::get(Type_e type, const PT_Data&) const {
     Indexes result;
     switch(type) {
-    case Type_e::Dataset: return indexes(dataset_list);
+        case Type_e::Dataset: return indexes(dataset_list);
     default: break;
     }
     return result;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -153,7 +153,7 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages {
     std::vector<navitia::georef::Admin*> admin_list;
     Network* network;
     std::vector<StopPointConnection*> stop_point_connection_list;
-    std::vector<Dataset*> dataset_list;
+    std::set<Dataset*> dataset_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         // The *_list are not serialized here to avoid stack abuse
@@ -300,7 +300,7 @@ struct Contributor : public Header, Nameable{
     const static Type_e type = Type_e::Contributor;
     std::string website;
     std::string license;
-    std::vector<Dataset*> dataset_list;
+    std::set<Dataset*> dataset_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & website & license & dataset_list;
@@ -316,7 +316,7 @@ struct Dataset : public Header, Nameable{
     boost::gregorian::date_period validation_period{boost::gregorian::date(), boost::gregorian::date()};
     std::string desc;
     std::string system;
-    std::vector<VehicleJourney*> vehiclejourney_list;
+    std::set<VehicleJourney*> vehiclejourney_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & uri & contributor & realtime_level & validation_period & desc & system;
@@ -596,7 +596,7 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties {
         // due to circular references we can't load the vjs in the dataset using only boost::serialize
         // so we need to save the vj in it's dataset
         if (dataset) {
-            dataset->vehiclejourney_list.push_back(this);
+            dataset->vehiclejourney_list.insert(this);
         }
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()
@@ -648,7 +648,7 @@ struct Route : public Header, Nameable, HasMessages {
 
     std::vector<DiscreteVehicleJourney*> discrete_vehicle_journey_list;
     std::vector<FrequencyVehicleJourney*> frequency_vehicle_journey_list;
-    std::vector<Dataset*> dataset_list;
+    std::set<Dataset*> dataset_list;
 
     type::hasOdtProperties get_odt_properties() const;
 


### PR DESCRIPTION
In ed2nav the building of dataset was really slow, almost 20% of the
time. It was the container that was really slow, with a set it take less
than 5%.

:warning: If this PR isn't merge in the same release than #1652 the version number of the data would need to be incremented

test run with NL dataset and without osm data:
before: 3min 20, gperf give us 28% in build dataset, all in contains call
after: 2min 32 , callgrind give us 0.12% in build_relations

I had some strange problems with gperf-tools after this changes, it seems to freeze randomly, there is a few known issues on x86-64.
