### PR TITLE
Ed: connexe component by mode

### DIFF
--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -102,7 +102,9 @@ private:
 
     // ces deux vectors servent pour ne pas charger les graphes secondaires
     std::set<uint64_t> way_to_ignore; //TODO if bottleneck change to flat_set
-    std::set<uint64_t> node_to_ignore;
+    std::unordered_set<uint64_t> node_to_ignore;
+    using EdgeId = std::pair<uint64_t, uint64_t>;
+    navitia::flat_enum_map<navitia::type::Mode_e, std::set<EdgeId>> edge_to_ignore_by_modes;
 
     void fill_meta(navitia::type::Data& data, pqxx::work& work);
     void fill_feed_infos(navitia::type::Data& data, pqxx::work& work);
@@ -147,7 +149,7 @@ private:
     void fill_graph(navitia::type::Data& data, pqxx::work& work, bool export_georef_edges_geometries);
     boost::optional<navitia::time_res_traits::sec_type>
     get_duration (nt::Mode_e mode, float len, uint64_t source, uint64_t target);
-    void fill_vector_to_ignore(navitia::type::Data& data, pqxx::work& work, const double percent_delete);
+    void fill_vector_to_ignore(pqxx::work& work, const double percent_delete);
     void fill_graph_bss(navitia::type::Data& data, pqxx::work& work);
     void fill_graph_parking(navitia::type::Data& data, pqxx::work& work);
 


### PR DESCRIPTION
We now compute the connexe components by mode.

This way we can disable some routing mode on the edges

This is done so we don't have any walking edges accessible only by car edges (like in a parking)

fixes http://jira.canaltp.fr/browse/NAVITIAII-2199

**Warning**: I did not reimplement the old behavior to filter the `Way` that do not have any edges any more

This will lead certain way to be found (like with the autocomplete) but we'll be unable to project  on them (thus we'll project to a near way).

I don't think this is bad (and it might even lead to better behavior)

Note: I did not do any automated tests as I do not know how to do them
easily

On the ile de france dataset:
total number of nodes: 587289

|                        | walking | bike    | car      |
|-------------------|-----------|---------|----------|
|useless nodes | 31699   |92076 |117237|
|disable edges  | 33796 | 14021  | 9001   |

| | before | now |
|--- | --- | ---- |
|total number of disable nodes | 19429 | 22900|
| computation time | 15.7 | 3.2s |


example of filtering:
near gare de l'est in paris, green is the classical graph, red is the filtered edges for walking.
The star is the starting point of the ticket example

![selection_002](https://cloud.githubusercontent.com/assets/3987698/24093920/a03d8f50-0d56-11e7-8fd8-0bf62f1b819f.png)
