### PR TITLE
jormungandr: hide /connections api

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -39,7 +39,7 @@ from flask.ext.cache import Cache
 from flask.ext.cors import CORS
 import sys
 from jormungandr.exceptions import log_exception
-from jormungandr.helper import ReverseProxied, NavitiaRequest
+from jormungandr.helper import ReverseProxied, NavitiaRequest, NavitiaRule
 from jormungandr import compat, utils
 import six
 
@@ -52,6 +52,7 @@ if 'JORMUNGANDR_CONFIG_FILE' in os.environ:
 # so we make it a global variable
 USE_SERPY = app.config.get('USE_SERPY')
 
+app.url_rule_class = NavitiaRule
 app.request_class = NavitiaRequest
 CORS(app, vary_headers=True, allow_credentials=True, send_wildcard=False,
         headers=['Access-Control-Request-Headers', 'Authorization'])

--- a/source/jormungandr/jormungandr/helper.py
+++ b/source/jormungandr/jormungandr/helper.py
@@ -32,6 +32,8 @@ import re
 from flask import Request
 import uuid
 
+from werkzeug.routing import Rule
+
 
 class ReverseProxied(object):
     """
@@ -64,3 +66,12 @@ class NavitiaRequest(Request):
     def __init__(self, *args, **kwargs):
         super(Request, self).__init__(*args, **kwargs)
         self.id = str(uuid.uuid4())
+
+
+class NavitiaRule(Rule):
+    """
+    custom class to add a 'hide' variable to hide a rule in swagger
+    """
+    def __init__(self, *args, **kwargs):
+        self.hide = kwargs.pop('hide', False)
+        super(NavitiaRule, self).__init__(*args, **kwargs)

--- a/source/jormungandr/jormungandr/interfaces/v1/JSONSchema.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/JSONSchema.py
@@ -66,6 +66,10 @@ def get_all_described_paths():
             if 'OPTIONS' not in rule.methods or rule.provide_automatic_options:
                 continue
 
+            if rule.hide:
+                # we might want to hide some rule
+                continue
+
             view_function = app.view_functions.get(endpoint)
             if view_function is not None:
                 view_class = view_function.view_class

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -133,6 +133,9 @@ class V1Routing(AModule):
                               coord + '<uri:uri>/' + collection,
                               endpoint=collection + '.collection', hide=hide)
 
+            if collection == 'connections':
+                # connections api cannot be query by id
+                continue
             self.add_resource(getattr(Uri, collection)(False),
                               region + collection + '/<id:id>',
                               coord + collection + '/<id:id>',

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -124,19 +124,21 @@ class V1Routing(AModule):
 
         collecs = list(converters_collection_type.collections_to_resource_type.keys())
         for collection in collecs:
+            # we want to hide the connections apis, as they are only for debug
+            hide = collection == 'connections'
             self.add_resource(getattr(Uri, collection)(True),
                               region + collection,
                               coord + collection,
                               region + '<uri:uri>/' + collection,
                               coord + '<uri:uri>/' + collection,
-                              endpoint=collection + '.collection')
+                              endpoint=collection + '.collection', hide=hide)
 
             self.add_resource(getattr(Uri, collection)(False),
                               region + collection + '/<id:id>',
                               coord + collection + '/<id:id>',
                               region + '<uri:uri>/' + collection + '/<id:id>',
                               coord + '<uri:uri>/' + collection + '/<id:id>',
-                              endpoint=collection + '.id')
+                              endpoint=collection + '.id', hide=hide)
 
         collecs = ["routes", "lines", "line_groups", "networks", "stop_areas", "stop_points",
                    "vehicle_journeys"]

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -60,6 +60,9 @@ class TestSwaggerSchema(AbstractTestFixture):
         for typename in response.get('definitions'):
             assert typename  # we should newer have empty names
 
+        # we don't want to document /connections apis
+        assert not any('connections' in p for p in response['paths'])
+
     def _check_schema(self, url):
         schema = self.get_schema()
 


### PR DESCRIPTION
the `/connections` apis are only for debug, we don't want them in swagger