### PR TITLE
kraken: Disruption fixes

### DIFF
--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -610,20 +610,24 @@ class TestDisruptionsLineSections(AbstractTestFixture):
     def test_line_reports(self):
         response = self.query_region("line_reports?_current_datetime=20170103T120000")
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 1
+        assert len(disruptions) == 2
         line_reports = get_not_null(response, 'line_reports')
         assert len(line_reports) == 1
         is_valid_line_report(line_reports[0])
         assert line_reports[0]['line']['id'] == 'line:1'
-        assert len(line_reports[0]['pt_objects']) == 4
+        assert len(line_reports[0]['pt_objects']) == 5
         assert line_reports[0]['pt_objects'][0]['id'] == 'C_1'
         assert line_reports[0]['pt_objects'][1]['id'] == 'D_1'
         assert line_reports[0]['pt_objects'][2]['id'] == 'D_3'
         assert line_reports[0]['pt_objects'][3]['id'] == 'E_1'
+        assert line_reports[0]['pt_objects'][4]['id'] == 'F_1'
         for pt_object in line_reports[0]['pt_objects']:
             assert pt_object['embedded_type'] == 'stop_point'
-            assert len(pt_object['stop_point']['links']) == 1
-            assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
+            assert len(pt_object['stop_point']['links']) == (2 if pt_object['id'] == 'E_1' else 1)
+            if pt_object['id'] != 'F_1':
+                assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
+        assert line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id'] == 'line_section_on_line_1_other_effect'
+        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_1_other_effect'
 
     def test_line_reports_with_current_datetime_outof_application_period(self):
         #without since/until we use since=production_date.begin and until = production_date.end
@@ -635,38 +639,46 @@ class TestDisruptionsLineSections(AbstractTestFixture):
         response = self.query_region("line_reports?_current_datetime=20170101T120000"
                                      "&since=20170104T130000&until=20170106T000000")
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 1
+        assert len(disruptions) == 2
         line_reports = get_not_null(response, 'line_reports')
         assert len(line_reports) == 1
         is_valid_line_report(line_reports[0])
         assert line_reports[0]['line']['id'] == 'line:1'
-        assert len(line_reports[0]['pt_objects']) == 4
+        assert len(line_reports[0]['pt_objects']) == 5
         assert line_reports[0]['pt_objects'][0]['id'] == 'C_1'
         assert line_reports[0]['pt_objects'][1]['id'] == 'D_1'
         assert line_reports[0]['pt_objects'][2]['id'] == 'D_3'
         assert line_reports[0]['pt_objects'][3]['id'] == 'E_1'
+        assert line_reports[0]['pt_objects'][4]['id'] == 'F_1'
         for pt_object in line_reports[0]['pt_objects']:
             assert pt_object['embedded_type'] == 'stop_point'
-            assert len(pt_object['stop_point']['links']) == 1
-            assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
+            assert len(pt_object['stop_point']['links']) == (2 if pt_object['id'] == 'E_1' else 1)
+            if pt_object['id'] != 'F_1':
+                assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
+        assert line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id'] == 'line_section_on_line_1_other_effect'
+        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_1_other_effect'
 
     def test_line_reports_with_since_intersects_application_period(self):
         response = self.query_region("line_reports?_current_datetime=20170101T120000&since=20170104T130000")
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 1
+        assert len(disruptions) == 2
         line_reports = get_not_null(response, 'line_reports')
         assert len(line_reports) == 1
         is_valid_line_report(line_reports[0])
         assert line_reports[0]['line']['id'] == 'line:1'
-        assert len(line_reports[0]['pt_objects']) == 4
+        assert len(line_reports[0]['pt_objects']) == 5
         assert line_reports[0]['pt_objects'][0]['id'] == 'C_1'
         assert line_reports[0]['pt_objects'][1]['id'] == 'D_1'
         assert line_reports[0]['pt_objects'][2]['id'] == 'D_3'
         assert line_reports[0]['pt_objects'][3]['id'] == 'E_1'
+        assert line_reports[0]['pt_objects'][4]['id'] == 'F_1'
         for pt_object in line_reports[0]['pt_objects']:
             assert pt_object['embedded_type'] == 'stop_point'
-            assert len(pt_object['stop_point']['links']) == 1
-            assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
+            assert len(pt_object['stop_point']['links']) == (2 if pt_object['id'] == 'E_1' else 1)
+            if pt_object['id'] != 'F_1':
+                assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
+        assert line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id'] == 'line_section_on_line_1_other_effect'
+        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_1_other_effect'
 
     def test_line_reports_with_since_until_outof_application_period(self):
         response = self.query_region("line_reports?_current_datetime=20170101T120000"

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -128,9 +128,9 @@ class TestLineSections(AbstractTestFixture):
         assert not has_dis('networks/network:other/traffic_reports')
         r = self.default_query('traffic_reports')
         assert len(r['traffic_reports']) == 1 # only one network (base_network) is disrupted
-        assert len(r['traffic_reports'][0]['stop_areas']) == 3
+        assert len(r['traffic_reports'][0]['stop_areas']) == 4
         for sa in r['traffic_reports'][0]['stop_areas']:
-            assert len(sa['links']) == 1 # sa is disrupted only one time (D disrupted on multiple sp)
+            assert len(sa['links']) == (2 if sa['id'] == 'E' else 1)
 
     def test_traffic_reports_on_lines(self):
         """
@@ -373,3 +373,4 @@ class TestLineSections(AbstractTestFixture):
 
     def test_line_impacted_by_line_section(self):
         assert self.has_disruption(ObjGetter('lines', 'line:1'), 'line_section_on_line_1')
+        assert self.has_disruption(ObjGetter('lines', 'line:1'), 'line_section_on_line_1_other_effect')

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -295,6 +295,13 @@ struct add_impacts_visitor : public apply_impacts_visitor {
     void operator()(nt::StopPoint* stop_point) {
         log_start_action(stop_point->uri);
 
+        if (impact->severity->effect != nt::disruption::Effect::NO_SERVICE
+            && impact->severity->effect != nt::disruption::Effect::DETOUR) {
+            LOG4CPLUS_DEBUG(log, "Unhandled action on " << stop_point->uri << " for stop point");
+            this->log_end_action(stop_point->uri);
+            return;
+        }
+
         using namespace boost::posix_time;
         using namespace boost::gregorian;
 

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -129,7 +129,7 @@ static type::ValidityPattern compute_base_disrupted_vp(
 
 static std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
     std::stringstream impacts_uris;
-    for (auto& mvj_impacts : mvj.impacted_by) {
+    for (auto& mvj_impacts : mvj.modified_by) {
         if (auto i = mvj_impacts.lock()) {
             if (impacts_uris.str().find(i->disruption->uri) == std::string::npos) {
                 impacts_uris << ":" << i->disruption->uri;
@@ -543,18 +543,18 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
         boost::for_each(mvj->get_rt_vj(), set_empty_vp);
 
         const auto& impact = this->impact;
-        boost::range::remove_erase_if(mvj->impacted_by,
+        boost::range::remove_erase_if(mvj->modified_by,
             [&impact](const boost::weak_ptr<nt::disruption::Impact>& i) {
                 auto spt = i.lock();
                 return (spt) ? spt == impact : true;
         });
 
-        // add_impacts_visitor populate mvj->impacted_by, thus we swap
+        // add_impacts_visitor populate mvj->modified_by, thus we swap
         // it with an empty vector.
-        decltype(mvj->impacted_by) impacted_by_moved;
-        boost::swap(impacted_by_moved, mvj->impacted_by);
+        decltype(mvj->modified_by) modified_by_moved;
+        boost::swap(modified_by_moved, mvj->modified_by);
         
-        for(const auto& wptr: impacted_by_moved) {
+        for(const auto& wptr: modified_by_moved) {
             if (auto share_ptr = wptr.lock()){
                 disruptions_collection.insert(share_ptr);
             }
@@ -572,7 +572,7 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
             return false;
         };
         for (auto& mvj: pt_data.meta_vjs) {
-            if (std::any_of(std::begin(mvj->impacted_by), std::end(mvj->impacted_by), find_impact)) {
+            if (std::any_of(std::begin(mvj->modified_by), std::end(mvj->modified_by), find_impact)) {
                 (*this)(mvj.get());
             };
         }
@@ -608,7 +608,7 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
             return false;
         };
         for (auto& mvj: pt_data.meta_vjs) {
-            if (std::any_of(std::begin(mvj->impacted_by), std::end(mvj->impacted_by), find_impact)) {
+            if (std::any_of(std::begin(mvj->modified_by), std::end(mvj->modified_by), find_impact)) {
                 (*this)(mvj.get());
             };
         }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1170,25 +1170,25 @@ BOOST_AUTO_TEST_CASE(stop_point_deletion_test) {
 
     const auto* mvj_A = b.data->pt_data->meta_vjs["VjA"];
     const auto* mvj_B = b.data->pt_data->meta_vjs["VjB"];
-    BOOST_CHECK_EQUAL(mvj_A->impacted_by.size(), 3);
-    BOOST_CHECK_EQUAL(mvj_B->impacted_by.size(), 5);
+    BOOST_CHECK_EQUAL(mvj_A->modified_by.size(), 3);
+    BOOST_CHECK_EQUAL(mvj_B->modified_by.size(), 5);
 
     navitia::delete_disruption("disruption_does't_exist", *b.data->pt_data, *b.data->meta);
-    BOOST_CHECK_EQUAL(mvj_A->impacted_by.size(), 3);
-    BOOST_CHECK_EQUAL(mvj_B->impacted_by.size(), 5);
+    BOOST_CHECK_EQUAL(mvj_A->modified_by.size(), 3);
+    BOOST_CHECK_EQUAL(mvj_B->modified_by.size(), 5);
 
 
     navitia::delete_disruption("stop_area_closed_1", *b.data->pt_data, *b.data->meta);
-    BOOST_CHECK_EQUAL(mvj_A->impacted_by.size(), 2);
-    BOOST_CHECK_EQUAL(mvj_B->impacted_by.size(), 4);
+    BOOST_CHECK_EQUAL(mvj_A->modified_by.size(), 2);
+    BOOST_CHECK_EQUAL(mvj_B->modified_by.size(), 4);
 
     navitia::delete_disruption("stop_area_closed_2", *b.data->pt_data, *b.data->meta);
-    BOOST_CHECK_EQUAL(mvj_A->impacted_by.size(), 1);
-    BOOST_CHECK_EQUAL(mvj_B->impacted_by.size(), 3);
+    BOOST_CHECK_EQUAL(mvj_A->modified_by.size(), 1);
+    BOOST_CHECK_EQUAL(mvj_B->modified_by.size(), 3);
 
     navitia::delete_disruption("stop_area_closed_3", *b.data->pt_data, *b.data->meta);
-    BOOST_CHECK_EQUAL(mvj_A->impacted_by.size(), 0);
-    BOOST_CHECK_EQUAL(mvj_B->impacted_by.size(), 2);
+    BOOST_CHECK_EQUAL(mvj_A->modified_by.size(), 0);
+    BOOST_CHECK_EQUAL(mvj_B->modified_by.size(), 2);
 
     test_vjs_indexes(b.data->pt_data->vehicle_journeys);
 

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -124,6 +124,15 @@ int main(int argc, const char* const argv[]) {
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1_other_effect")
+                              .severity(nt::disruption::Effect::OTHER_EFFECT)
+                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                              .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                              .on_line_section("line:1", "E", "F", {"route:line:1:1", "route:line:1:3"})
+                              .on_line_section("line:1", "F", "E", {"route:line:1:1", "route:line:1:3"})
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
     mock_kraken kraken(b, "line_sections_test", argc, argv);
 
     return 0;

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -34,7 +34,7 @@ www.navitia.io
 
 #include <boost/format.hpp>
 #include <boost/algorithm/cxx11/all_of.hpp>
-#include <boost/algorithm/cxx11/one_of.hpp>
+#include <boost/algorithm/cxx11/any_of.hpp>
 
 namespace pt = boost::posix_time;
 namespace bg = boost::gregorian;
@@ -217,7 +217,7 @@ bool Impact::is_only_line_section() const {
 }
 
 bool Impact::is_line_section_of(const Line& line) const {
-    return boost::algorithm::one_of(informed_entities(), [&](const PtObj& entity) {
+    return boost::algorithm::any_of(informed_entities(), [&](const PtObj& entity) {
         const auto* line_section = boost::get<nt::disruption::LineSection>(&entity);
         return line_section && line_section->line && line_section->line->idx == line.idx;
     });

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -620,18 +620,10 @@ void PbCreator::Filler::fill_pb_object(const nt::Line* l, pbnavitia::Line* line)
          * We could have link the LineSection impact with the line, but that would change the code and
          * the behavior too much.
          * */
-        std::set<boost::shared_ptr<nt::disruption::Impact>> added_impact;
         auto fill_line_section_message = [&](const nt::VehicleJourney& vj) {
-            for(const auto& impact: vj.meta_vj->impacted_by) {
-                auto impact_ptr = impact.lock();
-                if (! impact_ptr)
-                    continue;
-                for (const auto& entity: impact_ptr->informed_entities()) {
-                    if (boost::get<nt::disruption::LineSection>(&entity) &&
-                            added_impact.insert(impact_ptr).second ) {
-                        fill_messages(vj.meta_vj, line);
-                        return true;
-                    }
+            for(const auto& impact_ptr: vj.meta_vj->get_publishable_messages(pb_creator.now)) {
+                if (impact_ptr->is_line_section_of(*vj.route->line)) {
+                    fill_message(impact_ptr, line);
                 }
             }
             return true;

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -687,16 +687,16 @@ Indexes MetaVehicleJourney::get(Type_e type, const PT_Data& data) const {
     return result;
 }
 
-bool MetaVehicleJourney::is_already_impacted_by(const boost::shared_ptr<disruption::Impact>& impact) {
-    return std::any_of(std::begin(impacted_by), std::end(impacted_by),
+bool MetaVehicleJourney::is_already_modified_by(const boost::shared_ptr<disruption::Impact>& impact) {
+    return std::any_of(std::begin(modified_by), std::end(modified_by),
             [&](const boost::weak_ptr<nt::disruption::Impact>& i) {
                 return i.lock() == impact;});
 }
 
 
 void MetaVehicleJourney::push_unique_impact(const boost::shared_ptr<disruption::Impact>& impact) {
-    if (! is_already_impacted_by(impact)) {
-        impacted_by.push_back(impact);
+    if (! is_already_modified_by(impact)) {
+        modified_by.push_back(impact);
     }
 }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -809,7 +809,7 @@ struct MetaVehicleJourney: public Header, HasMessages {
 
     // impacts not directly on this vj, by example an impact on a line will impact the vj, so we add the impact here
     // because it's not really on the vj
-    std::vector<boost::weak_ptr<disruption::Impact>> impacted_by;
+    std::vector<boost::weak_ptr<disruption::Impact>> modified_by;
 
     /// map of the calendars that nearly match union of the validity pattern
     /// of the theoric vj, key is the calendar name
@@ -818,7 +818,7 @@ struct MetaVehicleJourney: public Header, HasMessages {
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
         ar & idx & uri & rtlevel_to_vjs_map
            & associated_calendars & impacts
-           & impacted_by & tz_handler;
+           & modified_by & tz_handler;
     }
 
     FrequencyVehicleJourney*
@@ -874,7 +874,7 @@ struct MetaVehicleJourney: public Header, HasMessages {
 
     void push_unique_impact(const boost::shared_ptr<disruption::Impact>& impact);
 
-    bool is_already_impacted_by(const boost::shared_ptr<disruption::Impact>& impact);
+    bool is_already_modified_by(const boost::shared_ptr<disruption::Impact>& impact);
 
 private:
     template<typename VJ>


### PR DESCRIPTION
Several disruption fixes:
 - don't remove stop point with SIGNIFICANT_DELAYS as reported in https://github.com/CanalTP/navitia/issues/2225#issuecomment-345217591
 - output all line sections on /lines API (fix #2225)
 - fix a bug when an impact has 2 line sections