### PR TITLE
!BREAKING CHANGE! Jormungandr: enable configuration from environment variable

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -1,9 +1,11 @@
 # encoding: utf-8
 
 import logging
+import os
+import json
 
 # path of the configuration file for each instances
-INSTANCES_DIR = '/etc/jormungandr.d'
+INSTANCES_DIR = os.getenv('JORMUNGANDR_INSTANCES_DIR', '/etc/jormungandr.d')
 
 # Start the thread at startup, True in production, False for test environments
 START_MONITORING_THREAD = True
@@ -11,17 +13,20 @@ START_MONITORING_THREAD = True
 #URI for postgresql
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
-SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@localhost/jormungandr'
+SQLALCHEMY_DATABASE_URI = os.getenv('JORMUNGANDR_SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@localhost/jormungandr')
 
-DISABLE_DATABASE = False
+DISABLE_DATABASE = os.getenv('JORMUNGANDR_DISABLE_DATABASE', False)
 
 # disable authentication
-PUBLIC = True
+PUBLIC = os.getenv('JORMUNGANDR_IS_PUBLIC', True)
 
 #message returned on authentication request
-HTTP_BASIC_AUTH_REALM = 'Token Required'
+HTTP_BASIC_AUTH_REALM = os.getenv('JORMUNGANDR_HTTP_BASIC_AUTH_REALM', 'Token Required')
 
 from jormungandr.logging_utils import IdFilter
+
+log_level = os.getenv('JORMUNGANDR_LOG_LEVEL', 'DEBUG')
+log_format = os.getenv('JORMUNGANDR_LOG_FORMAT', '[%(asctime)s] [%(request_id)s] [%(levelname)5s] [%(process)5s] [%(name)10s] %(message)s')
 
 # logger configuration
 LOGGER = {
@@ -29,7 +34,7 @@ LOGGER = {
     'disable_existing_loggers': False,
     'formatters':{
         'default': {
-            'format': '[%(asctime)s] [%(request_id)s] [%(levelname)5s] [%(process)5s] [%(name)10s] %(message)s',
+            'format': log_format,
         },
     },
     'filters': {
@@ -39,7 +44,7 @@ LOGGER = {
     },
     'handlers': {
         'default': {
-            'level': 'DEBUG',
+            'level': log_level,
             'class': 'logging.StreamHandler',
             'formatter': 'default',
             'filters': ['IdFilter'],
@@ -48,22 +53,23 @@ LOGGER = {
     'loggers': {
         '': {
             'handlers': ['default'],
-            'level': 'DEBUG',
+            'level': log_level,
             'propagate': True
         },
     }
 }
 
 # Bike self-service configuration
-BSS_PROVIDER = ()
+# This should be moved in a central configuration system like ectd, consul, etc...
+BSS_PROVIDER = json.loads(os.getenv('JORMUNGANDR_BSS_PROVIDER', '{}')) or ()
 
 #Parameters for statistics
-SAVE_STAT = False
-BROKER_URL = 'amqp://guest:guest@localhost:5672//'
-EXCHANGE_NAME = 'stat_persistor_exchange'
+SAVE_STAT = os.getenv('JORMUNGANDR_SAVE_STAT', False)
+BROKER_URL = os.getenv('JORMUNGANDR_BROKER_URL', 'amqp://guest:guest@localhost:5672//')
+EXCHANGE_NAME = os.getenv('JORMUNGANDR_EXCHANGE_NAME', 'stat_persistor_exchange')
 
 #Cache configuration, see https://pythonhosted.org/Flask-Cache/ for more information
-CACHE_CONFIGURATION = {
+default_cache = {
     'CACHE_TYPE': 'null',  # by default cache is not activated
     'TIMEOUT_PTOBJECTS': 600,
     'TIMEOUT_AUTHENTICATION': 600,
@@ -71,6 +77,8 @@ CACHE_CONFIGURATION = {
     'TIMEOUT_TIMEO': 60,
     'TIMEOUT_SYNTHESE': 30,
 }
+
+CACHE_CONFIGURATION = json.loads(os.getenv('JORMUNGANDR_CACHE_CONFIGURATION', '{}')) or default_cache
 
 # List of enabled modules
 MODULES = {
@@ -80,9 +88,10 @@ MODULES = {
     }
 }
 
-AUTOCOMPLETE = None
+# This should be moved in a central configuration system like ectd, consul, etc...
+AUTOCOMPLETE = json.loads(os.getenv('JORMUNGANDR_AUTOCOMPLETE', '{}')) or None
 
-ISOCHRONE_DEFAULT_VALUE = 1800  # in s
+ISOCHRONE_DEFAULT_VALUE = os.getenv('JORMUNGANDR_ISOCHRONE_DEFAULT_VALUE', 1800) # in s
 
 # circuit breaker parameters.
 CIRCUIT_BREAKER_MAX_INSTANCE_FAIL = 4  # max instance call failures before stopping attempt
@@ -106,9 +115,9 @@ CIRCUIT_BREAKER_VALHALLA_TIMEOUT_S = 60  # the circuit breaker retries after thi
 # Default region instance
 # DEFAULT_REGION = 'default'
 
-    
-GRAPHICAL_ISOCHRONE = False
-HEAT_MAP = False
+
+GRAPHICAL_ISOCHRONE = os.getenv('JORMUNGANDR_GRAPHICAL_ISOCHRONE', False)
+HEAT_MAP = os.getenv('JORMUNGANDR_HEAT_MAP', False)
 # This parameter are used to apply gevent's monkey patch
 # The Goal is to activate parallel calling valhalla, without the patch, parallel http calling may not work
-PATCH_WITH_GEVENT_SOCKET = False
+PATCH_WITH_GEVENT_SOCKET = os.getenv('JORMUNGANDR_PATCH_WITH_GEVENT_SOCKET', False)

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -44,6 +44,7 @@ from jormungandr.exceptions import ApiNotFound, RegionNotFound,\
 from jormungandr import authentication, cache, app
 from jormungandr.instance import Instance
 import gevent
+import os
 
 def instances_comparator(instance1, instance2):
     """
@@ -96,6 +97,16 @@ class InstanceManager(object):
     def __repr__(self):
         return '<InstanceManager>'
 
+    def register_instance(self, config):
+        logging.getLogger(__name__).debug("instance configuration: %s", config)
+        name = config['key']
+        instance = Instance(self.context, name, config['zmq_socket'],
+                            config.get('street_network'),
+                            config.get('realtime_proxies', []),
+                            config.get('zmq_socket_type', 'persistent'),
+                            config.get('autocomplete'))
+        self.instances[instance.name] = instance
+
     def initialisation(self):
         """ Charge la configuration à partir d'un fichier ini indiquant
             les chemins des fichiers contenant :
@@ -104,29 +115,23 @@ class InstanceManager(object):
         """
 
         self.instances.clear()
+        for key, value in os.environ.items():
+            if key.startswith('JORMUNGANDR_INSTANCE_'):
+                logging.getLogger(__name__).info("Initialisation, reading: %s", key)
+                config_data = json.loads(value)
+                self.register_instance(config_data)
+
         for file_name in self.configuration_files:
-            logging.getLogger(__name__).info("Initialisation, reading file : " + file_name)
-            if file_name.endswith('.ini'):
-                # Note: the ini configuration file is kept only temporarily, to migration all the
-                # production configuration slowly
-                conf = configparser.ConfigParser()
-                conf.read(file_name)
-                instance = Instance(self.context, conf.get('instance', 'key'), conf.get('instance', 'socket'))
-            elif file_name.endswith('.json'):
+            logging.getLogger(__name__).info("Initialisation, reading file: %s", file_name)
+            if file_name.endswith('.json'):
                 with open(file_name) as f:
                     config_data = json.load(f)
-                    name = config_data['key']
-                    instance = Instance(self.context, name, config_data['zmq_socket'],
-                                        config_data.get('street_network'),
-                                        config_data.get('realtime_proxies', []),
-                                        config_data.get('zmq_socket_type', 'persistent'),
-                                        config_data.get('autocomplete'))
+                    self.register_instance(config_data)
+
             else:
                 logging.getLogger(__name__).warn('impossible to init an instance with the configuration '
-                                                 'file {}'.format(file_name))
+                                                 'file %s', file_name)
                 continue
-
-            self.instances[instance.name] = instance
 
         #we fetch the krakens metadata first
         # not on the ping thread to always have the data available (for the tests for example)

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -61,6 +61,8 @@ namespace navitia { namespace kraken{
             bool display_contributors() const;
             size_t raptor_cache_size() const;
             int slow_request_duration() const;
+            boost::optional<std::string> log_level() const;
+            boost::optional<std::string> log_format() const;
 
             std::vector<std::string> rt_topics() const;
     };

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -63,7 +63,13 @@ int main(int argn, char** argv){
         conf_file = path + application + ".ini";
     }
     conf.load(conf_file);
-    init_logger(conf_file);
+    auto log_level = conf.log_level();
+    auto log_format = conf.log_format();
+    if(log_level && log_format){
+        init_logger(*log_level, *log_format);
+    }else{
+        init_logger(conf_file);
+    }
 
     DataManager<navitia::type::Data> data_manager;
 


### PR DESCRIPTION
This PR also introduce the configuration of kraken from environment
variables and of course make the configuration file optional.

These variables are very badly named since we want to be able to read old
configuration files and a new option_descriptions or a mapping table
between environment variable and file's key is error prone since every
change has to be made two time at least.

So we have ugly names with the following form: `KRAKEN_{SECTION}_{FIELD_NAME}`
This will converted to `{SECTION}.{FIELD_NAME}`.

So to set the zmq_socket we need to define a variable named
`KRAKEN_GENERAL_zmq_socket`

Since the configuration file was also used for logger configuration, I
added two new properties so we can configure the logging with
environment variables too.

https://github.com/CanalTP/utils/pull/47 need to be merde before this one.