### PR TITLE
Kraken: broader disruption buckets

### DIFF
--- a/source/kraken/fill_disruption_from_database.cpp
+++ b/source/kraken/fill_disruption_from_database.cpp
@@ -54,7 +54,7 @@ void fill_disruption_from_database(const std::string& connection_string,
     pqxx::work work(*conn, "loading disruptions");
 
     size_t offset = 0,
-           items_per_request = 100;
+           items_per_request = 1000;
     DisruptionDatabaseReader reader(pt_data, meta);
     pqxx::result result;
     std::string contributors_array = boost::algorithm::join(contributors, ", ");


### PR DESCRIPTION
This way the first disruption load is quicker, from 5mn to 1mn on the customer chaos database (in local because the chaos server is very slow)

the memory impact seems negligible