### PR TITLE
Kraken: no disruptions on time for journeys and schedules

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -486,24 +486,27 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
         # it's not in journeys
         response = self.query_region(journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T1337")
         assert not has_the_disruption(response)
+        #no realtime flags on journeys yet
 
         # it's not in departures
         response = self.query_region("stop_points/stop_point:stopB/departures?_current_datetime=20120614T080000&data_freshness=realtime")
         assert not has_the_disruption(response)
+        assert response['departures'][0]['stop_date_time']['data_freshness'] == 'realtime'
 
         # it's not in arrivals
         response = self.query_region("stop_points/stop_point:stopA/arrivals?_current_datetime=20120614T080000&data_freshness=realtime")
-        print response
         assert not has_the_disruption(response)
+        assert response['arrivals'][0]['stop_date_time']['data_freshness'] == 'realtime'
 
         # it's not in stop_schedules
-        response = self.query_region("stop_points/stop_point:stopB/stop_schedules?_current_datetime=20120614T080000&data_freshness=realtime")
+        response = self.query_region("stop_points/stop_point:stopB/lines/A/stop_schedules?_current_datetime=20120614T080000&data_freshness=realtime")
         assert not has_the_disruption(response)
+        assert response['stop_schedules'][0]['date_times'][0]['data_freshness'] == 'realtime'
 
         # it's not in route_schedules
-        response = self.query_region("stop_points/stop_point:stopB/route_schedules?_current_datetime=20120614T080100&data_freshness=realtime")
+        response = self.query_region("stop_points/stop_point:stopB/lines/A/route_schedules?_current_datetime=20120614T080100&data_freshness=realtime")
         assert not has_the_disruption(response)
-
+        #no realtime flags on route_schedules yet
 
 
 def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None):

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -461,7 +461,7 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
         stop_schedules, but no vj disruption is outputed for the
         moment).
         """
-        disruptions_before = self.query_region('disruptions?_current_datetime=20120614T1337')
+        disruptions_before = self.query_region('disruptions?_current_datetime=20120614T080000')
         nb_disruptions_before = len(disruptions_before['disruptions'])
 
         # New disruption same as base schedule
@@ -479,12 +479,12 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
             return len([d['id'] for d in response['disruptions'] if d['id'] == 'vjA_on_time']) != 0
 
         # We have a new diruption
-        disruptions_after = self.query_region('disruptions?_current_datetime=20120614T1337')
+        disruptions_after = self.query_region('disruptions?_current_datetime=20120614T080000')
         assert nb_disruptions_before + 1 == len(disruptions_after['disruptions'])
         assert has_the_disruption(disruptions_after)
 
         # it's not in journeys
-        response = self.query_region(journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T1337")
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T080000")
         assert not has_the_disruption(response)
         #no realtime flags on journeys yet
 
@@ -523,12 +523,12 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
             return len([d['id'] for d in response['disruptions'] if d['id'] == 'vjA_late']) != 0
 
         # We have a new diruption
-        disruptions_after = self.query_region('disruptions?_current_datetime=20120614T1337')
+        disruptions_after = self.query_region('disruptions?_current_datetime=20120614T080000')
         assert nb_disruptions_before + 2 == len(disruptions_after['disruptions'])
         assert has_the_disruption(disruptions_after)
 
         # it's in journeys
-        response = self.query_region(journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T1337")
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T080000")
         assert has_the_disruption(response)
         #no realtime flags on journeys yet
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -38,6 +38,7 @@ www.navitia.io
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
 #include "routing/raptor.h"
+#include "routing/raptor_api.h"
 #include "kraken/apply_disruption.h"
 #include "disruption/traffic_reports_api.h"
 #include "type/pb_converter.h"
@@ -1950,4 +1951,97 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
     journeys = get_journeys(nt::RTLevel::RealTime, "A", "C");
     BOOST_REQUIRE_EQUAL(journeys.size(), 1);
     BOOST_CHECK_EQUAL(journeys[0].items.back().arrival, "20170101T083500"_dt);
+}
+
+/*delay: +5      0      0     +5      0
+ *        A ---- B ---- C ---- D ---- E
+ *
+ * A to B -> print disruption
+ * B to C -> no disruption
+ * C to D -> print disruption
+ * C to E -> print disruption
+ */
+BOOST_AUTO_TEST_CASE(train_delayed_and_on_time) {
+    ed::builder b("20150928");
+    b.vj("1", "000001", "", true, "vj:1")
+        ("A", "08:00"_t)
+        ("B", "09:00"_t)
+        ("C", "10:00"_t)
+        ("D", "11:00"_t)
+        ("E", "12:00"_t);
+
+    transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
+            "20150928",
+            {
+                    DelayedTimeStop("A", "20150928T0805"_pts).delay(5_min),
+                    DelayedTimeStop("B", "20150928T0900"_pts).delay(0_min),
+                    DelayedTimeStop("C", "20150928T1000"_pts).delay(0_min),
+                    DelayedTimeStop("D", "20150928T1105"_pts).delay(5_min),
+                    DelayedTimeStop("E", "20150928T1200"_pts).delay(0_min)
+            });
+    b.data->build_uri();
+
+    navitia::handle_realtime("bob", timestamp, trip_update, *b.data);
+
+    const auto& pt_data = b.data->pt_data;
+    pt_data->index();
+    b.finish();
+    b.data->build_raptor();
+
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    auto compute = [&](const char* from, const char* to, nt::RTLevel level) {
+        navitia::type::Type_e origin_type = b.data->get_type_of_id(from);
+        navitia::type::Type_e destination_type = b.data->get_type_of_id(to);
+        navitia::type::EntryPoint origin(origin_type, from);
+        navitia::type::EntryPoint destination(destination_type, to);
+
+        navitia::PbCreator pb_creator(b.data.get(), "20150928T073000"_dt, null_time_period);
+        make_response(pb_creator, raptor, origin, destination,
+                      {ntest::to_posix_timestamp("20150928T073000")},
+                      true, navitia::type::AccessibiliteParams(), {}, {},
+                      sn_worker, level, 2_min);
+        return  pb_creator.get_response();
+    };
+
+    auto res = compute("A", "B", nt::RTLevel::RealTime);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
+
+    res = compute("A", "B", nt::RTLevel::Base);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
+
+    res = compute("B", "C", nt::RTLevel::RealTime);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 0);
+
+    res = compute("B", "C", nt::RTLevel::Base);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 0);
+
+    res = compute("C", "D", nt::RTLevel::RealTime);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
+
+    res = compute("C", "D", nt::RTLevel::Base);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
+
+    res = compute("C", "E", nt::RTLevel::RealTime);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
+
+    res = compute("C", "E", nt::RTLevel::Base);
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
 }

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1953,8 +1953,12 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
     BOOST_CHECK_EQUAL(journeys[0].items.back().arrival, "20170101T083500"_dt);
 }
 
-/*delay: +5      0      0     +5      0
- *        A ---- B ---- C ---- D ---- E
+/*
+ * Test that we display delays on journeys only if the traveler is
+ * really impacted by it.
+ *
+ * delay: +5      0      0     +5      0
+ *         A ---- B ---- C ---- D ---- E
  *
  * A to B -> print disruption
  * B to C -> no disruption
@@ -1963,7 +1967,7 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
  */
 BOOST_AUTO_TEST_CASE(train_delayed_and_on_time) {
     ed::builder b("20150928");
-    b.vj("1", "000001", "", true, "vj:1")
+    b.vj("1").uri("vj:1")
         ("A", "08:00"_t)
         ("B", "09:00"_t)
         ("C", "10:00"_t)

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -164,7 +164,7 @@ void passages(PbCreator& pb_creator,
         } else {
             passage = pb_creator.add_next_arrivals();
         }
-        pb_creator.action_period = pt::time_period(base_ptime, pt::seconds(1));
+        pb_creator.action_period = pt::time_period(base_ptime - pt::seconds(1), pt::seconds(2));
 
         auto departure_dt = get_date_time(vis.stop_event(), dt_stop_time.second, dt_stop_time.second,
                                           base_ptime, true);

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -164,6 +164,9 @@ void passages(PbCreator& pb_creator,
         } else {
             passage = pb_creator.add_next_arrivals();
         }
+
+        // We need one second before because else, on terminus, we may
+        // miss something as period exclude the end.
         pb_creator.action_period = pt::time_period(base_ptime - pt::seconds(1), pt::seconds(2));
 
         auto departure_dt = get_date_time(vis.stop_event(), dt_stop_time.second, dt_stop_time.second,

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -168,6 +168,9 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
 bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
     // No delay on the section
     if (severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS && ! aux_info.stop_times.empty()) {
+        // We don't handle removed or added stop, but we already match
+        // on SIGNIFICANT_DELAYS, thus we should not have that here
+        // (removed and added stop should be a DETOUR)
         const auto nb_aux = aux_info.stop_times.size();
         for (const auto& st: stop_times) {
             const auto base_st = st->get_base_stop_time();

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -282,7 +282,7 @@ struct Impact {
     static void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact, const boost::gregorian::date_period&, type::RTLevel);
 
     bool is_valid(const boost::posix_time::ptime& current_time, const boost::posix_time::time_period& action_period) const;
-    bool is_relevent() const;
+    bool is_relevant(const std::vector<const StopTime*>& stop_times) const;
 
     const type::ValidityPattern get_impact_vp(const boost::gregorian::date_period& production_date) const;
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -282,6 +282,7 @@ struct Impact {
     static void link_informed_entity(PtObj ptobj, boost::shared_ptr<Impact>& impact, const boost::gregorian::date_period&, type::RTLevel);
 
     bool is_valid(const boost::posix_time::ptime& current_time, const boost::posix_time::time_period& action_period) const;
+    bool is_relevent() const;
 
     const type::ValidityPattern get_impact_vp(const boost::gregorian::date_period& production_date) const;
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1232,26 +1232,31 @@ void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
     for (const auto& message : meta_vj->get_applicable_messages(pb_creator.now,
                                                                 pb_creator.action_period)) {
         bool fill = [&](){
+            // useless disruption
+            if (! message->is_relevent()) { return false; }
+
+            // line section thing
             auto line_section_impacted_obj_it = boost::find_if(message->informed_entities(),
                                                             [](const nd::PtObj& ptobj) {
                return boost::get<nd::LineSection>(&ptobj) != nullptr;
             });
-            if (line_section_impacted_obj_it == message->informed_entities().end()) {
-                // there is no line section, thus we want to fill the message
-                return true;
-            }
-            // note in this we take the premise that an impact cannot impact a line section AND a vj
-            for (const auto& st: vj_stoptimes->stop_times) {
-                // if one stop point of the stoptimes is impacted by the same impact
-                // it means the section is impacted
-                for (const auto& sp_message: st->stop_point->get_applicable_messages(
-                         pb_creator.now, pb_creator.action_period)) {
-                    if (sp_message == message) {
-                        return true;
+            if (line_section_impacted_obj_it != message->informed_entities().end()) {
+                // note in this we take the premise that an impact
+                // cannot impact a line section AND a vj
+                for (const auto& st: vj_stoptimes->stop_times) {
+                    // if one stop point of the stoptimes is impacted by the same impact
+                    // it means the section is impacted
+                    for (const auto& sp_message: st->stop_point->get_applicable_messages(
+                             pb_creator.now, pb_creator.action_period)) {
+                        if (sp_message == message) {
+                            return true;
+                        }
                     }
                 }
+                return false;
             }
-            return false;
+            // nothing special, let's fill it
+            return true;
         }();
 
         if (! fill) { continue; }

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1229,38 +1229,8 @@ void PbCreator::Filler::fill_messages(const VjStopTimes* vj_stoptimes,
     if (vj_stoptimes == nullptr) { return ; }
     if (dump_message_options.dump_message == DumpMessage::No) { return; }
     const auto* meta_vj = vj_stoptimes->vj->meta_vj;
-    for (const auto& message : meta_vj->get_applicable_messages(pb_creator.now,
-                                                                pb_creator.action_period)) {
-        bool fill = [&](){
-            // useless disruption
-            if (! message->is_relevent()) { return false; }
-
-            // line section thing
-            auto line_section_impacted_obj_it = boost::find_if(message->informed_entities(),
-                                                            [](const nd::PtObj& ptobj) {
-               return boost::get<nd::LineSection>(&ptobj) != nullptr;
-            });
-            if (line_section_impacted_obj_it != message->informed_entities().end()) {
-                // note in this we take the premise that an impact
-                // cannot impact a line section AND a vj
-                for (const auto& st: vj_stoptimes->stop_times) {
-                    // if one stop point of the stoptimes is impacted by the same impact
-                    // it means the section is impacted
-                    for (const auto& sp_message: st->stop_point->get_applicable_messages(
-                             pb_creator.now, pb_creator.action_period)) {
-                        if (sp_message == message) {
-                            return true;
-                        }
-                    }
-                }
-                return false;
-            }
-            // nothing special, let's fill it
-            return true;
-        }();
-
-        if (! fill) { continue; }
-
+    for (const auto& message: meta_vj->get_applicable_messages(pb_creator.now, pb_creator.action_period)) {
+        if (! message->is_relevant(vj_stoptimes->stop_times)) { continue; }
         fill_message(message, pt_display_info);
     }
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -169,6 +169,29 @@ bool StopTime::is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel 
     return vehicle_journey->validity_patterns[rt_level]->check(day);
 }
 
+const StopTime* StopTime::get_base_stop_time() const {
+    const nt::StopTime* st_base = nullptr;
+    size_t nb_st_found = 0;
+    if (vehicle_journey == nullptr) { return nullptr; }
+    auto base_vj = vehicle_journey->get_corresponding_base();
+    if (base_vj == nullptr) { return nullptr; }
+
+    if (vehicle_journey == base_vj) { return this; }
+    for (const auto& st_it: base_vj->stop_time_list) {
+        if (stop_point == st_it.stop_point) {
+            st_base = &st_it;
+            ++nb_st_found;
+        }
+    }
+    //TODO handle lolipop vj, bob-commerce-commerce-bobito vj...
+    if (nb_st_found != 1) {
+        auto logger = log4cplus::Logger::getInstance("log");
+        LOG4CPLUS_DEBUG(logger, "Ignored stop_time finding: impossible to match exactly one base stop_time");
+        return nullptr;
+    }
+    return st_base;
+}
+
 bool FrequencyVehicleJourney::is_valid(int day, const RTLevel rt_level) const {
     if (day < 0)
         return false;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -778,6 +778,8 @@ struct StopTime {
 
     bool is_valid_day(u_int32_t day, const bool is_arrival, const RTLevel rt_level) const;
 
+    const StopTime* get_base_stop_time() const;
+
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
             ar & arrival_time & departure_time & boarding_time & alighting_time & vehicle_journey
             & stop_point & shape_from_prev & properties & local_traffic_zone;


### PR DESCRIPTION
When calling /journeys, /departures, /arrivals, /stop_schedules, /route_schedules, we don't send on time disruptions (useless and disturbing in this context)