### PR TITLE
All: expose car_co2_emission in context

### DIFF
--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -61,4 +61,14 @@ class Kraken(object):
         response = self.instance.send_and_receive(req)
         return response.places[0]
 
+    def get_car_co2_emission_on_crow_fly(self, origin, destination):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.car_co2_emission
+        req.car_co2_emission.origin.place = origin
+        req.car_co2_emission.origin.access_duration = 0
+        req.car_co2_emission.destination.place = destination
+        req.car_co2_emission.destination.access_duration = 0
+
+        response = self.instance.send_and_receive(req)
+        return response.car_co2_emission
 

--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -28,7 +28,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from navitiacommon import request_pb2, type_pb2
+from navitiacommon import request_pb2, response_pb2, type_pb2
 
 class Kraken(object):
 
@@ -70,5 +70,8 @@ class Kraken(object):
         req.car_co2_emission.destination.access_duration = 0
 
         response = self.instance.send_and_receive(req)
+        if response.error and response.error.id == \
+                response_pb2.Error.error_id.Value('no_solution'):
+            return None
         return response.car_co2_emission
 

--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -29,6 +29,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 from navitiacommon import request_pb2, response_pb2, type_pb2
+import logging
 
 class Kraken(object):
 
@@ -62,6 +63,7 @@ class Kraken(object):
         return response.places[0]
 
     def get_car_co2_emission_on_crow_fly(self, origin, destination):
+        logger = logging.getLogger(__name__)
         req = request_pb2.Request()
         req.requested_api = type_pb2.car_co2_emission
         req.car_co2_emission.origin.place = origin
@@ -72,6 +74,8 @@ class Kraken(object):
         response = self.instance.send_and_receive(req)
         if response.error and response.error.id == \
                 response_pb2.Error.error_id.Value('no_solution'):
+            logger.error("Cannot compute car co2 emission from {} to {}"
+                         .format(origin, destination))
             return None
         return response.car_co2_emission
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -38,7 +38,7 @@ from jormungandr import i_manager, app
 from jormungandr.interfaces.v1.fields import disruption_marshaller, Links
 from jormungandr.interfaces.v1.fields import display_informations_vj, error, place,\
     PbField, stop_date_time, enum_type, NonNullList, NonNullNested,\
-    SectionGeoJson, Co2Emission, PbEnum, feed_publisher, Durations
+    SectionGeoJson, PbEnum, feed_publisher, Durations
 
 from jormungandr.interfaces.parsers import option_value, date_time_format, default_count_arg_type, date_time_format
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri, complete_links
@@ -194,7 +194,10 @@ section = {
     "base_departure_date_time": DateTime(attribute="base_begin_date_time"),
     "arrival_date_time": DateTime(attribute="end_date_time"),
     "base_arrival_date_time": DateTime(attribute="base_end_date_time"),
-    "co2_emission": Co2Emission(),
+    "co2_emission": NonNullNested({
+        'value': fields.Raw,
+        'unit': fields.String
+        }),
 }
 
 cost = {
@@ -222,7 +225,10 @@ journey = {
     'tags': fields.List(fields.String),
     "status": fields.String(attribute="most_serious_disruption_effect"),
     "calendars": NonNullList(NonNullNested(calendar)),
-    "co2_emission": Co2Emission(),
+    "co2_emission": NonNullNested({
+        'value': fields.Raw,
+        'unit': fields.String
+        }),
     "durations": Durations(),
     "debug": JourneyDebugInfo()
 }

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -237,10 +237,12 @@ ticket = {
 }
 
 context = {
-    'car_co2_emission': NonNullNested({
-        'value': fields.Raw,
-        'unit': fields.String
-    })
+    'car_direct_path': {
+        'co2_emission': NonNullNested({
+            'value': fields.Raw,
+            'unit': fields.String
+        }, attribute="car_co2_emission")
+    }
 }
 
 journeys = {

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -236,6 +236,9 @@ ticket = {
     "links": TicketLinks(attribute="section_id")
 }
 
+context = {
+    "car_co2_emission": Co2Emission()
+}
 
 journeys = {
     "journeys": NonNullList(NonNullNested(journey)),
@@ -244,6 +247,7 @@ journeys = {
     "disruptions": fields.List(NonNullNested(disruption_marshaller), attribute="impacts"),
     "feed_publishers": fields.List(NonNullNested(feed_publisher)),
     "links": fields.List(Links()),
+    "context": context,
 }
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -237,7 +237,10 @@ ticket = {
 }
 
 context = {
-    "car_co2_emission": Co2Emission()
+    'car_co2_emission': NonNullNested({
+        'value': fields.Raw,
+        'unit': fields.String
+    })
 }
 
 journeys = {

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -426,18 +426,6 @@ class MultiPolyGeoJson(fields.Raw):
 
         return response
 
-
-class Co2Emission(fields.Raw):
-    def output(self, key, obj):
-        if not obj.HasField(key):
-            return
-        co2_emission = getattr(obj, key)
-        return {
-            'value': co2_emission.value,
-            'unit': co2_emission.unit
-        }
-
-
 class Durations(fields.Raw):
     def output(self, key, obj):
         if not obj.HasField(b"durations"):

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -429,11 +429,12 @@ class MultiPolyGeoJson(fields.Raw):
 
 class Co2Emission(fields.Raw):
     def output(self, key, obj):
-        if not obj.HasField(b"co2_emission"):
+        if not obj.HasField(key):
             return
+        co2_emission = getattr(obj, key)
         return {
-            'value': obj.co2_emission.value,
-            'unit': obj.co2_emission.unit
+            'value': co2_emission.value,
+            'unit': co2_emission.unit
         }
 
 

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -177,18 +177,15 @@ def tag_journeys(resp):
     tag the journeys
     """
     # if there is no available car_co2_emission in resp, no tag will be assigned
-    if not resp.car_co2_emission.value and \
-            not resp.car_co2_emission.unit:
-        return
-
-    for j in resp.journeys:
-        if not j.HasField('co2_emission'):
-            j.tags.append('ecologic')
-            continue
-        if j.co2_emission.unit != resp.car_co2_emission.unit:
-            continue
-        if j.co2_emission.value < resp.car_co2_emission.value * 0.5:
-            j.tags.append('ecologic')
+    if resp.car_co2_emission.value and resp.car_co2_emission.unit:
+        for j in resp.journeys:
+            if not j.HasField('co2_emission'):
+                j.tags.append('ecologic')
+                continue
+            if j.co2_emission.unit != resp.car_co2_emission.unit:
+                continue
+            if j.co2_emission.value < resp.car_co2_emission.value * 0.5:
+                j.tags.append('ecologic')
 
 
 def _get_section_id(section):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -156,36 +156,38 @@ def sort_journeys(resp, journey_order, clockwise):
         resp.journeys.sort(journey_sorter[journey_order](clockwise=clockwise))
 
 
-def tag_journeys(resp, request, instance):
-    """
-    qualify the journeys
-    """
-    car = next((j for j in resp.journeys if helpers.is_car_direct_path(j)), None)
-    co2_emission_value = 0
-    co2_emission_unit = 0
+def compute_car_co2_emission(pb_resp, api_request, instance):
+    car = next((j for j in pb_resp.journeys if helpers.is_car_direct_path(j)), None)
     if car is None or not car.HasField('co2_emission'):
         # if there is no car journey found, we request kraken to give us an estimation of
         # co2 emission
-        from jormungandr.georef import Kraken
-        co2_estimation = Kraken(instance).get_car_co2_emission_on_crow_fly(request['origin'], request['destination'])
-        co2_emission_value = co2_estimation.value
-        co2_emission_unit = co2_estimation.unit
+        co2_estimation = instance.georef.get_car_co2_emission_on_crow_fly(api_request['origin'], api_request['destination'])
+        if co2_estimation:
+            # Assign car_co2_emission into the resp, these value will be exposed in the final result
+            pb_resp.car_co2_emission.value = co2_estimation.value
+            pb_resp.car_co2_emission.unit = co2_estimation.unit
     else:
-        co2_emission_value = car.co2_emission.value
-        co2_emission_unit = car.co2_emission.unit
+        # Assign car_co2_emission into the resp, these value will be exposed in the final result
+        pb_resp.car_co2_emission.value = car.co2_emission.value
+        pb_resp.car_co2_emission.unit = car.co2_emission.unit
+
+
+def tag_journeys(resp):
+    """
+    tag the journeys
+    """
+    # if there is no available car_co2_emission in resp, no tag will be assigned
+    if not resp.car_co2_emission.value and \
+            not resp.car_co2_emission.unit:
+        return
 
     for j in resp.journeys:
         if not j.HasField('co2_emission'):
             j.tags.append('ecologic')
             continue
-        if j.co2_emission.unit != co2_emission_unit:
+        if j.co2_emission.unit != resp.car_co2_emission.unit:
             continue
-
-        # Assign car_co2_emission into the resp, these value will be exposed in the final result
-        resp.car_co2_emission.value = co2_emission_value
-        resp.car_co2_emission.unit = co2_emission_unit
-
-        if j.co2_emission.value < co2_emission_value * 0.5:
+        if j.co2_emission.value < resp.car_co2_emission.value * 0.5:
             j.tags.append('ecologic')
 
 
@@ -672,7 +674,8 @@ class Scenario(simple.Scenario):
         pb_resp = merge_responses(responses)
 
         sort_journeys(pb_resp, instance.journey_order, api_request['clockwise'])
-        tag_journeys(pb_resp, api_request, instance)
+        compute_car_co2_emission(pb_resp, api_request, instance)
+        tag_journeys(pb_resp)
         journey_filter.delete_journeys((pb_resp,), api_request)
         type_journeys(pb_resp, api_request)
         culling_journeys(pb_resp, api_request)

--- a/source/jormungandr/tests/bss_provider_tests.py
+++ b/source/jormungandr/tests/bss_provider_tests.py
@@ -265,7 +265,7 @@ class TestBssProvider(AbstractTestFixture):
 
     def pois_without_stands_on_places_nearby_test(self):
         with mock_bss_providers(pois_supported=['station_unknown']):
-            r = self.query_region("places/stop_area:stop1/places_nearby", display=False)
+            r = self.query_region("places/admin:74435/places_nearby", display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
             assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',
@@ -281,7 +281,7 @@ class TestBssProvider(AbstractTestFixture):
 
     def pois_with_stands_on_second_places_nearby_test(self):
         with mock_bss_providers(pois_supported=['station_1']):
-            r = self.query_region('places/stop_area:stop1/places_nearby', display=False)
+            r = self.query_region('places/admin:74435/places_nearby', display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
             assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',
@@ -306,7 +306,7 @@ class TestBssProvider(AbstractTestFixture):
 
     def pois_with_stands_on_all_places_nearby_test(self):
         with mock_bss_providers(pois_supported=[]):
-            r = self.query_region('places/stop_area:stop1/places_nearby', display=False)
+            r = self.query_region('places/admin:74435/places_nearby', display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
             assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',

--- a/source/jormungandr/tests/places_test.py
+++ b/source/jormungandr/tests/places_test.py
@@ -157,3 +157,10 @@ class TestPlaces(AbstractTestFixture):
 
         eq_(status, 404)
         assert(get_not_null(response, 'message'))
+
+    def test_non_existent_places_nearby(self):
+        """test that a non existing place URI"""
+        place_id = "I_am_not_existent"
+        response, status = self.query_region("places/{}/places_nearby".format(place_id), check=False)
+
+        eq_(response["error"]["message"], "The entry point: {} is not valid".format(place_id))

--- a/source/jormungandr/tests/routing_tests_new_default.py
+++ b/source/jormungandr/tests/routing_tests_new_default.py
@@ -173,13 +173,14 @@ class TestJourneysNewDefault(AbstractTestFixture):
         response = self.query_region(query)
         check_journeys(response)
         assert 'context' in response
-        assert 'car_co2_emission' in response['context']
+        assert 'car_direct_path' in response['context']
+        assert 'co2_emission' in response['context']['car_direct_path']
         assert len(response["journeys"]) == 3
 
-        assert response['context']['car_co2_emission']['value'] == \
+        assert response['context']['car_direct_path']['co2_emission']['value'] == \
                response['journeys'][0]['co2_emission']['value'] # car co2 emission
 
-        assert response['context']['car_co2_emission']['unit'] == \
+        assert response['context']['car_direct_path']['co2_emission']['unit'] == \
                response['journeys'][0]['co2_emission']['unit']
 
     def test_context_car_co2_emission_without_car(self):
@@ -194,10 +195,11 @@ class TestJourneysNewDefault(AbstractTestFixture):
         assert len(response["journeys"]) == 2
 
         assert 'context' in response
-        assert 'car_co2_emission' in response['context']
+        assert 'car_direct_path' in response['context']
+        assert 'co2_emission' in response['context']['car_direct_path']
 
-        assert response['context']['car_co2_emission']['value'] == 52.5908892104
-        assert response['context']['car_co2_emission']['unit'] == 'gEC'
+        assert response['context']['car_direct_path']['co2_emission']['value'] == 52.5908892104
+        assert response['context']['car_direct_path']['co2_emission']['unit'] == 'gEC'
         for j in response["journeys"]:
             assert "ecologic" in j["tags"]
 

--- a/source/jormungandr/tests/routing_tests_new_default.py
+++ b/source/jormungandr/tests/routing_tests_new_default.py
@@ -162,6 +162,43 @@ class TestJourneysNewDefault(AbstractTestFixture):
             else:
                 assert "ecologic" in j["tags"]
 
+    def test_context_car_co2_emission_with_car(self):
+        """
+        Test if car_co2_emission in context is the value in car journey
+        """
+        query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&"\
+                "first_section_mode[]=car&first_section_mode[]=walking&"\
+                "last_section_mode[]=walking&_min_car=0&_override_scenario=new_default"\
+                .format(from_coord=s_coord, to_coord=r_coord, datetime="20120614T075500")
+        response = self.query_region(query)
+        check_journeys(response)
+        assert 'context' in response
+        assert 'car_co2_emission' in response['context']
+        assert len(response["journeys"]) == 3
+
+        assert response['context']['car_co2_emission']['value'] == \
+               response['journeys'][0]['co2_emission']['value'] # car co2 emission
+
+        assert response['context']['car_co2_emission']['unit'] == \
+               response['journeys'][0]['co2_emission']['unit']
+
+    def test_context_car_co2_emission_without_car(self):
+        """
+        Test if car_co2_emission in context is the value in car journey
+        """
+        query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&"\
+                "first_section_mode[]=car&first_section_mode[]=walking&last_section_mode[]=walking&_override_scenario=new_default"\
+                .format(from_coord=s_coord, to_coord=r_coord, datetime="20120614T075500")
+        response = self.query_region(query)
+        check_journeys(response)
+        assert len(response["journeys"]) == 2
+
+        assert 'context' in response
+        assert 'car_co2_emission' in response['context']
+
+        assert response['context']['car_co2_emission']['value'] == 34.224
+        assert response['context']['car_co2_emission']['unit'] == 'gEC'
+
     def test_mode_tag(self):
         query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&"\
                 "first_section_mode[]=car&first_section_mode[]=walking&"\
@@ -178,7 +215,6 @@ class TestJourneysNewDefault(AbstractTestFixture):
         assert not 'bike' in response["journeys"][1]["tags"]
         assert 'walking' in response["journeys"][2]["tags"]
         assert 'walking' in response["journeys"][3]["tags"]
-
 
 @dataset({"main_ptref_test": {}})
 class TestJourneysNewDefaultWithPtref(AbstractTestFixture):

--- a/source/jormungandr/tests/routing_tests_new_default.py
+++ b/source/jormungandr/tests/routing_tests_new_default.py
@@ -187,7 +187,7 @@ class TestJourneysNewDefault(AbstractTestFixture):
         Test if car_co2_emission in context is the value in car journey
         """
         query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&"\
-                "first_section_mode[]=car&first_section_mode[]=walking&last_section_mode[]=walking&_override_scenario=new_default"\
+                "&first_section_mode[]=walking&last_section_mode[]=walking&_override_scenario=new_default"\
                 .format(from_coord=s_coord, to_coord=r_coord, datetime="20120614T075500")
         response = self.query_region(query)
         check_journeys(response)
@@ -196,8 +196,10 @@ class TestJourneysNewDefault(AbstractTestFixture):
         assert 'context' in response
         assert 'car_co2_emission' in response['context']
 
-        assert response['context']['car_co2_emission']['value'] == 34.224
+        assert response['context']['car_co2_emission']['value'] == 52.5908892104
         assert response['context']['car_co2_emission']['unit'] == 'gEC'
+        for j in response["journeys"]:
+            assert "ecologic" in j["tags"]
 
     def test_mode_tag(self):
         query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&"\

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -771,11 +771,14 @@ pbnavitia::Response Worker::car_co2_emission_on_crow_fly(const pbnavitia::CarCO2
     auto destin = get_geographical_coord(request.destination());
     auto distance = origin.distance_to(destin);
     pbnavitia::Response r;
-    if (data->pt_data->physical_modes_map["physical_mode:Car"]->co2_emission) {
+    auto car_mode = data->pt_data->physical_modes_map.find("physical_mode:Car");
+
+    if (car_mode != data->pt_data->physical_modes_map.end() &&
+            car_mode->second->co2_emission) {
         auto co2_emission = r.mutable_car_co2_emission();
         co2_emission->set_unit("gEC");
         co2_emission->set_value(CO2_ESTIMATION_COEFF * distance / 1000.0 *
-                data->pt_data->physical_modes_map["physical_mode:Car"]->co2_emission.get());
+                car_mode->second->co2_emission.get());
         return r;
     }
     fill_pb_error(pbnavitia::Error::no_solution,

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -121,6 +121,8 @@ class Worker {
         pbnavitia::Response nearest_stop_points(const pbnavitia::NearestStopPointsRequest& request);
         pbnavitia::Response graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest &request,
                                                const boost::posix_time::ptime& current_datetime);
+        pbnavitia::Response car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request);
+
 };
 
 }

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -86,8 +86,6 @@ class Worker {
 
         pbnavitia::Response dispatch(const pbnavitia::Request & request);
 
-        type::GeographicalCoord coord_of_entry_point(const type::EntryPoint & entry_point,
-                const boost::shared_ptr<const navitia::type::Data> data);
         type::StreetNetworkParams streetnetwork_params_of_entry_point(const pbnavitia::StreetNetworkParams & request, const boost::shared_ptr<const navitia::type::Data> data, const bool use_second = true);
 
         void init_worker_data(const boost::shared_ptr<const navitia::type::Data> data);

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -120,7 +120,6 @@ class Worker {
         pbnavitia::Response graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest &request,
                                                const boost::posix_time::ptime& current_datetime);
         pbnavitia::Response car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request);
-
 };
 
 }


### PR DESCRIPTION
http://jira.canaltp.fr/browse/ITI-17

display car co2 emission in the response API

which gives:

``` json
{
    "context": {
        "car_direct_path" : {
            "co2_emission": {
                "value": 42,
                "unit": "gEC"
            }
        }
    },
    "disruptions": [],
    "exceptions": [],
    "feed_publishers": [],
    "journeys": [ ... ],
    "links": [ ... ],
    "notes": [],
    "tickets": []
}
```
