### PR TITLE
Jormungandr: output line sections

### DIFF
--- a/documentation/rfc/line_sections.md
+++ b/documentation/rfc/line_sections.md
@@ -23,20 +23,26 @@ We impact a line and add some precisions on how this line is impacted
         }
         "id":"id_of_the_line",
      }, 
-     "line_section":{ // <- the integration is a bit tricky, you need to check this field to know the impact is on a line section
+     "impacted_section":{ // <- the integration is a bit tricky, you need to check this field to know the impact is on a line section
         "from": {
-            // a stop area
+            // a pt object
+            "embedded_type":"stop_area",
+            "stop_area":{
+            }
         },
         "to": {
-            // a stop area
+            // a pt object
+            "embedded_type":"stop_area",
+            "stop_area":{
+            }
         },
-        // routes ?
+        // no routes for the moment
       },
   }]
 }
 ```
 
-The downside is that the integration is harder, the user needs to check wheter or not a field `impacted_line_sections` is present to treat the impacted line differently, 
+The downside is that the integration is harder, the user needs to check wheter or not a field `impacted_section` is present to treat the impacted line differently, 
 but:
 * it's like what we have for the delays on trips
 * we find that it's quite clear

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -881,6 +881,11 @@ instance_traveler_types = {
 instance_status_with_parameters['traveler_profiles'] = fields.List(fields.Nested(instance_traveler_types,
                                                                                  allow_null=True))
 
+impacted_line_section = {
+    'from': NonNullNested(stop_area),
+    'to': NonNullNested(stop_area),
+}
+
 impacted_stop = {
     "stop_point": NonNullNested(stop_point),
     "base_arrival_time": SplitDateTime(date=None, time='base_stop_time.arrival_time'),
@@ -893,7 +898,8 @@ impacted_stop = {
 
 impacted_object = {
     'pt_object': NonNullNested(pt_object),
-    'impacted_stops': NonNullList(NonNullNested(impacted_stop))
+    'impacted_stops': NonNullList(NonNullNested(impacted_stop)),
+    'line_section': NonNullNested(impacted_line_section, attribute='impacted_line_sections') ## TODO to discuss during review, wouldn't 'impacted_section' be more consistent ?
 }
 
 disruption_marshaller = {

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -881,9 +881,9 @@ instance_traveler_types = {
 instance_status_with_parameters['traveler_profiles'] = fields.List(fields.Nested(instance_traveler_types,
                                                                                  allow_null=True))
 
-impacted_line_section = {
-    'from': NonNullNested(stop_area),
-    'to': NonNullNested(stop_area),
+impacted_section = {
+    'from': NonNullNested(pt_object),
+    'to': NonNullNested(pt_object),
 }
 
 impacted_stop = {
@@ -899,7 +899,7 @@ impacted_stop = {
 impacted_object = {
     'pt_object': NonNullNested(pt_object),
     'impacted_stops': NonNullList(NonNullNested(impacted_stop)),
-    'line_section': NonNullNested(impacted_line_section, attribute='impacted_line_section') ## TODO to discuss during review, wouldn't 'impacted_section' be more consistent ?
+    'impacted_section': NonNullNested(impacted_section)
 }
 
 disruption_marshaller = {

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -899,7 +899,7 @@ impacted_stop = {
 impacted_object = {
     'pt_object': NonNullNested(pt_object),
     'impacted_stops': NonNullList(NonNullNested(impacted_stop)),
-    'line_section': NonNullNested(impacted_line_section, attribute='impacted_line_sections') ## TODO to discuss during review, wouldn't 'impacted_section' be more consistent ?
+    'line_section': NonNullNested(impacted_line_section, attribute='impacted_line_section') ## TODO to discuss during review, wouldn't 'impacted_section' be more consistent ?
 }
 
 disruption_marshaller = {

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -123,9 +123,16 @@ class ImpactedStopSerializer(PbNestedSerializer):
         else:
             return None
 
+
+class ImpactedSectionSerializer(PbNestedSerializer):
+    f = PtObjectSerializer(label='from', attr='from')
+    to = PtObjectSerializer()
+
+
 class ImpactedSerializer(PbNestedSerializer):
     pt_object = PtObjectSerializer(display_none=False)
     impacted_stops = ImpactedStopSerializer(many=True, display_none=False)
+    impacted_section = ImpactedSectionSerializer(display_none=False)
 
 
 class DisruptionSerializer(PbNestedSerializer):
@@ -145,7 +152,6 @@ class DisruptionSerializer(PbNestedSerializer):
     uri = serpy.Field(attr='uri')
     disruption_uri = serpy.Field()
     contributor = serpy.Field()
-
 
 
 class AdminSerializer(GenericSerializer):

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1047,12 +1047,12 @@ def is_valid_line_section_disruption(disruption):
 
     line_section_impacted = next((d for d in get_not_null(disruption, 'impacted_objects')
                                   if d['pt_object']['embedded_type'] == 'line'
-                                 and d.get('line_section')), None)
+                                 and d.get('impacted_section')), None)
 
     assert line_section_impacted
-    line_section = get_not_null(line_section_impacted, 'line_section')
-    is_valid_stop_area(get_not_null(line_section, 'from'))
-    is_valid_stop_area(get_not_null(line_section, 'to'))
+    line_section = get_not_null(line_section_impacted, 'impacted_section')
+    is_valid_pt_object(get_not_null(line_section, 'from'))
+    is_valid_pt_object(get_not_null(line_section, 'to'))
 
 def is_valid_disruption(disruption, chaos_disrup=True):
     get_not_null(disruption, 'id')

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -889,7 +889,7 @@ def check_embedded_line_label(label, line, depth_check):
     if depth_check > 0:
         assert get_not_null(line, 'commercial_mode')['name'] in label
         assert get_not_null(line, 'network')['name'] in label
-    assert get_not_null(line, 'code') in label
+    assert line.get('code', '') in label
     assert get_not_null(line, 'name') in label
 
 
@@ -1037,6 +1037,22 @@ def get_disruptions(obj, response):
 
     return [all_disruptions[d['id']] for d in link_section if d['type'] == 'disruption']
 
+
+def is_valid_line_section_disruption(disruption):
+    """
+    a line section disruption is a classic disruption with it's line as the impacted object
+    and aside this a 'line_section' section with additional information on the line section
+    """
+    is_valid_disruption(disruption, chaos_disrup=False)
+
+    line_section_impacted = next((d for d in get_not_null(disruption, 'impacted_objects')
+                                  if d['pt_object']['embedded_type'] == 'line'
+                                 and d.get('line_section')), None)
+
+    assert line_section_impacted
+    line_section = get_not_null(line_section_impacted, 'line_section')
+    is_valid_stop_area(get_not_null(line_section, 'from'))
+    is_valid_stop_area(get_not_null(line_section, 'to'))
 
 def is_valid_disruption(disruption, chaos_disrup=True):
     get_not_null(disruption, 'id')
@@ -1243,4 +1259,3 @@ def new_default_pagination_journey_comparator(clockwise):
             make_crit(lambda j: get_valid_int(j['duration'])),
             make_crit(lambda j: len(j.get('sections', []))),
     ]
-

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -49,6 +49,12 @@ class TestLineSections(AbstractTestFixture):
         r = self.default_query('{col}/{uri}'.format(col=object_get.collection, uri=object_get.uri))
         return has_disruption(r, object_get, disruption_uri)
 
+    def test_line_section_structure(self):
+        r = self.default_query('stop_points/C_1')
+
+        assert len(get_not_null(r, 'disruptions')) == 1
+        is_valid_line_section_disruption(r['disruptions'][0])
+
     def test_on_stop_points(self):
         """
         the line section disruption should be linked to the impacted stop_points

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -84,6 +84,7 @@ int main(int argc, const char* const argv[]) {
     b.data->pt_data->index();
     b.data->build_raptor();
     b.data->build_uri();
+    b.build_autocomplete();
     b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(30));
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -71,7 +71,7 @@ struct PbCreator::Filler::PtObjVisitor: public boost::static_visitor<> {
         add_pt_object(bo);
     }
     void operator()(const nt::disruption::LineSection& line_section) const {
-        // a line section is displayed as a disruption on a line with additional information (like the vj)
+        // a line section is displayed as a disruption on a line with additional information
         auto* pobj = add_pt_object(line_section.line);
 
         auto* impacted_section = pobj->mutable_impacted_section();

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -74,13 +74,13 @@ struct PbCreator::Filler::PtObjVisitor: public boost::static_visitor<> {
         // a line section is displayed as a disruption on a line with additional information (like the vj)
         auto* pobj = add_pt_object(line_section.line);
 
-        auto* impacted_line_sections = pobj->mutable_impacted_line_sections();
+        auto* impacted_line_section = pobj->mutable_impacted_line_section();
 
         filler.copy(0, DumpMessage::No).fill_pb_object(line_section.start_point,
-                                                       impacted_line_sections->mutable_from());
+                                                       impacted_line_section->mutable_from());
 
         filler.copy(0, DumpMessage::No).fill_pb_object(line_section.end_point,
-                                                       impacted_line_sections->mutable_to());
+                                                       impacted_line_section->mutable_to());
     }
     void operator()(const nt::disruption::UnknownPtObj&) const {}
     void operator()(const nt::MetaVehicleJourney* mvj) const {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -71,8 +71,16 @@ struct PbCreator::Filler::PtObjVisitor: public boost::static_visitor<> {
         add_pt_object(bo);
     }
     void operator()(const nt::disruption::LineSection& line_section) const {
-        //TODO: for the moment a line section is only a line, but later we might want to output more stuff
-        add_pt_object(line_section.line);
+        // a line section is displayed as a disruption on a line with additional information (like the vj)
+        auto* pobj = add_pt_object(line_section.line);
+
+        auto* impacted_line_sections = pobj->mutable_impacted_line_sections();
+
+        filler.copy(0, DumpMessage::No).fill_pb_object(line_section.start_point,
+                                                       impacted_line_sections->mutable_from());
+
+        filler.copy(0, DumpMessage::No).fill_pb_object(line_section.end_point,
+                                                       impacted_line_sections->mutable_to());
     }
     void operator()(const nt::disruption::UnknownPtObj&) const {}
     void operator()(const nt::MetaVehicleJourney* mvj) const {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -74,13 +74,13 @@ struct PbCreator::Filler::PtObjVisitor: public boost::static_visitor<> {
         // a line section is displayed as a disruption on a line with additional information (like the vj)
         auto* pobj = add_pt_object(line_section.line);
 
-        auto* impacted_line_section = pobj->mutable_impacted_line_section();
+        auto* impacted_section = pobj->mutable_impacted_section();
 
         filler.copy(0, DumpMessage::No).fill_pb_object(line_section.start_point,
-                                                       impacted_line_section->mutable_from());
+                                                       impacted_section->mutable_from());
 
         filler.copy(0, DumpMessage::No).fill_pb_object(line_section.end_point,
-                                                       impacted_line_section->mutable_to());
+                                                       impacted_section->mutable_to());
     }
     void operator()(const nt::disruption::UnknownPtObj&) const {}
     void operator()(const nt::MetaVehicleJourney* mvj) const {


### PR DESCRIPTION
output the line section impact

the line_section will be outputed:

```javascript  "disruptions":[
    {
      //some fields
      "impacted_objects":[
        {
          "impacted_section":{                   // <--- new section
            "to":{                                         //  <--- pt object
              "embedded_type":"stop_area",
              "stop_area":{
                // some more fields
                "id":"E"
              },
              "name":"E",
              "id":"E"
            },
            "from":{
              "embedded_type":"stop_area",
              "stop_area":{
                // some more fields
                "id":"C"
              },
              "name":"C",
              "id":"C"
            }
          },
          "pt_object":{
            "embedded_type":"line",                      // <--- same impacted line object
            "line":{
              // some more fields
              "id":"line:1"
            },
            "name":"base_network  (line:1)",
            "id":"line:1"
          }
        }
      ],
      "id":"ce20937e-b60d-40a6-b63d-22eddd32b3c2",
      "disruption_uri":"line_section_on_line_1"
    }
```