### PR TITLE
routing: (almost) support street network when starting to a stop_point

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -320,6 +320,8 @@ PathFinder::start_dijkstra_and_fill_duration_map(const navitia::time_duration& r
 routing::map_stop_point_duration
 PathFinder::find_nearest_stop_points(const navitia::time_duration& radius,
                                      const proximitylist::ProximityList<type::idx_t>& pl) {
+    if (radius == navitia::seconds(0)) { return {}; }
+
     auto elements = crow_fly_find_nearest_stop_points(radius, pl);
 
     routing::map_stop_point_duration result;

--- a/source/jormungandr/tests/bss_provider_tests.py
+++ b/source/jormungandr/tests/bss_provider_tests.py
@@ -265,13 +265,13 @@ class TestBssProvider(AbstractTestFixture):
 
     def pois_without_stands_on_places_nearby_test(self):
         with mock_bss_providers(pois_supported=['station_unknown']):
-            r = self.query_region("places/admin:74435/places_nearby", display=False)
+            r = self.query_region("places/admin:74435/places_nearby?count=20", display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
-            assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',
-                                                                            'stop_point:stopB', 'stopB', 'station_2',
-                                                                            'parking_2', 'stopC', 'stop_point:stopC',
-                                                                            'stopA', 'stop_point:stopA'}
+            assert {p[p['embedded_type']]['id'] for p in places_nearby} == \
+                {'parking_1', 'station_1', 'stop_point:stopB', 'stopB', 'station_2',
+                 'parking_2', 'stopC', 'stop_point:stopC',
+                 'stopA', 'stop_point:stopA', 'stop_point:uselessA'}
             for p in places_nearby:
                 embedded_type = p['embedded_type']
                 if embedded_type == 'poi':
@@ -281,13 +281,13 @@ class TestBssProvider(AbstractTestFixture):
 
     def pois_with_stands_on_second_places_nearby_test(self):
         with mock_bss_providers(pois_supported=['station_1']):
-            r = self.query_region('places/admin:74435/places_nearby', display=False)
+            r = self.query_region('places/admin:74435/places_nearby?count=20', display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
-            assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',
-                                                                            'stop_point:stopB', 'stopB', 'station_2',
-                                                                            'parking_2', 'stopC', 'stop_point:stopC',
-                                                                            'stopA', 'stop_point:stopA'}
+            assert {p[p['embedded_type']]['id'] for p in places_nearby} == \
+                {'parking_1', 'station_1', 'stop_point:stopB', 'stopB', 'station_2',
+                 'parking_2', 'stopC', 'stop_point:stopC',
+                 'stopA', 'stop_point:stopA', 'stop_point:uselessA'}
             for p in places_nearby:
                 embedded_type = p['embedded_type']
                 if embedded_type == 'poi':
@@ -306,13 +306,13 @@ class TestBssProvider(AbstractTestFixture):
 
     def pois_with_stands_on_all_places_nearby_test(self):
         with mock_bss_providers(pois_supported=[]):
-            r = self.query_region('places/admin:74435/places_nearby', display=False)
+            r = self.query_region('places/admin:74435/places_nearby?count=20', display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
-            assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',
-                                                                            'stop_point:stopB', 'stopB', 'station_2',
-                                                                            'parking_2', 'stopC', 'stop_point:stopC',
-                                                                            'stopA', 'stop_point:stopA'}
+            assert {p[p['embedded_type']]['id'] for p in places_nearby} == \
+                {'parking_1', 'station_1', 'stop_point:stopB', 'stopB', 'station_2',
+                 'parking_2', 'stopC', 'stop_point:stopC',
+                 'stopA', 'stop_point:stopA', 'stop_point:uselessA'}
             for p in places_nearby:
                 embedded_type = p['embedded_type']
                 if embedded_type == 'poi':
@@ -339,13 +339,13 @@ class TestBssProvider(AbstractTestFixture):
         we don't want jormungandr to crash in this case
         """
         with mock_bss_providers(pois_supported=['station_1']):
-            r = self.query_region('places/admin:74435/places_nearby?depth=0', display=False)
+            r = self.query_region('places/admin:74435/places_nearby?depth=0&count=20', display=False)
 
             places_nearby = get_not_null(r, 'places_nearby')
-            assert {p[p['embedded_type']]['id'] for p in places_nearby} == {'parking_1', 'station_1',
-                                                                            'stop_point:stopB', 'stopB', 'station_2',
-                                                                            'parking_2', 'stopC', 'stop_point:stopC',
-                                                                            'stopA', 'stop_point:stopA'}
+            assert {p[p['embedded_type']]['id'] for p in places_nearby} == \
+                {'parking_1', 'station_1', 'stop_point:stopB', 'stopB', 'station_2',
+                 'parking_2', 'stopC', 'stop_point:stopC',
+                 'stopA', 'stop_point:stopA', 'stop_point:uselessA'}
 
 
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -755,7 +755,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
 
     def test_headsign_display_info_journeys(self):
         """test basic print of headsign in section for journeys"""
-        response = self.query_region('journeys?from=stop_point:stopB&to=stop_point:stopA&datetime=20120615T000000')
+        response = self.query_region('journeys?from=stop_point:stopB&to=stop_point:stopA&datetime=20120615T000000&max_duration_to_pt=0')
         assert 'error' not in response
         journeys = get_not_null(response, 'journeys')
         eq_(len(journeys), 1)
@@ -852,7 +852,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
 
     def test_attributs_in_display_info_journeys(self):
         """test some attributs in  display_information of a section for journeys"""
-        response = self.query_region('journeys?from=stop_point:stopB&to=stop_point:stopA&datetime=20120615T000000')
+        response = self.query_region('journeys?from=stop_point:stopB&to=stop_point:stopA&datetime=20120615T000000&max_duration_to_pt=0')
         assert 'error' not in response
         journeys = get_not_null(response, 'journeys')
         eq_(len(journeys), 1)

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -345,6 +345,26 @@ class TestJourneys(AbstractTestFixture):
         response = self.query_region(query)
         self.is_valid_journey_response(response, query)
 
+    def test_sp_to_sp(self):
+        """
+        Test journeys from stop point to stop point
+        """
+        query = "journeys?from=stop_point:uselessA&to=stop_point:stopB&datetime=20120615T080000"
+
+        # with street network desactivated
+        response = self.query_region(query + "&max_duration_to_pt=0")
+        assert('journeys' not in response)
+
+        # with street network activated
+        response = self.query_region(query + "&max_duration_to_pt=1")
+        assert('journeys' not in response)
+        #eq_(len(response['journeys']), 1)
+        #eq_(response['journeys'][0]['sections'][0]['from']['id'], 'stop_point:uselessA')
+        #eq_(response['journeys'][0]['sections'][0]['to']['id'], 'stop_point:stopA')
+        #eq_(response['journeys'][0]['sections'][0]['type'], 'street_network')
+        #eq_(response['journeys'][0]['sections'][0]['mode'], 'walking')
+        #eq_(response['journeys'][0]['sections'][0]['duration'], 0)
+
 
 @dataset({})
 class TestJourneysNoRegion(AbstractTestFixture):
@@ -372,7 +392,7 @@ class TestJourneysNoRegion(AbstractTestFixture):
 
 
 @dataset({"basic_routing_test": {}})
-class TestLongWaitingDurationFilter(AbstractTestFixture):
+class TestOnBasicRouting(AbstractTestFixture):
     """
     Test if the filter on long waiting duration is working
     """
@@ -517,6 +537,26 @@ class TestLongWaitingDurationFilter(AbstractTestFixture):
         response = self.query_region(query, display=False)
         eq_(len(response['journeys']), 1)
 
+    def test_sp_to_sp(self):
+        """
+        Test journeys from stop point to stop point without street network
+        """
+        query = "journeys?from=stop_point:uselessA&to=stop_point:B&datetime=20120615T080000"
+
+        # with street network desactivated
+        response = self.query_region(query + "&max_duration_to_pt=0")
+        assert('journeys' not in response)
+
+        # with street network activated
+        response = self.query_region(query + "&max_duration_to_pt=1")
+        assert('journeys' not in response)
+        #eq_(len(response['journeys']), 1)
+        #eq_(response['journeys'][0]['sections'][0]['from']['id'], 'stop_point:uselessA')
+        #eq_(response['journeys'][0]['sections'][0]['to']['id'], 'A')
+        #eq_(response['journeys'][0]['sections'][0]['type'], 'crow_fly')
+        #eq_(response['journeys'][0]['sections'][0]['mode'], 'walking')
+        #eq_(response['journeys'][0]['sections'][0]['duration'], 0)
+
 
 @dataset({"main_routing_test": {}})
 class TestShapeInGeoJson(AbstractTestFixture):
@@ -558,7 +598,7 @@ class TestOneDeadRegion(AbstractTestFixture):
         self.krakens_pool["basic_routing_test"].kill()
 
         response = self.query("v1/journeys?from=stop_point:stopA&"
-            "to=stop_point:stopB&datetime=20120614T080000&debug=true")
+            "to=stop_point:stopB&datetime=20120614T080000&debug=true&max_duration_to_pt=0")
         eq_(len(response['journeys']), 1)
         eq_(len(response['journeys'][0]['sections']), 1)
         eq_(response['journeys'][0]['sections'][0]['type'], 'public_transport')

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -603,9 +603,7 @@ create_journeys_entry_point(const ::pbnavitia::LocationContext& location,
     case type::Type_e::StopArea:
     case type::Type_e::POI:
     case type::Type_e::StopPoint:
-        if (sn_params
-            && entry_point.type != type::Type_e::StopPoint// TODO: remove this for sn on sp
-            ) {
+        if (sn_params) {
             entry_point.streetnetwork_params =
                 streetnetwork_params_of_entry_point(*sn_params, data, is_origin);
         }
@@ -629,14 +627,18 @@ JourneysArg::JourneysArg(){}
 navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest &request) {
     const auto data = data_manager.get_data();
     std::vector<type::EntryPoint> origins;
-    const auto& sn_params = request.has_streetnetwork_params() ? &request.streetnetwork_params() : nullptr;
+    const auto* sn_params = request.has_streetnetwork_params() ? &request.streetnetwork_params() : nullptr;
     for(int i = 0; i < request.origin().size(); i++) {
-        origins.push_back(create_journeys_entry_point(request.origin(i), sn_params, data, true));
+        const auto* cur_sn_params = sn_params;// TODO: remove this for sn on sp
+        if (data->get_type_of_id(request.origin(i).place()) == type::Type_e::StopPoint) { cur_sn_params = nullptr; }// TODO: remove this for sn on sp
+        origins.push_back(create_journeys_entry_point(request.origin(i), cur_sn_params, data, true));// TODO: remove cur_ for sn on sp
     }
 
     std::vector<type::EntryPoint> destinations;
     for (int i = 0; i < request.destination().size(); i++) {
-        destinations.push_back(create_journeys_entry_point(request.destination(i), sn_params, data, false));
+        const auto* cur_sn_params = sn_params;// TODO: remove this for sn on sp
+        if (data->get_type_of_id(request.destination(i).place()) == type::Type_e::StopPoint) { cur_sn_params = nullptr; }// TODO: remove this for sn on sp
+        destinations.push_back(create_journeys_entry_point(request.destination(i), cur_sn_params, data, false));// TODO: remove cur_ for sn on sp
     }
 
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -554,9 +554,9 @@ static void add_pathes(PbCreator& pb_creator,
             const auto& departure_stop_point = path.items.front().stop_points.front();
             georef::Path sn_departure_path = worker.get_path(departure_stop_point->idx);
 
-            if (is_same_stop_point(origin, departure_stop_point)) {
+            if (is_same_stop_point(origin, *departure_stop_point)) {
                 // nothing in this case
-            } else if (use_crow_fly(origin, departure_stop_point, sn_departure_path, pb_creator.data)){
+            } else if (use_crow_fly(origin, *departure_stop_point, sn_departure_path, pb_creator.data)){
                 type::EntryPoint destination_tmp(type::Type_e::StopPoint, departure_stop_point->uri);
                 destination_tmp.coordinates = departure_stop_point->coord;
                 pb_creator.action_period = bt::time_period (path.items.front().departures.front(),
@@ -619,9 +619,9 @@ static void add_pathes(PbCreator& pb_creator,
             const auto arrival_stop_point = path.items.back().stop_points.back();
             georef::Path sn_arrival_path = worker.get_path(arrival_stop_point->idx, true);
 
-            if (is_same_stop_point(destination, arrival_stop_point)) {
+            if (is_same_stop_point(destination, *arrival_stop_point)) {
                 // nothing in this case
-            } else if (use_crow_fly(destination, arrival_stop_point, sn_arrival_path, pb_creator.data)) {
+            } else if (use_crow_fly(destination, *arrival_stop_point, sn_arrival_path, pb_creator.data)) {
                 type::EntryPoint origin_tmp(type::Type_e::StopPoint, arrival_stop_point->uri);
                 origin_tmp.coordinates = arrival_stop_point->coord;
                 pb_creator.action_period = bt::time_period(path.items.back().departures.back(),

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -554,7 +554,9 @@ static void add_pathes(PbCreator& pb_creator,
             const auto& departure_stop_point = path.items.front().stop_points.front();
             georef::Path sn_departure_path = worker.get_path(departure_stop_point->idx);
 
-            if (use_crow_fly(origin, departure_stop_point, sn_departure_path, pb_creator.data)){
+            if (is_same_stop_point(origin, departure_stop_point)) {
+                // nothing in this case
+            } else if (use_crow_fly(origin, departure_stop_point, sn_departure_path, pb_creator.data)){
                 type::EntryPoint destination_tmp(type::Type_e::StopPoint, departure_stop_point->uri);
                 destination_tmp.coordinates = departure_stop_point->coord;
                 pb_creator.action_period = bt::time_period (path.items.front().departures.front(),
@@ -617,7 +619,9 @@ static void add_pathes(PbCreator& pb_creator,
             const auto arrival_stop_point = path.items.back().stop_points.back();
             georef::Path sn_arrival_path = worker.get_path(arrival_stop_point->idx, true);
 
-            if (use_crow_fly(destination, arrival_stop_point, sn_arrival_path, pb_creator.data)) {
+            if (is_same_stop_point(destination, arrival_stop_point)) {
+                // nothing in this case
+            } else if (use_crow_fly(destination, arrival_stop_point, sn_arrival_path, pb_creator.data)) {
                 type::EntryPoint origin_tmp(type::Type_e::StopPoint, arrival_stop_point->uri);
                 origin_tmp.coordinates = arrival_stop_point->coord;
                 pb_creator.action_period = bt::time_period(path.items.back().departures.back(),
@@ -840,6 +844,7 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
     if (ep.type == type::Type_e::Address
                 || ep.type == type::Type_e::Coord
                 || ep.type == type::Type_e::StopArea
+                || ep.type == type::Type_e::StopPoint
                 || ep.type == type::Type_e::POI) {
 
         if (ep.type == type::Type_e::StopArea) {
@@ -853,6 +858,16 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
                     }
                 }
             }
+        }
+
+        if (ep.type == type::Type_e::StopPoint) {
+            auto it = data.pt_data->stop_points_map.find(ep.uri);
+            if (it != data.pt_data->stop_points_map.end()){
+                const SpIdx sp_idx{*it->second};
+                concerned_path_finder.distance_to_entry_point[sp_idx] = {};
+                result[sp_idx] = {};
+            }
+            return result;// TODO: remove this for sn on sp
         }
 
         // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1
@@ -888,11 +903,6 @@ get_stop_points( const type::EntryPoint &ep, const type::Data& data,
             if(result.find(sp_idx) == result.end()) {
                 result[sp_idx] = idx_duration.second;
             }
-        }
-    } else if (ep.type == type::Type_e::StopPoint) {
-        auto it = data.pt_data->stop_points_map.find(ep.uri);
-        if (it != data.pt_data->stop_points_map.end()){
-            result[SpIdx{*it->second}] = {};
         }
     } else if(ep.type == type::Type_e::Admin) {
         //for an admin, we want to leave from it's main stop areas if we have some, else we'll leave from the center of the admin

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -64,11 +64,11 @@ std::string PathItem::print() const {
     return ss.str();
 }
 
-bool is_same_stop_point(const type::EntryPoint& point, const type::StopPoint* stop_point) {
-    return point.type == type::Type_e::StopPoint && point.uri == stop_point->uri;
+bool is_same_stop_point(const type::EntryPoint& point, const type::StopPoint& stop_point) {
+    return point.type == type::Type_e::StopPoint && point.uri == stop_point.uri;
 }
 
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point,
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint& stop_point,
                   const georef::Path& street_network_path, const type::Data& data) {
     if (is_same_stop_point(point, stop_point)) {
         return false;
@@ -79,14 +79,14 @@ bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_poi
     if(point.type == type::Type_e::StopArea){
         //if we have a stop area in the request,
         //we only do a crowfly section if the used stop point belongs to this stop area
-        return point.uri == stop_point->stop_area->uri;
+        return point.uri == stop_point.stop_area->uri;
     }else if(point.type == type::Type_e::Admin){
         //we handle the main_stop_area of an admin here
         //we want a crowfly for all main_stop_areas of an admin,
         //even if the stop_area is not in the admin
         auto admin = data.geo_ref->admins[data.geo_ref->admin_map[point.uri]];
         auto it = find_if(begin(admin->main_stop_areas), end(admin->main_stop_areas),
-                [stop_point](const type::StopArea* stop_area){return stop_area == stop_point->stop_area;});
+                [stop_point](const type::StopArea* stop_area){return stop_area == stop_point.stop_area;});
         return it != end(admin->main_stop_areas);
     }else{
         //if the request is on any other type we don't want a crowfly section

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -64,10 +64,13 @@ std::string PathItem::print() const {
     return ss.str();
 }
 
+bool is_same_stop_point(const type::EntryPoint& point, const type::StopPoint* stop_point) {
+    return point.type == type::Type_e::StopPoint && point.uri == stop_point->uri;
+}
 
 bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point,
                   const georef::Path& street_network_path, const type::Data& data) {
-    if (point.type == type::Type_e::StopPoint && point.uri == stop_point->uri) {
+    if (is_same_stop_point(point, stop_point)) {
         return false;
     }
     if (street_network_path.path_items.empty()) {

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -134,7 +134,7 @@ struct Path {
 
 bool operator==(const PathItem & a, const PathItem & b);
 
-bool is_same_stop_point(const type::EntryPoint&, const type::StopPoint*);
+bool is_same_stop_point(const type::EntryPoint&, const type::StopPoint&);
 
 /**
  * Choose if we must use a crowfly or a streetnework for a section.
@@ -147,7 +147,7 @@ bool is_same_stop_point(const type::EntryPoint&, const type::StopPoint*);
  * @param street_network_path: the street network path between point and stop_point
  * @param data: reference datas of the instance
  */
-bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint* stop_point,
+bool use_crow_fly(const type::EntryPoint& point, const type::StopPoint& stop_point,
                   const georef::Path& street_network_path, const type::Data& data);
 
 

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -134,6 +134,8 @@ struct Path {
 
 bool operator==(const PathItem & a, const PathItem & b);
 
+bool is_same_stop_point(const type::EntryPoint&, const type::StopPoint*);
+
 /**
  * Choose if we must use a crowfly or a streetnework for a section.
  * This function is called for the first and last section of a journey.

--- a/source/routing/tests/disruptions_test.cpp
+++ b/source/routing/tests/disruptions_test.cpp
@@ -73,6 +73,7 @@ BOOST_AUTO_TEST_CASE(ok_before_and_after_disruption) {
     // we ask for a journey
     pbnavitia::Response resp = w.dispatch(req);
     BOOST_REQUIRE(resp.journeys_size() != 0);
+    const auto nb_before = resp.journeys_size();
 
     // a clone and set
     auto data_cloned = data_manager.get_data_clone();
@@ -81,5 +82,5 @@ BOOST_AUTO_TEST_CASE(ok_before_and_after_disruption) {
 
     // we ask for a journey, we should have the same thing
     resp = w.dispatch(req);
-    BOOST_REQUIRE(resp.journeys_size() != 0);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), nb_before);
 }

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1794,46 +1794,46 @@ BOOST_AUTO_TEST_CASE(use_crow_fly){
 
     ep.type = navitia::type::Type_e::Address;
     ep.uri = "foo";
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(! nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::POI;
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(! nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::Coord;
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(! nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::StopArea;
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(! nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::Admin;
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(! nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::Admin;
     ep.uri = "admin";
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(!nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(!nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::StopArea;
     ep.uri = "sa:foo";
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, empty_sn_path, data));
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, empty_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp, filled_sn_path, data));
 
     ep.type = navitia::type::Type_e::Admin;
     ep.uri = "admin";
     navitia::type::StopPoint sp2;
     navitia::type::StopArea sa2;
     sp2.stop_area = &sa2;
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp2, empty_sn_path, data));
-    BOOST_CHECK(! nr::use_crow_fly(ep, &sp2, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp2, empty_sn_path, data));
+    BOOST_CHECK(! nr::use_crow_fly(ep, sp2, filled_sn_path, data));
 
     admin->main_stop_areas.push_back(&sa2);
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp2, empty_sn_path, data));
-    BOOST_CHECK(nr::use_crow_fly(ep, &sp2, filled_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp2, empty_sn_path, data));
+    BOOST_CHECK(nr::use_crow_fly(ep, sp2, filled_sn_path, data));
 }
 
 struct isochrone_fixture {

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -852,6 +852,8 @@ BOOST_FIXTURE_TEST_CASE(direct_path_exactly_the_limit, direct_path_routing_api_d
                         to_duration(B.distance_to(S), navitia::type::Mode_e::Walking);
     tested_map[navitia::routing::SpIdx(*(b.data->pt_data->stop_points_map["stop_point:stopA"]))] =
                         a_s_dur;
+    tested_map[navitia::routing::SpIdx(*(b.data->pt_data->stop_points_map["stop_point:uselessA"]))] =
+                        a_s_dur;
     BOOST_CHECK_EQUAL_COLLECTIONS(sp.cbegin(), sp.cend(), tested_map.cbegin(), tested_map.cend());
 }
 
@@ -867,6 +869,8 @@ BOOST_FIXTURE_TEST_CASE(direct_path_over_the_limit, direct_path_routing_api_data
     tested_map[navitia::routing::SpIdx(*(b.data->pt_data->stop_points_map["stop_point:stopB"]))] =
                         to_duration(B.distance_to(S), navitia::type::Mode_e::Walking);
     tested_map[navitia::routing::SpIdx(*(b.data->pt_data->stop_points_map["stop_point:stopA"]))] =
+                        a_s_dur;
+    tested_map[navitia::routing::SpIdx(*(b.data->pt_data->stop_points_map["stop_point:uselessA"]))] =
                         a_s_dur;
     BOOST_CHECK_EQUAL_COLLECTIONS(sp.cbegin(), sp.cend(), tested_map.cbegin(), tested_map.cend());
 }

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -406,7 +406,8 @@ struct routing_api_data {
 
 
         b.generate_dummy_basis();
-        b.sa("stopA", A.lon(), A.lat());
+        b.sa("stopA", A.lon(), A.lat())
+            ("stop_point:uselessA", A.lon(), A.lat());
         b.sa("stopB", B.lon(), B.lat());
         if (activate_pt) {
             //we add a very fast bus (2 seconds) to be faster than walking and biking

--- a/source/tests/basic_routing_test.cpp
+++ b/source/tests/basic_routing_test.cpp
@@ -61,6 +61,8 @@ int main(int argc, const char* const argv[]) {
 
     ed::builder b = {"20120614"};
     b.generate_dummy_basis();
+    b.sa("A", 1., 1.)("stop_point:uselessA", 1., 1.);
+    b.sa("B", 2., 2.);
     b.vj("l1")("A", 8*3600)("B", 8*3600+5*60);
     b.vj("l2")("A", 15*3600)("B", 15*3600+5*60);
     b.vj("l3")("C", 14*3600+7*60)("D", 15*3600);


### PR DESCRIPTION
This PR makes `max_duration_to_pt` completely forbid using the street network.

Everything is here to activate the street network at the stop points, just remove the 2 TODO lines and update the test by uncommenting them.
