### PR TITLE
jormungandr: removal of thread ping

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -83,7 +83,7 @@ class Instance(object):
         self.name = name
         self.timezone = None  # timezone will be fetched from the kraken
         self.publication_date = -1
-        self.is_initialized = False#kraken hasn't been call yet we don't have geom nor timezone
+        self.is_initialized = False #kraken hasn't been called yet we don't have geom nor timezone
         self.breaker = pybreaker.CircuitBreaker(fail_max=app.config['CIRCUIT_BREAKER_MAX_INSTANCE_FAIL'],
                                                 reset_timeout=app.config['CIRCUIT_BREAKER_INSTANCE_TIMEOUT_S'])
         self.georef = georef.Kraken(self)

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -93,6 +93,9 @@ class InstanceManager(object):
         self.instances = {}
         self.context = zmq.Context()
 
+    def __repr__(self):
+        return '<InstanceManager>'
+
     def initialisation(self):
         """ Charge la configuration à partir d'un fichier ini indiquant
             les chemins des fichiers contenant :

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -176,7 +176,7 @@ class InstanceManager(object):
 
         gevent.wait(futures)
         for future in futures:
-            #we check if an instance need the cache to be purged
+            #we check if an instance needs the cache to be purged
             if future.get():
                 self._clear_cache()
                 break;

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -144,7 +144,7 @@ class AbstractTestFixture:
             try:
                 retrying.Retrying(stop_max_delay=5000,
                                   wait_fixed=10,
-                                  retry_on_result=lambda x: not instance.is_up).call(instance.init)
+                                  retry_on_result=lambda x: not instance.is_initialized).call(instance.init)
             except RetryError:
                 logging.exception('impossible to start kraken {}'.format(name))
                 assert False, 'impossible to start a kraken'


### PR DESCRIPTION
Currently each jormun call every instance each 10 seconds to check if
it's still alive. It's useless since we don't do anything of this
information and it generate a lot of unneeded requests to kraken (remember
there are 60 jormungandr in production)

I kept the thread just to ensure that we call each instance at least one
time after the startup, this way we have the geom and the timezone of
the instance.

With this change after the startup jormungandr will only call kraken
when handling a request. This will allow us to spawn kraken only when
we need it (something based on xinetd probably) on some testing environments.
