### PR TITLE
[Tyr Api User] Insert shape = NULL instead of "null"

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -250,8 +250,8 @@ class Places(ResourceUri):
             if global_autocomplete:
                 user = authentication.get_user(token=authentication.get_token(), abort_if_no_token=False)
                 shape = None
-                if user and user.shape :
-                    shape = json.loads(user.shape)
+                if user and user.shape:
+                    shape = user.shape
                 bragi_response = global_autocomplete.get(args, None, shape=shape)
                 response = marshal(bragi_response, geocodejson)
             else:

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -37,7 +37,7 @@ from flask import current_app
 from sqlalchemy.orm import load_only, backref, aliased
 from datetime import datetime
 from sqlalchemy import func, and_, UniqueConstraint, cast, true, false
-from sqlalchemy.dialects.postgresql import ARRAY, UUID, INTERVAL
+from sqlalchemy.dialects.postgresql import ARRAY, UUID, INTERVAL, JSON
 from navitiacommon.utils import street_source_types, address_source_types, \
     poi_source_types, admin_source_types
 
@@ -124,7 +124,7 @@ class User(db.Model):
     type = db.Column(db.Enum('with_free_instances', 'without_free_instances', 'super_user', name='user_type'),
                              default='with_free_instances', nullable=False)
 
-    shape = db.Column(db.Text, nullable=True)
+    shape = db.Column(JSON(none_as_null=True), nullable=True)
 
 
     def __init__(self, login=None, email=None, block_until=None, keys=None, authorizations=None):

--- a/source/tyr/migrations/versions/3365e7b6458d_shape_column_type_json.py
+++ b/source/tyr/migrations/versions/3365e7b6458d_shape_column_type_json.py
@@ -1,0 +1,21 @@
+"""empty message
+
+Revision ID: 3365e7b6458d
+Revises: 44dab62dfff7
+Create Date: 2016-10-05 11:44:51.763828
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3365e7b6458d'
+down_revision = '44dab62dfff7'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute('ALTER TABLE "user" ALTER COLUMN shape TYPE JSON USING shape::json')
+
+
+def downgrade():
+    op.execute('ALTER TABLE "user" ALTER COLUMN shape TYPE TEXT')

--- a/source/tyr/tests/integration/users_test.py
+++ b/source/tyr/tests/integration/users_test.py
@@ -102,7 +102,7 @@ def create_user(geojson_feature_collection):
         user = models.User('test', 'test@example.com')
         user.end_point = models.EndPoint.get_default()
         user.billing_plan = models.BillingPlan.get_default(user.end_point)
-        user.shape = json.dumps(geojson_feature_collection)
+        user.shape = geojson_feature_collection
         models.db.session.add(user)
         models.db.session.commit()
         return user.id
@@ -142,7 +142,7 @@ def create_multiple_users(request, geojson_feature_collection):
         user1 = models.User('foo', 'foo@example.com')
         user1.end_point = end_point
         user1.billing_plan = billing_plan
-        user1.shape = json.dumps(geojson_feature_collection)
+        user1.shape = geojson_feature_collection
 
         user2 = models.User('foodefault', 'foo@example.com')
         user2.end_point = models.EndPoint.get_default()
@@ -490,6 +490,10 @@ def test_update_shape_with_none(create_multiple_users, mock_rabbit):
     assert resp['shape'] == None
     assert mock_rabbit.called
 
+    resp = api_get('/v0/users/{}'.format(create_multiple_users['user1']))
+    # Ensure that shape = None and not {}
+    assert resp['shape'] == None
+
 
 def test_update_shape_with_empty(create_multiple_users, mock_rabbit, geojson_feature_collection):
     """
@@ -565,7 +569,6 @@ def test_get_user_with_shape(create_user, geojson_feature_collection):
     We start by creating the user with a shape,
     and we test that the attribute shape={} and has_shape = True
     """
-    print api_get('/v0/users')
     resp = api_get('/v0/users/{}'.format(create_user))
 
     assert resp['has_shape'] == True
@@ -589,8 +592,7 @@ def test_get_user_without_shape(create_user_without_shape):
     and we test that  shape = None and has_shape = False
     """
     resp = api_get('/v0/users/{}'.format(create_user_without_shape))
-    print resp['shape']
-    print geojson_feature
+
     assert resp['has_shape'] == False
     assert resp['shape'] == None
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -78,9 +78,6 @@ class Shape(fields.Raw):
         if hasattr(g, 'disable_geojson') and g.disable_geojson and obj.has_shape():
             return {}
 
-        if obj.shape is not None:
-            return ujson.loads(obj.shape)
-
         return obj.shape
 
 
@@ -582,7 +579,7 @@ class User(flask_restful.Resource):
             user.type = args['type']
             user.end_point = end_point
             user.billing_plan = billing_plan
-            user.shape = ujson.dumps(args['shape'])
+            user.shape = args['shape']
             db.session.add(user)
             db.session.commit()
 
@@ -612,8 +609,8 @@ class User(flask_restful.Resource):
                             help='block until argument is not correct', location=('json', 'values'))
         parser.add_argument('billing_plan_id', type=int, default=user.billing_plan_id,
                             help='billing id of the end_point', location=('json', 'values'))
-        parser.add_argument('shape', type=parser_args_type.geojson_argument(ujson.loads(user.shape)),
-                            default=ujson.loads(user.shape), required=False, location=('json', 'values'))
+        parser.add_argument('shape', type=parser_args_type.geojson_argument(user.shape),
+                            default=user.shape, required=False, location=('json', 'values'))
         args = parser.parse_args()
 
         if not validate_email(args['email'],
@@ -638,7 +635,7 @@ class User(flask_restful.Resource):
             user.block_until = args['block_until']
             user.end_point = end_point
             user.billing_plan = billing_plan
-            user.shape = ujson.dumps(args['shape'])
+            user.shape = args['shape']
             db.session.commit()
 
             tyr_user_event = TyrUserEvent()


### PR DESCRIPTION
### Postgresql JSON type exists with Postgres >= 9.2

TODO:
- [ ] upgrade postgresql on all platforms

In database, shape is a TEXT. 
So we convert the json to a string with `json.dumps(shape)`
but `json.dumps(None) = "null"` so in database we have a string 'null'

When we get a user with `shape = "null"` we convert the string with `json.loads(shape)`
but `json.loads("null") = {}` and not `None`

|  | Database | Model after getting from database |
| --- | :-- | :-: |
| Before | "null" | {} |
| After | NULL | None |
