### PR TITLE
All: fix build on debian 9

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -70,7 +70,12 @@ include_directories("${CMAKE_SOURCE_DIR}"
 link_directories(${Boost_LIBRARY_DIRS})
 
 MACRO(ADD_BOOST_TEST EXE_NAME)
-    ADD_TEST(${EXE_NAME} "${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME}" --log_format=XML --log_sink=results_${EXE_NAME}.xml --log_level=all --report_level=no)
+    IF("${Boost_VERSION}" EQUAL "106200")
+        #Boost 1.62 doesn't support "log_sink" parameters, we disable reports with this version
+        ADD_TEST(${EXE_NAME} "${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME}" --log_format=XML --log_level=all --report_level=no)
+    ELSE("${Boost_VERSION}" EQUAL "106200")
+        ADD_TEST(${EXE_NAME} "${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME}" --log_format=XML --log_sink=results_${EXE_NAME}.xml --log_level=all --report_level=no)
+    ENDIF("${Boost_VERSION}" EQUAL "106200")
 ENDMACRO(ADD_BOOST_TEST)
 
 ENABLE_TESTING()

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -43,6 +43,7 @@ www.navitia.io
 #include "calendar/calendar_api.h"
 #include "routing/raptor.h"
 #include "type/meta_data.h"
+#include <numeric>
 
 namespace nt = navitia::type;
 namespace pt = boost::posix_time;


### PR DESCRIPTION
I had to disable unittest reports as they don't work with boost 1.62
fix #1858