### PR TITLE
jormungandr: add a ratelimiter to timeo

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -42,16 +42,10 @@ import requests as requests
 from jormungandr import cache, app
 from datetime import datetime, time
 from jormungandr.utils import timestamp_to_datetime
-from navitiacommon.ratelimit import RateLimiter
+from navitiacommon.ratelimit import RateLimiter, FakeRateLimiter
 from navitiacommon import type_pb2
 import redis
 
-class FakeRateLimiter(object):
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def acquire(self, *args, **kwargs):
-        return True
 
 class SyntheseRoutePoint(object):
 

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -38,6 +38,7 @@ from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy
 from jormungandr.schedule import RealTimePassage
 from datetime import datetime, time
 from jormungandr.utils import timestamp_to_datetime
+from navitiacommon.ratelimit import RateLimiter, FakeRateLimiter
 
 
 def _to_duration(hour_str):
@@ -62,7 +63,7 @@ class Timeo(RealtimeProxy):
                  object_id_tag=None, destination_id_tag=None, instance=None, timeout=10, **kwargs):
         self.service_url = service_url
         self.service_args = service_args
-        self.timeout = timeout  # timeout in seconds
+        self.timeout = timeout  #timeout in seconds
         self.rt_system_id = id
         self.object_id_tag = object_id_tag if object_id_tag else id
         self.destination_id_tag = destination_id_tag
@@ -72,6 +73,17 @@ class Timeo(RealtimeProxy):
 
         # Note: if the timezone is not know, pytz raise an error
         self.timezone = pytz.timezone(timezone)
+
+        if kwargs.get('redis_host') and kwargs.get('rate_limit_count'):
+            self.rate_limiter = RateLimiter(conditions=[{'requests': kwargs.get('rate_limit_count'),
+                                                         'seconds': kwargs.get('rate_limit_duration', 1)}],
+                                            redis_host=kwargs.get('redis_host'),
+                                            redis_port=kwargs.get('redis_port', 6379),
+                                            redis_db=kwargs.get('redis_db', 0),
+                                            redis_password=kwargs.get('redis_password'),
+                                            redis_namespace=kwargs.get('redis_namespace', 'jormungandr.rate_limiter'))
+        else:
+            self.rate_limiter = FakeRateLimiter()
 
 
     def __repr__(self):
@@ -90,6 +102,8 @@ class Timeo(RealtimeProxy):
         The call is also cached
         """
         try:
+            if not self.rate_limiter.acquire(self.rt_system_id, block=False):
+                return None
             return self.breaker.call(requests.get, url, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error('Timeo RT service dead, using base '

--- a/source/navitiacommon/navitiacommon/ratelimit.py
+++ b/source/navitiacommon/navitiacommon/ratelimit.py
@@ -265,3 +265,12 @@ if __name__ == '__main__':
         rate(key, block=False) # alternative interface
         time.sleep(1)
 
+class FakeRateLimiter(object):
+    """
+    emulate a ratelimiter but do nothing :)
+    """
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def acquire(self, *args, **kwargs):
+        return True


### PR DESCRIPTION
it's for preventing major outage when we ask us to set timeout value so
big that setting no timeout will have the same effect.
This PR is more of a quick bypass, a better will be needed, probably
something like a distributed semaphore, than complicate for almost
nothing, if you have better idea, I am listening
