### PR TITLE
Jormungandr: add schema for pt collections

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -191,6 +191,9 @@ class Uri(ResourceUri, ResourceUtc):
                                       instance_name=self.region)
         return response
 
+    def options(self, **kwargs):
+        return self.api_description(**kwargs)
+
 
 def journey_pattern_points(is_collection):
     class JourneyPatternPoints(Uri):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -124,7 +124,13 @@ class EnumField(jsonschema.Field):
 
 
 class EnumListField(EnumField):
+
     """WARNING: the enumlist field does not work without a self.attr"""
+
+    def __init__(self, pb_type=None, **kwargs):
+        super(EnumListField, self).__init__(pb_type, **kwargs)
+        self.many = True
+
     def as_getter(self, serializer_field_name, serializer_cls):
         return lambda x: x
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
@@ -129,7 +129,8 @@ class LinkSerializer(jsonschema.Field):
     Add link to disruptions on a pt object
     """
     def __init__(self, **kwargs):
-        super(LinkSerializer, self).__init__(schema_type=LinkSchema(many=True), **kwargs)
+        super(LinkSerializer, self).__init__(schema_type=LinkSchema(), **kwargs)
+        self.many = True
 
     def to_value(self, value):
         return [create_internal_link(_type="disruption", rel="disruptions", id=uri)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/fields.py
@@ -107,3 +107,33 @@ class MethodField(serpy.MethodField):
         self.schema_metadata = schema_metadata or {}
         # the remaining kwargs are added in the schema metadata to add a bit of syntaxic sugar
         self.schema_metadata.update(**kwargs)
+
+
+class CustomSchemaType(object):
+    def schema(self):
+        # by default we look for a _schema variable, but it can be overriden
+        return self._schema
+
+
+class DateTimeType(CustomSchemaType):
+    _schema = {
+        'type': 'string',
+        'format': 'navitia-date-time',  # we do not respect the official swagger datetime format :(
+        'pattern': '\d{4}\d{2}\d{2}T\d{2}\d{2}\d{2}'
+    }
+
+
+class DateType(CustomSchemaType):
+    _schema = {
+        'type': 'string',
+        'format': 'navitia-date',  # we do not respect the official swagger date format :(
+        'pattern': '\d{4}\d{2}\d{2}'
+    }
+
+
+class TimeType(CustomSchemaType):
+    _schema = {
+        'type': 'string',
+        'format': 'navitia-time',
+        'pattern': '\d{2}\d{2}\d{2}'
+    }

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
@@ -91,7 +91,7 @@ def serpy_extended_supported_serialization_test():
         jsonschemaMethodField = MethodField(schema_type=str)
         lambda_schema = LambdaField(method=lambda **kw: None, schema_type=lambda: Custom())
         list_lambda_schema = LambdaField(method=lambda **kw: None,
-                                         schema_type=lambda: Custom(many=True))
+                                         schema_type=Custom(many=True))
 
         def get_jsonschemaMethodField(self, obj):
             pass
@@ -113,7 +113,6 @@ def serpy_extended_supported_serialization_test():
 
     # we must find the 'CustomSerializer' in the definitions
     assert(next(iter(d for d in external_definitions if d.__class__ == Custom), None))
-
 
 
 def schema_type_test():
@@ -155,7 +154,6 @@ def nested_test():
     """
     Nested Serialization
     """
-
     class NestedType(serpy.Serializer):
         id = jsonschema.StrField()
 
@@ -205,8 +203,7 @@ def param_test():
 
 
 def param_list_test():
-    flask_arg = ArgumentDoc("pouet", type=str,
-                            action="append")
+    flask_arg = ArgumentDoc("pouet", type=str, action="append")
 
     swagger_args = SwaggerParam.make_from_flask_arg(flask_arg)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -36,8 +36,7 @@ from jormungandr.interfaces.v1.serializer.jsonschema.fields import BoolField, Fi
 from jormungandr.interfaces.v1.serializer.time import LocalTimeField, PeriodSerializer, DateTimeField
 from jormungandr.interfaces.v1.serializer.fields import *
 from jormungandr.interfaces.v1.serializer import jsonschema
-from navitiacommon.type_pb2 import ActiveStatus, Channel
-
+from navitiacommon.type_pb2 import ActiveStatus, Channel, hasEquipments
 
 LABEL_DESCRIPTION = """
 Label of the stop area. The name is directly taken from the data whereas the label is
@@ -46,8 +45,12 @@ Label of the stop area. The name is directly taken from the data whereas the lab
 
 class Equipments(EnumListField):
     """
-    hack for equiments their is a useless level in the proto
+    hack for equiments there is a useless level in the proto
     """
+
+    def __init__(self, **kwargs):
+        super(Equipments, self).__init__(hasEquipments.Equipment, **kwargs)
+
     def as_getter(self, serializer_field_name, serializer_cls):
         #For enum we need the full object :(
         return lambda x: x.has_equipments

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -32,7 +32,7 @@ import serpy
 from navitiacommon import type_pb2
 
 from jormungandr.interfaces.v1.serializer.base import GenericSerializer, EnumListField, LiteralField
-from jormungandr.interfaces.v1.serializer.jsonschema.fields import BoolField, Field
+from jormungandr.interfaces.v1.serializer.jsonschema.fields import BoolField, Field, DateTimeType, DateType
 from jormungandr.interfaces.v1.serializer.time import LocalTimeField, PeriodSerializer, DateTimeField
 from jormungandr.interfaces.v1.serializer.fields import *
 from jormungandr.interfaces.v1.serializer import jsonschema
@@ -124,8 +124,8 @@ class TripSerializer(GenericSerializer):
 
 
 class ValidityPatternSerializer(PbNestedSerializer):
-    beginning_date = Field()
-    days = Field()
+    beginning_date = Field(schema_type=DateType)
+    days = Field(schema_type=str)
 
 
 class WeekPatternSerializer(PbNestedSerializer):
@@ -139,12 +139,12 @@ class WeekPatternSerializer(PbNestedSerializer):
 
 
 class CalendarPeriodSerializer(PbNestedSerializer):
-    begin = Field()
-    end = Field()
+    begin = Field(schema_type=DateType)
+    end = Field(schema_type=DateType)
 
 
 class CalendarExceptionSerializer(PbNestedSerializer):
-    datetime = serpy.Field(attr='date')
+    datetime = jsonschema.Field(attr='date', schema_type=DateTimeType)
     type = EnumField()
 
 
@@ -364,7 +364,7 @@ class LineSerializer(GenericSerializer):
 
 
 class JourneyPatternPointSerializer(PbNestedSerializer):
-    id = serpy.Field(attr='uri')
+    id = jsonschema.Field(attr='uri', schema_type=str)
     stop_point = StopPointSerializer(display_none=False)
 
 
@@ -376,7 +376,7 @@ class JourneyPatternSerializer(GenericSerializer):
 class StopTimeSerializer(PbNestedSerializer):
     arrival_time = LocalTimeField()
     departure_time = LocalTimeField()
-    headsign = serpy.Field()
+    headsign = jsonschema.Field(schema_type=str)
     journey_pattern_point = JourneyPatternPointSerializer()
     stop_point = StopPointSerializer()
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import serpy
 from datetime import datetime
 from jormungandr.interfaces.v1.serializer.base import PbField, PbNestedSerializer, NestedPbField
-from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field
+from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field, TimeType, DateTimeType
 from jormungandr.utils import timestamp_to_str
 
 
@@ -40,7 +40,7 @@ from jormungandr.utils import timestamp_to_str
 __date_time_null_value__ = 2**64 - 1
 
 
-class LocalTimeField(NestedPbField):
+class LocalTimeField(NestedPbField, TimeType):
     """
     This field convert a number of second from midnight to a string with the format: HH:MM:SS
     No conversion from UTC will be done, we expect the time to already be in desired timezone
@@ -50,33 +50,21 @@ class LocalTimeField(NestedPbField):
             return ""
         return datetime.utcfromtimestamp(value).strftime('%H%M%S')
 
-    def __init__(self, schema_metadata={}, **kwargs):
-        schema_metadata.update(pattern='d{2}\d{2}\d{2}')
-        super(LocalTimeField, self).__init__(str, schema_metadata, **kwargs)
 
-class DateTimeField(PbField):
+class DateTimeField(PbField, DateTimeType):
     """
     custom date format from timestamp
     """
     def to_value(self, value):
         return timestamp_to_str(value)
 
-    def __init__(self, schema_metadata={}, **kwargs):
-        schema_metadata.update(pattern='\d{4}\d{2}\d{2}T\d{2}\d{2}\d{2}')
-        super(DateTimeField, self).__init__(str, schema_metadata, **kwargs)
 
-
-class DateTimeDictField(Field):
+class DateTimeDictField(Field, DateTimeType):
     """
     custom date format from timestamp
     """
     def to_value(self, value):
         return timestamp_to_str(value) if value else None
-
-    def __init__(self, schema_metadata=None, **kwargs):
-        if schema_metadata is None:
-            schema_metadata = {}
-        schema_metadata['pattern'] = '\d{4}\d{2}\d{2}T\d{2}\d{2}\d{2}'
         super(DateTimeDictField, self).__init__(schema_type=str, schema_metadata=schema_metadata, **kwargs)
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
@@ -166,11 +166,6 @@ def _from_nested_schema(field):
     schema = {
         '$ref': '#/definitions/' + get_serializer_name(field)
     }
-    if field.many:
-        schema = {
-            'type': "array",  # TODO check how swagger handle null arrays
-            'items': schema,
-        }
 
     return schema, field
 
@@ -232,6 +227,11 @@ def get_schema_properties(serializer):
                 schema_metadata.pop('deprecated')
             schema.update(schema_metadata)
         name = field.label if hasattr(field, 'label') and field.label else field_name
+        if getattr(field, 'many', False) or getattr(rendered_field, 'many', False):
+            schema = {
+                'type': "array",
+                'items': schema,
+            }
         properties[name] = schema
 
     return properties, external_definitions

--- a/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
@@ -34,6 +34,8 @@ import inspect
 import jormungandr
 import six
 
+from jormungandr.interfaces.v1.serializer.jsonschema.fields import CustomSchemaType
+
 
 class SwaggerDefinitions(object):
     pass
@@ -216,6 +218,8 @@ def get_schema_properties(serializer):
             # complex types are stored in the `definition` list and referenced
             schema, definition = _from_nested_schema(rendered_field)
             external_definitions.append(definition)
+        elif isinstance(rendered_field, CustomSchemaType):
+            schema = rendered_field.schema()
         elif not schema_metadata:
             raise ValueError('unsupported field type %s for attr %s in object %s' % (
                 rendered_field, field_name, get_serializer_name(serializer)))

--- a/source/jormungandr/jormungandr/resources_utils.py
+++ b/source/jormungandr/jormungandr/resources_utils.py
@@ -41,7 +41,8 @@ import logging
 import pytz
 from jormungandr.exceptions import RegionNotFound, UnableToParse
 from jormungandr.interfaces.argument import ArgumentDoc
-from jormungandr.interfaces.v1.serializer.jsonschema.serializer import SwaggerPathSerializer
+from jormungandr.interfaces.v1.serializer.jsonschema.serializer import SwaggerPathSerializer, \
+    SwaggerOptionPathSerializer
 from jormungandr.interfaces.v1.swagger_schema import make_schema
 
 
@@ -129,4 +130,4 @@ class DocumentedResource(Resource):
             return options_response
         from flask import request
         schema = make_schema(resource=self, rule=request.url_rule)
-        return SwaggerPathSerializer(schema).data, 200, {'Allow': options_response.allow}
+        return SwaggerOptionPathSerializer(schema).data, 200, {'Allow': options_response.allow}

--- a/source/jormungandr/requirements_dev.txt
+++ b/source/jormungandr/requirements_dev.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
+swagger-spec-validator==2.1.0
 mock==1.0.1
 validators==0.10
 pytest==3.1.1
 pytest-mock==1.0
 pytest-cov==2.3.0
 requests-mock==1.0.0
-swagger-spec-validator==2.1.0
 flex==6.10.0

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -44,16 +44,22 @@ class TestSwaggerSchema(AbstractTestFixture):
     Test swagger schema
     """
 
+    def get_schema(self):
+        """Since the schema is quite long to get we cache it"""
+        if not hasattr(self, '_schema'):
+            self._schema = self.query('v1/schema')
+        return self._schema
+
     def test_swagger(self):
         """
         Test the global schema
         """
-        response = self.query('v1/schema')
+        response = self.get_schema()
         flex.core.validate(response)
         validator20.validate_spec(response)
 
     def _check_schema(self, url):
-        schema = self.query('v1/schema')
+        schema = self.get_schema()
 
         raw_response = self.tester.get(url)
 
@@ -64,7 +70,7 @@ class TestSwaggerSchema(AbstractTestFixture):
             url=url,
             status_code=raw_response.status_code,
             content_type='application/json')
-        flex.core.validate_api_call(schema, req, resp)
+        # flex.core.validate_api_call(schema, req, resp)
         return json.loads(raw_response.data)
 
     def test_coverage_schema(self):

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -29,6 +29,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 import json
+import logging
 
 from tests.tests_mechanism import dataset, AbstractTestFixture
 import flex
@@ -37,7 +38,8 @@ import flex
 def get_params(schema):
     return {p['name']: p for p in schema.get('get', {}).get('parameters', [])}
 
-@dataset({"main_autocomplete_test": {}})
+
+@dataset({"main_routing_test": {}, "main_autocomplete_test": {}})
 class TestSwaggerSchema(AbstractTestFixture):
     """
     Test swagger schema
@@ -121,5 +123,24 @@ class TestSwaggerSchema(AbstractTestFixture):
         assert any((o for o in r.get('places', []) if o.get('embedded_type') == 'address'))
 
         # we also check an adress with a house number
-        r = self._check_schema('/v1/coverage/main_autocomplete_test/places?q=2 rue')
+        r = self._check_schema('/v1/coverage/main_routing_test/places?q=2 rue')
         assert any((o for o in r.get('places', []) if o.get('embedded_type') == 'address'))
+
+
+    def test_stop_points_schema(self):
+        """
+        Test the stop_points schema
+        """
+        self._check_schema('/v1/coverage/main_routing_test/stop_points')
+
+    def test_stop_areas_schema(self):
+        self._check_schema('/v1/coverage/main_routing_test/stop_areas')
+
+    def test_lines_schema(self):
+        self._check_schema('/v1/coverage/main_routing_test/lines')
+
+    def test_routes_schema(self):
+        self._check_schema('/v1/coverage/main_routing_test/routes')
+
+    def test_networks_schema(self):
+        self._check_schema('/v1/coverage/main_routing_test/networks')

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -31,7 +31,6 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import json
 
 from tests.tests_mechanism import dataset, AbstractTestFixture
-from swagger_spec_validator import validator20
 import flex
 
 
@@ -56,7 +55,6 @@ class TestSwaggerSchema(AbstractTestFixture):
         """
         response = self.get_schema()
         flex.core.validate(response)
-        validator20.validate_spec(response)
 
     def _check_schema(self, url):
         schema = self.get_schema()
@@ -70,7 +68,7 @@ class TestSwaggerSchema(AbstractTestFixture):
             url=url,
             status_code=raw_response.status_code,
             content_type='application/json')
-        # flex.core.validate_api_call(schema, req, resp)
+        flex.core.validate_api_call(schema, req, resp)
         return json.loads(raw_response.data)
 
     def test_coverage_schema(self):


### PR DESCRIPTION
Add all the pt collections to the schema (`/stop_points`, `lines`, ...)

the schema is now a bit long to generate (around 2s), but I don't think it's a problem, it will be easily cachable


Also change the date handling, we use some custom formats (`navitia-date-time`, `navitia-date`, and `navitia-time`) in order to have better SDKs