### PR TITLE
Jormungandr&Kraken: realtime proxy for stif

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -43,6 +43,7 @@ class BssProviderManager(object):
     def handle_places(self, places):
         providers = set()
         for place in places or []:
+            provider = None
             if 'poi_type' in place:
                 provider = self._handle_poi(place)
             elif 'embedded_type' in place and place['embedded_type'] == 'poi':

--- a/source/jormungandr/jormungandr/ptref.py
+++ b/source/jormungandr/jormungandr/ptref.py
@@ -112,6 +112,14 @@ class PtRef(object):
         req.matching_routes.destination_code = destination_code
         req.matching_routes.destination_code_key = destination_code_key
 
+        result = self.instance.send_and_receive(req)
+
+        if result.HasField('error'):
+            raise PTRefException('impossible to find matching routes because {}'.format(result.error.message))
+
+        return result.routes
+
+
 class FeedPublisher(object):
     def __init__(self, id, name, license='', url=''):
         self.id = id

--- a/source/jormungandr/jormungandr/ptref.py
+++ b/source/jormungandr/jormungandr/ptref.py
@@ -45,6 +45,10 @@ PT_TYPE_RESPONSE_MAPPING = {
 }
 
 
+class PTRefException(Exception):
+    pass
+
+
 class PtRef(object):
     def __init__(self, instance):
         self.instance = instance
@@ -100,6 +104,13 @@ class PtRef(object):
                 # we did not get as much results as planned, we can stop
                 return
 
+    def get_matching_routes(self, line_uri, start_sp_uri, destination_code, destination_code_key):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.matching_routes
+        req.matching_routes.line_uri = line_uri
+        req.matching_routes.start_stop_point_uri = start_sp_uri
+        req.matching_routes.destination_code = destination_code
+        req.matching_routes.destination_code_key = destination_code_key
 
 class FeedPublisher(object):
     def __init__(self, id, name, license='', url=''):

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -115,3 +115,11 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         params = {'realtime_system_id': repr(self.rt_system_id), 'status': status}
         params.update(kwargs)
         new_relic.record_custom_event('realtime_status', params)
+
+    def record_additional_info(self, status, **kwargs):
+        """
+        status can be in: ok, failure
+        """
+        params = {'realtime_system_id': repr(self.rt_system_id), 'status': status}
+        params.update(kwargs)
+        new_relic.record_custom_event('realtime_proxy_additional_info', params)

--- a/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
@@ -110,7 +110,7 @@ class SiriLite(RealtimeProxy):
                      if vj.get('MonitoredVehicleJourney', {}).get('LineRef', {}).get('value') == line_code]
         if not schedules:
             self.record_additional_info('no_departure')
-            return None
+            return []
         next_passages = []
         for next_expected_st in schedules:
             destination = next_expected_st.get('MonitoredVehicleJourney', {})\

--- a/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
@@ -30,7 +30,7 @@
 # www.navitia.io
 from __future__ import absolute_import
 from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError
-from flask import logging
+import logging
 import pybreaker
 import pytz
 import requests as requests
@@ -43,13 +43,15 @@ class SiriLite(RealtimeProxy):
     """
     class managing calls to a siri lite external service providing real-time next passages
     """
-    def __init__(self, id, service_url, object_id_tag=None, timeout=10, **kwargs):
+    def __init__(self, id, service_url, object_id_tag=None, instance=None, timeout=10, **kwargs):
         self.service_url = service_url
         self.timeout = timeout  # timeout in seconds
         self.rt_system_id = id
         self.object_id_tag = object_id_tag if object_id_tag else id
         self.breaker = pybreaker.CircuitBreaker(fail_max=app.config.get('CIRCUIT_BREAKER_MAX_SIRILITE_FAIL', 5),
                                                 reset_timeout=app.config.get('CIRCUIT_BREAKER_SIRILITE_TIMEOUT_S', 60))
+        self.instance = instance
+        self.log = logging.LoggerAdapter(logging.getLogger(__name__), extra={'rt_proxy': id})
 
     def __repr__(self):
         """
@@ -59,19 +61,17 @@ class SiriLite(RealtimeProxy):
 
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_SIRILITE', 30))
     def _call(self, url):
-        logging.getLogger(__name__).debug('sirilite RT service, call url: {}'.format(url))
+        self.log.debug('sirilite RT service, call url: {}'.format(url))
         try:
             return self.breaker.call(requests.get, url, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
-            logging.getLogger(__name__).error('sirilite RT service dead, using base '
-                                              'schedule (error: {}'.format(e))
+            self.log.error('sirilite RT service dead, using base schedule (error: {}'.format(e))
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
-            logging.getLogger(__name__).error('sitelite RT service timeout, using base '
-                                              'schedule (error: {}'.format(t))
+            self.log.error('sitelite RT service timeout, using base schedule (error: {}'.format(t))
             raise RealtimeProxyError('timeout')
         except Exception as e:
-            logging.getLogger(__name__).exception('sirilite RT error, using base schedule')
+            self.log.exception('sirilite RT error, using base schedule')
             raise RealtimeProxyError(str(e))
 
     def _make_url(self, route_point):
@@ -82,15 +82,17 @@ class SiriLite(RealtimeProxy):
         stop_id = route_point.fetch_stop_id(self.object_id_tag)
         line_id = route_point.fetch_line_id(self.object_id_tag)
 
-        #we don't use the line_id now, but we want to check that we have it
+        # Note: we don't use the line_id now because the stif's SIRILite does not handle it
+        # but we want to check that we have it
+        # if the stif starts to handle it, we can add it with '&LineRef={line_id}'
         if not stop_id or not line_id:
             # one of the id is missing, we'll not find any realtime
-            logging.getLogger(__name__).debug('missing realtime id for {obj}: stop code={s}'.
+            self.log.debug('missing realtime id for {obj}: stop code={s}'.
                                               format(obj=route_point, s=stop_id))
             self.record_internal_failure('missing id')
             return None
 
-        url = "{base_url}{stop_id}".format(base_url=self.service_url, stop_id=stop_id)
+        url = "{base_url}&MonitoringRef={stop_id}".format(base_url=self.service_url, stop_id=stop_id)
 
         return url
 
@@ -98,38 +100,54 @@ class SiriLite(RealtimeProxy):
         return pytz.utc.localize(datetime.strptime(datetime_str, "%Y-%m-%dT%H:%M:%S.%fZ"))
 
     def _get_passages(self, route_point, resp):
-        logging.getLogger(__name__).debug('sirilite response: {}'.format(resp))
+        self.log.debug('sirilite response: {}'.format(resp))
 
         line_code = route_point.fetch_line_id(self.object_id_tag)
-        monitored_stop_visit = resp.get('siri', {})\
-                                   .get('serviceDelivery', {})\
-                                   .get('stopMonitoringDelivery', {})\
-                                   .get('monitoredStopVisit', [])
-        schedules = (vj for vj in monitored_stop_visit
-                        if vj.get('monitoredVehicleJourney', {}).get('lineRef', {}).get('value', '') == line_code)
-        #TODO: we should use the destination to find the correct route
-        if schedules:
-            next_passages = []
-            for next_expected_st in schedules:
-                # for the moment we handle only the NextStop and the direction
-                expected_dt = next_expected_st.get('monitoredVehicleJourney', {})\
-                                              .get('monitoredCall', {})\
-                                              .get('expectedDepartureTime')
-                if not expected_dt:
-                    continue
-                dt = self._get_dt(expected_dt)
-                destination = next_expected_st.get('monitoredVehicleJourney', {}).get('destinationName', [])
-                if destination:
-                    direction = destination[0].get('value')
-                else:
-                    direction = None
-                is_real_time = True
-                next_passage = RealTimePassage(dt, direction, is_real_time)
-                next_passages.append(next_passage)
-
-            return next_passages
-        else:
+        stop_deliveries = resp.get('Siri', {}).get('ServiceDelivery', {}).get('StopMonitoringDelivery', [])
+        schedules = [vj
+                     for d in stop_deliveries
+                     for vj in d.get('MonitoredStopVisit', [])
+                     if vj.get('MonitoredVehicleJourney', {}).get('LineRef', {}).get('value') == line_code]
+        if not schedules:
             return None
+        next_passages = []
+        for next_expected_st in schedules:
+            destination = next_expected_st.get('MonitoredVehicleJourney', {})\
+                .get('DestinationRef', {}).get('value')
+
+            if not destination:
+                self.log.debug('no destination for next st {} for routepoint {}, skipping departure'
+                               .format(next_expected_st, route_point))
+                continue
+
+            possible_routes = self.get_matching_routes(
+                destination=destination,
+                line=route_point.fetch_line_uri(),
+                start=route_point.pb_stop_point.uri
+            )
+            if possible_routes and len(possible_routes) > 1:
+                self.log.info('multiple possible routes for destination {} and routepoint {}, we add the '
+                              'passages on all the routes'.format(destination, route_point))
+            if route_point.pb_route.uri not in possible_routes:
+                # the next passage does not concern our route point, we can skip it
+                continue
+            # for the moment we handle only the NextStop and the direction
+            expected_dt = next_expected_st.get('MonitoredVehicleJourney', {})\
+                                          .get('MonitoredCall', {})\
+                                          .get('ExpectedDepartureTime')
+            if not expected_dt:
+                continue
+            dt = self._get_dt(expected_dt)
+            destination = next_expected_st.get('MonitoredVehicleJourney', {}).get('DestinationName', [])
+            if destination:
+                direction = destination[0].get('value')
+            else:
+                direction = None
+            is_real_time = True
+            next_passage = RealTimePassage(dt, direction, is_real_time)
+            next_passages.append(next_passage)
+
+        return next_passages
 
     def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
         url = self._make_url(route_point)
@@ -138,9 +156,7 @@ class SiriLite(RealtimeProxy):
         r = self._call(url)
 
         if r.status_code != 200:
-            # TODO better error handling, the response might be in 200 but in error
-            logging.getLogger(__name__).error('sirilite RT service unavailable, impossible to query : {}'
-                                              .format(r.url))
+            self.log.error('sirilite RT service unavailable, impossible to query : {}'.format(r.url))
             raise RealtimeProxyError('non 200 response')
 
         return self._get_passages(route_point, r.json())
@@ -152,3 +168,11 @@ class SiriLite(RealtimeProxy):
                                     'fail_counter': self.breaker.fail_counter,
                                     'reset_timeout': self.breaker.reset_timeout},
                 }
+
+    def get_matching_routes(self, line, start, destination):
+        pb_routes = self.instance.ptref.get_matching_routes(line_uri=line,
+                                                            start_sp_uri=start,
+                                                            destination_code=destination,
+                                                            destination_code_key=self.object_id_tag)
+
+        return [r.uri for r in pb_routes]

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -62,7 +62,7 @@ def get_realtime_system_code(route_point):
 
 
 class RealTimePassage(object):
-    def __init__(self, datetime, direction=None, is_real_time = True):
+    def __init__(self, datetime, direction=None, is_real_time=True):
         self.datetime = datetime
         self.direction = direction
         self.is_real_time = is_real_time

--- a/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
@@ -29,7 +29,9 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
+
 import mock
+
 from jormungandr.tests.utils_test import MockRequests
 from tests.check_utils import get_not_null
 from .tests_mechanism import AbstractTestFixture, dataset

--- a/source/jormungandr/tests/proxy_realtime_sirilite_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_sirilite_integration_tests.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+import mock
+from jormungandr.tests.utils_test import MockRequests
+from tests.check_utils import get_not_null
+from .tests_mechanism import AbstractTestFixture, dataset
+
+MOCKED_PROXY_CONF = [
+    {
+        "object_id_tag": "KisioDigital",
+        "id": "KisioDigital",
+        "class": "jormungandr.realtime_schedule.siri_lite.SiriLite",
+        "args": {
+            "destination_id_tag": "KisioDigital",
+            "timezone": "Europe/Paris",
+            "service_url": "http://siri.com?apikey=bob",
+            "timeout": 15
+        }
+    }
+]
+
+
+def _get_formated_schedule(scs, sp, route):
+    """ small helper that extract the information from a route point stop schedule """
+    return [
+        {'rt': r['data_freshness'] == 'realtime', 'dt': r['date_time']}
+        for r in next(rp_sched['date_times']
+                      for rp_sched in scs
+                      if rp_sched['stop_point']['id'] == sp
+                      and rp_sched['route']['id'] == route)
+        ]
+
+
+@dataset({"multiple_schedules": {'instance_config': {'realtime_proxies': MOCKED_PROXY_CONF}}})
+class TestSiriLite(AbstractTestFixture):
+    query_template = 'stop_points/{sp}/stop_schedules?_current_datetime=20160102T0800'
+
+    def test_stop_schedule(self):
+        """
+        test a stop schedule with a sirilite realtime proxy
+
+        we have 3 routes that pass by sp_21
+
+        C1 : SP_20 -> SP_21 -> SP_22
+        C2 : SP_20 -> SP_21 -> SP_22
+        C-backward : SP_22 -> SP_21 -> SP_20
+
+        we have 5 departures in the realtime sirilite response:
+        - 2 that goes to SP_22 (so we attach them to C1 and C2)
+        - 1 that goes to SP_20 (so we attach them to C-backward)
+        - 1 with an unknown line ref
+        - 1 with an unknown destination
+        """
+        mock_requests = MockRequests({
+            'http://siri.com?apikey=bob&MonitoringRef=syn_stoppoint21':
+                (
+{
+    "Siri": {
+        "ServiceDelivery": {
+            "ProducerRef": "bob",
+            "ResponseMessageIdentifier": "bob_id",
+            "ResponseTimestamp": "2017-07-19T13:01:59Z",
+            "StopMonitoringDelivery": [
+                {
+                    "MonitoredStopVisit": [
+                        {
+                            "ItemIdentifier": "complex_id_for_syn_stoppoint1",
+                            "MonitoredVehicleJourney": {
+                                "DestinationName": [{"value": "to stop 22"}],
+                                "DestinationRef": {"value": "syn_stoppoint22"},
+                                "LineRef": {"value": "syn_lineC"},
+                                "MonitoredCall": {
+                                    "ExpectedDepartureTime": "2016-01-02T10:02:42.000Z",
+                                    "StopPointName": [{"value": "the stop"}],
+                                    "VehicleAtStop": False
+                                }
+                            },
+                            "MonitoringRef": {"value": "syn_stoppoint21"},
+                            "RecordedAtTime": "2017-07-19T13:01:54.727Z"
+                        },
+                        # we add another passage on to stop 22 (route C)
+                        {
+                            "ItemIdentifier": "complex_id_for_syn_stoppoint1",
+                            "MonitoredVehicleJourney": {
+                                "DestinationName": [{"value": "to stop 22"}],
+                                "DestinationRef": {"value": "syn_stoppoint22"},
+                                "LineRef": {"value": "syn_lineC"},
+                                "MonitoredCall": {
+                                    "ExpectedDepartureTime": "2016-01-02T10:05:42.000Z",
+                                    "StopPointName": [{"value": "the stop"}],
+                                    "VehicleAtStop": False
+                                }
+                            },
+                            "MonitoringRef": {"value": "syn_stoppoint21"},
+                            "RecordedAtTime": "2017-07-19T13:01:54.727Z"
+                        },
+                        # we add a passage to SP_20 (route C-backward)
+                        {
+                            "ItemIdentifier": "complex_id_for_syn_stoppoint1",
+                            "MonitoredVehicleJourney": {
+                                "DestinationName": [{"value": "to stop 20"}],
+                                "DestinationRef": {"value": "syn_stoppoint20"},
+                                "LineRef": {"value": "syn_lineC"},
+                                "MonitoredCall": {
+                                    "ExpectedDepartureTime": "2016-01-02T10:03:42.000Z",
+                                    "StopPointName": [{"value": "the stop"}],
+                                    "VehicleAtStop": False
+                                }
+                            },
+                            "MonitoringRef": {"value": "syn_stoppoint21"},
+                            "RecordedAtTime": "2017-07-19T13:01:54.727Z"
+                        },
+                        # we add a passage on an unknown line (we should not consider it)
+                        {
+                            "ItemIdentifier": "complex_id_for_syn_stoppoint1",
+                            "MonitoredVehicleJourney": {
+                                "DestinationName": [{"value": "to stop 20"}],
+                                "DestinationRef": {"value": "syn_stoppoint20"},
+                                "LineRef": {"value": "an_unkonwn_line"},
+                                "MonitoredCall": {
+                                    "ExpectedDepartureTime": "2016-01-02T10:13:42.000Z",
+                                    "StopPointName": [{"value": "the stop"}],
+                                    "VehicleAtStop": False
+                                }
+                            },
+                            "MonitoringRef": {"value": "syn_stoppoint21"},
+                            "RecordedAtTime": "2017-07-19T13:01:54.727Z"
+                        },
+                        # we add a passage on an unknown destination, we should skip it too
+                        {
+                            "ItemIdentifier": "complex_id_for_syn_stoppoint1",
+                            "MonitoredVehicleJourney": {
+                                "DestinationName": [{"value": "to stop bob"}],
+                                "DestinationRef": {"value": "an_unknown_stop"},
+                                "LineRef": {"value": "syn_lineC"},
+                                "MonitoredCall": {
+                                    "ExpectedDepartureTime": "2016-01-02T10:23:42.000Z",
+                                    "StopPointName": [{"value": "the stop"}],
+                                    "VehicleAtStop": False
+                                }
+                            },
+                            "MonitoringRef": {"value": "syn_stoppoint21"},
+                            "RecordedAtTime": "2017-07-19T13:01:54.727Z"
+                        },
+                    ],
+                    "ResponseTimestamp": "2017-07-19T13:01:59Z",
+                    "Status": "true",
+                    "Version": "2.0"
+                }
+            ]
+        }
+    }
+}, 200)
+        })
+        with mock.patch('requests.get', mock_requests.get):
+            # first we make a base schedule call for the test to be more readable
+            query = self.query_template.format(sp='SP_21') + "&data_freshness=base_schedule"
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 3
+            # we have 1 passage per route point
+            assert _get_formated_schedule(scs, sp='SP_21', route='C-backward') == [
+                {'rt': False, 'dt': '20160102T101000'}
+            ]
+
+            assert _get_formated_schedule(scs, sp='SP_21', route='C1') == [
+                {'rt': False, 'dt': '20160102T090000'}
+            ]
+
+            assert _get_formated_schedule(scs, sp='SP_21', route='C2') == [
+                {'rt': False, 'dt': '20160102T100000'}
+            ]
+
+            # now we make a realtime call
+            query = self.query_template.format(sp='SP_21') + "&data_freshness=realtime"
+            response = self.query_region(query)
+            scs = get_not_null(response, 'stop_schedules')
+            assert len(scs) == 3
+
+            assert _get_formated_schedule(scs, sp='SP_21', route='C-backward') == [
+                {'rt': True, 'dt': '20160102T100342'}
+            ]
+
+            # c1 and c2 have the same destination, so we cannot know at which route it is from the
+            # realtime passage data, so we have the realtime passage on both routes
+            # this is not great, but it will do for the moment
+            assert _get_formated_schedule(scs, sp='SP_21', route='C1') ==\
+                   _get_formated_schedule(scs, sp='SP_21', route='C2') == [
+                {'rt': True, 'dt': '20160102T100242'},
+                {'rt': True, 'dt': '20160102T100542'}
+            ]

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -259,7 +259,7 @@ class TestSyntheseSchedules(AbstractTestFixture):
             query = self.query_template.format(sp='SP_21')
             response = self.query_region(query)
             scs = get_not_null(response, 'stop_schedules')
-            assert len(scs) == 2
+            assert len(scs) == 3
             assert _get_schedule(response, 'SP_21', 'C1') == [{
                 'rt': False, 'dt': '20160102T090000'
             }]

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -127,6 +127,8 @@ class Worker {
          * */
         void street_network_routing_matrix(const pbnavitia::StreetNetworkRoutingMatrixRequest& request);
         void odt_stop_points(const pbnavitia::GeographicalCoord& request);
+
+        void get_matching_routes(const pbnavitia::MatchingRoute&);
 };
 
 type::EntryPoint make_sn_entry_point(const std::string& place,

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -52,4 +52,11 @@ std::vector<const type::Route*> get_matching_routes(const type::Data*,
                                                const type::Line*,
                                                const type::StopPoint* start,
                                                const std::pair<std::string, std::string>& destination_code);
+
+
+void fill_matching_routes(navitia::PbCreator& pb_creator,
+                          const type::Data*,
+                          const type::Line*,
+                          const type::StopPoint* start,
+                          const std::pair<std::string, std::string>& destination_code);
 }}

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -47,4 +47,9 @@ void query_pb(navitia::PbCreator& pb_creator,
               const boost::optional<boost::posix_time::ptime>& since,
               const boost::optional<boost::posix_time::ptime>& until,
               const type::Data& data);
+
+std::vector<const type::Route*> get_matching_routes(const type::Data*,
+                                               const type::Line*,
+                                               const type::StopPoint* start,
+                                               const std::pair<std::string, std::string>& destination_code);
 }}

--- a/source/tests/multiple_schedules.cpp
+++ b/source/tests/multiple_schedules.cpp
@@ -51,6 +51,8 @@ int main(int argc, const char* const argv[]) {
 
     b.vj("C").route("C1")("SP_20", "08:00"_t)("SP_21", "09:00"_t)("SP_22", "11:00"_t);
     b.vj("C").route("C2")("SP_20", "09:00"_t)("SP_21", "10:00"_t)("SP_22", "12:00"_t);
+    // we add a backward route on line C
+    b.vj("C").route("C-backward")("SP_22", "09:10"_t)("SP_21", "10:10"_t)("SP_20", "12:10"_t);
 
     b.data->complete();
     b.finish();
@@ -70,7 +72,9 @@ int main(int argc, const char* const argv[]) {
 
     b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_1"), "KisioDigital", "syn_stoppoint1");
     b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_11"), "KisioDigital", "syn_stoppoint11");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_20"), "KisioDigital", "syn_stoppoint20");
     b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_21"), "KisioDigital", "syn_stoppoint21");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_22"), "KisioDigital", "syn_stoppoint22");
     b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_31"), "KisioDigital", "syn_stoppoint31");
     b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_41"), "KisioDigital", "syn_stoppoint41");
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -82,7 +82,7 @@ set_source_files_properties(${PROTO_HDRS} ${PROTO_SRCS} PROPERTIES GENERATED TRU
 
 
 add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
-target_link_libraries(pb_lib vptranslator pthread ${PROTOBUF_LIBRARY} tcmalloc)
+target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY} tcmalloc)
 
 add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp validity_pattern.cpp type_utils.cpp)
 target_link_libraries(types ptreferential utils pb_lib protobuf)

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1462,7 +1462,7 @@ void PbCreator::Filler::fill_pb_object(const nt::Contributor* c, pbnavitia::Feed
 
 template<typename N>
 void PbCreator::pb_fill(const std::vector<N*>& nav_list, int depth,
-        const DumpMessageOptions& dump_message_options){
+        const DumpMessageOptions& dump_message_options) {
     auto* pb_object = get_mutable<typename std::remove_cv<N>::type>(response);
     Filler(depth, dump_message_options, *this).fill_pb_object(nav_list, pb_object);
 }
@@ -1479,6 +1479,7 @@ template void PbCreator::pb_fill(const std::vector<nt::LineGroup*>&, int, const 
 template void PbCreator::pb_fill(const std::vector<nt::Network*>&, int, const DumpMessageOptions&);
 template void PbCreator::pb_fill(const std::vector<nt::PhysicalMode*>&, int, const DumpMessageOptions&);
 template void PbCreator::pb_fill(const std::vector<nt::Route*>&, int, const DumpMessageOptions&);
+template void PbCreator::pb_fill(const std::vector<const nt::Route*>&, int, const DumpMessageOptions&);
 template void PbCreator::pb_fill(const std::vector<nt::StopArea*>&, int, const DumpMessageOptions&);
 template void PbCreator::pb_fill(const std::vector<nt::StopPoint*>&, int, const DumpMessageOptions&);
 template void PbCreator::pb_fill(const std::vector<const nt::StopPoint*>&, int, const DumpMessageOptions&);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -339,7 +339,7 @@ private:
         template<typename Nav, typename Pb>
         void fill_pb_object(const std::vector<Nav*>& nav_list,
                             ::google::protobuf::RepeatedPtrField<Pb>* pb_list) {
-            for (auto* nav_obj: nav_list) {
+            for (const auto* nav_obj: nav_list) {
                 fill_pb_object(nav_obj, pb_list->Add());
             }
         }


### PR DESCRIPTION
Correction of the Sirilite connector used to get realtime schedules on fr-idf.

In the siri's realtime response we only got a destination to match a route, so we added a guessing function that try to find all the routes of a line that pass first by a stop and after by another stop (even if the 2nd stop is not the destination)


## Test

to test it, the sirilite codes in the data are needed.
if you have some you can test it on the gare de lyon

`/stop_areas/stop_area%3AOIF%3ASA%3A8768600/stop_schedules`
there should be realtime data on the line 1 and line 14

## new relic monitoring
To monitor a bit the service's response a new_relic event was added:
`realtime_proxy_additional_info`
with for moment the values:
 * `no_departure`
 * `no_destination`
 * `no_route_found`
 * `no_departure_time`

## deploy
Note: we need to remove `&MonitoringRef=` from the url in the deployment conf