### PR TITLE
Stat: fix TZ bug when launching tests on a London platform

### DIFF
--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -41,6 +41,7 @@ from jormungandr import utils
 import re
 from threading import Lock
 
+import pytz
 import time
 import sys
 import kombu
@@ -296,14 +297,19 @@ class StatManager(object):
         of the node journeys in the result.
         """
         init_journey(stat_journey)
+
+        tz = utils.get_timezone()
         if 'requested_date_time' in resp_journey:
-            stat_journey.requested_date_time = utils.str_to_time_stamp(resp_journey['requested_date_time'])
+            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_journey['requested_date_time'])))
+            stat_journey.requested_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
 
         if 'departure_date_time' in resp_journey:
-            stat_journey.departure_date_time = utils.str_to_time_stamp(resp_journey['departure_date_time'])
+            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_journey['departure_date_time'])))
+            stat_journey.departure_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
 
         if 'arrival_date_time' in resp_journey:
-            stat_journey.arrival_date_time = utils.str_to_time_stamp(resp_journey['arrival_date_time'])
+            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_journey['arrival_date_time'])))
+            stat_journey.arrival_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
 
         if 'duration' in resp_journey:
             stat_journey.duration = resp_journey['duration']
@@ -347,11 +353,13 @@ class StatManager(object):
 
     def fill_journeys(self, stat_request, call_result):
         """
-        Fill journeys and sections for each journey
+        Fill journeys and sections for each journey (datetimes are all UTC)
         """
         journey_request = stat_request.journey_request
         if hasattr(g, 'stat_interpreted_parameters') and g.stat_interpreted_parameters['original_datetime']:
-            journey_request.requested_date_time = int(time.mktime(g.stat_interpreted_parameters['original_datetime'].timetuple()))
+            tz = utils.get_timezone()
+            utc_dt = tz.normalize(tz.localize(g.stat_interpreted_parameters['original_datetime'])).astimezone(pytz.utc)
+            journey_request.requested_date_time = utils.date_to_timestamp(utc_dt)
             journey_request.clockwise = g.stat_interpreted_parameters['clockwise']
         if 'journeys' in call_result[0] and call_result[0]['journeys']:
             first_journey = call_result[0]['journeys'][0]
@@ -385,11 +393,14 @@ class StatManager(object):
         return result
 
     def fill_section(self, stat_section, resp_section, previous_section):
+        tz = utils.get_timezone()
         if 'departure_date_time' in resp_section:
-            stat_section.departure_date_time = utils.str_to_time_stamp(resp_section['departure_date_time'])
+            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_section['departure_date_time'])))
+            stat_section.departure_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
 
         if 'arrival_date_time' in resp_section:
-            stat_section.arrival_date_time = utils.str_to_time_stamp(resp_section['arrival_date_time'])
+            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_section['arrival_date_time'])))
+            stat_section.arrival_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
 
         if 'duration' in resp_section:
             stat_section.duration = resp_section['duration']

--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -106,6 +106,11 @@ def find_destination_admin(journey):
     return find_admin(journey['sections'][-1]['to'])
 
 
+def tz_str_to_utc_timestamp(dt_str, timezone):
+    dt = timezone.normalize(timezone.localize(utils.str_to_dt(dt_str)))
+    return utils.date_to_timestamp(dt.astimezone(pytz.utc))
+
+
 class StatManager(object):
 
     def __init__(self):
@@ -300,16 +305,13 @@ class StatManager(object):
 
         tz = utils.get_timezone()
         if 'requested_date_time' in resp_journey:
-            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_journey['requested_date_time'])))
-            stat_journey.requested_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
+            stat_journey.requested_date_time = tz_str_to_utc_timestamp(resp_journey['requested_date_time'], tz)
 
         if 'departure_date_time' in resp_journey:
-            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_journey['departure_date_time'])))
-            stat_journey.departure_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
+            stat_journey.departure_date_time = tz_str_to_utc_timestamp(resp_journey['departure_date_time'], tz)
 
         if 'arrival_date_time' in resp_journey:
-            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_journey['arrival_date_time'])))
-            stat_journey.arrival_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
+            stat_journey.arrival_date_time = tz_str_to_utc_timestamp(resp_journey['arrival_date_time'], tz)
 
         if 'duration' in resp_journey:
             stat_journey.duration = resp_journey['duration']
@@ -358,8 +360,8 @@ class StatManager(object):
         journey_request = stat_request.journey_request
         if hasattr(g, 'stat_interpreted_parameters') and g.stat_interpreted_parameters['original_datetime']:
             tz = utils.get_timezone()
-            utc_dt = tz.normalize(tz.localize(g.stat_interpreted_parameters['original_datetime'])).astimezone(pytz.utc)
-            journey_request.requested_date_time = utils.date_to_timestamp(utc_dt)
+            dt = tz.normalize(tz.localize(g.stat_interpreted_parameters['original_datetime']))
+            journey_request.requested_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
             journey_request.clockwise = g.stat_interpreted_parameters['clockwise']
         if 'journeys' in call_result[0] and call_result[0]['journeys']:
             first_journey = call_result[0]['journeys'][0]
@@ -395,12 +397,10 @@ class StatManager(object):
     def fill_section(self, stat_section, resp_section, previous_section):
         tz = utils.get_timezone()
         if 'departure_date_time' in resp_section:
-            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_section['departure_date_time'])))
-            stat_section.departure_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
+            stat_section.departure_date_time = tz_str_to_utc_timestamp(resp_section['departure_date_time'], tz)
 
         if 'arrival_date_time' in resp_section:
-            dt = tz.normalize(tz.localize(utils.str_to_dt(resp_section['arrival_date_time'])))
-            stat_section.arrival_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
+            stat_section.arrival_date_time = tz_str_to_utc_timestamp(resp_section['arrival_date_time'], tz)
 
         if 'duration' in resp_section:
             stat_section.duration = resp_section['duration']

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -52,6 +52,15 @@ def str_to_time_stamp(str):
     return date_to_timestamp(date)
 
 
+def str_to_dt(str):
+    """
+    convert a string to a datetime
+    the string must be in the YYYYMMDDTHHMMSS format
+    like 20170534T124500
+    """
+    return datetime.strptime(str, DATETIME_FORMAT)
+
+
 def date_to_timestamp(date):
     """
     convert a datatime objet to a posix timestamp (number of seconds from 1070/1/1)

--- a/source/jormungandr/tests/stats_tests.py
+++ b/source/jormungandr/tests/stats_tests.py
@@ -88,17 +88,18 @@ class MockWrapper:
         #Verify elements of request.journeys
         assert len(stat.journeys) == 2
 
-        assert stat.journeys[0].requested_date_time == str_to_time_stamp("20120614T080000") #1339653600
-        assert stat.journeys[0].departure_date_time == str_to_time_stamp("20120614T080043") #1339653643
-        assert stat.journeys[0].arrival_date_time == str_to_time_stamp("20120614T080222") #1339653742
+        #datetimes stored in UTC, no matter instance or jormun TZ (here instance is UTC)
+        assert stat.journeys[0].requested_date_time == str_to_time_stamp("20120614T080000")
+        assert stat.journeys[0].departure_date_time == str_to_time_stamp("20120614T080043")
+        assert stat.journeys[0].arrival_date_time == str_to_time_stamp("20120614T080222")
         assert stat.journeys[0].duration == 99
         assert stat.journeys[0].type == "best"
         assert stat.journeys[0].nb_transfers == 0
 
         #Verify elements of request.journeys.sections
         assert len(stat.journeys[0].sections) == 3
-        assert stat.journeys[0].sections[1].departure_date_time == str_to_time_stamp("20120614T080100") #1339653660
-        assert stat.journeys[0].sections[1].arrival_date_time == str_to_time_stamp("20120614T080102") #1339653662
+        assert stat.journeys[0].sections[1].departure_date_time == str_to_time_stamp("20120614T080100")
+        assert stat.journeys[0].sections[1].arrival_date_time == str_to_time_stamp("20120614T080102")
         assert stat.journeys[0].sections[1].duration == 2
         assert stat.journeys[0].sections[1].from_embedded_type == "stop_area"
         assert stat.journeys[0].sections[1].from_id == "stopB"
@@ -115,8 +116,8 @@ class MockWrapper:
         assert abs(stat.journeys[0].sections[1].to_coord.lat - 0.000718649585564) < epsilon
         assert abs(stat.journeys[0].sections[1].to_coord.lon - 0.00107797437835) < epsilon
         assert len(stat.journeys[1].sections) == 1
-        assert stat.journeys[1].sections[0].departure_date_time == str_to_time_stamp("20120614T080000") #1339653600
-        assert stat.journeys[1].sections[0].arrival_date_time == str_to_time_stamp("20120614T080435") #1339653875
+        assert stat.journeys[1].sections[0].departure_date_time == str_to_time_stamp("20120614T080000")
+        assert stat.journeys[1].sections[0].arrival_date_time == str_to_time_stamp("20120614T080435")
         assert stat.journeys[1].sections[0].duration == 275
         assert stat.journeys[1].sections[0].from_embedded_type == "address"
         assert stat.journeys[1].sections[0].from_id == "8.98312e-05;8.98312e-05"
@@ -127,7 +128,8 @@ class MockWrapper:
         assert stat.journeys[1].sections[0].to_name == "rue ag"
         assert stat.journeys[1].sections[0].type == "street_network"
 
-        eq_(stat.journey_request.requested_date_time, 1339653600)
+        #journey_request is stored UTC no matter instance or jormun TZ (but instance TZ is in UTC)
+        eq_(stat.journey_request.requested_date_time, str_to_time_stamp("20120614T080000"))
         eq_(stat.journey_request.clockwise, True)
         eq_(stat.journey_request.departure_insee, '03430')
         eq_(stat.journey_request.departure_admin, 'admin:74435')

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -51,6 +51,7 @@ static const double CO2_ESTIMATION_COEFF = 1.35;
 
 namespace navitia {
 
+namespace {
 // local exception, only used in this file
 struct coord_conversion_exception : public recoverable_exception
 {
@@ -58,8 +59,9 @@ struct coord_conversion_exception : public recoverable_exception
     coord_conversion_exception() = default;
     coord_conversion_exception(const coord_conversion_exception&) = default;
     coord_conversion_exception& operator=(const coord_conversion_exception&) = default;
-    virtual ~coord_conversion_exception() noexcept{};
+    virtual ~coord_conversion_exception() noexcept {}
 };
+}
 
 static type::GeographicalCoord coord_of_entry_point(
         const type::EntryPoint & entry_point,
@@ -602,7 +604,9 @@ create_journeys_entry_point(const ::pbnavitia::LocationContext& location,
     case type::Type_e::POI:
         entry_point.streetnetwork_params =
             streetnetwork_params_of_entry_point(sn_params, data, is_origin);
-        // StopPoint doesn't use street network
+        entry_point.coordinates = coord_of_entry_point(entry_point, data);
+        break;
+    // StopPoint doesn't use street network
     case type::Type_e::StopPoint:
         entry_point.coordinates = coord_of_entry_point(entry_point, data);
         break;

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -357,14 +357,14 @@ std::string build_raster_isochrone(const georef::GeoRef& worker,
                                    clockwise, bound);
     auto distances = init_distance(worker, stop_points, init_dt, raptor, mode, coord_origin,
                                    clockwise, bound, speed, duration);
+    // We cannot make a dijkstra multi start with old boost version
+#if BOOST_VERSION >= 105500
     auto start = init_points.begin();
     auto end = init_points.end();
     double speed_factor = speed / georef::default_speed[mode];
     auto visitor = georef::distance_visitor(navitia::seconds(duration), distances);
     auto index_map = boost::identity_property_map();
     using filtered_graph = boost::filtered_graph<georef::Graph, boost::keep_all, georef::TransportationModeFilter>;
-    // We cannot make a dijkstra multi start with old boost version
-#if BOOST_VERSION >= 105500
     try {
         boost::dijkstra_shortest_paths_no_init(filtered_graph(worker.graph, {},
                                                               georef::TransportationModeFilter(mode, worker)),
@@ -375,7 +375,7 @@ std::string build_raster_isochrone(const georef::GeoRef& worker,
                                                georef::SpeedDistanceCombiner(speed_factor),
                                                navitia::seconds(0),
                                                visitor);
-    } catch (georef::DestinationFound){};
+    } catch (georef::DestinationFound) {}
 #endif
     return build_grid(worker, box, distances, speed, duration, resolution);
 }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1291,9 +1291,9 @@ static boost::optional<pbnavitia::Response> fill_isochrone_common(IsochroneCommo
     return boost::none;
 }
 
-DateTime make_isochrone_date (const DateTime& init_dt,
-                             const DateTime& offset,
-                             const bool clockwise) {
+static DateTime make_isochrone_date (const DateTime& init_dt,
+                                     const DateTime& offset,
+                                     const bool clockwise) {
         return init_dt + (clockwise ? 1: -1) * offset;
 }
 


### PR DESCRIPTION
we now consider kraken TZ to build UTC datetimes for all stats
 (used to do it considering jormun TZ for journey_request, and sending local kraken datetimes in journey)
also removed some clang warnings
