### PR TITLE
Jormungandr: Use sources to targets in scenario distributed

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -117,7 +117,8 @@ class Scenario(new_default.Scenario):
                                                              proximities_by_crowfly_pool=orig_proximities_by_crowfly,
                                                              places_free_access=orig_places_free_access,
                                                              direct_paths_by_mode=direct_paths_by_mode,
-                                                             request=request)
+                                                             request=request,
+                                                             origin=True)
 
         dest_fallback_durations_pool = FallbackDurationsPool(future_manager=future_manager,
                                                              instance=instance,
@@ -126,7 +127,8 @@ class Scenario(new_default.Scenario):
                                                              proximities_by_crowfly_pool=dest_proximities_by_crowfly,
                                                              places_free_access=dest_places_free_access,
                                                              direct_paths_by_mode=direct_paths_by_mode,
-                                                             request=request)
+                                                             request=request,
+                                                             origin=False)
 
         pt_journey_pool = PtJourneyPool(future_manager=future_manager,
                                         instance=instance,

--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -118,7 +118,7 @@ class Scenario(new_default.Scenario):
                                                              places_free_access=orig_places_free_access,
                                                              direct_paths_by_mode=direct_paths_by_mode,
                                                              request=request,
-                                                             origin=True)
+                                                             direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK)
 
         dest_fallback_durations_pool = FallbackDurationsPool(future_manager=future_manager,
                                                              instance=instance,
@@ -128,7 +128,7 @@ class Scenario(new_default.Scenario):
                                                              places_free_access=dest_places_free_access,
                                                              direct_paths_by_mode=direct_paths_by_mode,
                                                              request=request,
-                                                             origin=False)
+                                                             direct_path_type=StreetNetworkPathType.ENDING_FALLBACK)
 
         pt_journey_pool = PtJourneyPool(future_manager=future_manager,
                                         instance=instance,

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
@@ -31,6 +31,7 @@ from navitiacommon import response_pb2
 from collections import namedtuple
 from math import sqrt
 from helper_utils import get_max_fallback_duration
+from jormungandr.street_network.street_network import StreetNetworkPathType
 import logging
 
 DurationElement = namedtuple('DurationElement', ['duration', 'status'])
@@ -50,8 +51,9 @@ class FallbackDurations:
 
     The returned dict will look like {'stop_point:stopA': 360, 'stop_point:stopB': 180, 'stop_point:stopC': 60}
     """
-    def __init__(self, future_manager, instance, requested_place_obj, mode, proximities_by_crowfly_pool, places_free_access,
-                 max_duration_to_pt, request, speed_switcher, origin=True):
+    def __init__(self, future_manager, instance, requested_place_obj, mode, proximities_by_crowfly_pool,
+                 places_free_access, max_duration_to_pt, request, speed_switcher,
+                 direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK):
         """
         :param future_manager: a module that manages the future pool properly
         :param instance: instance of the coverage, all outside services callings pass through it(street network,
@@ -74,7 +76,7 @@ class FallbackDurations:
         self._request = request
         self._speed_switcher = speed_switcher
         self._value = None
-        self._origin = origin
+        self._direct_path_type = direct_path_type
         self._async_request()
 
     def _get_duration(self, resp, place):
@@ -118,21 +120,18 @@ class FallbackDurations:
             else:
                 return result
 
-        if self._origin:
-            sn_routing_matrix = self._instance.get_street_network_routing_matrix([center_isochrone],
-                                                                                 places_isochrone,
-                                                                                 self._mode,
-                                                                                 self._max_duration_to_pt,
-                                                                                 self._request,
-                                                                                 **self._speed_switcher)
+        if self._direct_path_type == StreetNetworkPathType.BEGINNING_FALLBACK:
+            origins = [center_isochrone]
+            destinations = places_isochrone
         else:
-            sn_routing_matrix = self._instance.get_street_network_routing_matrix(places_isochrone,
-                                                                                 [center_isochrone],
-                                                                                 self._mode,
-                                                                                 self._max_duration_to_pt,
-                                                                                 self._request,
-                                                                                 **self._speed_switcher)
-
+            origins = places_isochrone
+            destinations = [center_isochrone]
+        sn_routing_matrix = self._instance.get_street_network_routing_matrix(origins,
+                                                                             destinations,
+                                                                             self._mode,
+                                                                             self._max_duration_to_pt,
+                                                                             self._request,
+                                                                             **self._speed_switcher)
 
         if not len(sn_routing_matrix.rows) or not len(sn_routing_matrix.rows[0].routing_response):
             logger.debug("no fallback durations found from %s by %s", self._requested_place_obj.uri, self._mode)
@@ -167,7 +166,7 @@ class FallbackDurationsPool(dict):
     A fallback durations pool is set of "fallback durations" grouped by mode.
     """
     def __init__(self, future_manager, instance, requested_place_obj, modes, proximities_by_crowfly_pool, places_free_access,
-                 direct_paths_by_mode, request, origin=True):
+                 direct_paths_by_mode, request, direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK):
         super(FallbackDurationsPool, self).__init__()
         self._future_manager = future_manager
         self._instance = instance
@@ -177,7 +176,7 @@ class FallbackDurationsPool(dict):
         self._places_free_access = places_free_access
         self._direct_paths_by_mode = direct_paths_by_mode
         self._request = request
-        self._origin = origin
+        self._direct_path_type = direct_path_type
         self._speed_switcher = {
             "walking": instance.walking_speed,
             "bike": instance.bike_speed,
@@ -195,7 +194,7 @@ class FallbackDurationsPool(dict):
             fallback_durations = FallbackDurations(self._future_manager, self._instance, self._requested_place_obj, mode,
                                                    self._proximities_by_crowfly_pool, self._places_free_access,
                                                    max_fallback_duration,
-                                                   self._request, self._speed_switcher, self._origin)
+                                                   self._request, self._speed_switcher, self._direct_path_type)
             self._value[mode] = fallback_durations
 
     def wait_and_get(self, mode):

--- a/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
@@ -129,10 +129,10 @@ def format_coord_func_invalid_api_test():
     assert 'ApiNotFound' in str(excinfo.typename)
 
 
-def format_coord_func_valid_coord_one_to_many_test():
+def format_coord_func_valid_coord_sources_to_targets_test():
     pt_object = make_pt_object(type_pb2.ADDRESS, 1.12, 13.15)
 
-    coord = Valhalla._format_coord(pt_object, 'one_to_many')
+    coord = Valhalla._format_coord(pt_object, 'sources_to_targets')
     coord_res = {'lat': pt_object.address.coord.lat, 'lon': pt_object.address.coord.lon}
     assert len(coord) == 2
     for key, value in coord_res.items():
@@ -541,7 +541,7 @@ def get_valhalla_mode_valid_mode_test():
         assert Valhalla._get_valhalla_mode(kraken_mode) == valhalla_mode
 
 
-def one_to_many_valhalla_test():
+def souces_to_targets_valhalla_test():
     instance = MagicMock()
     instance.walking_speed = 1.12
     valhalla = Valhalla(instance=instance,
@@ -550,7 +550,7 @@ def one_to_many_valhalla_test():
     origin = make_pt_object(type_pb2.ADDRESS, 2.439938, 48.572841)
     destination = make_pt_object(type_pb2.ADDRESS, 2.440548, 48.57307)
     response = {
-        'one_to_many': [
+        'sources_to_targets': [
             [
                 {
                     'time': 0
@@ -568,7 +568,7 @@ def one_to_many_valhalla_test():
         ]
     }
     with requests_mock.Mocker() as req:
-        req.post('http://bob.com/one_to_many', json=response, status_code=200)
+        req.post('http://bob.com/sources_to_targets', json=response, status_code=200)
         valhalla_response = valhalla.get_street_network_routing_matrix(
             [origin],
             [destination, destination, destination],

--- a/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
@@ -541,7 +541,7 @@ def get_valhalla_mode_valid_mode_test():
         assert Valhalla._get_valhalla_mode(kraken_mode) == valhalla_mode
 
 
-def souces_to_targets_valhalla_test():
+def sources_to_targets_valhalla_test():
     instance = MagicMock()
     instance.walking_speed = 1.12
     valhalla = Valhalla(instance=instance,

--- a/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
@@ -553,9 +553,6 @@ def souces_to_targets_valhalla_test():
         'sources_to_targets': [
             [
                 {
-                    'time': 0
-                },
-                {
                     'time': 42
                 },
                 {
@@ -603,9 +600,6 @@ def sources_to_targets_valhalla_with_park_cost_test():
     response = {
         'sources_to_targets': [
             [
-                {
-                    'time': 0
-                },
                 {
                     'time': 42
                 },

--- a/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
@@ -158,7 +158,7 @@ def format_url_func_with_walking_mode_test():
     valhalla = Valhalla(instance=instance,
                         service_url='http://bob.com',
                         costing_options={'bib': 'bom'})
-    data = valhalla._make_request_arguments("walking", origin, [destination], MOCKED_REQUEST)
+    data = valhalla._make_request_arguments("walking", [origin], [destination], MOCKED_REQUEST)
     assert json.loads(data) == json.loads('''{
                         "costing_options": {
                           "pedestrian": {
@@ -196,7 +196,7 @@ def format_url_func_with_bike_mode_test():
                         service_url='http://bob.com',
                         costing_options={'bib': 'bom'})
     valhalla.costing_options = None
-    data = valhalla._make_request_arguments("bike", origin, [destination], MOCKED_REQUEST)
+    data = valhalla._make_request_arguments("bike", [origin], [destination], MOCKED_REQUEST)
     assert json.loads(data) == json.loads('''
                                             {
                                               "costing_options": {
@@ -236,7 +236,7 @@ def format_url_func_with_car_mode_test():
                         service_url='http://bob.com',
                         costing_options={'bib': 'bom'})
     valhalla.costing_options = None
-    data = valhalla._make_request_arguments("car", origin, [destination], MOCKED_REQUEST)
+    data = valhalla._make_request_arguments("car", [origin], [destination], MOCKED_REQUEST)
     assert json.loads(data) == json.loads(''' {
                                       "locations": [
                                         {
@@ -272,7 +272,7 @@ def format_url_func_with_different_ptobject_test():
                           type_pb2.POI):
         origin = make_pt_object(ptObject_type, 1.0, 1.0)
         destination = make_pt_object(ptObject_type, 2.0, 2.0)
-        data = valhalla._make_request_arguments("car", origin, [destination], MOCKED_REQUEST)
+        data = valhalla._make_request_arguments("car", [origin], [destination], MOCKED_REQUEST)
         assert json.loads(data) == json.loads(''' {
                                          "locations": [
                                            {
@@ -301,7 +301,7 @@ def format_url_func_invalid_mode_test():
     with pytest.raises(InvalidArguments) as excinfo:
         origin = make_pt_object(type_pb2.ADDRESS, 1.0, 1.0)
         destination = make_pt_object(type_pb2.ADDRESS, 2.0, 2.0)
-        valhalla._make_request_arguments("bob", origin, [destination], MOCKED_REQUEST)
+        valhalla._make_request_arguments("bob", [origin], [destination], MOCKED_REQUEST)
     assert '400: Bad Request' == str(excinfo.value)
     assert 'InvalidArguments' == str(excinfo.typename)
 
@@ -583,7 +583,7 @@ def souces_to_targets_valhalla_test():
         assert valhalla_response.rows[0].routing_response[2].routing_status == response_pb2.reached
 
 
-def one_to_many_valhalla_with_park_cost_test():
+def sources_to_targets_valhalla_with_park_cost_test():
     """
     test with a parking cost,
     we add a different cost on car and bike and no cost on walking
@@ -601,7 +601,7 @@ def one_to_many_valhalla_with_park_cost_test():
     origin = make_pt_object(type_pb2.ADDRESS, 2.439938, 48.572841)
     destination = make_pt_object(type_pb2.ADDRESS, 2.440548, 48.57307)
     response = {
-        'one_to_many': [
+        'sources_to_targets': [
             [
                 {
                     'time': 0
@@ -619,7 +619,7 @@ def one_to_many_valhalla_with_park_cost_test():
         ]
     }
     with requests_mock.Mocker() as req:
-        req.post('http://bob.com/one_to_many', json=response, status_code=200)
+        req.post('http://bob.com/sources_to_targets', json=response, status_code=200)
         # it changes nothing for walking
         valhalla_response = valhalla.get_street_network_routing_matrix(
             [origin],

--- a/source/jormungandr/jormungandr/street_network/valhalla.py
+++ b/source/jormungandr/jormungandr/street_network/valhalla.py
@@ -286,8 +286,6 @@ class Valhalla(AbstractStreetNetworkService):
             if len(destinations) > 1:
                 logging.getLogger(__name__).error('routing matrix error, no unique center point')
                 raise TechnicalError('routing matrix error, no unique center point')
-            else:
-                origins, destinations = destinations, origins
 
         data = self._make_request_arguments(mode, origins, destinations, request, api='sources_to_targets')
         r = self._call_valhalla('{}/{}'.format(self.service_url, 'sources_to_targets'), requests.post, data)

--- a/source/jormungandr/jormungandr/street_network/valhalla.py
+++ b/source/jormungandr/jormungandr/street_network/valhalla.py
@@ -265,9 +265,9 @@ class Valhalla(AbstractStreetNetworkService):
     @classmethod
     def _get_matrix(cls, json_response, mode_park_cost):
         sn_routing_matrix = response_pb2.StreetNetworkRoutingMatrix()
-        for souce_to_target in json_response['sources_to_targets']:
+        for source_to_target in json_response['sources_to_targets']:
             row = sn_routing_matrix.rows.add()
-            for one in souce_to_target:
+            for one in source_to_target:
                 routing = row.routing_response.add()
                 if one['time']:
                     # the mode's base cost represent the initial cost to take the given mode

--- a/source/jormungandr/tests/direct_path_valhalla_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_valhalla_integration_tests.py
@@ -96,14 +96,18 @@ def route_response(mode):
     }
 
 
-def one_to_many_response():
+def sources_to_targets_response():
     return {
-        "locations": [
+        "sources": [
             [
                 {
                     "lon": 2.428405,
                     "lat": 48.625626
-                },
+                }
+            ]
+        ],
+        "targets": [
+            [
                 {
                     "lon": 2.428379,
                     "lat": 48.625679
@@ -111,18 +115,12 @@ def one_to_many_response():
             ]
         ],
         "units": "kilometers",
-        "one_to_many": [
+        "sources_to_targets": [
             [
-                {
-                    "distance": 0,
-                    "time": 0,
-                    "to_index": 0,
-                    "from_index": 0
-                },
                 {
                     "distance": 0.227,
                     "time": 177,
-                    "to_index": 1,
+                    "to_index": 0,
                     "from_index": 0
                 }
             ]
@@ -133,8 +131,8 @@ def one_to_many_response():
 def response_valid(api, mode):
     if api == 'route':
         return route_response(mode)
-    elif api == 'one_to_many':
-        return one_to_many_response()
+    elif api == 'sources_to_targets':
+        return sources_to_targets_response()
 
 
 def check_journeys(resp):


### PR DESCRIPTION
Instead of api valhalla one_to_many, we use sources_to_targets to calcaulate fallback_durations for origin and destination. The use of this api calculates the durations from fallback points toward the destination (durations calculated from destination towards fallback points using one_to_many previously).

Ticket concerned: https://jira.canaltp.fr/browse/NAVP-651