### PR TITLE
Build: sync pip versions between tyr and jormun + boost 1.62

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,4 @@ debian/tmp
 debian/*.substvars
 debian/*.debhelper
 source/jormungandr/jormungandr/_version.py
-/source/jormungandr/jormungandr/.cache
-/source/jormungandr/.cache
-/source/jormungandr/tests/.cache
+.cache

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -70,12 +70,11 @@ include_directories("${CMAKE_SOURCE_DIR}"
 link_directories(${Boost_LIBRARY_DIRS})
 
 MACRO(ADD_BOOST_TEST EXE_NAME)
-    IF("${Boost_VERSION}" EQUAL "106200")
-        #Boost 1.62 doesn't support "log_sink" parameters, we disable reports with this version
-        ADD_TEST(${EXE_NAME} "${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME}" --log_format=XML --log_level=all --report_level=no)
-    ELSE("${Boost_VERSION}" EQUAL "106200")
+    IF("${Boost_VERSION}" LESS 106200)
         ADD_TEST(${EXE_NAME} "${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME}" --log_format=XML --log_sink=results_${EXE_NAME}.xml --log_level=all --report_level=no)
-    ENDIF("${Boost_VERSION}" EQUAL "106200")
+    ELSE()
+        ADD_TEST(${EXE_NAME} "${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME}" --logger=XML,all,results_${EXE_NAME}.xml --report_level=no)
+    ENDIF()
 ENDMACRO(ADD_BOOST_TEST)
 
 ENABLE_TESTING()

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -51,10 +51,18 @@ SET(BOOST_TEST_SEPARATOR "")
 if(NOT ${Boost_VERSION} LESS 106000) #if boost version newer or equal 1.60, passing cli_params new way
     SET(BOOST_TEST_SEPARATOR "--")
 endif()
-add_custom_command(TARGET run_test
-                   COMMAND ed_integration_test
-                   ARGS --log_format=XML --log_sink=results_ed_integration_test.xml --log_level=all
-                        --report_level=no ${BOOST_TEST_SEPARATOR} ${TEST_CLI_PARAMS})
+
+IF("${Boost_VERSION}" LESS 106200)
+    add_custom_command(TARGET run_test
+                       COMMAND ed_integration_test
+                       ARGS --log_format=XML --log_sink=results_ed_integration_test.xml --log_level=all
+                            --report_level=no ${BOOST_TEST_SEPARATOR} ${TEST_CLI_PARAMS})
+ELSE()
+    add_custom_command(TARGET run_test
+                       COMMAND ed_integration_test
+                       ARGS --logger=XML,all,results_ed_integration_test.xml
+                            --report_level=no ${BOOST_TEST_SEPARATOR} ${TEST_CLI_PARAMS})
+ENDIF()
 
 add_dependencies(ed_integration_test datanav_files)
 add_dependencies(docker_test run_test)

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -21,9 +21,9 @@ six==1.10.0
 kombu==3.0.30
 python-dateutil==2.5.3
 pytz==2013.9
-retrying==1.2.3
+retrying==1.3.3
 aniso8601==0.82
-ujson==1.33
+ujson==1.35
 urllib3==1.10.1
 numpy==1.9.0
 pybreaker==0.2.3

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -273,7 +273,7 @@ def mock_here(_, url, params):
     assert False, 'invalid url'
 
 
-@pytest.yield_fixture(scope="function", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def mock_http_here(monkeypatch):
     monkeypatch.setattr('jormungandr.street_network.here.Here._call_here', mock_here)
 

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -26,7 +26,7 @@ psycopg2
 pydns==2.3.6
 pytz==2013.9
 redis==2.9.1
-six>=1.10.0
+six==1.10.0
 validate-email==1.1
 wsgiref==0.1.2
 retrying==1.3.3

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 docker-py==1.6.0
-pytest==2.8.7
-python-dateutil==2.4.2
+pytest==3.1.1
+python-dateutil==2.5.3
 mock==1.0.1


### PR DESCRIPTION
for boost 1.62, see workaround at https://svn.boost.org/trac10/ticket/12507

yeld_fixture is deprecated and an alias of fixture. It doesn't work with older py.test versions using yeld_fixture because such fixture must have yeld in it...