### PR TITLE
jormungandr: fix a few error on bss connectors

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/bss/atos.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/atos.py
@@ -50,16 +50,17 @@ class AtosProvider(BssProvider):
 
     def support_poi(self, poi):
         properties = poi.get('properties', {})
-        return properties.get('operator').lower() in self.operators and \
-               properties.get('network').lower() == self.network
+        return properties.get('operator', '').lower() in self.operators and \
+               properties.get('network', '').lower() == self.network
 
     def get_informations(self, poi):
         logging.debug('building stands')
         try:
             all_stands = self.get_all_stands()
-            ref = poi.get('properties', {}).get('ref').lstrip('0')
-            stands = all_stands.get(ref)
-            return stands
+            ref = poi.get('properties', {}).get('ref')
+            if ref:
+                stands = all_stands.get(ref.lstrip('0'))
+                return stands
         except:
             #suds raide a lot of crap... don't want to handle all of them
             logging.getLogger(__name__).exception('transport error during call to %s bss provider', self.id_ao)

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
@@ -51,8 +51,8 @@ class JcdecauxProvider(BssProvider):
 
     def support_poi(self, poi):
         properties = poi.get('properties', {})
-        return properties.get('operator').lower() in self.operators and \
-               properties.get('network').lower() == self.network
+        return properties.get('operator', '').lower() in self.operators and \
+               properties.get('network', '').lower() == self.network
 
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_JCDECAUX', 30))
     def _call_webservice(self, station_id):

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/atos_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/atos_test.py
@@ -69,6 +69,11 @@ def parking_space_availability_atos_support_poi_test():
     poi['properties']['operator'] = 'Bad_operator'
     assert not provider.support_poi(poi)
 
+    invalid_poi = {}
+    assert not provider.support_poi(invalid_poi)
+    invalid_poi = {'properties': {}}
+    assert not provider.support_poi(invalid_poi)
+
 def parking_space_availability_atos_get_informations_test():
     """
     Atos validate return good stands informations or None if an error occured
@@ -81,6 +86,12 @@ def parking_space_availability_atos_get_informations_test():
     provider = AtosProvider(u'10', u'vélitul', u'https://webservice.atos.com?wsdl', {'keolis'})
     provider.get_all_stands = MagicMock(return_value=all_stands)
     assert provider.get_informations(poi) == stands
+    invalid_poi = {}
+    assert provider.get_informations(invalid_poi) is None
+
+    poi_blur_ref = {'properties': {'ref': '02'}}
+    assert provider.get_informations(poi_blur_ref) == stands
+
     provider.get_all_stands = MagicMock(side_effect=WebFault('fake fault', 'mock'))
     assert provider.get_informations(poi) is None
 

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/jcdecaux_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/jcdecaux_test.py
@@ -59,6 +59,11 @@ def parking_space_availability_jcdecaux_support_poi_test():
     poi['properties']['operator'] = 'Bad_operator'
     assert not provider.support_poi(poi)
 
+    invalid_poi = {}
+    assert not provider.support_poi(invalid_poi)
+    invalid_poi = {'properties': {}}
+    assert not provider.support_poi(invalid_poi)
+
 def parking_space_availability_jcdecaux_get_informations_test():
     """
     Jcdecaux validate return good stands informations or None if an error occured
@@ -72,6 +77,8 @@ def parking_space_availability_jcdecaux_get_informations_test():
     assert provider.get_informations(poi) == Stands(4, 8)
     provider._call_webservice = MagicMock(return_value=None)
     assert provider.get_informations(poi) is None
+    invalid_poi = {}
+    assert provider.get_informations(invalid_poi) is None
 
 def parking_space_availability_jcdecaux_get_informations_unauthorized_test():
     """


### PR DESCRIPTION
If a POI didn't have all the required fields (operator, network and ref) it could cause some errors leading to incomplete responses.
