### PR TITLE
Jormungandr: ability for the proxy to merge kraken / realtime proxy datas

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -128,7 +128,7 @@ class Cleverage(RealtimeProxy):
         else:
             return None
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -30,8 +30,15 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 from abc import abstractmethod, ABCMeta
+from copy import deepcopy
+from jormungandr.schedule import RoutePoint
 from jormungandr.utils import timestamp_to_datetime, record_external_failure
+from jormungandr.utils import date_to_timestamp, pb_del_if
 from jormungandr import new_relic
+from navitiacommon import type_pb2
+import datetime
+import hashlib
+import logging
 import six
 
 class RealtimeProxyError(RuntimeError):
@@ -94,6 +101,83 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         except RealtimeProxyError as e:
             self.record_call('failure', reason=str(e))
             return None
+
+    # Method used to filter schedules from kraken before merging. By default remove all schedules.
+    # Overload this to keep some and mix kraken and proxy datas.
+    def _filter_base_stop_schedule(self, date_time):
+        return True
+
+    def _update_stop_schedule(self, stop_schedule, next_realtime_passages):
+        """
+        Update the stopschedule response with the new realtime passages
+
+        By default we remove all base schedule data and replace them with the realtime
+        Each proxy can define is own way to merge passages
+
+        If next_realtime_passages is None (and not if it's []) it means that the proxy failed,
+        so we use the base schedule
+        """
+        if next_realtime_passages is None:
+            return
+
+        logging.getLogger(__name__).debug('next passages: : {}'
+                                         .format(["dt: {}".format(d.datetime) for d in next_realtime_passages]))
+
+        # we clean up the old schedule
+        pb_del_if(stop_schedule.date_times, self._filter_base_stop_schedule)
+        for passage in next_realtime_passages:
+            new_dt = stop_schedule.date_times.add()
+            # the midnight is calculated from passage.datetime and it keeps the same timezone as passage.datetime
+            midnight = passage.datetime.replace(hour=0, minute=0, second=0, microsecond=0)
+            time = (passage.datetime - midnight).total_seconds()
+            new_dt.time = int(time)
+            new_dt.date = date_to_timestamp(midnight)
+
+            if passage.is_real_time:
+                new_dt.realtime_level = type_pb2.REALTIME
+            else:
+                new_dt.realtime_level = type_pb2.BASE_SCHEDULE
+
+            # we also add the direction in the note
+            if passage.direction:
+                note = type_pb2.Note()
+                note.note = passage.direction
+                note_uri = hashlib.md5(note.note.encode('utf-8')).hexdigest()
+                note.uri = 'note:{md5}'.format(md5=note_uri)  # the id is a md5 of the direction to factorize them
+                new_dt.properties.notes.extend([note])
+        stop_schedule.date_times.sort(key=lambda dt: dt.date + dt.time)
+
+    # By default filter passage if they are on the same route point
+    def _filter_base_passage(self, passage, route_point):
+        return RoutePoint(passage.route, passage.stop_point) == route_point
+
+    def _update_passages(self, passages, route_point, template, next_realtime_passages):
+        if next_realtime_passages is None:
+            return
+
+        # filter passages with proxy method
+        pb_del_if(passages, lambda passage: self._filter_base_passage(passage, route_point))
+
+        # append the realtime passages
+        for rt_passage in next_realtime_passages:
+            new_passage = deepcopy(template)
+            new_passage.stop_date_time.arrival_date_time = date_to_timestamp(rt_passage.datetime)
+            new_passage.stop_date_time.departure_date_time = date_to_timestamp(rt_passage.datetime)
+
+            if rt_passage.is_real_time:
+                new_passage.stop_date_time.data_freshness = type_pb2.REALTIME
+            else:
+                new_passage.stop_date_time.data_freshness = type_pb2.BASE_SCHEDULE
+
+            # we also add the direction in the note
+            if rt_passage.direction:
+                new_passage.pt_display_informations.direction = rt_passage.direction
+
+            # we add physical mode from route
+            if len(route_point.pb_route.physical_modes) > 0:
+                new_passage.pt_display_informations.physical_mode = route_point.pb_route.physical_modes[0].name
+
+            passages.extend([new_passage])
 
     @abstractmethod
     def status(self):

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -64,7 +64,7 @@ class Siri(RealtimeProxy):
         """
         return self.rt_system_id
 
-    def _get_next_passage_for_route_point(self, route_point, count, from_dt, current_dt):
+    def _get_next_passage_for_route_point(self, route_point, count, from_dt, current_dt, duration=None):
         stop = route_point.fetch_stop_id(self.object_id_tag)
         request = self._make_request(monitoring_ref=stop, dt=from_dt, count=count)
         if not request:

--- a/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
@@ -153,7 +153,7 @@ class SiriLite(RealtimeProxy):
 
         return next_passages
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
         url = self._make_url(route_point)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -121,7 +121,7 @@ class Synthese(RealtimeProxy):
             logging.getLogger(__name__).exception('Synthese RT error, using base schedule')
             raise RealtimeProxyError(str(e))
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
         url = self._make_url(route_point, count, from_dt)
         if not url:
             return None

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -48,7 +48,7 @@ class CustomProxy(RealtimeProxy):
     def status(self):
         return None
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
         return self.hard_coded_passages
 
 
@@ -124,3 +124,11 @@ def filter_filter_dt_all_test(mocker):
 
     r = proxy.next_passage_for_route_point(None, count=1, from_dt=d2t(dt("15:00")))
     assert r is None
+
+def filter_filter_dt_duration_test(mocker):
+    mocker.patch('jormungandr.utils.get_timezone', return_value=pytz.timezone('UTC'))
+    passages = [passage("10:00"), passage("11:00"), passage("12:00"), passage("13:00")]
+    proxy = CustomProxy(passages)
+
+    r = proxy.next_passage_for_route_point(None, from_dt=d2t(dt("10:00")), duration=3600)
+    assert list(map(get_dt, r)) == [dt("10:00"), dt("11:00")]

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -123,7 +123,7 @@ class Timeo(RealtimeProxy):
         req_dt = self._timestamp_to_date(request_dt)
         return now.date() < req_dt.date()
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
         if self._is_tomorrow(from_dt, current_dt):
             logging.getLogger(__name__).info('Timeo RT service , Can not call Timeo for tomorrow.',
                                              extra={'rt_system_id': self.rt_system_id})

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -258,7 +258,8 @@ class MixedSchedule(object):
             next_rt_passages = rt_system.next_passage_for_route_point(route_point,
                                                                       request['items_per_schedule'],
                                                                       request['from_datetime'],
-                                                                      request['_current_datetime'])
+                                                                      request['_current_datetime'],
+                                                                      request['duration'])
         except Exception as e:
             log.exception('failure while requesting next passages to external RT system {}'.format(rt_system_code))
             new_relic.record_custom_event('realtime_internal_failure', {'rt_system_id': rt_system_code,

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -30,15 +30,11 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-import hashlib
 
 import logging
-import pytz
 from jormungandr import utils
 
 from navitiacommon import type_pb2, request_pb2, response_pb2
-from jormungandr.utils import date_to_timestamp, pb_del_if
-import datetime
 from copy import deepcopy
 from jormungandr import new_relic
 
@@ -68,45 +64,6 @@ class RealTimePassage(object):
         self.is_real_time = is_real_time
 
 
-def _update_stop_schedule(stop_schedule, next_realtime_passages):
-    """
-    Update the stopschedule response with the new realtime passages
-
-    for the moment we remove all base schedule data and replace them with the realtime
-
-    If next_realtime_passages is None (and not if it's []) it means that the proxy failed,
-    so we use the base schedule
-    """
-    if next_realtime_passages is None:
-        return
-
-    logging.getLogger(__name__).debug('next passages: : {}'
-                                     .format(["dt: {}".format(d.datetime) for d in next_realtime_passages]))
-
-    # we clean up the old schedule
-    del stop_schedule.date_times[:]
-    for passage in next_realtime_passages:
-        new_dt = stop_schedule.date_times.add()
-        # the midnight is calculated from passage.datetime and it keeps the same timezone as passage.datetime
-        midnight = passage.datetime.replace(hour=0, minute=0, second=0, microsecond=0)
-        time = (passage.datetime - midnight).total_seconds()
-        new_dt.time = int(time)
-        new_dt.date = date_to_timestamp(midnight)
-
-        if passage.is_real_time:
-            new_dt.realtime_level = type_pb2.REALTIME
-        else:
-            new_dt.realtime_level = type_pb2.BASE_SCHEDULE
-
-        # we also add the direction in the note
-        if passage.direction:
-            note = type_pb2.Note()
-            note.note = passage.direction
-            note_uri = hashlib.md5(note.note.encode('utf-8')).hexdigest()
-            note.uri = 'note:{md5}'.format(md5=note_uri)  # the id is a md5 of the direction to factorize them
-            new_dt.properties.notes.extend([note])
-
-
 def _create_template_from_passage(passage):
     template = deepcopy(passage)
     template.pt_display_informations.ClearField(str("headsign"))
@@ -134,35 +91,6 @@ def _create_template_from_pb_route_point(pb_route_point):
     template.route.CopyFrom(pb_route_point.route)
     template.stop_point.CopyFrom(pb_route_point.stop_point)
     return _create_template_from_passage(template)
-
-
-def _update_passages(passages, route_point, template, next_realtime_passages):
-    if next_realtime_passages is None:
-        return
-
-    # filter passages with entries of the asked route_point
-    pb_del_if(passages, lambda p: RoutePoint(p.route, p.stop_point) == route_point)
-
-    # append the realtime passages
-    for rt_passage in next_realtime_passages:
-        new_passage = deepcopy(template)
-        new_passage.stop_date_time.arrival_date_time = date_to_timestamp(rt_passage.datetime)
-        new_passage.stop_date_time.departure_date_time = date_to_timestamp(rt_passage.datetime)
-
-        if rt_passage.is_real_time:
-            new_passage.stop_date_time.data_freshness = type_pb2.REALTIME
-        else:
-            new_passage.stop_date_time.data_freshness = type_pb2.BASE_SCHEDULE
-
-        # we also add the direction in the note
-        if rt_passage.direction:
-            new_passage.pt_display_informations.direction = rt_passage.direction
-
-        # we add physical mode from route
-        if len(route_point.pb_route.physical_modes) > 0:
-            new_passage.pt_display_informations.physical_mode = route_point.pb_route.physical_modes[0].name
-
-        passages.extend([new_passage])
 
 
 class RoutePoint(object):
@@ -236,9 +164,8 @@ class MixedSchedule(object):
     def __init__(self, instance):
         self.instance = instance
 
-    def _get_next_realtime_passages(self, route_point, request):
+    def _get_realtime_proxy(self, route_point):
         log = logging.getLogger(__name__)
-
         if not route_point:
             return None
 
@@ -252,6 +179,10 @@ class MixedSchedule(object):
             new_relic.record_custom_event('realtime_internal_failure', {'rt_system_id': rt_system_code,
                                                                         'message': 'no handler found'})
             return None
+        return rt_system
+
+    def _get_next_realtime_passages(self, rt_system, route_point, request):
+        log = logging.getLogger(__name__)
 
         next_rt_passages = None
         try:
@@ -261,8 +192,8 @@ class MixedSchedule(object):
                                                                       request['_current_datetime'],
                                                                       request['duration'])
         except Exception as e:
-            log.exception('failure while requesting next passages to external RT system {}'.format(rt_system_code))
-            new_relic.record_custom_event('realtime_internal_failure', {'rt_system_id': rt_system_code,
+            log.exception('failure while requesting next passages to external RT system {}'.format(rt_system.rt_system_id))
+            new_relic.record_custom_event('realtime_internal_failure', {'rt_system_id': rt_system.rt_system_id,
                                                                         'message': str(e)})
 
         if next_rt_passages is None:
@@ -274,7 +205,7 @@ class MixedSchedule(object):
     def __stop_times(self, request, api, departure_filter="", arrival_filter=""):
         req = request_pb2.Request()
         req.requested_api = api
-        req._current_datetime = date_to_timestamp(request['_current_datetime'])
+        req._current_datetime = utils.date_to_timestamp(request['_current_datetime'])
         st = req.next_stop_times
         st.disable_geojson = request["disable_geojson"]
         st.departure_filter = departure_filter
@@ -325,8 +256,10 @@ class MixedSchedule(object):
                             for rp in resp.route_points)
 
         for route_point, template in route_points.items():
-            next_rt_passages = self._get_next_realtime_passages(route_point, request)
-            _update_passages(resp.next_departures, route_point, template, next_rt_passages)
+            rt_proxy = self._get_realtime_proxy(route_point)
+            if rt_proxy:
+                next_rt_passages = self._get_next_realtime_passages(rt_proxy, route_point, request)
+                rt_proxy._update_passages(resp.next_departures, route_point, template, next_rt_passages)
 
         # sort
         def comparator(p1, p2):
@@ -348,6 +281,8 @@ class MixedSchedule(object):
 
         for stop_schedule in resp.stop_schedules:
             route_point = _get_route_point_from_stop_schedule(stop_schedule)
-            next_rt_passages = self._get_next_realtime_passages(route_point, request)
-            _update_stop_schedule(stop_schedule, next_rt_passages)
+            rt_proxy = self._get_realtime_proxy(route_point)
+            if rt_proxy:
+                next_rt_passages = self._get_next_realtime_passages(rt_proxy, route_point, request)
+                rt_proxy._update_stop_schedule(stop_schedule, next_rt_passages)
         return resp

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -65,7 +65,7 @@ class MockedTestProxy(realtime_proxy.RealtimeProxy):
             next_passages.append(next_passage)
         return next_passages
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
         if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigital_C:S1":
             return []
 
@@ -274,7 +274,7 @@ class MockedTestProxyWithTimezone(MockedTestProxy):
     def __init__(self, id, object_id_tag, instance):
         super(MockedTestProxyWithTimezone, self).__init__(id, object_id_tag, instance)
 
-    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None):
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
 
         if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigital_C:S0":
             return self._create_next_passages([("00:03:00", "l'infini"), ("00:04:00", "l'au dela")],

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -295,3 +295,131 @@ class TestDeparturesWithTimeZone(AbstractTestFixture):
         stop_schedules = response['stop_schedules'][0]['date_times']
         next_passage_dts = [dt["date_time"] for dt in stop_schedules]
         assert next_passage_dts
+
+
+MOCKED_PROXY_WITH_CUSTOM_MERGING_CONF = [
+    {
+        "id": "KisioDigital",
+        "class": "tests.proxy_realtime_tests.MockedTestProxyWithCustomMerging",
+        "args": {}
+    }
+]
+
+class MockedTestProxyWithCustomMerging(MockedTestProxy):
+    def __init__(self, id, object_id_tag, instance):
+        super(MockedTestProxyWithCustomMerging, self).__init__(id, object_id_tag, instance)
+
+    def _get_proxy_time_bounds(self):
+        start = datetime.datetime.strptime('20160103T040000', '%Y%m%dT%H%M%S')
+        end = datetime.datetime.strptime('20160104T040000', '%Y%m%dT%H%M%S')
+        return start, end
+
+    # Make proxy active between 20160103T040000 and 20160104T040000
+    # Keep everything outside this time bounds
+    def _filter_base_stop_schedule(self, date_time):
+        start, end = self._get_proxy_time_bounds()
+        return start <= datetime.datetime.fromtimestamp(date_time.date + date_time.time) <= end
+
+    def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=86400):
+        return self._create_next_passages(
+            [("06:00:00", "l'infini"), ("10:00:00", "l'au dela")], year=2016, month=1, day=3
+        )
+
+@dataset({"basic_schedule_test": {'instance_config': {'realtime_proxies': MOCKED_PROXY_WITH_CUSTOM_MERGING_CONF}}})
+class TestPassagesWithMerging(AbstractTestFixture):
+
+    def test_stop_schedule_with_merging(self):
+        query_template = 'stop_points/{sp}/stop_schedules?from_datetime={dt}&duration={d}&data_freshness={data_freshness}'
+        # data from the proxy in the middle of the time frame
+        query = query_template.format(sp='C:S0', dt='20160102T113000', d=3600 * 24 * 3, data_freshness='realtime')
+        response = self.query_region(query)
+        stop_schedules = response['stop_schedules'][0]['date_times']
+
+        next_passages = [(dt["date_time"], dt["data_freshness"]) for dt in stop_schedules]
+        expected_passages = [
+            ('20160102T113000', 'base_schedule'),
+            ('20160103T060000', 'realtime'),
+            ('20160103T100000', 'realtime'),
+            ('20160104T113000', 'base_schedule'),
+            ('20160105T113000', 'base_schedule')
+        ]
+
+        assert next_passages == expected_passages
+
+        # Outside of proxy scopes, should keep all base_schedule datas
+        query = query_template.format(sp='C:S0', dt='20160104T113000', d=3600 * 24, data_freshness='realtime')
+        response = self.query_region(query)
+        stop_schedules = response['stop_schedules'][0]['date_times']
+
+        next_passages = [(dt["date_time"], dt["data_freshness"]) for dt in stop_schedules]
+        expected_passages = [
+            ('20160104T113000', 'base_schedule'),
+            ('20160105T113000', 'base_schedule')
+        ]
+
+        assert next_passages == expected_passages
+
+        # Time frame ends in the proxy time frame
+        query = query_template.format(sp='C:S0', dt='20160102T080000', d=3600 * 24, data_freshness='realtime')
+        response = self.query_region(query)
+        stop_schedules = response['stop_schedules'][0]['date_times']
+
+        next_passages = [(dt["date_time"], dt["data_freshness"]) for dt in stop_schedules]
+        expected_passages = [
+            ('20160102T113000', 'base_schedule'),
+            ('20160103T060000', 'realtime')
+        ]
+
+        assert next_passages == expected_passages
+
+        # Time frame starts in the proxy time frame
+        query = query_template.format(sp='C:S0', dt='20160103T080000', d=3600 * 24 * 2, data_freshness='realtime')
+        response = self.query_region(query)
+        stop_schedules = response['stop_schedules'][0]['date_times']
+
+        next_passages = [(dt["date_time"], dt["data_freshness"]) for dt in stop_schedules]
+        expected_passages = [
+            ('20160103T100000', 'realtime'),
+            ('20160104T113000', 'base_schedule')
+        ]
+
+        assert next_passages == expected_passages
+
+    # The departures filtering has not been overloaded
+    def test_departures_without_merging(self):
+        query_template = 'stop_points/{sp}/departures?from_datetime={dt}&duration={d}&data_freshness={data_freshness}'
+
+        # Check that we have indeed 4 departures
+        query = query_template.format(sp='C:S0', dt='20160102T113000', d=3600 * 24 * 3, data_freshness='base_schedule')
+        response = self.query_region(query)
+
+        assert "departures" in response
+        assert len(response["departures"]) == 4
+
+        departures = response['departures']
+        next_passages = [(d['stop_date_time']['departure_date_time'], d['stop_date_time']['data_freshness']) for d in departures]
+        expected_passages = [
+            ('20160102T113000', 'base_schedule'),
+            ('20160103T113000', 'base_schedule'),
+            ('20160104T113000', 'base_schedule'),
+            ('20160105T113000', 'base_schedule')
+        ]
+
+        assert next_passages == expected_passages
+
+        # data from the proxy in the middle of the time frame
+        # since there is no merging we have only realtime datas
+        query = query_template.format(sp='C:S0', dt='20160102T113000', d=3600 * 24 * 3, data_freshness='realtime')
+        response = self.query_region(query)
+
+        assert "departures" in response
+        assert len(response["departures"]) == 2
+
+        departures = response['departures']
+        next_passages = [(d['stop_date_time']['departure_date_time'], d['stop_date_time']['data_freshness']) for d in departures]
+        expected_passages = [
+            ('20160103T060000', 'realtime'),
+            ('20160103T100000', 'realtime'),
+        ]
+
+        assert next_passages == expected_passages


### PR DESCRIPTION
This PR is related to #2009.

For us the goal is to be able to respond to a request "What are the real time departures at this stop for the next seven days?" with realtime datas, but with a proxy having less than 7 days of datas.
At Tisséo our realtime database has datas for the current day, until 3:30am. What we want to do with this type of request is remove all departures from kraken before 3:30am, and replace them with departures from the proxy, but keep everything else.

I have made two changes in this PR : 
- First, I have added `duration` as a parameter of `next_passage_for_route_point`. Currently, if you want the next departures for the next 3600 seconds, the proxy doesn't have this information, and has no limits. The default value is the same as in stop_schedule and departures duration.
- Second. I moved `_update_passage` and `_update_stop_schedule` in `realtime_proxy.py`. I have also moved the function parameter of pb_del_if in another method. When the merging criteria is simple enough, you just have to overload those functions (It is what I did in `proxy_realtime_tests.py` and our proxy).

Since _update_stop_schedule can be overloaded completely, we could add some custom informations on each passage in notes too (like short / long train @kinnou02 ;)).
I have used this on our instance and it seems to work well. Let me know what you think and if you see anything that needs some changes.
