### PR TITLE
Tyr: api to get last_datasets

### DIFF
--- a/source/tyr/tests/integration/conftest.py
+++ b/source/tyr/tests/integration/conftest.py
@@ -57,7 +57,9 @@ def clean_db():
     before all tests the database is cleared
     """
     with app.app_context():
-        tables = ['"{}"'.format(table) for table in ['user', 'instance', 'authorization', 'key', 'data_set', 'job', 'poi_type_json']]
+        tables = ['"{}"'.format(table) for table in ['user', 'instance', 'authorization', 'key',
+                                                     'data_set', 'job', 'poi_type_json',
+                                                     'autocomplete_parameter']]
         db.session.execute('TRUNCATE {} CASCADE;'.format(', '.join(tables)))
         db.session.commit()
 

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -34,10 +34,13 @@ from tyr import resources
 
 from tyr import app, api
 import flask_restful
+from flask import Blueprint
 
 # we always want pretty json
 flask_restful.representations.json.settings = {'indent': 4}
 api.app.url_map.strict_slashes = False
+
+api_bp = Blueprint('api', __name__)
 
 api.add_resource(resources.Instance, '/v0/instances/', '/v0/instances/<int:id>/', '/v0/instances/<string:name>/')
 api.add_resource(resources.Api, '/v0/api/')
@@ -68,6 +71,12 @@ api.add_resource(resources.PoiType,
 api.add_resource(resources.AutocompleteParameter,
                  '/v0/autocomplete_parameters/',
                  '/v0/autocomplete_parameters/<string:name>')
+
+api.add_resource(resources.InstanceDataset,
+                 '/v0/instances/<instance_name>/last_datasets')
+
+api.add_resource(resources.AutocompleteDataset,
+                 '/v0/autocomplete_parameters/<ac_instance_name>/last_datasets')
 
 @app.errorhandler(Exception)
 def error_handler(exception):

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -34,13 +34,10 @@ from tyr import resources
 
 from tyr import app, api
 import flask_restful
-from flask import Blueprint
 
 # we always want pretty json
 flask_restful.representations.json.settings = {'indent': 4}
 api.app.url_map.strict_slashes = False
-
-api_bp = Blueprint('api', __name__)
 
 api.add_resource(resources.Instance, '/v0/instances/', '/v0/instances/<int:id>/', '/v0/instances/<string:name>/')
 api.add_resource(resources.Api, '/v0/api/')

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -190,16 +190,19 @@ user_fields_full = {
     'shape': Shape
 }
 
+dataset_field = {
+    'type': fields.Raw,
+    'name': fields.Raw,
+    'family_type': fields.Raw,
+}
+
 jobs_fields = {
     'jobs': fields.List(fields.Nested({
         'id': fields.Raw,
         'state': fields.Raw,
         'created_at': FieldDate,
         'updated_at': FieldDate,
-        'data_sets': fields.List(fields.Nested({
-            'type': fields.Raw,
-            'name': fields.Raw
-        })),
+        'data_sets': fields.List(fields.Nested(dataset_field)),
         'instance': fields.Nested(instance_fields)
     }))
 }
@@ -1203,3 +1206,31 @@ class AutocompleteParameter(flask_restful.Resource):
             logging.exception("fail")
             raise
         return ({}, 204)
+
+
+class InstanceDataset(flask_restful.Resource):
+
+    def get(self, instance_name):
+        parser = reqparse.RequestParser()
+        parser.add_argument('count', type=int, required=False,
+                            help='number of last dataset to dump per type',
+                            location=('json', 'values'), default=1)
+        args = parser.parse_args()
+        instance = models.Instance.get_by_name(instance_name)
+        datasets = instance.last_datasets(args['count'])
+
+        return marshal(datasets, dataset_field)
+
+
+class AutocompleteDataset(flask_restful.Resource):
+
+    def get(self, ac_instance_name):
+        parser = reqparse.RequestParser()
+        parser.add_argument('count', type=int, required=False,
+                            help='number of last dataset to dump per type',
+                            location=('json', 'values'), default=1)
+        args = parser.parse_args()
+        instance = models.AutocompleteParameter.query.filter_by(name=ac_instance_name).first_or_404()
+        datasets = instance.last_datasets(args['count'])
+
+        return marshal(datasets, dataset_field)

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -199,7 +199,7 @@ def import_autocomplete(files, autocomplete_instance, async=True, backup_file=Tr
     for _file in files:
         dataset = models.DataSet()
         dataset.type = type_of_autocomplete_data(_file)
-        dataset.family_type = 'autocomplete'
+        dataset.family_type = 'autocomplete_{}'.format(dataset.type)
         if dataset.type in task:
             if backup_file:
                 filename = move_to_backupdirectory(_file, autocomplete_instance.backup_dir(autocomplete_dir))
@@ -424,7 +424,7 @@ def purge_autocomplete():
         logger.info('purging autocomplete backup directories for %s', ac_instance.name)
         max_backups = current_app.config.get('AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP', 5)
         dir_to_keep = set(os.path.realpath(os.path.dirname(dataset.name))
-                          for dataset in ac_instance.autocomplete_latest_datasets(max_backups))
+                          for dataset in ac_instance.last_datasets(max_backups))
         autocomplete_dir = current_app.config['TYR_AUTOCOMPLETE_DIR']
         backup_dir = os.path.join(autocomplete_dir, ac_instance.name, 'backup')
         all_backups = set(os.path.join(backup_dir, backup)


### PR DESCRIPTION
for Mimir industrialization we'll need a way to reimport the last datasets

this is the first stone for this, it provides an api to get the n last datasets for either a navitia's `Instance` or an `AutocompleteParameter`.

The autocomplete's dataset's `family_type` has been changed to (`autocomplete_bano` and `autocomple_osm`).

I don't really know how to fit the stops dataset into this :confused:

We'll also need to discuss how we implement the way to import all the autocomplete last datasets. 
* api (can be executed from another machine)
* or tyr command (easier for the deployment script to be synchronous)