### PR TITLE
Jormun: fix initialization order of BssProviderManager and CarProviderManager

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -35,11 +35,11 @@ POI_TYPE_ID = 'poi_type:amenity:bicycle_rental'
 class BssProviderManager(AbstractProviderManager):
 
     def __init__(self, bss_providers_configuration):
+        super(BssProviderManager, self).__init__()
         self.bss_providers = []
         for configuration in bss_providers_configuration:
             arguments = configuration.get('args', {})
             self.bss_providers.append(self._init_class(configuration['class'], arguments))
-        super(BssProviderManager, self).__init__()
 
     def _handle_poi(self, item):
         if 'poi_type' in item and item['poi_type']['id'] == POI_TYPE_ID:

--- a/source/jormungandr/jormungandr/parking_space_availability/car/car_park_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/car_park_provider_manager.py
@@ -35,11 +35,11 @@ POI_TYPE_ID = 'poi_type:amenity:parking'
 class CarParkingProviderManager(AbstractProviderManager):
 
     def __init__(self, car_park_providers_configurations):
+        super(CarParkingProviderManager, self).__init__()
         self.car_park_providers = []
         for configuration in car_park_providers_configurations:
             arguments = configuration.get('args', {})
             self.car_park_providers.append(self._init_class(configuration['class'], arguments))
-        super(CarParkingProviderManager, self).__init__()
 
     def _handle_poi(self, item):
         if 'poi_type' in item and item['poi_type']['id'] == POI_TYPE_ID:


### PR DESCRIPTION


The parent contructor was call too late, so the logger wasn't
initialized when we needed it in `self._init_class`