### PR TITLE
Kraken: fix disruption.updated_at

### DIFF
--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -143,7 +143,7 @@ class TestPlacesWithDisruptions(ChaosDisruptionsFixture):
         assert response['places'][0]['id'] == 'stopB'
 
         assert len(response['disruptions']) == 1
-        assert response['disruptions'][0]['updated_at'] == u'20160405T150623'
+        assert response['disruptions'][0]['updated_at'] == u'20160405T150733'
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING)
@@ -684,7 +684,8 @@ def make_mock_chaos_item(disruption_name, impacted_obj, impacted_obj_type, start
     impact = disruption.impacts.add()
     impact.id = "impact_" + disruption_name + "_1"
     enums_impact = gtfs_realtime_pb2.Alert.DESCRIPTOR.enum_values_by_name
-    impact.created_at = 1459868783 # u'20160405T150623' 
+    impact.created_at = 1459868783 # u'20160405T150623'
+    impact.updated_at = 1459868853 # u'20160405T150733'
     if blocking:
         impact.severity.effect = enums_impact["NO_SERVICE"].number
         impact.severity.id = 'blocking'

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -684,8 +684,8 @@ def make_mock_chaos_item(disruption_name, impacted_obj, impacted_obj_type, start
     impact = disruption.impacts.add()
     impact.id = "impact_" + disruption_name + "_1"
     enums_impact = gtfs_realtime_pb2.Alert.DESCRIPTOR.enum_values_by_name
-    impact.created_at = 1459868783 # u'20160405T150623'
-    impact.updated_at = 1459868853 # u'20160405T150733'
+    impact.created_at = utils.str_to_time_stamp(u'20160405T150623')
+    impact.updated_at = utils.str_to_time_stamp(u'20160405T150733')
     if blocking:
         impact.severity.effect = enums_impact["NO_SERVICE"].number
         impact.severity.id = 'blocking'

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -251,7 +251,7 @@ make_impact(const chaos::Impact& chaos_impact, nt::PT_Data& pt_data,
     auto impact = boost::make_shared<nt::disruption::Impact>();
     impact->uri = chaos_impact.id();
     impact->created_at = from_posix(chaos_impact.created_at());
-    auto updated_at = chaos_impact.created_at();
+    auto updated_at = chaos_impact.updated_at();
     impact->updated_at = updated_at ? from_posix(updated_at) : impact->created_at;
     for (const auto& chaos_ap: chaos_impact.application_periods()) {
         impact->application_periods.emplace_back(from_posix(chaos_ap.start()), from_posix(chaos_ap.end()));
@@ -319,7 +319,7 @@ make_disruption(const chaos::Disruption& chaos_disruption, nt::PT_Data& pt_data,
 void make_and_apply_disruption(const chaos::Disruption& chaos_disruption,
                     navitia::type::PT_Data& pt_data,
                     const navitia::type::MetaData& meta) {
-    //we delete the disrupion before adding the new one
+    //we delete the disruption before adding the new one
     delete_disruption(chaos_disruption.id(), pt_data, meta);
 
     const auto& disruption = make_disruption(chaos_disruption, pt_data, meta);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1172,7 +1172,7 @@ void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
                                                             [](const nt::disruption::PtObj& ptobj) {
                return boost::get<nt::disruption::LineSection>(&ptobj) != nullptr;
             });
-           if (line_section_impacted_obj_it != message->informed_entities().end()) {
+            if (line_section_impacted_obj_it != message->informed_entities().end()) {
                 // note in this we take the premise that an impact cannot impact a line section AND a vj
                 for (const auto& st: vj_stoptimes->stop_times) {
                     // if one stop point of the stoptimes is impacted by the same impact
@@ -1184,8 +1184,9 @@ void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
                         }
                     }
                 }
-                return false;
-            }}();
+            }
+            return false;
+            }();
           // we haven't found a stoppoint impacted by this line section impact, it does not concern this vj
           if (! found) continue;
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1186,9 +1186,9 @@ void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
                 }
             }
             return false;
-            }();
-          // we haven't found a stoppoint impacted by this line section impact, it does not concern this vj
-          if (! found) continue;
+        }();
+        // we haven't found a stoppoint impacted by this line section impact, it does not concern this vj
+        if (! found) continue;
 
         fill_message(message, pt_display_info);
     }


### PR DESCRIPTION
Fixing http://jira.canaltp.fr/browse/NAVITIAII-2198

We where using `created_at` field from chaos, using now `updated_at`

Last commit corrects https://github.com/CanalTP/navitia/pull/1991/files#diff-9db5f8b2306c44a2a59af3215f2beb47R1187