### PR TITLE
Kraken: add a log for slow request

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -59,6 +59,8 @@ po::options_description get_options_description(const boost::optional<std::strin
                                   "timeout in ms for loading realtime data from kirin")
         ("GENERAL.kirin_retry_timeout", po::value<int>()->default_value(5*60*1000),
                                   "timeout in ms before retrying to load realtime data")
+        ("GENERAL.slow_request_duration", po::value<int>()->default_value(1000),
+                                  "request running a least this number of milliseconds are logged")
 
         ("GENERAL.display_contributors", display_contributors ?
              po::value<bool>()->default_value(*display_contributors) : po::value<bool>()->default_value(false),
@@ -178,6 +180,10 @@ bool Configuration::display_contributors() const{
         return false;
     }
     return vm["GENERAL.display_contributors"].as<bool>();
+}
+
+int Configuration::slow_request_duration() const{
+    return vm["GENERAL.slow_request_duration"].as<int>();
 }
 
 size_t Configuration::raptor_cache_size() const{

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -60,6 +60,7 @@ namespace navitia { namespace kraken{
             int kirin_retry_timeout() const;
             bool display_contributors() const;
             size_t raptor_cache_size() const;
+            int slow_request_duration() const;
 
             std::vector<std::string> rt_topics() const;
     };

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -48,6 +48,24 @@ inline pbnavitia::Response make_internal_error(const std::exception& e) {
     return response;
 }
 
+void respond(zmq::socket_t& socket,
+             const std::string& address,
+             const pbnavitia::Response& response){
+    zmq::message_t reply(response.ByteSize());
+    try{
+        response.SerializeToArray(reply.data(), response.ByteSize());
+    }catch(const google::protobuf::FatalException& e){
+        auto logger = log4cplus::Logger::getInstance("worker");
+        LOG4CPLUS_ERROR(logger, "failure during serialization: " << e.what());
+        auto error_response = make_internal_error(e);
+        reply.rebuild(error_response.ByteSize());
+        error_response.SerializeToArray(reply.data(), error_response.ByteSize());
+    }
+    z_send(socket, address, ZMQ_SNDMORE);
+    z_send(socket, "", ZMQ_SNDMORE);
+    socket.send(reply);
+}
+
 namespace pt = boost::posix_time;
 inline void doWork(zmq::context_t& context,
                    DataManager<navitia::type::Data>& data_manager,
@@ -59,8 +77,9 @@ inline void doWork(zmq::context_t& context,
     bool run = true;
     navitia::Worker w(data_manager, conf);
     z_send(socket, "READY");
+    auto slow_request_duration = pt::milliseconds(conf.slow_request_duration());
     while(run) {
-        std::string address = z_recv(socket);
+        const std::string address = z_recv(socket);
         {
             std::string empty = z_recv(socket);
             assert(empty.size() == 0);
@@ -81,47 +100,38 @@ inline void doWork(zmq::context_t& context,
         if(!pb_req.ParseFromArray(request.data(), request.size())){
             LOG4CPLUS_WARN(logger, "receive invalid protobuf");
             result.mutable_error()->set_id(pbnavitia::Error::invalid_protobuf_request);
-        } else {
-            api = pb_req.requested_api();
-            log4cplus::NDCContextCreator ndc(pb_req.request_id());
-            if(api != pbnavitia::METADATAS){
-                LOG4CPLUS_DEBUG(logger, "receive request: " << pb_req.DebugString());
-            }
-            try {
-                result = w.dispatch(pb_req);
-                if(api != pbnavitia::METADATAS){
-                    LOG4CPLUS_TRACE(logger, "response: " << result.DebugString());
-                }
-            } catch (const navitia::recoverable_exception& e) {
-                //on a recoverable an internal server error is returned
-                LOG4CPLUS_ERROR(logger, "internal server error: " << e.what());
-                LOG4CPLUS_ERROR(logger, "on query: " << pb_req.DebugString());
-                LOG4CPLUS_ERROR(logger, "backtrace: " << e.backtrace());
-                result = make_internal_error(e);
-            }
-            if (! data_manager.get_data()->loaded){
-                result.set_publication_date(-1);
-            } else {
-                result.set_publication_date(navitia::to_posix_timestamp(data_manager.get_data()->meta->publication_date));
-            }
+            respond(socket, address, result);
+            continue;
         }
-        zmq::message_t reply(result.ByteSize());
-        try{
-            result.SerializeToArray(reply.data(), result.ByteSize());
-        }catch(const google::protobuf::FatalException& e){
-            LOG4CPLUS_ERROR(logger, "failure during serialization: " << e.what());
-            result = make_internal_error(e);
-            reply.rebuild(result.ByteSize());
-            result.SerializeToArray(reply.data(), result.ByteSize());
-
-        }
-        z_send(socket, address, ZMQ_SNDMORE);
-        z_send(socket, "", ZMQ_SNDMORE);
-        socket.send(reply);
-
+        api = pb_req.requested_api();
+        log4cplus::NDCContextCreator ndc(pb_req.request_id());
         if(api != pbnavitia::METADATAS){
-            LOG4CPLUS_DEBUG(logger, "processing time : "
-                            << (pt::microsec_clock::universal_time() - start).total_milliseconds());
+            LOG4CPLUS_DEBUG(logger, "receive request: " << pb_req.DebugString());
+        }
+        try {
+            result = w.dispatch(pb_req);
+            if(api != pbnavitia::METADATAS){
+                LOG4CPLUS_TRACE(logger, "response: " << result.DebugString());
+            }
+        } catch (const navitia::recoverable_exception& e) {
+            //on a recoverable an internal server error is returned
+            LOG4CPLUS_ERROR(logger, "internal server error: " << e.what());
+            LOG4CPLUS_ERROR(logger, "on query: " << pb_req.DebugString());
+            LOG4CPLUS_ERROR(logger, "backtrace: " << e.backtrace());
+            result = make_internal_error(e);
+        }
+        if (! data_manager.get_data()->loaded){
+            result.set_publication_date(-1);
+        } else {
+            result.set_publication_date(navitia::to_posix_timestamp(data_manager.get_data()->meta->publication_date));
+        }
+        respond(socket, address, result);
+        auto duration = pt::microsec_clock::universal_time() - start;
+        if(duration >= slow_request_duration){
+            LOG4CPLUS_WARN(logger, "slow request! duration: " << duration.total_milliseconds()
+                                << "ms request: " << pb_req.DebugString());
+        }else if(api != pbnavitia::METADATAS){
+            LOG4CPLUS_DEBUG(logger, "processing time : " << duration.total_milliseconds());
         }
     }
 }


### PR DESCRIPTION
We log all request longer that one second, this value is of course configurable.
This should help understanding some scheduling issue
