### PR TITLE
from_datetime is not required

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1172,7 +1172,7 @@ access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource
 
 Required | Name               | Type      | Description                                                                              | Default Value
 ---------|--------------------|-----------|------------------------------------------------------------------------------------------|--------------
-yep      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                    |
+nop      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                    |
 nop      | duration           | int       | Maximum duration in seconds between from_datetime and the retrieved datetimes.           | 86400
 nop      | items_per_schedule | int       | Maximum number of columns per schedule.                                                  |
 nop      | forbidden_uris[]   | id        | If you want to avoid lines, modes, networks, etc.                                        |
@@ -1301,7 +1301,7 @@ You can access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_
 
 Required | Name           | Type                    | Description        | Default Value
 ---------|----------------|-------------------------|--------------------|--------------
-yep      | from_datetime  | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules |
+nop      | from_datetime  | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules |
 nop      | duration         | int                            | Maximum duration in seconds between from_datetime and the retrieved datetimes.                            | 86400
 nop      | forbidden_uris[] | id                             | If you want to avoid lines, modes, networks, etc.    |
 nop      | items_per_schedule | int       | Maximum number of datetimes per schedule.                                                  |
@@ -1397,7 +1397,7 @@ Departures are ordered chronologically in ascending order as:
 
 Required | Name           | Type                    | Description        | Default Value
 ---------|----------------|-------------------------|--------------------|--------------
-yep      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules |
+nop      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules |
 nop      | duration         | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                            | 86400
 nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.    |
 nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul> | realtime


### PR DESCRIPTION
from_datetime parameter seems not required in departures/stop_schedules/route_schedules apis

see with @antoine-de 
