### PR TITLE
type: fix ptref in pb_converter with non word uris

### DIFF
--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -502,15 +502,17 @@ std::vector<Target*> ptref_indexes(const Source* nav_obj, const nt::Data& data) 
     type::Indexes indexes;
     std::string request;
     try{
-        request = nt::static_data::get()->captionByType(nav_obj->type) +
-            ".uri=" + nav_obj->uri;
+        std::stringstream ss;
+        ss << nt::static_data::get()->captionByType(nav_obj->type)
+           << ".uri=\"" << boost::replace_all_copy(nav_obj->uri, "\"", "\\\"") << "\"";
+        request = ss.str();
         indexes = navitia::ptref::make_query(type_e, request, data);
     } catch(const navitia::ptref::parsing_error &parse_error) {
         LOG4CPLUS_DEBUG(log4cplus::Logger::getInstance("logger"),
-                        "ptref_indexes, Unable to parse :" + parse_error.more + ", request: " + request);
+                        "ptref_indexes, Unable to parse :" << parse_error.more << ", request: " << request);
     } catch(const navitia::ptref::ptref_error &pt_error) {
         LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("logger"),
-                        "pb_converter::ptref_indexes, " + pt_error.more + ", request: " + request);
+                        "pb_converter::ptref_indexes, " << pt_error.more << ", request: " << request);
     }
     return data.get_data<Target>(indexes);
 }

--- a/source/type/tests/fill_pb_object_tests.cpp
+++ b/source/type/tests/fill_pb_object_tests.cpp
@@ -42,6 +42,11 @@ www.navitia.io
 
 using namespace navitia::type;
 
+struct logger_initialized {
+    logger_initialized()   { init_logger(); }
+};
+BOOST_GLOBAL_FIXTURE( logger_initialized );
+
 BOOST_AUTO_TEST_CASE(test_pt_displayinfo_destination) {
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050);
@@ -251,4 +256,20 @@ BOOST_AUTO_TEST_CASE(label_formater_line) {
     BOOST_CHECK_EQUAL(rer_a->get_label(), "Transilien Rer A");
     rer_a->commercial_mode = nullptr;
     BOOST_CHECK_EQUAL(rer_a->get_label(), "Transilien A");
+}
+
+BOOST_AUTO_TEST_CASE(pb_convertor_ptref) {
+    ed::builder b("20161026");
+    b.generate_dummy_basis();
+
+    b.vj("A great \"uri\" for café");
+    b.finish();
+    b.data->build_uri();
+    b.data->pt_data->index();
+    b.data->build_raptor();
+
+    auto modes = navitia::ptref_indexes<navitia::type::PhysicalMode>(
+        b.data->pt_data->lines.front(),
+        *b.data);
+    BOOST_CHECK_EQUAL(modes.size(), 1);
 }


### PR DESCRIPTION
An uri can have any character.  We were doing badly formated request toptref in pb_converter, mainly to add modes to objects.

Example of problematic uris:
  * with accents: `Intercité42`
  * with double quote: `"toto`
  * with spaces: `an uri`