### PR TITLE
Jormungandr: do not use old AUTOCOMPLETE conf

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -71,8 +71,8 @@ from navitiacommon.models import db
 db.init_app(app)
 cache = Cache(app, config=app.config['CACHE_CONFIGURATION'])
 
-if app.config['AUTOCOMPLETE'] is not None:
-    global_autocomplete = { k: utils.create_object(v) for k, v in app.config['AUTOCOMPLETE'].items() }
+if app.config['AUTOCOMPLETE_SYSTEMS'] is not None:
+    global_autocomplete = {k: utils.create_object(v) for k, v in app.config['AUTOCOMPLETE_SYSTEMS'].items()}
 else:
     from jormungandr.autocomplete.kraken import Kraken
     global_autocomplete = {'kraken': Kraken()}

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -92,7 +92,7 @@ MODULES = {
 }
 
 # This should be moved in a central configuration system like ectd, consul, etc...
-AUTOCOMPLETE = json.loads(os.getenv('JORMUNGANDR_AUTOCOMPLETE', '{}')) or None
+AUTOCOMPLETE_SYSTEMS = json.loads(os.getenv('JORMUNGANDR_AUTOCOMPLETE_SYSTEMS', '{}')) or None
 
 ISOCHRONE_DEFAULT_VALUE = os.getenv('JORMUNGANDR_ISOCHRONE_DEFAULT_VALUE', 1800) # in s
 

--- a/source/jormungandr/tests/integration_tests_serpy_settings.py
+++ b/source/jormungandr/tests/integration_tests_serpy_settings.py
@@ -54,7 +54,7 @@ MODULES = {
     }
 }
 
-AUTOCOMPLETE = {
+AUTOCOMPLETE_SYSTEMS = {
     'bragi': {
         'class': 'jormungandr.autocomplete.geocodejson.GeocodeJson',
         'args': {

--- a/source/jormungandr/tests/integration_tests_settings.py
+++ b/source/jormungandr/tests/integration_tests_settings.py
@@ -53,7 +53,7 @@ MODULES = {
     }
 }
 
-AUTOCOMPLETE = {
+AUTOCOMPLETE_SYSTEMS = {
     'bragi': {
         'class': 'jormungandr.autocomplete.geocodejson.GeocodeJson',
         'args': {


### PR DESCRIPTION
if we use the old AUTOCOMPLETE configuration variable we are not
retrocompatible since the configuration has changed

The new variable to define the autocomplete is AUTOCOMPLETE_SYSTEMS