### PR TITLE
jormun: add the ability to use transient zmq socket

### DIFF
--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -115,7 +115,8 @@ class InstanceManager(object):
                     name = config_data['key']
                     instance = Instance(self.context, name, config_data['zmq_socket'],
                                         config_data.get('street_network', None),
-                                        config_data.get('realtime_proxies', []))
+                                        config_data.get('realtime_proxies', []),
+                                        config_data.get('zmq_socket_type', 'persistent'))
             else:
                 logging.getLogger(__name__).warn('impossible to init an instance with the configuration '
                                                  'file {}'.format(file_name))


### PR DESCRIPTION
By default jormungandr keeps it's zmq socket between calls, this PR gives
us the ability to use transient socket: each time a call to kraken has
to be made we create a new connection. The main advantage is that the
load balancing will be done correctly between the available krakens, of
course this has consequences on performance, it costs us a tcp roundtrip,
so if the network is already slow things are getting worse. When using
IPC it's free: I wasn't able to see any difference during bench.

This PR will allow us to do some tests on production with this setup, it
will let us measure the impacts on response time and the load on our network's
equipments.

A few informations on load balancing: We actually load balance so that
each kraken has the same number of connection established, so in
production that at least 60 connections to distribute over our 4 kraken.
When we do parallel calls to a kraken, new connections are created.
A parallel journey can use 10 connections, and there is absolutely no
guarantee that this connections will be on different krakens, so it's
possible to run all of our requests on one kraken ending up queuing some of the
requests because no threads are available on this kraken, while the other krakens
have nothing to do but remain unsolicited.
