### PR TITLE
Tyr: import stops in global autocomplete

### DIFF
--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -241,6 +241,9 @@ class Instance(db.Model):
 
     poi_type_json = db.relationship('PoiTypeJson', uselist=False, backref=backref('instance'),
                                  cascade='save-update, merge, delete, delete-orphan')
+
+    import_stops_in_mimir = db.Column(db.Boolean, default=False, nullable=False)
+
     # ============================================================
     # params for jormungandr
     # ============================================================

--- a/source/tyr/migrations/versions/361f3993960e_import_stops_in_global_autocomplete_.py
+++ b/source/tyr/migrations/versions/361f3993960e_import_stops_in_global_autocomplete_.py
@@ -8,7 +8,7 @@ Create Date: 2016-12-23 11:48:47.003811
 
 # revision identifiers, used by Alembic.
 revision = '361f3993960e'
-down_revision = '57ee5581cc30'
+down_revision = '502b7c6fd00b'
 
 from alembic import op
 import sqlalchemy as sa

--- a/source/tyr/migrations/versions/361f3993960e_import_stops_in_global_autocomplete_.py
+++ b/source/tyr/migrations/versions/361f3993960e_import_stops_in_global_autocomplete_.py
@@ -1,0 +1,24 @@
+"""import stops in global autocomplete (mimir)
+
+Revision ID: 361f3993960e
+Revises: 57ee5581cc30
+Create Date: 2016-12-23 11:48:47.003811
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '361f3993960e'
+down_revision = '57ee5581cc30'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('instance', sa.Column('import_stops_in_mimir', sa.Boolean(), nullable=True))
+    op.execute('update instance set import_stops_in_mimir=false')
+    op.alter_column('instance', 'import_stops_in_mimir', nullable=False)
+
+
+def downgrade():
+    op.drop_column('instance', 'import_stops_in_mimir')

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -459,15 +459,16 @@ class Instance(flask_restful.Resource):
                             location=('json', 'values'), default=instance.night_bus_filter_base_factor)
         parser.add_argument('priority', type=int, help='instance priority',
                             location=('json', 'values'), default=instance.priority)
-        parser.add_argument('bss_provider', type=bool, help='bss provider activation',
+        parser.add_argument('bss_provider', type=inputs.boolean, help='bss provider activation',
                             location=('json', 'values'), default=instance.bss_provider)
-        parser.add_argument('full_sn_geometries', type=bool, help='activation of full geometries',
+        parser.add_argument('full_sn_geometries', type=inputs.boolean, help='activation of full geometries',
                             location=('json', 'values'), default=instance.full_sn_geometries)
-        parser.add_argument('is_free', type=bool, help='instance doesn\'t require authorization to be used',
+        parser.add_argument('is_free', type=inputs.boolean, help='instance doesn\'t require authorization to be used',
                             location=('json', 'values'), default=instance.is_free)
-        parser.add_argument('is_open_data', type=bool, help='instance only use open data',
+        parser.add_argument('is_open_data', type=inputs.boolean, help='instance only use open data',
                             location=('json', 'values'), default=instance.is_open_data)
-        parser.add_argument('import_stops_in_mimir', type=bool, help='import stops in global autocomplete',
+        parser.add_argument('import_stops_in_mimir', type=inputs.boolean,
+                            help='import stops in global autocomplete',
                             location=('json', 'values'), default=instance.import_stops_in_mimir)
         args = parser.parse_args()
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -109,6 +109,7 @@ instance_fields = {
     'name': fields.Raw,
     'discarded': fields.Raw,
     'is_free': fields.Raw,
+    'import_stops_in_mimir': fields.Raw,
     'scenario': fields.Raw,
     'journey_order': fields.Raw,
     'max_walking_duration_to_pt': fields.Raw,
@@ -466,6 +467,8 @@ class Instance(flask_restful.Resource):
                             location=('json', 'values'), default=instance.is_free)
         parser.add_argument('is_open_data', type=bool, help='instance only use open data',
                             location=('json', 'values'), default=instance.is_open_data)
+        parser.add_argument('import_stops_in_mimir', type=bool, help='import stops in global autocomplete',
+                            location=('json', 'values'), default=instance.import_stops_in_mimir)
         args = parser.parse_args()
 
         try:
@@ -502,7 +505,8 @@ class Instance(flask_restful.Resource):
                                        'bss_provider',
                                        'full_sn_geometries',
                                        'is_free',
-                                       'is_open_data'])
+                                       'is_open_data',
+                                       'import_stops_in_mimir'])
             db.session.commit()
         except Exception:
             logging.exception("fail")

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -40,8 +40,7 @@ from flask import current_app
 import kombu
 
 from tyr.binarisation import gtfs2ed, osm2ed, ed2nav, fusio2ed, geopal2ed, fare2ed, poi2ed, synonym2ed, \
-    shape2ed, \
-    load_bounding_shape, bano2mimir, osm2mimir
+    shape2ed, load_bounding_shape, bano2mimir, osm2mimir, stops2mimir
 from tyr.binarisation import reload_data, move_to_backupdirectory
 from tyr import celery
 from navitiacommon import models, task_pb2, utils
@@ -123,15 +122,15 @@ def import_data(files, instance, backup_file, async=True, reload=True, custom_ou
         models.db.session.commit()
         for action in actions:
             action.kwargs['job_id'] = job.id
-        #We pass the job id to each tasks, but job need to be commited for
-        #having an id
+        #We pass the job id to each tasks, but job need to be commited for having an id
         binarisation = [ed2nav.si(instance_config, job.id, custom_output_dir)]
-        #We pass the job id to each tasks, but job need to be commited for
-        #having an id
         actions.append(chain(*binarisation))
         if reload:
             actions.append(reload_data.si(instance_config, job.id))
         actions.append(finish_job.si(job.id))
+        if dataset.family_type == 'pt' and instance.import_stops_in_mimir:
+            # if we are loading pt data we might want to load the stops to autocomplete
+            actions.append(stops2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
         if async:
             return chain(*actions).delay()
         else:

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -125,12 +125,12 @@ def import_data(files, instance, backup_file, async=True, reload=True, custom_ou
         #We pass the job id to each tasks, but job need to be commited for having an id
         binarisation = [ed2nav.si(instance_config, job.id, custom_output_dir)]
         actions.append(chain(*binarisation))
-        if reload:
-            actions.append(reload_data.si(instance_config, job.id))
-        actions.append(finish_job.si(job.id))
         if dataset.family_type == 'pt' and instance.import_stops_in_mimir:
             # if we are loading pt data we might want to load the stops to autocomplete
             actions.append(stops2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
+        if reload:
+            actions.append(reload_data.si(instance_config, job.id))
+        actions.append(finish_job.si(job.id))
         if async:
             return chain(*actions).delay()
         else:


### PR DESCRIPTION
when importing NTGF or GTFS import the stops in the global autocomplete
(mimir)

the import is very quick for the moment and is done with `ed2nav`

It is not activated by default and can be activated for one instance
with `import_stops_in_mimir` in the instance API