### PR TITLE
Jormungandr: fix unknown ticket cost in serpy

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -37,9 +37,8 @@ from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field
 
 
 class PbField(Field):
-    def __init__(self, default_value=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(PbField, self).__init__(*args, **kwargs)
-        self.default_value = default_value
 
     """
     This field handle protobuf, it aim to handle field absent value:
@@ -50,12 +49,12 @@ class PbField(Field):
         op = operator.attrgetter(self.attr or serializer_field_name)
         def getter(obj):
             if obj is None:
-                return self.default_value
+                return None
             try:
-                if obj.HasField(self.attr or serializer_field_name):
+                if self.display_none or obj.HasField(self.attr or serializer_field_name):
                     return op(obj)
                 else:
-                    return self.default_value
+                    return None
             except ValueError:
                 #HasField throw an exception if the field is repeated...
                 return op(obj)
@@ -63,8 +62,8 @@ class PbField(Field):
 
 
 class PbStrField(PbField):
-    def __init__(self, default_value=None, *args, **kwargs):
-        super(PbStrField, self).__init__(default_value, schema_type=str, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super(PbStrField, self).__init__(schema_type=str, *args, **kwargs)
 
     to_value = staticmethod(six.text_type)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -34,7 +34,7 @@ from jormungandr.interfaces.v1.serializer.pt import PlaceSerializer, CalendarSer
 from jormungandr.interfaces.v1.serializer.time import DateTimeField
 from jormungandr.interfaces.v1.serializer.fields import LinkSchema, RoundedField, SectionGeoJsonField, StrField
 from jormungandr.interfaces.v1.serializer.base import AmountSerializer, PbNestedSerializer, \
-        LambdaField, EnumField, EnumListField, NestedEnumField
+    LambdaField, EnumField, EnumListField, NestedEnumField, PbField, PbStrField
 from flask import g
 from navitiacommon.type_pb2 import StopDateTime
 from navitiacommon.response_pb2 import SectionAdditionalInformationType
@@ -51,8 +51,8 @@ class ContextSerializer(PbNestedSerializer):
 
 
 class CostSerializer(PbNestedSerializer):
-    value = StrField()
-    currency = jsonschema.Field(schema_type=str)
+    value = PbStrField(default_value='')
+    currency = PbField(schema_type=str, default_value='')
 
 
 class FareSerializer(PbNestedSerializer):
@@ -85,7 +85,7 @@ class TicketSerializer(PbNestedSerializer):
     name = jsonschema.Field(schema_type=str, display_none=True, description='Name of the object')
     comment = jsonschema.Field(schema_type=str)
     found = jsonschema.BoolField()
-    cost = CostSerializer()
+    cost = CostSerializer(display_none=True)
     links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
 
     def get_links(self, obj):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -51,8 +51,8 @@ class ContextSerializer(PbNestedSerializer):
 
 
 class CostSerializer(PbNestedSerializer):
-    value = PbStrField(default_value='')
-    currency = PbField(schema_type=str, default_value='')
+    value = PbStrField()
+    currency = PbField(schema_type=str)
 
 
 class FareSerializer(PbNestedSerializer):


### PR DESCRIPTION
the retrocompatibility had been broken because there was no `cost` field
in the tickets for the `unkown_ticket`.

before
```json
{
"comment": "unknown ticket",
"found": false,
"name": "unknown_ticket",
"links": [
    {
      "internal": true,
      "type": "section",
      "id": "section_7_0",
      "rel": "sections",
      "templated": false
    }
],
"id": "unknown_ticket_0"
}

```

after
```python
{
"comment": "unknown ticket",
"name": "unknown_ticket",
"links": [
    {
      "internal": true,
      "type": "section",
      "id": "section_7_0",
      "rel": "sections",
      "templated": false
    }
],
"cost": {  # <-- default cost field
    "currency": "",
    "value": ""
},
"found": false,
"id": "unknown_ticket_0"
}
```

(yeah the `""` default values and string `value` are crap, but for
retrocompatibility sake we can't change it)

there is no test because there is no tests with `unkown_tickets`