### PR TITLE
Kraken: fix partial terminus

### DIFF
--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -196,13 +196,10 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
         if (! calendar_id) {
             stop_times = routing::get_stop_times(routing::StopEvent::pick_up, routepoint_jpps, handler.date_time,
                     handler.max_datetime, items_per_route_point, pb_creator.data, rt_level);
+            std::sort(stop_times.begin(), stop_times.end(), sort_predicate);
         } else {
             stop_times = routing::get_calendar_stop_times(routepoint_jpps, DateTimeUtils::hour(handler.date_time),
                     DateTimeUtils::hour(handler.max_datetime), pb_creator.data, *calendar_id);
-        }
-        if ( ! calendar_id) {
-            std::sort(stop_times.begin(), stop_times.end(), sort_predicate);
-        } else {
             // for calendar we want the first stop time to start from handler.date_time
             std::sort(stop_times.begin(), stop_times.end(), routing::CalendarScheduleSort(handler.date_time));
             if (stop_times.size() > items_per_route_point) {

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -192,7 +192,6 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
             routepoint_jpps.push_back(jpp_idx);
         }
 
-        std::vector<routing::datetime_stop_time> tmp;
         if (! calendar_id) {
             stop_times = routing::get_stop_times(routing::StopEvent::pick_up, routepoint_jpps, handler.date_time,
                     handler.max_datetime, items_per_route_point, pb_creator.data, rt_level);

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -171,14 +171,12 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
     }
     size_t total_result = sps_routes.size();
     sps_routes = paginate(sps_routes, count, start_page);
-    //Trie des vecteurs de date_times stop_times
     auto sort_predicate = [](routing::datetime_stop_time dt1, routing::datetime_stop_time dt2) {
                     return dt1.first < dt2.first;
                 };
-    // On regroupe entre eux les stop_times appartenant
-    // au meme couple (stop_point, route)
-    // On veut en effet afficher les départs regroupés par route
-    // (une route étant une vague direction commerciale
+    // we group the stoptime belonging to the same pair (stop_point, route)
+    // since we want to display the departures grouped by route
+    // the route being a loose commercial direction
     for (const auto& sp_route: sps_routes) {
         std::vector<routing::datetime_stop_time> stop_times;
         const type::StopPoint* stop_point = pb_creator.data.pt_data->stop_points[sp_route.first.val];

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -208,8 +208,7 @@ void departure_board(PbCreator& pb_creator, const std::string& request,
         }
 
         //we compute the route status
-        for (const auto& jpp_from_sp: jpps) {
-            const routing::JppIdx& jpp_idx = jpp_from_sp.idx;
+        for (const auto& jpp_idx: routepoint_jpps) {
             const auto& jpp = pb_creator.data.dataRaptor->jp_container.get(jpp_idx);
             const auto& jp = pb_creator.data.dataRaptor->jp_container.get(jpp.jp_idx);
             const auto& last_jpp = pb_creator.data.dataRaptor->jp_container.get(jp.jpps.back());

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -336,6 +336,43 @@ BOOST_AUTO_TEST_CASE(partial_terminus_test1) {
 }
 
 
+BOOST_AUTO_TEST_CASE(terminus_multiple_route) {
+    /*
+     * Check partial terminus tag
+     *
+     * 1 line, 2 route, bob and bobette (one forward, and one backward)
+     * Bob    :  A -> B -> C
+     * Bobette:  C -> B -> A
+     *
+     * for a stop schedule on A, A must be the terminus only for bobette
+     * */
+    ed::builder b("20160802");
+    b.vj("bob")    ("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
+    b.vj("bobette")("C", "10:00"_t)("B", "11:00"_t)("A", "12:00"_t);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+
+    navitia::PbCreator pb_creator(*(b.data), bt::second_clock::universal_time(), null_time_period);
+    departure_board(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"), 86400, 0,
+                    10, 0, nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+
+    pbnavitia::Response resp = pb_creator.get_response();
+    BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
+    for (const auto& stop_sched: resp.stop_schedules()) {
+        if (stop_sched.route().name() == "bob") {
+            BOOST_CHECK_EQUAL(stop_sched.response_status(), pbnavitia::ResponseStatus::none);
+        } else if (stop_sched.route().name() == "bobette") {
+            BOOST_CHECK_EQUAL(stop_sched.response_status(), pbnavitia::ResponseStatus::terminus);
+        } else {
+            BOOST_FAIL("wrong route name");
+        }
+    }
+}
+
+
 BOOST_FIXTURE_TEST_CASE(test_data_set, calendar_fixture) {
     //simple test on the data set creation
 


### PR DESCRIPTION
in /stop_schedule, the route point  status was computed using all jpp of the stop_point, not only with the route's jpp.

It was thus leading to the first stop of a route being a partial terminus because it was the terminus of the backward route...
