### PR TITLE
kraken: fix debian 7 compilation problem

### DIFF
--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -76,7 +76,7 @@ struct Autocomplete
         int quality = 0;
         navitia::type::GeographicalCoord coord;
         int house_number = -1;
-        std::tuple<int, size_t, int> scores = std::make_tuple(0, 0, 0);
+        std::tuple<int, size_t, int> scores = std::make_tuple(0, size_t(0), 0);
         bool operator<(const fl_quality & other) const{
             return this->quality > other.quality;
         }


### PR DESCRIPTION
debian 7 old gcc version does not seem to be able to implicitly cast 0
to size_t