### PR TITLE
Kraken: Fix disruption status when calling /lines

### DIFF
--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -311,6 +311,22 @@ class TestPtRef(AbstractTestFixture):
         lg = line_groups[0]
         is_valid_line_group(lg)
 
+    def test_line_with_active_disruption(self):
+        """test disruption is active"""
+        response = self.query_region("v1/lines/line:A?_current_datetime=20140115T235959")
+
+        disruptions = get_not_null(response, 'disruptions')
+
+        assert len(disruptions) == 1
+        d = disruptions[0]
+
+        # in pt_ref, the status is always active as the checked
+        # period is the validity period
+        assert d["status"] == "active"
+
+        messages = get_not_null(d, 'messages')
+        assert(messages[0]['text']) == 'Disruption on Line line:A'
+
     def test_line_codes(self):
         """test line formating"""
         response = self.query_region("v1/lines/line:A?show_codes=true")

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -49,11 +49,11 @@ static pbnavitia::Response extract_data(const type::Data& data,
     const auto& action_period = data.meta->production_period();
         switch(requested_type){
         case Type_e::ValidityPattern:
-            return get_response(data.get_data<nt::ValidityPattern>(rows), data, depth, current_time);
+            return get_response(data.get_data<nt::ValidityPattern>(rows), data, depth, current_time, action_period);
         case Type_e::Line:
-            return get_response(data.get_data<nt::Line>(rows), data, depth, current_time);
+            return get_response(data.get_data<nt::Line>(rows), data, depth, current_time, action_period);
         case Type_e::LineGroup:
-            return get_response(data.get_data<nt::LineGroup>(rows), data, depth, current_time);
+            return get_response(data.get_data<nt::LineGroup>(rows), data, depth, current_time, action_period);
         case Type_e::JourneyPattern:{
             navitia::PbCreator pb_creator(data, current_time, action_period);
             for(const auto& idx : rows){


### PR DESCRIPTION
Hello!

We notice a strange behavior while playing with disruptions. When we were adding a disruption on a line the disruption returned by the API when calling /lines always had a status set to "past".
Since PR #1460 action_period is not passed anymore to get_response for line, line_groups and validity pattern. It's probably just a mistake that [has been made while removing show_codes](https://github.com/CanalTP/navitia/pull/1460/files#diff-1dfed77d1f8e2a82b800972f0b7e7d54L52)
I added a jormungandr integration test failing without the second commit.

Let me know if I am wrong or if I need to change anything.
