### PR TITLE
Jormungandr: add is_walking_direct_path and is_bike_direct_path tags on a journey

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -195,7 +195,7 @@ def tag_direct_path(resp):
     for j in resp.journeys:
         # if there is only one section
         if len(j.sections) == 1:
-            if hasattr(j.sections[0], 'street_network'):
+            if j.sections[0].type == response_pb2.STREET_NETWORK and hasattr(j.sections[0], 'street_network'):
                 tag = street_network_mode_tag_map.get(j.sections[0].street_network.mode)
                 if tag:
                     j.tags.extend(tag)

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -175,11 +175,7 @@ def compute_car_co2_emission(pb_resp, api_request, instance):
         pb_resp.car_co2_emission.value = car.co2_emission.value
         pb_resp.car_co2_emission.unit = car.co2_emission.unit
 
-
-def tag_journeys(resp):
-    """
-    tag the journeys
-    """
+def tag_ecologic(resp):
     # if there is no available car_co2_emission in resp, no tag will be assigned
     if resp.car_co2_emission.value and resp.car_co2_emission.unit:
         for j in resp.journeys:
@@ -191,6 +187,24 @@ def tag_journeys(resp):
             if j.co2_emission.value < resp.car_co2_emission.value * 0.5:
                 j.tags.append('ecologic')
 
+def tag_direct_path(resp):
+    for j in resp.journeys:
+        # if there is only one section
+        if len(j.sections) == 1:
+            if j.sections[0].street_network.mode == response_pb2.Walking:
+                j.tags.append('is_walking_direct_path')
+            elif j.sections[0].street_network.mode == response_pb2.Bike:
+                j.tags.append('is_bike_direct_path')
+
+
+def tag_journeys(resp):
+    """
+    tag the journeys
+    """
+    tag_ecologic(resp)
+
+    # tag the direct path
+    tag_direct_path(resp)
 
 def _get_section_id(section):
     street_network_mode = None

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -188,8 +188,8 @@ def tag_ecologic(resp):
                 j.tags.append('ecologic')
 
 def tag_direct_path(resp):
-    street_network_mode_tag_map = {response_pb2.Walking: ['is_walking_direct_path', 'non_pt'],
-                                   response_pb2.Bike: ['is_bike_direct_path', 'non_pt'],
+    street_network_mode_tag_map = {response_pb2.Walking: ['non_pt_walking', 'non_pt'],
+                                   response_pb2.Bike: ['non_pt_bike', 'non_pt'],
                                    response_pb2.Bss: ['non_pt'],
                                    response_pb2.Car: ['non_pt']}
     for j in resp.journeys:

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -188,13 +188,17 @@ def tag_ecologic(resp):
                 j.tags.append('ecologic')
 
 def tag_direct_path(resp):
+    street_network_mode_tag_map = {response_pb2.Walking: ['is_walking_direct_path', 'non_pt'],
+                                   response_pb2.Bike: ['is_bike_direct_path', 'non_pt'],
+                                   response_pb2.Bss: ['non_pt'],
+                                   response_pb2.Car: ['non_pt']}
     for j in resp.journeys:
         # if there is only one section
         if len(j.sections) == 1:
-            if j.sections[0].street_network.mode == response_pb2.Walking:
-                j.tags.append('is_walking_direct_path')
-            elif j.sections[0].street_network.mode == response_pb2.Bike:
-                j.tags.append('is_bike_direct_path')
+            if hasattr(j.sections[0], 'street_network'):
+                tag = street_network_mode_tag_map.get(j.sections[0].street_network.mode)
+                if tag:
+                    j.tags.extend(tag)
 
 
 def tag_journeys(resp):

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -440,8 +440,8 @@ def tag_direct_path_test():
     section = journey_pt.sections.add()
     section.type = response_pb2.PUBLIC_TRANSPORT
     new_default.tag_direct_path(response)
-    assert 'is_walking_direct_path' in response.journeys[0].tags
+    assert 'non_pt_walking' in response.journeys[0].tags
     assert 'non_pt' in response.journeys[0].tags
-    assert 'is_bike_direct_path' in response.journeys[1].tags
+    assert 'non_pt_bike' in response.journeys[1].tags
     assert 'non_pt' in response.journeys[1].tags
     assert not response.journeys[2].tags

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -429,21 +429,19 @@ def tag_direct_path_test():
 
     # test with one walk and one pt
     journey_walk = response.journeys.add()
-    journey_walk.departure_date_time = 100000
-    journey_walk.arrival_date_time = 101500
-    journey_walk.duration = 1500
     section = journey_walk.sections.add()
     section.type = response_pb2.STREET_NETWORK
     section.street_network.mode = response_pb2.Walking
     journey_bike = response.journeys.add()
-    journey_bike.departure_date_time = 100500
-    journey_bike.arrival_date_time = 103000
-    journey_bike.duration = 2500
     section = journey_bike.sections.add()
     section.type = response_pb2.STREET_NETWORK
     section.street_network.mode = response_pb2.Bike
+    journey_pt = response.journeys.add()
+    section = journey_pt.sections.add()
+    section.type = response_pb2.PUBLIC_TRANSPORT
     new_default.tag_direct_path(response)
     assert 'is_walking_direct_path' in response.journeys[0].tags
     assert 'non_pt' in response.journeys[0].tags
     assert 'is_bike_direct_path' in response.journeys[1].tags
     assert 'non_pt' in response.journeys[1].tags
+    assert not response.journeys[2].tags

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -423,3 +423,25 @@ def tag_by_mode_test():
     bssc = helpers_tests.get_bss_car_journey()
     _tag_journey_by_mode(bssc)
     assert 'car' in bssc.tags
+
+def tag_direct_path_test():
+    response = response_pb2.Response()
+
+    # test with one walk and one pt
+    journey_walk = response.journeys.add()
+    journey_walk.departure_date_time = 100000
+    journey_walk.arrival_date_time = 101500
+    journey_walk.duration = 1500
+    section = journey_walk.sections.add()
+    section.type = response_pb2.STREET_NETWORK
+    section.street_network.mode = response_pb2.Walking
+    journey_bike = response.journeys.add()
+    journey_bike.departure_date_time = 100500
+    journey_bike.arrival_date_time = 103000
+    journey_bike.duration = 2500
+    section = journey_bike.sections.add()
+    section.type = response_pb2.STREET_NETWORK
+    section.street_network.mode = response_pb2.Bike
+    new_default.tag_direct_path(response)
+    assert 'is_walking_direct_path' in response.journeys[0].tags
+    assert 'is_bike_direct_path' in response.journeys[1].tags

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -444,4 +444,6 @@ def tag_direct_path_test():
     section.street_network.mode = response_pb2.Bike
     new_default.tag_direct_path(response)
     assert 'is_walking_direct_path' in response.journeys[0].tags
+    assert 'non_pt' in response.journeys[0].tags
     assert 'is_bike_direct_path' in response.journeys[1].tags
+    assert 'non_pt' in response.journeys[1].tags


### PR DESCRIPTION
If we have only one section for a journey, and if this section has a street network mode in `walking` or `bike`, we had a tag on this journey, like:
- `is_walking_direct_path` for a walking mode
- `is_bike_direct_path` for a bike mode
