### PR TITLE
journeys get_label(). return name before code

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -357,12 +357,12 @@ class stop_time_properties_links(fields.Raw):
 class get_label(fields.Raw):
 
     def output(self, key, obj):
-        if obj.code != '':
-            return obj.code
+        if obj.name != '':
+            return obj.name
         else:
-            if obj.name != '':
-                return obj.name
-
+            if obj.code != '':
+                return obj.code
+			
 class get_key_value(fields.Raw):
 
     def output(self, key, obj):


### PR DESCRIPTION
I propose this modification to change the "display_information" in a section type:"public_transport". 
The fields "code" and "label" were always valued with the code. 
With this modification, the name of the line is accessible in the display_information in the "label" field