### PR TITLE
jormungandr: refacto of error handling in realtime proxy

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -72,15 +72,14 @@ class Cleverage(RealtimeProxy):
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error('Cleverage RT service dead, using base '
                                               'schedule (error: {}'.format(e))
-            self.record_external_failure('circuit breaker open')
+            raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error('Cleverage RT service timeout, using base '
                                               'schedule (error: {}'.format(t))
-            self.record_external_failure('timeout')
+            raise RealtimeProxyError('timeout')
         except Exception as e:
             logging.getLogger(__name__).exception('Cleverage RT error, using base schedule')
-            self.record_external_failure(str(e))
-        return None
+            raise RealtimeProxyError(str(e))
 
     def _make_url(self, route_point):
         """
@@ -140,8 +139,7 @@ class Cleverage(RealtimeProxy):
             # TODO better error handling, the response might be in 200 but in error
             logging.getLogger(__name__).error('Cleverage RT service unavailable, impossible to query : {}'
                                               .format(r.url))
-            self.record_external_failure('non 200 response')
-            return None
+            raise RealtimeProxyError('non 200 response')
 
         return self._get_passages(route_point, r.json())
 

--- a/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
@@ -28,7 +28,7 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
-from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy
+from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError
 from flask import logging
 import pybreaker
 import pytz
@@ -64,15 +64,14 @@ class SiriLite(RealtimeProxy):
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error('sirilite RT service dead, using base '
                                               'schedule (error: {}'.format(e))
-            self.record_external_failure('circuit breaker open')
+            raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error('sitelite RT service timeout, using base '
                                               'schedule (error: {}'.format(t))
-            self.record_external_failure('timeout')
+            raise RealtimeProxyError('timeout')
         except Exception as e:
             logging.getLogger(__name__).exception('sirilite RT error, using base schedule')
-            self.record_external_failure(str(e))
-        return None
+            raise RealtimeProxyError(str(e))
 
     def _make_url(self, route_point):
         """
@@ -136,15 +135,12 @@ class SiriLite(RealtimeProxy):
         if not url:
             return None
         r = self._call(url)
-        if not r:
-            return None
 
         if r.status_code != 200:
             # TODO better error handling, the response might be in 200 but in error
             logging.getLogger(__name__).error('sirilite RT service unavailable, impossible to query : {}'
                                               .format(r.url))
-            self.record_external_failure('non 200 response')
-            return None
+            raise RealtimeProxyError('non 200 response')
 
         return self._get_passages(route_point, r.json())
 

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -41,6 +41,7 @@ class CustomProxy(RealtimeProxy):
     """
     def __init__(self, passages):
         self.hard_coded_passages = passages
+        self.rt_system_id = 'test'
 
     def status(self):
         return None

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -50,7 +50,7 @@ MOCKED_PROXY_CONF = [
 
 class MockedTestProxy(realtime_proxy.RealtimeProxy):
     def __init__(self, id, object_id_tag, instance):
-        self.service_id = id
+        self.rt_system_id = id
         self.object_id_tag = object_id_tag if object_id_tag else id
         self.instance = instance
 


### PR DESCRIPTION
Internally exception are used as a way of signaling an error, this allow
us to generate some statistics for each connectors that will help to
improve our monitoring