### PR TITLE
All: Line sections on ptref

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -417,9 +417,9 @@ Impacter& Impacter::on_line_section(const std::string& line_uri,
     line_section.line = b.get<nt::Line>(line_uri);
     line_section.start_point = b.get<nt::StopArea>(start_stop_uri);
     line_section.end_point = b.get<nt::StopArea>(end_stop_uri);
-    for(auto& uri: route_uris) {
+    for (auto& uri: route_uris) {
         auto* route = b.get<nt::Route>(uri);
-        if(route) {
+        if (route) {
             line_section.routes.push_back(route);
         }
     }

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -403,7 +403,12 @@ Impacter& Impacter::severity(const std::string& uri) {
 }
 
 Impacter& Impacter::on(nt::Type_e type, const std::string& uri) {
-    link_informed_entity(dis::make_pt_obj(type, uri, *b.data->pt_data), impact, b.data->meta->production_date, get_disruption().rt_level);
+    dis::Impact::link_informed_entity(
+                dis::make_pt_obj(type, uri, *b.data->pt_data),
+                impact,
+                b.data->meta->production_date,
+                get_disruption().rt_level
+    );
     return *this;
 }
 
@@ -425,7 +430,8 @@ Impacter& Impacter::on_line_section(const std::string& line_uri,
         }
     }
 
-    link_informed_entity(std::move(line_section), impact, b.data->meta->production_date, get_disruption().rt_level);
+    dis::Impact::link_informed_entity(std::move(line_section),
+                                      impact, b.data->meta->production_date, get_disruption().rt_level);
     return *this;
 }
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -411,7 +411,8 @@ Impacter& Impacter::on_line_section(const std::string& line_uri,
                                     const std::string& start_stop_uri,
                                     const std::string& end_stop_uri,
                                     const std::vector<std::string>& route_uris) {
-
+    // Note: don't forget to set the application period before calling this method for the correct
+    // vehicle_journeys to be impacted
 
     dis::LineSection line_section;
     line_section.line = b.get<nt::Line>(line_uri);

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -360,7 +360,6 @@ DisruptionCreator builder::disrupt(nt::RTLevel lvl, const std::string& uri) {
     return DisruptionCreator(*this, uri, lvl);
 }
 
-
 Impacter& Impacter::severity(dis::Effect e,
                              std::string uri,
                              const std::string& wording,
@@ -404,7 +403,7 @@ Impacter& Impacter::severity(const std::string& uri) {
 }
 
 Impacter& Impacter::on(nt::Type_e type, const std::string& uri) {
-    impact->informed_entities.push_back(dis::make_pt_obj(type, uri, *b.data->pt_data, impact));
+    link_informed_entity(dis::make_pt_obj(type, uri, *b.data->pt_data), impact);
     return *this;
 }
 
@@ -412,9 +411,20 @@ Impacter& Impacter::on_line_section(const std::string& line_uri,
                                     const std::string& start_stop_uri,
                                     const std::string& end_stop_uri,
                                     const std::vector<std::string>& route_uris) {
-    impact->informed_entities.push_back(
-        dis::make_line_section(line_uri, start_stop_uri, end_stop_uri, route_uris, *b.data->pt_data, impact)
-    );
+
+
+    dis::LineSection line_section;
+    line_section.line = b.get<nt::Line>(line_uri);
+    line_section.start_point = b.get<nt::StopArea>(start_stop_uri);
+    line_section.end_point = b.get<nt::StopArea>(end_stop_uri);
+    for(auto& uri: route_uris) {
+        auto* route = b.get<nt::Route>(uri);
+        if(route) {
+            line_section.routes.push_back(route);
+        }
+    }
+
+    link_informed_entity(std::move(line_section), impact);
     return *this;
 }
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -403,7 +403,7 @@ Impacter& Impacter::severity(const std::string& uri) {
 }
 
 Impacter& Impacter::on(nt::Type_e type, const std::string& uri) {
-    link_informed_entity(dis::make_pt_obj(type, uri, *b.data->pt_data), impact);
+    link_informed_entity(dis::make_pt_obj(type, uri, *b.data->pt_data), impact, b.data->meta->production_date, get_disruption().rt_level);
     return *this;
 }
 
@@ -424,7 +424,7 @@ Impacter& Impacter::on_line_section(const std::string& line_uri,
         }
     }
 
-    link_informed_entity(std::move(line_section), impact);
+    link_informed_entity(std::move(line_section), impact, b.data->meta->production_date, get_disruption().rt_level);
     return *this;
 }
 

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -149,36 +149,27 @@ class TestChaosDisruptionsLineSection(ChaosDisruptionsFixture):
     """
     Note: it is done as a new fixture, to spawn a new kraken, in order not the get previous disruptions
     """
+
     def test_disruption_on_line_section(self):
         """
-        when calling the pt object line:A, at first we have no disruptions,
+        the test blocking a line section
 
-        then we mock a disruption sent from chaos, and we call again the pt object line:A
-        we then must have one disruption
+        we check that before we have not our disruption and we have it after sending it
+
+        TODO add more checks when all the line section features will be implemented
         """
-        response = self.query_region('lines/A')
-
-        lines = get_not_null(response, 'lines')
-        assert len(lines) == 1
-        line = lines[0]
-        #at first no disruption
-        assert 'disruptions' not in line
+        response = self.query_region('disruptions')
+        assert 'bobette_the_disruption' not in [d['disruption_id'] for d in response['disruptions']]
 
         self.send_mock("bobette_the_disruption", "A",
                        "line_section", start="stopA", end="stopB", blocking=True)
 
-        #and we call again, we must have the disruption now
-        response = self.query_region('lines/A')
-        lines = get_not_null(response, 'lines')
-        assert len(lines) == 1
-        line = lines[0]
+        response = self.query_region('disruptions')
+        # and we call again, we must have the disruption now
+        assert 'bobette_the_disruption' in [d['disruption_id'] for d in response['disruptions']]
 
-        disruptions = get_disruptions(line, response)
-
-        #at first we got only one disruption
-        print(disruptions)
-        assert len(disruptions) == 1
-        assert any(d['disruption_id'] == 'bobette_the_disruption' for d in disruptions)
+        # the disruption is linked to the trips of the line and to the stoppoints
+        # TODO line sections!
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING)

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1085,6 +1085,22 @@ def is_valid_disruption(disruption, chaos_disrup=True):
                 assert 'base_arrival_time' in impacted_stop and 'base_departure_time' in impacted_stop or \
                        'amended_arrival_time' in impacted_stop and 'amended_arrival_time' in impacted_stop
 
+ObjGetter = namedtuple('ObjGetter', ['collection', 'uri'])
+
+
+def has_disruption(response, object_get, disruption_uri):
+    """
+    Little helper to check if a specific object is linked to a specific disruption
+
+    object_spec is a ObjGetter
+    """
+    o = next((s for s in response[object_get.collection] if s['id'] == object_get.uri), None)
+    assert o, 'impossible to find object {}'.format(object_get)
+
+    disruptions = get_disruptions(o, response) or []
+
+    return disruption_uri in (d['disruption_uri'] for d in disruptions)
+
 
 s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
 r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1030,9 +1030,12 @@ def get_disruptions(obj, response):
     """
     all_disruptions = {d['id']: d for d in response['disruptions']}
 
-    if 'links' not in obj:
-        return None
-    return [all_disruptions[d['id']] for d in obj['links'] if d['type'] == 'disruption']
+    # !! uggly hack !!
+    # for vehicle journeys we do not respect the right way to represent disruption,
+    # we do not put the disruption link in a generic `links` section but in a `disruptions` sections...
+    link_section = obj.get('links', obj.get('disruptions', []))
+
+    return [all_disruptions[d['id']] for d in link_section if d['type'] == 'disruption']
 
 
 def is_valid_disruption(disruption, chaos_disrup=True):

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -40,10 +40,39 @@ class TestLineSections(AbstractTestFixture):
         """query navitia with a current date in the publication period of the impacts"""
         return self.query_region('{}?_current_datetime=20170101T100000'.format(q), **kwargs)
 
+    def has_disruption(self, q, object_spec, disruption_uri, **kwargs):
+        """
+        Little helper to check if a specific object is linked to a specific disruption
+
+        object_spec is a tuple with:
+          * the name of the collection to search
+          * the uri of the object
+        """
+        r = self.default_query(q, **kwargs)
+        object_getter = lambda r: next((s for s in r[object_spec[0]] if s['id'] == object_spec[1]), None)
+        o = object_getter(r)
+        assert o
+
+        disruptions = get_disruptions(o, r) or []
+
+        return disruption_uri in (d['disruption_uri'] for d in disruptions)
+
     def test_on_stop_points(self):
+        """
+        the line section disruption should be linked to the impacted stop_points
+        """
+        assert not self.has_disruption('stop_points/A_1', ('stop_points', 'A_1'), 'line_section_on_line_1')
+        assert not self.has_disruption('stop_points/B_1', ('stop_points', 'B_1'), 'line_section_on_line_1')
+        assert self.has_disruption('stop_points/C_1', ('stop_points', 'C_1'), 'line_section_on_line_1')
+        assert self.has_disruption('stop_points/D_1', ('stop_points', 'D_1'), 'line_section_on_line_1')
+        assert self.has_disruption('stop_points/E_1', ('stop_points', 'E_1'), 'line_section_on_line_1')
+        assert not self.has_disruption('stop_points/F_1', ('stop_points', 'F_1'), 'line_section_on_line_1')
 
-        response = self.default_query('stop_points/', display=True)
-
-
-        # response = self.query_region('disruptions', display=True)
-        # assert response.get('disruptions')
+    def test_on_vehicle_journeys(self):
+        """
+        the line section disruption should be linked to the impacted vehicle journeys
+        """
+        assert self.has_disruption('vehicle_journeys/', ('vehicle_journeys', 'vj:1:1'),
+                                   'line_section_on_line_1')
+        assert not self.has_disruption('vehicle_journeys/', ('vehicle_journeys', 'vj:1:2'),
+                                   'line_section_on_line_1')

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+import logging
+
+from .tests_mechanism import AbstractTestFixture, dataset
+from .check_utils import *
+
+
+@dataset({"line_sections_test": {}})
+class TestLineSections(AbstractTestFixture):
+
+    def default_query(self, q, **kwargs):
+        """query navitia with a current date in the publication period of the impacts"""
+        return self.query_region('{}?_current_datetime=20170101T100000'.format(q), **kwargs)
+
+    def test_on_stop_points(self):
+
+        response = self.default_query('stop_points/', display=True)
+
+
+        # response = self.query_region('disruptions', display=True)
+        # assert response.get('disruptions')

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -209,57 +209,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
         LOG4CPLUS_TRACE(log, "canceling " << uri);
 
         // Get all impacted VJs and compute the corresponding base_canceled vp
-        using SectionBounds = const std::pair<boost::optional<uint16_t>, boost::optional<uint16_t>>;
-        std::vector<std::tuple<const nt::VehicleJourney*, nt::ValidityPattern, SectionBounds>> vj_vp_pairs;
-
-        // Computing a validity_pattern of impact used to pre-filter concerned vjs later
-        type::ValidityPattern impact_vp = impact->get_impact_vp(meta.production_date);
-
-        // Loop on impacted routes of the line section
-        for(auto* route: ls.routes) {
-            // Loop on each vj
-            bool has_affected_vj(false);
-            route->for_each_vehicle_journey([&](nt::VehicleJourney& vj) {
-                /*
-                 * Pre-filtering by validity pattern, which allows us to check if the vj is impacted quickly
-                 *
-                 * Since the validity pattern runs only by day not by hour, we'll compute in detail to
-                 * check if the vj is really impacted or not.
-                 *
-                 * */
-                if ((vj.validity_patterns[rt_level]->days & impact_vp.days).none()) {
-                    return true;
-                }
-
-                // Filtering each journey to see if it's impacted by the section.
-                SectionBounds bounds_st = vj.get_bounds_orders_for_section(ls.start_point, ls.end_point);
-                // If the vj pass by both stops both elements will be different than nullptr, otherwise
-                // it's not passing by both stops and should not be impacted
-                if(bounds_st.first && bounds_st.second) {
-                    // Once we know the line section is part of the vj we compute the vp for the adapted_vj
-                    LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
-                    nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
-                    for(const auto& period : impact->application_periods) {
-                        // get the vp of the section
-                        new_vp.days |= vj.get_vp_for_section(bounds_st, rt_level, period).days;
-                    }
-                    // If there is effective days for the adapted vp we're keeping it
-                    if(!new_vp.days.none()){
-                        LOG4CPLUS_TRACE(log, "vj " << vj.uri << " is affected, keeping it.");
-                        new_vp.days >>= vj.shift;
-                        has_affected_vj = true;
-                        vj_vp_pairs.emplace_back(&vj, new_vp, bounds_st);
-                    }
-                }
-                return true;
-            });
-
-            // The route isn't really impacted since no vj pass by the section
-            if(!has_affected_vj) {
-                LOG4CPLUS_DEBUG(log, "Route  "<< route->uri << " has no affected vj, removing impact.");
-                route->remove_impact(impact);
-            }
-        }
+        auto vj_vp_pairs = nt::disruption::get_impacted_vehicle_journeys(ls, *impact, meta.production_date, rt_level);
 
         // Loop on each affected vj
         for (auto& vj_vp_section : vj_vp_pairs) {

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -237,7 +237,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 // it's not passing by both stops and should not be impacted
                 if(bounds_st.first && bounds_st.second) {
                     // Once we know the line section is part of the vj we compute the vp for the adapted_vj
-                    LOG4CPLUS_TRACE(log, "vj "<< vj.uri << " pass by both stops, might be affected.");
+                    LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
                     nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
                     for(const auto& period : impact->application_periods) {
                         // get the vp of the section
@@ -245,7 +245,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                     }
                     // If there is effective days for the adapted vp we're keeping it
                     if(!new_vp.days.none()){
-                        LOG4CPLUS_TRACE(log, "vj "<< vj.uri << " is affected, keeping it.");
+                        LOG4CPLUS_TRACE(log, "vj " << vj.uri << " is affected, keeping it.");
                         new_vp.days >>= vj.shift;
                         has_affected_vj = true;
                         vj_vp_pairs.emplace_back(&vj, new_vp, bounds_st);
@@ -516,7 +516,7 @@ void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact,
     LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("log"), "Adding impact: " << impact->uri);
 
     add_impacts_visitor v(impact, pt_data, meta, impact->disruption->rt_level);
-    boost::for_each(impact->informed_entities, boost::apply_visitor(v));
+    boost::for_each(impact->mut_informed_entities(), boost::apply_visitor(v));
     LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("log"), impact->uri << " impact added");
 }
 
@@ -648,7 +648,7 @@ void delete_impact(boost::shared_ptr<nt::disruption::Impact> impact,
     auto log = log4cplus::Logger::getInstance("log");
     LOG4CPLUS_DEBUG(log, "Deleting impact: " << impact.get()->uri);
     delete_impacts_visitor v(impact, pt_data, meta, impact->disruption->rt_level);
-    boost::for_each(impact->informed_entities, boost::apply_visitor(v));
+    boost::for_each(impact->mut_informed_entities(), boost::apply_visitor(v));
     LOG4CPLUS_DEBUG(log, impact.get()->uri << " deleted");
 }
 

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -255,8 +255,9 @@ make_impact(const chaos::Impact& chaos_impact, nt::PT_Data& pt_data,
     }
     impact->severity = make_severity(chaos_impact.severity(), holder);
 
-    for (auto ptobj: make_pt_objects(chaos_impact.informed_entities(), pt_data)) {
-        link_informed_entity(std::move(ptobj), impact, meta.production_date, nt::RTLevel::Adapted);
+    for (auto& ptobj: make_pt_objects(chaos_impact.informed_entities(), pt_data)) {
+        nt::disruption::Impact::link_informed_entity(std::move(ptobj),
+                                                     impact, meta.production_date, nt::RTLevel::Adapted);
     }
     for (const auto& chaos_message: chaos_impact.messages()) {
         const auto& channel = chaos_message.channel();

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -162,6 +162,7 @@ make_line_section(const chaos::PtObject& chaos_section,
         line_section.routes = line_section.line->route_list;
     }
 
+    // we store the impact in the impacted objects
     if(impact) {
         line->add_impact(impact);
         for(auto* route: line_section.routes) {

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -161,14 +161,6 @@ make_line_section(const chaos::PtObject& chaos_section,
         line_section.routes = line_section.line->route_list;
     }
 
-    // we store the impact in the impacted objects
-//    if(impact) {
-//        line->add_impact(impact);
-//        for(auto* route: line_section.routes) {
-//            route->add_impact(impact);
-//        }
-//    }
-
     return line_section;
 }
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -271,7 +271,7 @@ create_disruption(const std::string& id,
             LOG4CPLUS_ERROR(log, "unhandled real time message");
         }
         impact->severity = make_severity(id, std::move(wording), effect, timestamp, holder);
-        link_informed_entity(
+        nd::Impact::link_informed_entity(
                     nd::make_pt_obj(nt::Type_e::MetaVehicleJourney, trip_update.trip().trip_id(), *data.pt_data),
                     impact, data.meta->production_date, nt::RTLevel::RealTime);
         // messages

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -273,7 +273,7 @@ create_disruption(const std::string& id,
         impact->severity = make_severity(id, std::move(wording), effect, timestamp, holder);
         link_informed_entity(
                     nd::make_pt_obj(nt::Type_e::MetaVehicleJourney, trip_update.trip().trip_id(), *data.pt_data),
-                    impact);
+                    impact, data.meta->production_date, nt::RTLevel::RealTime);
         // messages
         disruption.add_impact(std::move(impact), holder);
     }

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -271,8 +271,9 @@ create_disruption(const std::string& id,
             LOG4CPLUS_ERROR(log, "unhandled real time message");
         }
         impact->severity = make_severity(id, std::move(wording), effect, timestamp, holder);
-        impact->informed_entities.push_back(
-            make_pt_obj(nt::Type_e::MetaVehicleJourney, trip_update.trip().trip_id(), *data.pt_data, impact));
+        link_informed_entity(
+                    nd::make_pt_obj(nt::Type_e::MetaVehicleJourney, trip_update.trip().trip_id(), *data.pt_data),
+                    impact);
         // messages
         disruption.add_impact(std::move(impact), holder);
     }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1254,8 +1254,8 @@ BOOST_AUTO_TEST_CASE(add_simple_impact_on_line_section) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
                               .application_periods(btp("20160404T120000"_dt, "20160406T090000"_dt))
+                              .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
@@ -1379,8 +1379,8 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_with_vj_pass_midnight) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
                               .application_periods(btp("20160405T003000"_dt, "20160406T090000"_dt))
+                              .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
@@ -1571,8 +1571,8 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     navitia::apply_disruption(
         b.impact(nt::RTLevel::Adapted, "line_section_sa1_sa5_routesA1-2-3")
          .severity(nt::disruption::Effect::NO_SERVICE)
-         .on_line_section("line:A", "stop_area:2", "stop_area:5", {"route:A1", "route:A2", "route:A3"})
          .application_periods(btp("20160404T000000"_dt, "20160409T240000"_dt))
+         .on_line_section("line:A", "stop_area:2", "stop_area:5", {"route:A1", "route:A2", "route:A3"})
          .get_disruption(),
          *b.data->pt_data, *b.data->meta
     );
@@ -1582,20 +1582,25 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     // Only 6 vj, vj:3 shouldn't be affected by the section, vj:4 shouldn't be affected since the route isn't
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 6);
 
-    // Make sur only the first two routes are impacted
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A1"]->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A2"]->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A3"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A4"]->get_impacts().size(), 0);
+    // we should be able to find the disuption on the stoppoints [s2, s5]
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s1")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s2")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s3")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s4")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s5")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s6")->get_impacts().size(), 0);
 
     // Check the original vjs
     auto* vj = b.get<nt::VehicleJourney>("vj:1");
+    // this vj should be impacted by the line section, so the impact should be found in it's metavj
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
     auto adapted_vp = vj->adapted_validity_pattern()->days;
     auto base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000000"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     vj = b.get<nt::VehicleJourney>("vj:2");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000000"), adapted_vp);
@@ -1603,12 +1608,15 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
 
     // vj3 shouldn't be impacted since there is no section stop_area:2 -> stop_area:5
     vj = b.get<nt::VehicleJourney>("vj:3");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
+    // vj4 shouldn't be impacted too since it's route isn't
     vj = b.get<nt::VehicleJourney>("vj:4");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
@@ -1616,6 +1624,7 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
 
     // Check adapted vjs
     vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
@@ -1625,6 +1634,7 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "s6");
 
     vj = b.get<nt::VehicleJourney>("vj:2:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
@@ -1644,19 +1654,23 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     navitia::delete_disruption("line_section_sa1_sa5_routesA1-2-3", *b.data->pt_data, *b.data->meta);
 
     // Make sur there is no impacts anymore
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A1"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A2"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A3"]->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes_map["route:A4"]->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s1")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s2")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s3")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s4")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s5")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("s6")->get_impacts().size(), 0);
 
     // Check the original vjs
     vj = b.get<nt::VehicleJourney>("vj:1");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0); // there shouldn't be any impacts anymore
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     vj = b.get<nt::VehicleJourney>("vj:2");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
@@ -1664,12 +1678,14 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
 
     // vj3 shouldn't be impacted since there is no section stop_area:2 -> stop_area:5
     vj = b.get<nt::VehicleJourney>("vj:3");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     vj = b.get<nt::VehicleJourney>("vj:4");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
@@ -1677,12 +1693,14 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
 
     // Check that adapted vjs are deactivated
     vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000000"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
     vj = b.get<nt::VehicleJourney>("vj:2:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
+    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 0);
     adapted_vp = vj->adapted_validity_pattern()->days;
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000000"), adapted_vp);

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -40,6 +40,7 @@ www.navitia.io
 #include "kraken/realtime.h"
 #include "type/kirin.pb.h"
 #include "routing/raptor.h"
+#include "type/pb_converter.h"
 
 struct logger_initialized {
     logger_initialized()   { init_logger(); }
@@ -1902,5 +1903,4 @@ BOOST_AUTO_TEST_CASE(update_impact) {
     navitia::delete_disruption("stop3_closed", *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
-
 }

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -293,7 +293,7 @@ static Indexes get_indexes_by_impacts(const Data & d, const type::Type_e& type_e
         if (imp->severity->effect != type::disruption::Effect::NO_SERVICE) {
             continue;
         }
-        for(const auto& entitie: imp->informed_entities){
+        for(const auto& entitie: imp->informed_entities()){
             auto pair_type_indexes = boost::apply_visitor(visit, entitie);
             if(type_e == pair_type_indexes.first){
                 result.insert(pair_type_indexes.second.begin(), pair_type_indexes.second.end());

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 SET(ALL_LIBS workers ed disruption_api calendar_api time_tables types autocomplete proximitylist
-    ptreferential time_tables data routing fare georef utils SimpleAmqpClient
+    ptreferential time_tables data routing fare types georef utils SimpleAmqpClient
     rabbitmq-static log4cplus tcmalloc ${Boost_LIBRARIES} protobuf)
 
 # every tests will produce an executable used in jormungandr integration tests
@@ -26,6 +26,8 @@ add_executable(main_routing_without_pt_test main_routing_without_pt_test.cpp)
 
 add_executable(multiple_schedules multiple_schedules.cpp)
 
+add_executable(line_sections_test line_sections_test.cpp)
+
 
 target_link_libraries(main_routing_test ${ALL_LIBS})
 target_link_libraries(main_ptref_test ${ALL_LIBS})
@@ -38,3 +40,4 @@ target_link_libraries(main_stif_test ${ALL_LIBS})
 target_link_libraries(null_status_test ${ALL_LIBS})
 target_link_libraries(main_routing_without_pt_test ${ALL_LIBS})
 target_link_libraries(multiple_schedules ${ALL_LIBS})
+target_link_libraries(line_sections_test ${ALL_LIBS})

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -1,0 +1,101 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "utils/init.h"
+#include "ed/build_helper.h"
+#include "kraken/apply_disruption.h"
+#include "mock_kraken.h"
+#include "tests/utils_test.h"
+
+/*
+  Test on when to display the line section disruptions
+
+A           B           C           D           E           F
+o --------- o --------- o --------- o --------- o --------- o   <- route_1_of_the_line_1
+
+                        XXXXXXXXXXXXXXXXXXXXXXXXX               <- impact on the route_1_of_the_line_1 on [C, E]
+
+  We also add another route route_2_of_the_line_1 that pass through the same stops areas but different stop points
+  */
+
+namespace bg = boost::gregorian;
+using btp = boost::posix_time::time_period;
+
+int main(int argc, const char* const argv[]) {
+    navitia::init_app();
+
+    ed::builder b("20170101");
+    b.sa("A")("A_1")("A_2");
+    b.sa("B")("B_1")("B_2");
+    b.sa("C")("C_1")("C_2");
+    b.sa("D")("D_1")("D_2");
+    b.sa("E")("E_1")("E_2");
+    b.sa("F")("F_1")("F_2");
+
+    b.vj("line:1")
+            .route("route:line:1:1")
+            .uri("vj:1:1")
+            ("A_1", "08:00"_t)
+            ("B_1", "08:15"_t)
+            ("C_1", "08:45"_t)
+            ("D_1", "09:00"_t)
+            ("E_1", "09:15"_t)
+            ("F_1", "09:30"_t);
+
+    b.vj("line:1")
+            .route("route:line:1:2")
+            .uri("vj:1:2")
+            ("A_2", "08:00"_t)
+            ("B_2", "08:15"_t)
+            ("C_2", "08:45"_t)
+            ("D_2", "09:00"_t)
+            ("E_2", "09:15"_t)
+            ("F_2", "09:30"_t);
+
+    b.generate_dummy_basis();
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(30));
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .on_line_section("line:1", "C", "D", {"route:line:1:1"})
+                              .application_periods(btp("20170101T000000"_dt, "20170106T090000"_dt))
+                              .publish(btp("20170101T000000"_dt, "20170110T090000"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+
+    mock_kraken kraken(b, "line_sections_test", argc, argv);
+
+    return 0;
+}

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -88,12 +88,11 @@ int main(int argc, const char* const argv[]) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on_line_section("line:1", "C", "D", {"route:line:1:1"})
                               .application_periods(btp("20170101T000000"_dt, "20170106T090000"_dt))
                               .publish(btp("20170101T000000"_dt, "20170110T090000"_dt))
+                              .on_line_section("line:1", "C", "E", {"route:line:1:1"})
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
-
 
     mock_kraken kraken(b, "line_sections_test", argc, argv);
 

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -136,12 +136,11 @@ struct InformedEntitiesLinker: public boost::static_visitor<> {
                 }
             }
         }
-
     }
     void operator()(const nt::disruption::UnknownPtObj&) const {}
 };
 
-void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact,
+void Impact::link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact,
                           const boost::gregorian::date_period& production_period, type::RTLevel rt_level) {
     InformedEntitiesLinker v(impact, production_period, rt_level);
     boost::apply_visitor(v, ptobj);

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -121,9 +121,9 @@ struct InformedEntitiesLinker: public boost::static_visitor<> {
             auto& bounds_st = std::get<2>(vj_vp_section);
 
             if (!bounds_st.first || ! bounds_st.second) { continue; }
-            if (vj->stop_time_list.size() < *bounds_st.first ||
-                         vj->stop_time_list.size() < *bounds_st.second) {
-                throw navitia::recoverable_exception("the line section bound are invalid, we skip the linesection");
+            if (vj->stop_time_list.size() <= *bounds_st.first ||
+                         vj->stop_time_list.size() <= *bounds_st.second) {
+                throw navitia::recoverable_exception("the line section bounds are invalid, we skip the linesection");
             }
             auto impacted_stoptimes = boost::make_iterator_range(vj->stop_time_list.begin() + *bounds_st.first,
                                                                  vj->stop_time_list.begin() + *bounds_st.second + 1);

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -121,8 +121,12 @@ struct InformedEntitiesLinker: public boost::static_visitor<> {
             auto& bounds_st = std::get<2>(vj_vp_section);
 
             if (!bounds_st.first || ! bounds_st.second) { continue; }
+            if (vj->stop_time_list.size() < *bounds_st.first ||
+                         vj->stop_time_list.size() < *bounds_st.second) {
+                throw navitia::recoverable_exception("the line section bound are invalid, we skip the linesection");
+            }
             auto impacted_stoptimes = boost::make_iterator_range(vj->stop_time_list.begin() + *bounds_st.first,
-                                                                 vj->stop_time_list.begin() + *bounds_st.second);
+                                                                 vj->stop_time_list.begin() + *bounds_st.second + 1);
 
             for (const auto& st : impacted_stoptimes) {
                 auto* sp = st.stop_point;

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -55,7 +55,6 @@ get_impacted_vehicle_journeys(const LineSection& ls,
     // Loop on impacted routes of the line section
     for(const auto* route: ls.routes) {
         // Loop on each vj
-        bool has_affected_vj(false);
         route->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
             /*
              * Pre-filtering by validity pattern, which allows us to check if the vj is impacted quickly
@@ -84,7 +83,6 @@ get_impacted_vehicle_journeys(const LineSection& ls,
                 if(!new_vp.days.none()){
                     LOG4CPLUS_TRACE(log, "vj " << vj.uri << " is affected, keeping it.");
                     new_vp.days >>= vj.shift;
-                    has_affected_vj = true;
                     vj_vp_pairs.emplace_back(&vj, new_vp, bounds_st);
                 }
             }

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -40,11 +40,68 @@ namespace bg = boost::gregorian;
 
 namespace navitia { namespace type { namespace disruption {
 
+std::vector<std::tuple<const nt::VehicleJourney*, nt::ValidityPattern, SectionBounds>>
+get_impacted_vehicle_journeys(const LineSection& ls,
+                              const Impact& impact,
+                              const boost::gregorian::date_period& production_period,
+                              type::RTLevel rt_level) {
+    auto log = log4cplus::Logger::getInstance("log");
+    // Get all impacted VJs and compute the corresponding base_canceled vp
+    std::vector<std::tuple<const nt::VehicleJourney*, nt::ValidityPattern, SectionBounds>> vj_vp_pairs;
+
+    // Computing a validity_pattern of impact used to pre-filter concerned vjs later
+    type::ValidityPattern impact_vp = impact.get_impact_vp(production_period);
+
+    // Loop on impacted routes of the line section
+    for(const auto* route: ls.routes) {
+        // Loop on each vj
+        bool has_affected_vj(false);
+        route->for_each_vehicle_journey([&](const nt::VehicleJourney& vj) {
+            /*
+             * Pre-filtering by validity pattern, which allows us to check if the vj is impacted quickly
+             *
+             * Since the validity pattern runs only by day not by hour, we'll compute in detail to
+             * check if the vj is really impacted or not.
+             *
+             * */
+            if ((vj.validity_patterns[rt_level]->days & impact_vp.days).none()) {
+                return true;
+            }
+
+            // Filtering each journey to see if it's impacted by the section.
+            SectionBounds bounds_st = vj.get_bounds_orders_for_section(ls.start_point, ls.end_point);
+            // If the vj pass by both stops both elements will be different than nullptr, otherwise
+            // it's not passing by both stops and should not be impacted
+            if(bounds_st.first && bounds_st.second) {
+                // Once we know the line section is part of the vj we compute the vp for the adapted_vj
+                LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
+                nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
+                for(const auto& period : impact.application_periods) {
+                    // get the vp of the section
+                    new_vp.days |= vj.get_vp_for_section(bounds_st, rt_level, period).days;
+                }
+                // If there is effective days for the adapted vp we're keeping it
+                if(!new_vp.days.none()){
+                    LOG4CPLUS_TRACE(log, "vj " << vj.uri << " is affected, keeping it.");
+                    new_vp.days >>= vj.shift;
+                    has_affected_vj = true;
+                    vj_vp_pairs.emplace_back(&vj, new_vp, bounds_st);
+                }
+            }
+            return true;
+        });
+    }
+    return vj_vp_pairs;
+}
+
 struct InformedEntitiesLinker: public boost::static_visitor<> {
     const boost::shared_ptr<Impact>& impact;
-
-    InformedEntitiesLinker(const boost::shared_ptr<Impact>& impact):
-        impact(impact) {}
+    const boost::gregorian::date_period& production_period;
+    type::RTLevel rt_level;
+    InformedEntitiesLinker(const boost::shared_ptr<Impact>& impact,
+                           const boost::gregorian::date_period& production_period,
+                           RTLevel rt_level):
+        impact(impact), production_period(production_period), rt_level(rt_level) {}
 
     template <typename NavitiaPTObject>
     void operator()(NavitiaPTObject* bo) const {
@@ -54,12 +111,37 @@ struct InformedEntitiesLinker: public boost::static_visitor<> {
     void operator()(const nt::disruption::LineSection& line_section) const {
         // for a line section it's a bit more complex, we need to register the impact
         // to all impacted stoppoints and vehiclejourneys
+        auto vj_vp_pairs = get_impacted_vehicle_journeys(line_section, *impact, production_period, rt_level);
+        std::set<type::StopPoint*> impacted_stop_points;
+        std::set<type::MetaVehicleJourney*> impacted_meta_vjs;
+        for (auto& vj_vp_section : vj_vp_pairs) {
+            const auto* vj = std::get<0>(vj_vp_section);
+            if (impacted_meta_vjs.insert(vj->meta_vj).second) {
+                // it's the first time we see this metavj, we add the impact to it
+                vj->meta_vj->add_impact(impact);
+            }
+            auto& bounds_st = std::get<2>(vj_vp_section);
+
+            if (!bounds_st.first || ! bounds_st.second) { continue; }
+            auto impacted_stoptimes = boost::make_iterator_range(vj->stop_time_list.begin() + *bounds_st.first,
+                                                                 vj->stop_time_list.begin() + *bounds_st.second);
+
+            for (const auto& st : impacted_stoptimes) {
+                auto* sp = st.stop_point;
+                if (impacted_stop_points.insert(sp).second) {
+                    // it's the first time we see this stoppoint, we add the impact to it
+                    sp->add_impact(impact);
+                }
+            }
+        }
+
     }
     void operator()(const nt::disruption::UnknownPtObj&) const {}
 };
 
-void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact) {
-    InformedEntitiesLinker v(impact);
+void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact,
+                          const boost::gregorian::date_period& production_period, type::RTLevel rt_level) {
+    InformedEntitiesLinker v(impact, production_period, rt_level);
     boost::apply_visitor(v, ptobj);
 
     impact->_informed_entities.push_back(std::move(ptobj));

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -263,8 +263,8 @@ struct Impact {
     }
 
     // add the ptobj to the enformed entities and make all the needed backref
-    // Note: it's a friend function because we need the shared_ptr to the impact
-    friend void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact, const boost::gregorian::date_period&, type::RTLevel);
+    // Note: it's a static method because we need the shared_ptr to the impact
+    static void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact, const boost::gregorian::date_period&, type::RTLevel);
 
     bool is_valid(const boost::posix_time::ptime& current_time, const boost::posix_time::time_period& action_period) const;
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -264,7 +264,7 @@ struct Impact {
 
     // add the ptobj to the enformed entities and make all the needed backref
     // Note: it's a friend function because we need the shared_ptr to the impact
-    friend void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact);
+    friend void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact, const boost::gregorian::date_period&, type::RTLevel);
 
     bool is_valid(const boost::posix_time::ptime& current_time, const boost::posix_time::time_period& action_period) const;
 
@@ -366,6 +366,11 @@ public:
         ar & disruptions_by_uri & causes & severities & tags & weak_impacts;
     }
 };
+
+using SectionBounds = const std::pair<boost::optional<uint16_t>, boost::optional<uint16_t>>;
+std::vector<std::tuple<const VehicleJourney*, ValidityPattern, SectionBounds>>
+get_impacted_vehicle_journeys(const LineSection&, const Impact&, const boost::gregorian::date_period&, type::RTLevel);
+
 }
 
 }}//namespace

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -43,6 +43,7 @@ www.navitia.io
 #include <boost/serialization/set.hpp>
 #include <boost/variant.hpp>
 #include <boost/serialization/variant.hpp>
+#include <boost/range/iterator_range.hpp>
 
 #include <atomic>
 #include <map>
@@ -180,15 +181,7 @@ typedef boost::variant<
 
 PtObj make_pt_obj(Type_e type,
                   const std::string &uri,
-                  PT_Data& pt_data,
-                  const boost::shared_ptr<Impact> &impact = {});
-
-PtObj make_line_section(const std::string& line_uri,
-                        const std::string& start_stop_uri,
-                        const std::string& end_stop_uri,
-                        const std::vector<std::string>& route_uris,
-                        PT_Data& pt_data,
-                        const boost::shared_ptr<Impact>& impact = {});
+                  PT_Data& pt_data);
 
 struct Disruption;
 
@@ -246,8 +239,6 @@ struct Impact {
 
     boost::shared_ptr<Severity> severity;
 
-    std::vector<PtObj> informed_entities;
-
     std::vector<Message> messages;
 
     detail::AuxInfoForMetaVJ aux_info;
@@ -260,15 +251,29 @@ struct Impact {
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar & uri & created_at & updated_at & application_periods
-           & severity & informed_entities & messages & disruption
+           & severity & _informed_entities & messages & disruption
            & aux_info;
     }
+
+    boost::iterator_range<std::vector<PtObj>::const_iterator> informed_entities() const {
+        return boost::make_iterator_range(_informed_entities.begin(), _informed_entities.end());
+    }
+    boost::iterator_range<std::vector<PtObj>::iterator> mut_informed_entities() {
+        return boost::make_iterator_range(_informed_entities.begin(), _informed_entities.end());
+    }
+
+    // add the ptobj to the enformed entities and make all the needed backref
+    // Note: it's a friend function because we need the shared_ptr to the impact
+    friend void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact);
 
     bool is_valid(const boost::posix_time::ptime& current_time, const boost::posix_time::time_period& action_period) const;
 
     const type::ValidityPattern get_impact_vp(const boost::gregorian::date_period& production_date) const;
 
     bool operator<(const Impact& other);
+
+private:
+    std::vector<PtObj> _informed_entities;
 };
 
 struct Tag {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1000,7 +1000,7 @@ void PbCreator::Filler::fill_pb_object(const nt::disruption::Impact* impact, pbn
     //we need to compute the active status
     pb_impact->set_status(compute_disruption_status(*impact, pb_creator.action_period));
 
-    for (const auto& informed_entity: impact->informed_entities) {
+    for (const auto& informed_entity: impact->informed_entities()) {
         fill_informed_entity(informed_entity, *impact, pb_impact);
     }
 }


### PR DESCRIPTION
this PR is part of the work on how to display the [line sections](https://github.com/CanalTP/navitia/blob/dev/documentation/rfc/line_sections.md)

For the moment we display the line section impact as before (as a line impact), on the impacted stop_points and impacted vehicle_journeys

