### PR TITLE
Kraken: better autocomplete

### DIFF
--- a/source/autocomplete/autocomplete.cpp
+++ b/source/autocomplete/autocomplete.cpp
@@ -161,7 +161,7 @@ std::pair<size_t, size_t> longest_common_substring(const std::string& str1, cons
     }
     auto curr = std::vector<size_t>(str2.size());
     auto prev = std::vector<size_t>(str2.size());
-    size_t maxSubstr = 0;
+    size_t max_substr = 0;
     size_t position = 0;
 
     for (size_t i = 0; i < str1.size(); ++i) {
@@ -175,14 +175,14 @@ std::pair<size_t, size_t> longest_common_substring(const std::string& str1, cons
             } else {
                 curr[j] = 1 + prev[j - 1];
             }
-            if (maxSubstr < curr[j]) {
-                maxSubstr = curr[j];
+            if (max_substr < curr[j]) {
+                max_substr = curr[j];
                 position = j;
             }
         }
         std::swap(curr, prev);
     }
-    return {maxSubstr, position};
+    return {max_substr, position};
 }
 
 // https://isocpp.org/wiki/faq/templates#separate-template-class-defn-from-decl

--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -55,6 +55,8 @@ struct Compare {
     }
 };
 
+std::pair<size_t, size_t> longest_common_substring(const std::string&, const std::string&);
+
 using autocomplete_map = std::map<std::string, std::string, Compare>;
 /** Map de type Autocomplete
   *
@@ -67,20 +69,20 @@ template<class T>
 struct Autocomplete
 {
     /// structure qui contient la position des mots dans autocomplete et le nombre de match.
-    struct fl_quality{
-        T idx;
-        int nb_found;
-        int word_len;
-        int score;
-        int quality;
+    struct fl_quality {
+        T idx = 0;
+        int nb_found = 0;
+        int word_len = 0;
+        int quality = 0;
         navitia::type::GeographicalCoord coord;
-        int house_number;
-
-        fl_quality() :idx(0), nb_found(0), word_len(0), score(0), quality(0), house_number(-1) {}
+        int house_number = -1;
+        std::tuple<int, size_t, int> scores = std::make_tuple(0, 0, 0);
+        int score() const {
+            return std::get<0>(scores) * 100 + std::get<1>(scores) * 10 + std::get<2>(scores);
+        }
         bool operator<(const fl_quality & other) const{
             return this->quality > other.quality;
         }
-
     };
 
     /// Structure temporaire pour garder les informations sur chaque ObjetTC:
@@ -117,8 +119,11 @@ struct Autocomplete
     /// Structure pour garder les informations comme nombre des mots, la distance des mots...dans chaque Autocomplete (Position)
     std::map<T, word_quality> word_quality_list;
 
+    // for each T, we store the originaly indexed string (for better score handling)
+    std::map<T, std::string> indexed_string;
+
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
-        ar & word_dictionnary & word_quality_list &pattern_dictionnary &object_type;
+        ar & word_dictionnary & word_quality_list & pattern_dictionnary & object_type & indexed_string;
     }
 
     /// Efface les structures de données sérialisées
@@ -128,6 +133,7 @@ struct Autocomplete
         temp_pattern_map.clear();
         pattern_dictionnary.clear();
         word_quality_list.clear();
+        indexed_string.clear();
     }
 
     // Méthodes permettant de construire l'indexe
@@ -157,6 +163,7 @@ struct Autocomplete
         wc.word_distance = distance;
         wc.score = 0;
         word_quality_list[position] = wc;
+        indexed_string[position] = strip_accents_and_lower(str);
     }
 
     void add_vec_pattern(const std::set<std::string> &vec_words, T position){
@@ -303,13 +310,29 @@ struct Autocomplete
         }
     };
 
-    void sort_and_truncate_by_score(std::vector<fl_quality>& input, size_t nbmax) const {
-        sort_and_truncate(input, nbmax, [](const fl_quality& a, const fl_quality& b){return a.score > b.score;});
-    }
-
     std::vector<fl_quality> sort_and_truncate_by_quality(std::vector<fl_quality> input, size_t nbmax) const {
         sort_and_truncate(input, nbmax, [](const fl_quality& a, const fl_quality& b){return a.quality > b.quality;});
         return input;
+    }
+
+    /**
+     * compute the scores of a result
+     *
+     * it's a list of scores and the scores are compared lexicographicaly
+     * @param str: string to search
+     * @param position: element to score
+     */
+    std::tuple<int, size_t, int> compute_result_scores(const std::string& str, T position) const {
+        auto global_score = word_quality_list.at(position).score;
+
+        // TODO lache un com'!
+        const auto& indexed_str = indexed_string.at(position);
+
+        return std::make_tuple(
+            global_score,
+            lcs_and_pos.first,
+            -1 * lcs_and_pos.second // we want to minimize the position
+        );
     }
 
     /** On passe une chaîne de charactère contenant des mots et on trouve toutes les positions contenant au moins un des mots*/
@@ -317,7 +340,7 @@ struct Autocomplete
                                           size_t nbmax,
                                           std::function<bool(T)> keep_element,
                                           const std::set<std::string>& ghostwords)
-                                          const{
+                                          const {
         auto vec = tokenize(str, ghostwords);
         int wordLength = 0;
         fl_quality quality;
@@ -329,17 +352,21 @@ struct Autocomplete
         // Créer un vector de réponse:
         std::vector<fl_quality> vec_quality;
 
-        for(auto i : index_result){
-            if(keep_element(i)) {
+        for (auto i : index_result) {
+            if (keep_element(i)) {
                 quality.idx = i;
                 quality.nb_found = word_quality_list.at(quality.idx).word_count;
                 quality.word_len = wordLength;
-                quality.score = word_quality_list.at(quality.idx).score;
+                quality.scores = this->compute_result_scores(str, quality.idx);
+
                 quality.quality = 100;
                 vec_quality.push_back(quality);
             }
         }
-        sort_and_truncate_by_score(vec_quality, nbmax);
+
+        sort_and_truncate(vec_quality, nbmax, [](const fl_quality& a, const fl_quality& b) {
+            return a.scores > b.scores;
+        });
         return vec_quality;
     }
 
@@ -409,7 +436,7 @@ struct Autocomplete
                     quality.idx = pair.first;
                     quality.nb_found = pair.second.nb_found;
                     quality.word_len = wordLength;
-                    quality.score = word_quality_list.at(quality.idx).score;
+                    quality.scores = this->compute_result_scores(str, quality.idx);
                     quality.quality = calc_quality_pattern(quality, word_weight, max_score, pattern_count);
                     vec_quality.push_back(quality);
                 }

--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -377,12 +377,6 @@ struct Autocomplete
                                                 std::function<bool(T)> keep_element,
                                                 int word_length) const;
 
-    std::vector<fl_quality> find_complete_way(const std::string& str,
-                                              size_t nbmax,
-                                              std::function<bool(T)> keep_element,
-                                              const std::set<std::string>& ghostwords,
-                                              const navitia::georef::GeoRef& geo_ref) const;
-
     /** Recherche des patterns les plus proche : faute de frappe */
     std::vector<fl_quality> find_partial_with_pattern(const std::string & str,
                                                       const int word_weight,

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -42,34 +42,28 @@ static void create_place_pb(const std::vector<Autocomplete<nt::idx_t>::fl_qualit
                             navitia::PbCreator& pb_creator){
     for(auto result_item : result){
         pbnavitia::PtObject* place = pb_creator.add_places();
+        place->set_quality(result_item.quality);
+        place->add_scores(std::get<0>(result_item.scores));
+        place->add_scores(std::get<1>(result_item.scores));
+        place->add_scores(std::get<2>(result_item.scores));
         switch(type){
         case nt::Type_e::StopArea:
             pb_creator.fill(data.pt_data->stop_areas[result_item.idx], place, depth);
-            place->set_quality(result_item.quality);
-            place->set_score(result_item.score);
             break;
         case nt::Type_e::Admin:
             pb_creator.fill(data.geo_ref->admins[result_item.idx], place, depth);
-            place->set_quality(result_item.quality);
-            place->set_score(result_item.score);
             break;
         case nt::Type_e::StopPoint:
             pb_creator.fill(data.pt_data->stop_points[result_item.idx], place, depth);
-            place->set_quality(result_item.quality);
-            place->set_score(result_item.score);
             break;
         case nt::Type_e::Address:{
             const auto& way_coord = navitia::WayCoord(data.geo_ref->ways[result_item.idx],
                     result_item.coord, result_item.house_number);
             pb_creator.fill(&way_coord, place, depth);
-            place->set_quality(result_item.quality);
-            place->set_score(result_item.score);
             break;
         }
         case nt::Type_e::POI:
             pb_creator.fill(data.geo_ref->pois[result_item.idx], place, depth);
-            place->set_quality(result_item.quality);
-            place->set_score(result_item.score);
             break;
         case nt::Type_e::Network:
             pb_creator.fill(data.pt_data->networks[result_item.idx], place, depth);
@@ -333,8 +327,10 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
         if ((a.quality() != b.quality()) && (a.quality() == 100  || b.quality() == 100)) {
             return a.quality() > b.quality();
         }
-        if (a.score() != b.score()) {
-            return a.score() > b.score();
+        for (auto s_idx = 0; s_idx < std::min(a.scores_size(), b.scores_size()) ; ++s_idx) {
+            if (a.scores(s_idx) != b.scores(s_idx)) {
+                return a.scores(s_idx) > b.scores(s_idx);
+            }
         }
         if (a.quality() != b.quality()) {
             return a.quality() > b.quality();

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -1763,21 +1763,15 @@ BOOST_AUTO_TEST_CASE(test_ways){
     way->uri = "2";
     geo_ref.ways.push_back(way);
 
-    auto res = ac.find_complete_way("rue de la loire saint seb", nbmax, [](int){return true;}, ghostwords, geo_ref);
+    auto res = ac.find_complete("rue de la loire saint seb", nbmax, [](int){return true;}, ghostwords);
     BOOST_REQUIRE_EQUAL(res.size(), 3);
 
-    BOOST_REQUIRE_EQUAL(res[0].idx, 2); // The first one is "rue de la Loire"
-    BOOST_REQUIRE_EQUAL(std::get<0>(res[0].scores), 6);
-    BOOST_REQUIRE_EQUAL(res[1].idx, 1); // The second one is "rue De BOURDAILLERIE"
-    BOOST_REQUIRE_EQUAL(std::get<0>(res[1].scores), 5);
-    BOOST_REQUIRE_EQUAL(res[2].idx, 0); // The second one is "rue De BOURDAILLERIE"
-    BOOST_REQUIRE_EQUAL(std::get<0>(res[2].scores), 1);
-
+    BOOST_CHECK_EQUAL(res[0].idx, 2); // The first one is "rue de la Loire"
+    BOOST_CHECK_EQUAL(res[1].idx, 1); // The second one is "rue De BOURDAILLERIE"
+    BOOST_CHECK_EQUAL(res[2].idx, 0); // The third one is "rue CERNAVODA"
 }
 
-
 BOOST_AUTO_TEST_CASE(test_toknizer_with_delimitor_synonyms_tests){
-
     autocomplete_map synonyms;
     synonyms["cc"]="centre commercial";
     synonyms["ld"]="Lieu-Dit";

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -609,7 +609,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_duplicate_words_and_weight_test){
 4. In the result the administrative_region is the first one
 5. All the stop_areas with same quality are sorted first by the number of stoppoints,
    then by size of the stop name
-   (because the name "Quimper" is aggregated after the stop name and we check the position of if)
+   (because the name "Quimper" is aggregated after the stop name and we check its position)
 6. There 10 elements in the result.
 */
 BOOST_AUTO_TEST_CASE(autocomplete_functional_test_admin_and_SA_test) {

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -809,8 +809,7 @@ void builder::finish() {
  }
 
  void builder::build_autocomplete() {
-    data->pt_data->build_autocomplete(*(data->geo_ref));
-    data->geo_ref->build_autocomplete_list();
+    data->build_autocomplete();
     data->compute_labels();
 }
 }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -501,7 +501,7 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(const std
         search_str = str;
     }
     if (search_type == 0){
-        to_return = fl_way.find_complete_way(search_str, nbmax, keep_element, ghostwords, *this);
+        to_return = fl_way.find_complete(search_str, nbmax, keep_element, ghostwords);
     }else{
         to_return = fl_way.find_partial_with_pattern(search_str, word_weight, nbmax, keep_element, ghostwords);
     }

--- a/source/jormungandr/tests/autocomplete_tests.py
+++ b/source/jormungandr/tests/autocomplete_tests.py
@@ -54,7 +54,7 @@ def valid_autocomplete_with_multi_object(response):
     assert len(places) == 10
     assert places[0]['embedded_type'] == 'administrative_region'
     assert places[1]['embedded_type'] == 'stop_area'
-    assert places[1]['name'] == 'Becharles (Quimper)'
+    assert places[1]['name'] == 'IUT (Quimper)'
     assert places[2]['embedded_type'] == 'stop_area'
     assert places[3]['embedded_type'] == 'stop_area'
     assert places[4]['embedded_type'] == 'stop_area'

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -64,7 +64,7 @@ namespace navitia { namespace type {
 
 wrong_version::~wrong_version() noexcept {}
 
-const unsigned int Data::data_version = 64; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 65; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     data_identifier(data_identifier),


### PR DESCRIPTION
there was a problem, the 'ligne b' was impossible to find because it all lines (with 'ligne' in their indexed label), and various starting with 'b' (like 'bus' :wink:)

So the autocomplete algorithm has been a bit reworked and now, after the scoring of all the prefix, we score all the candidates with:
* the absolute score of the object (like the size of the admin, of the stoppoints, ...)
* by trying to find the longest common substring between the string search and the indexed string
* the position of this substring in the indexed string

so when we search 'rer b':

if we get 3 candidates:

1 -> 'Busval d'Oise Bus 95-01 (Zone Aéroportuaire Aéroport Charles de 1 RER B - Luzarches Gare)'
2 -> 'Rosny Bois Perrier RER (Rosny-sous-Bois)'
3 -> 'rer b'

for 1 the longest common substring is 'rer b' and its position is 74
for 2 the longest common substring is 'rer' and its position is 22
for 3 the longest common substring is 'rer b' and its position is 5 (it's the end of the substring)

thus we sort in the order (3, 1, 2)


as a side effect we can remove the uggly hack to be able to find "rue de loire saint sebastien sur loire" :tada: 

Note: the lz4 for pdl grow from 293M to 302M (since we now store the full indexed label for each object) and the kraken RAM from 1450M to 1472M)