### PR TITLE
 	Jormgundanr: add swagger definitions for schedules

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -43,7 +43,8 @@ from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.serializer import api
 import datetime
 from jormungandr.interfaces.argument import ArgumentDoc
-from jormungandr.interfaces.parsers import DateTimeFormat, default_count_arg_type
+from jormungandr.interfaces.parsers import DateTimeFormat, default_count_arg_type, depth_argument, \
+    UnsignedInteger
 from jormungandr.interfaces.v1.errors import ManageError
 from flask_restful.inputs import natural
 from jormungandr.interfaces.v1.fields import disruption_marshaller, NonNullList, NonNullNested
@@ -63,7 +64,6 @@ class Schedules(ResourceUri, ResourceUtc):
         ResourceUri.__init__(self, *args, **kwargs)
         ResourceUtc.__init__(self)
         self.endpoint = endpoint
-        self.parsers = {}
         self.parsers["get"] = reqparse.RequestParser(argument_class=ArgumentDoc)
         parser_get = self.parsers["get"]
         parser_get.add_argument("filter", type=six.text_type)
@@ -73,14 +73,14 @@ class Schedules(ResourceUri, ResourceUtc):
                                 help="The datetime until which you want the schedules")
         parser_get.add_argument("duration", type=int, default=3600 * 24,
                                 help="Maximum duration between datetime and the retrieved stop time")
-        parser_get.add_argument("depth", type=int, default=2)
+        parser_get.add_argument("depth", type=depth_argument, default=2)
         parser_get.add_argument("count", type=default_count_arg_type, default=10,
                                 help="Number of schedules per page")
         parser_get.add_argument("start_page", type=int, default=0,
                                 help="The current page")
-        parser_get.add_argument("max_date_times", type=natural,
+        parser_get.add_argument("max_date_times", type=UnsignedInteger(), deprecated=True,
                                 help="DEPRECATED, replaced by `items_per_schedule`")
-        parser_get.add_argument("forbidden_id[]", type=six.text_type,
+        parser_get.add_argument("forbidden_id[]", type=six.text_type,deprecated=True,
                                 help="DEPRECATED, replaced by `forbidden_uris[]`",
                                 dest="__temporary_forbidden_id[]",
                                 default=[],
@@ -105,10 +105,12 @@ class Schedules(ResourceUri, ResourceUtc):
                                      'maintenances, ...). '
                                      'realtime is to have the freshest possible data',
                                 type=OptionValue(['base_schedule', 'adapted_schedule', 'realtime']))
-        parser_get.add_argument("_current_datetime", type=DateTimeFormat(), default=datetime.datetime.utcnow(),
+        parser_get.add_argument("_current_datetime", type=DateTimeFormat(),
+                                schema_metadata={'default': 'now'}, hidden=True,
+                                default=datetime.datetime.utcnow(),
                                 help="The datetime we want to publish the disruptions from."
                                      " Default is the current date and it is mainly used for debug.")
-        parser_get.add_argument("items_per_schedule", type=natural, default=10000,
+        parser_get.add_argument("items_per_schedule", type=UnsignedInteger(), default=10000,
                                 help="maximum number of date_times per schedule")
         parser_get.add_argument("disable_geojson", type=BooleanType(), default=False,
                                 help="remove geojson from the response")
@@ -116,6 +118,9 @@ class Schedules(ResourceUri, ResourceUtc):
         self.get_decorators.insert(0, ManageError())
         self.get_decorators.insert(1, get_obj_serializer(self))
         self.get_decorators.append(complete_links(self))
+
+    def options(self, **kwargs):
+        return self.api_description(**kwargs)
 
     def get(self, uri=None, region=None, lon=None, lat=None):
         args = self.parsers["get"].parse_args()

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -80,7 +80,7 @@ class Schedules(ResourceUri, ResourceUtc):
                                 help="The current page")
         parser_get.add_argument("max_date_times", type=UnsignedInteger(), deprecated=True,
                                 help="DEPRECATED, replaced by `items_per_schedule`")
-        parser_get.add_argument("forbidden_id[]", type=six.text_type,deprecated=True,
+        parser_get.add_argument("forbidden_id[]", type=six.text_type, deprecated=True,
                                 help="DEPRECATED, replaced by `forbidden_uris[]`",
                                 dest="__temporary_forbidden_id[]",
                                 default=[],

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
@@ -38,15 +38,23 @@ from navitiacommon import response_pb2
 
 point_2D_schema = {
     'type': 'array',
-    'items':{'type': 'array',
-             'items':{'type':'number',
-                      'format': 'float'}}}
+    'items': {
+        'type': 'array',
+        'items': {
+            'type': 'number',
+            'format': 'float'
+        }
+    }
+}
 
 class MultiLineStringField(jsonschema.Field):
     class MultiLineStringSchema(serpy.Serializer):
         """used not as a serializer, but only for the schema"""
         type = StrField()
-        coordinates = jsonschema.Field(schema_metadata=point_2D_schema)
+        coordinates = jsonschema.Field(schema_metadata={
+            'type': 'array',
+            'items': point_2D_schema
+        })
 
     def __init__(self, **kwargs):
         super(MultiLineStringField, self).__init__(schema_type=MultiLineStringField.MultiLineStringSchema,

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -29,7 +29,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 from jormungandr.interfaces.v1.serializer import jsonschema
-from jormungandr.interfaces.v1.serializer.pt import PlaceSerializer, CalendarSerializer, DisplayInformationSerializer, \
+from jormungandr.interfaces.v1.serializer.pt import PlaceSerializer, CalendarSerializer, VJDisplayInformationSerializer, \
     StopDateTimeSerializer, StringListField
 from jormungandr.interfaces.v1.serializer.time import DateTimeField
 from jormungandr.interfaces.v1.serializer.fields import LinkSchema, RoundedField, SectionGeoJsonField, StrField
@@ -190,7 +190,7 @@ class SectionSerializer(PbNestedSerializer):
     mode = NestedEnumField(attr='street_network.mode')
     type = SectionTypeEnum()
 
-    display_informations = DisplayInformationSerializer(attr='pt_display_informations', display_none=False)
+    display_informations = VJDisplayInformationSerializer(attr='pt_display_informations', display_none=False)
 
     links = jsonschema.MethodField(display_none=True, schema_type=LinkSchema(many=True))
     def get_links(self, obj):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/fields.py
@@ -128,3 +128,9 @@ class TimeType(CustomSchemaType):
     _schema = TypeSchema(type=str,
                          metadata={'format': 'navitia-time',
                                    'pattern': '\d{2}\d{2}\d{2}'})
+
+class TimeOrDateTimeType(CustomSchemaType):
+    # either a time or a datetime
+    _schema = TypeSchema(type=str,
+                         metadata={'format': 'navitia-time-or-date-time',
+                                   'pattern': '(\d{4}\d{2}\d{2}T)?\d{2}\d{2}\d{2}'})

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/serializer.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/serializer.py
@@ -46,6 +46,7 @@ class SwaggerParamSerializer(serpy.Serializer):
     enum = Field()
     minimum = Field()
     maximum = Field()
+    format = Field()
     items = LambdaField(method=lambda _, obj: SwaggerParamSerializer(obj.items).data if obj.items else None,
                         display_none=False)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -465,9 +465,7 @@ class DatasetSerializer(PbNestedSerializer):
     contributor = ContributorSerializer(description='Contributor providing the dataset')
 
 
-class DisplayInformationSerializer(PbNestedSerializer):
-    description = jsonschema.Field(schema_type=str)
-    physical_mode = jsonschema.Field(schema_type=str)
+class RouteDisplayInformationSerializer(PbNestedSerializer):
     commercial_mode = jsonschema.Field(schema_type=str)
     network = jsonschema.Field(schema_type=str)
     direction = jsonschema.Field(schema_type=str, display_none=True)
@@ -483,11 +481,17 @@ class DisplayInformationSerializer(PbNestedSerializer):
 
     color = jsonschema.Field(schema_type=str)
     code = jsonschema.Field(schema_type=str)
-    equipments = Equipments(attr='has_equipments', display_none=True)
-    headsign = jsonschema.Field(schema_type=str, display_none=True)
-    headsigns = StringListField(display_none=False)
     links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
     text_color = jsonschema.Field(schema_type=str)
+
+
+class VJDisplayInformationSerializer(RouteDisplayInformationSerializer):
+    description = jsonschema.Field(schema_type=str)
+    physical_mode = jsonschema.Field(schema_type=str)
+    equipments = Equipments(attr='has_equipments')
+    headsign = jsonschema.Field(schema_type=str, display_none=True)
+    headsigns = StringListField(display_none=False)
+
 
 class StopDateTimeSerializer(PbNestedSerializer):
     departure_date_time = DateTimeField()

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -499,6 +499,7 @@ class StopDateTimeSerializer(PbNestedSerializer):
     arrival_date_time = DateTimeField()
     base_arrival_date_time = DateTimeField()
     stop_point = StopPointSerializer()
+    # additional_informations is a nullable field, add nullable=True when we migrate to swagger 3
     additional_informations = AdditionalInformation(attr='additional_informations', display_none=True)
     links = jsonschema.MethodField(display_none=True, schema_type=lambda: LinkSchema(many=True))
     def get_links(self, obj):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -143,7 +143,7 @@ class TableSerializer(PbNestedSerializer):
 
 class RouteScheduleSerializer(PbNestedSerializer):
     table = TableSerializer()
-    display_informations = pt.VJDisplayInformationSerializer(attr='pt_display_informations')
+    display_informations = pt.RouteDisplayInformationSerializer(attr='pt_display_informations')
     geojson = MultiLineStringField(display_none=False)
     additional_informations = EnumField(attr="response_status", display_none=True)
     links = jsonschema.MethodField(schema_type=LinkSchema(many=True))

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -33,6 +33,7 @@ from jormungandr.interfaces.v1.serializer import pt
 from jormungandr.interfaces.v1.serializer import jsonschema
 from jormungandr.interfaces.v1.serializer.fields import LinkSchema, MultiLineStringField
 from jormungandr.interfaces.v1.make_links import create_internal_link
+from jormungandr.interfaces.v1.serializer.jsonschema.fields import TimeOrDateTimeType
 from jormungandr.utils import timestamp_to_str
 
 def _get_links(obj):
@@ -56,16 +57,16 @@ class PassageSerializer(PbNestedSerializer):
     stop_point = pt.StopPointSerializer()
     stop_date_time = pt.StopDateTimeSerializer()
     display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
-    links = jsonschema.MethodField(schema_type=LinkSchema(), many=True)
+    links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):
         return _get_links(obj)
 
 
-class DateTimeSerializer(PbNestedSerializer):
-    date_time = jsonschema.MethodField(schema_type=LinkSchema(), display_none=True)
+class DateTimeTypeSerializer(PbNestedSerializer):
+    date_time = jsonschema.MethodField(schema_type=TimeOrDateTimeType, display_none=True)
     additional_informations = pt.AdditionalInformation(attr='additional_informations', display_none=True)
-    links = jsonschema.MethodField(schema_type=LinkSchema(), many=True, display_none=True)
+    links = jsonschema.MethodField(schema_type=LinkSchema(many=True), display_none=True)
     data_freshness = EnumField(attr="realtime_level", display_none=True)
 
     def get_date_time(self, obj):
@@ -114,8 +115,8 @@ class StopScheduleSerializer(PbNestedSerializer):
     route = pt.RouteSerializer()
     additional_informations = EnumField(attr="response_status", display_none=True)
     display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
-    date_times = DateTimeSerializer(many=True, display_none=True)
-    links = jsonschema.MethodField(schema_type=LinkSchema(), many=True)
+    date_times = DateTimeTypeSerializer(many=True, display_none=True)
+    links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):
         return _get_links(obj)
@@ -123,13 +124,13 @@ class StopScheduleSerializer(PbNestedSerializer):
 
 class RowSerializer(PbNestedSerializer):
     stop_point = pt.StopPointSerializer()
-    date_times = DateTimeSerializer(many=True, display_none=True)
+    date_times = DateTimeTypeSerializer(many=True, display_none=True)
 
 
 class HeaderSerializer(PbNestedSerializer):
     additional_informations = EnumListField(attr='additional_informations', display_none=True)
     display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
-    links = jsonschema.MethodField(schema_type=LinkSchema(), many=True)
+    links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):
         return _get_links(obj)
@@ -145,7 +146,7 @@ class RouteScheduleSerializer(PbNestedSerializer):
     display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
     geojson = MultiLineStringField(display_none=False)
     additional_informations = EnumField(attr="response_status", display_none=True)
-    links = jsonschema.MethodField(schema_type=LinkSchema(), many=True)
+    links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):
         return _get_links(obj)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -56,7 +56,7 @@ class PassageSerializer(PbNestedSerializer):
     route = pt.RouteSerializer()
     stop_point = pt.StopPointSerializer()
     stop_date_time = pt.StopDateTimeSerializer()
-    display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
+    display_informations = pt.VJDisplayInformationSerializer(attr='pt_display_informations')
     links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):
@@ -114,7 +114,7 @@ class StopScheduleSerializer(PbNestedSerializer):
     stop_point = pt.StopPointSerializer()
     route = pt.RouteSerializer()
     additional_informations = EnumField(attr="response_status", display_none=True)
-    display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
+    display_informations = pt.RouteDisplayInformationSerializer(attr='pt_display_informations')
     date_times = DateTimeTypeSerializer(many=True, display_none=True)
     links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
@@ -129,7 +129,7 @@ class RowSerializer(PbNestedSerializer):
 
 class HeaderSerializer(PbNestedSerializer):
     additional_informations = EnumListField(attr='additional_informations', display_none=True)
-    display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
+    display_informations = pt.VJDisplayInformationSerializer(attr='pt_display_informations')
     links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):
@@ -143,7 +143,7 @@ class TableSerializer(PbNestedSerializer):
 
 class RouteScheduleSerializer(PbNestedSerializer):
     table = TableSerializer()
-    display_informations = pt.DisplayInformationSerializer(attr='pt_display_informations')
+    display_informations = pt.VJDisplayInformationSerializer(attr='pt_display_informations')
     geojson = MultiLineStringField(display_none=False)
     additional_informations = EnumField(attr="response_status", display_none=True)
     links = jsonschema.MethodField(schema_type=LinkSchema(many=True))

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -109,6 +109,7 @@ class TestSwaggerSchema(AbstractTestFixture):
             flex.core.validate_api_call(schema, req, resp)
             return obj
         except ValidationError as e:
+            logging.exception('validation error')
             if hard_check:
                 raise
             return obj, collect_all_errors(e)

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -31,12 +31,39 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import json
 import logging
 
+from flex.exceptions import ValidationError
+
 from tests.tests_mechanism import dataset, AbstractTestFixture
 import flex
 
 
 def get_params(schema):
     return {p['name']: p for p in schema.get('get', {}).get('parameters', [])}
+
+
+def collect_all_errors(validation_error):
+    """
+    collect all errors from a flex ValidationError
+
+    the ValidationError is an aggregate of dict and list to have structured errors,
+    we destructure them to get a simple dict with a 'path' to the error and the error
+    """
+    def _collect(err, key):
+        errors = {}
+        if isinstance(err, dict):
+            for k, v in err.items():
+                if k == 'default_factory':
+                    continue
+                errors.update(_collect(v, key='{prev}.{k}'.format(prev=key, k=k)))
+            return errors
+
+        if isinstance(err, list):
+            for i, e in enumerate(err):
+                errors.update(_collect(e, key='{k}[{i}]'.format(k=key, i=i)))
+            return errors
+
+        return {key: err}
+    return _collect(validation_error.messages, key='.')
 
 
 @dataset({"main_routing_test": {}, "main_autocomplete_test": {}})
@@ -63,7 +90,7 @@ class TestSwaggerSchema(AbstractTestFixture):
         # we don't want to document /connections apis
         assert not any('connections' in p for p in response['paths'])
 
-    def _check_schema(self, url):
+    def _check_schema(self, url, hard_check=True):
         schema = self.get_schema()
 
         raw_response = self.tester.get(url)
@@ -75,8 +102,16 @@ class TestSwaggerSchema(AbstractTestFixture):
             url=url,
             status_code=raw_response.status_code,
             content_type='application/json')
-        flex.core.validate_api_call(schema, req, resp)
-        return json.loads(raw_response.data)
+
+        obj = json.loads(raw_response.data)
+
+        try:
+            flex.core.validate_api_call(schema, req, resp)
+            return obj
+        except ValidationError as e:
+            if hard_check:
+                raise
+            return obj, collect_all_errors(e)
 
     def test_coverage_schema(self):
         """
@@ -155,3 +190,54 @@ class TestSwaggerSchema(AbstractTestFixture):
                            'from=0.001527130369323005;0.0004491559909773545&'
                            'to=station_1&'
                            'datetime=20120615T080000')
+
+    def test_stop_schedule(self):
+        """
+        test the stop_schedule swagger
+
+        the problem with this API is that we return sometime `null` field and swagger does not like this
+        since the navitia SDK handle those and we haven't found a way around those (we can't use swagger3 yet)
+        we consider those error acceptable
+        """
+        # Note: swagger does not handle '/' in parameters, so we cannot express our '<uris>'
+        # so the '/' is urlencoded as %2F to be able to test the call
+
+        obj, errors = self._check_schema('/v1/coverage/main_routing_test/stop_areas%2FstopB/stop_schedules?'
+                           'from_datetime=20120614T165200', hard_check=False)
+
+        # we have some errors, but only on additional_informations
+        assert len(errors) == 2
+        for k, e in errors.items():
+            assert k.endswith('additional_informations[0].type[0]')
+            assert e == "Got value `None` of type `null`. Value must be of type(s): `(u'string',)`"
+
+        # we check that the response is not empty
+        assert any((o.get('date_times') for o in obj.get('stop_schedules', [])))
+
+    def test_route_schedule(self):
+        """
+        test the route_schedule swagger
+
+        the problem with this API is that we return sometime `null` field and swagger does not like this
+        since the navitia SDK handle those and we haven't found a way around those (we can't use swagger3 yet)
+        we consider those error acceptable
+        """
+        # Note: swagger does not handle '/' in parameters, so we cannot express our '<uris>'
+        # so the '/' is urlencoded as %2F to be able to test the call
+
+        _, errors = self._check_schema('/v1/coverage/main_routing_test/routes%2FA:0/route_schedules?'
+                                       'from_datetime=20120614T165200', hard_check=False)
+
+        # we have some errors, but only on additional_informations
+        assert len(errors) == 1
+        for k, e in errors.items():
+            assert k.endswith('additional_informations[0].type[0]')
+            assert e == "Got value `None` of type `null`. Value must be of type(s): `(u'string',)`"
+
+    def test_departures(self):
+        self._check_schema('/v1/coverage/main_routing_test/stop_areas%2FstopB/departures?'
+                           'from_datetime=20120614T165200')
+
+    def test_arrivals(self):
+        self._check_schema('/v1/coverage/main_routing_test/stop_areas%2FstopB/arrivals?'
+                           'from_datetime=20120614T165200')


### PR DESCRIPTION
add swagger definition for `/stop_schedules`, `/route_schedules`, `/departures` and `/arrivals`

There is one gotcha, in `/stop_schedules` and `/route_schedules`, we display null field and this does not seems accepted by swagger 2, and swagger 3 codegen is not yet available :cry: 

so the swagger validator in the 2 is not happy, but the swagger 2 codegen seems to accept the null values...
so for the moment we let this as it is.