### PR TITLE
graphical_isochrones_test failing if dateutil > 2.4.0

### DIFF
--- a/source/jormungandr/tests/graphical_isochrones_tests.py
+++ b/source/jormungandr/tests/graphical_isochrones_tests.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 from .tests_mechanism import AbstractTestFixture, dataset
 from .check_utils import *
 from jormungandr import app
+from nose.tools import eq_
 from shapely.geometry import asShape, Point
 
 
@@ -275,7 +276,7 @@ class TestGraphicalIsochrone(AbstractTestFixture):
         normal_response, error_code = self.query_no_assert(p)
 
         assert error_code == 400
-        assert normal_response['message'] == 'Unable to parse datetime, unknown string format'
+        eq_(normal_response['message'].lower(), 'unable to parse datetime, unknown string format')
 
     def test_graphical_isochros_no_isochrones(self):
         q = "v1/coverage/main_routing_test/isochrones?datetime={}&from={}&max_duration={}"


### PR DESCRIPTION
Hello.

I was testing the last release of navitia and I have an error when running `make test`.

```
56/59 Test #56: jormungandr ........................   Passed    2.06 sec
      Start 57: jormungandr_integration_tests
57/59 Test #57: jormungandr_integration_tests ......***Failed   35.73 sec
      Start 58: disruption_test
58/59 Test #58: disruption_test ....................   Passed    0.05 sec
```

Here is the error : 

```
======================================================================
FAIL: tests.graphical_isochrons_tests.TestGraphicalIsochron.test_graphical_isochrons_invalid_datetime
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/eturck/Git/navitia/.venv/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/eturck/Git/navitia/source/jormungandr/tests/graphical_isochrons_tests.py", line 249, in test_graphical_isochrons_invalid_datetime
    assert normal_response['message'] == 'Unable to parse datetime, unknown string format'
AssertionError:
-------------------- >> begin captured logging << --------------------
jormungandr.exceptions: DEBUG: BadRequest Unable to parse datetime, year is out of range http://localhost/v1/coverage/main_routing_test/isochrons?datetime=2005061&from=0.0000898312%3B0.0000898312&max_duration=3600
jormungandr.access: INFO: "GET /v1/coverage/main_routing_test/isochrons?datetime=2005061&from=0.0000898312;0.0000898312&max_duration=3600" 400
jormungandr.exceptions: DEBUG: BadRequest Unable to parse datetime, Unknown string format http://localhost/v1/coverage/main_routing_test/isochrons?datetime=toto&from=0.0000898312%3B0.0000898312&max_duration=3600
jormungandr.access: INFO: "GET /v1/coverage/main_routing_test/isochrons?datetime=toto&from=0.0000898312;0.0000898312&max_duration=3600" 400
--------------------- >> end captured logging << ---------------------
```

There is a slight difference on the second error message : 

```
assert normal_response['message'] == 'Unable to parse datetime, unknown string format'
jormungandr.exceptions: DEBUG: BadRequest Unable to parse datetime, Unknown string format
```

This is caused by dateutil who made the change on January 2015, you can see the diff here : https://github.com/dateutil/dateutil/commit/d3cad5dcd51939fd59330b27216ebabb90fe58f7#diff-ed798069162e7ab7db9a45da6c4a076fL315
This was introduced in 2.4.1, I have 2.4.2.

The jormungandr requirements download dateutil 1.5, I only encoutered the problem because I installed tyr dev requirements in the same virtualenv. I don't really know if it's something you want to merge, but since everything seems to work as intended except for this, here it is! Commit totally inspired by ebca7ee00f906a73d30ba74870a60a219784789d, thanks @antoine-de :smiley:
