### PR TITLE
kraken: improve performance of add_contributor

### DIFF
--- a/source/ptreferential/ptref_graph.cpp
+++ b/source/ptreferential/ptref_graph.cpp
@@ -145,6 +145,11 @@ Jointures::Jointures() {
     boost::add_edge(vertex_map.at(Type_e::Dataset), vertex_map.at(Type_e::Route), Edge(2), g);
     // From a StopPoint we can have datasets
     boost::add_edge(vertex_map.at(Type_e::Dataset), vertex_map.at(Type_e::StopPoint), Edge(3), g);
+    // We use a weight to avoid the usage of this path: we want it to be used only when we look for the dataset
+    // or the contributor of a network. If we want the vehicle_journeys of a network we have to use the path:
+    // Network -> Line -> Route -> VJ with a cost a 3 and not the path using the dataset:
+    // Network -> Dataset -> VJ that has a cost of 4
+    boost::add_edge(vertex_map.at(Type_e::Dataset), vertex_map.at(Type_e::Network), Edge(3), g);
 
     // edges for the impacts. for the moment we only need unilateral links,
     // we don't need from an impact all the impacted objects

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -64,7 +64,7 @@ namespace navitia { namespace type {
 
 wrong_version::~wrong_version() noexcept {}
 
-const unsigned int Data::data_version = 60; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 61; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     data_identifier(data_identifier),
@@ -440,6 +440,9 @@ static void build_datasets(navitia::type::VehicleJourney* vj){
         if(st.stop_point){
             st.stop_point->dataset_list.insert(vj->dataset);
         }
+    }
+    if(vj->route && vj->route->line && vj->route->line->network){
+        vj->route->line->network->dataset_list.insert(vj->dataset);
     }
 }
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -727,6 +727,7 @@ Indexes Network::get(Type_e type, const PT_Data& data) const {
     switch(type) {
     case Type_e::Line: return indexes(line_list);
     case Type_e::Impact: return data.get_impacts_idx(get_impacts());
+    case Type_e::Dataset: return indexes(dataset_list);
     default: break;
     }
     return result;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -277,10 +277,11 @@ struct Network : public Header, HasMessages {
     int sort = std::numeric_limits<int>::max();
 
     std::vector<Line*> line_list;
+    std::set<Dataset*> dataset_list;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & idx & name & uri & address_name & address_number & address_type_name
-            & mail & website & fax & sort & line_list & impacts;
+            & mail & website & fax & sort & line_list & impacts & dataset_list;
     }
 
     Indexes get(Type_e type, const PT_Data & data) const;


### PR DESCRIPTION
For a ptref on linelist we would insert the contributor n² time, with n
being the number of lines, this was pretty slow, in production it would
take 6sec for fr-pdl, with these change we are down to less than 100ms.
We had to add another shortcut for the dataset to the networks.
