### PR TITLE
jormun: Fix stat error on journeys without datetime

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
@@ -91,8 +91,6 @@ class GraphicalIsochrone(JourneyCommon):
         original_datetime = args['original_datetime']
         if original_datetime:
             new_datetime = self.convert_to_utc(original_datetime)
-        else:
-            new_datetime = args['_current_datetime']
         args['datetime'] = date_to_timestamp(new_datetime)
 
         response = i_manager.dispatch(args, "graphical_isochrones", self.region)

--- a/source/jormungandr/jormungandr/interfaces/v1/HeatMap.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/HeatMap.py
@@ -85,8 +85,6 @@ class HeatMap(JourneyCommon):
         original_datetime = args['original_datetime']
         if original_datetime:
             new_datetime = self.convert_to_utc(original_datetime)
-        else:
-            new_datetime = args['_current_datetime']
         args['datetime'] = date_to_timestamp(new_datetime)
 
         response = i_manager.dispatch(args, "heat_maps", self.region)

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -515,8 +515,6 @@ class Journeys(JourneyCommon):
             original_datetime = args['original_datetime']
             if original_datetime:
                 new_datetime = self.convert_to_utc(original_datetime)
-            else:
-                new_datetime = args['_current_datetime']
             args['datetime'] = date_to_timestamp(new_datetime)
 
             response = i_manager.dispatch(args, api, instance_name=self.region)

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -47,6 +47,7 @@ from functools import cmp_to_key
 from jormungandr.instance_manager import instances_comparator
 from jormungandr.travelers_profile import TravelerProfile
 from navitiacommon.default_traveler_profile_params import acceptable_traveler_types
+import pytz
 
 
 def dt_represents(value):
@@ -240,7 +241,11 @@ class JourneyCommon(ResourceUri, ResourceUtc) :
         if args['destination']:
             args['destination'] = transform_id(args['destination'])
 
-        args['original_datetime'] = args['datetime']
+        if args['datetime']:
+            args['original_datetime'] = args['datetime']
+        else:
+            args['original_datetime'] = pytz.UTC.localize(args['_current_datetime'])
+
 
         if args.get('traveler_type'):
             traveler_profile = TravelerProfile.make_traveler_profile(region, args['traveler_type'])


### PR DESCRIPTION
When no datetime was set in the request the resulting protobuf message
was invalid as the parameter `requested_date_time` is required. So we
did lost some stats.
We now set this datetime to now.