### PR TITLE
Kraken: don't segfault when 2 different disruptions modify the same vj

### DIFF
--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -329,6 +329,16 @@ void DisruptionHolder::clean_weak_impacts(){
     clean_up_weak_ptr(weak_impacts);
 }
 
+void DisruptionHolder::forget_vj(const VehicleJourney* vj) {
+    for (const auto& impact: vj->meta_vj->get_impacts()) {
+        for (auto& stu: impact->aux_info.stop_times) {
+            if (stu.stop_time.vehicle_journey == vj) {
+                stu.stop_time.vehicle_journey = nullptr;
+            }
+        }
+    }
+}
+
 namespace detail {
 
 const StopTime* AuxInfoForMetaVJ::get_base_stop_time(const StopTimeUpdate& stu) const {

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -369,6 +369,7 @@ public:
     size_t nb_disruptions() const { return disruptions_by_uri.size(); }
     void add_weak_impact(boost::weak_ptr<Impact>);
     void clean_weak_impacts();
+    void forget_vj(const VehicleJourney*);
     const std::vector<boost::weak_ptr<Impact>>&
     get_weak_impacts() const{ return weak_impacts;}
     // causes, severities and tags are a pool (weak_ptr because the owner ship

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -848,7 +848,7 @@ void PbCreator::Filler::fill_pb_object(const nt::StopPointConnection* c, pbnavit
 
 static uint32_t get_st_utc_offset(const nt::StopTime* st, const uint32_t time) {
     static const auto flag = std::numeric_limits<uint32_t>::max();
-    return time == flag ? 0 : st->vehicle_journey->utc_to_local_offset();
+    return time == flag || st->vehicle_journey == nullptr ? 0 : st->vehicle_journey->utc_to_local_offset();
 }
 
 void PbCreator::Filler::fill_pb_object(const nd::StopTimeUpdate* stu, pbnavitia::StopTime* stop_time) {

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -467,6 +467,7 @@ void cleanup_useless_vj_link(const nt::VehicleJourney* vj, nt::PT_Data& pt_data)
     }
 
     pt_data.headsign_handler.forget_vj(vj);
+    pt_data.disruption_holder.forget_vj(vj);
 
     // remove the vj from the global list/map
     erase_vj_from_list(vj, pt_data.vehicle_journeys);


### PR DESCRIPTION
If we have a disruption updating the stop times of a vj, and then another disruption on the same vj with another id, we have dangling pointers.  It should not arrive but better to secure that.

This PR fixes that in a simple way:
  * the disruption is kept, as some tests require it.
  * the disruption will be printed when it applies, even if the other disruption override it.
  * the impacted stops will be printed relative to UTC instead of local.

This is safe, but not the prettiest. As it should not happen, keep it simple.