### PR TITLE
jormungandr: better parameter validation messages

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/argument.py
+++ b/source/jormungandr/jormungandr/interfaces/argument.py
@@ -55,13 +55,13 @@ class ArgumentDoc(reqparse.Argument):
         Override method to output message from exception and from argument's help
         """
         error_str = six.text_type(error)
-        error_msg = u''
+        error_msg = u'parameter "{}" invalid: '.format(self.name)
         if error_str:
             error_msg += error_str
         if self.help:
             if error_msg:
                 error_msg += u'\n'
-            error_msg += u'Help: {}'.format(self.help)
+            error_msg += u'{} description: {}'.format(self.name, self.help)
         msg = {self.name: error_msg}
 
         if current_app.config.get("BUNDLE_ERRORS", False) or bundle_errors:

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -86,8 +86,10 @@ class Uri(ResourceUri, ResourceUtc):
                             dest="forbidden_uris[]",
                             default=[],
                             action="append")
+        # for the top level collection apis (/v1/networks, /v1/lines, ...) the external_code is mandatory
+        external_code_mandatory = '.external_codes' in self.endpoint
         parser.add_argument("external_code", type=six.text_type,
-                            help="An external code to query")
+                            help="An external code to query", required=external_code_mandatory)
         parser.add_argument("headsign", type=six.text_type,
                             help="filter vehicle journeys on headsign")
         parser.add_argument("show_codes", type=BooleanType(), default=False,

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -155,7 +155,12 @@ class JourneyCommon(object):
 
         assert status == 400, "the response should not be valid"
 
-        assert response['message'].startswith("The type argument must be in list")
+        m = "parameter \"type\" invalid: The type argument must be in list [u'all', u'non_pt_bss', " \
+            "u'non_pt_bike', u'fastest', u'less_fallback_bss', u'best', u'less_fallback_bike', " \
+            "u'rapid', u'car', u'comfort', u'no_train', u'less_fallback_walk', u'non_pt_walk'], " \
+            "you gave sponge_bob\n" \
+            "type description: DEPRECATED, desired type of journey."
+        assert response['message'] == m
 
     def test_journeys_no_bss_and_walking(self):
         query = journey_basic_query + "&first_section_mode=walking&first_section_mode=bss"

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -619,6 +619,23 @@ class TestPtRefRoutingAndPtrefCov(AbstractTestFixture):
         assert len(lines) == 1
         assert 'A' in [code['value'] for code in lines[0]['codes'] if code['type'] == 'external_code']
 
+    def test_external_code_no_code(self):
+        """the external_code is a mandatory parameter for collection without coverage"""
+        r, status = self.query_no_assert("v1/lines")
+        assert status == 400
+        assert "parameter \"external_code\" invalid: " \
+               "Missing required parameter in the post body or the query string" \
+               "\nexternal_code description: An external code to query" == \
+               r.get('message')
+
+    def test_parameter_error_message(self):
+        """test the parameter validation error message"""
+        r, status = self.query_no_assert("v1/coverage/lines?disable_geojson=12")
+        assert status == 400
+        assert "parameter \"disable_geojson\" invalid: Invalid literal for boolean(): 12\n" \
+               "disable_geojson description: hide the coverage geojson to reduce response size" == \
+               r.get('message')
+
     def test_invalid_url(self):
         """the following bad url was causing internal errors, it should only be a 404"""
         _, status = self.query_no_assert("v1/coverage/lines/bob")


### PR DESCRIPTION
better error message on invalid parameters:

example:

```
"parameter \"external_code\" invalid: Missing required parameter in the
post body or the query string
external_code description: An external code to query"
```

or

```
parameter \"disable_geojson\" invalid: Invalid literal for boolean(): 12
disable_geojson description: hide the coverage geojson to reduce
response size
```

Also change for the collection apis without networks (/v1/networks, /v1/lines, ...) the external_code parameter as mandatory

this is done to have a more precise swagger