### PR TITLE
kraken: impact on the shortest line sections

### DIFF
--- a/documentation/rfc/line_sections.md
+++ b/documentation/rfc/line_sections.md
@@ -1,10 +1,23 @@
 The line sections is a way to impact some routes between 2 stops areas
 
-We know (thanks to @eturk!) how to handle blocking line section (the buses don't stop anymore at the stops between the 2 stops), now we need to kown how to show them
+# Blocking a line section
 
-Here's a proposal on how to handle them:
+For each vehicle journey corresponding to the line/route, we get the corresponding base vehicle journey and identify all the smallest sections starting with the first stop and ending with the other.  Then, the new vehicle journey doesn't stop at all corresponding stop points.
 
-# representation
+For example, if we want the section A B on the following lollipop vehicle journey:
+
+```
+A B C D E A B
+***       ***
+```
+
+The disrupted vehicle journey will not stop at A and B:
+
+```
+C D E
+```
+
+# Displaying line sections
 
 The chosen approach is a bit like how delays are handled with `impacted_objects` being a `trip` and `impacted_stops` being the stop_times of this trip
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -110,7 +110,7 @@ target_link_libraries(fill_pb_placemark_test ed data types routing fare georef a
 ADD_BOOST_TEST(fill_pb_placemark_test)
 
 add_executable(type_test tests/test.cpp)
-target_link_libraries(type_test types data utils ${BOOST_DEV_LIBS} log4cplus)
+target_link_libraries(type_test types data ed utils ${BOOST_DEV_LIBS} log4cplus)
 add_dependencies(type_test protobuf_files)
 ADD_BOOST_TEST(type_test)
 

--- a/source/type/tests/test.cpp
+++ b/source/type/tests/test.cpp
@@ -38,12 +38,14 @@ www.navitia.io
 #include "type/datetime.h"
 #include "tests/utils_test.h"
 #include "type/meta_data.h"
+#include "ed/build_helper.h"
 
 #include <boost/geometry.hpp>
 #include <boost/make_shared.hpp>
 
 namespace pt = boost::posix_time;
 namespace bg = boost::gregorian;
+using namespace navitia;
 using navitia::type::disruption::Impact;
 using navitia::type::disruption::Disruption;
 
@@ -215,4 +217,70 @@ BOOST_AUTO_TEST_CASE(tz_handler_overflow_test) {
 
     BOOST_CHECK_EQUAL_RANGE(periods, build_dst_periods);
     BOOST_CHECK_EQUAL(build_dst_periods.begin()->first, 60*60*12);
+}
+
+BOOST_AUTO_TEST_CASE(get_sections_stop_points){
+    ed::builder b("20120614");
+    // 0 1 0 2 3 0 4 2
+    b.vj("A")
+        ("0", 8000, 8000)
+        ("1", 8000, 8000)
+        ("0", 8000, 8000)
+        ("2", 8000, 8000)
+        ("3", 8000, 8000)
+        ("0", 8000, 8000)
+        ("4", 8000, 8000)
+        ("2", 8000, 8000)
+        ("5", 8000, 8000)
+        ("2", 8000, 8000);
+    b.data->pt_data->index();
+    b.data->complete();
+    b.finish();
+
+    const auto* vj = b.data->pt_data->vehicle_journeys.at(0);
+    const auto sa = std::vector<type::StopArea*>{
+        b.data->pt_data->stop_areas_map.at("0"),
+        b.data->pt_data->stop_areas_map.at("1"),
+        b.data->pt_data->stop_areas_map.at("2"),
+        b.data->pt_data->stop_areas_map.at("3"),
+        b.data->pt_data->stop_areas_map.at("4"),
+        b.data->pt_data->stop_areas_map.at("5"),
+    };
+    const auto sp = std::vector<type::StopPoint*>{
+        b.data->pt_data->stop_points_map.at("0"),
+        b.data->pt_data->stop_points_map.at("1"),
+        b.data->pt_data->stop_points_map.at("2"),
+        b.data->pt_data->stop_points_map.at("3"),
+        b.data->pt_data->stop_points_map.at("4"),
+        b.data->pt_data->stop_points_map.at("5"),
+    };
+
+    // 0 1 0 2 3 0 4 2 5 2
+    //   *
+    BOOST_CHECK_EQUAL(vj->get_sections_stop_points(sa[1], sa[1]),
+                      std::set<type::StopPoint*>({sp[1]}));
+    // 0 1 0 2 3 0 4 2 5 2
+    //   *******
+    BOOST_CHECK_EQUAL(vj->get_sections_stop_points(sa[1], sa[3]),
+                      std::set<type::StopPoint*>({sp[1], sp[0], sp[2], sp[3]}));
+    // 0 1 0 2 3 0 4 2 5 2
+    //
+    // 4 is after 0 -> empty
+    BOOST_CHECK_EQUAL(vj->get_sections_stop_points(sa[4], sa[0]),
+                      std::set<type::StopPoint*>({}));
+    // 0 1 0 2 3 0 4 2 5 2
+    // *   *     *
+    // route point, only the corresponding stop point
+    BOOST_CHECK_EQUAL(vj->get_sections_stop_points(sa[0], sa[0]),
+                      std::set<type::StopPoint*>({sp[0]}));
+    // 0 1 0 2 3 0 4 2 5 2
+    //     *****
+    // shortest sections, thus we don't have 1
+    BOOST_CHECK_EQUAL(vj->get_sections_stop_points(sa[0], sa[3]),
+                      std::set<type::StopPoint*>({sp[0], sp[2], sp[3]}));
+    // 0 1 0 2 3 0 4 2 5 2
+    //     ***   *****
+    // shortest sections, thus we don't have 1, 3 and 5
+    BOOST_CHECK_EQUAL(vj->get_sections_stop_points(sa[0], sa[2]),
+                      std::set<type::StopPoint*>({sp[0], sp[2], sp[4]}));
 }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -237,18 +237,31 @@ std::set<StopPoint*> VehicleJourney::get_sections_stop_points(
        const StopArea* start_stop,
        const StopArea* end_stop
 ) const {
-     /*
-     * We are checking if the journey pass first by the start_point of the line_section and
-     * the end_point. We can have start_point == end_point.
+    /*
+     * Identify all the smallest sections starting with start_stop and
+     * ending with end_stop. Then we return the set of stop points
+     * corresponding to the identified sections.
      *
-     * We perform the check on the base_vj stop_times, if it exists, in order to be able to
-     * apply multiple line_section disruption.
+     * For example, if we want the section A B:
+     *    A B C D E A B
+     *    ***       ***
+     * we return {A, B} (not everything)
+     *
+     * Note:
+     *
+     * We are checking if the journey pass first by the start_point of
+     * the line_section and the end_point. We can have start_point ==
+     * end_point.
+     *
+     * We perform the check on the base_vj stop_times, if it exists,
+     * in order to be able to apply multiple line_section disruption.
      *
      * If we have a line A :
      *
      *      s1----->s2----->s3----->s4----->s5
      *
-     * if you first impact [s2, s3] then in another disruption impact [s2, s4], you need the base stops
+     * if you first impact [s2, s3] then in another disruption impact
+     * [s2, s4], you need the base stops
      *
      * There is also the temporal problem.
      * For example if we have two disruptions :


### PR DESCRIPTION
To be able to modelize a route point impact, we handle differently the line sections: we take all the shortest corresponding line sections of the vj to select the stop points to remove.  So now, if we impact A-A to A B C A, only A will be removed.