### PR TITLE
Jormungandr: rename all the serializer

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
@@ -78,7 +78,7 @@ def serpy_extended_supported_serialization_test():
     """
     Supported custom serpy children fields
     """
-    class CustomSerializer(serpy.Serializer):
+    class Custom(serpy.Serializer):
         bob = jsonschema.IntField()
 
     class JsonchemaSupportedType(serpy.Serializer):
@@ -88,9 +88,9 @@ def serpy_extended_supported_serialization_test():
         jsonschemaIntField = IntField()
         jsonschemaField = Field(schema_type=int)
         jsonschemaMethodField = MethodField(schema_type=str)
-        lambda_schema = LambdaField(method=lambda **kw: None, schema_type=lambda: CustomSerializer())
+        lambda_schema = LambdaField(method=lambda **kw: None, schema_type=lambda: Custom())
         list_lambda_schema = LambdaField(method=lambda **kw: None,
-                                         schema_type=lambda: CustomSerializer(many=True))
+                                         schema_type=lambda: Custom(many=True))
 
         def get_jsonschemaMethodField(self, obj):
             pass
@@ -106,12 +106,12 @@ def serpy_extended_supported_serialization_test():
     assert properties.get('jsonschemaIntField', {}).get('type') == 'integer'
     assert properties.get('jsonschemaField', {}).get('type') == 'integer'
     assert properties.get('jsonschemaMethodField', {}).get('type') == 'string'
-    assert properties.get('lambda_schema', {}).get('$ref') == '#/definitions/CustomResponse'
+    assert properties.get('lambda_schema', {}).get('$ref') == '#/definitions/Custom'
     assert properties.get('list_lambda_schema', {}).get('type') == 'array'
-    assert properties.get('list_lambda_schema').get('items').get('$ref') == '#/definitions/CustomResponse'
+    assert properties.get('list_lambda_schema').get('items').get('$ref') == '#/definitions/Custom'
 
     # we must find the 'CustomSerializer' in the definitions
-    assert(next(iter(d for d in external_definitions if d.__class__ == CustomSerializer), None))
+    assert(next(iter(d for d in external_definitions if d.__class__ == Custom), None))
 
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
@@ -263,7 +263,7 @@ def get_serializer_name(serializer):
     class_name = serializer.__name__ if inspect.isclass(serializer) else serializer.__class__.__name__
     # this replace is temporary, we need to find a better way to have good names there since they are now
     # exposed in the documentation / SDK
-    name = class_name.replace('Serializer', 'Response')
+    name = class_name.replace('Serializer', '')
     return name
 
 


### PR DESCRIPTION
to have better names in the SDK generation we remove the postfix
`Serializer`

if the SDK is happy with this, we'll rename all the serializer for good