### PR TITLE
kraken: optimization of direct path

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -208,8 +208,7 @@ StreetNetwork::get_direct_path(const type::EntryPoint& origin, const type::Entry
                             origin.streetnetwork_params.mode,
                             origin.streetnetwork_params.speed_factor);
 
-    //direct_path_finder.start_distance_dijkstra(max_dur);
-    direct_path_finder.start_distance_and_target_dijkstra(max_dur, {dest_edge[source_e], dest_edge[target_e]});
+    direct_path_finder.start_distance_or_target_dijkstra(max_dur, {dest_edge[source_e], dest_edge[target_e]});
     const auto dest_vertex = direct_path_finder.find_nearest_vertex(dest_edge, true);
     const auto res = direct_path_finder.get_path(dest_edge, dest_vertex);
     if (res.duration > max_dur) { return Path(); }
@@ -276,7 +275,7 @@ void PathFinder::start_distance_dijkstra(const navitia::time_duration& radius) {
 
 }
 
-void PathFinder::start_distance_and_target_dijkstra(const navitia::time_duration& radius, const std::vector<vertex_t>& destinations){
+void PathFinder::start_distance_or_target_dijkstra(const navitia::time_duration& radius, const std::vector<vertex_t>& destinations){
     if (! starting_edge.found)
         return ;
     computation_launch = true;

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -208,7 +208,8 @@ StreetNetwork::get_direct_path(const type::EntryPoint& origin, const type::Entry
                             origin.streetnetwork_params.mode,
                             origin.streetnetwork_params.speed_factor);
 
-    direct_path_finder.start_distance_dijkstra(max_dur);
+    //direct_path_finder.start_distance_dijkstra(max_dur);
+    direct_path_finder.start_distance_and_target_dijkstra(max_dur, {dest_edge[source_e], dest_edge[target_e]});
     const auto dest_vertex = direct_path_finder.find_nearest_vertex(dest_edge, true);
     const auto res = direct_path_finder.get_path(dest_edge, dest_vertex);
     if (res.duration > max_dur) { return Path(); }
@@ -272,6 +273,21 @@ void PathFinder::start_distance_dijkstra(const navitia::time_duration& radius) {
         dijkstra(starting_edge[target_e], printer_distance_visitor(radius, distances, "target"));
 #endif
     } catch(DestinationFound){}
+
+}
+
+void PathFinder::start_distance_and_target_dijkstra(const navitia::time_duration& radius, const std::vector<vertex_t>& destinations){
+    if (! starting_edge.found)
+        return ;
+    computation_launch = true;
+    // We start dijkstra from source and target nodes
+    try {
+        dijkstra(starting_edge[source_e], distance_or_target_visitor(radius, distances, destinations));
+    } catch(DestinationFound&){}
+
+    try {
+        dijkstra(starting_edge[target_e], distance_or_target_visitor(radius, distances, destinations));
+    } catch(DestinationFound&){}
 
 }
 

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -141,6 +141,7 @@ struct PathFinder {
     void init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor);
 
     void start_distance_dijkstra(const navitia::time_duration& radius);
+    void start_distance_and_target_dijkstra(const navitia::time_duration& radius, const std::vector<vertex_t>& destinations);
 
     /// compute the reachable stop points within the radius
     routing::map_stop_point_duration
@@ -284,7 +285,7 @@ struct target_visitor : public boost::dijkstra_visitor<> {
 };
 
 // Visitor who stops (throw a DestinationFound exception) when a certain distance is reached
-struct distance_visitor : public boost::dijkstra_visitor<> {
+struct distance_visitor : virtual public boost::dijkstra_visitor<> {
     navitia::time_duration max_duration;
     const std::vector<navitia::time_duration>& durations;
 
@@ -348,7 +349,7 @@ struct printer_distance_visitor : public distance_visitor {
 #endif
 
 //Visitor who stops (throw a DestinationFound exception) when all targets has been visited
-struct target_all_visitor : public boost::dijkstra_visitor<> {
+struct target_all_visitor : virtual public boost::dijkstra_visitor<> {
     std::vector<vertex_t> destinations;
     size_t nbFound = 0;
     target_all_visitor(const std::vector<vertex_t>& destinations) : destinations(destinations.begin(), destinations.end()){}
@@ -374,6 +375,22 @@ struct target_unique_visitor : public boost::dijkstra_visitor<> {
     void finish_vertex(vertex_t u, const graph_type&){
         if(u == destination)
             throw DestinationFound();
+    }
+};
+
+//Visitor who stops when a target has been visited or a certain distance is reached
+struct distance_or_target_visitor: virtual public distance_visitor, virtual public target_all_visitor {
+    distance_or_target_visitor(const time_duration& max_dur, const std::vector<time_duration>& dur,
+                                      const std::vector<vertex_t>& destinations):
+        distance_visitor(max_dur, dur), target_all_visitor(destinations){}
+    template <typename graph_type>
+    void finish_vertex(vertex_t u, const graph_type& g){
+        target_all_visitor::finish_vertex(u, g);
+    }
+
+    template <typename G>
+    void examine_vertex(typename boost::graph_traits<G>::vertex_descriptor u, const G& g) {
+        distance_visitor::examine_vertex(u, g);
     }
 };
 

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -141,7 +141,7 @@ struct PathFinder {
     void init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor);
 
     void start_distance_dijkstra(const navitia::time_duration& radius);
-    void start_distance_and_target_dijkstra(const navitia::time_duration& radius, const std::vector<vertex_t>& destinations);
+    void start_distance_or_target_dijkstra(const navitia::time_duration& radius, const std::vector<vertex_t>& destinations);
 
     /// compute the reachable stop points within the radius
     routing::map_stop_point_duration


### PR DESCRIPTION
* For direct path of 10 to 20minutes in a query the processing time is reduced from 14ms to 6 ms.
* For direct path of 11 to 22 minutes in another query the processing time is reduced from "slow request" (> 1000 ms) to  between 42ms and 217ms  

*concerned ticket: http://jira.canaltp.fr/browse/ITI-373