### PR TITLE
Jormun: Don't clear the cache on kraken error, it's only making all thing slower

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -427,10 +427,7 @@ class Instance(object):
                 self.publication_date = resp.publication_date
                 return True
         except DeadSocketException:
-            #but if there is a error, we reset the geom manually
-            self.geom = None
+            #we don't do anything on error, a new session will be established to an available kraken on
+            # the next request. We don't want to purge all our cache for a small error.
             self.is_up = False
-            if self.publication_date != -1:
-                self.publication_date = -1
-                return True
         return False


### PR DESCRIPTION
Currently a dead socket will always trigger a purge of the cache.
If an instance is dead this will trigger a purge of the cache every ten seconds. 
In most of the case it only a transient error and the next request will create a new connection that should be routed to a healthy kraken.

On the production during the last six hours we have purged the cache 100 000 times making it useless.
Without cache call to /journeys with ids but without coverage is much slower since it need to call each instances.
