### PR TITLE
Ed: fix graph component ratio filtering

### DIFF
--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -173,7 +173,7 @@ int main(int argc, char * argv[])
         ("name,n", po::value<std::string>(&region_name)->default_value("default"),
             "Name of the region you are extracting")
         ("min_non_connected_ratio,m",
-         po::value<double>(&min_non_connected_graph_ratio)->default_value(0.1),
+         po::value<double>(&min_non_connected_graph_ratio)->default_value(0.01),
          "min ratio for the size of non connected graph")
         ("full_street_network_geometries", "If true export street network geometries allowing kraken to return accurate"
          "geojson for street network sections. Also improve projections accuracy. "

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1380,7 +1380,7 @@ static std::vector<component_vertex_t> get_useless_nodes(const filtered_graph& g
     LOG4CPLUS_INFO(log, "the biggest has " << principal_component->second << " nodes");
 
     auto big_enough = [&](const size_t size) {
-        return size / principal_component->second >= min_non_connected_graph_ratio;
+        return double(size) / principal_component->second >= min_non_connected_graph_ratio;
     };
 
     for (component_vertex_t vertex_idx = 0;  vertex_idx != vertex_component.size(); ++vertex_idx) {


### PR DESCRIPTION
the filtering was depending on an integer division, so we always kept the main component :stuck_out_tongue_winking_eye: 

also change the default ratio to 1%

this will still keep quite big connected components, but will filter the
very small one (1-10 nodes)

This ratio is not configurable by instance in tyr, I don't think it's necessary

this fixes https://jira.canaltp.fr/browse/NAVITIAII-2226

for this problem, the OSM data loaded were cut in a strange way leading to several components (not just the Groix island):
![graph_component](https://cloud.githubusercontent.com/assets/3987698/26832071/87114386-4ace-11e7-9961-00be7a970814.png)


Note: there is no tests as it's very difficult to test in our current test framework