### PR TITLE
Tyr: new tyr target to refresh autocomplete data

### DIFF
--- a/source/tyr/migrations/versions/4af6f969bfa8_rename_family_type.py
+++ b/source/tyr/migrations/versions/4af6f969bfa8_rename_family_type.py
@@ -1,0 +1,21 @@
+""" rename autocomplete's dataset family_type
+
+Revision ID: 4af6f969bfa8
+Revises: 132cbd5a61a4
+Create Date: 2017-01-16 15:11:10.661733
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4af6f969bfa8'
+down_revision = '132cbd5a61a4'
+
+from alembic import op
+
+
+def upgrade():
+    op.execute("update data_set set family_type = 'autocomplete_' || type where family_type = 'autocomplete';")
+
+
+def downgrade():
+    op.execute("update data_set set family_type = 'autocomplete' where family_type like 'autocomplete_%';")

--- a/source/tyr/tyr/command/import_last_autocomplete_dataset.py
+++ b/source/tyr/tyr/command/import_last_autocomplete_dataset.py
@@ -38,10 +38,7 @@ def import_last_autocomplete_dataset(instance_name, wait=True):
     """
     reimport the last datasets of an autocomplete instance
 
-    If not given, the instance default one is taken
-    By default job is not run on the workers, you need to pass --background for use them, in that case you can
-    also pass --nowait for not waiting the end of the job
-
+    you can set wait=False if you don't want to wait for the result
     """
     instance = models.AutocompleteParameter.query.filter_by(name=instance_name).first()
 
@@ -59,7 +56,10 @@ def import_last_autocomplete_dataset(instance_name, wait=True):
 
 
 @manager.command
-def import_all_last_autocomplete_dataset(wait=True):
+def refresh_autocomplete_data(wait=True):
+    """
+    reimport all the last autocomplete datas
+    """
     instances_name = [i.name for i in models.AutocompleteParameter.query.all()]
     for name in instances_name:
         import_last_autocomplete_dataset(instance_name=name, wait=wait)

--- a/source/tyr/tyr/command/import_last_autocomplete_dataset.py
+++ b/source/tyr/tyr/command/import_last_autocomplete_dataset.py
@@ -32,6 +32,7 @@ from tyr import tasks
 import logging
 from tyr import manager
 
+
 @manager.command
 def import_last_autocomplete_dataset(instance_name, wait=True):
     """
@@ -55,3 +56,12 @@ def import_last_autocomplete_dataset(instance_name, wait=True):
         future.wait()
 
     logger.info('last datasets reimport finished for %s', instance_name)
+
+
+@manager.command
+def import_all_last_autocomplete_dataset(wait=True):
+    instances_name = [i.name for i in models.AutocompleteParameter.query.all()]
+    for name in instances_name:
+        import_last_autocomplete_dataset(instance_name=name, wait=wait)
+
+    # TODO we need to find a way to reimport also the public transport dataset in the autocomplete

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -228,10 +228,10 @@ def import_autocomplete(files, autocomplete_instance, async=True, backup_file=Tr
         action.kwargs['job_id'] = job.id
     actions.append(finish_job.si(job.id))
     if async:
-        chain(*actions).delay()
+        return chain(*actions).delay()
     else:
         # all job are run in sequence and import_data will only return when all the jobs are finish
-        chain(*actions).apply()
+        return chain(*actions).apply()
 
 
 @celery.task()


### PR DESCRIPTION
Add a `refresh_autocomplete_data` tyr target to reload all the autocomplete's last dataset

This should (and will ? :roll_eyes: ) be done via an API but there are still pending questions and a tyr target is easier to do and use, so the first version is a tyr target

We also need to discuss how to reimport the GTFS datasets loaded, but I think this can (and needs to) be done outside this PR