### PR TITLE
Test: clean up volumes after teardown

### DIFF
--- a/source/eitri/docker_wrapper.py
+++ b/source/eitri/docker_wrapper.py
@@ -98,7 +98,7 @@ class PostgresDocker(object):
         self.docker.stop(container=self.container_id)
 
         logging.getLogger(__name__).info("removing the temporary docker")
-        self.docker.remove_container(container=self.container_id)
+        self.docker.remove_container(container=self.container_id, v=True)
 
         # test to be sure the docker is removed at the end
         for cont in self.docker.containers(all=True):

--- a/source/tyr/tests/docker_wrapper.py
+++ b/source/tyr/tests/docker_wrapper.py
@@ -86,7 +86,7 @@ class PostgresDocker(object):
         self.docker.stop(container=self.container_id)
 
         logging.getLogger(__name__).info("removing the temporary docker")
-        self.docker.remove_container(container=self.container_id)
+        self.docker.remove_container(container=self.container_id, v=True)
 
         # test to be sure the docker is removed at the end
         for cont in self.docker.containers(all=True):


### PR DESCRIPTION
remove the docker's volume at the teardown of the docker. else the
volume will take some space on the disk.

we should really make have a shared python utils lib to share this
across all repo :wink:
