### PR TITLE
kraken: fix a test on georef_test

### DIFF
--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -257,7 +257,7 @@ struct GeoRef {
     flat_enum_map<nt::Mode_e, nt::idx_t> offsets;
 
     /// number of vertex by transportation mode
-    nt::idx_t nb_vertex_by_mode;
+    nt::idx_t nb_vertex_by_mode = 0;
     navitia::autocomplete::autocomplete_map synonyms;
     std::set<std::string> ghostwords;
 

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -231,6 +231,7 @@ BOOST_AUTO_TEST_CASE(nearest_edge_with_geometries) {
     nt::GeographicalCoord x3(23, 2, false);
     nt::GeographicalCoord x4(15, 5, false);
     nt::GeographicalCoord x5(40, 32, false);
+    b.geo_ref.init();
 
     BOOST_CHECK(b.geo_ref.nearest_edge(x1) == b.get("b", "e"));
     BOOST_CHECK(b.geo_ref.nearest_edge(x2) == b.get("c", "d"));

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -1127,6 +1127,7 @@ BOOST_AUTO_TEST_CASE(build_autocomplete_test){
         way.way_type = "place";
         geo_ref.add_way(way);*/
 
+        geo_ref.init();
         geo_ref.build_autocomplete_list();
 
         result = geo_ref.find_ways("10 rue jean jaures", nbmax, false, [](int){return true;}, ghostwords);


### PR DESCRIPTION
A `georef.init()` was missing since the change from https://github.com/CanalTP/navitia/commit/70e3ea351c78b9684ea2575d4fa42bd1cde9758a