### PR TITLE
Jormungandr: fix zip_code attribute on universal places API

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -86,6 +86,16 @@ class AddressId(fields.Raw):
         geocoding = obj.get('properties', {}).get('geocoding', {})
         return delete_prefix(geocoding.get('id'), "addr:")
 
+
+def format_zip_code(zip_codes):
+    if all(zip_code == "" for zip_code in zip_codes):
+        return None
+    elif len(zip_codes) == 1:
+        return zip_codes[0]
+    else:
+        return '{}-{}'.format(min(zip_codes), max(zip_codes))
+
+
 def create_administrative_regions_field(geocoding):
     if not geocoding:
         return None
@@ -95,6 +105,7 @@ def create_administrative_regions_field(geocoding):
         coord = admin.get('coord', {})
         lat = coord.get('lat') if coord else None
         lon = coord.get('lon') if coord else None
+        zip_codes = admin.get('zip_codes', [])
         response.append({
             "insee": admin.get('insee'),
             "name": admin.get('label'),
@@ -105,7 +116,7 @@ def create_administrative_regions_field(geocoding):
             },
             "label": admin.get('label'),
             "id": admin.get('id'),
-            "zip_code": admin.get('zip_code')
+            "zip_code": format_zip_code(zip_codes)
         })
     return response
 

--- a/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
@@ -451,7 +451,7 @@ def bragi_poi_feature():
                     "insee": "2B231",
                     "level": 8,
                     "label": "Pigna",
-                    "zip_codes": ["20220"],
+                    "zip_codes": ["20220", "20221", "20222"],
                     "weight": 0,
                     "coord": {
                         "lat": 42.5996043,
@@ -491,6 +491,7 @@ def bragi_poi_reading_test():
     assert administrative_region.get('id') == 'admin:fr:2B231'
     assert administrative_region.get('coord').get('lat') == 42.5996043
     assert administrative_region.get('coord').get('lon') == 8.9027334
+    assert administrative_region.get('zip_code') == "20220-20222"
 
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/test/places_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/places_tests.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+# the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from jormungandr.interfaces.v1.Places import format_zip_code
+
+
+def test_format_zip_code():
+    zip_codes = []
+    assert format_zip_code(zip_codes) == None
+
+    zip_codes = [""]
+    assert format_zip_code(zip_codes) == None
+
+    zip_codes = ["", ""]
+    assert format_zip_code(zip_codes) == None
+
+    zip_codes = ["75000"]
+    assert format_zip_code(zip_codes) == "75000"
+
+    zip_codes = ["75012", "75013"]
+    assert format_zip_code(zip_codes) == "75012-75013"
+
+    zip_codes = ["75013", "75014", "75012"]
+    assert format_zip_code(zip_codes) == "75012-75014"


### PR DESCRIPTION
Fixed zip_code attribute in administrative_region

|   administrative_region.zip_codes       |     Before    |   After |
| ------------- | :-------------: | :---------: |
| `[""]`      |        `null`        |      `null` |
| `["", ""]`        |        `null`        |      `null` |
| `["75012"]`      |        `null`        |      `75012` |
| `["75012", "75013", "75014"]`      |        `null`        |      `75012-75014` |