### PR TITLE
Jormungandr: better display of line_sections in /journeys and schedules

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -462,7 +462,9 @@ Impacter builder::impact(nt::RTLevel lvl, std::string disruption_uri) {
         disruption_uri = get_random_id();
     }
     auto& disruption = data->pt_data->disruption_holder.make_disruption(disruption_uri, lvl);
-    return Impacter(*this, disruption);
+    auto i = Impacter(*this, disruption);
+    i.uri(disruption_uri); //by default we set the same uri to the impact and the disruption
+    return i;
 }
 
 VJ builder::vj(const std::string& line_name,

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1132,10 +1132,11 @@ heat_map_basic_query = "heat_maps?from={from_coord}&datetime={datetime}&max_dura
     .format(from_coord=s_coord, datetime="20120614T080000", max_duration="3600")
 
 
-def get_all_disruptions(elem, response):
+def get_all_element_disruptions(elem, response):
     """
     return a map with the disruption id as key and the list of disruption + impacted object as value for a item of the response
     """
+    DisruptAndElt = namedtuple('DisruptAndElt', ['disruption', 'impacted_object'])
     disruption_by_obj = defaultdict(list)
 
     all_disruptions = {d['id']: d for d in response['disruptions']}
@@ -1150,7 +1151,7 @@ def get_all_disruptions(elem, response):
         real_disruptions = [all_disruptions[d['id']] for d in obj['links'] if d['type'] == 'disruption']
 
         for d in real_disruptions:
-            disruption_by_obj[d['id']].append((d, obj))
+            disruption_by_obj[d['id']].append(DisruptAndElt(disruption=d, impacted_object=obj))
 
     #we import utils here else it will import jormungandr too early in the test
     from jormungandr import utils

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -190,14 +190,14 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(departures), 2)
 
         departure = departures[0]
-        disruptions = get_all_disruptions(departure, response)
+        disruptions = get_all_element_disruptions(departure, response)
         assert disruptions
         eq_(len(disruptions), 1)
         assert 'too_bad_all_lines' in disruptions
-        is_valid_disruption(disruptions['too_bad_all_lines'][0][0])
+        is_valid_disruption(disruptions['too_bad_all_lines'][0].disruption)
 
         departure = departures[1]
-        disruptions = get_all_disruptions(departure, response)
+        disruptions = get_all_element_disruptions(departure, response)
         assert not disruptions
 
     def test_disruption_with_arrival(self):
@@ -212,14 +212,14 @@ class TestDisruptions(AbstractTestFixture):
         eq_(len(arrivals), 2)
 
         arrival = arrivals[0]
-        disruptions = get_all_disruptions(arrival, response)
+        disruptions = get_all_element_disruptions(arrival, response)
         assert disruptions
         eq_(len(disruptions), 1)
         assert 'too_bad_all_lines' in disruptions
-        is_valid_disruption(disruptions['too_bad_all_lines'][0][0])
+        is_valid_disruption(disruptions['too_bad_all_lines'][0].disruption)
 
         arrival = arrivals[1]
-        disruptions = get_all_disruptions(arrival, response)
+        disruptions = get_all_element_disruptions(arrival, response)
         assert not disruptions
 
     def test_direct_disruption_call(self):

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -176,13 +176,8 @@ static void fill_section(PbCreator& pb_creator, pbnavitia::Section *pb_section, 
     }
     auto* vj_pt_display_information = pb_section->mutable_pt_display_informations();
 
-    if (! stop_times.empty()) {
-        const auto& vj_stoptimes = navitia::VjStopTimes(vj, stop_times.front(), stop_times.back());
-        pb_creator.fill(&vj_stoptimes, vj_pt_display_information, 1);
-    } else {
-        const auto& vj_stoptimes = navitia::VjStopTimes(vj, nullptr, nullptr);
-        pb_creator.fill(&vj_stoptimes, vj_pt_display_information, 1);
-    }
+    const auto& vj_stoptimes = navitia::VjStopTimes(vj, stop_times);
+    pb_creator.fill(&vj_stoptimes, vj_pt_display_information, 1);
 
     fill_shape(pb_section, stop_times);
     set_length(pb_section);

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -56,12 +56,12 @@ int main(int argc, const char* const argv[]) {
     navitia::init_app();
 
     ed::builder b("20170101");
-    b.sa("A")("A_1")("A_2");
-    b.sa("B")("B_1")("B_2");
-    b.sa("C")("C_1")("C_2");
-    b.sa("D")("D_1")("D_2");
-    b.sa("E")("E_1")("E_2");
-    b.sa("F")("F_1")("F_2");
+    b.sa("A", 0., 1.)("A_1", 0., 1.)("A_2", 0., 1.);
+    b.sa("B", 0., 2.)("B_1", 0., 2.)("B_2", 0., 2.);
+    b.sa("C", 0., 3.)("C_1", 0., 3.)("C_2", 0., 3.);
+    b.sa("D", 0., 4.)("D_1", 0., 4.)("D_2", 0., 4.);
+    b.sa("E", 0., 5.)("E_1", 0., 5.)("E_2", 0., 5.);
+    b.sa("F", 0., 6.)("F_1", 0., 6.)("F_2", 0., 6.);
 
     b.vj("line:1")
             .route("route:line:1:1")
@@ -76,26 +76,26 @@ int main(int argc, const char* const argv[]) {
     b.vj("line:1")
             .route("route:line:1:2")
             .uri("vj:1:2")
-            ("A_2", "08:00"_t)
-            ("B_2", "08:15"_t)
-            ("C_2", "08:45"_t)
-            ("D_2", "09:00"_t)
-            ("E_2", "09:15"_t)
-            ("F_2", "09:30"_t);
+            ("A_2", "09:00"_t)
+            ("B_2", "09:15"_t)
+            ("C_2", "09:45"_t)
+            ("D_2", "10:00"_t)
+            ("E_2", "10:15"_t)
+            ("F_2", "10:30"_t);
 
     b.vj("line:1")
             .route("route:line:1:3")
             .uri("vj:1:3")
-            ("A_1", "08:00"_t)
-            ("B_1", "08:15"_t)
-            ("F_1", "09:30"_t);
+            ("A_1", "10:00"_t)
+            ("B_1", "10:15"_t)
+            ("F_1", "11:30"_t);
 
     b.vj("line:2")
             .route("route:line:2:1")
             .uri("vj:2")
-            ("A_1", "08:00"_t)
-            ("B_1", "08:15"_t)
-            ("F_1", "09:30"_t);
+            ("A_1", "11:00"_t)
+            ("B_1", "11:15"_t)
+            ("F_1", "12:30"_t);
 
     b.generate_dummy_basis();
     b.finish();
@@ -107,8 +107,8 @@ int main(int argc, const char* const argv[]) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .application_periods(btp("20170101T000000"_dt, "20170106T090000"_dt))
-                              .publish(btp("20170101T000000"_dt, "20170110T090000"_dt))
+                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                              .publish(btp("20170101T000000"_dt, "20170105T000000"_dt))
                               .on_line_section("line:1", "C", "E", {"route:line:1:1", "route:line:1:3"})
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -191,7 +191,8 @@ void passages(PbCreator& pb_creator,
 
         const type::VehicleJourney* vj = dt_stop_time.second->vehicle_journey;
         passage->mutable_stop_date_time()->set_data_freshness(to_pb_realtime_level(vj->realtime_level));
-        const auto& vj_st = navitia::VjStopTimes(vj, dt_stop_time.second, nullptr);
+        const auto sts = std::vector<const nt::StopTime*>{dt_stop_time.second};
+        const auto& vj_st = navitia::VjStopTimes(vj, sts);
         pb_creator.fill(&vj_st, passage->mutable_pt_display_informations(), 1);
         fill_route_point(pb_creator, depth, vj->route, dt_stop_time.second->stop_point, passage);
     }

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -398,7 +398,8 @@ void route_schedule(PbCreator& pb_creator, const std::string& filter,
                     pbnavitia::Header* header = table->mutable_headers(j);
                     pbnavitia::PtDisplayInfo* vj_display_information = header->mutable_pt_display_informations();
                     auto vj = dt_stop_time.second->vehicle_journey;
-                    const auto& vj_st = navitia::VjStopTimes(vj, dt_stop_time.second, nullptr);
+                    auto sts = std::vector<const nt::StopTime*>{dt_stop_time.second};
+                    const auto& vj_st = navitia::VjStopTimes(vj, sts);
                     pb_creator.fill(&vj_st, vj_display_information, 0);
                     // as we only issue headsign for vj in route_schedules:
                     // - need to override headsign with trip headsign (i.e. vj.name)

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -68,22 +68,22 @@ get_impacted_vehicle_journeys(const LineSection& ls,
             }
 
             // Filtering each journey to see if it's impacted by the section.
-            SectionBounds bounds_st = vj.get_bounds_orders_for_section(ls.start_point, ls.end_point);
+            auto section = vj.get_sections_stop_points(ls.start_point, ls.end_point);
             // If the vj pass by both stops both elements will be different than nullptr, otherwise
             // it's not passing by both stops and should not be impacted
-            if(bounds_st.first && bounds_st.second) {
+            if( ! section.empty()) {
                 // Once we know the line section is part of the vj we compute the vp for the adapted_vj
                 LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
                 nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
                 for(const auto& period : impact.application_periods) {
                     // get the vp of the section
-                    new_vp.days |= vj.get_vp_for_section(bounds_st, rt_level, period).days;
+                    new_vp.days |= vj.get_vp_for_section(section, rt_level, period).days;
                 }
                 // If there is effective days for the adapted vp we're keeping it
                 if(!new_vp.days.none()){
                     LOG4CPLUS_TRACE(log, "vj " << vj.uri << " is affected, keeping it.");
                     new_vp.days >>= vj.shift;
-                    vj_vp_pairs.emplace_back(&vj, new_vp, bounds_st);
+                    vj_vp_pairs.emplace_back(&vj, new_vp, std::move(section));
                 }
             }
             return true;

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1153,8 +1153,51 @@ void PbCreator::Filler::fill_pb_object(const VjOrigDest* vj_orig_dest, pbnavitia
     }
 }
 
+/*
+ * override fill_messages for journey sections to handle line sections impacts
+ *
+ * for a journey section, we get:
+ *  - all of the meta journey impacts but the line sections impacts
+ *  - for the line sections impacts we check that theyintersect the journey section
+ */
+void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
+                                      pbnavitia::PtDisplayInfo* pt_display_info) {
+    if (vj_stoptimes == nullptr) {return ;}
+    if (dump_message == DumpMessage::No) { return; }
+    const auto* meta_vj = vj_stoptimes->vj->meta_vj;
+    for (const auto& message : meta_vj->get_applicable_messages(pb_creator.now,
+                                                                pb_creator.action_period)) {
+        auto line_section_impacted_obj_it = boost::find_if(message->informed_entities(),
+                                                        [](const nt::disruption::PtObj& ptobj) {
+           return boost::get<nt::disruption::LineSection>(&ptobj) != nullptr;
+        });
+        if (line_section_impacted_obj_it != message->informed_entities().end()) {
+            // note in this we take the premise that an impact cannot impact a line section AND a vj
+            const auto& line_section = *line_section_impacted_obj_it;
+            bool found = false;
+            for (const auto& st: vj_stoptimes->stop_times) {
+                // if one stop point of the stoptimes is impacted by the same impact
+                // it means the section is impacted
+                for (const auto& sp_message : st->stop_point->get_applicable_messages(pb_creator.now,
+                                                                            pb_creator.action_period)) {
+                    if (sp_message == message) {
+                        found = true;
+                        break;
+                    }
+                }
+                if (found) { break; }
+            }
+            if (! found) {
+                // we haven't found a stoppoint impacted by this line section impact, it does not concern this vj
+                continue;
+            }
+        }
+        fill_message(message, pt_display_info);
+    }
+}
+
 void PbCreator::Filler::fill_pb_object(const VjStopTimes* vj_stoptimes,
-                                       pbnavitia::PtDisplayInfo* pt_display_info){
+                                       pbnavitia::PtDisplayInfo* pt_display_info) {
     if(vj_stoptimes->vj == nullptr) { return ;}
 
     pbnavitia::Uris* uris = pt_display_info->mutable_uris();
@@ -1171,10 +1214,11 @@ void PbCreator::Filler::fill_pb_object(const VjStopTimes* vj_stoptimes,
         uris->set_journey_pattern(pb_creator.data->dataRaptor->jp_container.get_id(jp_idx));
     }
 
-    fill_messages(vj_stoptimes->vj->meta_vj, pt_display_info);
+    fill_messages(vj_stoptimes, pt_display_info);
 
-    if (vj_stoptimes->orig != nullptr) {
-        pt_display_info->set_headsign(pb_creator.data->pt_data->headsign_handler.get_headsign(*vj_stoptimes->orig));
+    const auto* first_st = vj_stoptimes->stop_times.empty() ? nullptr : vj_stoptimes->stop_times.front();
+    if (first_st != nullptr) {
+        pt_display_info->set_headsign(pb_creator.data->pt_data->headsign_handler.get_headsign(*first_st));
     }
     pt_display_info->set_direction(vj_stoptimes->vj->get_direction());
     if (vj_stoptimes->vj->physical_mode != nullptr) {
@@ -1183,8 +1227,10 @@ void PbCreator::Filler::fill_pb_object(const VjStopTimes* vj_stoptimes,
     }
     pt_display_info->set_description(vj_stoptimes->vj->odt_message);
     pbnavitia::hasEquipments* has_equipments = pt_display_info->mutable_has_equipments();
-    if (vj_stoptimes->orig && vj_stoptimes->dest) {
-        const auto& vj = VjOrigDest(vj_stoptimes->vj, vj_stoptimes->orig->stop_point, vj_stoptimes->dest->stop_point);
+    if (vj_stoptimes->stop_times.size() >= 2) {
+        const auto& vj = VjOrigDest(vj_stoptimes->vj,
+                                    vj_stoptimes->stop_times.front()->stop_point,
+                                    vj_stoptimes->stop_times.back()->stop_point);
         fill_with_creator(&vj, [&](){return has_equipments;});
     } else {
         fill_with_creator(vj_stoptimes->vj, [&](){return has_equipments;});

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1158,7 +1158,7 @@ void PbCreator::Filler::fill_pb_object(const VjOrigDest* vj_orig_dest, pbnavitia
  *
  * for a journey section, we get:
  *  - all of the meta journey impacts but the line sections impacts
- *  - for the line sections impacts we check that theyintersect the journey section
+ *  - for the line sections impacts we check that they intersect the journey section
  */
 void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
                                       pbnavitia::PtDisplayInfo* pt_display_info) {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1167,31 +1167,28 @@ void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
     const auto* meta_vj = vj_stoptimes->vj->meta_vj;
     for (const auto& message : meta_vj->get_applicable_messages(pb_creator.now,
                                                                 pb_creator.action_period)) {
-        auto line_section_impacted_obj_it = boost::find_if(message->informed_entities(),
-                                                        [](const nt::disruption::PtObj& ptobj) {
-           return boost::get<nt::disruption::LineSection>(&ptobj) != nullptr;
-        });
-        if (line_section_impacted_obj_it != message->informed_entities().end()) {
-            // note in this we take the premise that an impact cannot impact a line section AND a vj
-            const auto& line_section = *line_section_impacted_obj_it;
-            bool found = false;
-            for (const auto& st: vj_stoptimes->stop_times) {
-                // if one stop point of the stoptimes is impacted by the same impact
-                // it means the section is impacted
-                for (const auto& sp_message : st->stop_point->get_applicable_messages(pb_creator.now,
-                                                                            pb_creator.action_period)) {
-                    if (sp_message == message) {
-                        found = true;
-                        break;
+        bool found = [&](){
+            auto line_section_impacted_obj_it = boost::find_if(message->informed_entities(),
+                                                            [](const nt::disruption::PtObj& ptobj) {
+               return boost::get<nt::disruption::LineSection>(&ptobj) != nullptr;
+            });
+           if (line_section_impacted_obj_it != message->informed_entities().end()) {
+                // note in this we take the premise that an impact cannot impact a line section AND a vj
+                for (const auto& st: vj_stoptimes->stop_times) {
+                    // if one stop point of the stoptimes is impacted by the same impact
+                    // it means the section is impacted
+                    for (const auto& sp_message : st->stop_point->get_applicable_messages(pb_creator.now,
+                                                                                pb_creator.action_period)) {
+                        if (sp_message == message) {
+                            return true;
+                        }
                     }
                 }
-                if (found) { break; }
-            }
-            if (! found) {
-                // we haven't found a stoppoint impacted by this line section impact, it does not concern this vj
-                continue;
-            }
-        }
+                return false;
+            }}();
+          // we haven't found a stoppoint impacted by this line section impact, it does not concern this vj
+          if (! found) continue;
+
         fill_message(message, pt_display_info);
     }
 }

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1162,7 +1162,7 @@ void PbCreator::Filler::fill_pb_object(const VjOrigDest* vj_orig_dest, pbnavitia
  */
 void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
                                       pbnavitia::PtDisplayInfo* pt_display_info) {
-    if (vj_stoptimes == nullptr) {return ;}
+    if (vj_stoptimes == nullptr) { return ; }
     if (dump_message == DumpMessage::No) { return; }
     const auto* meta_vj = vj_stoptimes->vj->meta_vj;
     for (const auto& message : meta_vj->get_applicable_messages(pb_creator.now,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -88,10 +88,9 @@ struct VjOrigDest{
 
 struct VjStopTimes{
     const nt::VehicleJourney* vj;
-    const nt::StopTime* orig;
-    const nt::StopTime* dest;
-    VjStopTimes(const nt::VehicleJourney* vj, const nt::StopTime* orig, const nt::StopTime* dest): vj(vj),
-        orig(orig), dest(dest){}
+    const std::vector<const nt::StopTime*>& stop_times;
+    VjStopTimes(const nt::VehicleJourney* vj, const std::vector<const nt::StopTime*>& st): vj(vj),
+        stop_times(st){}
 };
 
 struct StopTimeCalandar{
@@ -363,6 +362,8 @@ private:
                 fill_message(message, pb_obj);
             }
         }
+        // override fill_messages for journey sections to handle line sections impacts
+        void fill_messages(const VjStopTimes*, pbnavitia::PtDisplayInfo*);
 
         template <typename Target, typename Source>
         std::vector<Target*> ptref_indexes(const Source* nav_obj);


### PR DESCRIPTION
For /journeys:
we display a line section impact if:
 * a vj we use is impacted on the stops we use in the journey section
 * a stop_point we use is impacted by a line section

for schedules (/departures, /arrivals, /stop_schedules...):
* we display a line section if the (stop_points, vj) used is part of a line sections

to better understand this you can read the tests :wink: 

Note:
I'm not a fan of line section detection (`fill_messages(const VjStopTimes* vj_stoptimes, PtDisplayInfo* pt_display_info)`), but I don't see a better way :confused: 
