### PR TITLE
osm2ed: remove a lot of useless node

### DIFF
--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -97,7 +97,7 @@ struct OSMNode {
     }
 
     bool is_used() const {
-        return is_used_more_than_once() || is_first_or_last() || admin != nullptr;
+        return is_used_more_than_once() || is_first_or_last();
     }
 
     bool is_first_or_last() const {


### PR DESCRIPTION
A lot of node where inserted in the database but weren't used and had to
be removed in ed2nav.

In green we have the nodes before the modification, and in blue/purple after:
![node_osm](https://cloud.githubusercontent.com/assets/448185/16310471/edf1bf6e-396c-11e6-9e8f-8b4af5786672.jpg)
