### PR TITLE
Jormungandr: add a feed publisher for bss

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/bss/atos.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/atos.py
@@ -37,10 +37,7 @@ import pybreaker
 
 from jormungandr.ptref import FeedPublisher
 
-DEFAULT_ATOS_FEED_PUBLISHER = {
-    'id': 'atos',
-    'name': 'atos'
-}
+DEFAULT_ATOS_FEED_PUBLISHER = None
 
 
 class AtosProvider(BssProvider):
@@ -54,7 +51,7 @@ class AtosProvider(BssProvider):
         self.timeout = timeout
         self._client = None
         self.breaker = pybreaker.CircuitBreaker(fail_max=kwargs.get('fail_max', 5), reset_timeout=kwargs.get('reset_timeout', 120))
-        self._feed_publisher = FeedPublisher(**feed_publisher)
+        self._feed_publisher = FeedPublisher(**feed_publisher) if feed_publisher else None
 
     def __repr__(self):
         return self.WS_URL + str(self.id_ao)

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/atos.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/atos.py
@@ -35,10 +35,18 @@ import zeep
 import logging
 import pybreaker
 
+from jormungandr.ptref import FeedPublisher
+
+DEFAULT_ATOS_FEED_PUBLISHER = {
+    'id': 'atos',
+    'name': 'atos'
+}
+
 
 class AtosProvider(BssProvider):
 
-    def __init__(self, id_ao, network, url, operators={'keolis'}, timeout=5, **kwargs):
+    def __init__(self, id_ao, network, url, operators={'keolis'}, timeout=5,
+                 feed_publisher=DEFAULT_ATOS_FEED_PUBLISHER, **kwargs):
         self.id_ao = id_ao
         self.network = network.lower()
         self.WS_URL = url
@@ -46,6 +54,7 @@ class AtosProvider(BssProvider):
         self.timeout = timeout
         self._client = None
         self.breaker = pybreaker.CircuitBreaker(fail_max=kwargs.get('fail_max', 5), reset_timeout=kwargs.get('reset_timeout', 120))
+        self._feed_publisher = FeedPublisher(**feed_publisher)
 
     def __repr__(self):
         return self.WS_URL + str(self.id_ao)
@@ -83,3 +92,6 @@ class AtosProvider(BssProvider):
 
     def status(self):
         return {'network': self.network, 'operators': self.operators, 'id_ao': self.id_ao}
+
+    def feed_publisher(self):
+        return self._feed_publisher

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider.py
@@ -47,3 +47,7 @@ class BssProvider(six.with_metaclass(ABCMeta, object)):
     @abstractmethod
     def status(self):
         pass
+
+    @abstractmethod
+    def feed_publisher(self):
+        pass

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
@@ -34,12 +34,21 @@ import pybreaker
 import requests as requests
 import logging
 
+from jormungandr.ptref import FeedPublisher
+
+DEFAULT_JCDECAUX_FEED_PUBLISHER = {
+    'id': 'jcdecaux',
+    'name': 'jcdecaux',
+    'license': 'Licence Ouverte / Open License',
+    'url': 'https://developer.jcdecaux.com/#/opendata/license'
+}
 
 class JcdecauxProvider(BssProvider):
 
     WS_URL_TEMPLATE = 'https://api.jcdecaux.com/vls/v1/stations/{}?contract={}&apiKey={}'
 
-    def __init__(self, network, contract, api_key, operators={'jcdecaux'}, timeout=10, **kwargs):
+    def __init__(self, network, contract, api_key, operators={'jcdecaux'}, timeout=10,
+                 feed_publisher=DEFAULT_JCDECAUX_FEED_PUBLISHER, **kwargs):
         self.network = network.lower()
         self.contract = contract
         self.api_key = api_key
@@ -48,6 +57,7 @@ class JcdecauxProvider(BssProvider):
         fail_max = kwargs.get('circuit_breaker_max_fail', app.config['CIRCUIT_BREAKER_MAX_JCDECAUX_FAIL'])
         reset_timeout = kwargs.get('circuit_breaker_reset_timeout', app.config['CIRCUIT_BREAKER_JCDECAUX_TIMEOUT_S'])
         self.breaker = pybreaker.CircuitBreaker(fail_max=fail_max, reset_timeout=reset_timeout)
+        self._feed_publisher = FeedPublisher(**feed_publisher)
 
     def support_poi(self, poi):
         properties = poi.get('properties', {})
@@ -75,3 +85,6 @@ class JcdecauxProvider(BssProvider):
 
     def status(self):
         return {'network': self.network, 'operators': self.operators, 'contract': self.contract}
+
+    def feed_publisher(self):
+        return self._feed_publisher

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
@@ -57,7 +57,7 @@ class JcdecauxProvider(BssProvider):
         fail_max = kwargs.get('circuit_breaker_max_fail', app.config['CIRCUIT_BREAKER_MAX_JCDECAUX_FAIL'])
         reset_timeout = kwargs.get('circuit_breaker_reset_timeout', app.config['CIRCUIT_BREAKER_JCDECAUX_TIMEOUT_S'])
         self.breaker = pybreaker.CircuitBreaker(fail_max=fail_max, reset_timeout=reset_timeout)
-        self._feed_publisher = FeedPublisher(**feed_publisher)
+        self._feed_publisher = FeedPublisher(**feed_publisher) if feed_publisher else None
 
     def support_poi(self, poi):
         properties = poi.get('properties', {})

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/stands_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/stands_manager.py
@@ -39,7 +39,9 @@ def _add_feed_publisher(response, providers):
     """
     feeds = response.get('feed_publishers', [])
     for p in providers or []:
-        feeds.append(p.feed_publisher())
+        f = p.feed_publisher()
+        if f:
+            feeds.append(f)
 
 
 class ManageStands(object):

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/stands_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/stands_manager.py
@@ -32,6 +32,16 @@ from jormungandr import i_manager, bss_provider_manager
 from functools import wraps
 import logging
 
+
+def _add_feed_publisher(response, providers):
+    """
+    add the feed publisher of the providers to the global feed_publishers of the response
+    """
+    feeds = response.get('feed_publishers', [])
+    for p in providers or []:
+        feeds.append(p.feed_publisher())
+
+
 class ManageStands(object):
 
     def __init__(self, resource, attribute):
@@ -52,7 +62,8 @@ class ManageStands(object):
                     add_bss_availability = bss_provider_manager.handle_journeys if self.attribute == 'journeys' \
                         else bss_provider_manager.handle_places
                     try:
-                        response[self.attribute] = add_bss_availability(response[self.attribute])
+                        providers = add_bss_availability(response[self.attribute])
+                        _add_feed_publisher(response, providers)
                     except:
                         logger = logging.getLogger(__name__)
                         logger.exception('Error while handling BSS realtime availability')

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_mock.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_mock.py
@@ -29,6 +29,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from jormungandr.parking_space_availability.bss.bss_provider import BssProvider
 from jormungandr.parking_space_availability.bss.stands import Stands
+from jormungandr.ptref import FeedPublisher
 
 
 class BssMockProvider(BssProvider):
@@ -41,3 +42,6 @@ class BssMockProvider(BssProvider):
 
     def status(self):
         return {}
+
+    def feed_publisher(self):
+        return FeedPublisher(id='mock', name='mock provider')

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_provider_manager_test.py
@@ -81,12 +81,16 @@ def realtime_places_handle_test():
         }
     ]
     manager = BssProviderManager(CONFIG)
-    places_with_stands = manager.handle_places(places)
-    assert 'stands' in places_with_stands[0]['poi']
-    stands = places_with_stands[0]['poi']['stands']
+    providers = manager.handle_places(places)
+    assert 'stands' in places[0]['poi']
+    stands = places[0]['poi']['stands']
     assert stands.available_places == 5
     assert stands.available_bikes == 9
     assert stands.total_stands == 14
+
+    assert providers and len(providers) == 1
+    f = providers.pop().feed_publisher()
+    assert f and f.name == 'mock provider'
 
 
 def realtime_pois_handle_test():
@@ -103,9 +107,9 @@ def realtime_pois_handle_test():
         }
     ]
     manager = BssProviderManager(CONFIG)
-    pois_with_stands = manager.handle_places(pois)
-    assert 'stands' in pois_with_stands[0]
-    stands = pois_with_stands[0]['stands']
+    manager.handle_places(pois)
+    assert 'stands' in pois[0]
+    stands = pois[0]['stands']
     assert stands.available_places == 5
     assert stands.available_bikes == 9
     assert stands.total_stands == 14
@@ -123,9 +127,9 @@ def realtime_poi_supported_handle_test():
         'id': 'station_1'
     }
     manager = BssProviderManager(CONFIG)
-    poi_with_stands = manager.handle_poi(poi)
-    assert 'stands' in poi_with_stands
-    stands = poi_with_stands['stands']
+    manager._handle_poi(poi)
+    assert 'stands' in poi
+    stands = poi['stands']
     assert stands.available_places == 5
     assert stands.available_bikes == 9
     assert stands.total_stands == 14
@@ -143,8 +147,8 @@ def realtime_poi_not_supported_handle_test():
         'id': 'station_2'
     }
     manager = BssProviderManager(CONFIG)
-    poi_with_stands = manager.handle_poi(poi)
-    assert not 'stands' in poi_with_stands
+    manager._handle_poi(poi)
+    assert 'stands' not in poi
 
 
 def realtime_place_find_provider_test():
@@ -159,7 +163,7 @@ def realtime_place_find_provider_test():
         'id': 'station_1'
     }
     manager = BssProviderManager(CONFIG)
-    provider = manager.find_provider(poi)
+    provider = manager._find_provider(poi)
     assert provider == manager.bss_providers[0]
 
 
@@ -197,9 +201,9 @@ def realtime_journey_handle_test():
     ]
 
     manager = BssProviderManager(CONFIG)
-    journeys_with_stand = manager.handle_journeys(journeys)
-    journey_from = journeys_with_stand[0]['sections'][0]['from']
-    journey_to = journeys_with_stand[0]['sections'][0]['to']
+    manager.handle_journeys(journeys)
+    journey_from = journeys[0]['sections'][0]['from']
+    journey_to = journeys[0]['sections'][0]['to']
     assert 'stands' in journey_from['poi']
     assert 'stands' in journey_to['poi']
 

--- a/source/jormungandr/jormungandr/ptref.py
+++ b/source/jormungandr/jormungandr/ptref.py
@@ -99,3 +99,11 @@ class PtRef(object):
             if req.ptref.count > result.pagination.itemsOnPage:
                 # we did not get as much results as planned, we can stop
                 return
+
+
+class FeedPublisher(object):
+    def __init__(self, id, name, license='', url=''):
+        self.id = id
+        self.name = name
+        self.license = license
+        self.url = url


### PR DESCRIPTION
now each time a bss provider is called, we add it's license in the
response (as a feed publisher)

by default the jcdecaux license has been defined as

```json
{
    "id": "jcdecaux",
    "name": "jcdecaux",
    "license": "Licence Ouverte / Open License",
    "url": "https://developer.jcdecaux.com/#/opendata/license"
}
```

and the atos has no feed publisher as I don't know what to put for it