### PR TITLE
jormungandr: add patch_ssl after patch_socket

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -44,6 +44,7 @@ from jormungandr.authentication import get_user, get_token, get_app_name, get_us
 # http://www.gevent.org/intro.html#monkey-patching
 import gevent.monkey
 gevent.monkey.patch_socket()
+gevent.monkey.patch_ssl()
 
 @rest_api.representation("text/jsonp")
 @rest_api.representation("application/jsonp")


### PR DESCRIPTION
We have a module in our jormungandr calling some URL in HTTPS. I updated from the 2.21 to 2.22 and it's not working anymore. urllib2 or requests are both broken.

According to : 
- http://stackoverflow.com/a/20580706,
- https://github.com/kennethreitz/requests/issues/1480#issuecomment-22604424;
- https://github.com/42cc/bets-api/pull/1

It is caused by the monkey patching of the socket by gevent done in 1724a243108025690201b1564dd21b0fd749212b, I added patch_ssl and it's now working again. 

I don't have a good way to test this right now but your calls to the JCDecaux API might be broken in 2.22 except if it's linked to some versions I use.