### PR TITLE
Tyr: post data

### DIFF
--- a/source/tyr/Procfile
+++ b/source/tyr/Procfile
@@ -1,4 +1,3 @@
 web: ./manage_tyr.py runserver
 worker: celery worker -A tyr.tasks
 scheduler: celery beat -A tyr.tasks
-reloader_at: ./manage_tyr.py at_reloader

--- a/source/tyr/Procfile
+++ b/source/tyr/Procfile
@@ -1,3 +1,4 @@
 web: ./manage_tyr.py runserver
 worker: celery worker -A tyr.tasks
 scheduler: celery beat -A tyr.tasks
+reloader_at: ./manage_tyr.py at_reloader

--- a/source/tyr/readme.md
+++ b/source/tyr/readme.md
@@ -67,7 +67,6 @@ Procfile:
 web: ./manage_tyr.py runserver
 worker: celery worker -A tyr.tasks
 scheduler: celery beat -A tyr.tasks
-reloader_at: ./manage_tyr.py at_reloader
 ```
 
 .env:
@@ -289,9 +288,9 @@ Look for a user with his email:
             "id": 1
         },
         "end_point": {
-            "default": false, 
-            "hostnames": [], 
-            "id": 1, 
+            "default": false,
+            "hostnames": [],
+            "id": 1,
             "name": "foo"
         },
         "type": "with_free_instances",
@@ -317,9 +316,9 @@ Get all users for a specific endpoint
             "id": 1
         },
         "end_point": {
-            "default": false, 
-            "hostnames": [], 
-            "id": 1, 
+            "default": false,
+            "hostnames": [],
+            "id": 1,
             "name": "foo"
         },
         "type": "with_free_instances",
@@ -349,9 +348,9 @@ Get all a user information:
     "keys": [],
     "login": "alex",
     "end_point": {
-        "default": false, 
-        "hostnames": [], 
-        "id": 1, 
+        "default": false,
+        "hostnames": [],
+        "id": 1,
         "name": "foo"
     },
 }
@@ -662,4 +661,3 @@ A little help if you want to add a new POI type and keep all the default ones:
     curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/amenity:townhall?name=Mairie' -X POST
     curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/leisure:garden?name=Jardin' -X POST
     curl 'http://localhost:5000/v0/instances/<INSTANCE>/poi_types/leisure:park?name=Zone+Parc.+Zone+verte+ouverte,+pour+déambuler.+habituellement+municipale' -X POST
-

--- a/source/tyr/tests/__init__.py
+++ b/source/tyr/tests/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+if not 'TYR_CONFIG_FILE' in os.environ:
+    os.environ['TYR_CONFIG_FILE'] = os.path.dirname(os.path.realpath(__file__)) \
+        + '/tests_default_settings.py'

--- a/source/tyr/tests/fixtures/fr.ini
+++ b/source/tyr/tests/fixtures/fr.ini
@@ -1,0 +1,13 @@
+[instance]
+name = fr
+source-directory = /tmp/
+backup-directory = /tmp/
+tmp-file = /tmp/ed/tmpdata.nav.lz4
+target-file = /tmp/ed/data.nav.lz4
+rt-topics = realtime.at, realtime.ire
+
+[database]
+host = 127.0.0.1
+dbname = navitia
+username = navitia
+password = navitia

--- a/source/tyr/tests/integration/datapost_test.py
+++ b/source/tyr/tests/integration/datapost_test.py
@@ -4,16 +4,17 @@ import pytest
 import os
 from navitiacommon import models
 from tyr import app
+import logging
 
-@pytest.fixture
-def create_instance2():
+@pytest.fixture(scope="module")
+def create_instance_fr():
     with app.app_context():
         instance = models.Instance('fr')
         models.db.session.add(instance)
         models.db.session.commit()
         return instance.id
 
-def test_post_pbf(create_instance2):
+def test_post_pbf(create_instance_fr):
     filename = 'empty_pbf.osm.pbf'
     path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'tests/fixtures/', filename)
     files = {'file': (open(path, 'rb'), filename)}
@@ -21,4 +22,16 @@ def test_post_pbf(create_instance2):
     tester = app.test_client()
     resp = tester.post('/v0/data/instances/fr', data=files)
     assert resp.status_code == 200
-    #assert os.path.isfile()
+    assert os.path.isfile('/tmp/empty_pbf.osm.pbf')
+    os.remove('/tmp/empty_pbf.osm.pbf')
+    assert (not os.path.isfile('/tmp/empty_pbf.osm.pbf'))
+
+def test_post_no_file(create_instance_fr):
+    tester = app.test_client()
+    resp = tester.post('/v0/data/instances/fr')
+    assert resp.status_code == 404
+
+def test_get(create_instance_fr):
+    tester = app.test_client()
+    resp = tester.get('/v0/data/instances/fr')
+    assert resp.status_code == 400

--- a/source/tyr/tests/integration/datapost_test.py
+++ b/source/tyr/tests/integration/datapost_test.py
@@ -1,0 +1,24 @@
+from tests.check_utils import api_get, api_post, api_delete, api_put, _dt
+import json
+import pytest
+from navitiacommon import models
+from tyr import app
+
+@pytest.fixture
+def create_instance():
+    with app.app_context():
+        instance = models.Instance('fr')
+        models.db.session.add(instance)
+        models.db.session.commit()
+        return instance.id
+
+def test_post_pbf(create_instance):
+    filename = 'empty_pbf.osm.pbf'
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'fixtures/', filename)
+    files = {'file': (open(path, 'rb'), filename)}
+
+    resp = api_post('/v0/data/instances/{}'.fomat(create_instance), data=files)
+    assert resp.status_code == 200
+    assert len(resp) == 1
+    assert resp[0]['name'] == 'fr'
+    assert resp[0]['id'] == create_instance

--- a/source/tyr/tests/integration/datapost_test.py
+++ b/source/tyr/tests/integration/datapost_test.py
@@ -1,24 +1,24 @@
 from tests.check_utils import api_get, api_post, api_delete, api_put, _dt
 import json
 import pytest
+import os
 from navitiacommon import models
 from tyr import app
 
 @pytest.fixture
-def create_instance():
+def create_instance2():
     with app.app_context():
         instance = models.Instance('fr')
         models.db.session.add(instance)
         models.db.session.commit()
         return instance.id
 
-def test_post_pbf(create_instance):
+def test_post_pbf(create_instance2):
     filename = 'empty_pbf.osm.pbf'
-    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'fixtures/', filename)
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'tests/fixtures/', filename)
     files = {'file': (open(path, 'rb'), filename)}
 
-    resp = api_post('/v0/data/instances/{}'.fomat(create_instance), data=files)
+    tester = app.test_client()
+    resp = tester.post('/v0/data/instances/fr', data=files)
     assert resp.status_code == 200
-    assert len(resp) == 1
-    assert resp[0]['name'] == 'fr'
-    assert resp[0]['id'] == create_instance
+    #assert os.path.isfile()

--- a/source/tyr/tests/integration/datapost_test.py
+++ b/source/tyr/tests/integration/datapost_test.py
@@ -23,7 +23,7 @@ def test_post_pbf(create_instance_fr):
     try:
         files = {'file': (f, filename)}
         tester = app.test_client()
-        resp = tester.post('/v0/data/instances/fr', data=files)
+        resp = tester.post('/v0/jobs/fr', data=files)
     finally:
         f.close()
     assert resp.status_code == 200
@@ -34,17 +34,10 @@ def test_post_pbf(create_instance_fr):
 
 def test_post_no_file(create_instance_fr):
     tester = app.test_client()
-    resp = tester.post('/v0/data/instances/fr')
+    resp = tester.post('/v0/jobs/fr')
     assert resp.status_code == 404
 
 def test_post_bad_instance(create_instance_fr):
     tester = app.test_client()
-    resp = tester.post('/v0/data/instances/fr_ko')
+    resp = tester.post('/v0/jobs/fr_ko')
     assert resp.status_code == 404
-
-def test_get(create_instance_fr):
-    tester = app.test_client()
-    resp = tester.get('/v0/data/instances/fr')
-    assert resp.status_code == 400
-    r = _to_json(resp.data, True)
-    assert r.get('error') == 'service unavailable'

--- a/source/tyr/tests/integration/instance_test.py
+++ b/source/tyr/tests/integration/instance_test.py
@@ -43,7 +43,6 @@ def test_get_instances(create_instance):
     assert resp[0]['name'] == 'fr'
     assert resp[0]['id'] == create_instance
 
-
 def test_get_instance(create_instance):
     resp = api_get('/v0/instances/fr')
     assert len(resp) == 1

--- a/source/tyr/tests/tests_default_settings.py
+++ b/source/tyr/tests/tests_default_settings.py
@@ -1,0 +1,2 @@
+#Path to the directory where the configuration file of each instance of ed are defined
+INSTANCES_DIR = './tests/fixtures/'

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -70,7 +70,7 @@ api.add_resource(resources.AutocompleteParameter,
                  '/v0/autocomplete_parameters/',
                  '/v0/autocomplete_parameters/<string:name>')
 
-api.add_resource(resources.Data, '/v0/data/instances/<string:name>/')
+api.add_resource(resources.Data, '/v0/data/instances/<string:instance_name>/')
 
 
 @app.errorhandler(Exception)

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -70,9 +70,6 @@ api.add_resource(resources.AutocompleteParameter,
                  '/v0/autocomplete_parameters/',
                  '/v0/autocomplete_parameters/<string:name>')
 
-api.add_resource(resources.Data, '/v0/data/instances/<string:instance_name>/')
-
-
 @app.errorhandler(Exception)
 def error_handler(exception):
     """

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -70,6 +70,8 @@ api.add_resource(resources.AutocompleteParameter,
                  '/v0/autocomplete_parameters/',
                  '/v0/autocomplete_parameters/<string:name>')
 
+api.add_resource(resources.Data, '/v0/data/instances/<string:name>/')
+
 
 @app.errorhandler(Exception)
 def error_handler(exception):

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -23,7 +23,7 @@ CITIES_DATABASE_URI = 'postgresql://navitia:navitia@localhost/cities'
 
 
 #Path to the directory where the configuration file of each instance of ed are defined
-INSTANCES_DIR = './tests/fixtures/'
+INSTANCES_DIR = '.'
 
 #Path to the directory where the data sources for autocomplete are stocked
 TYR_AUTOCOMPLETE_DIR = "/srv/ed/autocomplete"

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -23,7 +23,7 @@ CITIES_DATABASE_URI = 'postgresql://navitia:navitia@localhost/cities'
 
 
 #Path to the directory where the configuration file of each instance of ed are defined
-INSTANCES_DIR = '.'
+INSTANCES_DIR = './tests/fixtures/'
 
 #Path to the directory where the data sources for autocomplete are stocked
 TYR_AUTOCOMPLETE_DIR = "/srv/ed/autocomplete"

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -105,7 +105,7 @@ def load_instance_config(instance_name):
     confspec.append('port = string(default="5432")')
 
     ini_file = '%s/%s.ini' % \
-               (current_app.config['INSTANCES_DIR'], instance_name)
+               (os.path.realpath(current_app.config['INSTANCES_DIR']), instance_name)
     if not os.path.isfile(ini_file):
         raise ValueError("File doesn't exists or is not a file %s" % ini_file)
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -38,7 +38,7 @@ from datetime import datetime
 from itertools import combinations, chain
 from tyr_user_event import TyrUserEvent
 from tyr_end_point_event import EndPointEventMessage, TyrEventsRabbitMq
-from tyr.helper import load_instance_config
+from tyr.helper import load_instance_config, get_instance_logger
 import logging
 import os
 import shutil
@@ -1119,16 +1119,14 @@ class AutocompleteParameter(flask_restful.Resource):
 class Data(flask_restful.Resource):
     def post(self, instance_name):
         instance = models.Instance.query_existing().filter_by(name=instance_name).first_or_404()
-        if instance is None:
-            return {'message': 'bad instance {}'.format(instance_name)}, 404
 
         if not request.files:
             return {'message': 'the Data file is missing'}, 400
         content = request.files['file']
-        logger = logging.getLogger(__name__)
+        logger = get_instance_logger(instance)
         logger.info('content received: %s', content)
 
-        instance = load_instance_config('fr')
+        instance = load_instance_config(instance_name)
         if not os.path.exists(instance.source_directory):
             return ({'error': 'input folder unavailable'}, 500)
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1138,3 +1138,6 @@ class Data(flask_restful.Resource):
         shutil.move(full_file_name + ".tmp", full_file_name)
 
         return {'message': 'OK'}, 200
+
+    def get(self, instance_name):
+        return ({'error': 'service unavailable'}, 400)


### PR DESCRIPTION
Adding a /data/instances/string:instance_name/ API (POST only) to allow sending data by API. It may reduce Devops actions when configuring shared directories.
It will be used by tartare in a near future to send geo_data to several tyr environnements.
