### PR TITLE
Tyr: Fix shape value when is "null" in database

### DIFF
--- a/source/tyr/migrations/versions/c5cd5a41def_update_shape_null_string_to_null_postgres.py
+++ b/source/tyr/migrations/versions/c5cd5a41def_update_shape_null_string_to_null_postgres.py
@@ -1,0 +1,23 @@
+"""empty message
+
+Revision ID: c5cd5a41def
+Revises: 44dab62dfff7
+Create Date: 2016-10-06 14:38:01.870272
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c5cd5a41def'
+down_revision = '44dab62dfff7'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    user = sa.table('user', sa.column('shape'))
+    op.execute(user.update().values(shape='null').where(user.c.shape==None))
+
+
+def downgrade():
+    pass

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -75,6 +75,9 @@ class Shape(fields.Raw):
         super(Shape, self).__init__(**kwargs)
 
     def output(self, key, obj):
+        if obj.shape == 'null':
+            obj.shape = None
+
         if hasattr(g, 'disable_geojson') and g.disable_geojson and obj.has_shape():
             return {}
 


### PR DESCRIPTION
In database, shape is a TEXT. 
So we convert the json to a string with `json.dumps(shape)`
but `json.dumps(None) = "null"` so in database we have a string 'null'

When we get a user with `shape = "null"` we convert the string with `json.loads(shape)`
but `json.loads("null") = {}` and not `None`

There is a better fix https://github.com/CanalTP/navitia/pull/1813 for postgres >= 9.2
