### PR TITLE
jormungandr: put 'USE_SERPY' outside of the app context

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -47,6 +47,10 @@ app.config.from_object('jormungandr.default_settings')
 if 'JORMUNGANDR_CONFIG_FILE' in os.environ:
     app.config.from_envvar('JORMUNGANDR_CONFIG_FILE')
 
+# there is a import order problem to get this variable in decorators (current_app is not in the context)
+# so we make it a global variable
+USE_SERPY = app.config.get('USE_SERPY')
+
 app.request_class = NavitiaRequest
 CORS(app, vary_headers=True, allow_credentials=True, send_wildcard=False,
         headers=['Access-Control-Request-Headers', 'Authorization'])

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -31,6 +31,8 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
+
+import jormungandr
 from jormungandr.autocomplete.abstract_autocomplete import AbstractAutocomplete
 from jormungandr.utils import get_lon_lat as get_lon_lat_from_id
 import requests
@@ -319,7 +321,7 @@ class GeocodeJson(AbstractAutocomplete):
         cls._check_response(response_bragi, uri)
         json_response = response_bragi.json()
 
-        if current_app.config.get('USE_SERPY', False):
+        if jormungandr.USE_SERPY:
             from jormungandr.interfaces.v1.serializer.geocode_json import GeocodePlacesSerializer
             return GeocodePlacesSerializer(json_response).data
         else:

--- a/source/jormungandr/jormungandr/interfaces/v1/decorators.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/decorators.py
@@ -25,7 +25,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from flask import current_app
+import jormungandr
 from jormungandr.interfaces.v1.serializer import serialize_with, api
 from flask.ext.restful import marshal_with
 from collections import OrderedDict
@@ -50,13 +50,7 @@ map_serializer = {
 
 
 def get_serializer(collection, collections, display_null=False):
-    try:
-        # we have to do this if this method is used outside a flask application context
-        use_serpy = current_app.config.get('USE_SERPY', False)
-    except RuntimeError:
-        use_serpy = False
-
-    if use_serpy:
+    if jormungandr.USE_SERPY:
         return serialize_with(map_serializer.get(collection))
     else:
         return marshal_with(OrderedDict(collections), display_null=display_null)


### PR DESCRIPTION
due to an import order problem (to get this variable in decorators since 'current_app' is not already in the context) we make 'USE_SERPY' a global variable

Note: it might break artemis as serpy was not activated in some APIs before