### PR TITLE
kraken: parameters since and until added in line_reports

### DIFF
--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -115,7 +115,7 @@ void line_reports(navitia::PbCreator& pb_creator,
                   const std::vector<std::string>& forbidden_uris,
                   const boost::optional<boost::posix_time::ptime>& since,
                   const boost::optional<boost::posix_time::ptime>& until) {
-    auto start = (since ? *since: pb_creator.now);
+    auto start = (since ? *since: bt::ptime(d.meta->production_date.begin()));
     auto end = (until ? *until:  bt::ptime(d.meta->production_date.end()));
     pb_creator.action_period = bt::time_period(start, end);
 

--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -50,14 +50,14 @@ struct LineReport {
                const std::vector<std::string>& forbidden_uris,
                const type::Data& d,
                const boost::posix_time::ptime now,
-               const boost::posix_time::time_period active_period
+               const boost::posix_time::time_period filter_period
                ):
         line(line)
     {
-        add_objects(filter, forbidden_uris, d, now, active_period, networks);
-        add_objects(filter, forbidden_uris, d, now, active_period, routes);
-        add_objects(filter, forbidden_uris, d, now, active_period, stop_areas);
-        add_objects(filter, forbidden_uris, d, now, active_period, stop_points);
+        add_objects(filter, forbidden_uris, d, now, filter_period, networks);
+        add_objects(filter, forbidden_uris, d, now, filter_period, routes);
+        add_objects(filter, forbidden_uris, d, now, filter_period, stop_areas);
+        add_objects(filter, forbidden_uris, d, now, filter_period, stop_points);
     }
 
     template<typename T>
@@ -65,7 +65,7 @@ struct LineReport {
                      const std::vector<std::string>& forbidden_uris,
                      const type::Data& d,
                      const boost::posix_time::ptime now,
-                     const boost::posix_time::time_period active_period,
+                     const boost::posix_time::time_period filter_period,
                      std::vector<const T*>& objects) {
         std::string new_filter = "line.uri=" + line->uri;
         if (!filter.empty()) { new_filter += " and " + filter; }
@@ -77,15 +77,15 @@ struct LineReport {
 
         for (const auto& idx: indices) {
             const auto* obj = d.pt_data->collection<T>()[idx];
-            if (obj->has_applicable_message(now, active_period)) {
+            if (obj->has_applicable_message(now, filter_period)) {
                 objects.push_back(obj);
             }
         }
     }
 
     bool has_disruption(const boost::posix_time::ptime& current_time,
-                        const boost::posix_time::time_period& active_period) const {
-        return line->has_applicable_message(current_time, active_period)
+                        const boost::posix_time::time_period& filter_peiod) const {
+        return line->has_applicable_message(current_time, filter_peiod)
                 || ! networks.empty()
                 || ! routes.empty()
                 || ! stop_areas.empty()
@@ -115,13 +115,14 @@ void line_reports(navitia::PbCreator& pb_creator,
                   const std::vector<std::string>& forbidden_uris,
                   const boost::optional<boost::posix_time::ptime>& since,
                   const boost::optional<boost::posix_time::ptime>& until) {
-    if (since && until && until < since) {
-        pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse, "invalid filtering period");
-        return;
-    }
     auto start = (since ? *since: pb_creator.now);
     auto end = (until ? *until:  bt::ptime(d.meta->production_date.end()));
     pb_creator.action_period = bt::time_period(start, end);
+
+    if (end < start) {
+        pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse, "invalid filtering period");
+        return;
+    }    
 
     type::Indexes line_indices;
     try {
@@ -135,7 +136,8 @@ void line_reports(navitia::PbCreator& pb_creator,
     }
     std::vector<LineReport> line_reports;
     for (auto idx: line_indices) {
-        auto line_report = LineReport(d.pt_data->lines[idx], filter, forbidden_uris, d, pb_creator.now, pb_creator.action_period);
+        auto line_report = LineReport(d.pt_data->lines[idx], filter, forbidden_uris, d,
+                                      pb_creator.now, pb_creator.action_period);
         if (line_report.has_disruption(pb_creator.now, pb_creator.action_period)) {
             line_reports.push_back(line_report);
         }

--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -83,12 +83,13 @@ struct LineReport {
         }
     }
 
-    bool has_disruption(const boost::posix_time::ptime& current_time) const {
-        return line->has_publishable_message(current_time)
-            || ! networks.empty()
-            || ! routes.empty()
-            || ! stop_areas.empty()
-            || ! stop_points.empty();
+    bool has_disruption(const boost::posix_time::ptime& current_time,
+                        const boost::posix_time::time_period& active_period) const {
+        return line->has_applicable_message(current_time, active_period)
+                || ! networks.empty()
+                || ! routes.empty()
+                || ! stop_areas.empty()
+                || ! stop_points.empty();
     }
 
     void to_pb(navitia::PbCreator& pb_creator, const size_t depth) const {
@@ -135,7 +136,7 @@ void line_reports(navitia::PbCreator& pb_creator,
     std::vector<LineReport> line_reports;
     for (auto idx: line_indices) {
         auto line_report = LineReport(d.pt_data->lines[idx], filter, forbidden_uris, d, pb_creator.now, pb_creator.action_period);
-        if (line_report.has_disruption(pb_creator.now)) {
+        if (line_report.has_disruption(pb_creator.now, pb_creator.action_period)) {
             line_reports.push_back(line_report);
         }
     }

--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -29,6 +29,7 @@ www.navitia.io
 */
 
 #include "line_reports_api.h"
+#include "type/meta_data.h"
 
 namespace bt = boost::posix_time;
 namespace nt = navitia::type;
@@ -48,13 +49,15 @@ struct LineReport {
                const std::string& filter,
                const std::vector<std::string>& forbidden_uris,
                const type::Data& d,
-               const boost::posix_time::ptime now):
+               const boost::posix_time::ptime now,
+               const boost::posix_time::time_period active_period
+               ):
         line(line)
     {
-        add_objects(filter, forbidden_uris, d, now, networks);
-        add_objects(filter, forbidden_uris, d, now, routes);
-        add_objects(filter, forbidden_uris, d, now, stop_areas);
-        add_objects(filter, forbidden_uris, d, now, stop_points);
+        add_objects(filter, forbidden_uris, d, now, active_period, networks);
+        add_objects(filter, forbidden_uris, d, now, active_period, routes);
+        add_objects(filter, forbidden_uris, d, now, active_period, stop_areas);
+        add_objects(filter, forbidden_uris, d, now, active_period, stop_points);
     }
 
     template<typename T>
@@ -62,6 +65,7 @@ struct LineReport {
                      const std::vector<std::string>& forbidden_uris,
                      const type::Data& d,
                      const boost::posix_time::ptime now,
+                     const boost::posix_time::time_period active_period,
                      std::vector<const T*>& objects) {
         std::string new_filter = "line.uri=" + line->uri;
         if (!filter.empty()) { new_filter += " and " + filter; }
@@ -73,7 +77,7 @@ struct LineReport {
 
         for (const auto& idx: indices) {
             const auto* obj = d.pt_data->collection<T>()[idx];
-            if (obj->has_publishable_message(now)) {
+            if (obj->has_applicable_message(now, active_period)) {
                 objects.push_back(obj);
             }
         }
@@ -90,7 +94,7 @@ struct LineReport {
     void to_pb(navitia::PbCreator& pb_creator, const size_t depth) const {
         auto* report = pb_creator.add_line_reports();
         pb_creator.fill(line, report->mutable_line(), depth-1);
-        if (line->has_publishable_message(pb_creator.now)) {
+        if (line->has_applicable_message(pb_creator.now, pb_creator.action_period)) {
             pb_creator.fill(line, report->add_pt_objects(), 0);
         }
         pb_creator.fill(networks, report->mutable_pt_objects(), 0);
@@ -107,8 +111,17 @@ void line_reports(navitia::PbCreator& pb_creator,
                   const size_t depth,
                   size_t count,
                   size_t start_page, const std::string& filter,
-                  const std::vector<std::string>& forbidden_uris) {
-    pb_creator.action_period = bt::time_period(pb_creator.now, bt::seconds(1));
+                  const std::vector<std::string>& forbidden_uris,
+                  const boost::optional<boost::posix_time::ptime>& since,
+                  const boost::optional<boost::posix_time::ptime>& until) {
+    if (since && until && until < since) {
+        pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse, "invalid filtering period");
+        return;
+    }
+    auto start = (since ? *since: pb_creator.now);
+    auto end = (until ? *until:  bt::ptime(d.meta->production_date.end()));
+    pb_creator.action_period = bt::time_period(start, end);
+
     type::Indexes line_indices;
     try {
         line_indices = ptref::make_query(type::Type_e::Line, filter, forbidden_uris, d);
@@ -121,7 +134,7 @@ void line_reports(navitia::PbCreator& pb_creator,
     }
     std::vector<LineReport> line_reports;
     for (auto idx: line_indices) {
-        auto line_report = LineReport(d.pt_data->lines[idx], filter, forbidden_uris, d, pb_creator.now);
+        auto line_report = LineReport(d.pt_data->lines[idx], filter, forbidden_uris, d, pb_creator.now, pb_creator.action_period);
         if (line_report.has_disruption(pb_creator.now)) {
             line_reports.push_back(line_report);
         }

--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -30,6 +30,7 @@ www.navitia.io
 
 #include "line_reports_api.h"
 #include "type/meta_data.h"
+#include <boost/optional.hpp>
 
 namespace bt = boost::posix_time;
 namespace nt = navitia::type;
@@ -50,7 +51,7 @@ struct LineReport {
                const std::vector<std::string>& forbidden_uris,
                const type::Data& d,
                const boost::posix_time::ptime now,
-               const boost::posix_time::time_period filter_period
+               const boost::posix_time::time_period& filter_period
                ):
         line(line)
     {
@@ -65,7 +66,7 @@ struct LineReport {
                      const std::vector<std::string>& forbidden_uris,
                      const type::Data& d,
                      const boost::posix_time::ptime now,
-                     const boost::posix_time::time_period filter_period,
+                     const boost::posix_time::time_period& filter_period,
                      std::vector<const T*>& objects) {
         std::string new_filter = "line.uri=" + line->uri;
         if (!filter.empty()) { new_filter += " and " + filter; }
@@ -115,8 +116,8 @@ void line_reports(navitia::PbCreator& pb_creator,
                   const std::vector<std::string>& forbidden_uris,
                   const boost::optional<boost::posix_time::ptime>& since,
                   const boost::optional<boost::posix_time::ptime>& until) {
-    auto start = (since ? *since: bt::ptime(d.meta->production_date.begin()));
-    auto end = (until ? *until:  bt::ptime(d.meta->production_date.end()));
+    const auto& start = get_optional_value_or(since, bt::ptime(d.meta->production_date.begin()));
+    const auto& end = get_optional_value_or(until, bt::ptime(d.meta->production_date.end()));
     pb_creator.action_period = bt::time_period(start, end);
 
     if (end < start) {

--- a/source/disruption/line_reports_api.h
+++ b/source/disruption/line_reports_api.h
@@ -40,6 +40,8 @@ void line_reports(navitia::PbCreator& pb_creator,
                   const size_t depth,
                   size_t count,
                   size_t start_page, const std::string& filter,
-                  const std::vector<std::string>& forbidden_uris);
+                  const std::vector<std::string>& forbidden_uris,
+                  const boost::optional<boost::posix_time::ptime>& since,
+                  const boost::optional<boost::posix_time::ptime>& until);
 }}
 

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -16,7 +16,7 @@ START_MONITORING_THREAD = boolean(os.getenv('JORMUNGANDR_START_MONITORING_THREAD
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
 SQLALCHEMY_DATABASE_URI = os.getenv('JORMUNGANDR_SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@localhost/jormungandr')
 
-DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', False))
+DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', True))
 
 # disable authentication
 PUBLIC = boolean(os.getenv('JORMUNGANDR_IS_PUBLIC', True))

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -16,7 +16,7 @@ START_MONITORING_THREAD = boolean(os.getenv('JORMUNGANDR_START_MONITORING_THREAD
 #http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
 SQLALCHEMY_DATABASE_URI = os.getenv('JORMUNGANDR_SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@localhost/jormungandr')
 
-DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', True))
+DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', False))
 
 # disable authentication
 PUBLIC = boolean(os.getenv('JORMUNGANDR_IS_PUBLIC', True))

--- a/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
@@ -89,9 +89,9 @@ class LineReports(ResourceUri, ResourceUtc):
         parser_get.add_argument("disable_geojson", type=BooleanType(), default=False,
                                 help="remove geojson from the response")
         parser_get.add_argument("since", type=DateTimeFormat(),
-                                help="filters objects not valid before this date")
+                                help="filters disruptions valid after this date")
         parser_get.add_argument("until", type=DateTimeFormat(),
-                                help="filters objects not valid after this date")
+                                help="filters disruptions valid before this date")
 
         self.collection = 'line_reports'
         self.collections = line_reports

--- a/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
@@ -89,9 +89,9 @@ class LineReports(ResourceUri, ResourceUtc):
         parser_get.add_argument("disable_geojson", type=BooleanType(), default=False,
                                 help="remove geojson from the response")
         parser_get.add_argument("since", type=DateTimeFormat(),
-                                help="filters disruptions valid after this date")
+                                help="use disruptions valid after this date")
         parser_get.add_argument("until", type=DateTimeFormat(),
-                                help="filters disruptions valid before this date")
+                                help="use disruptions valid before this date")
 
         self.collection = 'line_reports'
         self.collections = line_reports

--- a/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
@@ -41,11 +41,14 @@ from jormungandr.interfaces.v1.fields import PbField, line, pt_object, NonNullLi
     pagination, disruption_marshaller, error, ListLit, beta_endpoint
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from jormungandr.interfaces.v1.serializer import api
+from jormungandr.resources_utils import ResourceUtc
+from jormungandr.utils import date_to_timestamp
 
 from flask.ext.restful import fields, reqparse
 from flask.globals import g
 from datetime import datetime
 import six
+
 
 line_report = {
     "line": PbField(line),
@@ -61,9 +64,10 @@ line_reports = {
 }
 
 
-class LineReports(ResourceUri):
+class LineReports(ResourceUri, ResourceUtc):
     def __init__(self):
         ResourceUri.__init__(self, output_type_serializer=api.LineReportsSerializer)
+        ResourceUtc.__init__(self)
         parser_get = self.parsers["get"]
         parser_get.add_argument("depth", type=int, default=1, help="The depth of your object")
         parser_get.add_argument("count", type=default_count_arg_type, default=25,
@@ -84,6 +88,11 @@ class LineReports(ResourceUri):
                                 schema_metadata={'format': 'pt-object'})
         parser_get.add_argument("disable_geojson", type=BooleanType(), default=False,
                                 help="remove geojson from the response")
+        parser_get.add_argument("since", type=DateTimeFormat(),
+                                help="filters objects not valid before this date")
+        parser_get.add_argument("until", type=DateTimeFormat(),
+                                help="filters objects not valid after this date")
+
         self.collection = 'line_reports'
         self.collections = line_reports
         self.get_decorators.insert(0, ManageError())
@@ -107,6 +116,11 @@ class LineReports(ResourceUri):
             args["filter"] = self.get_filter(uris, args)
         else:
             args["filter"] = ""
+
+        if args['since']:
+            args['since'] = date_to_timestamp(self.convert_to_utc(args['since']))
+        if args['until']:
+            args['until'] = date_to_timestamp(self.convert_to_utc(args['until']))
 
         response = i_manager.dispatch(args, "line_reports", instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -156,6 +156,12 @@ class Scenario(object):
             for forbidden_uri in request["forbidden_uris[]"]:
                 req.traffic_reports.forbidden_uris.append(forbidden_uri)
 
+        # change dt to utc
+        if request['since']:
+            req.line_reports.since_datetime = request['since']
+        if request['until']:
+            req.line_reports.until_datetime = request['until']
+
         resp = instance.send_and_receive(req)
         return resp
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -156,7 +156,6 @@ class Scenario(object):
             for forbidden_uri in request["forbidden_uris[]"]:
                 req.traffic_reports.forbidden_uris.append(forbidden_uri)
 
-        # change dt to utc
         if request['since']:
             req.line_reports.since_datetime = request['since']
         if request['until']:

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -537,6 +537,34 @@ class TestDisruptions(AbstractTestFixture):
         warnings = get_not_null(response, 'warnings')
         assert len(warnings) == 1
         assert warnings[0]['id'] == 'beta_endpoint'
+        assert len(get_not_null(response, 'disruptions')) == 3
+        line_reports = get_not_null(response, 'line_reports')
+        for line_report in line_reports:
+            is_valid_line_report(line_report)
+        assert len(line_reports) == 4
+        assert line_reports[0]['line']['id'] == 'A'
+        assert len(line_reports[0]['pt_objects']) == 3
+        assert line_reports[0]['pt_objects'][0]['id'] == 'A'
+        assert len(line_reports[0]['pt_objects'][0]['line']['links']) == 2
+        assert line_reports[0]['pt_objects'][0]['line']['links'][0]['id'] == 'too_bad_again'
+        assert line_reports[0]['pt_objects'][0]['line']['links'][1]['id'] == 'later_impact'
+        assert line_reports[0]['pt_objects'][1]['id'] == 'base_network'
+        assert len(line_reports[0]['pt_objects'][1]['network']['links']) == 2
+        assert line_reports[0]['pt_objects'][1]['network']['links'][0]['id'] == 'too_bad_again'
+        assert line_reports[0]['pt_objects'][1]['network']['links'][1]['id'] == 'later_impact'
+        assert line_reports[0]['pt_objects'][2]['id'] == 'stopA'
+
+        for line_report in line_reports[1:]:
+            assert len(line_report['pt_objects']) == 2
+            assert line_report['pt_objects'][0]['id'] == 'base_network'
+            assert line_report['pt_objects'][1]['id'] == 'stopA'
+
+    def test_line_reports_with_since_and_until(self):
+        response = self.query_region("line_reports?_current_datetime=20120801T000000"
+                                     "&since=20120801T000000&until=20120803T000000")
+        warnings = get_not_null(response, 'warnings')
+        assert len(warnings) == 1
+        assert warnings[0]['id'] == 'beta_endpoint'
         assert len(get_not_null(response, 'disruptions')) == 2
         line_reports = get_not_null(response, 'line_reports')
         for line_report in line_reports:
@@ -545,8 +573,17 @@ class TestDisruptions(AbstractTestFixture):
         assert line_reports[0]['line']['id'] == 'A'
         assert len(line_reports[0]['pt_objects']) == 3
         assert line_reports[0]['pt_objects'][0]['id'] == 'A'
+        assert len(line_reports[0]['pt_objects'][0]['line']['links']) == 1
+        assert line_reports[0]['pt_objects'][0]['line']['links'][0]['id'] == 'too_bad_again'
         assert line_reports[0]['pt_objects'][1]['id'] == 'base_network'
+        assert len(line_reports[0]['pt_objects'][1]['network']['links']) == 1
+        assert line_reports[0]['pt_objects'][1]['network']['links'][0]['id'] == 'too_bad_again'
         assert line_reports[0]['pt_objects'][2]['id'] == 'stopA'
+
+        for line_report in line_reports[1:]:
+            assert len(line_report['pt_objects']) == 2
+            assert line_report['pt_objects'][0]['id'] == 'base_network'
+            assert line_report['pt_objects'][1]['id'] == 'stopA'
 
         for line_report in line_reports[1:]:
             assert len(line_report['pt_objects']) == 2
@@ -622,5 +659,6 @@ class TestDisruptionsLineSections(AbstractTestFixture):
             assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
 
     def test_line_reports_with_since_until_outof_application_period(self):
-        response = self.query_region("line_reports?_current_datetime=20170101T120000&since=20170105T130000&until=20170108T000000")
+        response = self.query_region("line_reports?_current_datetime=20170101T120000"
+                                     "&since=20170105T130000&until=20170108T000000")
         assert len(response['disruptions']) == 0

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -593,9 +593,10 @@ class TestDisruptions(AbstractTestFixture):
 
 @dataset({"line_sections_test": {}})
 class TestDisruptionsLineSections(AbstractTestFixture):
-    #b.data->meta->production_date = "20170101T000000", "20170131T000000"
-    #publication_periods:"20170101T000000", "20170110T000000"
-    #application_periods:"20170102T000000", "20170105T000000"
+    #Information about the data in line_section_test
+    #The data is valid from "20170101T000000" to "20170131T000000"
+    #The disruption has publication_period from "20170101T000000" to "20170110T000000"
+    #and one application_period from "20170102T000000" to "20170105T000000"
     def test_line_reports(self):
         response = self.query_region("line_reports?_current_datetime=20170103T120000")
         disruptions = get_not_null(response, 'disruptions')

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -616,11 +616,16 @@ class TestDisruptionsLineSections(AbstractTestFixture):
 
     def test_line_reports_with_current_datetime_outof_application_period(self):
         #without since/until we use since=_current_datetime and until = production_date.end
+        #application period intersects with active period of the disruption (current date + data production end date)
         response = self.query_region("line_reports?_current_datetime=20170101T120000")
         disruptions = get_not_null(response, 'disruptions')
         assert len(disruptions) == 1
         line_reports = get_not_null(response, 'line_reports')
         assert len(line_reports) == 1
+
+        #Since application period does not intersect with active period of the disruption
+        response = self.query_region("line_reports?_current_datetime=20170105T130000")
+        assert len(response['disruptions']) == 0
 
     def test_line_reports_with_since_until_intersects_application_period(self):
         response = self.query_region("line_reports?_current_datetime=20170101T120000&since=20170104T130000&until=20170106T000000")

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -384,7 +384,11 @@ void Worker::line_reports(const pbnavitia::LineReportsRequest &request){
                                       request.count(),
                                       request.start_page(),
                                       request.filter(),
-                                      forbidden_uris);
+                                      forbidden_uris,
+                                      boost::make_optional(request.has_since_datetime(),
+                                                           bt::from_time_t(request.since_datetime())),
+                                      boost::make_optional(request.has_until_datetime(),
+                                                           bt::from_time_t(request.until_datetime())));
 }
 
 void Worker::calendars(const pbnavitia::CalendarsRequest &request){

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -112,7 +112,7 @@ int main(int argc, const char* const argv[]) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .application_periods(btp("20170102T000000"_dt, "20170105T000000"_dt))
+                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
                               .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
                               .on_line_section("line:1", "C", "E", {"route:line:1:1", "route:line:1:3"})
                               .get_disruption(),

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -112,8 +112,8 @@ int main(int argc, const char* const argv[]) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
-                              .publish(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                              .application_periods(btp("20170102T000000"_dt, "20170105T000000"_dt))
+                              .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
                               .on_line_section("line:1", "C", "E", {"route:line:1:1", "route:line:1:3"})
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);


### PR DESCRIPTION
- parameters since and until added in API line_reports

- if absent since takes the value of data production_date.start (so min_datetime)

- if absent until takes the value of data production_date.end (so max_datetime)

- Verifies that impact is published  between since and until

- Verifies that active_period of impact intersects with the period:  since and until