### PR TITLE
jormungandr: deactivate by default the schema on OPTIONS

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
@@ -89,9 +89,4 @@ class Coverage(StatedResource):
         return resp, 200
 
     def options(self, **kwargs):
-        from flask import request
-        if not request.headers.get('DUMP_SCHEMA'):
-            import jormungandr
-            return jormungandr.app.make_default_options_response()
-        schema = make_schema(resource=self, rule=request.url_rule)
-        return SwaggerPathSerializer(schema).data, 200
+        return self.api_description(**kwargs)

--- a/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
@@ -89,5 +89,6 @@ class Coverage(StatedResource):
         return resp, 200
 
     def options(self, **kwargs):
-        schema = make_schema(resource=self)
+        from flask import request
+        schema = make_schema(resource=self, rule=request.url_rule)
         return SwaggerPathSerializer(schema).data, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Coverage.py
@@ -90,5 +90,8 @@ class Coverage(StatedResource):
 
     def options(self, **kwargs):
         from flask import request
+        if not request.headers.get('DUMP_SCHEMA'):
+            import jormungandr
+            return jormungandr.app.make_default_options_response()
         schema = make_schema(resource=self, rule=request.url_rule)
         return SwaggerPathSerializer(schema).data, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/JSONSchema.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/JSONSchema.py
@@ -38,7 +38,7 @@ import serpy
 
 from jormungandr.interfaces.v1.serializer.base import LiteralField, LambdaField
 from jormungandr.interfaces.v1.serializer.jsonschema.serializer import SwaggerPathSerializer
-from jormungandr.interfaces.v1.swagger_schema import make_schema, Swagger
+from jormungandr.interfaces.v1.swagger_schema import make_schema, Swagger, ARGS_REGEXP
 
 BASE_PATH = 'v1'
 
@@ -47,12 +47,9 @@ def set_definitions_in_rule(self, rule):
     return re.sub(r'<(?P<name>.*?):.*?>', self.definition_repl, rule)
 
 
-args_regexp = re.compile(r'<(?P<name>.*?):.*?>')
-
-
 def format_args(rule):
     """format argument like swagger : {arg1}&{arg2}"""
-    formatted_rule = args_regexp.sub(lambda m: '{' + m.group('name') + '}', rule)
+    formatted_rule = ARGS_REGEXP.sub(lambda m: '{' + m.group('name') + '}', rule)
     return formatted_rule
 
 base_path_regexp = re.compile('^/{base}'.format(base=BASE_PATH))
@@ -72,7 +69,7 @@ def get_all_described_paths():
             if view_function is not None:
                 view_class = view_function.view_class
                 resource = view_class()
-                schema_path = make_schema(resource, rule._converters)
+                schema_path = make_schema(resource=resource, rule=rule)
 
                 # the definitions are stored aside and referenced in the response
                 swagger.definitions.update(schema_path.definitions)

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -150,9 +150,7 @@ class Places(ResourceUri):
         return response, 200
 
     def options(self, **kwargs):
-        from flask import request
-        schema = make_schema(resource=self, rule=request.url_rule)
-        return SwaggerOptionPathSerializer(schema).data, 200
+        return self.api_description(**kwargs)
 
 
 class PlaceUri(ResourceUri):

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -150,7 +150,8 @@ class Places(ResourceUri):
         return response, 200
 
     def options(self, **kwargs):
-        schema = make_schema(resource=self)
+        from flask import request
+        schema = make_schema(resource=self, rule=request.url_rule)
         return SwaggerOptionPathSerializer(schema).data, 200
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/serializer.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/serializer.py
@@ -59,6 +59,8 @@ class SwaggerMethodSerializer(serpy.Serializer):
     responses = SwaggerResponseSerializer(attr='output_type')
     parameters = SwaggerParamSerializer(many=True)
     summary = serpy.Field()
+    operationId = serpy.Field(attr='id')
+    tags = serpy.Field()
 
 
 class SwaggerPathSerializer(serpy.Serializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
@@ -106,9 +106,9 @@ def serpy_extended_supported_serialization_test():
     assert properties.get('jsonschemaIntField', {}).get('type') == 'integer'
     assert properties.get('jsonschemaField', {}).get('type') == 'integer'
     assert properties.get('jsonschemaMethodField', {}).get('type') == 'string'
-    assert properties.get('lambda_schema', {}).get('$ref') == '#/definitions/CustomSerializer'
+    assert properties.get('lambda_schema', {}).get('$ref') == '#/definitions/CustomResponse'
     assert properties.get('list_lambda_schema', {}).get('type') == 'array'
-    assert properties.get('list_lambda_schema').get('items').get('$ref') == '#/definitions/CustomSerializer'
+    assert properties.get('list_lambda_schema').get('items').get('$ref') == '#/definitions/CustomResponse'
 
     # we must find the 'CustomSerializer' in the definitions
     assert(next(iter(d for d in external_definitions if d.__class__ == CustomSerializer), None))


### PR DESCRIPTION
since an OPTIONS call is very common, we do not want to add a big
overhead on it.

so by default we do not dump a route's schema with the OPTIONS verb, we
need the param `schema=true`)

Note: since they touch the same files, this PR needs https://github.com/CanalTP/navitia/pull/2104 you can review only the last commit