### PR TITLE
Jormungandr: handle authentication on /v1/places

### DIFF
--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -136,6 +136,26 @@ def has_access(region, api, abort, user):
         else:
             return False
 
+@cache.memoize(current_app.config['CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 300))
+def has_access_to_global_places(user):
+    """
+    Since there is only open data in the global /places by default, to access the global places the user
+    should be either a super user or have access to the open data
+    """
+    if current_app.config.get('PUBLIC', False):
+        #if jormungandr is on public mode we skip the authentification process
+        return True
+    if not user:
+        # a user is mandatory even for free region
+        return False
+    return user.is_super_user or user.have_access_to_free_instances
+
+
+def check_access_to_global_places(user):
+    if not has_access_to_global_places(user):
+        abort_request(user=user)
+
+
 
 @cache.memoize(current_app.config['CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 300))
 def cache_get_user(token):

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -358,7 +358,9 @@ class Places(ResourceUri):
             autocomplete = global_autocomplete.get('bragi')
             if autocomplete:
                 user = authentication.get_user(token=authentication.get_token(), abort_if_no_token=False)
+                authentication.check_access_to_global_places(user)
                 shape = None
+
                 if user and user.shape:
                     shape = json.loads(user.shape)
                 response = autocomplete.get(args, instance=None, shape=shape)


### PR DESCRIPTION
the users that can access the open data can access the global autocomplete service