### PR TITLE
ed: add tcmalloc especially to bina (also to tests)

### DIFF
--- a/source/ed/connectors/CMakeLists.txt
+++ b/source/ed/connectors/CMakeLists.txt
@@ -17,6 +17,6 @@ SET(SOURCE_LIB
 )
 
 add_library(connectors ${SOURCE_LIB})
-target_link_libraries(connectors ${PROJ})
+target_link_libraries(connectors ${PROJ} tcmalloc)
 
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -82,7 +82,7 @@ set_source_files_properties(${PROTO_HDRS} ${PROTO_SRCS} PROPERTIES GENERATED TRU
 
 
 add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
-target_link_libraries(pb_lib vptranslator pthread ${PROTOBUF_LIBRARY})
+target_link_libraries(pb_lib vptranslator pthread ${PROTOBUF_LIBRARY} tcmalloc)
 
 add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp validity_pattern.cpp type_utils.h)
 target_link_libraries(types ptreferential utils pb_lib protobuf)


### PR DESCRIPTION
There was a big memory load on cities with GCC without that... Not on Clang.
(bad mix of allocator and stdlib impl?)