### PR TITLE
jormungandr: modifications for same_journey_schedules

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -294,9 +294,17 @@ class add_journey_href(object):
                 return objects
             for journey in objects[0]['journeys']:
                 args = dict(request.args)
-                ids = {o['stop_point']['stop_area']['id']
+                ids = {o['stop_point']['id']
                        for s in journey.get('sections', []) if 'from' in s
                        for o in (s['from'], s['to']) if 'stop_point' in o}
+
+                #only one first_section_mode is allowed if present in the request
+                #same for last_section_mode also
+                if 'first_section_mode[]' in args:
+                    args['first_section_mode[]'] = journey['sections'][0]['mode']
+                if 'last_section_mode[]' in args:
+                    args['last_section_mode[]'] = journey['sections'][-1]['mode']
+
                 if 'region' in kwargs:
                     args['region'] = kwargs['region']
                 if "sections" not in journey:#this mean it's an isochrone...

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -294,17 +294,9 @@ class add_journey_href(object):
                 return objects
             for journey in objects[0]['journeys']:
                 args = dict(request.args)
-                ids = {o['stop_point']['id']
+                allowed_ids = {o['stop_point']['id']
                        for s in journey.get('sections', []) if 'from' in s
                        for o in (s['from'], s['to']) if 'stop_point' in o}
-
-                #only one first_section_mode is allowed if present in the request
-                #same for last_section_mode also
-                if 'first_section_mode[]' in args:
-                    args['first_section_mode[]'] = journey['sections'][0]['mode']
-                if 'last_section_mode[]' in args:
-                    args['last_section_mode[]'] = journey['sections'][-1]['mode']
-                args['min_nb_transfers'] = journey['nb_transfers']
 
                 if 'region' in kwargs:
                     args['region'] = kwargs['region']
@@ -314,10 +306,23 @@ class add_journey_href(object):
                     if 'from' not in args:
                         args['from'] = journey['from']['id']
                     journey['links'] = [create_external_link('v1.journeys', rel='journeys', **args)]
-                elif ids and 'public_transport' in (s['type'] for s in journey['sections']):
+                elif allowed_ids and 'public_transport' in (s['type'] for s in journey['sections']):
+                    # exactly one first_section_mode
+                    if next(iter(journey['sections'][1:]), {}).get('type', '').startswith('bss'):
+                        args['first_section_mode[]'] = 'bss'
+                    else:
+                        args['first_section_mode[]'] = journey['sections'][0].get('mode', 'walking')
+
+                    # exactly one last_section_mode
+                    if next(iter(journey['sections'][-2:]), {}).get('type', '').startswith('bss'):
+                        args['last_section_mode[]'] = 'bss'
+                    else:
+                        args['last_section_mode[]'] = journey['sections'][-1].get('mode', 'walking')
+
+                    args['min_nb_transfers'] = journey['nb_transfers']
                     args['min_nb_journeys'] = 5
-                    ids.update(args.get('allowed_id[]', []))
-                    args['allowed_id[]'] = list(ids)
+                    allowed_ids.update(args.get('allowed_id[]', []))
+                    args['allowed_id[]'] = list(allowed_ids)
                     journey['links'] = [
                         create_external_link('v1.journeys', rel='same_journey_schedules', _type='journeys', **args)
                     ]

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -304,6 +304,7 @@ class add_journey_href(object):
                     args['first_section_mode[]'] = journey['sections'][0]['mode']
                 if 'last_section_mode[]' in args:
                     args['last_section_mode[]'] = journey['sections'][-1]['mode']
+                args['min_nb_transfers'] = journey['nb_transfers']
 
                 if 'region' in kwargs:
                     args['region'] = kwargs['region']

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -193,6 +193,7 @@ class JourneyCommon(ResourceUri, ResourceUtc) :
                                             " Note: it will mainly change the disruptions that concern "
                                             "the object The timezone should be specified in the format,"
                                             " else we consider it as UTC")
+        parser_get.add_argument("min_nb_transfers", type=int, default=0)
 
     def parse_args(self, region=None, uri=None):
         args = self.parsers['get'].parse_args()

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -87,6 +87,8 @@ def final_filter_journeys(response_list, instance, request):
 
     _filter_too_much_connections(journeys, instance, request)
 
+    _filter_min_transfers(journeys, instance, request)
+
     return response_list
 
 
@@ -281,6 +283,22 @@ def _filter_too_much_connections(journeys, instance, request):
             if get_nb_connections(j) > max_connections_allowed:
                 logger.debug("the journey {} has a too much connections, we delete it".format(j.internal_id))
                 mark_as_dead(j, "too_much_connections")
+
+
+def _filter_min_transfers(journeys, instance, request):
+    """
+    eliminates journeys with number of connections more then max_nb_transfers among journeys
+    eliminates journeys with number of connections less then min_nb_transfers among journeys
+    """
+    logger = logging.getLogger(__name__)
+    min_nb_transfers = get_or_default(request, 'min_nb_transfers', 0)
+
+    for j in journeys:
+        if to_be_deleted(j):
+            continue
+        if get_nb_connections(j) < min_nb_transfers:
+            logger.debug("the journey {} has not enough connections, we delete it".format(j.internal_id))
+            mark_as_dead(j, "not_enough_connections")
 
 
 def get_min_connections(journeys):

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -287,7 +287,6 @@ def _filter_too_much_connections(journeys, instance, request):
 
 def _filter_min_transfers(journeys, instance, request):
     """
-    eliminates journeys with number of connections more then max_nb_transfers among journeys
     eliminates journeys with number of connections less then min_nb_transfers among journeys
     """
     logger = logging.getLogger(__name__)

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -520,7 +520,7 @@ class AbstractAutocompleteAndRouting(AbstractTestFixture):
 
 @config({'scenario': 'new_default'})
 class TestNewDefaultAutocompleteAndRouting(AbstractAutocompleteAndRouting,
-                                         NewDefaultScenarioAbstractTestFixture):
+                                           NewDefaultScenarioAbstractTestFixture):
     pass
 
 @config({'scenario': 'experimental'})

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -367,6 +367,10 @@ class AbstractTestFixture(object):
                 assert j['links'][0]['type'] == 'journeys'
                 assert '/journeys?' in j['links'][0]['href']
                 assert 'allowed_id%5B%5D=' in j['links'][0]['href']
+                if 'first_secion_mode%5B%5D=' in j['links'][0]['href']:
+                    assert j['links'][0]['href'].count('first_secion_mode%5B%5D=') == 1
+                if 'last_secion_mode%5B%5D=' in j['links'][0]['href']:
+                    assert j['links'][0]['href'].count('last_secion_mode%5B%5D=') == 1
             else:
                 assert 'links' not in j
 

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -367,10 +367,8 @@ class AbstractTestFixture(object):
                 assert j['links'][0]['type'] == 'journeys'
                 assert '/journeys?' in j['links'][0]['href']
                 assert 'allowed_id%5B%5D=' in j['links'][0]['href']
-                if 'first_secion_mode%5B%5D=' in j['links'][0]['href']:
-                    assert j['links'][0]['href'].count('first_secion_mode%5B%5D=') == 1
-                if 'last_secion_mode%5B%5D=' in j['links'][0]['href']:
-                    assert j['links'][0]['href'].count('last_secion_mode%5B%5D=') == 1
+                assert j['links'][0]['href'].count('first_section_mode%5B%5D=') == 1
+                assert j['links'][0]['href'].count('last_section_mode%5B%5D=') == 1
             else:
                 assert 'links' not in j
 


### PR DESCRIPTION
1. Only one value of first_section_mode[] and last_section_mode[] if
present in url.

2. StopPoints instead of StopAreas added in allowed_id[]

3. Ticket concerned: https://jira.canaltp.fr/browse/NAVP-657

4. parameter min_nb_transfers added in the links and used to filter journeys to have same journey schedules.