### PR TITLE
Jormungandr: hide some deprecated routes

### DIFF
--- a/source/jormungandr/jormungandr/helper.py
+++ b/source/jormungandr/jormungandr/helper.py
@@ -72,6 +72,9 @@ class NavitiaRule(Rule):
     """
     custom class to add a 'hide' variable to hide a rule in swagger
     """
-    def __init__(self, *args, **kwargs):
-        self.hide = kwargs.pop('hide', False)
-        super(NavitiaRule, self).__init__(*args, **kwargs)
+    def __init__(self, name, **kwargs):
+        routes_to_hide = kwargs.pop('hide_routes', [])
+        name_no_version = name.replace('/v1', '')
+        self.hide = kwargs.pop('hide', False) or name_no_version in routes_to_hide
+
+        super(NavitiaRule, self).__init__(name, **kwargs)

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -181,7 +181,9 @@ class V1Routing(AModule):
                           region + 'journeys',
                           coord + 'journeys',
                           '/journeys',
-                          endpoint='journeys')
+                          endpoint='journeys',
+                          # we don't want to document those routes as we consider them deprecated
+                          hide_routes=(region + '<uri:uri>/journeys', coord + '<uri:uri>/journeys'))
 
         if app.config['GRAPHICAL_ISOCHRONE']:
             self.add_resource(GraphicalIsochrone.GraphicalIsochrone,

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -89,6 +89,8 @@ class TestSwaggerSchema(AbstractTestFixture):
 
         # we don't want to document /connections apis
         assert not any('connections' in p for p in response['paths'])
+        # we also don't want this api, as we consider it deprecated
+        assert not any('/coverage/{lon};{lat}/{uri}/journeys' in p for p in response['paths'])
 
     def _check_schema(self, url, hard_check=True):
         schema = self.get_schema()


### PR DESCRIPTION
we consider  `/v1/coverage/<some_uri>/journeys/` (in this case the last object of `<some_uri>` is used as the `from` of the journey) as deprecated so we don't want to explose them in swagger

fix #2171