### PR TITLE
type: fix order of stoptime and route

### DIFF
--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -804,6 +804,13 @@ std::string Line::get_label() const {
     return s.str();
 }
 
+bool Route::operator<(const Route & other) const{
+    if(this->uri != other.uri){
+        return this->uri < other.uri;
+    }
+    return this < &other;
+}
+
 std::string Route::get_label() const {
     //RouteName = NetworkName + ModeName + LineCode + (RouteName)
     std::stringstream s;
@@ -885,6 +892,13 @@ Indexes VehicleJourney::get(Type_e type, const PT_Data& data) const {
 VehicleJourney::~VehicleJourney() {}
 FrequencyVehicleJourney::~FrequencyVehicleJourney() {}
 DiscreteVehicleJourney::~DiscreteVehicleJourney() {}
+
+bool StopPoint::operator<(const StopPoint & other) const{
+    if(this->uri != other.uri){
+        return this->uri < other.uri;
+    }
+    return this < &other;
+}
 
 Indexes StopPoint::get(Type_e type, const PT_Data& data) const {
     Indexes result;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -167,7 +167,7 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages {
     StopPoint(): fare_zone(0),  stop_area(nullptr), network(nullptr) {}
 
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const StopPoint & other) const { return this < &other; }
+    bool operator<(const StopPoint & other) const;
 
 };
 
@@ -668,7 +668,7 @@ struct Route : public Header, Nameable, HasMessages {
     }
 
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const Route & other) const { return this < &other; }
+    bool operator<(const Route & other) const;
 
     std::string get_label() const;
 };


### PR DESCRIPTION
A few tests were failing randomly on stop_schedule since the tests are
dependant of the order of the response
