### PR TITLE
Kraken: add an osm feed_publisher

### DIFF
--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -944,15 +944,19 @@ class OnBasicRouting():
 
         assert len(response["disruptions"]) == 0
         feed_publishers = response["feed_publishers"]
-        assert len(feed_publishers) == 1
+        assert len(feed_publishers) == 2
         for feed_publisher in feed_publishers:
             is_valid_feed_publisher(feed_publisher)
 
-        feed_publisher = feed_publishers[0]
-        assert (feed_publisher["id"] == "base_contributor")
+        feed_publisher = next(f for f in feed_publishers if f['id'] == "base_contributor")
         assert (feed_publisher["name"] == "base contributor")
         assert (feed_publisher["license"] == "L-contributor")
         assert (feed_publisher["url"] == "www.canaltp.fr")
+
+        osm = next(f for f in feed_publishers if f['id'] == "osm")
+        assert (osm["name"] == "openstreetmap")
+        assert (osm["license"] == "ODbL")
+        assert (osm["url"] == "https://www.openstreetmap.org/copyright")
 
     def test_sp_outside_georef(self):
         """

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -299,20 +299,29 @@ void Worker::feed_publisher(){
     if (!conf.display_contributors()){
         this->pb_creator.clear_feed_publishers();
     }
-    if (d->meta->license.empty()){
-        return;
+    if (! d->meta->license.empty()) {
+        auto pt_feed_publisher = this->pb_creator.add_feed_publishers();
+        // instance_name is required
+        pt_feed_publisher->set_id(d->meta->instance_name);
+        if (!d->meta->publisher_name.empty()){
+            pt_feed_publisher->set_name(d->meta->publisher_name);
+        }
+        if (!d->meta->publisher_url.empty()){
+            pt_feed_publisher->set_url(d->meta->publisher_url);
+        }
+        if (!d->meta->license.empty()){
+            pt_feed_publisher->set_license(d->meta->license);
+        }
     }
-    auto pb_feed_publisher = this->pb_creator.add_feed_publishers();
-    // instance_name is required
-    pb_feed_publisher->set_id(d->meta->instance_name);
-    if (!d->meta->publisher_name.empty()){
-        pb_feed_publisher->set_name(d->meta->publisher_name);
-    }
-    if (!d->meta->publisher_url.empty()){
-        pb_feed_publisher->set_url(d->meta->publisher_url);
-    }
-    if (!d->meta->license.empty()){
-        pb_feed_publisher->set_license(d->meta->license);
+
+    if (d->meta->street_network_source == "osm") {
+        // we hardcode the osm feed_publisher
+        auto osm_fp = this->pb_creator.add_feed_publishers();
+        // instance_name is required
+        osm_fp->set_id("osm");
+        osm_fp->set_name("openstreetmap");
+        osm_fp->set_url("https://www.openstreetmap.org/copyright");
+        osm_fp->set_license("ODbL");
     }
 }
 

--- a/source/tests/basic_routing_test.cpp
+++ b/source/tests/basic_routing_test.cpp
@@ -95,6 +95,8 @@ int main(int argc, const char* const argv[]) {
     b.connection("F", "G", 2*60);
     // Empty license for global feed publisher
     b.data->meta->license = "";
+    // and we set the streetnetwork provider as osm to test the osm licence
+    b.data->meta->street_network_source = "osm";
     b.data->pt_data->codes.add(b.sps.at("A"), "external_code", "stop_point:A");
     b.data->pt_data->codes.add(b.sps.at("A"), "source", "Ain");
     b.data->pt_data->codes.add(b.sps.at("A"), "source", "Aisne");

--- a/source/type/meta_data.h
+++ b/source/type/meta_data.h
@@ -40,11 +40,8 @@ www.navitia.io
 namespace navitia { namespace type {
 
 struct MetaData{
-
     boost::gregorian::date_period production_date;
-
     boost::posix_time::ptime publication_date;
-
 
     std::string shape;
 


### PR DESCRIPTION
when the data are provided by osm, we add a hardcoded feedpublisher for
osm:

```json
{
    "id": "osm",
    "license": "ODbL",
    "name": "openstreetmap",
    "url": "http://www.openstreetmap.org/copyright"
}
```

linked to https://jira.canaltp.fr/browse/NAVP-667