### PR TITLE
Jormun: Can't explicitly disable bss_stands or disable_geojson

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
@@ -31,6 +31,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 from flask.ext.restful import Resource, fields, marshal_with, reqparse
+from flask.ext.restful.inputs import boolean
 from jormungandr import i_manager
 from jormungandr.interfaces.v1.StatedResource import StatedResource
 from jormungandr.interfaces.v1.make_links import add_coverage_link, add_coverage_link, add_collection_links, clean_links
@@ -70,7 +71,7 @@ class Coverage(StatedResource):
     def get(self, region=None, lon=None, lat=None):
 
         parser = reqparse.RequestParser()
-        parser.add_argument("disable_geojson", type=bool, default=False)
+        parser.add_argument("disable_geojson", type=boolean, default=False)
 
         args = parser.parse_args()
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -31,6 +31,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 from flask.ext.restful import marshal_with, reqparse, fields
+from flask.ext.restful.inputs import boolean
 from flask.globals import g
 from jormungandr import i_manager, timezone
 from jormungandr.interfaces.v1.fields import PbField, error, network, line,\
@@ -87,7 +88,7 @@ class TrafficReport(ResourceUri):
                                 action="append")
         parser_get.add_argument("distance", type=int, default=200,
                                 description="Distance range of the query. Used only if a coord is in the query")
-        parser_get.add_argument("disable_geojson", type=bool, default=False,
+        parser_get.add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
         self.collection = 'traffic_reports'
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -32,6 +32,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from flask import Flask, request
 from flask.ext.restful import Resource, fields, reqparse, abort
+from flask.ext.restful.inputs import boolean
 from flask.globals import g
 from jormungandr import i_manager, timezone, global_autocomplete, bss_provider_manager
 from jormungandr.interfaces.v1.fields import disruption_marshaller
@@ -225,7 +226,7 @@ class Places(ResourceUri):
                                                      " Note: it will mainly change the disruptions that concern "
                                                      "the object The timezone should be specified in the format,"
                                                      " else we consider it as UTC")
-        self.parsers['get'].add_argument("disable_geojson", type=bool, default=False,
+        self.parsers['get'].add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
 
     def get(self, region=None, lon=None, lat=None):
@@ -260,9 +261,9 @@ class PlaceUri(ResourceUri):
         self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(
             argument_class=ArgumentDoc)
-        self.parsers["get"].add_argument("bss_stands", type=bool, default=True,
+        self.parsers["get"].add_argument("bss_stands", type=boolean, default=True,
                                          description="Show bss stands availability")
-        self.parsers['get'].add_argument("disable_geojson", type=bool, default=False,
+        self.parsers['get'].add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
         args = self.parsers["get"].parse_args()
         if args["bss_stands"]:
@@ -321,7 +322,7 @@ class PlacesNearby(ResourceUri):
         self.parsers["get"].add_argument("start_page", type=int, default=0,
                                          description="The page number of the\
                                          ptref result")
-        self.parsers["get"].add_argument("bss_stands", type=bool, default=True,
+        self.parsers["get"].add_argument("bss_stands", type=boolean, default=True,
                                          description="Show bss stands availability")
 
         self.parsers["get"].add_argument("_current_datetime", type=date_time_format, default=datetime.datetime.utcnow(),
@@ -330,7 +331,7 @@ class PlacesNearby(ResourceUri):
                                                      " Note: it will mainly change the disruptions that concern "
                                                      "the object The timezone should be specified in the format,"
                                                      " else we consider it as UTC")
-        self.parsers['get'].add_argument("disable_geojson", type=bool, default=False,
+        self.parsers['get'].add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
         args = self.parsers["get"].parse_args()
         if args["bss_stands"]:

--- a/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
@@ -32,6 +32,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from flask import Flask, request
 from flask.ext.restful import Resource, fields, marshal_with, reqparse, abort
+from flask.ext.restful.inputs import boolean
 from flask.globals import g
 from jormungandr import i_manager, timezone
 from jormungandr.interfaces.v1.fields import disruption_marshaller
@@ -86,7 +87,7 @@ class Ptobjects(ResourceUri):
                                                      " Note: it will mainly change the disruptions that concern "
                                                      "the object The timezone should be specified in the format,"
                                                      " else we consider it as UTC")
-        self.parsers['get'].add_argument("disable_geojson", type=bool, default=False,
+        self.parsers['get'].add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
 
     @marshal_with(pt_objects)

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -110,7 +110,7 @@ class Schedules(ResourceUri, ResourceUtc):
                                             " Default is the current date and it is mainly used for debug.")
         parser_get.add_argument("items_per_schedule", type=natural, default=10000,
                                 description="maximum number of date_times per schedule")
-        parser_get.add_argument("disable_geojson", type=bool, default=False,
+        parser_get.add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
 
         self.method_decorators.append(complete_links(self))

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -105,7 +105,7 @@ class Uri(ResourceUri, ResourceUtc):
                             description="filters objects not valid before this date")
         parser.add_argument("until", type=date_time_format,
                             description="filters objects not valid after this date")
-        parser.add_argument("disable_geojson", type=bool, default=False,
+        parser.add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
 
         if is_collection:
@@ -544,7 +544,7 @@ def pois(is_collection):
             self.parsers["get"].add_argument("original_id", type=unicode,
                             description="original uri of the object you"
                                     "want to query")
-            self.parsers["get"].add_argument("bss_stands", type=bool, default=True,
+            self.parsers["get"].add_argument("bss_stands", type=boolean, default=True,
                                              description="Show bss stands availability")
             args = self.parsers["get"].parse_args()
             if args["bss_stands"]:

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -225,7 +225,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_line(self):
         """test line formating"""
-        response = self.query_region("v1/lines")
+        response = self.query_region("v1/lines?disable_geojson=false")
 
         lines = get_not_null(response, 'lines')
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -225,7 +225,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_line(self):
         """test line formating"""
-        response = self.query_region("v1/lines?disable_geojson=false")
+        response = self.query_region("v1/lines")
 
         lines = get_not_null(response, 'lines')
 
@@ -281,6 +281,22 @@ class TestPtRef(AbstractTestFixture):
 
         #we check our geojson, just to be safe :)
         assert 'geojson' in l
+        geo = get_not_null(l, 'geojson')
+        shape(geo)
+
+    def test_line_with_shape(self):
+        """test line formating with shape explicitly enabled"""
+        response = self.query_region("v1/lines?disable_geojson=false")
+
+        lines = get_not_null(response, 'lines')
+
+        assert len(lines) == 3
+
+        l = lines[0]
+
+        is_valid_line(l, depth_check=1)
+
+        # Test that the geojson is indeed there
         geo = get_not_null(l, 'geojson')
         shape(geo)
 


### PR DESCRIPTION
We can't explicitly disable those 2 parameters when calling the API since the type of the argument is set to `bool` with add_argument. As long as the parameter is passed to the API with a value the argument will be set to True, even if this value is false. I changed it to use boolean, declared in flask.ext.restful.inputs, already used for other boolean parameters.
