### PR TITLE
Jormun: pass lon and lat to geocodejson autocomplete

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -649,7 +649,7 @@ Differents kind of objects can be returned (sorted as):
   nop      | type[]      | array of string | Type of objects you want to query It takes one the following values: [`stop_area`, `address`, `administrative_region`, `poi`, `stop_point`] | [`stop_area`, `address`, `poi`, `administrative_region`]
   nop      | admin_uri[] | array of string | If filled, it will filter the search within the given admin uris
   nop      | disable_geojson | boolean | remove geojson from the response | False
-  nop      | from | string | Coordinates longitude;latitude used to prioritize the objects around this coordinate |
+  nop      | from | string | Coordinates longitude;latitude used to prioritize the objects around this coordinate. Note this parameter will be taken into account only if the autocomplete's backend can handle it |
 
 
 

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -649,6 +649,7 @@ Differents kind of objects can be returned (sorted as):
   nop      | type[]      | array of string | Type of objects you want to query It takes one the following values: [`stop_area`, `address`, `administrative_region`, `poi`, `stop_point`] | [`stop_area`, `address`, `poi`, `administrative_region`]
   nop      | admin_uri[] | array of string | If filled, it will filter the search within the given admin uris
   nop      | disable_geojson | boolean | remove geojson from the response | False
+  nop      | from | string | Coordinates longitude;latitude used to prioritize the objects around this coordinate |
 
 
 

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -34,7 +34,6 @@ import logging
 from jormungandr.autocomplete.abstract_autocomplete import AbstractAutocomplete
 import requests
 from jormungandr.exceptions import TechnicalError
-from urllib import urlencode
 
 
 class GeocodeJson(AbstractAutocomplete):
@@ -59,13 +58,11 @@ class GeocodeJson(AbstractAutocomplete):
         if request["from"]:
             params["lon"], params["lat"] = self.get_coords(request["from"])
 
-        url = '{endpoint}?{query}'.format(endpoint=self.external_api, query=urlencode(params))
-
         try:
             if shape:
-                raw_response = requests.post(url, timeout=self.timeout, json=shape)
+                raw_response = requests.post(self.external_api, timeout=self.timeout, json=shape, params=params)
             else:
-                raw_response = requests.get(url, timeout=self.timeout)
+                raw_response = requests.get(self.external_api, timeout=self.timeout, params=params)
 
         except requests.Timeout:
             logging.getLogger(__name__).error('autocomplete request timeout')
@@ -84,4 +81,8 @@ class GeocodeJson(AbstractAutocomplete):
         raise NotImplementedError
 
     def get_coords(self, param):
+        """
+        Get coordinates (longitude, latitude).
+        For moment we consider that the param can only be a coordinate.
+        """
         return param.split(";")

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -55,7 +55,7 @@ class GeocodeJson(AbstractAutocomplete):
             "count": request["count"]
         }
 
-        if request["from"]:
+        if request.get("from"):
             params["lon"], params["lat"] = self.get_coords(request["from"])
 
         try:

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -52,7 +52,7 @@ class GeocodeJson(AbstractAutocomplete):
 
         params = {
             "q": request["q"],
-            "count": request["count"]
+            "limit": request["count"]
         }
 
         if request.get("from"):

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -34,6 +34,7 @@ import logging
 from jormungandr.autocomplete.abstract_autocomplete import AbstractAutocomplete
 import requests
 from jormungandr.exceptions import TechnicalError
+from urllib import urlencode
 
 
 class GeocodeJson(AbstractAutocomplete):
@@ -50,9 +51,16 @@ class GeocodeJson(AbstractAutocomplete):
         if not self.external_api:
             raise TechnicalError('global autocomplete not configured')
 
-        url = '{endpoint}?q={q}&limit={count}'.format(endpoint=self.external_api,
-                                                      q=request['q'],
-                                                      count=request['count'])
+        params = {
+            "q": request["q"],
+            "count": request["count"]
+        }
+
+        if request["from"]:
+            params["lon"], params["lat"] = self.get_coords(request["from"])
+
+        url = '{endpoint}?{query}'.format(endpoint=self.external_api, query=urlencode(params))
+
         try:
             if shape:
                 raw_response = requests.post(url, timeout=self.timeout, json=shape)
@@ -75,4 +83,5 @@ class GeocodeJson(AbstractAutocomplete):
     def geo_status(self, instance):
         raise NotImplementedError
 
-
+    def get_coords(self, param):
+        return param.split(";")

--- a/source/jormungandr/jormungandr/autocomplete/kraken.py
+++ b/source/jormungandr/jormungandr/autocomplete/kraken.py
@@ -50,7 +50,7 @@ places = {
 class Kraken(AbstractAutocomplete):
 
     @marshal_with(places)
-    def get(self, request, instance):
+    def get(self, request, instance, shape=None):
 
         req = request_pb2.Request()
         req.requested_api = type_pb2.places

--- a/source/jormungandr/jormungandr/interfaces/parsers.py
+++ b/source/jormungandr/jormungandr/interfaces/parsers.py
@@ -85,7 +85,11 @@ def coord_format(coord):
         raise ValueError('Invalid coordinate parameter. It must be lon;lat where lon and lat are floats.')
 
     lon, lat = lon_lat_splitted
-    float(lon)
-    float(lat)
+    lat = float(lat)
+    if not (-90.0 <= lat <= 90.0):
+        raise ValueError("lat should be between -90 and 90")
+    lon = float(lon)
+    if not (180.0 >= lon >= -180.0):
+        raise ValueError("lon should be between -180 and 180")
 
     return coord

--- a/source/jormungandr/jormungandr/interfaces/parsers.py
+++ b/source/jormungandr/jormungandr/interfaces/parsers.py
@@ -74,3 +74,18 @@ def unsigned_integer(value):
         return d
     except ValueError as e:
         raise ValueError("Unable to evaluate, {}".format(e))
+
+
+def coord_format(coord):
+    """
+    Validate coordinates format (lon;lat)
+    """
+    lon_lat_splitted = coord.split(";")
+    if len(lon_lat_splitted) != 2:
+        raise ValueError('Invalid coordinate parameter. It must be lon;lat where lon and lat are floats.')
+
+    lon, lat = lon_lat_splitted
+    float(lon)
+    float(lat)
+
+    return coord

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -315,7 +315,8 @@ class Places(ResourceUri):
                             description="remove geojson from the response")
 
         self.parsers['get'].add_argument("from", type=coord_format,
-                                         description="Coorddinates longitude:latitude from where you want to search")
+                                         description="Coordinates longitude;latitude used to prioritize "
+                                                     "the objects around this coordinate")
 
     def get(self, region=None, lon=None, lat=None):
         args = self.parsers["get"].parse_args()

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -50,6 +50,7 @@ from flask_restful import marshal, marshal_with
 import datetime
 from jormungandr.parking_space_availability.bss.stands_manager import ManageStands
 import ujson as json
+from jormungandr.interfaces.parsers import coord_format
 
 
 #global marshal
@@ -312,6 +313,9 @@ class Places(ResourceUri):
                                                      " else we consider it as UTC")
         self.parsers['get'].add_argument("disable_geojson", type=boolean, default=False,
                             description="remove geojson from the response")
+
+        self.parsers['get'].add_argument("from", type=coord_format,
+                                         description="Coorddinates longitude:latitude from where you want to search")
 
     def get(self, region=None, lon=None, lat=None):
         args = self.parsers["get"].parse_args()

--- a/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
@@ -550,7 +550,7 @@ def bragi_call_test():
         ]
     }
     mock_requests = MockRequests({
-        'http://bob.com/autocomplete?q=rue+bobette&count=10':
+        'http://bob.com/autocomplete?q=rue+bobette&limit=10':
         (bragi_response, 200)
     })
 

--- a/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
@@ -550,7 +550,7 @@ def bragi_call_test():
         ]
     }
     mock_requests = MockRequests({
-        'http://bob.com/autocomplete?q=rue bobette&limit=10':
+        'http://bob.com/autocomplete?q=rue+bobette&count=10':
         (bragi_response, 200)
     })
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -140,8 +140,8 @@ class Scenario(object):
         resp = instance.send_and_receive(req)
         return resp
 
-    def places(self, request, instance):
-        return instance.autocomplete.get(request, instance)
+    def places(self, request, instance, shape=None):
+        return instance.autocomplete.get(request, instance, shape)
 
     def pt_objects(self, request, instance):
         req = request_pb2.Request()

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -58,4 +58,8 @@ class MockRequests(object):
         self.responses = responses
 
     def get(self, url, *args, **kwargs):
+        if kwargs.get('params'):
+            from urllib import urlencode
+            url += "?{}".format(urlencode(kwargs.get('params')))
+
         return MockResponse(self.responses[url][0], self.responses[url][1], url)

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -30,7 +30,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 import mock
-from jormungandr.tests.utils_test import MockRequests
+from jormungandr.tests.utils_test import MockRequests, MockResponse
 from tests.check_utils import is_valid_global_autocomplete
 from .tests_mechanism import AbstractTestFixture, dataset
 
@@ -48,49 +48,50 @@ MOCKED_INSTANCE_CONF = {
 
 @dataset({'main_autocomplete_test': MOCKED_INSTANCE_CONF})
 class TestBragiAutocomplete(AbstractTestFixture):
+
     def test_autocomplete_call(self):
         mock_requests = MockRequests({
-            'https://host_of_bragi/autocomplete?q=bob&limit=10':
-                (
-                    {"features": [
-                        {
-                            "geometry": {
-                                "coordinates": [
-                                    3.282103,
-                                    49.847586
-                                ],
-                                "type": "Point"
-                            },
-                            "properties": {
-                                "geocoding": {
-                                    "city": "Bobtown",
-                                    "housenumber": "20",
-                                    "id": "49.847586;3.282103",
-                                    "label": "20 Rue Bob (Bobtown)",
-                                    "name": "Rue Bob",
-                                    "postcode": "02100",
-                                    "street": "Rue Bob",
-                                    "type": "house",
-                                    "administrative_regions": [
-                                        {
-                                            "id": "admin:fr:02000",
-                                            "insee": "02000",
-                                            "level": 8,
-                                            "label": "Bobtown (02000)",
-                                            "zip_codes": ["02000"],
-                                            "weight": 1,
-                                            "coord": {
-                                                "lat": 48.8396154,
-                                                "lon": 2.3957517
-                                            }
+        'https://host_of_bragi/autocomplete?q=bob&limit=10':
+            (
+                {"features": [
+                    {
+                        "geometry": {
+                            "coordinates": [
+                                3.282103,
+                                49.847586
+                            ],
+                            "type": "Point"
+                        },
+                        "properties": {
+                            "geocoding": {
+                                "city": "Bobtown",
+                                "housenumber": "20",
+                                "id": "49.847586;3.282103",
+                                "label": "20 Rue Bob (Bobtown)",
+                                "name": "Rue Bob",
+                                "postcode": "02100",
+                                "street": "Rue Bob",
+                                "type": "house",
+                                "administrative_regions": [
+                                    {
+                                        "id": "admin:fr:02000",
+                                        "insee": "02000",
+                                        "level": 8,
+                                        "label": "Bobtown (02000)",
+                                        "zip_codes": ["02000"],
+                                        "weight": 1,
+                                        "coord": {
+                                            "lat": 48.8396154,
+                                            "lon": 2.3957517
                                         }
-                                    ],
+                                    }
+                                ],
                                 }
-                            },
-                            "type": "Feature"
-                        }
-                    ]
-                    }, 200)
+                        },
+                        "type": "Feature"
+                    }
+                ]
+                }, 200)
         })
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region('places?q=bob')
@@ -104,56 +105,16 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert r[0]['address']['label'] == '20 Rue Bob (Bobtown)'
 
     def test_autocomplete_call_with_param_from(self):
-        mock_requests = MockRequests({
-            'https://host_of_bragi/autocomplete?q=bob&limit=10&lon=3.25&lat=49.84':
-                (
-                    {"features": [
-                        {
-                            "geometry": {
-                                "coordinates": [
-                                    3.282103,
-                                    49.847586
-                                ],
-                                "type": "Point"
-                            },
-                            "properties": {
-                                "geocoding": {
-                                    "city": "Bobtown",
-                                    "housenumber": "20",
-                                    "id": "49.847586;3.282103",
-                                    "label": "20 Rue Bob (Bobtown)",
-                                    "name": "Rue Bob",
-                                    "postcode": "02100",
-                                    "street": "Rue Bob",
-                                    "type": "house",
-                                    "administrative_regions": [
-                                        {
-                                            "id": "admin:fr:02000",
-                                            "insee": "02000",
-                                            "level": 8,
-                                            "label": "Bobtown (02000)",
-                                            "zip_codes": ["02000"],
-                                            "weight": 1,
-                                            "coord": {
-                                                "lat": 48.8396154,
-                                                "lon": 2.3957517
-                                            }
-                                        }
-                                    ],
-                                }
-                            },
-                            "type": "Feature"
-                        }
-                    ]
-                    }, 200)
-        })
-        with mock.patch('requests.get', mock_requests.get):
-            response = self.query_region('places?q=bob&from=3.25;49.84')
+        """
+        test that the from param of the autocomplete is correctly given to bragi
+        :return:
+        """
+        def http_get(url, *args, **kwargs):
+            params = kwargs.pop('params')
+            assert params
+            assert params.get('lon') == '3.25'
+            assert params.get('lat') == '49.84'
+            return MockResponse({}, 200, '')
+        with mock.patch('requests.get', http_get) as mock_method:
+            self.query_region('places?q=bob&from=3.25;49.84')
 
-            is_valid_global_autocomplete(response, depth=1)
-            r = response.get('places')
-            assert len(r) == 1
-            assert r[0]['name'] == '20 Rue Bob (Bobtown)'
-            assert r[0]['embedded_type'] == 'address'
-            assert r[0]['address']['name'] == 'Rue Bob'
-            assert r[0]['address']['label'] == '20 Rue Bob (Bobtown)'

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -102,3 +102,58 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert r[0]['embedded_type'] == 'address'
             assert r[0]['address']['name'] == 'Rue Bob'
             assert r[0]['address']['label'] == '20 Rue Bob (Bobtown)'
+
+    def test_autocomplete_call_with_param_from(self):
+        mock_requests = MockRequests({
+            'https://host_of_bragi/autocomplete?q=bob&limit=10&lon=3.25&lat=49.84':
+                (
+                    {"features": [
+                        {
+                            "geometry": {
+                                "coordinates": [
+                                    3.282103,
+                                    49.847586
+                                ],
+                                "type": "Point"
+                            },
+                            "properties": {
+                                "geocoding": {
+                                    "city": "Bobtown",
+                                    "housenumber": "20",
+                                    "id": "49.847586;3.282103",
+                                    "label": "20 Rue Bob (Bobtown)",
+                                    "name": "Rue Bob",
+                                    "postcode": "02100",
+                                    "street": "Rue Bob",
+                                    "type": "house",
+                                    "administrative_regions": [
+                                        {
+                                            "id": "admin:fr:02000",
+                                            "insee": "02000",
+                                            "level": 8,
+                                            "label": "Bobtown (02000)",
+                                            "zip_codes": ["02000"],
+                                            "weight": 1,
+                                            "coord": {
+                                                "lat": 48.8396154,
+                                                "lon": 2.3957517
+                                            }
+                                        }
+                                    ],
+                                }
+                            },
+                            "type": "Feature"
+                        }
+                    ]
+                    }, 200)
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            response = self.query_region('places?q=bob&from=3.25;49.84')
+
+            is_valid_global_autocomplete(response, depth=1)
+            r = response.get('places')
+            assert len(r) == 1
+            assert r[0]['name'] == '20 Rue Bob (Bobtown)'
+            assert r[0]['embedded_type'] == 'address'
+            assert r[0]['address']['name'] == 'Rue Bob'
+            assert r[0]['address']['label'] == '20 Rue Bob (Bobtown)'


### PR DESCRIPTION
Add the possibility to give a coordinate to the autocomplete's API to prioritize the objects around the coordinate.

### Example
http://127.0.0.1:5000/v1/coverage/default/places?q=parking&from=2.34;48.85
