### PR TITLE
Jormungandr: disabling of sql connection pooling

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -156,3 +156,7 @@ GREENLET_POOL_SIZE = int(os.getenv('JORMUNGANDR_GEVENT_POOL_SIZE', 10))
 USE_SERPY = boolean(os.getenv('JORMUNGANDR_USE_SERPY', False))
 
 PARSER_MAX_COUNT = int(os.getenv('JORMUNGANDR_PARSER_MAX_COUNT', 1000))
+
+if boolean(os.getenv('JORMUNGANDR_DISABLE_SQLPOOLING', False)):
+    from sqlalchemy.pool import NullPool
+    SQLALCHEMY_POOLCLASS = NullPool

--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -29,9 +29,10 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
+from __future__ import absolute_import
 import uuid
 import re
-from flask_sqlalchemy import SQLAlchemy
+from navitiacommon.sqlalchemy import SQLAlchemy
 from geoalchemy2.types import Geography
 from flask import current_app
 from sqlalchemy.orm import load_only, backref, aliased

--- a/source/navitiacommon/navitiacommon/sqlalchemy.py
+++ b/source/navitiacommon/navitiacommon/sqlalchemy.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import flask_sqlalchemy
+
+class SQLAlchemy(flask_sqlalchemy.SQLAlchemy):
+
+    def init_app(self, app):
+        super(SQLAlchemy, self).init_app(app)
+        app.config.setdefault('SQLALCHEMY_POOLCLASS', None)
+
+
+    def apply_pool_defaults(self, app, options):
+        super(SQLAlchemy, self).apply_pool_defaults(app, options)
+        def _setdefault(optionkey, configkey):
+            value = app.config[configkey]
+            if value is not None:
+                options[optionkey] = value
+        _setdefault('poolclass', 'SQLALCHEMY_POOLCLASS')


### PR DESCRIPTION
This PR give us the possibility to disable connection pooling to the postgresql database.
Currently each jormungrandr process keep it's sql connection open forever.
The number of connection a database can handle is limited and can't be increased without a restart.
Pooling is enabled by default because it increases the performance by not having to reopen a connection for each query, but in production we already use an external connection pooler (pg_pool) that allows us to share connections between multiple process or even box.

With this change we will be able to increase the number of jormungandr processes without impacting the database too much