### PR TITLE
Doc: NTFS - fix bug contributor_id on stops.txt

### DIFF
--- a/documentation/ntfs/ntfs_0.6.md
+++ b/documentation/ntfs/ntfs_0.6.md
@@ -331,7 +331,7 @@ geometry_id | géometrie | Optionnel | Ce champ est un lien vers le fichier geom
 parent_station | chaine | Optionnel | Identifiant de la zone d'arrêt, utilisé que sur des arrêts de type 0 (point d'arrêt)
 stop_timezone | timezones | Optionnel | Fuseau horaire, se référer à http://en.wikipedia.org/wiki/List_of_tz_zones
 equipment_id | chaine | Optionnel | Identifiant de la propriété accessibilité
-contributor_id | chaine | Optionnel | Identifiant du contributeur. Cette valeur est renseignée sur les objets de plus bas niveau (points d'arrêts et zone géographique de location_type 0 et 2) et est ignorée sur les autres. Ce champ est ignoré si le champ dataset_id est renseigné avec un identifiant valide.
+contributor_id | chaine | Optionnel | Identifiant du contributeur. Cette valeur est renseignée sur les objets de plus bas niveau (points d'arrêts et zone géographique de location_type 0 et 2) et est ignorée sur les autres. 
 
     (1) Type de l'arrêt ou de la zone :
         0 ou non spécifié - Arrêt physique


### PR DESCRIPTION
Removing a reference to non existing dataset_id in contributor_id field description.