### PR TITLE
jormungandr: make start_page an int for last link

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -159,7 +159,7 @@ class add_pagination_links(object):
                             kwargs["start_page"] = 0
                         else:
                             nb_last_page = total_result - 1
-                            nb_last_page = nb_last_page / items_per_page
+                            nb_last_page = int(nb_last_page / items_per_page)
                             kwargs["start_page"] = nb_last_page
                             data["links"].append({
                                 "href": url_for(endpoint, **kwargs),


### PR DESCRIPTION
I was using navitia.io : http://api.navitia.io/v1/coverage/fr-idf/stop_areas
And I saw that the start_page of the link of type "start" was a float : 
```json
(...)
{
    "href": "http://api.navitia.io/v1/coverage/fr-idf/stop_areas?start_page=709.64",
    "type": "last",
    "templated": false
},
(...)
```

And [this link](http://api.navitia.io/v1/coverage/fr-idf/stop_areas?start_page=709.64) doesn't work :
```json
{
    "message": "invalid literal for int() with base 10: '709.64'"
}
```