### PR TITLE
Ed & Kraken: collections and stop_schedules ordering

### DIFF
--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -44,7 +44,7 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace timetables {
 
-typedef std::pair<routing::RouteIdx, routing::SpIdx> RoutePointIdx;
+using RoutePointIdx = std::pair<routing::RouteIdx, routing::SpIdx>;
 
 static bool is_last_stoptime(const nt::StopTime* stop_time, const nt::StopPoint* stp){
     return stop_time->vehicle_journey

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -36,7 +36,6 @@ www.navitia.io
 
 namespace navitia { namespace timetables {
 typedef std::vector<DateTime> vector_datetime;
-typedef std::pair<routing::SpIdx, routing::RouteIdx> stop_point_route;
 typedef std::vector<routing::datetime_stop_time> vector_dt_st;
 
 void departure_board(PbCreator& pb_creator, const std::string &filter,

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -794,9 +794,7 @@ void Calendar::build_validity_pattern(boost::gregorian::date_period production_p
 }
 
 bool VehicleJourney::operator<(const VehicleJourney& other) const {
-    if (this->route->uri != other.route->uri) {
-        return this->route->uri < other.route->uri;
-    }
+    if (this->route != other.route) { return *this->route < *other.route; }
     return this->uri < other.uri;
 }
 
@@ -819,6 +817,12 @@ Indexes Calendar::get(Type_e type, const PT_Data & data) const{
     }
     return result;
 }
+
+bool StopArea::operator<(const StopArea & other) const {
+    if (name != other.name) { return name < other.name; }
+    return uri < other.uri;
+}
+
 Indexes StopArea::get(Type_e type, const PT_Data & data) const {
     Indexes result;
     switch(type) {
@@ -828,6 +832,12 @@ Indexes StopArea::get(Type_e type, const PT_Data & data) const {
     default: break;
     }
     return result;
+}
+
+bool Network::operator<(const Network & other) const {
+    if (this->sort != other.sort) { return this->sort < other.sort; }
+    if (this->name != other.name) { return this->name < other.name; }
+    return this->uri < other.uri;
 }
 
 Indexes Network::get(Type_e type, const PT_Data& data) const {
@@ -894,6 +904,14 @@ Indexes Line::get(Type_e type, const PT_Data& data) const {
     return result;
 }
 
+bool Line::operator<(const Line & other) const {
+    if (this->network != other.network) { return *this->network < *other.network; }
+    if (this->sort != other.sort) { return this->sort < other.sort; }
+    if (this->code != other.code) { return navitia::pseudo_natural_sort()(this->code, other.code); }
+    if (this->name != other.name) { return this->name < other.name; }
+    return this->uri < other.uri;
+}
+
 type::hasOdtProperties Line::get_odt_properties() const{
     type::hasOdtProperties result;
     if (!this->route_list.empty()){
@@ -924,11 +942,10 @@ std::string Line::get_label() const {
     return s.str();
 }
 
-bool Route::operator<(const Route & other) const{
-    if(this->uri != other.uri){
-        return this->uri < other.uri;
-    }
-    return this < &other;
+bool Route::operator<(const Route& other) const {
+    if (this->line != other.line) { return *this->line < *other.line; }
+    if (this->name != other.name) { return this->name < other.name; }
+    return this->uri < other.uri;
 }
 
 std::string Route::get_label() const {
@@ -1017,10 +1034,9 @@ FrequencyVehicleJourney::~FrequencyVehicleJourney() {}
 DiscreteVehicleJourney::~DiscreteVehicleJourney() {}
 
 bool StopPoint::operator<(const StopPoint & other) const{
-    if(this->uri != other.uri){
-        return this->uri < other.uri;
-    }
-    return this < &other;
+    if (this->stop_area != other.stop_area) { return *this->stop_area < *other.stop_area; }
+    if (this->name != other.name) { return this->name < other.name; }
+    return this->uri < other.uri;
 }
 
 Indexes StopPoint::get(Type_e type, const PT_Data& data) const {
@@ -1050,7 +1066,10 @@ Indexes StopPointConnection::get(Type_e type, const PT_Data & ) const {
     }
     return result;
 }
-bool StopPointConnection::operator<(const StopPointConnection& other) const { return this < &other; }
+bool StopPointConnection::operator<(const StopPointConnection& other) const {
+    if (this->departure != other.departure) { return *this->departure < *other.departure; }
+    return *this->destination < *other.destination;
+}
 
 Indexes Dataset::get(Type_e type, const PT_Data&) const {
     Indexes result;

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -38,6 +38,7 @@ www.navitia.io
 #include <boost/assign.hpp>
 #include <boost/algorithm/string.hpp>
 #include "utils/functions.h"
+#include "utils/coord_parser.h"
 #include "utils/logger.h"
 
 //they need to be included for the BOOST_CLASS_EXPORT_GUID macro
@@ -1101,11 +1102,6 @@ std::string to_string(ExceptionDate::ExceptionType t) {
     }
 }
 
-
-// the new way to represent a coord is : "lon;lat"
-const std::string match_double = "[-+]?[0-9]*\\.?[0-9]*[eE]?[-+]?[0-9]*";
-const auto coord_regex = boost::regex("^(" + match_double + ");(" + match_double + ")$");
-
 EntryPoint::EntryPoint(const Type_e type, const std::string &uri, int access_duration) : type(type), uri(uri), access_duration(access_duration) {
     if (type == Type_e::Address) {
         auto vect = split_string(uri, ":");
@@ -1115,39 +1111,22 @@ EntryPoint::EntryPoint(const Type_e type, const std::string &uri, int access_dur
         }
     }
     if (type == Type_e::Coord) {
-        auto set_coord = [&](const std::string& lon, const std::string& lat) {
-            try {
-                this->coordinates.set_lon(boost::lexical_cast<double>(lon));
-                this->coordinates.set_lat(boost::lexical_cast<double>(lat));
-            } catch(boost::bad_lexical_cast) {
-                this->coordinates.set_lon(0);
-                this->coordinates.set_lat(0);
-            }
-        };
-
-        if (uri.size() > 6 && uri.substr(0, 6) == "coord:") {
-            // old style to represent coord.
-            // done for retrocompatibility
-            size_t pos2 = uri.find(":", 6);
-            if (pos2 != std::string::npos) {
-                set_coord(uri.substr(6, pos2 - 6), uri.substr(pos2+1));
-            }
-            return;
-        }
-        boost::smatch matches;
-        bool res = boost::regex_match(uri, matches, coord_regex);
-        if (res && matches.size() == 3) {
-            set_coord(matches[1], matches[2]);
-        } else {
+        try {
+            const auto coord = navitia::parse_coordinate(uri);
+            this->coordinates.set_lon(coord.first);
+            this->coordinates.set_lat(coord.second);
+        } catch (const navitia::wrong_coordinate&) {
             LOG4CPLUS_INFO(log4cplus::Logger::getInstance("logger"), 
-                    "uri " << uri << " partialy match coordinate, cannot work");
+                           "uri " << uri << " partialy match coordinate, cannot work");
+            this->coordinates.set_lon(0);
+            this->coordinates.set_lat(0);
         }
     }
 }
 
 bool EntryPoint::is_coord(const std::string& uri) {
     return (uri.size() > 6 && uri.substr(0, 6) == "coord:")
-        || (boost::regex_match(uri, coord_regex) && uri != ";");
+        || (boost::regex_match(uri, navitia::coord_regex) && uri != ";");
 }
 
 EntryPoint::EntryPoint(const Type_e type, const std::string &uri) : EntryPoint(type, uri, 0) { }

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -265,7 +265,7 @@ struct StopArea : public Header, Nameable, hasProperties, HasMessages {
 
     std::vector<StopPoint*> stop_point_list;
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const StopArea & other) const { return this < &other; }
+    bool operator<(const StopArea & other) const;
 };
 
 struct Network : public Header, HasMessages {
@@ -289,16 +289,7 @@ struct Network : public Header, HasMessages {
     }
 
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const Network & other) const {
-        if(this->sort != other.sort) {
-            return this->sort < other.sort;
-        }
-        if(this->name != other.name) {
-             return this->name < other.name;
-        }
-        return this < &other;
-    }
-
+    bool operator<(const Network & other) const;
 };
 
 struct Contributor : public Header, Nameable{
@@ -311,7 +302,7 @@ struct Contributor : public Header, Nameable{
         ar & idx & name & uri & website & license & dataset_list;
     }
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const Contributor & other) const { return this->idx < other.idx; }
+    bool operator<(const Contributor & other) const { return this->uri < other.uri; }
 };
 
 struct Dataset : public Header, Nameable{
@@ -327,7 +318,7 @@ struct Dataset : public Header, Nameable{
         ar & idx & uri & contributor & realtime_level & validation_period & desc & system;
     }
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const Dataset & other) const { return this < &other; }
+    bool operator<(const Dataset & other) const { return this->uri < other.uri; }
 };
 
 struct Company : public Header, Nameable {
@@ -347,7 +338,7 @@ struct Company : public Header, Nameable {
         address_type_name & phone_number & mail & website & fax & line_list;
     }
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const Company & other) const { return this < &other; }
+    bool operator<(const Company & other) const { return this->uri < other.uri; }
 };
 
 struct CommercialMode : public Header, Nameable{
@@ -357,7 +348,7 @@ struct CommercialMode : public Header, Nameable{
         ar & idx & name & uri & line_list;
     }
     Indexes get(Type_e type, const PT_Data & data) const;
-    bool operator<(const CommercialMode & other) const { return this < &other; }
+    bool operator<(const CommercialMode & other) const { return this->uri < other.uri; }
 
 };
 
@@ -372,7 +363,7 @@ struct PhysicalMode : public Header, Nameable{
     Indexes get(Type_e type, const PT_Data & data) const;
 
     PhysicalMode() {}
-    bool operator<(const PhysicalMode & other) const { return this < &other; }
+    bool operator<(const PhysicalMode & other) const { return this->uri < other.uri; }
 
 };
 
@@ -442,24 +433,8 @@ struct Line : public Header, Nameable, HasMessages {
                 & opening_time & properties & line_group_list;
     }
     Indexes get(Type_e type, const PT_Data & data) const;
-
-    bool operator<(const Line & other) const {
-        if(this->network != other.network){
-            return this->network < other.network;
-        }
-        if(this->sort != other.sort) {
-            return this->sort < other.sort;
-        }
-        if(this->code != other.code) {
-            return navitia::pseudo_natural_sort()(this->code, other.code);
-        }
-        if(this->name != other.name) {
-            return this->name < other.name;
-        }
-        return this < &other;
-    }
+    bool operator<(const Line & other) const;
     type::hasOdtProperties get_odt_properties() const;
-
     std::string get_label() const;
 };
 


### PR DESCRIPTION
https://jira.canaltp.fr/browse/NAVP-701

Order is almost as asked, except case insensitivity.

The order of the stop_schedules is changed after an online grooming to line > route > stop point

TODO:
  - [x] a stop_schedules test with line 13 and line 5 with 2 routes each, 2 stop areas with 2 stop points each
 - [x] update utils commit after https://github.com/CanalTP/utils/pull/52 is merged