### PR TITLE
Tyr: fix tyr test

### DIFF
--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -576,7 +576,7 @@ class AutocompleteParameter(db.Model, TimestampMixin):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.Text, nullable=False, unique=True)
     street = db.Column(db.Enum(*street_source_types, name='source_street'), nullable=True)
-    address = db.Column(db.Enum(address_source_types, name='source_address'), nullable=True)
+    address = db.Column(db.Enum(*address_source_types, name='source_address'), nullable=True)
     poi = db.Column(db.Enum(*poi_source_types, name='source_poi'), nullable=True)
     admin = db.Column(db.Enum(*admin_source_types, name='source_admin'), nullable=True)
     admin_level = db.Column(ARRAY(db.Integer), nullable=False)

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.10.1
 Flask-Migrate==1.1.1
-git+https://github.com/CanalTP/flask-restful.git@76346f65ca12a8edb9b32688cdc192ad391fa686#egg=Flask_RESTful-master
+git+https://github.com/CanalTP/flask-restful.git@76346f65ca12a8edb9b32688cdc192ad391fa686#egg=Flask_RESTful
 Flask-SQLAlchemy==1.0
 Flask-Script==0.6.7
 GeoAlchemy2==0.2.4

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -753,9 +753,9 @@ class TravelerProfile(flask_restful.Resource):
 
         # flask parser returns a list for first_section_mode and last_section_mode
         parser.add_argument('first_section_mode',
-                            type=OptionValue(fb_modes), required=False, location='json')
+                            type=OptionValue(fb_modes), action='append', required=False, location='json')
         parser.add_argument('last_section_mode',
-                            type=OptionValue(fb_modes), required=False, location='json')
+                            type=OptionValue(fb_modes), action='append', required=False, location='json')
 
         self.args = parser.parse_args()
 


### PR DESCRIPTION
the tyr tests (run by running `py.test source/tyr/tests` or `make
docker_test`) were broken since the last flask restful update

this was because of a missing `action='append'` on the fallback modes.
I don't know how that was working before :grin:

I renamed the egg too because of a warning while installing with pip