### PR TITLE
jormungandr: attribut 'templated' deleted from args

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -328,8 +328,10 @@ class add_journey_href(object):
                     args['is_journey_schedules'] = True
                     allowed_ids.update(args.get('allowed_id[]', []))
                     args['allowed_id[]'] = list(allowed_ids)
+                    args['_type'] = 'journeys'
+
                     journey['links'] = [
-                        create_external_link('v1.journeys', rel='same_journey_schedules', _type='journeys', **args)
+                        create_external_link('v1.journeys', rel='same_journey_schedules', **args)
                     ]
             return objects
         return wrapper

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -308,7 +308,8 @@ class add_journey_href(object):
                         args['to'] = journey['to']['id']
                     if 'from' not in args:
                         args['from'] = journey['from']['id']
-                    journey['links'] = [create_external_link('v1.journeys', rel='journeys', **args)]
+                    args['rel'] = 'journeys'
+                    journey['links'] = [create_external_link('v1.journeys', **args)]
                 elif allowed_ids and 'public_transport' in (s['type'] for s in journey['sections']):
                     # exactly one first_section_mode
                     if any(s['type'].startswith('bss') for s in journey['sections'][:2]):
@@ -329,10 +330,8 @@ class add_journey_href(object):
                     allowed_ids.update(args.get('allowed_id[]', []))
                     args['allowed_id[]'] = list(allowed_ids)
                     args['_type'] = 'journeys'
-
-                    journey['links'] = [
-                        create_external_link('v1.journeys', rel='same_journey_schedules', **args)
-                    ]
+                    args['rel'] = 'same_journey_schedules'
+                    journey['links'] = [create_external_link('v1.journeys', **args)]
             return objects
         return wrapper
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -344,11 +344,13 @@ class add_passages_links:
             if g.stat_interpreted_parameters.get('data_freshness') != 'realtime':
                 kwargs_links["_type"] = api
                 kwargs_links["templated"] = False
+                kwargs_links["rel"] = "prev"
                 kwargs_links['until_datetime'] = (dt - delta).strftime("%Y%m%dT%H%M%S")
-                response["links"].append(create_external_link("v1."+api, rel="prev", **kwargs_links))
+                response["links"].append(create_external_link("v1."+api, **kwargs_links))
                 kwargs_links.pop('until_datetime')
                 kwargs_links['from_datetime'] = (datetime.strptime(max_dt, "%Y%m%dT%H%M%S") + delta).strftime("%Y%m%dT%H%M%S")
-                response["links"].append(create_external_link("v1."+api, rel="next", **kwargs_links))
+                kwargs_links["rel"] = "next"
+                response["links"].append(create_external_link("v1."+api, **kwargs_links))
             return response, status, other
         return wrapper
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -342,13 +342,13 @@ class add_passages_links:
             delta = timedelta(seconds=1)
             dt = datetime.strptime(min_dt, "%Y%m%dT%H%M%S")
             if g.stat_interpreted_parameters.get('data_freshness') != 'realtime':
-                if "templated" in kwargs_links:
-                    del kwargs_links["templated"]
+                kwargs_links["_type"] = api
+                kwargs_links["templated"] = False
                 kwargs_links['until_datetime'] = (dt - delta).strftime("%Y%m%dT%H%M%S")
-                response["links"].append(create_external_link("v1."+api, rel="prev", _type=api, **kwargs_links))
+                response["links"].append(create_external_link("v1."+api, rel="prev", **kwargs_links))
                 kwargs_links.pop('until_datetime')
                 kwargs_links['from_datetime'] = (datetime.strptime(max_dt, "%Y%m%dT%H%M%S") + delta).strftime("%Y%m%dT%H%M%S")
-                response["links"].append(create_external_link("v1."+api, rel="next", _type=api, **kwargs_links))
+                response["links"].append(create_external_link("v1."+api, rel="next", **kwargs_links))
             return response, status, other
         return wrapper
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -342,6 +342,8 @@ class add_passages_links:
             delta = timedelta(seconds=1)
             dt = datetime.strptime(min_dt, "%Y%m%dT%H%M%S")
             if g.stat_interpreted_parameters.get('data_freshness') != 'realtime':
+                if "templated" in kwargs_links:
+                    del kwargs_links["kwargs"]
                 kwargs_links['until_datetime'] = (dt - delta).strftime("%Y%m%dT%H%M%S")
                 response["links"].append(create_external_link("v1."+api, rel="prev", _type=api, **kwargs_links))
                 kwargs_links.pop('until_datetime')

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -343,7 +343,7 @@ class add_passages_links:
             dt = datetime.strptime(min_dt, "%Y%m%dT%H%M%S")
             if g.stat_interpreted_parameters.get('data_freshness') != 'realtime':
                 if "templated" in kwargs_links:
-                    del kwargs_links["kwargs"]
+                    del kwargs_links["templated"]
                 kwargs_links['until_datetime'] = (dt - delta).strftime("%Y%m%dT%H%M%S")
                 response["links"].append(create_external_link("v1."+api, rel="prev", _type=api, **kwargs_links))
                 kwargs_links.pop('until_datetime')

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -137,8 +137,9 @@ class Links(fields.Raw):
             if len(e.values) > 1:
                 args[e.key] = [v for v in e.values]
             else:
-                 args[e.key] = e.values[0]
-
+                args[e.key] = e.values[0]
+        if "templated" in args:
+            del args["templated"]
         return create_external_link('v1.{}'.format(value.ressource_name),
                                     rel=value.rel,
                                     _type=value.type,

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -138,14 +138,11 @@ class Links(fields.Raw):
                 args[e.key] = [v for v in e.values]
             else:
                 args[e.key] = e.values[0]
-        if "templated" in args:
-            del args["templated"]
-        return create_external_link('v1.{}'.format(value.ressource_name),
-                                    rel=value.rel,
-                                    _type=value.type,
-                                    templated=value.is_templated,
-                                    description=value.description,
-                                    **args)
+        args["_type"] = value.type
+        args["templated"] = value.is_templated
+        args["description"] = value.description
+
+        return create_external_link('v1.{}'.format(value.ressource_name), rel=value.rel, **args)
 
 
 # a time null value is represented by the max value (since 0 is a perfectly valid value)

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -141,8 +141,9 @@ class Links(fields.Raw):
         args["_type"] = value.type
         args["templated"] = value.is_templated
         args["description"] = value.description
+        args["rel"] = value.rel
 
-        return create_external_link('v1.{}'.format(value.ressource_name), rel=value.rel, **args)
+        return create_external_link('v1.{}'.format(value.ressource_name), **args)
 
 
 # a time null value is represented by the max value (since 0 is a perfectly valid value)

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -36,7 +36,7 @@ from jormungandr.interfaces.v1.converters_collection_type import resource_type_t
 from flask.ext.restful.utils import unpack
 
 
-def create_external_link(url, rel, _type=None, templated=False, description=None, **kwargs):
+def create_external_link(url, rel=None, _type=None, templated=False, description=None, **kwargs):
     """
     :param url: url forwarded to flask's url_for
     :param rel: relation of the link to the current object
@@ -199,8 +199,8 @@ class add_coverage_link(generate_links):
                 kwargs = self.prepare_kwargs(kwargs, data)
                 kwargs["templated"] = True
                 for link in self.links:
-                    data["links"].append(
-                        create_external_link("v1.{}".format(link), rel=link, **kwargs))
+                    kwargs["rel"] = link
+                    data["links"].append(create_external_link("v1.{}".format(link), **kwargs))
             if isinstance(objects, tuple):
                 return data, code, header
             else:
@@ -228,8 +228,8 @@ class add_collection_links(generate_links):
                 kwargs = self.prepare_kwargs(kwargs, data)
                 kwargs["templated"] = True
                 for collection in self.collections:
-                    data["links"].append(create_external_link("v1.{c}.collection".format(c=collection),
-                                                              rel=collection, **kwargs))
+                    kwargs["rel"] = collection
+                    data["links"].append(create_external_link("v1.{c}.collection".format(c=collection), **kwargs))
             if isinstance(objects, tuple):
                 return data, code, header
             else:
@@ -274,7 +274,8 @@ class add_id_links(generate_links):
                     to_pass = {k: v for k, v in kwargs.items() if k != "collection"}
                     to_pass["_type"] = obj
                     to_pass["templated"] = True
-                    data["links"].append(create_external_link(url=endpoint, rel=collection, **to_pass))
+                    to_pass["rel"] = collection
+                    data["links"].append(create_external_link(url=endpoint, **to_pass))
             if isinstance(objects, tuple):
                 return data, code, header
             else:

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -108,6 +108,8 @@ class generate_links(object):
 
         if "uri" in kwargs:
             del kwargs["uri"]
+        if "templated" in kwargs:
+            del kwargs["templated"]
         return kwargs
 
 
@@ -225,9 +227,11 @@ class add_collection_links(generate_links):
             if isinstance(data, dict) or isinstance(data, OrderedDict):
                 data = self.prepare_objetcs(objects, True)
                 kwargs = self.prepare_kwargs(kwargs, data)
+                if "templated" in kwargs:
+                    del kwargs["kwargs"]
                 for collection in self.collections:
                     data["links"].append(create_external_link("v1.{c}.collection".format(c=collection),
-                                                     rel=collection, templated=True, **kwargs))
+                                                              rel=collection, templated=True, **kwargs))
             if isinstance(objects, tuple):
                 return data, code, header
             else:
@@ -270,7 +274,7 @@ class add_id_links(generate_links):
                     endpoint = "v1." + kwargs["collection"] + ".id"
 
                     collection = kwargs["collection"]
-                    to_pass = {k: v for k, v in kwargs.items() if k != "collection"}
+                    to_pass = {k: v for k, v in kwargs.items() if k != "collection" and k != "templated"}
                     data["links"].append(create_external_link(url=endpoint, rel=collection,
                                                               _type=obj, templated=True,
                                                               **to_pass))

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -108,8 +108,6 @@ class generate_links(object):
 
         if "uri" in kwargs:
             del kwargs["uri"]
-        if "templated" in kwargs:
-            del kwargs["templated"]
         return kwargs
 
 
@@ -199,9 +197,10 @@ class add_coverage_link(generate_links):
             if isinstance(data, dict) or isinstance(data, OrderedDict):
                 data = self.prepare_objetcs(data)
                 kwargs = self.prepare_kwargs(kwargs, data)
+                kwargs["templated"] = True
                 for link in self.links:
                     data["links"].append(
-                        create_external_link("v1.{}".format(link), rel=link, templated=True, **kwargs))
+                        create_external_link("v1.{}".format(link), rel=link, **kwargs))
             if isinstance(objects, tuple):
                 return data, code, header
             else:
@@ -227,11 +226,10 @@ class add_collection_links(generate_links):
             if isinstance(data, dict) or isinstance(data, OrderedDict):
                 data = self.prepare_objetcs(objects, True)
                 kwargs = self.prepare_kwargs(kwargs, data)
-                if "templated" in kwargs:
-                    del kwargs["kwargs"]
+                kwargs["templated"] = True
                 for collection in self.collections:
                     data["links"].append(create_external_link("v1.{c}.collection".format(c=collection),
-                                                              rel=collection, templated=True, **kwargs))
+                                                              rel=collection, **kwargs))
             if isinstance(objects, tuple):
                 return data, code, header
             else:
@@ -272,12 +270,11 @@ class add_id_links(generate_links):
                         kwargs["id"] = "{" + obj + ".id}"
 
                     endpoint = "v1." + kwargs["collection"] + ".id"
-
                     collection = kwargs["collection"]
-                    to_pass = {k: v for k, v in kwargs.items() if k != "collection" and k != "templated"}
-                    data["links"].append(create_external_link(url=endpoint, rel=collection,
-                                                              _type=obj, templated=True,
-                                                              **to_pass))
+                    to_pass = {k: v for k, v in kwargs.items() if k != "collection"}
+                    to_pass["_type"] = obj
+                    to_pass["templated"] = True
+                    data["links"].append(create_external_link(url=endpoint, rel=collection, **to_pass))
             if isinstance(objects, tuple):
                 return data, code, header
             else:

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -36,7 +36,7 @@ from jormungandr.interfaces.v1.converters_collection_type import resource_type_t
 from flask.ext.restful.utils import unpack
 
 
-def create_external_link(url, rel=None, _type=None, templated=False, description=None, **kwargs):
+def create_external_link(url, rel, _type=None, templated=False, description=None, **kwargs):
     """
     :param url: url forwarded to flask's url_for
     :param rel: relation of the link to the current object

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -212,6 +212,8 @@ class JourneysCommon(PbNestedSerializer):
                 else:
                      args[e.key] = e.values[0]
 
+            if "templated" in args:
+                    del args["kwargs"]
             response.append(create_external_link('v1.{}'.format(value.ressource_name),
                                                  rel=value.rel,
                                                  _type=value.type,

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -210,16 +210,12 @@ class JourneysCommon(PbNestedSerializer):
                 if len(e.values) > 1:
                     args[e.key] = [v for v in e.values]
                 else:
-                     args[e.key] = e.values[0]
+                    args[e.key] = e.values[0]
 
-            if "templated" in args:
-                    del args["templated"]
-            response.append(create_external_link('v1.{}'.format(value.ressource_name),
-                                                 rel=value.rel,
-                                                 _type=value.type,
-                                                 templated=value.is_templated,
-                                                 description=value.description,
-                                                 **args))
+            args["_type"] = value.type
+            args["templated"] = value.is_templated
+            args["description"] = value.description
+            response.append(create_external_link('v1.{}'.format(value.ressource_name), rel=value.rel, **args))
         return response
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -213,7 +213,7 @@ class JourneysCommon(PbNestedSerializer):
                      args[e.key] = e.values[0]
 
             if "templated" in args:
-                    del args["kwargs"]
+                    del args["templated"]
             response.append(create_external_link('v1.{}'.format(value.ressource_name),
                                                  rel=value.rel,
                                                  _type=value.type,

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -215,7 +215,8 @@ class JourneysCommon(PbNestedSerializer):
             args["_type"] = value.type
             args["templated"] = value.is_templated
             args["description"] = value.description
-            response.append(create_external_link('v1.{}'.format(value.ressource_name), rel=value.rel, **args))
+            args["rel"] = value.rel
+            response.append(create_external_link('v1.{}'.format(value.ressource_name), **args))
         return response
 
 


### PR DESCRIPTION
Before calling the function "create_external_link" with parameter "templated", we should delete this parameter in the parameter **kwargs if present.