### PR TITLE
Kraken: use boost for regex

### DIFF
--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -36,7 +36,6 @@ www.navitia.io
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/map.hpp>
 #include <algorithm>
-#include <regex>
 #include <boost/regex.hpp>
 #include <map>
 #include <unordered_map>

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -35,7 +35,6 @@ www.navitia.io
 #include "type/data.h"
 
 #include <algorithm>
-#include <regex>
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_lit.hpp>

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -948,7 +948,7 @@ std::string to_string(ExceptionDate::ExceptionType t) {
 
 // the new way to represent a coord is : "lon;lat"
 const std::string match_double = "[-+]?[0-9]*\\.?[0-9]*[eE]?[-+]?[0-9]*";
-const auto coord_regex = std::regex("^(" + match_double + ");(" + match_double + ")$");
+const auto coord_regex = boost::regex("^(" + match_double + ");(" + match_double + ")$");
 
 EntryPoint::EntryPoint(const Type_e type, const std::string &uri, int access_duration) : type(type), uri(uri), access_duration(access_duration) {
     if (type == Type_e::Address) {
@@ -978,8 +978,8 @@ EntryPoint::EntryPoint(const Type_e type, const std::string &uri, int access_dur
             }
             return;
         }
-        std::smatch matches;
-        bool res = std::regex_match(uri, matches, coord_regex);
+        boost::smatch matches;
+        bool res = boost::regex_match(uri, matches, coord_regex);
         if (res && matches.size() == 3) {
             set_coord(matches[1], matches[2]);
         } else {
@@ -991,7 +991,7 @@ EntryPoint::EntryPoint(const Type_e type, const std::string &uri, int access_dur
 
 bool EntryPoint::is_coord(const std::string& uri) {
     return (uri.size() > 6 && uri.substr(0, 6) == "coord:")
-        || (std::regex_match(uri, coord_regex) && uri != ";");
+        || (boost::regex_match(uri, coord_regex) && uri != ";");
 }
 
 EntryPoint::EntryPoint(const Type_e type, const std::string &uri) : EntryPoint(type, uri, 0) { }

--- a/source/tyr/tests/tests_default_settings.py
+++ b/source/tyr/tests/tests_default_settings.py
@@ -1,3 +1,9 @@
 import os
 #Path to the directory where the configuration file of each instance of ed are defined
 INSTANCES_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+#Validate the presence of a mx record on the domain
+EMAIL_CHECK_MX = False
+
+#Validate the email by connecting to the smtp server, but doesn't send an email
+EMAIL_CHECK_SMTP = False


### PR DESCRIPTION
On gcc (4.7) for debian 7, std::regex is not stable, so it's crashing tests