### PR TITLE
Kraken: clean useless vehicle journeys

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -64,7 +64,7 @@ VJ::VJ(builder& b,
     is_frequency(is_frequency),
     wheelchair_boarding(wheelchair_boarding),
     _uri(uri),
-    meta_vj_name(meta_vj_name),
+    _meta_vj_name(meta_vj_name),
     physical_mode(physical_mode),
     start_time(start_time),
     end_time(end_time),
@@ -138,8 +138,8 @@ nt::VehicleJourney* VJ::make() {
     }
 
     std::string name;
-    if (! meta_vj_name.empty()) {
-        name = meta_vj_name;
+    if (! _meta_vj_name.empty()) {
+        name = _meta_vj_name;
     } else if (! _uri.empty()) {
         name = _uri;
     } else {

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -65,7 +65,7 @@ VJ::VJ(builder& b,
     wheelchair_boarding(wheelchair_boarding),
     _uri(uri),
     _meta_vj_name(meta_vj_name),
-    physical_mode(physical_mode),
+    _physical_mode(physical_mode),
     start_time(start_time),
     end_time(end_time),
     headway_secs(headway_secs),
@@ -197,20 +197,20 @@ nt::VehicleJourney* VJ::make() {
         }
     }
     //add physical mode
-    if (!physical_mode.empty()) {
+    if (!_physical_mode.empty()) {
         // at this moment, the physical_modes_map might not be filled, we look up in the vector
         auto it = boost::find_if(pt_data.physical_modes, [this](const nt::PhysicalMode* phy) {
-            return phy->uri == this->physical_mode;
+            return phy->uri == this->_physical_mode;
         });
         if (it != std::end(pt_data.physical_modes)) {
             vj->physical_mode = *it;
         }
     }
     if (!vj->physical_mode) {
-        if (physical_mode.empty() && pt_data.physical_modes.size()){
+        if (_physical_mode.empty() && pt_data.physical_modes.size()){
             vj->physical_mode = pt_data.physical_modes.front();
         } else {
-            const auto name = physical_mode.empty() ? "physical_mode:0" : physical_mode;
+            const auto name = _physical_mode.empty() ? "physical_mode:0" : _physical_mode;
             auto* physical_mode = new navitia::type::PhysicalMode();
             physical_mode->idx = pt_data.physical_modes.size();
             physical_mode->uri = name;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -72,7 +72,7 @@ struct VJ {
     const bool wheelchair_boarding;
     std::string _uri;
     std::string _meta_vj_name;
-    const std::string physical_mode;
+    std::string _physical_mode;
     const uint32_t start_time;
     const uint32_t end_time;
     const uint32_t headway_secs;
@@ -135,6 +135,7 @@ struct VJ {
     VJ& valid_all_days() { _vp.days.set(); return *this; }
     VJ& meta_vj(const std::string& m) { _meta_vj_name = m; return *this; }
     VJ& vp(const std::string& v) { _vp = {_vp.beginning_date, v}; return *this; }
+    VJ& physical_mode(const std::string& p) { _physical_mode = p; return *this; }
 
     // create the vj
     nt::VehicleJourney* make();

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -71,7 +71,7 @@ struct VJ {
     const bool is_frequency;
     const bool wheelchair_boarding;
     std::string _uri;
-    const std::string meta_vj_name;
+    std::string _meta_vj_name;
     const std::string physical_mode;
     const uint32_t start_time;
     const uint32_t end_time;
@@ -133,6 +133,8 @@ struct VJ {
 
     VJ& uri(const std::string& u) { _uri = u; return *this; }
     VJ& valid_all_days() { _vp.days.set(); return *this; }
+    VJ& meta_vj(const std::string& m) { _meta_vj_name = m; return *this; }
+    VJ& vp(const std::string& v) { _vp = {_vp.beginning_date, v}; return *this; }
 
     // create the vj
     nt::VehicleJourney* make();

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -247,7 +247,7 @@ class TestKirinOnVJDelay(MockKirinDisruptionsFixture):
 
         new_response = self.query_region(journey_basic_query + "&data_freshness=realtime")
         assert get_arrivals(new_response) == ['20120614T080436', '20120614T080520']
-        assert get_used_vj(new_response), [[] == ['vjA:modified:0:vjA_delayed']]
+        assert get_used_vj(new_response) == [[], ['vjA:modified:0:vjA_delayed']]
 
         pt_journey = new_response['journeys'][1]
 
@@ -297,11 +297,9 @@ class TestKirinOnVJDelay(MockKirinDisruptionsFixture):
                             arrival_delay=3 * 60 + 58, departure_delay=3 * 60 + 58)],
            disruption_id='vjA_delayed')
 
-        # A new vj is created
+        # A new vj is created, but a useless vj has been cleaned, so the number of vj does not change
         pt_response = self.query_region('vehicle_journeys')
-        # No vj cleaning for the moment, vj nb SHOULD be 5, the first vj created for the first
-        # disruption is useless
-        assert len(pt_response['vehicle_journeys']) == 7
+        assert len(pt_response['vehicle_journeys']) == 6
 
         pt_response = self.query_region('vehicle_journeys/vjA?_current_datetime=20120614T1337')
         assert len(pt_response['disruptions']) == 1
@@ -345,7 +343,7 @@ class TestKirinOnVJDelay(MockKirinDisruptionsFixture):
 
         # A new vj is created
         vjs = self.query_region('vehicle_journeys?_current_datetime=20120614T1337')
-        assert len(vjs['vehicle_journeys']) == 9
+        assert len(vjs['vehicle_journeys']) == 7
 
         vjA = self.query_region('vehicle_journeys/vjA?_current_datetime=20120614T1337')
         # we now have 2 disruption on vjA

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -547,6 +547,8 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
                 disruptions_collection.insert(share_ptr);
             }
         }
+        // we check if we now have useless vehicle_journeys to cleanup
+        mvj->clean_up_useless_vjs(pt_data);
     }
 
     void operator()(nt::StopPoint* stop_point) {

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -384,13 +384,12 @@ BOOST_AUTO_TEST_CASE(two_different_delays_on_same_vj) {
         res = compute(nt::RTLevel::RealTime, "stop1", "stop2");
         BOOST_REQUIRE_EQUAL(res.size(), 1);
         BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0910"_dt);
-
     }
 
     // we add a second time the realtime message
     navitia::handle_realtime(feed_id_1, timestamp, trip_update_2, *b.data);
 
-    BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 3);
+    BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 2);
@@ -641,7 +640,7 @@ BOOST_AUTO_TEST_CASE(add_blocking_disruption_and_delay_disruption) {
 
     navitia::delete_disruption(std::string(disrup.uri), *b.data->pt_data, *b.data->meta);
 
-    BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 3);
+    BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 2);
     BOOST_REQUIRE_EQUAL(pt_data->meta_vjs.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -1618,7 +1617,7 @@ BOOST_AUTO_TEST_CASE(ordered_delay_message_test) {
     navitia::handle_realtime("feed_43", "20150101T1338"_dt, trip_update_2, *b.data);
     navitia::handle_realtime("feed_44", "20150101T1339"_dt, trip_update_3, *b.data);
 
-    BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 4);
+    BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->validity_patterns.size(), 2);
@@ -1900,7 +1899,7 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
-    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 3);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 
     // Check the original vj
     auto* vj = b.get<nt::VehicleJourney>("vj:1");
@@ -1908,13 +1907,8 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
     BOOST_CHECK_END_VP(vj->base_validity_pattern(), "1111111");
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
 
-    // first impacted vj (useless now)
-    vj = b.get<nt::VehicleJourney>("vj:1:modified:0:feed");
-    BOOST_CHECK_END_VP(vj->rt_validity_pattern(), "0000000");
-    BOOST_CHECK_END_VP(vj->base_validity_pattern(), "0000000");
-
     // Check the realtime vj
-    vj = b.get<nt::VehicleJourney>("vj:1:modified:1:feed");
+    vj = b.get<nt::VehicleJourney>("vj:1:modified:0:feed");
     BOOST_CHECK_END_VP(vj->rt_validity_pattern(), "0000001");
     BOOST_CHECK_END_VP(vj->base_validity_pattern(), "0000000");
     // The realtime vj should have all 3 stop_times but lose the ability to pickup/dropoff on B

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -300,9 +300,7 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
     BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0910"_dt);
 }
 
-BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES(train_delayed_expected_failure, 1)
-
-BOOST_AUTO_TEST_CASE(train_delayed_expected_failure) {
+BOOST_AUTO_TEST_CASE(train_delayed_vj_cleaned_up) {
 
     ed::builder b("20150928");
     b.vj("A", "000001", "", true, "vj:1")("stop1", "08:01"_t)("stop2", "09:01"_t);
@@ -317,10 +315,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_expected_failure) {
     navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
     navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
 
-    /*****************Expected Failure********************/
-    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2); // Current size is 3, hopefully it should be 2
-    /*****************************************************/
-
+    BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 }
 
 BOOST_AUTO_TEST_CASE(two_different_delays_on_same_vj) {

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -79,11 +79,11 @@ struct data_set {
 
         // we add a stop area with a strange name (with space and special char)
         b.sa("stop_with name bob \" , é", 20, 20);
-        b.vj("line:B", "", "", true, "vj_b", "", "physical_mode:Car")
+        b.vj("line:B").physical_mode("physical_mode:Car")
                 ("stop_point:stop_with name bob \" , é", "8:00"_t)("stop_area:stop1", "9:00"_t);
 
         // add a line with a unicode name
-        b.vj("line:Ça roule", "11111111", "", true, "vj_b")
+        b.vj("line:Ça roule").uri("vj_b")
                 ("stop_area:stop2", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)
                 ("stop_area:stop1", 11 * 3600 + 10 * 60, 11 * 3600 + 10 * 60);
 

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -222,11 +222,11 @@ struct calendar_fixture {
                                                           ("stop2", "18:00"_t, "18:10"_t);
 
         // Check partial terminus tag
-        b.vj("A", "10111111", "", true, "vj1", "")("Tstop1", "10:00"_t, "10:00"_t)
-                                                  ("Tstop2", "10:30"_t, "10:30"_t);
-        b.vj("A", "00000011", "", true, "vj2", "")("Tstop1", "10:30"_t, "10:30"_t)
-                                                  ("Tstop2", "11:00"_t,"11:00"_t)
-                                                  ("Tstop3", "11:30"_t,"11:30"_t);
+        b.vj("A").vp("10111111").uri("vj1")("Tstop1", "10:00"_t, "10:00"_t)
+                                           ("Tstop2", "10:30"_t, "10:30"_t);
+        b.vj("A").vp("00000011").uri("vj2")("Tstop1", "10:30"_t, "10:30"_t)
+                                           ("Tstop2", "11:00"_t, "11:00"_t)
+                                           ("Tstop3", "11:30"_t, "11:30"_t);
 
         // Check date_time_estimated at stoptime
         b.vj("B", "10111111", "", true, "date_time_estimated", "")
@@ -246,12 +246,6 @@ struct calendar_fixture {
                 ("stop1_D", "00:10"_t, "00:10"_t)
                 ("stop2_D", "01:40"_t, "01:40"_t)
                 ("stop3_D", "02:50"_t, "02:50"_t);
-
-        b.vj("A", "10111111", "", true, "vj1", "")("Tstop1", "10:00"_t, "10:00"_t)
-                                                  ("Tstop2", "10:30"_t, "10:30"_t);
-        b.vj("A", "00000011", "", true, "vj2", "")("Tstop1", "10:30"_t, "10:30"_t)
-                                                  ("Tstop2", "11:00"_t,"11:00"_t)
-                                                  ("Tstop3", "11:30"_t,"11:30"_t);
         /*
                                                    StopR3                            StopR4
                                             ------------------------------------------

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -185,8 +185,11 @@ void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time,
     update_headsign_mvj_after_remove(*vj, prev_headsign_for_stop_time);
 }
 
-void HeadsignHandler::forget_vj(const VehicleJourney* vj) {
- // TODO
+void HeadsignHandler::forget_vj(const VehicleJourney*) {
+    // actually we never wants to forget vj
+    // it would be MANDATORY to do it if we added realtime vjs to the headsigns handler,
+    // but for the moment we only index base schedule VJ
+    // if that change be sure to add the mechanism here to remove the useless VJ before we delete it
 }
 
 }} //namespace navitia::type

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -185,4 +185,8 @@ void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time,
     update_headsign_mvj_after_remove(*vj, prev_headsign_for_stop_time);
 }
 
+void HeadsignHandler::forget_vj(const VehicleJourney* vj) {
+ // TODO
+}
+
 }} //namespace navitia::type

--- a/source/type/headsign_handler.h
+++ b/source/type/headsign_handler.h
@@ -62,6 +62,8 @@ struct HeadsignHandler {
         ar & headsign_changes & headsign_mvj;
     }
 
+    void forget_vj(const VehicleJourney*);
+
 protected:
     bool has_headsign_or_name(const VehicleJourney& vj, const std::string& headsign) const;
     void update_headsign_mvj_after_remove(const VehicleJourney& vj,

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -54,8 +54,8 @@ namespace nt = navitia::type;
 struct HeadsignFixture {
     ed::builder b;
     HeadsignFixture() : b("20120614") {
-        b.vj("A", "1111", "", true, "A1", "metaVJA")("stop00", 8000)("stop01", 8100);
-        b.vj("A", "1111", "", true, "A2", "metaVJA")("stop10", 8000)("stop11", 8100)("stop12", 8200);
+        b.vj("A").uri("A1").meta_vj("metaVJA").vp("01")("stop00", 8000)("stop01", 8100);
+        b.vj("A").uri("A2").meta_vj("metaVJA").vp("10")("stop10", 8000)("stop11", 8100)("stop12", 8200);
         b.vj("C")("stop20", 8000)("stop21", 8100)("stop22", 8200);
         b.vj("D")("stop30", 8000);
         b.vj("E")("stop40", 8000);

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -66,7 +66,7 @@ struct HeadsignFixture {
 
 BOOST_FIXTURE_TEST_CASE(headsign_handler_functionnal_test, HeadsignFixture) {
     nt::HeadsignHandler& headsign_handler = b.data->pt_data->headsign_handler;
-    auto& vj_vec = b.data->pt_data->vehicle_journeys;
+    const auto& vj_vec = b.data->pt_data->vehicle_journeys;
 
     headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(0), "A00");
     headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(1), vj_vec[1]->name);

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -44,6 +44,7 @@ www.navitia.io
 #include "third_party/eos_portable_archive/portable_oarchive.hpp"
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>
+#include <boost/range/algorithm/find.hpp>
 
 namespace bt = boost::posix_time;
 
@@ -405,8 +406,8 @@ static bool is_useless(const nt::VehicleJourney& vj) {
 }
 
 template <typename C>
-static C::iterator erase_vj_from_list(const nt::VehicleJourney* vj, C& vjs) {
-    auto it = std::find(vjs.begin(), vjs.end(), vj);
+static typename C::iterator erase_vj_from_list(const nt::VehicleJourney* vj, C& vjs) {
+    auto it = boost::range::find(vjs, vj);
     if (it == vjs.end()) {
         LOG4CPLUS_WARN(log4cplus::Logger::getInstance("logger"),
                        "impossible to find the vj " << vj->uri << " in the list, something is strange");

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -411,6 +411,7 @@ static typename C::iterator erase_vj_from_list(const nt::VehicleJourney* vj, C& 
     if (it == vjs.end()) {
         LOG4CPLUS_WARN(log4cplus::Logger::getInstance("logger"),
                        "impossible to find the vj " << vj->uri << " in the list, something is strange");
+        return it;
     }
     return vjs.erase(it);
 }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -439,8 +439,6 @@ void cleanup_useless_vj_link(const nt::VehicleJourney* vj, nt::PT_Data& pt_data)
         erase_vj_from_list(vj, vj->route->frequency_vehicle_journey_list);
     } else if (dynamic_cast<const nt::DiscreteVehicleJourney*>(vj)) {
         erase_vj_from_list(vj, vj->route->discrete_vehicle_journey_list);
-    } else {
-        throw std::logic_error("c'est la merde"); // TODO remove this
     }
 
     pt_data.headsign_handler.forget_vj(vj);

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -857,6 +857,8 @@ struct MetaVehicleJourney: public Header, HasMessages {
                        std::vector<StopTime>,
                        PT_Data&);
 
+    void clean_up_useless_vjs(PT_Data&);
+
     template<typename T>
     void for_all_vjs(T fun) const{
         for (const auto& rt_vjs: rtlevel_to_vjs_map) {

--- a/source/type/validity_pattern.h
+++ b/source/type/validity_pattern.h
@@ -55,6 +55,7 @@ public:
     void remove(boost::gregorian::date day);
     void remove(int day);
     void reset() { days.reset(); }
+    bool empty() const { return days.none(); }
     std::string str() const;
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
         ar & beginning_date & days & idx & uri;


### PR DESCRIPTION
When receiving multiple realtime data, some realtime vehicle journeys might become useless (their validity pattern are always empty, so cannot be used)

Before, we used to keep them because of the fear of memory corruption, but thus the memory consumption was ever growing (and we are unfortunately not in an infinite memory world :cry: ) and the growing number of vehicle journeys was leading to timeouts on some APIs (`/traffic_reports` for example).

With this PR we now clean the useless vehicle journeys.
As kraken is written in C++ ( :heart: [rust](https://github.com/rust-lang/rust) ) it is quite dangerous and we'll need to be extra careful in the future not to add a backref to a vehicle journey without cleaning it :boom: 

Note: I still need to do some more tests again the production realtime flow 
Edit: tests done, seems OK