### PR TITLE
Tyr: consider all osm2ed args are utf8  (no ascii convert)

### DIFF
--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -296,14 +296,14 @@ class PoiType(flask_restful.Resource):
             args = ["--connection-string", "nowhere"]
             if poi_types_json:
                 args.append("-p")
-                poi_types = json.dumps(poi_types_json)
-                args.append(u'{}'.format(poi_types))
+                poi_types = json.dumps(poi_types_json, ensure_ascii=False)
+                args.append(poi_types)
 
             res, traces = launch_exec_traces('osm2ed', args, logger)
             if res != 0:
                 abort(400, status="error", message='{}'.format(traces))
 
-            poi_types = models.PoiTypeJson(json.dumps(poi_types_json), instance)
+            poi_types = models.PoiTypeJson(json.dumps(poi_types_json, ensure_ascii=False), instance)
             db.session.add(poi_types)
             db.session.commit()
         except Exception:


### PR DESCRIPTION
Special characters wil now be correctly managed.
(they were previously converted to \uXXXX ascii in tyr, and then not managed in osm2ed)
when passing poi-type json to osm2ed, we are supposed to get utf8 in POST so no ascii convert, unix is utf8 also and so is osm2ed.