### PR TITLE
Doc: Specify collectionFormat in swagger

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/serializer.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/serializer.py
@@ -47,6 +47,7 @@ class SwaggerParamSerializer(serpy.Serializer):
     minimum = Field()
     maximum = Field()
     format = Field()
+    collectionFormat = Field(attr='collection_format')
     items = LambdaField(method=lambda _, obj: SwaggerParamSerializer(obj.items).data if obj.items else None,
                         display_none=False)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/jsonschema/test/serializer_tests.py
@@ -200,6 +200,7 @@ def param_test():
     assert(swagger_arg.description == 'kind of bob')
     assert(swagger_arg.default == ['bob', 'bobette'])
     assert(swagger_arg.format is None)  # no additional format provided
+    assert(swagger_arg.collection_format is None)
 
 
 def param_list_test():
@@ -213,3 +214,4 @@ def param_list_test():
     assert(swagger_arg.type == 'array')
     assert(swagger_arg.items is not None)
     assert(swagger_arg.items.type == 'string')
+    assert(swagger_arg.collection_format == 'multi')

--- a/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/swagger_schema.py
@@ -68,7 +68,8 @@ def convert_to_swagger_type(type_):
 
 class SwaggerParam(object):
     def __init__(self, description=None, name=None, required=None, type=None, pattern=None,
-                 default=None, enum=None, minimum=None, maximum=None, format=None, location=None, items=None):
+                 default=None, enum=None, minimum=None, maximum=None, format=None, location=None, items=None,
+                 collection_format=None):
         self.description = description
         self.name = name
         self.required = required
@@ -81,6 +82,7 @@ class SwaggerParam(object):
         self.maximum = maximum
         self.items = items
         self.pattern = pattern
+        self.collection_format = collection_format
 
     @classmethod
     def make_from_flask_arg(cls, argument):
@@ -135,17 +137,20 @@ class SwaggerParam(object):
                 metadata['description'] += desc_meta
 
             items = None
+            collection_format = None
             if argument.action == 'append':
                 items = SwaggerParam(type=swagger_type,
                                      format=metadata.pop('format', None),
                                      enum=metadata.pop('enum', None))
                 swagger_type = 'array'
+                collection_format = 'multi'
 
             args.append(SwaggerParam(name=argument.name,
                                      type=swagger_type,
                                      location=location,
                                      required=argument.required,
                                      items=items,
+                                     collection_format=collection_format,
                                      **metadata))
 
         return args


### PR DESCRIPTION
According to Swagger specification,
the default array format is `csv` style `first_section_mode[]=bike,walking`
but navitia use `multi` style `first_section_mode[]=bike&first_section_mode[]=walking`

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object