### PR TITLE
Stats: Change exchange type for stat and add api as the routing key

### DIFF
--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -134,7 +134,7 @@ class StatManager(object):
         """
         try:
             self.connection = kombu.Connection(self.broker_url)
-            exchange = kombu.Exchange(self.exchange_name, type="direct")
+            exchange = kombu.Exchange(self.exchange_name, type="topic")
             self.producer = self.connection.Producer(exchange=exchange)
         except:
             logging.getLogger(__name__).exception('Unable to activate the producer of stat')
@@ -485,7 +485,7 @@ class StatManager(object):
                 if self.producer is None:
                     #if the initialization failed we have to retry the creation of the objects
                     self._init_rabbitmq()
-                self.producer.publish(pbf)
+                self.producer.publish(pbf, routing_key=stat_request.api)
             except self.connection.connection_errors + self.connection.channel_errors:
                 logging.getLogger(__name__).exception('Server went away, will be reconnected..')
                 #Relese and close the previous connection
@@ -495,7 +495,7 @@ class StatManager(object):
                 self._init_rabbitmq()
                 #If connection is established publish the stat message.
                 if self.save_stat:
-                    self.producer.publish(pbf)
+                    self.producer.publish(pbf, routing_key=stat_request.api)
 
     def fill_admin_from(self, stat_section, admin):
         if admin[0]:


### PR DESCRIPTION
This PR changes the exchange type used by Jormungandr to post the stat messages.

The use of a topic will ease the filtering of messages based upon the api type, and avoid to check all the messages when only the 'v1.journeys' requests are needed.

This will have impacts on stat-persistor, quota-manager which will need to be updated first. navitia-leds will need to be updated after.

Moreover, this suppose the exchange name to be different from the one used currently (to avoid rejection by RabbitMQ).
