### PR TITLE
Jormungandr: fix some links

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -122,6 +122,9 @@ class add_computed_resources(object):
             kwargs["_external"] = True
             templated = True
             for key in data:
+                if key == 'disruptions' and collection is not None:
+                    # disruption is a special case since it can be present in all responses
+                    continue
                 if key in collections_to_resource_type:
                     collection = key
                 if key in resource_type_to_collection:


### PR DESCRIPTION
in some wizard decorator adding link we were using the json response
content to deduce the type of the returned object.

since 'disruptions' is a list we can get in all navitia's responses (and
in /disruptions responses) we consider the type is a disruption only if
we do not find another list (like stop_areas, networks, ...)

this was creating arbitrary behavior (and leading serpy tests to be
different)

as it is a random behavior I don't see an easy way to test this.

Note: beware, this will break artemis