### PR TITLE
Cmake: add a target to get all ed executables

### DIFF
--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -51,6 +51,8 @@ target_link_libraries(synonym2ed transportation_data_import connectors)
 SET(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 INSTALL_TARGETS(/usr/bin/ ${ED_TARGETS_TO_INSTALL})
 
+add_custom_target(ed_executables DEPENDS ${ED_TARGETS_TO_INSTALL})
+
 # Ed integration tests with docker, build with the docker_test target 
 # and not with the default target not to have a strong docker dependency
 add_subdirectory(docker_tests EXCLUDE_FROM_ALL)


### PR DESCRIPTION
it will be easier to build only them in dockers (we can even use `make
install` in your dockerfile @kinnou02 no ?)