### PR TITLE
Jormungandr: remove useless fields

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -660,8 +660,6 @@ line["network"] = PbField(network)
 
 commercial_mode = deepcopy(generic_type)
 physical_mode = deepcopy(generic_type)
-commercial_mode["physical_modes"] = NonNullList(NonNullNested(commercial_mode))
-physical_mode["commercial_modes"] = NonNullList(NonNullNested(physical_mode))
 line["commercial_mode"] = PbField(commercial_mode)
 line["physical_modes"] = NonNullList(NonNullNested(physical_mode))
 route["physical_modes"] = NonNullList(NonNullNested(physical_mode))

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -163,12 +163,11 @@ class AdminSerializer(GenericSerializer):
 
 
 class PhysicalModeSerializer(GenericSerializer):
-    commercial_modes = serpy.MethodField()
-    def get_commercial_modes(self, obj):
-        return CommercialModeSerializer(obj.commercial_modes, many=True, display_none=False).data
+    pass
+
 
 class CommercialModeSerializer(GenericSerializer):
-    physical_modes = PhysicalModeSerializer(many=True, display_none=False)
+    pass
 
 
 class StopPointSerializer(GenericSerializer):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -442,8 +442,10 @@ class TestPtRef(AbstractTestFixture):
 
         modes = get_not_null(s, 'physical_modes')
         assert len(modes) == 1
+        is_valid_physical_mode(modes[0], depth_check=1)
         modes = get_not_null(s, 'commercial_modes')
         assert len(modes) == 1
+        is_valid_commercial_mode(modes[0], depth_check=1)
 
         self._test_links(response, 'stop_points')
 


### PR DESCRIPTION
commercial and physical modes are just id and name

this should also fix some serpy differences (as serpy was displaying an
empty commercial_modes list in physical_modes)