### PR TITLE
Jormungandr: Ability to call HERE routing service to get realtime car routing data

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -125,6 +125,9 @@ CIRCUIT_BREAKER_VALHALLA_TIMEOUT_S = 60  # the circuit breaker retries after thi
 CIRCUIT_BREAKER_MAX_GEOVELO_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_GEOVELO_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 
+CIRCUIT_BREAKER_MAX_HERE_FAIL = 4  # max instance call failures before stopping attempt
+CIRCUIT_BREAKER_HERE_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
+
 # Default region instance
 # DEFAULT_REGION = 'default'
 

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -100,6 +100,7 @@ class StreetNetworkPathPool:
                           period_extremity,
                           request,
                           streetnetwork_path_type):
+
         streetnetwork_service = self._instance.street_network_services.get(mode)
         key = streetnetwork_service.make_path_key(mode,
                                                   requested_orig_obj.uri,

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -1,0 +1,264 @@
+#  Copyright (c) 2001-2016, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from navitiacommon import response_pb2
+import logging
+import pybreaker
+import requests as requests
+from jormungandr import app
+import json
+from jormungandr.exceptions import TechnicalError, InvalidArguments, ApiNotFound
+from jormungandr.utils import is_url, kilometers_to_meters, get_pt_object_coord, decode_polyline
+from copy import deepcopy
+from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathKey, \
+    StreetNetworkPathType
+
+
+def _get_coord(pt_object):
+    coord = get_pt_object_coord(pt_object)
+    return 'geo!{lat},{lon}'.format(lat=coord.lat, lon=coord.lon)
+
+
+def get_here_mode(mode):
+    if mode == 'walking':
+        return 'pedestrian'
+    elif mode == 'bike':
+        return 'bicycle'
+    elif mode == 'car':
+        return 'car'
+    else:  # HERE does not handle bss
+        raise TechnicalError('HERE does not handle the mode {}'.format(mode))
+
+
+class Here(AbstractStreetNetworkService):
+
+    def __init__(self, instance, service_base_url, id='here', timeout=10, api_id=None, api_code=None,
+                 **kwargs):
+        self.instance = instance
+        self.sn_system_id = id
+        if not service_base_url:
+            raise ValueError('service_url {} is not a valid HERE url'.format(service_base_url))
+        service_base_url = service_base_url.rstrip('/')
+        self.routing_service_url = 'https://{base_url}/calculateroute.json'.format(base_url=service_base_url)
+        self.matrix_service_url = 'https://matrix.{base_url}/calculatematrix.json'.format(base_url=service_base_url)
+        self.api_id = api_id
+        self.api_code = api_code
+        self.timeout = timeout
+        self.max_points = 100  # max number of point asked in the routing matrix
+        self.breaker = pybreaker.CircuitBreaker(fail_max=app.config['CIRCUIT_BREAKER_MAX_HERE_FAIL'],
+                                                reset_timeout=app.config['CIRCUIT_BREAKER_HERE_TIMEOUT_S'])
+
+    def _call_here(self, url, params):
+        log = logging.getLogger(__name__)
+        log.debug('Here routing service, url: {}'.format(url))
+        try:
+            return self.breaker.call(requests.get, url, timeout=self.timeout, params=params)
+        except pybreaker.CircuitBreakerError as e:
+            log.error('Valhalla routing service dead (error: {})'.format(e))
+            self.record_external_failure('circuit breaker open')
+            raise TechnicalError('HERE service not available')
+        except requests.Timeout as t:
+            log.error('Valhalla routing service dead (error: {})'.format(t))
+            self.record_external_failure('timeout')
+            raise TechnicalError('impossible to access HERE service, timeout reached')
+        except Exception as e:
+            log.exception('Valhalla routing error')
+            self.record_external_failure(str(e))
+            raise TechnicalError('impossible to access HERE service')
+
+    @staticmethod
+    def _read_response(response, origin, destination, mode, fallback_extremity):
+        resp = response_pb2.Response()
+        resp.status_code = 200
+        routes = response.get('response', {}).get('route', [])
+        if not routes:
+            resp.response_type = response_pb2.NO_SOLUTION
+            return resp
+
+        resp.response_type = response_pb2.ITINERARY_FOUND
+        route = routes[0]
+
+        journey = resp.journeys.add()
+        journey.duration = route.get('summary', {}).get('travelTime')
+
+        datetime, represents_start_fallback = fallback_extremity
+        if represents_start_fallback:
+            journey.departure_date_time = datetime
+            journey.arrival_date_time = datetime + journey.duration
+        else:
+            journey.departure_date_time = datetime - journey.duration
+            journey.arrival_date_time = datetime
+
+        journey.durations.total = journey.duration
+
+        if mode == 'walking':
+            journey.durations.walking = journey.duration
+
+        legs = route.get('leg')
+        if not legs:
+            return journey
+
+        leg = legs[0]
+
+        section = journey.sections.add()
+        section.type = response_pb2.STREET_NETWORK
+
+        section.duration = leg.get('travelTime', 0)
+        section.begin_date_time = journey.departure_date_time
+        section.end_date_time = section.begin_date_time + section.duration
+
+        section.id = 'section_0'
+        section.length = int(leg.get('length', 0))
+
+        section.origin.CopyFrom(origin)
+        section.destination.CopyFrom(destination)
+
+        section.street_network.length = section.length
+        section.street_network.duration = section.duration
+        map_mode = {
+            "walking": response_pb2.Walking,
+            "car": response_pb2.Car,
+            "bike": response_pb2.Bike
+        }
+        section.street_network.mode = map_mode[mode]
+        # for maneuver in leg['maneuver']:  #TODO
+
+        shape = route.get('shape', [])
+        for sh in shape:
+            coord = section.street_network.coordinates.add()
+            lat, lon = sh.split(',')
+            coord.lon = float(lon)
+            coord.lat = float(lat)
+
+        return resp
+
+    def get_direct_path_params(self, origin, destination, mode):
+        params = {
+            # those are used to identify in the API
+            'app_id': self.api_id,
+            'app_code': self.api_code,
+            'waypoint0': _get_coord(origin),
+            'waypoint1': _get_coord(destination),
+            'routeAttributes': 'sh',  # to get the shape in the response
+            # used to get the travel time in the response
+            'summaryAttributes': 'traveltime',
+            # used to get the fasted journeys using the given mode and with traffic data
+            'mode': 'fastest;{mode};traffic:enabled'.format(mode=get_here_mode(mode)),
+            # 'departure': ''  # TODO give the departure hour to use traffic data
+        }
+        return params
+
+    def direct_path(self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type):
+        params = self.get_direct_path_params(pt_object_origin, pt_object_destination, mode)
+        r = self._call_here(self.routing_service_url, params=params)
+        if r.status_code != 200:
+            l = logging.getLogger(__name__)
+            l.debug('impossible to find a path between {o} and {d}, response ({code}) {r}'
+                   .format(o=pt_object_origin, d=pt_object_destination, code=r.status_code, r=r.text))
+            resp = response_pb2.Response()
+            resp.status_code = 200
+            resp.response_type = response_pb2.NO_SOLUTION
+            return resp
+
+        return self._read_response(r.json(), pt_object_origin, pt_object_destination, mode,
+                                   fallback_extremity)
+
+    @classmethod
+    def _get_matrix(cls, json_response, origins, destinations):
+        sn_routing_matrix = response_pb2.StreetNetworkRoutingMatrix()
+        # by convenience we create a temporary structure. If it's a bottleneck, refactor this
+        entries = {
+            (e.get('startIndex'), e.get('destinationIndex')): e.get('summary', {}).get('travelTime')
+            for e in json_response.get('response', {}).get('matrixEntry', [])
+        }
+        for i_o, o in enumerate(origins):
+            row = sn_routing_matrix.rows.add()
+            for i_d, d in enumerate(destinations):
+                routing = row.routing_response.add()
+                travel_time = entries.get((i_o, i_d))
+                if travel_time:
+                    routing.duration = travel_time
+                    routing.routing_status = response_pb2.reached
+                else:
+                    # since we limit the number of points given to HERE, we say that all the others cannot be
+                    # reached (and not response_pb2.unkown since we don't want a crow fly section)
+                    routing.duration = -1
+                    routing.routing_status = response_pb2.unreached
+
+        return sn_routing_matrix
+
+    def get_matrix_params(self, origins, destinations, mode, max_duration):
+        params = {
+            # those are used to identify in the API
+            'app_id': self.api_id,
+            'app_code': self.api_code,
+            # used to get the travel time in the response
+            'summaryAttributes': 'traveltime',
+            # used to get the fasted journeys using the given mode and with traffic data
+            'mode': 'fastest;{mode};traffic:enabled'.format(mode=get_here_mode(mode)),
+            # 'departure': ''  # TODO give the departure hour to use traffic data
+        }
+
+        # Note: for the moment we limit to self.max_points the number of n:m asked
+        for i, o in enumerate(origins[:self.max_points]):
+            params['start{}'.format(i)] = _get_coord(o)
+
+        for i, o in enumerate(destinations[:self.max_points]):
+            params['destination{}'.format(i)] = _get_coord(o)
+
+        # TODO handle max_duration (but the API can only handle a max distance (searchRange)
+
+        return params
+
+    def get_street_network_routing_matrix(self, origins, destinations, mode, max_duration, request, **kwargs):
+        params = self.get_matrix_params(origins, destinations, mode, max_duration)
+        r = self._call_here(self.matrix_service_url, params=params)
+
+        if r.status_code != 200:
+            logging.getLogger(__name__).error('impossible to query HERE: {} with {} response: {}'
+                                              .format(r.url, r.status_code, r.text))
+            raise TechnicalError('invalid HERE call, impossible to query: {}'.format(r.url))
+
+        resp_json = r.json()
+
+        return self._get_matrix(resp_json, origins, destinations)
+
+    def make_path_key(self, mode, orig_uri, dest_uri, streetnetwork_path_type, period_extremity):
+        """
+        :param orig_uri, dest_uri, mode: matters obviously
+        :param streetnetwork_path_type: whether it's a fallback at
+        the beginning, the end of journey or a direct path without PT also matters especially for car (to know if we
+        park before or after)
+        :param period_extremity: is a PeriodExtremity (a datetime and it's meaning on the
+        fallback period)
+        Nota: period_extremity is taken into consideration so far because we assume that a
+        direct path from A to B change change with the realtime
+        """
+        return StreetNetworkPathKey(mode, orig_uri, dest_uri, streetnetwork_path_type, period_extremity)

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -145,6 +145,11 @@ class Here(AbstractStreetNetworkService):
         section.begin_date_time = journey.departure_date_time
         section.end_date_time = section.begin_date_time + section.duration
 
+        # since HERE can give us the base time, we display it.
+        # we do not try to do clever stuff (like taking the 'clockwise' into account) here
+        section.base_begin_date_time = section.begin_date_time
+        section.base_end_date_time = section.base_begin_date_time + leg.get('baseTime', section.duration)
+
         section.id = 'section_0'
         section.length = int(leg.get('length', 0))
 
@@ -187,6 +192,8 @@ class Here(AbstractStreetNetworkService):
             'routeAttributes': 'sh',  # to get the shape in the response
             # used to get the travel time in the response
             'summaryAttributes': 'traveltime',
+            # used to get the base time
+            'legAttributes': 'baseTime',
             # used to get the fasted journeys using the given mode and with traffic data
             'mode': 'fastest;{mode};traffic:enabled'.format(mode=get_here_mode(mode)),
             # in HERE it's only possible to constraint the departure

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -176,7 +176,7 @@ class Here(AbstractStreetNetworkService):
 
         return resp
 
-    def get_direct_path_params(self, origin, destination, mode, fallback_extremity):
+    def get_direct_path_params(self, origin, destination, mode, fallback_extremity, direct_path_type):
         params = {
             # those are used to identify in the API
             'app_id': self.api_id,
@@ -189,16 +189,19 @@ class Here(AbstractStreetNetworkService):
             # used to get the fasted journeys using the given mode and with traffic data
             'mode': 'fastest;{mode};traffic:enabled'.format(mode=get_here_mode(mode)),
         }
-        datetime, represents_start_fallback = fallback_extremity
-        if represents_start_fallback:
-            params['departure'] = _str_to_dt(datetime)
-        else:
-            params['arrival'] = _str_to_dt(datetime)
+        datetime, clockwise = fallback_extremity
+
+        # for clockwise we need to constraint the departure time, else the arrival
+        # Note that the the BEGINNING_FALLBAK is always non clockwise (and end END_FALLBACK clockwise)
+        # because the constraint is to be able to get in the bus (resp. leave it)
+        constrainted_dt = 'departure' if clockwise else 'arrival'
+        params[constrainted_dt] = _str_to_dt(datetime)
 
         return params
 
     def direct_path(self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type):
-        params = self.get_direct_path_params(pt_object_origin, pt_object_destination, mode, fallback_extremity)
+        params = self.get_direct_path_params(pt_object_origin, pt_object_destination, mode,
+                                             fallback_extremity, direct_path_type)
         r = self._call_here(self.routing_service_url, params=params)
         if r.status_code != 200:
             l = logging.getLogger(__name__)

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -116,6 +116,7 @@ class Here(AbstractStreetNetworkService):
             journey.departure_date_time = datetime - journey.duration
             journey.arrival_date_time = datetime
 
+        journey.requested_date_time = journey.departure_date_time  # TODO use the real requested datetime
         journey.durations.total = journey.duration
 
         if mode == 'walking':
@@ -148,7 +149,13 @@ class Here(AbstractStreetNetworkService):
             "bike": response_pb2.Bike
         }
         section.street_network.mode = map_mode[mode]
-        # for maneuver in leg['maneuver']:  #TODO
+        for maneuver in leg.get('maneuver', []):
+            path_item = section.street_network.path_items.add()
+            # TODO get the street name
+            path_item.length = maneuver.get('length')
+            path_item.duration = maneuver.get('travelTime')
+            # TODO: calculate direction
+            path_item.direction = 0
 
         shape = route.get('shape', [])
         for sh in shape:

--- a/source/jormungandr/jormungandr/street_network/street_network.py
+++ b/source/jormungandr/jormungandr/street_network/street_network.py
@@ -30,7 +30,7 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
-from jormungandr import utils
+from jormungandr import utils, new_relic
 from jormungandr.exceptions import ConfigException
 import abc
 
@@ -77,6 +77,14 @@ class AbstractStreetNetworkService(ABC):
 
     def record_external_failure(self, message):
         utils.record_external_failure(message, 'streetnetwork', self.sn_system_id)
+
+    def record_call(self, status, **kwargs):
+        """
+        status can be in: ok, failure
+        """
+        params = {'streetnetwork_id': repr(self.sn_system_id), 'status': status}
+        params.update(kwargs)
+        new_relic.record_custom_event('streetnetwork', params)
 
 
 class StreetNetwork(object):

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -154,7 +154,7 @@ def test_matrix(valid_here_matrix):
             [destination, destination, destination],
             mode='walking',
             max_duration=42,
-            request={})
+            request={'datetime': str_to_time_stamp('20170621T174600')})
         assert response.rows[0].routing_response[0].duration == 440
         assert response.rows[0].routing_response[0].routing_status == response_pb2.reached
         assert response.rows[0].routing_response[1].duration == -1
@@ -171,7 +171,8 @@ def here_basic_routing_test(valid_here_routing_response):
                                    mode='walking',
                                    origin=origin,
                                    destination=destination,
-                                   fallback_extremity=fallback_extremity)
+                                   fallback_extremity=fallback_extremity,
+                                   request={'datetime': str_to_time_stamp('20170621T174600')})
     assert response.status_code == 200
     assert response.response_type == response_pb2.ITINERARY_FOUND
     assert len(response.journeys) == 1

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -1,0 +1,187 @@
+#  Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+import pytest
+import requests_mock
+from mock import MagicMock
+
+from jormungandr.street_network.here import Here
+from jormungandr.street_network.tests.streetnetwork_test_utils import make_pt_object
+from jormungandr.utils import PeriodExtremity, str_to_time_stamp
+from navitiacommon import type_pb2, response_pb2
+
+
+@pytest.fixture()
+def valid_here_matrix():
+    return {
+        "response": {
+            "matrixEntry": [
+                {
+                    "destinationIndex": 0,
+                    "startIndex": 0,
+                    "summary": {
+                        "travelTime": 440
+                    }
+                },
+                {
+                    "destinationIndex": 1,
+                    "startIndex": 0,
+                    "status": "failed"
+                },
+                {
+                    "destinationIndex": 2,
+                    "startIndex": 0,
+                    "summary": {
+                        "travelTime": 701
+                    }
+                },
+            ],
+        }
+    }
+
+
+@pytest.fixture()
+def valid_here_routing_response():
+    # it's not a real response, it's a truncated to reduce its size
+    return {
+            "response": {
+                "route": [
+                    {
+                        "leg": [
+                            {
+                                "length": 4012,
+                                "maneuver": [
+                                    {
+                                        "_type": "PrivateTransportManeuverType",
+                                        "id": "M1",
+                                        "instruction": "Head <span class=\"heading\">southeast</span> on "
+                                                       "<span class=\"street\">Bob street</span>. <span "
+                                                       "class=\"distance-description\">Go for <span class=\"length\">46 m</span>.</span>",
+                                        "length": 46,
+                                        "position": {
+                                            "latitude": 52.4999825,
+                                            "longitude": 13.3999652
+                                        },
+                                        "travelTime": 27
+                                    },
+                                    {
+                                        "_type": "PrivateTransportManeuverType",
+                                        "id": "M10",
+                                        "instruction": "Arrive at <span class=\"street\">Schleusenufer</span>.",
+                                        "length": 0,
+                                        "position": {
+                                            "latitude": 52.4987912,
+                                            "longitude": 13.4510744
+                                        },
+                                        "travelTime": 0
+                                    }
+                                ],
+                                "travelTime": 588
+                            }
+                        ],
+                        "mode": {
+                            "feature": [],
+                            "trafficMode": "disabled",
+                            "transportModes": [
+                                "car"
+                            ],
+                            "type": "fastest"
+                        },
+                        "shape": [
+                            "52.4999825,13.3999652",
+                            "52.4999607,13.3999944",
+                            "52.4972355,13.4488964",
+                            "52.4987912,13.4510744"
+                        ],
+                        "summary": {
+                            "_type": "RouteSummaryType",
+                            "baseTime": 588,
+                            "distance": 4012,
+                            "flags": [
+                                "noThroughRoad",
+                                "builtUpArea",
+                                "park",
+                                "privateRoad"
+                            ],
+                            "text": "The trip takes <span class=\"length\">4.0 km</span> and <span class=\"time\">10 mins</span>.",
+                            "trafficTime": 1036,
+                            "travelTime": 588
+                        }
+                    }
+                ]
+            }
+        }
+
+
+def test_matrix(valid_here_matrix):
+    instance = MagicMock()
+    instance.walking_speed = 1.12
+    here = Here(instance=instance, service_base_url='bob.com', app_id='toto', app_code='tata')
+    origin = make_pt_object(type_pb2.ADDRESS, 2.439938, 48.572841)
+    destination = make_pt_object(type_pb2.ADDRESS, 2.440548, 48.57307)
+    with requests_mock.Mocker() as req:
+        req.get(requests_mock.ANY,
+                json=valid_here_matrix,
+                status_code=200)
+        response = here.get_street_network_routing_matrix(
+            [origin],
+            [destination, destination, destination],
+            mode='walking',
+            max_duration=42,
+            request={})
+        assert response.rows[0].routing_response[0].duration == 440
+        assert response.rows[0].routing_response[0].routing_status == response_pb2.reached
+        assert response.rows[0].routing_response[1].duration == -1
+        assert response.rows[0].routing_response[1].routing_status == response_pb2.unreached
+        assert response.rows[0].routing_response[2].duration == 701
+        assert response.rows[0].routing_response[2].routing_status == response_pb2.reached
+
+
+def here_basic_routing_test(valid_here_routing_response):
+    origin = make_pt_object(type_pb2.POI, 2.439938, 48.572841)
+    destination = make_pt_object(type_pb2.STOP_AREA, 2.440548, 48.57307)
+    fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), True)
+    response = Here._read_response(response=valid_here_routing_response,
+                                   mode='walking',
+                                   origin=origin,
+                                   destination=destination,
+                                   fallback_extremity=fallback_extremity)
+    assert response.status_code == 200
+    assert response.response_type == response_pb2.ITINERARY_FOUND
+    assert len(response.journeys) == 1
+    assert response.journeys[0].duration == 588
+    assert len(response.journeys[0].sections) == 1
+    section = response.journeys[0].sections[0]
+    assert section.type == response_pb2.STREET_NETWORK
+    assert section.length == 4012
+    assert section.duration == 588
+    assert section.destination == destination
+    assert section.origin == origin
+    assert section.begin_date_time == str_to_time_stamp('20161010T152000')
+    assert section.end_date_time == section.begin_date_time + section.duration

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -40,7 +40,7 @@ class MockResponse(object):
     """
     small class to mock an http response
     """
-    def __init__(self, data, status_code, url, *args, **kwargs):
+    def __init__(self, data, status_code, url=None, *args, **kwargs):
         self.data = data
         self.status_code = status_code
         self.url = url

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -171,7 +171,8 @@ HERE_ROUTING_RESPONSE_END_FALLBACK_PATH = {
                                 "travelTime": 50
                             }
                         ],
-                        "travelTime": 60
+                        "travelTime": 60,
+                        'BaseTime': 60
                     }
                 ],
                 "shape": [
@@ -208,7 +209,8 @@ HERE_ROUTING_RESPONSE_DIRECT_PATH = {
                                 "travelTime": 200
                             },
                         ],
-                        "travelTime": 300
+                        "travelTime": 300,
+                        'BaseTime': 200
                     }
                 ],
                 "shape": [

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -263,11 +263,9 @@ def mock_here(_, url, params):
             assert params.get('departure') == '2012-06-14T07:00:00'
             return MockResponse(HERE_ROUTING_RESPONSE_DIRECT_PATH, 200)
         if params['waypoint0'] == s and params['waypoint1'] == b:
-            # for the begin fallback, the constraint is to arrive before the departure of the bus
-            assert params.get('arrival') == '2012-06-14T08:01:00'
+            assert params.get('departure') == '2012-06-14T08:01:00'
             return MockResponse(HERE_ROUTING_RESPONSE_BEGINNING_FALLBACK_PATH, 200)
         if params['waypoint0'] == a and params['waypoint1'] == r:
-            # for the end fallback, the constraint is to leave after the arrival of the bus
             assert params.get('departure') == '2012-06-14T08:01:02'
             return MockResponse(HERE_ROUTING_RESPONSE_END_FALLBACK_PATH, 200)
     assert False, 'invalid url'

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -314,7 +314,7 @@ class TestHere(NewDefaultScenarioAbstractTestFixture):
 
         assert car_fallback.get('departure_date_time') == '20120614T080045'
         assert car_fallback.get('arrival_date_time') == '20120614T080202'
-        
+
         sections = car_fallback.get('sections')
         assert len(sections) == 3
         assert sections[0].get('mode') == 'car'

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -1,0 +1,334 @@
+# Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+import pytest
+
+from jormungandr.tests.utils_test import MockResponse
+from tests.check_utils import journey_basic_query, get_not_null, s_coord, r_coord
+from tests.tests_mechanism import AbstractTestFixture, dataset, config, NewDefaultScenarioAbstractTestFixture
+
+MOCKED_INSTANCE_CONF = {
+    'scenario': 'distributed',
+    'instance_config': {
+        'street_network': [
+            {
+                "args": {
+                    "api_id": "bob_id",
+                    "api_code": "bob_code",
+                    "service_base_url": "route.bob.here.com/routing/7.2/",
+                    "timeout": 20
+                },
+                "modes": [
+                    "car"
+                ],
+                "class": "jormungandr.street_network.here.Here"
+            },
+            {
+                "modes": [
+                    "walking",
+                    "bike",
+                    "bss"
+                ],
+                "class": "jormungandr.street_network.kraken.Kraken"
+            }
+        ]
+    }
+}
+
+# the destinations are B, C, A and useless_a
+HERE_BEGGINING_MATRIX_RESPONSE = {
+    "response": {
+        "matrixEntry": [
+            {
+                "destinationIndex": 0,
+                "startIndex": 0,
+                "summary": {
+                    "travelTime": 15
+                }
+            },
+            {
+                "destinationIndex": 0,
+                "startIndex": 0,
+                "summary": {
+                    "travelTime": 100
+                }
+            },
+            {
+                "destinationIndex": 2,
+                "startIndex": 0,
+                "status": "failed"
+            },
+            {
+                "destinationIndex": 2,
+                "startIndex": 0,
+                "status": "failed"
+            },
+        ],
+    }
+}
+
+# the start and A, useless_A and C
+HERE_END_MATRIX_RESPONSE = {
+    "response": {
+        "matrixEntry": [
+            {
+                "destinationIndex": 0,
+                "startIndex": 0,
+                "summary": {
+                    "travelTime": 60
+                }
+            },
+            {
+                "destinationIndex": 0,
+                "startIndex": 0,
+                "summary": {
+                    "travelTime": 60
+                }
+            },
+            {
+                "destinationIndex": 2,
+                "startIndex": 0,
+                "status": "failed"
+            },
+        ],
+    }
+}
+
+HERE_ROUTING_RESPONSE_BEGINNING_FALLBACK_PATH = {
+    "response": {
+        "route": [
+            {
+                "leg": [
+                    {
+                        "length": 10,
+                        "maneuver": [
+                            {
+                                "length": 10,
+                                "travelTime": 15
+                            }
+                        ],
+                        "travelTime": 15
+                    }
+                ],
+                "shape": [
+                    "52.4999825,13.3999652",
+                    "52.4987912,13.4510744"
+                ],
+                "summary": {
+                    "_type": "RouteSummaryType",
+                    "baseTime": 13,
+                    "distance": 10,
+                    "trafficTime": 2,
+                    "travelTime": 15
+                }
+            }
+        ]
+    }
+}
+
+
+HERE_ROUTING_RESPONSE_END_FALLBACK_PATH = {
+    "response": {
+        "route": [
+            {
+                "leg": [
+                    {
+                        "length": 100,
+                        "maneuver": [
+                            {
+                                "length": 10,
+                                "travelTime": 10
+                            },
+                            {
+                                "length": 90,
+                                "travelTime": 50
+                            }
+                        ],
+                        "travelTime": 60
+                    }
+                ],
+                "shape": [
+                    "52.4999825,13.3999652",
+                    "52.4987912,13.4510744"
+                ],
+                "summary": {
+                    "_type": "RouteSummaryType",
+                    "baseTime": 50,
+                    "distance": 100,
+                    "trafficTime": 10,
+                    "travelTime": 60
+                }
+            }
+        ]
+    }
+}
+
+
+HERE_ROUTING_RESPONSE_DIRECT_PATH = {
+    "response": {
+        "route": [
+            {
+                "leg": [
+                    {
+                        "length": 100,
+                        "maneuver": [
+                            {
+                                "length": 20,
+                                "travelTime": 100
+                            },
+                            {
+                                "length": 80,
+                                "travelTime": 200
+                            },
+                        ],
+                        "travelTime": 300
+                    }
+                ],
+                "shape": [
+                    "52.4999825,13.3999652",
+                    "52.4987912,13.4510744"
+                ],
+                "summary": {
+                    "_type": "RouteSummaryType",
+                    "baseTime": 200,
+                    "distance": 1000,
+                    "trafficTime": 100,
+                    "travelTime": 300
+                }
+            }
+        ]
+    }
+}
+
+
+def mock_here(_, url, params):
+    s = 'geo!8.98312e-05,8.98312e-05'
+    r = 'geo!0.00071865,0.00188646'
+
+    a = 'geo!0.000718649585564,0.00107797437835'
+    b = 'geo!0.000269493594586,8.98311981955e-05'
+    c = 'geo!0.00107797437835,0.000628818387368'
+    useless_a = a
+
+    if url == 'https://matrix.route.bob.here.com/routing/7.2/calculatematrix.json':
+        if params['start0'] == s:
+            # we check that the destinations are correct since the order is important
+            assert params.get('destination0') == b
+            assert params.get('destination1') == c
+            assert params.get('destination2') == a
+            assert params.get('destination3') == useless_a
+            return MockResponse(HERE_BEGGINING_MATRIX_RESPONSE, 200)
+        if params['destination0'] == r:
+            assert params.get('start0') == a
+            assert params.get('start1') == useless_a
+            assert params.get('start2') == c
+            return MockResponse(HERE_END_MATRIX_RESPONSE, 200)
+    elif url == 'https://route.bob.here.com/routing/7.2/calculateroute.json':
+        if params['waypoint0'] == s and params['waypoint1'] == r:
+            return MockResponse(HERE_ROUTING_RESPONSE_DIRECT_PATH, 200)
+        if params['waypoint0'] == s and params['waypoint1'] == b:
+            return MockResponse(HERE_ROUTING_RESPONSE_BEGINNING_FALLBACK_PATH, 200)
+        if params['waypoint0'] == a and params['waypoint1'] == r:
+            return MockResponse(HERE_ROUTING_RESPONSE_END_FALLBACK_PATH, 200)
+    assert False, 'invalid url'
+
+
+@pytest.yield_fixture(scope="function", autouse=True)
+def mock_http_here(monkeypatch):
+    monkeypatch.setattr('jormungandr.street_network.here.Here._call_here', mock_here)
+
+
+@dataset({'main_routing_test': MOCKED_INSTANCE_CONF})
+class TestHere(NewDefaultScenarioAbstractTestFixture):
+    """
+    Integration test with HERE
+
+    To better understand the dataset see routing_api_test_data.h
+
+    As a reminder the simplified dataset is:
+
+    S == B -- A == R
+
+    We want to go from R to S
+
+    We mock Here response with the following durations:
+
+    S -> R = 5mn
+    S -> B = 15s
+    A -> R = 1mn
+    """
+
+    def test_basic_car_routing(self):
+        """
+        test with car fallback and car direct path
+        """
+        q = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&first_section_mode[]=car" \
+            "&last_section_mode[]=car&debug=true&min_nb_journeys=0"\
+            .format(from_coord=s_coord, to_coord=r_coord, datetime="20120614T070000")
+        response = self.query_region(q)
+        self.is_valid_journey_response(response, q)
+
+        journeys = get_not_null(response, 'journeys')
+
+        assert len(journeys) == 2
+
+        car_direct = journeys[0]
+
+        assert car_direct.get('departure_date_time') == '20120614T070000'
+        assert car_direct.get('arrival_date_time') == '20120614T070500'
+        sections = car_direct.get('sections')
+        assert len(sections) == 1
+        assert sections[0].get('mode') == 'car'
+        assert sections[0].get('departure_date_time') == '20120614T070000'
+        assert sections[0].get('arrival_date_time') == '20120614T070500'
+        assert sections[0].get('duration') == 300
+        assert sections[0].get('type') == 'street_network'
+
+        car_fallback = journeys[1]
+
+        assert car_fallback.get('departure_date_time') == '20120614T080045'
+        assert car_fallback.get('arrival_date_time') == '20120614T080202'
+        
+        sections = car_fallback.get('sections')
+        assert len(sections) == 3
+        assert sections[0].get('mode') == 'car'
+        assert sections[0].get('departure_date_time') == '20120614T080045'
+        assert sections[0].get('arrival_date_time') == '20120614T080100'
+        assert sections[0].get('duration') == 15
+
+        assert sections[1].get('departure_date_time') == '20120614T080100'
+        assert sections[1].get('arrival_date_time') == '20120614T080102'
+        assert sections[1].get('duration') == 2
+        assert sections[1].get('type') == 'public_transport'
+
+        assert sections[2].get('departure_date_time') == u'20120614T080102'
+        assert sections[2].get('arrival_date_time') == u'20120614T080202'
+        assert sections[2].get('duration') == 60
+        assert sections[2].get('type') == 'street_network'
+        assert sections[2].get('mode') == 'car'

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -314,7 +314,7 @@ class AbstractTestFixture(unittest.TestCase):
             assert 'line' in types
             assert 'network' in types
 
-    def is_valid_journey_response(self, response, query_str):
+    def is_valid_journey_response(self, response, query_str, check_journey_links=True):
         """
         check that the journey's response is valid
 
@@ -345,8 +345,9 @@ class AbstractTestFixture(unittest.TestCase):
 
         check_internal_links(response, self.tester)
 
-        #check other links
-        check_links(response, self.tester)
+        # check other links
+        if check_journey_links:
+            check_links(response, self.tester)
 
         # more checks on links, we want the prev/next/first/last,
         # to have forwarded all params, (and the time must be right)


### PR DESCRIPTION
Add another streetnetwork connector calling [HERE](https://developer.here.com) service

the nice feature of this service is that there is realtime data on the streetnetwork.

One of the down side is that the routing matrix is limited to 100 elements, so it is usable only in a very sparse dataset (like the SNCF).

This is a first rough implementation.

some stuff needs to be implemented (but I'm not sure they are mandatory):
* search range (but the here api limit the range as a distance and we do it as a travel time)
* better directions (for the moment there is not the name of the streets and the direction to take)

what do cannot do:
* change the vehicle speed (only the walking speed can be set)
* the end fallback will have a false datetime as we cannot be precise (it depends on the public transport taken)
