### PR TITLE
Kraken: no delays on line

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -155,8 +155,13 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             LOG4CPLUS_TRACE(log, "canceling " << mvj->uri);
             mvj->cancel_vj(rt_level, impact->application_periods, pt_data, r);
             mvj->push_unique_impact(impact);
-        } else if (impact->severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS ||
-                   impact->severity->effect == nt::disruption::Effect::DETOUR ) {
+        } else if ((impact->severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS ||
+                   impact->severity->effect == nt::disruption::Effect::DETOUR) &&
+                   // we don't want to apply delay or detour without stoptime's information
+                   // if there is no stoptimes it should be modeled as a NO_SERVICE
+                   // else it is something else, like for example a SIGNIFICANT_DELAYS on a line
+                   // and in this case we do not have enough information to apply the impact
+                   ! impact->aux_info.stop_times.empty()) {
             LOG4CPLUS_TRACE(log, "modifying " << mvj->uri);
             auto canceled_vp = compute_base_disrupted_vp(impact->application_periods,
                                                          meta.production_date);


### PR DESCRIPTION
we are receiving delays message applied on lines.

We are not able to handle those message, we only know how to delay a trip, because we need precise information (and we do not have when delaying a whole line)

So a delay on a line is treated only as an information message, it does change anything