### PR TITLE
jormun: fix on /v1/status

### DIFF
--- a/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
@@ -88,6 +88,10 @@ class TechnicalStatus(ModuleResource):
                                                                         timeout=1000)
 
                 raw_resp_dict = protobuf_to_dict(resp, use_enum_labels=True)
+                raw_resp_dict['status']["is_open_data"] = i_manager.instances[key_region].is_free
+                raw_resp_dict['status']['realtime_proxies'] = []
+                for realtime_proxy in i_manager.instances[key_region].realtime_proxy_manager.realtime_proxies.values():
+                    raw_resp_dict['status']['realtime_proxies'].append(realtime_proxy.status())
 
                 resp_dict = marshal(raw_resp_dict['status'],
                                     fields.instance_status)


### PR DESCRIPTION
`is_free` and `realtime_proxies` were always set to null on /v1/status,
they were filled only on /v1/coverage/foo/status.
This PR fix that by filling them on both.