### PR TITLE
jormun: add a parameters to remove geojson from lines responses

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -278,6 +278,21 @@ Example:
     vehicle journey, "since" is included and "until" is excluded.
 </aside>
 
+#### disable_geojson
+
+By default geojson part of an object are returned in navitia's responses, this parameter allows you to
+remove them, it's useful when searching lines that you don't want to display on a map.
+
+<aside class="notice">
+    Geojson objects can be very large, 1MB is not unheard of, and they don't compress very well.
+    So this parameter is mostly here for reducing your downloading times and helping your json parser.
+    It's almost mandatory on mobile devices since most cellular networks are still relatively slow.
+</aside>
+
+Examples :
+
+-   <https://api.navitia.io/v1/coverage/fr-idf/lines?disable_geojson=true>
+
 ### <a name="filter"></a>Filter
 
 It is possible to apply a filter to the returned collection, using

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -54,6 +54,7 @@ from jormungandr.interfaces.common import odt_levels
 from jormungandr.utils import date_to_timestamp
 from jormungandr.resources_utc import ResourceUtc
 from datetime import datetime
+from flask import g
 
 
 class Uri(ResourceUri, ResourceUtc):
@@ -104,6 +105,8 @@ class Uri(ResourceUri, ResourceUtc):
                             description="filters objects not valid before this date")
         parser.add_argument("until", type=date_time_format,
                             description="filters objects not valid after this date")
+        parser.add_argument("disable_geojson", type=bool, default=False,
+                            description="remove geojson from the response")
 
         if is_collection:
             parser.add_argument("filter", type=unicode, default="",
@@ -123,6 +126,9 @@ class Uri(ResourceUri, ResourceUtc):
                 args["filter"] += " and " + f
             else:
                 args["filter"] = f
+
+        if args['disable_geojson']:
+            g.disable_geojson = True
 
         # for retrocompatibility purpose
         for forbid_id in args['__temporary_forbidden_id[]']:

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -354,6 +354,9 @@ class MultiLineString(fields.Raw):
         super(MultiLineString, self).__init__(**kwargs)
 
     def output(self, key, obj):
+        if hasattr(g, 'disable_geojson') and g.disable_geojson:
+            return None
+
         val = fields.get_value(key if self.attribute is None else self.attribute, obj)
 
         lines = []

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -261,6 +261,29 @@ class TestPtRef(AbstractTestFixture):
 
         self._test_links(response, 'lines')
 
+    def test_line_without_shape(self):
+        """test line formating with shape disabled"""
+        response = self.query_region("v1/lines?disable_geojson=true")
+        lines = get_not_null(response, 'lines')
+
+        assert len(lines) == 3
+        l = lines[0]
+        is_valid_line(l, depth_check=1)
+        #we don't want a geojson since we have desactivate them
+        assert 'geojson' not in l
+
+        response = self.query_region("v1/lines")
+        lines = get_not_null(response, 'lines')
+
+        assert len(lines) == 3
+        l = lines[0]
+        is_valid_line(l, depth_check=1)
+
+        #we check our geojson, just to be safe :)
+        assert 'geojson' in l
+        geo = get_not_null(l, 'geojson')
+        shape(geo)
+
     def test_line_groups(self):
         """test line group formating"""
         # Test for each possible range to ensure main_line is always at a depth of 0


### PR DESCRIPTION
On fr-cen we have some very detailed geojson for lines, the resulting json weight 9MB and compression only put it down to 3MB

On good 3G network the downloading time should approximate 16sec, and our application cannot use `depth=0` since they need modes and routes.
