### PR TITLE
Kraken: fix search route by external_codes

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -577,7 +577,7 @@ void Worker::place_code(const pbnavitia::PlaceCodeRequest &request) {
         fill_or_error<nt::Line>(request, pb_creator);
         break;
     case pbnavitia::PlaceCodeRequest::Route:
-        fill_or_error<nt::Line>(request, pb_creator);
+        fill_or_error<nt::Route>(request, pb_creator);
         break;
     case pbnavitia::PlaceCodeRequest::VehicleJourney:
         fill_or_error<nt::VehicleJourney>(request, pb_creator);


### PR DESCRIPTION
fix https://github.com/CanalTP/navitia/issues/2172

this was preventing the search of route by external code (with
`/v1/routes?external_code=bob` or
`/v1/coverage/toto/routes?external_code=bob`)