### PR TITLE
Jormungandr: get all bss stands in one call to jcdecaux api

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
@@ -95,3 +95,7 @@ class JcdecauxProvider(AbstractParkingPlacesProvider):
 
     def feed_publisher(self):
         return self._feed_publisher
+
+    def __repr__(self):
+        #TODO: make this shit python 3 compatible
+        return ('jcdecaux-{}-{}'.format(self.network, self.contract)).encode('utf-8')

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/jcdecaux.py
@@ -47,7 +47,7 @@ DEFAULT_JCDECAUX_FEED_PUBLISHER = {
 
 class JcdecauxProvider(AbstractParkingPlacesProvider):
 
-    WS_URL_TEMPLATE = 'https://api.jcdecaux.com/vls/v1/stations/{}?contract={}&apiKey={}'
+    WS_URL_TEMPLATE = 'https://api.jcdecaux.com/vls/v1/stations/?contract={}&apiKey={}'
 
     def __init__(self, network, contract, api_key, operators={'jcdecaux'}, timeout=10,
                  feed_publisher=DEFAULT_JCDECAUX_FEED_PUBLISHER, **kwargs):
@@ -67,10 +67,13 @@ class JcdecauxProvider(AbstractParkingPlacesProvider):
                properties.get('network', '').lower() == self.network
 
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_JCDECAUX', 30))
-    def _call_webservice(self, station_id):
+    def _call_webservice(self):
         try:
-            data = self.breaker.call(requests.get, self.WS_URL_TEMPLATE.format(station_id, self.contract, self.api_key), timeout=self.timeout)
-            return data.json()
+            data = self.breaker.call(requests.get, self.WS_URL_TEMPLATE.format(self.contract, self.api_key), timeout=self.timeout)
+            stands = {}
+            for s in data.json():
+                stands[str(s['number'])] = s
+            return stands
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error('JCDecaux service dead (error: {})'.format(e))
         except requests.Timeout as t:
@@ -81,9 +84,11 @@ class JcdecauxProvider(AbstractParkingPlacesProvider):
 
     def get_informations(self, poi):
         ref = poi.get('properties', {}).get('ref')
-        data = self._call_webservice(ref)
-        if data and 'available_bike_stands' in data and 'available_bikes' in data:
-            return Stands(data['available_bike_stands'], data['available_bikes'])
+        data = self._call_webservice()
+        if not data or ref not in data:
+            return None
+        if 'available_bike_stands' in data[ref] and 'available_bikes' in data[ref]:
+            return Stands(data[ref]['available_bike_stands'], data[ref]['available_bikes'])
 
     def status(self):
         return {'network': self.network, 'operators': self.operators, 'contract': self.contract}

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/jcdecaux_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/jcdecaux_test.py
@@ -68,10 +68,10 @@ def parking_space_availability_jcdecaux_get_informations_test():
     """
     Jcdecaux validate return good stands informations or None if an error occured
     """
-    webservice_response = {
+    webservice_response = {'2': {
         'available_bike_stands': 4,
         'available_bikes': 8
-    }
+    }}
     provider = JcdecauxProvider(u"vélib'", 'Paris', 'api_key', {'jcdecaux'})
     provider._call_webservice = MagicMock(return_value=webservice_response)
     assert provider.get_informations(poi) == Stands(4, 8)
@@ -92,12 +92,13 @@ def parking_space_availability_jcdecaux_get_informations_unauthorized_test():
     assert provider.get_informations(poi) is None
 
 def test_call_mocked_request():
-    webservice_response = {
+    webservice_response = [{
+        'number': 2,
         'available_bike_stands': 4,
         'available_bikes': 8
-    }
+    }]
     provider = JcdecauxProvider(u"vélib'", 'Paris', 'api_key', {'jcdecaux'})
     with requests_mock.Mocker() as m:
-        m.get('https://api.jcdecaux.com/vls/v1/stations/2', json=webservice_response)
+        m.get('https://api.jcdecaux.com/vls/v1/stations/', json=webservice_response)
         assert provider.get_informations(poi) == Stands(4, 8)
         assert m.called


### PR DESCRIPTION
With this PR we only call the jcdecaux's api one time for all the
stations, this result is then cached so it be reuse for other request.
This will greatly improve performance on call like this one:
https://api.navitia.io/v1/coverage/fr-idf/poi_types/poi_type%3Aamenity%3Abicycle_rental/pois?count=500
In most case the hard timeout of 30sec was hit before navitia can
respond.