### PR TITLE
Ed: change uri of admin to match mimir

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -43,22 +43,22 @@ Want to test the API ?
 The easiest way to do this is a to go to `navitia.io <https://www.navitia.io/>`_.
 `Signup <https://www.navitia.io/register/>`_, grab a token, read the `doc <http://doc.navitia.io>`_ and start using the API!
 
-For a more friendly interface you can use the API through `navitia playground <http://canaltp.github.io/navitia-playground/>`_
+For a more friendly interface you can use the API through `navitia playground <http://canaltp.github.io/navitia-playground/>`_ (no matter the server used)
 
 Want to use you own datasets or infrastructure ?
 ------------------------------------------------
 
 docker
 ~~~~~~
-The easiest way to do have your own navitia is to use the navitia `docker-compose <https://github.com/CanalTP/navitia-docker-compose>`_.
+The easiest way to have your own navitia is to use the navitia `docker-compose <https://github.com/CanalTP/navitia-docker-compose>`_.
 
 fabric
 ~~~~~~
-If you don't want to use the prebuild docker images you can use the `fabric scripts <https://github.com/CanalTP/fabric_navitia>`_ we use to deploy to api.navitia.io.
+If you don't want to use the prebuilt docker images you can use the `fabric scripts <https://github.com/CanalTP/fabric_navitia>`_ we use to deploy to api.navitia.io.
 
-*WARNING:* Those scripts should be usable, but they are not meant to be completly generics and are designed for own servers architecture.
+*WARNING:* Those scripts should be usable, but they are not meant to be completly generics and are designed for our own servers architecture.
 
-Use this only if the docker is not fit for your needs and if you are an experienced user :wink:
+Use this only if the docker does not suit your needs and if you are an experienced user :wink:
 
 Want to dev in navitia ?
 ------------------------

--- a/source/cities/cities.cpp
+++ b/source/cities/cities.cpp
@@ -178,10 +178,14 @@ void OSMCache::insert_relations() {
             std::string polygon_str = polygon_stream.str();
             const auto coord = "POINT(" + std::to_string(relation.second.centre.get<0>())
                 + " " + std::to_string(relation.second.centre.get<1>()) + ")";
+
+            auto uri = "admin:osm:" + std::to_string(relation.first);
+            if ( ! relation.second.insee.empty()) {
+                uri = "admin:fr:" + relation.second.insee;
+            }
             lotus.insert({std::to_string(relation.first), relation.second.name,
                           relation.second.postal_code(), relation.second.insee,
-                          std::to_string(relation.second.level), coord, polygon_str,
-                          "admin:"+std::to_string(relation.first)});
+                          std::to_string(relation.second.level), coord, polygon_str, uri});
         } else {
             ++nb_empty_polygons;
         }

--- a/source/ed/connectors/geopal_parser.cpp
+++ b/source/ed/connectors/geopal_parser.cpp
@@ -288,7 +288,7 @@ private:
         }
     }
     void add_house_number(const Coord& coord, const int house_number, Way* way) {
-        const std::string hn_uri = way->uri + std::to_string(house_number);
+        const std::string hn_uri = way->uri + ":" + std::to_string(house_number);
         if (parser.data.house_numbers.count(hn_uri) == 0){
             ed::types::HouseNumber& current_hn = parser.data.house_numbers[hn_uri];
             current_hn.coord = coord;

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -124,7 +124,7 @@ struct FindAdminWithCities {
         pqxx::result result = work.exec(request);
         result_type res;
         for (auto it = result.begin(); it != result.end(); ++it) {
-            const std::string uri = it["uri"].as<std::string>() + "extern";
+            const std::string uri = it["uri"].as<std::string>();
             const std::string insee = it["insee"].as<std::string>();
             //we try to find the admin in georef by using it's insee code (only work in France)
             navitia::georef::Admin* admin = nullptr;

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -130,7 +130,8 @@ void EdPersistor::insert_admins(const ed::Georef& data){
     for(const auto& itm : data.admins){
         if(itm.second->is_used){
             this->lotus.insert({std::to_string(itm.second->id), itm.second->name, itm.second->insee,
-                               itm.second->level, this->to_geographic_point(itm.second->coord),"admin:" + itm.second->insee});
+                               itm.second->level, this->to_geographic_point(itm.second->coord),
+                               "admin:fr:" + itm.second->insee});
         }
     }
     this->lotus.finish_bulk_insert();

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -395,9 +395,12 @@ void OSMCache::insert_relations() {
             std::string polygon_str = polygon_stream.str();
             const auto coord = "POINT(" + std::to_string(relation.centre.get<0>())
                 + " " + std::to_string(relation.centre.get<1>()) + ")";
+            auto uri = "admin:osm:" + std::to_string(relation.osm_id);
+            if ( ! relation.insee.empty()) {
+                uri = "admin:fr:" + relation.insee;
+            }
             lotus.insert({std::to_string(relation.osm_id), relation.name, relation.insee,
-                          std::to_string(relation.level), coord, polygon_str,
-                          "admin:"+std::to_string(relation.osm_id)});
+                          std::to_string(relation.level), coord, polygon_str, uri});
             ++nb_admins;
         } else {
             LOG4CPLUS_WARN(logger, "admin " << relation.name << " id: " << relation.osm_id << " of level "

--- a/source/jormungandr/jormungandr/interfaces/v1/test/transform_id_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/transform_id_tests.py
@@ -40,13 +40,13 @@ class TestTransformId:
         assert transform_id(id) == uri
 
     def test_transform_id_admin(self):
-        id = "admin:1:12345"
-        uri = "admin:12345"
+        id = "admin:fr:12345"
+        uri = id
         assert transform_id(id) == uri
 
     def test_transform_id_address(self):
-        id = "address:1:12345"
-        uri = "address:12345"
+        id = "address:toto:12345"
+        uri = id
         assert transform_id(id) == uri
 
     def test_transform_id_something(self):

--- a/source/jormungandr/jormungandr/interfaces/v1/transform_id.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/transform_id.py
@@ -32,7 +32,6 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 
 def transform_id(id):
     splitted_coord = id.split(";")
-    splitted_address = id.split(":")
     if len(splitted_coord) == 2:
         try:
             # check if lon and lat are convertible to float
@@ -41,10 +40,4 @@ def transform_id(id):
             return "coord:" + id.replace(";", ":")
         except ValueError:
             pass
-    if len(splitted_address) >= 3 and splitted_address[0] == 'address':
-        del splitted_address[1]
-        return ':'.join(splitted_address)
-    if len(splitted_address) >= 3 and splitted_address[0] == 'admin':
-        del splitted_address[1]
-        return ':'.join(splitted_address)
     return id


### PR DESCRIPTION
id of admin is now `admin:fr:<insee>` if admin has insee code (France),
`admin:osm:<osmid>` otherwise

WARNING: this is a breaking change for anyone using admin's ids (which, as we frequently stress, is not a good practice)

TODO:
- [x] Test docker? all is tested in artemis
- [x] Prepare artemis that should break (add tests to ensure cities, osm and geopal is ok)
- [x] Check that the cities database is updated on deploy (to be seen with @Hoshiyo and @fdegomme-canaltp ) : ticket on HOR board for that
- [x] Check why 63/1.5million addresses are lost on artemis destineo geo_status: https://github.com/CanalTP/navitia/pull/1927/files#diff-c2e4a88ca2720be59f239d69571c963aR291

Needs https://github.com/CanalTP/artemis/pull/249 and https://github.com/CanalTP/artemis_references/pull/91 to be merged for artemis