### PR TITLE
Jormungandr: handle localized datetime in query

### DIFF
--- a/source/jormungandr/jormungandr/resources_utils.py
+++ b/source/jormungandr/jormungandr/resources_utils.py
@@ -77,11 +77,17 @@ class ResourceUtc(object):
         and fetch the tz of this point.
         we'll have to store the tz for stop area and the coord for admin, poi, ...
         """
-
         if self.tz() is None:
             return original_datetime
+
+        if original_datetime.tzinfo is not None:
+            localized_dt = original_datetime
+        else:
+            # if we don't have a timezone in the datetime, we consider it a local time from the coverage's tz
+            localized_dt = self.tz().normalize(self.tz().localize(original_datetime))
+
         try:
-            utctime = self.tz().normalize(self.tz().localize(original_datetime)).astimezone(pytz.utc)
+            utctime = localized_dt.astimezone(pytz.utc)
         except ValueError as e:
             raise UnableToParse("Unable to parse datetime, " + e.message)
 

--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -354,7 +354,9 @@ class StatManager(object):
         journey_request = stat_request.journey_request
         if hasattr(g, 'stat_interpreted_parameters') and g.stat_interpreted_parameters['original_datetime']:
             tz = utils.get_timezone()
-            dt = tz.normalize(tz.localize(g.stat_interpreted_parameters['original_datetime']))
+            dt = g.stat_interpreted_parameters['original_datetime']
+            if dt.tzinfo is None:
+                dt = tz.normalize(tz.localize(dt))
             journey_request.requested_date_time = utils.date_to_timestamp(dt.astimezone(pytz.utc))
             journey_request.clockwise = g.stat_interpreted_parameters['clockwise']
         if 'journeys' in call_result[0] and call_result[0]['journeys']:


### PR DESCRIPTION
now datetime can be given with their time zone '20120615T080000Z' for
UTC or '20120615T080000+02' (and since we are not strict on the format
'2012-06-15 08-00-00+02' also works)

if a datetime has no time zone we consider it in the coverage's timezone
(as before)