### PR TITLE
Jorm: add an API "geo_status" providing stats on georef data

### DIFF
--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -449,8 +449,15 @@ void EdPersistor::insert_metadata(const navitia::type::MetaData& meta) {
 
 void EdPersistor::insert_metadata_georef() {
     // If we do one poi2ed, we don't want to read pois from OSM anymore
-    this->lotus.exec(Lotus::make_upsert_string("navitia.parameters",
-                {{"parse_pois_from_osm", is_osm_reader ? "t" : "f"}}));
+    std::vector<std::pair<std::string, std::string>> values = {{"parse_pois_from_osm", (is_osm_reader && parse_pois) ? "t" : "f"}};
+
+    if(!street_network_source.empty()){
+        values.push_back({"street_network_source", street_network_source});
+    }
+    if(parse_pois && !poi_source.empty()){
+        values.push_back({"poi_source", poi_source});
+    }
+    this->lotus.exec(Lotus::make_upsert_string("navitia.parameters", values));
 }
 
 void EdPersistor::clean_georef(){

--- a/source/ed/ed_persistor.h
+++ b/source/ed/ed_persistor.h
@@ -45,9 +45,11 @@ struct EdPersistor{
     log4cplus::Logger logger;
     bool parse_pois = true, is_osm_reader;
 
+    std::string poi_source = "";
+    std::string street_network_source = "";
 
-    EdPersistor(const std::string& connection_string,
-            const bool is_osm_reader = true);
+
+    EdPersistor(const std::string& connection_string, const bool is_osm_reader = true);
 
     std::set<std::string> ignored_uris;
 
@@ -78,11 +80,11 @@ struct EdPersistor{
     void insert_poi_properties(const ed::Georef& data);
 
     void compute_bounding_shape();
+    void insert_metadata_georef();
 
 private:
     void insert_feed_info(const std::map<std::string, std::string>& feed_infos);
     void insert_metadata(const navitia::type::MetaData& meta);
-    void insert_metadata_georef();
     void insert_sa_sp_properties(const ed::Data& data);
     void insert_stop_areas(const std::vector<types::StopArea*>& stop_areas);
 

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -248,7 +248,8 @@ void EdReader::fill_object_codes(navitia::type::Data& data, pqxx::work& work){
 }
 
 void EdReader::fill_meta(navitia::type::Data& nav_data, pqxx::work& work){
-    std::string request = "SELECT beginning_date, end_date, st_astext(shape) as bounding_shape FROM navitia.parameters";
+    std::string request = "SELECT beginning_date, end_date, st_astext(shape) as bounding_shape,"
+        "street_network_source, poi_source  FROM navitia.parameters";
     pqxx::result result = work.exec(request);
 
     if (result.empty()) {
@@ -266,6 +267,12 @@ void EdReader::fill_meta(navitia::type::Data& nav_data, pqxx::work& work){
     bg::date end = bg::from_string(const_it["end_date"].as<std::string>()) + bg::days(1);
 
     nav_data.meta->production_date = bg::date_period(begin, end);
+    if (!const_it["poi_source"].is_null()){
+        const_it["poi_source"].to(nav_data.meta->poi_source);
+    }
+    if (!const_it["street_network_source"].is_null()){
+        const_it["street_network_source"].to(nav_data.meta->street_network_source);
+    }
 
     const_it["bounding_shape"].to(nav_data.meta->shape);
 }

--- a/source/ed/geopal2ed.cpp
+++ b/source/ed/geopal2ed.cpp
@@ -99,6 +99,7 @@ int main(int argc, char * argv[])
     }
 
     ed::EdPersistor p(connection_string);
+    p.street_network_source = "geopal";
     p.persist(geopal_parser.data);
 
     LOG4CPLUS_INFO(logger, "time to load geopal: " << to_simple_string(pt::microsec_clock::local_time() - start));

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -1024,6 +1024,8 @@ int main(int argc, char** argv) {
     po::notify(vm);
 
     ed::EdPersistor persistor(connection_string);
+    persistor.street_network_source = "osm";
+    persistor.poi_source = "osm";
     persistor.clean_georef();
     persistor.clean_poi();
 
@@ -1052,5 +1054,6 @@ int main(int argc, char** argv) {
     poi_visitor.finish();
     LOG4CPLUS_INFO(logger, "compute bounding shape");
     persistor.compute_bounding_shape();
+    persistor.insert_metadata_georef();
     return 0;
 }

--- a/source/ed/poi2ed.cpp
+++ b/source/ed/poi2ed.cpp
@@ -101,6 +101,7 @@ int main(int argc, char * argv[])
     }
 
     ed::EdPersistor p(connection_string, false);
+    p.poi_source = "poi2ed";
     p.persist_pois(poi_parser.data);
     LOG4CPLUS_INFO(logger, "time to load the pois: " << to_simple_string(pt::microsec_clock::local_time() - start));
 

--- a/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
+++ b/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
@@ -56,4 +56,4 @@ class GeoStatusResponse(object):
         self.nb_admins_from_cities = None
         self.nb_ways = None
         self.nb_addresses = None
-        self.nb_poi = None
+        self.nb_pois = None

--- a/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
+++ b/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
@@ -42,3 +42,18 @@ class AbstractAutocomplete(object):
     @abstractmethod
     def get(self, query, instance):
         pass
+
+    @abstractmethod
+    def geo_status(self, instance):
+        pass
+
+
+class GeoStatusResponse(object):
+    def __init__(self):
+        self.street_network_sources = []
+        self.poi_sources = []
+        self.nb_admins = None
+        self.nb_admins_from_cities = None
+        self.nb_ways = None
+        self.nb_addresses = None
+        self.nb_poi = None

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -74,4 +74,7 @@ class GeocodeJson(AbstractAutocomplete):
 
         return raw_response.json()
 
+    def geo_status(self, instance):
+        raise NotImplementedError
+
 

--- a/source/jormungandr/jormungandr/autocomplete/kraken.py
+++ b/source/jormungandr/jormungandr/autocomplete/kraken.py
@@ -83,7 +83,7 @@ class Kraken(AbstractAutocomplete):
         req.requested_api = type_pb2.geo_status
         resp = instance.send_and_receive(req)
         status = GeoStatusResponse()
-        status.nb_poi = resp.geo_status.nb_poi
+        status.nb_pois = resp.geo_status.nb_poi
         status.nb_ways = resp.geo_status.nb_ways
         status.nb_admins = resp.geo_status.nb_admins
         status.nb_addresses = resp.geo_status.nb_addresses

--- a/source/jormungandr/jormungandr/autocomplete/kraken.py
+++ b/source/jormungandr/jormungandr/autocomplete/kraken.py
@@ -29,7 +29,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
-from jormungandr.autocomplete.abstract_autocomplete import AbstractAutocomplete
+from jormungandr.autocomplete.abstract_autocomplete import AbstractAutocomplete, GeoStatusResponse
 from jormungandr.scenarios.utils import build_pagination, pb_type
 from jormungandr.interfaces.v1.fields import NonNullList, place, NonNullNested, PbField, error, feed_publisher,\
     disruption_marshaller
@@ -77,3 +77,19 @@ class Kraken(AbstractAutocomplete):
             resp = instance.send_and_receive(req)
         build_pagination(request, resp)
         return resp
+
+    def geo_status(self, instance):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.geo_status
+        resp = instance.send_and_receive(req)
+        status = GeoStatusResponse()
+        status.nb_poi = resp.geo_status.nb_poi
+        status.nb_ways = resp.geo_status.nb_ways
+        status.nb_admins = resp.geo_status.nb_admins
+        status.nb_addresses = resp.geo_status.nb_addresses
+        status.nb_admins_from_cities = resp.geo_status.nb_admins_from_cities
+        if resp.geo_status.street_network_source:
+            status.street_network_sources.append(resp.geo_status.street_network_source)
+        if resp.geo_status.poi_source:
+            status.poi_sources.append(resp.geo_status.poi_source)
+        return status

--- a/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
@@ -38,7 +38,7 @@ geo_status = {
             'nb_admins_from_cities': fields.Raw,
             'nb_ways': fields.Raw,
             'nb_addresses': fields.Raw,
-            'nb_poi': fields.Raw,
+            'nb_pois': fields.Raw,
             'poi_sources': fields.List(fields.String),
         })
 }

--- a/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from flask.ext.restful import Resource, fields, marshal_with
+from jormungandr import i_manager
+from jormungandr.protobuf_to_dict import protobuf_to_dict
+from jormungandr import app
+
+geo_status = {
+        'geo_status': fields.Nested({'street_network_source': fields.Raw,
+            'nb_admins': fields.Raw,
+            'nb_admins_from_cities': fields.Raw,
+            'nb_ways': fields.Raw,
+            'nb_addresses': fields.Raw,
+            'nb_poi': fields.Raw,
+        })
+}
+
+class GeoStatus(Resource):
+    @marshal_with(geo_status)
+    def get(self, region):
+        response = protobuf_to_dict(i_manager.dispatch({}, "geo_status", instance_name=region), use_enum_labels=True)
+        response['geo_status']
+        return response, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
@@ -30,22 +30,21 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from flask.ext.restful import Resource, fields, marshal_with
 from jormungandr import i_manager
-from jormungandr.protobuf_to_dict import protobuf_to_dict
 from jormungandr import app
 
 geo_status = {
-        'geo_status': fields.Nested({'street_network_source': fields.Raw,
+        'geo_status': fields.Nested({'street_network_sources': fields.List(fields.String),
             'nb_admins': fields.Raw,
             'nb_admins_from_cities': fields.Raw,
             'nb_ways': fields.Raw,
             'nb_addresses': fields.Raw,
             'nb_poi': fields.Raw,
-            'poi_source': fields.Raw,
+            'poi_sources': fields.List(fields.String),
         })
 }
 
 class GeoStatus(Resource):
     @marshal_with(geo_status)
     def get(self, region):
-        response = i_manager.dispatch({}, "geo_status", instance_name=region)
-        return response, 200
+        instance = i_manager.get_instances(region)[0]
+        return {'geo_status': instance.autocomplete.geo_status(instance)}, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GeoStatus.py
@@ -40,12 +40,12 @@ geo_status = {
             'nb_ways': fields.Raw,
             'nb_addresses': fields.Raw,
             'nb_poi': fields.Raw,
+            'poi_source': fields.Raw,
         })
 }
 
 class GeoStatus(Resource):
     @marshal_with(geo_status)
     def get(self, region):
-        response = protobuf_to_dict(i_manager.dispatch({}, "geo_status", instance_name=region), use_enum_labels=True)
-        response['geo_status']
+        response = i_manager.dispatch({}, "geo_status", instance_name=region)
         return response, 200

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -41,6 +41,7 @@ from jormungandr.interfaces.v1 import Disruptions
 from jormungandr.interfaces.v1 import Calendars
 from jormungandr.interfaces.v1 import converters_collection_type
 from jormungandr.interfaces.v1 import Status
+from jormungandr.interfaces.v1 import GeoStatus
 from werkzeug.routing import BaseConverter, FloatConverter, PathConverter
 from jormungandr.modules_loader import AModule
 from jormungandr import app
@@ -225,6 +226,9 @@ class V1Routing(AModule):
         self.add_resource(Status.Status,
                           region + 'status',
                           endpoint='status')
+        self.add_resource(GeoStatus.GeoStatus,
+                          region + 'geo_status',
+                          endpoint='geo_status')
 
         self.add_resource(Calendars.Calendars,
                           region + 'calendars',

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -227,7 +227,7 @@ class V1Routing(AModule):
                           region + 'status',
                           endpoint='status')
         self.add_resource(GeoStatus.GeoStatus,
-                          region + 'geo_status',
+                          region + '_geo_status',
                           endpoint='geo_status')
 
         self.add_resource(Calendars.Calendars,

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -58,6 +58,12 @@ class Scenario(object):
         resp = instance.send_and_receive(req)
         return resp
 
+    def geo_status(self, request, instance):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.geo_status
+        resp = instance.send_and_receive(req)
+        return resp
+
     def metadatas(self, request, instance):
         req = request_pb2.Request()
         req.requested_api = type_pb2.METADATAS

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -156,7 +156,7 @@ class TestEndPoint(AbstractTestFixture):
         assert json_response["status"]["is_open_data"] == False
 
     def test_geo_status(self):
-        response = self.query('/v1/coverage/main_routing_test/geo_status', display=True)
+        response = self.query('/v1/coverage/main_routing_test/_geo_status', display=True)
         assert response['geo_status']
         assert response['geo_status']['nb_ways'] > 0
         assert response['geo_status']['nb_pois'] > 0

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -154,3 +154,14 @@ class TestEndPoint(AbstractTestFixture):
 
         is_valid_region_status(get_not_null(json_response, "status"))
         assert json_response["status"]["is_open_data"] == False
+
+    def test_geo_status(self):
+        response = self.query('/v1/coverage/main_routing_test/geo_status', display=True)
+        assert response['geo_status']
+        assert response['geo_status']['nb_ways'] > 0
+        assert response['geo_status']['nb_pois'] > 0
+        assert response['geo_status']['nb_admins'] > 0
+        assert response['geo_status']['nb_addresses'] > 0
+        assert response['geo_status']['nb_admins_from_cities'] == 0
+        assert response['geo_status']['street_network_sources'] == []
+        assert response['geo_status']['poi_sources'] == []

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -150,6 +150,8 @@ pbnavitia::Response Worker::geo_status() {
             });
     status->set_nb_admins_from_cities(nb_admins_from_cities);
     status->set_nb_poi(d->geo_ref->pois.size());
+    status->set_poi_source(d->meta->poi_source);
+    status->set_street_network_source(d->meta->street_network_source);
     return result;
 }
 
@@ -172,9 +174,6 @@ pbnavitia::Response Worker::status() {
         status->set_start_production_date(bg::to_iso_string(d->meta->production_date.begin()));
         status->set_end_production_date(bg::to_iso_string(d->meta->production_date.last()));
         status->set_dataset_created_at(pt::to_iso_string(d->meta->dataset_created_at));
-        for(auto data_sources: d->meta->data_sources){
-            status->add_data_sources(data_sources);
-        }
     } else {
         status->set_publication_date("");
         status->set_start_production_date("");

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -133,6 +133,26 @@ static std::string get_string_status(const boost::shared_ptr<const nt::Data>& da
     return "no_data";
 }
 
+pbnavitia::Response Worker::geo_status() {
+    pbnavitia::Response result;
+    auto status = result.mutable_geo_status();
+    const auto d = data_manager.get_data();
+    status->set_nb_admins(d->geo_ref->admins.size());
+    status->set_nb_ways(d->geo_ref->ways.size());
+    int nb_addr = std::accumulate(begin(d->geo_ref->ways), end(d->geo_ref->ways), 0,
+            [](int sum, const georef::Way* w) {
+                return sum + w->house_number_left.size() + w->house_number_right.size();
+            });
+    status->set_nb_addresses(nb_addr);
+    int nb_admins_from_cities = std::accumulate(begin(d->geo_ref->admins), end(d->geo_ref->admins), 0,
+            [](int sum, const georef::Admin* a) {
+                return (a->from_original_dataset ? sum : sum + 1);
+            });
+    status->set_nb_admins_from_cities(nb_admins_from_cities);
+    status->set_nb_poi(d->geo_ref->pois.size());
+    return result;
+}
+
 pbnavitia::Response Worker::status() {
     pbnavitia::Response result;
     auto status = result.mutable_status();
@@ -777,6 +797,7 @@ pbnavitia::Response Worker::dispatch(const pbnavitia::Request& request) {
     case pbnavitia::place_code : response = place_code(request.place_code()); break;
     case pbnavitia::nearest_stop_points : response = nearest_stop_points(request.nearest_stop_points()); break;
     case pbnavitia::graphical_isochrone : response = graphical_isochrone(request.isochrone(), current_datetime); break;
+    case pbnavitia::geo_status: response = geo_status(); break;
     default:
         LOG4CPLUS_WARN(logger, "Unknown API : " + API_Name(request.requested_api()));
         fill_pb_error(pbnavitia::Error::unknown_api, "Unknown API", response.mutable_error());

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -95,6 +95,7 @@ class Worker {
         void metadatas(pbnavitia::Response& response);
         void feed_publisher(pbnavitia::Response& response);
         pbnavitia::Response status();
+        pbnavitia::Response geo_status();
         pbnavitia::Response autocomplete(const pbnavitia::PlacesRequest &request,
                                          const boost::posix_time::ptime& current_datetime);
         pbnavitia::Response place_uri(const pbnavitia::PlaceUriRequest &request,

--- a/source/sql/alembic/versions/4429fe91ac94_add_poi_and_streetnetwork_source.py
+++ b/source/sql/alembic/versions/4429fe91ac94_add_poi_and_streetnetwork_source.py
@@ -1,0 +1,25 @@
+"""add source for poi and street_network
+
+Revision ID: 4429fe91ac94
+Revises: 27fae61b6786
+Create Date: 2016-07-07 16:30:29.214966
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4429fe91ac94'
+down_revision = '27fae61b6786'
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2 as ga
+
+
+def upgrade():
+    op.add_column('parameters', sa.Column('poi_source', sa.TEXT(), nullable=True), schema='navitia')
+    op.add_column('parameters', sa.Column('street_network_source', sa.TEXT(), nullable=True), schema='navitia')
+
+
+def downgrade():
+    op.drop_column('parameters', 'street_network_source', schema='navitia')
+    op.drop_column('parameters', 'poi_source', schema='navitia')

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -64,7 +64,7 @@ namespace navitia { namespace type {
 
 wrong_version::~wrong_version() noexcept {}
 
-const unsigned int Data::data_version = 59; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 60; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     data_identifier(data_identifier),

--- a/source/type/meta_data.h
+++ b/source/type/meta_data.h
@@ -45,7 +45,6 @@ struct MetaData{
 
     boost::posix_time::ptime publication_date;
 
-    std::vector<std::string> data_sources;
 
     std::string shape;
 
@@ -54,6 +53,8 @@ struct MetaData{
     std::string license;
     std::string instance_name;
     boost::posix_time::ptime dataset_created_at;
+    std::string poi_source;
+    std::string street_network_source;
 
     MetaData() : production_date(boost::gregorian::date(), boost::gregorian::date()) {}
 
@@ -62,8 +63,9 @@ struct MetaData{
       * Elle est appelée par boost et pas directement
       */
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
-        ar & production_date & publication_date & data_sources & shape &
-                publisher_name & publisher_url & license & instance_name & dataset_created_at;
+        ar & production_date & publication_date & shape & publisher_name
+            & publisher_url & license & instance_name & dataset_created_at
+            & poi_source & street_network_source;
     }
     boost::posix_time::time_period production_period() const {
         namespace pt = boost::posix_time;


### PR DESCRIPTION
This PR is related to http://jira.canaltp.fr/browse/NAVITIAII-2150
The goal of this API is to provide statistics on georef data, it isn't
at destination of our users but more for the data team, it will help
them see the impacts of their update

Maybe georef_stats would be better
require: https://github.com/CanalTP/navitia-proto/pull/63

More is coming
