### PR TITLE
Change behavior of passages on first and last production day

### DIFF
--- a/source/time_tables/tests/passages_test.cpp
+++ b/source/time_tables/tests/passages_test.cpp
@@ -101,3 +101,69 @@ BOOST_AUTO_TEST_CASE(passages_boarding_order) {
     BOOST_REQUIRE_EQUAL(resp.next_arrivals(0).stop_date_time().arrival_date_time(), "20170101T081000"_pts);
     BOOST_REQUIRE_EQUAL(resp.next_arrivals(1).stop_date_time().arrival_date_time(), "20170101T080500"_pts);
 }
+
+// Check that previous departures work on first production day
+BOOST_AUTO_TEST_CASE(previous_passages_on_first_production_day) {
+    ed::builder b("20170101");
+
+    b.vj("L1", "1111111").uri("vj:0")
+        ("stop1", "8:00"_t, "8:01"_t)
+        ("stop2", "8:05"_t, "8:06"_t)
+        ("stop3", "8:10"_t, "8:11"_t);
+
+    b.vj("L1", "1111111").uri("vj:1")
+        ("stop1", "9:00"_t, "9:01"_t)
+        ("stop2", "9:05"_t, "9:06"_t)
+        ("stop3", "9:10"_t, "9:11"_t);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto * data_ptr = b.data.get();
+
+    navitia::PbCreator pb_creator_pdep1(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    passages(pb_creator_pdep1, "stop_point.uri=stop2", {}, "20170101T090000"_dt, 86400, 10, 3,
+             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::PREVIOUS_DEPARTURES, 10, 0);
+    auto resp = pb_creator_pdep1.get_response();
+    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.next_departures(0).stop_date_time().departure_date_time(), "20170101T080600"_pts);
+
+    // Check that we have no error when dt and max_dt will be both at 0
+    navitia::PbCreator pb_creator_pdep2(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    passages(pb_creator_pdep2, "stop_point.uri=stop2", {}, "20170101T000000"_dt, 86400, 10, 3,
+             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::PREVIOUS_DEPARTURES, 10, 0);
+    resp = pb_creator_pdep2.get_response();
+    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(next_passages_on_last_production_day) {
+    ed::builder b("20170101");
+    boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20170101");
+    boost::gregorian::date end = boost::gregorian::date_from_iso_string("20170108");
+    b.data->meta->production_date = boost::gregorian::date_period(begin, end);
+
+    b.vj("L1", "1111111").uri("vj:0")
+        ("stop1", "8:00"_t, "8:01"_t)
+        ("stop2", "8:05"_t, "8:06"_t)
+        ("stop3", "8:10"_t, "8:11"_t);
+
+    b.vj("L1", "1111111").uri("vj:1")
+        ("stop1", "9:00"_t, "9:01"_t)
+        ("stop2", "9:05"_t, "9:06"_t)
+        ("stop3", "9:10"_t, "9:11"_t);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto * data_ptr = b.data.get();
+
+    navitia::PbCreator pb_creator_pdep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    passages(pb_creator_pdep, "stop_point.uri=stop2", {}, "20170107T080000"_dt, 86400, 10, 3,
+             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0);
+    auto resp = pb_creator_pdep.get_response();
+    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
+    BOOST_REQUIRE_EQUAL(resp.next_departures(0).stop_date_time().departure_date_time(), "20170107T080600"_pts);
+    BOOST_REQUIRE_EQUAL(resp.next_departures(1).stop_date_time().departure_date_time(), "20170107T090600"_pts);
+}


### PR DESCRIPTION
Following issue #2001. This is fixing the bug I encountered and also change the behavior of max_datetime calculation. Now : 
- We're throwing an out of bound error only if the requested datetime is outside the production_period,
- In clockwise we limit max_datetime at production_period.end() at midnight,
- In !clockwise we limit max_datetime at 0 if duration is greater than the requested datetime.

This way, even if we're not returning all the departures for the requested duration we are at least returning the departures we have.