### PR TITLE
Ed: add parameter to fusio and gtfs2ed to define simplify tolerance

### DIFF
--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -488,7 +488,8 @@ get_smallest_range(const LineStringIterPair& p1, const LineStringIterPair& p2) {
 nt::LineString
 create_shape(const nt::GeographicalCoord& from,
              const nt::GeographicalCoord& to,
-             const nt::LineString& shape)
+             const nt::LineString& shape,
+             const double simplify_tolerance)
 {
     const auto nearest_from = get_nearest(from, shape);
     const auto nearest_to = get_nearest(to, shape);
@@ -508,7 +509,7 @@ create_shape(const nt::GeographicalCoord& from,
 
     // simplification at about 3m precision
     nt::LineString simplified;
-    boost::geometry::simplify(res, simplified, 0.00003);
+    boost::geometry::simplify(res, simplified, simplify_tolerance);
 
     return simplified;
 }
@@ -532,7 +533,8 @@ void Data::build_shape_from_prev() {
                                 create_shape(
                                              prev_stop_point->coord,
                                              stop_time->stop_point->coord,
-                                             shape.front()));
+                                             shape.front(),
+                                             simplify_tolerance));
                         this->shapes_from_prev.push_back(s);
                         shape_cache[key] = s;
                     }

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -102,10 +102,13 @@ protected:
 //  - from -> nearest(from).second ---> nearest(to).second -> to
 // is returned, ---> being the path between 2 points in the given
 // shape.
+// The returned linestring is simplified via boost::simplify to reduce the size of the result.
+// An additional optional parameter is available to set the level of simplification.
 nt::LineString
 create_shape(const nt::GeographicalCoord& from,
              const nt::GeographicalCoord& to,
-             const nt::LineString& shape);
+             const nt::LineString& shape,
+             const double simplify_tolerance = 0.00003);
 
 /** Structure de donnée temporaire destinée à être remplie par un connecteur
       *
@@ -166,6 +169,7 @@ public:
     size_t count_too_long_connections = 0,
            count_empty_connections = 0;
 
+    double simplify_tolerance = 0.00003;
 
     /**
          * trie les différentes donnée et affecte l'idx

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -54,11 +54,15 @@ int main(int argc, char * argv[])
 
     std::string input, date, connection_string,
                 fare_dir;
+    double simplify_tolerance;
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help,h", "Show this message")
         ("date,d", po::value<std::string>(&date), "Beginning date")
         ("input,i", po::value<std::string>(&input), "Input directory")
+        ("simplify_tolerance,s", po::value<double>(&simplify_tolerance)->default_value(0.00003),
+         "Distance in unit of coordinate used to simplify geometries and reduce memory usage. Default is "
+         "0.00003 (~ 3m). Pass 0 to disable any simplification.")
         ("version,v", "Show version")
         ("fare,f", po::value<std::string>(&fare_dir), "Directory of fare files")
         ("config-file", po::value<std::string>(), "Path to configuration file")
@@ -100,6 +104,7 @@ int main(int argc, char * argv[])
     int read, complete, clean, sort, save, fare(0), main_destination(0);
 
     ed::Data data;
+    data.simplify_tolerance = simplify_tolerance;
 
     start = pt::microsec_clock::local_time();
 

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -51,11 +51,15 @@ int main(int argc, char * argv[])
     auto logger = log4cplus::Logger::getInstance("log");
 
     std::string input, date, connection_string;
+    double simplify_tolerance;
     po::options_description desc("Allowed options");
     desc.add_options()
         ("help,h", "Show this message")
         ("date,d", po::value<std::string>(&date), "Beginning date")
         ("input,i", po::value<std::string>(&input), "Input directory")
+        ("simplify_tolerance,s", po::value<double>(&simplify_tolerance)->default_value(0.00003),
+         "Distance in unit of coordinate used to simplify geometries and reduce memory usage. Default is "
+         "0.00003 (~ 3m). Pass 0 to disable any simplification.")
         ("version,v", "Show version")
         ("config-file", po::value<std::string>(), "Path to a config file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
@@ -93,6 +97,7 @@ int main(int argc, char * argv[])
     int read, complete, clean, sort, save, main_destination(0);
 
     ed::Data data;
+    data.simplify_tolerance = simplify_tolerance;
 
     start = pt::microsec_clock::local_time();
 

--- a/source/ed/tests/jpp_shape_test.cpp
+++ b/source/ed/tests/jpp_shape_test.cpp
@@ -102,3 +102,36 @@ BOOST_AUTO_TEST_CASE(create_shape) {
     // A->F, a long path
     shape_eq(A, F, LS({A, M, N, O, F}));
 }
+
+/*
+ * Test simplify. The default distance is 0.00003 in coordinate distance (approximately 3m for WGS84).
+ *
+ *            U
+ *            /\
+ *           /  \
+ * S ------ T    V  X ----- Y
+ *                \/
+ *                 W
+ *
+ */
+static const navitia::type::GeographicalCoord S(0, 0);
+static const navitia::type::GeographicalCoord T(0.00005, 0);
+static const navitia::type::GeographicalCoord U(0.00006, 0.00004);
+static const navitia::type::GeographicalCoord V(0.00007, 0);
+static const navitia::type::GeographicalCoord W(0.00008, -0.00001);
+static const navitia::type::GeographicalCoord X(0.00009, 0);
+static const navitia::type::GeographicalCoord Y(0.00012, 0);
+static const navitia::type::LineString curved_shape  = {S, T, U, V, W, X, Y};
+
+BOOST_AUTO_TEST_CASE(simplify_create_shape) {
+    typedef navitia::type::LineString LS;
+
+    // Based on the coordinates we will remove T, V and X from the resulting string
+    BOOST_REQUIRE_EQUAL(ed::create_shape(S, Y, curved_shape), LS({S, U, W, Y}));
+
+    // No simplification
+    BOOST_REQUIRE_EQUAL(ed::create_shape(S, Y, curved_shape, 0), LS({S, T, U, V, W, X, Y}));
+
+    // Bigger simplification (we keep a straight line only)
+    BOOST_REQUIRE_EQUAL(ed::create_shape(S, Y, curved_shape, 0.0001), LS({S, Y}));
+}


### PR DESCRIPTION
Since at Tisséo we have only one kraken with a very limited dataset compare to what you have we would like to keep the full shape in the journey response (even if it is more expensive memory-wise). We have a dedicated person drawing lines so they can be quite precise on roundabouts or curved roads.

We talked about it with @kinnou02 and he was ok to add another parameters to the different importers. I added --simplify_tolerance (the term seemed to be used on multiple GIS forums).
I have added it to fusio2ed and gtfs2ed. I added an attribute to the data structure instead of passing the parameter to complete and other functions let me know if it was not the right way.

I have also noticed that for NTFS files, the shapes references for lines or routes are not simplified. We call boost::geometry::simplify only when building shape_from_prev. I don't know if it is by design or not, so I just left everything as it is.