### PR TITLE
Kraken: find best UTC offset for a validity pattern

### DIFF
--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -1036,7 +1036,7 @@ std::vector<nm::StopTime*> StopTimeGtfsHandler::handle_line(Data& data, const cs
         nm::StopTime* stop_time = new nm::StopTime();
 
         //we need to convert the stop times in UTC
-        int utc_offset = data.tz_wrapper.tz_handler.get_first_utc_offset(*vj_it->second->validity_pattern);
+        int utc_offset = data.tz_wrapper.tz_handler.get_utc_offset(*vj_it->second->validity_pattern);
 
         stop_time->arrival_time = to_utc(row[arrival_c], utc_offset);
         stop_time->departure_time = to_utc(row[departure_c], utc_offset);
@@ -1091,7 +1091,7 @@ void FrequenciesGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
         }
 
         //we need to convert the stop times in UTC
-        int utc_offset = data.tz_wrapper.tz_handler.get_first_utc_offset(*vj->validity_pattern);
+        int utc_offset = data.tz_wrapper.tz_handler.get_utc_offset(*vj->validity_pattern);
 
         vj->start_time = to_utc(row[start_time_c], utc_offset);
         vj->end_time = to_utc(row[end_time_c], utc_offset);

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -87,8 +87,8 @@ void Data::build_block_id() {
         if(vj1->block_id != vj2->block_id) {
             return vj1->block_id < vj2->block_id;
         } else {
-            auto offset1 = tz_wrapper.tz_handler.get_first_utc_offset(*vj1->validity_pattern);
-            auto offset2 = tz_wrapper.tz_handler.get_first_utc_offset(*vj2->validity_pattern);
+            auto offset1 = tz_wrapper.tz_handler.get_utc_offset(*vj1->validity_pattern);
+            auto offset2 = tz_wrapper.tz_handler.get_utc_offset(*vj2->validity_pattern);
 
             // we don't want to link the splited vjs
             if (offset1 != offset2) {
@@ -119,8 +119,8 @@ void Data::build_block_id() {
                 if (vj->stop_time_list.front()->departure_time >= prev_vj->stop_time_list.back()->arrival_time) {
 
                     //we add another check that the vjs are on the same offset (that they are not the from vj split on different dst)
-                    if (tz_wrapper.tz_handler.get_first_utc_offset(*vj->validity_pattern) ==
-                            tz_wrapper.tz_handler.get_first_utc_offset(*prev_vj->validity_pattern)) {
+                    if (tz_wrapper.tz_handler.get_utc_offset(*vj->validity_pattern) ==
+                            tz_wrapper.tz_handler.get_utc_offset(*prev_vj->validity_pattern)) {
                         prev_vj->next_vj = vj;
                         vj->prev_vj = prev_vj;
                     }

--- a/source/ed/tests/gtfsparser_test.cpp
+++ b/source/ed/tests/gtfsparser_test.cpp
@@ -445,8 +445,8 @@ static void check_gtfs_google_example(const ed::Data& data) {
 
     BOOST_CHECK_EQUAL(data.tz_wrapper.tz_name, "America/Los_Angeles");
     //we check that the shift for vj[0] is -480 minutes and -420 for vj[1]
-    BOOST_CHECK_EQUAL(data.tz_wrapper.tz_handler.get_first_utc_offset(*data.vehicle_journeys[0]->validity_pattern), -480 * 60);
-    BOOST_CHECK_EQUAL(data.tz_wrapper.tz_handler.get_first_utc_offset(*data.vehicle_journeys[1]->validity_pattern), -420 * 60);
+    BOOST_CHECK_EQUAL(data.tz_wrapper.tz_handler.get_utc_offset(*data.vehicle_journeys[0]->validity_pattern), -480 * 60);
+    BOOST_CHECK_EQUAL(data.tz_wrapper.tz_handler.get_utc_offset(*data.vehicle_journeys[1]->validity_pattern), -420 * 60);
 
     //Stop time
     BOOST_REQUIRE_EQUAL(data.stops.size(), 28 * 2);

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -283,7 +283,7 @@ struct calendar_fixture {
         b.data->pt_data->codes.add(b.get<nt::StopPoint>("StopR4"), "source", "Code-StopR4");
 
         beg = b.data->meta->production_date.begin();
-        end_of_year = beg + boost::gregorian::years(1) + boost::gregorian::days(1);
+        end_of_year = beg + boost::gregorian::years(1);
 
         navitia::type::VehicleJourney* vj = pt_data.vehicle_journeys_map["on_demand_transport"];
         vj->stop_time_list[0].set_odt(true);

--- a/source/type/timezone_manager.h
+++ b/source/type/timezone_manager.h
@@ -59,7 +59,7 @@ public:
     TimeZoneHandler() {}
     int32_t get_utc_offset(boost::gregorian::date day) const;
     int32_t get_utc_offset(int day) const;
-    int32_t get_first_utc_offset(const ValidityPattern& vp) const;
+    int32_t get_utc_offset(const ValidityPattern& vp) const;
     dst_periods get_periods_and_shift() const;
 
     template<class Archive> void serialize(Archive& ar, const unsigned int) {

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -649,7 +649,7 @@ int32_t VehicleJourney::utc_to_local_offset() const {
         throw navitia::recoverable_exception("vehicle journey " + uri +
                                  " not valid, no validitypattern on " + get_string_from_rt_level(realtime_level));
     }
-    return meta_vj->tz_handler->get_first_utc_offset(*vp);
+    return meta_vj->tz_handler->get_utc_offset(*vp);
 }
 
 const VehicleJourney* VehicleJourney::get_corresponding_base() const {


### PR DESCRIPTION
Sometime, a validity pattern will not be a subset of a time shift, for example if we shift the validity pattern for technical reasons.

Fix vehicle_journeys API in the times of the stop_times, that can be sometimes badly shifted (and thus gives wrong times).