### PR TITLE
Kraken: fix line section bug

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -214,18 +214,14 @@ struct add_impacts_visitor : public apply_impacts_visitor {
         // Loop on each affected vj
         for (auto& vj_vp_section : vj_vp_pairs) {
             std::vector<nt::StopTime> new_stop_times;
-            const auto* vj = std::get<0>(vj_vp_section);
-            auto& new_vp = std::get<1>(vj_vp_section);
-            auto& bounds_st = std::get<2>(vj_vp_section);
+            const auto* vj = vj_vp_section.vj;
+            auto& new_vp = vj_vp_section.new_vp;
+            const auto& stop_points_section = vj_vp_section.impacted_stops;
 
-            bool ignore_stop(false);
             for (const auto& st : vj->stop_time_list) {
-                // Ignore stop if it's the range of impacted stop_times
-                ignore_stop |= (st.order() == *(bounds_st.first));
-                if(ignore_stop) {
+                // Ignore stop if it's stop_point has to be ignored
+                if(stop_points_section.count(st.stop_point)) {
                     LOG4CPLUS_TRACE(log, "Ignoring stop " << st.stop_point->uri << "on " << vj->uri);
-                    // Reset ignore_stop if it's the end stop_time
-                    ignore_stop = !(st.order() == *(bounds_st.second));
                     continue;
                 }
                 nt::StopTime new_st = st.clone();

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -209,17 +209,17 @@ struct add_impacts_visitor : public apply_impacts_visitor {
         LOG4CPLUS_TRACE(log, "canceling " << uri);
 
         // Get all impacted VJs and compute the corresponding base_canceled vp
-        auto vj_vp_pairs = nt::disruption::get_impacted_vehicle_journeys(ls, *impact, meta.production_date, rt_level);
+        auto impacted_vjs = nt::disruption::get_impacted_vehicle_journeys(ls, *impact, meta.production_date, rt_level);
 
         // Loop on each affected vj
-        for (auto& vj_vp_section : vj_vp_pairs) {
+        for (auto& impacted_vj : impacted_vjs) {
             std::vector<nt::StopTime> new_stop_times;
-            const auto* vj = vj_vp_section.vj;
-            auto& new_vp = vj_vp_section.new_vp;
-            const auto& stop_points_section = vj_vp_section.impacted_stops;
+            const auto* vj = impacted_vj.vj;
+            auto& new_vp = impacted_vj.new_vp;
+            const auto& stop_points_section = impacted_vj.impacted_stops;
 
             for (const auto& st : vj->stop_time_list) {
-                // Ignore stop if it's stop_point has to be ignored
+                // stop is ignored if its stop_point is not in impacted_stops
                 if(stop_points_section.count(st.stop_point)) {
                     LOG4CPLUS_TRACE(log, "Ignoring stop " << st.stop_point->uri << "on " << vj->uri);
                     continue;

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1503,7 +1503,8 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
     BOOST_CHECK(ba::ends_with(first_adapted_vj->adapted_validity_pattern()->days.to_string(), "000000"));
     BOOST_CHECK(ba::ends_with(second_adapted_vj->adapted_validity_pattern()->days.to_string(), "000000"));
 
-    const auto* third_adapted_vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:first_ls_B_C:Adapted:1:second_ls_E_F:Adapted:2:third_ls_C_G");
+    const auto* third_adapted_vj = b.get<nt::VehicleJourney>
+            ("vj:1:Adapted:0:first_ls_B_C:Adapted:1:second_ls_E_F:Adapted:2:third_ls_C_G");
     BOOST_REQUIRE(third_adapted_vj);
     BOOST_CHECK(ba::ends_with(third_adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
     BOOST_CHECK(ba::ends_with(third_adapted_vj->base_validity_pattern()->days.to_string(), "000000"));

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1357,6 +1357,160 @@ BOOST_AUTO_TEST_CASE(add_simple_impact_on_line_section) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 }
 
+BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
+    ed::builder b("20160404");
+    b.vj("line:1").uri("vj:1")
+            ("A", "08:10"_t)
+            ("B", "08:20"_t)
+            ("C", "08:30"_t)
+            ("D", "08:40"_t)
+            ("E", "08:50"_t)
+            ("F", "08:60"_t)
+            ("G", "08:70"_t);
+
+    b.generate_dummy_basis();
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    b.data->meta->production_date = bg::date_period(bg::date(2016,4,4), bg::days(7));
+
+    auto get_stops = [](const nt::VehicleJourney* vj) {
+          std::vector<std::string> res;
+          for (const auto st: vj->stop_time_list) {
+              res.push_back(st.stop_point->uri);
+          }
+          return res;
+    };
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "first_ls_B_C")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .application_periods(btp("20160404T080000"_dt, "20160406T230000"_dt))
+                              .publish(btp("20160404T080000"_dt, "20160406T090000"_dt))
+                              .on_line_section("line:1", "B", "C", {"line:1:0"})
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    // it should have created one vj
+    BOOST_CHECK_EQUAL(b.data->pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
+
+    // we should be able to find the disuption on the stoppoints [B, C]
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("A")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("B")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("C")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("D")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("E")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("F")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("G")->get_impacts().size(), 0);
+
+    // Check the original vjs
+    auto* vj = b.get<nt::VehicleJourney>("vj:1");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 7);
+    auto* meta_vj = vj->meta_vj;
+    // this vj should be impacted by the line section, so the impact should be found in it's metavj
+    BOOST_CHECK_EQUAL(meta_vj->get_impacts().size(), 1);
+
+    // Check adapted vjs
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    const auto* adapted_vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:first_ls_B_C");
+    BOOST_REQUIRE(adapted_vj);
+    BOOST_CHECK(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
+    BOOST_CHECK(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
+    BOOST_CHECK_EQUAL(adapted_vj->meta_vj->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 5);
+
+    BOOST_CHECK_EQUAL_RANGE(get_stops(adapted_vj), std::vector<std::string>({"A", "D", "E", "F", "G"}));
+
+    // we now cut E->F
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "second_ls_E_F")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .application_periods(btp("20160404T080000"_dt, "20160406T230000"_dt))
+                              .publish(btp("20160404T080000"_dt, "20160406T090000"_dt))
+                              .on_line_section("line:1", "E", "F", {"line:1:0"})
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    // it will have created another vj, the previous one being deactivated (because we do not clean yet)
+    BOOST_CHECK_EQUAL(b.data->pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 3);
+
+    // we should be able to find the disuption on the stoppoints [B, C] and [E, F]
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("A")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("B")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("C")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("D")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("E")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("F")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("G")->get_impacts().size(), 0);
+
+    // Check the original vjs
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 7);
+    // the 2 impacts should be there
+    BOOST_CHECK_EQUAL(meta_vj->get_impacts().size(), 2);
+
+    // Check adapted vjs, there should be 2, one being deactivated
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 2);
+
+    const auto* first_adapted_vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:first_ls_B_C");
+    BOOST_REQUIRE(first_adapted_vj);
+    BOOST_CHECK(ba::ends_with(first_adapted_vj->adapted_validity_pattern()->days.to_string(), "000000"));
+    BOOST_CHECK(ba::ends_with(first_adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
+
+    const auto* second_adapted_vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:first_ls_B_C:Adapted:1:second_ls_E_F");
+    BOOST_REQUIRE(second_adapted_vj);
+    BOOST_CHECK(ba::ends_with(second_adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
+    BOOST_CHECK(ba::ends_with(second_adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
+
+    BOOST_CHECK_EQUAL(second_adapted_vj->meta_vj->get_impacts().size(), 2);
+    BOOST_CHECK_EQUAL_RANGE(get_stops(second_adapted_vj), std::vector<std::string>({"A", "D", "G"}));
+
+    // we now cut D->G
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "third_ls_C_G")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .application_periods(btp("20160404T080000"_dt, "20160406T230000"_dt))
+                              .publish(btp("20160404T080000"_dt, "20160406T090000"_dt))
+                              .on_line_section("line:1", "B", "G", {"line:1:0"})
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    // it should not have created another vj
+    BOOST_CHECK_EQUAL(b.data->pt_data->lines.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->routes.size(), 1);
+    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 4);
+
+    // we should be able to find the disuption on the stoppoints [B, G]
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("A")->get_impacts().size(), 0);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("B")->get_impacts().size(), 2);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("C")->get_impacts().size(), 2);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("D")->get_impacts().size(), 1);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("E")->get_impacts().size(), 2);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("F")->get_impacts().size(), 2);
+    BOOST_CHECK_EQUAL(b.get<nt::StopPoint>("G")->get_impacts().size(), 1);
+
+    // Check the original vjs
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 7);
+    // the 3 impacts should be there
+    BOOST_CHECK_EQUAL(meta_vj->get_impacts().size(), 3);
+
+    // Check adapted vjs, there should still be 3, with 2 being inactive
+    BOOST_CHECK(ba::ends_with(first_adapted_vj->adapted_validity_pattern()->days.to_string(), "000000"));
+    BOOST_CHECK(ba::ends_with(second_adapted_vj->adapted_validity_pattern()->days.to_string(), "000000"));
+
+    const auto* third_adapted_vj = b.get<nt::VehicleJourney>("vj:1:Adapted:0:first_ls_B_C:Adapted:1:second_ls_E_F:Adapted:2:third_ls_C_G");
+    BOOST_REQUIRE(third_adapted_vj);
+    BOOST_CHECK(ba::ends_with(third_adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
+    BOOST_CHECK(ba::ends_with(third_adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
+    BOOST_CHECK_EQUAL(third_adapted_vj->meta_vj->get_impacts().size(), 3);
+    BOOST_CHECK_EQUAL_RANGE(get_stops(third_adapted_vj), std::vector<std::string>({"A"}));
+}
+
 BOOST_AUTO_TEST_CASE(add_impact_on_line_section_with_vj_pass_midnight) {
     ed::builder b("20160404");
     b.sa("stop_area:1", 0, 0, false, true)("stop_point:10");

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -40,14 +40,14 @@ namespace bg = boost::gregorian;
 
 namespace navitia { namespace type { namespace disruption {
 
-std::vector<std::tuple<const nt::VehicleJourney*, nt::ValidityPattern, SectionBounds>>
+std::vector<ImpactedVJ>
 get_impacted_vehicle_journeys(const LineSection& ls,
                               const Impact& impact,
                               const boost::gregorian::date_period& production_period,
                               type::RTLevel rt_level) {
     auto log = log4cplus::Logger::getInstance("log");
     // Get all impacted VJs and compute the corresponding base_canceled vp
-    std::vector<std::tuple<const nt::VehicleJourney*, nt::ValidityPattern, SectionBounds>> vj_vp_pairs;
+    std::vector<ImpactedVJ> vj_vp_pairs;
 
     // Computing a validity_pattern of impact used to pre-filter concerned vjs later
     type::ValidityPattern impact_vp = impact.get_impact_vp(production_period);
@@ -68,22 +68,22 @@ get_impacted_vehicle_journeys(const LineSection& ls,
             }
 
             // Filtering each journey to see if it's impacted by the section.
-            SectionBounds bounds_st = vj.get_bounds_orders_for_section(ls.start_point, ls.end_point);
+            auto section = vj.get_sections_stop_points(ls.start_point, ls.end_point);
             // If the vj pass by both stops both elements will be different than nullptr, otherwise
             // it's not passing by both stops and should not be impacted
-            if(bounds_st.first && bounds_st.second) {
+            if (! section.empty()) {
                 // Once we know the line section is part of the vj we compute the vp for the adapted_vj
                 LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
                 nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
                 for(const auto& period : impact.application_periods) {
                     // get the vp of the section
-                    new_vp.days |= vj.get_vp_for_section(bounds_st, rt_level, period).days;
+                    new_vp.days |= vj.get_vp_for_section(section, rt_level, period).days;
                 }
                 // If there is effective days for the adapted vp we're keeping it
                 if(!new_vp.days.none()){
                     LOG4CPLUS_TRACE(log, "vj " << vj.uri << " is affected, keeping it.");
                     new_vp.days >>= vj.shift;
-                    vj_vp_pairs.emplace_back(&vj, new_vp, bounds_st);
+                    vj_vp_pairs.emplace_back(&vj, new_vp, std::move(section));
                 }
             }
             return true;
@@ -113,23 +113,12 @@ struct InformedEntitiesLinker: public boost::static_visitor<> {
         std::set<type::StopPoint*> impacted_stop_points;
         std::set<type::MetaVehicleJourney*> impacted_meta_vjs;
         for (auto& vj_vp_section : vj_vp_pairs) {
-            const auto* vj = std::get<0>(vj_vp_section);
+            const auto* vj = vj_vp_section.vj;
             if (impacted_meta_vjs.insert(vj->meta_vj).second) {
                 // it's the first time we see this metavj, we add the impact to it
                 vj->meta_vj->add_impact(impact);
             }
-            auto& bounds_st = std::get<2>(vj_vp_section);
-
-            if (!bounds_st.first || ! bounds_st.second) { continue; }
-            if (vj->stop_time_list.size() <= *bounds_st.first ||
-                         vj->stop_time_list.size() <= *bounds_st.second) {
-                throw navitia::recoverable_exception("the line section bounds are invalid, we skip the linesection");
-            }
-            auto impacted_stoptimes = boost::make_iterator_range(vj->stop_time_list.begin() + *bounds_st.first,
-                                                                 vj->stop_time_list.begin() + *bounds_st.second + 1);
-
-            for (const auto& st : impacted_stoptimes) {
-                auto* sp = st.stop_point;
+            for (auto* sp: vj_vp_section.impacted_stops) {
                 if (impacted_stop_points.insert(sp).second) {
                     // it's the first time we see this stoppoint, we add the impact to it
                     sp->add_impact(impact);

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -109,16 +109,16 @@ struct InformedEntitiesLinker: public boost::static_visitor<> {
     void operator()(const nt::disruption::LineSection& line_section) const {
         // for a line section it's a bit more complex, we need to register the impact
         // to all impacted stoppoints and vehiclejourneys
-        auto vj_vp_pairs = get_impacted_vehicle_journeys(line_section, *impact, production_period, rt_level);
+        auto impacted_vjs = get_impacted_vehicle_journeys(line_section, *impact, production_period, rt_level);
         std::set<type::StopPoint*> impacted_stop_points;
         std::set<type::MetaVehicleJourney*> impacted_meta_vjs;
-        for (auto& vj_vp_section : vj_vp_pairs) {
-            const auto* vj = vj_vp_section.vj;
+        for (auto& impacted_vj : impacted_vjs) {
+            const auto* vj = impacted_vj.vj;
             if (impacted_meta_vjs.insert(vj->meta_vj).second) {
                 // it's the first time we see this metavj, we add the impact to it
                 vj->meta_vj->add_impact(impact);
             }
-            for (auto* sp: vj_vp_section.impacted_stops) {
+            for (auto* sp: impacted_vj.impacted_stops) {
                 if (impacted_stop_points.insert(sp).second) {
                     // it's the first time we see this stoppoint, we add the impact to it
                     sp->add_impact(impact);

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -368,9 +368,17 @@ public:
     }
 };
 
-using SectionBounds = const std::pair<boost::optional<uint16_t>, boost::optional<uint16_t>>;
-std::vector<std::tuple<const VehicleJourney*, ValidityPattern, SectionBounds>>
-get_impacted_vehicle_journeys(const LineSection&, const Impact&, const boost::gregorian::date_period&, type::RTLevel);
+struct ImpactedVJ {
+    const VehicleJourney* vj;
+    ValidityPattern new_vp;
+    std::set<StopPoint*> impacted_stops;
+    ImpactedVJ(const VehicleJourney* vj,
+               ValidityPattern vp,
+               std::set<StopPoint*>&& r):
+        vj(vj), new_vp(vp), impacted_stops(r) {}
+};
+
+std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const LineSection&, const Impact&, const boost::gregorian::date_period&, type::RTLevel);
 
 }
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -369,16 +369,21 @@ public:
 };
 
 struct ImpactedVJ {
-    const VehicleJourney* vj;
+    const VehicleJourney* vj; // vj before impact
     ValidityPattern new_vp;
     std::set<StopPoint*> impacted_stops;
     ImpactedVJ(const VehicleJourney* vj,
                ValidityPattern vp,
-               std::set<StopPoint*>&& r):
-        vj(vj), new_vp(vp), impacted_stops(r) {}
+               std::set<StopPoint*> r):
+        vj(vj), new_vp(vp), impacted_stops(std::move(r)) {}
 };
-
-std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const LineSection&, const Impact&, const boost::gregorian::date_period&, type::RTLevel);
+/*
+ * return the list of vehicle journey that are impacted by the linesection
+ */
+std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const LineSection&,
+                                                      const Impact&,
+                                                      const boost::gregorian::date_period&,
+                                                      type::RTLevel);
 
 }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -555,16 +555,12 @@ struct VehicleJourney: public Header, Nameable, hasVehicleProperties {
 
     // Return the vp for all the stops of the section
     ValidityPattern get_vp_for_section(
-            const std::pair<boost::optional<uint16_t>, boost::optional<uint16_t>> bounds_st,
+            const std::set<StopPoint*>& bounds_st,
             RTLevel rt_level,
             const boost::posix_time::time_period& period) const;
 
-    // Return the stop_times for a section between start_stop and end_stop
-    // Return nullptr if not found
-    const std::pair<boost::optional<uint16_t>, boost::optional<uint16_t>> get_bounds_orders_for_section(
-            const StopArea* start_stop,
-            const StopArea* end_stop
-    ) const;
+    // return all the stoppoints of the base vj between the 2 stop areas
+    std::set<StopPoint*> get_sections_stop_points(const StopArea*, const StopArea*) const;
 
     //return the time period of circulation of the vj for one day
     boost::posix_time::time_period execution_period(const boost::gregorian::date& date) const;


### PR DESCRIPTION
a vj could not be impacted by several line sections.

To do it, we stop using stoptimes orders (indexes) because it was confusing that the orders were from the base vehicle journey.

We now store instead the impacted stoppoints

thus we can do:

```
A               B                 C                   D                E
x               x                 x                   x                x

                [xxxxxxxxxxxxxxxxx]                             first impact [B, C]

-> resulting adapted vj

A                                                     D                E
x                                                     x                x

                [xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]       second impact [B, D]

-> resulting adapted vj
A                                                                      E
x                                                                      x
```