### PR TITLE
RT-proxy: consider line object code given by conf

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -106,7 +106,7 @@ class Cleverage(RealtimeProxy):
     def _get_passages(self, route_point, cleverage_resp):
         logging.getLogger(__name__).debug('cleverage response: {}'.format(cleverage_resp))
 
-        line_code = route_point.fetch_line_code()
+        line_code = route_point.fetch_line_id(self.object_id_tag)
 
         schedules = next((line['schedules'] for line in cleverage_resp if line['code'].lower() == line_code.lower()), None)
 

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/cleverage_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/cleverage_test.py
@@ -359,10 +359,10 @@ class MockRoutePoint(object):
         self._hardcoded_line_code = kwars['line_code']
         self._hardcoded_stop_id = kwars['stop_id']
 
-    def fetch_stop_id(self, rt_proxy_id):
+    def fetch_stop_id(self, object_id_tag):
         return self._hardcoded_stop_id
 
-    def fetch_line_code(self):
+    def fetch_line_id(self, object_id_tag):
         return self._hardcoded_line_code
 
 

--- a/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
@@ -88,7 +88,7 @@ class TestCleverageSchedules(AbstractTestFixture):
                 ([
                  {
                      "name": "Lianes 5",
-                     "code": "code A",
+                     "code": "KisioDigital A",
                      "type": "Bus",
                      "schedules": [
                          {
@@ -165,7 +165,7 @@ class TestCleverageSchedules(AbstractTestFixture):
                 ([
                  {
                      "name": "Lianes 5",
-                     "code": "code A",
+                     "code": "KisioDigital A",
                      "type": "Bus",
                      "schedules": [
                          {

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -230,8 +230,8 @@ class TestSyntheseSchedules(AbstractTestFixture):
             response = self.query_region(query)
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
-            print(_get_schedule(response, 'SP_11', 'B1'))
-            assert _get_schedule(response, 'SP_11', 'B1') == [
+            sched = _get_schedule(response, 'SP_11', 'B1')
+            assert sched == [
                 {'rt': True, 'dt': '20160102T091717'},
                 {'rt': True, 'dt': '20160102T101717'},
             ]

--- a/source/tests/multiple_schedules.cpp
+++ b/source/tests/multiple_schedules.cpp
@@ -78,6 +78,7 @@ int main(int argc, const char* const argv[]) {
     b.data->pt_data->codes.add(r1, "KisioDigital", "syn_routeA1");
     b.data->pt_data->codes.add(r1, "KisioDigital", "syn_cute_routeA1");
 
+    b.data->pt_data->codes.add(b.get<nt::Line>("A"), "KisioDigital", "KisioDigital A");
     b.data->pt_data->codes.add(b.get<nt::Line>("B"), "KisioDigital", "syn_lineB");
     b.data->pt_data->codes.add(b.get<nt::Line>("C"), "KisioDigital", "syn_lineC");
 


### PR DESCRIPTION
We have to consider line.codes[<conf.object_id_tag>] to filter lines from cleverage service, not line.code

To work, this PR needs CanalTP/navitia_deployment_conf#193  to be merged also.
