### PR TITLE
RT proxy: custom Synthese route lookup

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -101,8 +101,13 @@ nt::VehicleJourney* VJ::make() {
         if (search_route == b.routes_by_line[line->uri].end()) {
             route = new navitia::type::Route();
             route->idx = pt_data.routes.size();
-            route->name = _route_name.empty() ? line_name : _route_name;
-            route->uri = route->name + ":" + std::to_string(pt_data.routes.size());;
+            if (_route_name.empty()) {
+                route->name = line_name;
+                route->uri = route->name + ":" + std::to_string(pt_data.routes.size());;
+            } else {
+                route->name = _route_name;
+                route->uri = _route_name;
+            }
             route->line = line;
             line->route_list.push_back(route);
             b.routes_by_line[line->uri][_route_name] = route;

--- a/source/jormungandr/jormungandr/ptref.py
+++ b/source/jormungandr/jormungandr/ptref.py
@@ -96,3 +96,6 @@ class PtRef(object):
                 yield o
 
             req.ptref.start_page += 1
+            if req.ptref.count > result.pagination.itemsOnPage:
+                # we did not get as much results as planned, we can stop
+                return

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -143,7 +143,7 @@ class Synthese(RealtimeProxy):
         logging.getLogger(__name__).debug("synthese response: {}".format(r.text))
         passages = self._get_synthese_passages(r.content)
 
-        return self._find_route_point(route_point, passages)
+        return self._find_route_point_passages(route_point, passages)
 
     def _make_url(self, route_point, count=None, from_dt=None):
         """
@@ -226,7 +226,7 @@ class Synthese(RealtimeProxy):
         dt = pytz.utc.localize(dt)
         return dt.astimezone(self.timezone)
 
-    def _find_route_point(self, route_point, passages):
+    def _find_route_point_passages(self, route_point, passages):
         """
         To find the right passage in synthese:
 

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -236,10 +236,12 @@ class Synthese(RealtimeProxy):
 
          * we first look if by miracle we can find a route with the synthese code of our route in it's
          external codes (it can have several if the route is a fusion of many routes)
-         * if query navitia to get all routes that pass by the stoppoint for the line of the route point
+            -> if we found the route, we return it's passages
+         * else we query navitia to get all routes that pass by the stoppoint for the line of the route point
             * if we get only one route, we search for this route's line in the synthese response
                 (because lines synthese code are move coherent)
                 -> if we have only one line with this code, we return it's passages
+         -> else we return the base schedule
         """
         log = logging.getLogger(__name__)
         stop_point_id = str(route_point.fetch_stop_id(self.object_id_tag))
@@ -266,11 +268,14 @@ class Synthese(RealtimeProxy):
             if len(line_passages) == 1:
                 return line_passages[0]
 
-            log.debug('stoppoint {} has {} routes for line {} in navitia and {} in synthese'
-                      .format(route_point.pb_stop_point.uri,
-                              len(first_routes),
-                              route_point.fetch_line_uri(),
-                              len(passages)))
+            log.debug('stoppoint {sp} has {nb_r} routes for line {l} ({l_codes}) in navitia and {nb_syn_r} '
+                      'in synthese (lines: {syn_lines})'
+                      .format(sp=route_point.pb_stop_point.uri,
+                              nb_r=len(first_routes),
+                              l=route_point.fetch_line_uri(),
+                              l_codes=route_point.fetch_line_id(self.object_id_tag),
+                              nb_syn_r=len(passages),
+                              syn_lines=[l.syn_line_id for l in passages.keys()]))
 
         if passages:
             log.info('impossible to find a valid passage for {} (passage = {})'

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -240,7 +240,7 @@ class Synthese(RealtimeProxy):
          * else we query navitia to get all routes that pass by the stoppoint for the line of the route point
             * if we get only one route, we search for this route's line in the synthese response
                 (because lines synthese code are move coherent)
-                -> if we have only one line with this code, we return it's passages
+                -> we concatenate all synthese passages on this line
          -> else we return the base schedule
         """
         log = logging.getLogger(__name__)
@@ -261,12 +261,12 @@ class Synthese(RealtimeProxy):
 
         if len(first_routes) == 1:
             # there is only one route that pass through our stoppoint for the line of the routepoint
-            # we check if we can find the line of this route in synthese
+            # we can concatenate all synthese's route of this line
             line_passages = [p for syn_rp, p in passages.items() if syn_rp.syn_line_id ==
                              route_point.fetch_line_id(self.object_id_tag)]
 
-            if len(line_passages) == 1:
-                return line_passages[0]
+            if line_passages:
+                return itertools.chain(*line_passages)
 
             log.debug('stoppoint {sp} has {nb_r} routes for line {l} ({l_codes}) in navitia and {nb_syn_r} '
                       'in synthese (lines: {syn_lines})'

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/utils.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/utils.py
@@ -52,6 +52,9 @@ class MockRoutePoint(object):
     def fetch_line_uri(self):
         return self._hardcoded_line_id
 
+    def fetch_all_route_id(self, rt_proxy_id):
+        return [self._hardcoded_route_id]
+
 def _dt(dt_to_parse="00:00", year=2016, month=2, day=7):
     """
     small helper to ease the reading of the tests

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -173,8 +173,11 @@ class RoutePoint(object):
         return hash(self.__key())
 
     @staticmethod
-    def _get_code(obj, object_id_tag):
-        tags = [c.value for c in obj.codes if c.type == object_id_tag]
+    def _get_all_codes(obj, object_id_tag):
+        return [c.value for c in obj.codes if c.type == object_id_tag]
+
+    def _get_code(self, obj, object_id_tag):
+        tags = self._get_all_codes(obj, object_id_tag)
         if len(tags) < 1:
             return None
         if len(tags) > 1:
@@ -192,6 +195,9 @@ class RoutePoint(object):
 
     def fetch_route_id(self, object_id_tag):
         return self._get_code(self.pb_route, object_id_tag)
+
+    def fetch_all_route_id(self, object_id_tag):
+        return self._get_all_codes(self.pb_route, object_id_tag)
 
     def fetch_line_code(self):
         return self.pb_route.line.code

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -41,6 +41,14 @@ class MockResponse(object):
     def json(self):
         return self.data
 
+    @property
+    def text(self):
+        return self.data
+
+    @property
+    def content(self):
+        return self.data
+
 
 class MockRequests(object):
     """

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -161,8 +161,8 @@ class TestSyntheseSchedules(AbstractTestFixture):
     def test_stop_schedule_bad_id_multiple_response(self):
         """
         test for a route point when the route code is not in synthese
-        since there is only one route in navitia but multiple routes in synthese, we don't get some
-        realtime
+        since there is only one route in navitia but multiple routes in synthese, we get all the synthese
+        passage on this route
         """
         mock_requests = MockRequests({
             'http://bob.com?SERVICE=tdg&roid=syn_stoppoint11&rn=10000&date=2016-01-02 08:00':
@@ -176,10 +176,18 @@ class TestSyntheseSchedules(AbstractTestFixture):
                     </line>
                   </journey>
 
-                  <journey routeId="unknown_route_code2" dateTime="2016-Jan-02 09:17:17" realTime="yes"
+                  <journey routeId="unknown_route_code2" dateTime="2016-Jan-02 10:17:17" realTime="yes"
                   waiting_time="00:07:10">
                     <stop id="syn_stoppoint11"/>
                     <line id="syn_lineB">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+
+                  <journey routeId="unknown_route_code3" dateTime="2016-Jan-02 11:17:17" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint11"/>
+                    <line id="another_line_this_will_not_be_taken">
                       <network id="syn_network" name="nice_network" image=""/>
                     </line>
                   </journey>
@@ -191,9 +199,11 @@ class TestSyntheseSchedules(AbstractTestFixture):
             response = self.query_region(query)
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
-            assert _get_schedule(response, 'SP_11', 'B1') == [{
-                'rt': False, 'dt': '20160102T090000'
-            }]
+            print(_get_schedule(response, 'SP_11', 'B1'))
+            assert _get_schedule(response, 'SP_11', 'B1') == [
+                {'rt': True, 'dt': '20160102T091717'},
+                {'rt': True, 'dt': '20160102T101717'},
+            ]
 
     def test_stop_schedule_bad_id_multiple_routes(self):
         """
@@ -219,14 +229,12 @@ class TestSyntheseSchedules(AbstractTestFixture):
             response = self.query_region(query)
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 2
-            print(_get_schedule(response, 'SP_21', 'C1'))
             assert _get_schedule(response, 'SP_21', 'C1') == [{
                 'rt': False, 'dt': '20160102T090000'
             }]
             assert _get_schedule(response, 'SP_21', 'C2') == [{
                 'rt': False, 'dt': '20160102T100000'
             }]
-
 
     def test_pt_ref(self):
         """there are 50 stopareas in the dataset to test the pagination handling"""

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -67,13 +67,36 @@ class TestSyntheseSchedules(AbstractTestFixture):
     def test_stop_schedule_good_id(self):
         """
         test for a route point with good codes (but with multiple codes on the route)
-        we should be able to find the synthese realtime
+        we should be able to find all the synthese passages and aggregate them
         """
         mock_requests = MockRequests({
             'http://bob.com?SERVICE=tdg&roid=syn_stoppoint1&rn=10000&date=2016-01-02 08:00':
             ("""<?xml version="1.0" encoding="UTF-8"?>
                 <timeTable>
                   <journey routeId="syn_cute_routeA1" dateTime="2016-Jan-02 09:17:17" blink="0" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint1"/>
+                    <line id="syn_lineA">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                <journey routeId="syn_cute_routeA1" dateTime="2016-Jan-02 10:17:17" blink="0" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint1"/>
+                    <line id="syn_lineA">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                <!-- another of the route's code-->
+                <journey routeId="syn_routeA1" dateTime="2016-Jan-02 11:17:17" blink="0" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint1"/>
+                    <line id="syn_lineA">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                <!-- an unkown route's code, should not be considered-->
+                <journey routeId="unknown_route" dateTime="2016-Jan-02 12:17:17" blink="0" realTime="yes"
                   waiting_time="00:07:10">
                     <stop id="syn_stoppoint1"/>
                     <line id="syn_lineA">
@@ -88,9 +111,12 @@ class TestSyntheseSchedules(AbstractTestFixture):
             response = self.query_region(query)
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
-            assert _get_schedule(response, 'SP_1', 'A1') == [{
-                'rt': True, 'dt': '20160102T091717'
-            }]
+            print(_get_schedule(response, 'SP_1', 'A1'))
+            assert _get_schedule(response, 'SP_1', 'A1') == [
+                {'rt': True, 'dt': '20160102T091717'},
+                {'rt': True, 'dt': '20160102T101717'},
+                {'rt': True, 'dt': '20160102T111717'},
+            ]
 
     def test_stop_schedule_bad_id_one_route_good_line(self):
         """

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -1,0 +1,237 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+import mock
+from jormungandr.tests.utils_test import MockRequests
+from tests.check_utils import get_not_null
+from .tests_mechanism import AbstractTestFixture, dataset
+
+
+MOCKED_PROXY_CONF = ('[{ "object_id_tag": "KisioDigital",'
+                     '"id": "KisioDigital",'
+                     '"class": "jormungandr.realtime_schedule.synthese.Synthese",'
+                     '"args": {'
+                     '"timezone": "UTC",'
+                     '"service_url": "http://bob.com",'
+                     '"timeout": 15}}]')
+
+
+def _get_schedule(sched, sp_uri, route_uri):
+    """ small helper that extract the information from a route point stop schedule """
+    return [
+        {'rt': r['data_freshness'] == 'realtime', 'dt': r['date_time']}
+        for r in next(rp_sched['date_times']
+                      for rp_sched in sched['stop_schedules']
+                      if rp_sched['stop_point']['id'] == sp_uri
+                      and rp_sched['route']['id'] == route_uri)
+    ]
+
+
+@dataset({'multiple_schedules': {'proxy_conf': MOCKED_PROXY_CONF}})
+class TestSyntheseSchedules(AbstractTestFixture):
+    """
+    integration tests for synthese
+
+    Note: for readability, in the dataset, base schedule is always on hours (8:00, 9:00),
+    and realtime schedule is always at 17min (8:17, 9:17)
+    """
+    query_template = 'stop_points/{sp}/stop_schedules?data_freshness=realtime&_current_datetime=20160102T0800'
+
+    def test_stop_schedule_good_id(self):
+        """
+        test for a route point with good codes (but with multiple codes on the route)
+        we should be able to find the synthese realtime
+        """
+        mock_requests = MockRequests({
+            'http://bob.com?SERVICE=tdg&roid=syn_stoppoint1&rn=10000&date=2016-01-02 08:00':
+            ("""<?xml version="1.0" encoding="UTF-8"?>
+                <timeTable>
+                  <journey routeId="syn_cute_routeA1" dateTime="2016-Jan-02 09:17:17" blink="0" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint1"/>
+                    <line id="syn_lineA">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                </timeTable>
+            """, 200)
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            query = self.query_template.format(sp='SP_1')
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 1
+            assert _get_schedule(response, 'SP_1', 'A1') == [{
+                'rt': True, 'dt': '20160102T091717'
+            }]
+
+    def test_stop_schedule_bad_id_one_route_good_line(self):
+        """
+        test for a route point when the route code is not in synthese
+        since there is only one route in navitia and 1 response in synthese (with the good line),
+        we get some realtime
+        """
+        mock_requests = MockRequests({
+            'http://bob.com?SERVICE=tdg&roid=syn_stoppoint11&rn=10000&date=2016-01-02 08:00':
+            ("""<?xml version="1.0" encoding="UTF-8"?>
+                <timeTable>
+                  <journey routeId="unknown_route_code" dateTime="2016-Jan-02 09:17:17" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint11"/>
+                    <line id="syn_lineB">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                  <journey routeId="unknown_route_code" dateTime="2016-Jan-02 10:17:17" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint11"/>
+                    <line id="syn_lineB">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                </timeTable>
+             """, 200),
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            query = self.query_template.format(sp='SP_11')
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 1
+            assert _get_schedule(response, 'SP_11', 'B1') == [
+                {'rt': True, 'dt': '20160102T091717'},
+                {'rt': True, 'dt': '20160102T101717'},
+            ]
+
+    def test_stop_schedule_bad_id_one_route_bad_line(self):
+        """
+        test for a route point when the route code is not in synthese
+        since there is only one route in navitia and 1 response in synthese but not on the same line
+        we don't get some realtime
+        """
+        mock_requests = MockRequests({
+            'http://bob.com?SERVICE=tdg&roid=syn_stoppoint11&rn=10000&date=2016-01-02 08:00':
+            ("""<?xml version="1.0" encoding="UTF-8"?>
+                <timeTable>
+                  <journey routeId="unknown_route_code" dateTime="2016-Jan-02 09:17:17" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint11"/>
+                    <line id="another_line_code_but_not_B">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                </timeTable>
+             """, 200),
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            query = self.query_template.format(sp='SP_11')
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 1
+            assert _get_schedule(response, 'SP_11', 'B1') == [{
+                'rt': False, 'dt': '20160102T090000'
+            }]
+
+    def test_stop_schedule_bad_id_multiple_response(self):
+        """
+        test for a route point when the route code is not in synthese
+        since there is only one route in navitia but multiple routes in synthese, we don't get some
+        realtime
+        """
+        mock_requests = MockRequests({
+            'http://bob.com?SERVICE=tdg&roid=syn_stoppoint11&rn=10000&date=2016-01-02 08:00':
+            ("""<?xml version="1.0" encoding="UTF-8"?>
+                <timeTable>
+                  <journey routeId="unknown_route_code1" dateTime="2016-Jan-02 09:17:17" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint11"/>
+                    <line id="syn_lineB">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+
+                  <journey routeId="unknown_route_code2" dateTime="2016-Jan-02 09:17:17" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint11"/>
+                    <line id="syn_lineB">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                </timeTable>
+             """, 200),
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            query = self.query_template.format(sp='SP_11')
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 1
+            assert _get_schedule(response, 'SP_11', 'B1') == [{
+                'rt': False, 'dt': '20160102T090000'
+            }]
+
+    def test_stop_schedule_bad_id_multiple_routes(self):
+        """
+        test for a route point when the route code is not in synthese
+        since there are multiple routes in navitia, we can't sort them out, and we don't get some realtime
+        """
+        mock_requests = MockRequests({
+            'http://bob.com?SERVICE=tdg&roid=syn_stoppoint21&rn=10000&date=2016-01-02 08:00':
+            ("""<?xml version="1.0" encoding="UTF-8"?>
+                <timeTable>
+                  <journey routeId="unknown_route" dateTime="2016-Jan-02 09:17:17" blink="0" realTime="yes"
+                  waiting_time="00:07:10">
+                    <stop id="syn_stoppoint21"/>
+                    <line id="syn_lineC">
+                      <network id="syn_network" name="nice_network" image=""/>
+                    </line>
+                  </journey>
+                </timeTable>
+            """, 200)
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            query = self.query_template.format(sp='SP_21')
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 2
+            print(_get_schedule(response, 'SP_21', 'C1'))
+            assert _get_schedule(response, 'SP_21', 'C1') == [{
+                'rt': False, 'dt': '20160102T090000'
+            }]
+            assert _get_schedule(response, 'SP_21', 'C2') == [{
+                'rt': False, 'dt': '20160102T100000'
+            }]
+
+
+    def test_pt_ref(self):
+        """there are 50 stopareas in the dataset to test the pagination handling"""
+        from jormungandr import i_manager
+        from navitiacommon import type_pb2
+        i = i_manager.instances['multiple_schedules']
+
+        assert len([r for r in i.ptref.get_objs(type_pb2.STOP_AREA)]) == 50

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -127,7 +127,7 @@ class MockTimeo(Timeo):
 
 MOCKED_PROXY_CONF = ('[{ "object_id_tag": "KisioDigital",'
                      '"id": "KisioDigital",'
-                     '"class": "tests.proxy_realtime_integration_tests.MockTimeo",'
+                     '"class": "tests.proxy_realtime_timeo_integration_tests.MockTimeo",'
                      '"args": {'
                      '"destination_id_tag": "KisioDigital",'
                      '"timezone": "Europe/Paris",'

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -526,6 +526,13 @@ class TestPtRef(AbstractTestFixture):
         assert code == 400
         assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
 
+    def test_pt_ref_internal_method(self):
+        from jormungandr import i_manager
+        from navitiacommon import type_pb2
+        i = i_manager.instances['main_ptref_test']
+
+        assert len([r for r in i.ptref.get_objs(type_pb2.ROUTE)]) == 3
+
 
 @dataset({"main_ptref_test": {}, "main_routing_test": {}})
 class TestPtRefRoutingAndPtrefCov(AbstractTestFixture):

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1570,7 +1570,7 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     navitia::apply_disruption(
         b.impact(nt::RTLevel::Adapted, "line_section_sa1_sa5_routesA1-2-3")
          .severity(nt::disruption::Effect::NO_SERVICE)
-         .on_line_section("line:A", "stop_area:2", "stop_area:5", {"route:A1:0", "route:A2:1", "route:A3:2"})
+         .on_line_section("line:A", "stop_area:2", "stop_area:5", {"route:A1", "route:A2", "route:A3"})
          .application_periods(btp("20160404T000000"_dt, "20160409T240000"_dt))
          .get_disruption(),
          *b.data->pt_data, *b.data->meta
@@ -1582,10 +1582,10 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 6);
 
     // Make sur only the first two routes are impacted
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A1:0"]->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A2:1"]->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A3:2"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A4:3"]->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A1"]->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A2"]->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A3"]->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A4"]->get_impacts().size(), 0);
 
     // Check the original vjs
     auto* vj = b.get<nt::VehicleJourney>("vj:1");
@@ -1643,10 +1643,10 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     navitia::delete_disruption("line_section_sa1_sa5_routesA1-2-3", *b.data->pt_data, *b.data->meta);
 
     // Make sur there is no impacts anymore
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A1:0"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A2:1"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A3:2"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A4:3"]->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A1"]->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A2"]->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A3"]->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A4"]->get_impacts().size(), 0);
 
     // Check the original vjs
     vj = b.get<nt::VehicleJourney>("vj:1");

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -24,6 +24,8 @@ add_executable(null_status_test null_status_test.cpp)
 
 add_executable(main_routing_without_pt_test main_routing_without_pt_test.cpp)
 
+add_executable(multiple_schedules multiple_schedules.cpp)
+
 
 target_link_libraries(main_routing_test ${ALL_LIBS})
 target_link_libraries(main_ptref_test ${ALL_LIBS})
@@ -35,3 +37,4 @@ target_link_libraries(main_autocomplete_test ${ALL_LIBS})
 target_link_libraries(main_stif_test ${ALL_LIBS})
 target_link_libraries(null_status_test ${ALL_LIBS})
 target_link_libraries(main_routing_without_pt_test ${ALL_LIBS})
+target_link_libraries(multiple_schedules ${ALL_LIBS})

--- a/source/tests/multiple_schedules.cpp
+++ b/source/tests/multiple_schedules.cpp
@@ -1,0 +1,83 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+  
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+ 
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+  
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+   
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+   
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+  
+Stay tuned using
+twitter @navitia 
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "utils/init.h"
+#include "mock_kraken.h"
+#include "ed/build_helper.h"
+#include "tests/utils_test.h"
+
+namespace ntest = navitia::test;
+
+int main(int argc, const char* const argv[]) {
+    navitia::init_app();
+    ed::builder b("20160101");
+
+    //for some tests on ptref we create 50 stop areas
+    for (size_t i = 0; i < 50; ++i) {
+        const auto n = boost::lexical_cast<std::string>(i);
+        b.sa("SA_" + n, 0, 0, false)("SP_" + n);
+    }
+
+    b.vj("A").route("A1")("SP_0", "08:00"_t)("SP_1", "09:00"_t)("SP_2", "11:00"_t);
+
+    b.vj("B").route("B1")("SP_10", "08:00"_t)("SP_11", "09:00"_t)("SP_12", "11:00"_t);
+
+    b.vj("C").route("C1")("SP_20", "08:00"_t)("SP_21", "09:00"_t)("SP_22", "11:00"_t);
+    b.vj("C").route("C2")("SP_20", "09:00"_t)("SP_21", "10:00"_t)("SP_22", "12:00"_t);
+
+    b.data->complete();
+    b.finish();
+    b.data->pt_data->index();
+    b.data->pt_data->build_uri();
+    b.data->build_raptor();
+
+    b.data->compute_labels();
+
+    b.get<nt::Line>("A")->properties["realtime_system"] = "KisioDigital";
+    b.get<nt::Line>("B")->properties["realtime_system"] = "KisioDigital";
+    b.get<nt::Line>("C")->properties["realtime_system"] = "KisioDigital";
+
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_1"), "KisioDigital", "syn_stoppoint1");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_11"), "KisioDigital", "syn_stoppoint11");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_21"), "KisioDigital", "syn_stoppoint21");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_31"), "KisioDigital", "syn_stoppoint31");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_41"), "KisioDigital", "syn_stoppoint41");
+
+    auto r1 = b.get<nt::Route>("A1");
+    b.data->pt_data->codes.add(r1, "KisioDigital", "syn_routeA1");
+    b.data->pt_data->codes.add(r1, "KisioDigital", "syn_cute_routeA1");
+
+    b.data->pt_data->codes.add(b.get<nt::Line>("B"), "KisioDigital", "syn_lineB");
+    b.data->pt_data->codes.add(b.get<nt::Line>("C"), "KisioDigital", "syn_lineC");
+
+    mock_kraken kraken(b, "multiple_schedules", argc, argv);
+
+    return 0;
+}


### PR DESCRIPTION
linked to http://jira.canaltp.fr/browse/HOR-10

since we have some bad synchronization between synthese routes code and our route code, implementation of a custom lookup
- we first look if we can find a route with the synthese code of our route in it's external codes (it can have several if the route is a fusion of many routes)
- else, we query navitia to get all routes that pass by the stoppoint for the line of the route point
  - if we get only one route, we search for this route's line in the synthese response (because lines synthese code are move coherent)
    - we concatenate all synthese passage of this line (since we have have fusioned some routes)
- else we failed, we return the base schedule

On T2C data with this we now have 68% of realtime data
