### PR TITLE
Kraken: use boost::container::ordered_unique_range_t for flat_set insert

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -647,7 +647,7 @@ Data::get_target_by_source(Type_e source, Type_e target,
     result.reserve(source_idx.size());
     for(idx_t idx : source_idx) {
         Indexes tmp = get_target_by_one_source(source, target, idx);
-        // Use flat_set's merge when we pass to boost 1.62
+        // TODO: Use flat_set's merge when we pass to boost 1.62
         result.insert(boost::container::ordered_unique_range_t(),
                       tmp.begin(), tmp.end());
     }

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -647,10 +647,9 @@ Data::get_target_by_source(Type_e source, Type_e target,
     result.reserve(source_idx.size());
     for(idx_t idx : source_idx) {
         Indexes tmp = get_target_by_one_source(source, target, idx);
-        result.insert(/*boost::container::ordered_unique_range_t(),
-                        // Note the tag does not work on old boost version,
-                        //   put it back when we stop boost 1.49 support*/
-                        tmp.begin(), tmp.end());
+        // Use flat_set's merge when we pass to boost 1.62
+        result.insert(boost::container::ordered_unique_range_t(),
+                      tmp.begin(), tmp.end());
     }
     return result;
 }


### PR DESCRIPTION
Problem:

Very long response time on "/traffic_reports" when we have a lot of vehicle_journey(1M vj) 

I tested on my machine with 

- 200000 VJs
  With the old algo: traffic_reports responded after ~2s
  With the new algo: traffic_reports responded after ~500ms

- 400000 VJs
  With the old algo: traffic_reports responded after ~7s
  With the new algo: traffic_reports responded after ~1s
 