### PR TITLE
Jormun & Tyr: add a default coord to a user

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/parsers.py
+++ b/source/jormungandr/jormungandr/interfaces/parsers.py
@@ -77,26 +77,3 @@ def unsigned_integer(value):
         return d
     except ValueError as e:
         raise ValueError("Unable to evaluate, {}".format(e))
-
-
-class coord_format(object):
-    def __call__(self, coord):
-        """
-        Validate coordinates format (lon;lat)
-        """
-        lon_lat_splitted = coord.split(";")
-        if len(lon_lat_splitted) != 2:
-            raise ValueError('Invalid coordinate parameter. It must be lon;lat where lon and lat are floats.')
-
-        lon, lat = lon_lat_splitted
-        lat = float(lat)
-        if not (-90.0 <= lat <= 90.0):
-            raise ValueError("lat should be between -90 and 90")
-        lon = float(lon)
-        if not (180.0 >= lon >= -180.0):
-            raise ValueError("lon should be between -180 and 180")
-
-        return coord
-
-    def description(self):
-        return ParameterDescription(type=str, metadata={'pattern': '.*;.*'})

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -51,13 +51,11 @@ from flask_restful import marshal_with
 import datetime
 from jormungandr.parking_space_availability.bss.stands_manager import ManageStands
 import ujson as json
-from jormungandr.interfaces.parsers import coord_format, option_value
+from jormungandr.interfaces.parsers import option_value
 from jormungandr.scenarios.utils import pb_type
-
-
-# instance marshal
-from navitiacommon.parser_args_type import ParameterDescription
+from navitiacommon.parser_args_type import ParameterDescription, coord_format
 import six
+
 
 places = {
     "places": NonNullList(NonNullNested(place)),
@@ -133,6 +131,9 @@ class Places(ResourceUri):
 
         if args['shape'] is None and user and user.shape:
             args['shape'] = json.loads(user.shape)
+
+        if args['from'] is None and user and user.default_coord:
+            args['from'] = coord_format()(user.default_coord)
 
         # If a region or coords are asked, we do the search according
         # to the region, else, we do a word wide search

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -81,7 +81,8 @@ class FakeUser:
     We create a user independent from a database
     """
     def __init__(self, name, id,
-                 have_access_to_free_instances=True, is_super_user=False, is_blocked=False, shape=None):
+                 have_access_to_free_instances=True, is_super_user=False, is_blocked=False, shape=None,
+                 default_coord=None):
         """
         We just need a fake user, we don't really care about its identity
         """
@@ -92,6 +93,7 @@ class FakeUser:
         self.end_point_id = None
         self._is_blocked = is_blocked
         self.shape = shape
+        self.default_coord = default_coord
 
     @classmethod
     def get_from_token(cls, token):

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -61,7 +61,7 @@ class ArrayOfEnum(ARRAY):
         super_rp = super(ArrayOfEnum, self).result_processor(dialect, coltype)
 
         def handle_raw_string(value):
-            if value==None:
+            if value is None:
                 return []
             inner = re.match(r"^{(.*)}$", value).group(1)
             return inner.split(",")
@@ -124,8 +124,10 @@ class User(db.Model):
     type = db.Column(db.Enum('with_free_instances', 'without_free_instances', 'super_user', name='user_type'),
                              default='with_free_instances', nullable=False)
 
+    # Note: we don't store postgis object for the shape and the default_coord
+    # because we don't want postgis dependency for the tyr database
     shape = db.Column(db.Text, nullable=True)
-
+    default_coord = db.Column(db.Text, nullable=True)
 
     def __init__(self, login=None, email=None, block_until=None, keys=None, authorizations=None):
         self.login = login

--- a/source/navitiacommon/navitiacommon/parser_args_type.py
+++ b/source/navitiacommon/navitiacommon/parser_args_type.py
@@ -117,10 +117,16 @@ def geojson_argument(value):
 
 
 class coord_format(object):
+    def __init__(self, nullable=False):
+        super(coord_format, self).__init__()
+        self.nullable = nullable
+
     def __call__(self, coord):
         """
         Validate coordinates format (lon;lat)
         """
+        if coord == '' and self.nullable:
+            return coord
         lon_lat_splitted = coord.split(";")
         if len(lon_lat_splitted) != 2:
             raise ValueError('Invalid coordinate parameter. It must be lon;lat where lon and lat are floats.')

--- a/source/navitiacommon/navitiacommon/parser_args_type.py
+++ b/source/navitiacommon/navitiacommon/parser_args_type.py
@@ -116,4 +116,27 @@ def geojson_argument(value):
     return value
 
 
+class coord_format(object):
+    def __call__(self, coord):
+        """
+        Validate coordinates format (lon;lat)
+        """
+        lon_lat_splitted = coord.split(";")
+        if len(lon_lat_splitted) != 2:
+            raise ValueError('Invalid coordinate parameter. It must be lon;lat where lon and lat are floats.')
+
+        lon, lat = lon_lat_splitted
+        lat = float(lat)
+        if not (-90.0 <= lat <= 90.0):
+            raise ValueError("lat should be between -90 and 90")
+        lon = float(lon)
+        if not (180.0 >= lon >= -180.0):
+            raise ValueError("lon should be between -180 and 180")
+
+        return coord
+
+    def description(self):
+        return ParameterDescription(type=str, metadata={'pattern': '.*;.*'})
+
+
 default_count_arg_type = _make_interval_argument(max_value=1000, min_value=0)

--- a/source/tyr/migrations/versions/4ec9c897fc03_default_user_coord.py
+++ b/source/tyr/migrations/versions/4ec9c897fc03_default_user_coord.py
@@ -1,0 +1,22 @@
+"""add a default coord in the user to be used in the bragi autocomplete service
+
+Revision ID: 4ec9c897fc03
+Revises: 4af6f969bfa8
+Create Date: 2017-07-07 09:38:59.021358
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4ec9c897fc03'
+down_revision = '4af6f969bfa8'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('user', sa.Column('default_coord', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user', 'default_coord')

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -142,7 +142,8 @@ user_fields = {
     'end_point': fields.Nested(end_point_fields),
     'billing_plan': fields.Nested(billing_plan_fields),
     'has_shape': HasShape,
-    'shape': Shape
+    'shape': Shape,
+    'default_coord': fields.Raw,
 }
 
 user_fields_full = {
@@ -159,7 +160,8 @@ user_fields_full = {
     'end_point': fields.Nested(end_point_fields),
     'billing_plan': fields.Nested(billing_plan_fields),
     'has_shape': HasShape,
-    'shape': Shape
+    'shape': Shape,
+    'default_coord': fields.Raw,
 }
 
 dataset_field = {


### PR DESCRIPTION
we add the possibility to set a default coordinate to a user.

This coordinate is given to the autocomplete service (bragi) if no
coordinate is set in the query (the coord is used to sort the result by
proximity to this coord)

Note: for a user with a default autocomplete coord to call the autocomplete without any coord he must call the api with an empty coord (`/places?q=whatewer&from=`)

this form is allowed only for user with default coord defined