### PR TITLE
Jormun: manage Cykleo station with id starting by "0"

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/bss/cykleo.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/cykleo.py
@@ -138,6 +138,8 @@ class CykleoProvider(AbstractParkingPlacesProvider):
 
     def get_informations(self, poi):
         ref = poi.get('properties', {}).get('ref')
+        if ref is not None:
+            ref = ref.lstrip('0')
         data = self._call_webservice()
         if not data:
             return None

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/cykleo_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/cykleo_test.py
@@ -29,6 +29,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
+from copy import deepcopy
 from jormungandr.parking_space_availability.bss.cykleo import CykleoProvider
 from jormungandr.parking_space_availability.bss.stands import Stands
 from mock import MagicMock
@@ -63,24 +64,26 @@ def parking_space_availability_cykleo_support_poi_test():
     CykleoProvider bss provider support
     """
     provider = CykleoProvider('http://bob', network, 'big', 'big', {'CYKLEO'})
-    assert provider.support_poi(poi)
-    poi['properties']['operator'] = 'Bad_operator'
-    assert not provider.support_poi(poi)
-    poi['properties']['operator'] = 'JCDecaux'
-    poi['properties']['network'] = 'Bad_network'
-    assert not provider.support_poi(poi)
-    poi['properties']['operator'] = 'Bad_operator'
-    assert not provider.support_poi(poi)
+    poi_copy = deepcopy(poi)
+    assert provider.support_poi(poi_copy)
+    poi_copy['properties']['operator'] = 'Bad_operator'
+    assert not provider.support_poi(poi_copy)
+    poi_copy['properties']['operator'] = 'JCDecaux'
+    poi_copy['properties']['network'] = 'Bad_network'
+    assert not provider.support_poi(poi_copy)
+    poi_copy['properties']['operator'] = 'Bad_operator'
+    assert not provider.support_poi(poi_copy)
 
     # same test with "02" in id, not "2"
-    assert provider.support_poi(poi_with_0)
-    poi_with_0['properties']['operator'] = 'Bad_operator'
-    assert not provider.support_poi(poi_with_0)
-    poi_with_0['properties']['operator'] = 'JCDecaux'
-    poi_with_0['properties']['network'] = 'Bad_network'
-    assert not provider.support_poi(poi_with_0)
-    poi['properties']['operator'] = 'Bad_operator'
-    assert not provider.support_poi(poi_with_0)
+    poi_with_0_copy = deepcopy(poi_with_0)
+    assert provider.support_poi(poi_with_0_copy)
+    poi_with_0_copy['properties']['operator'] = 'Bad_operator'
+    assert not provider.support_poi(poi_with_0_copy)
+    poi_with_0_copy['properties']['operator'] = 'JCDecaux'
+    poi_with_0_copy['properties']['network'] = 'Bad_network'
+    assert not provider.support_poi(poi_with_0_copy)
+    poi_with_0_copy['properties']['operator'] = 'Bad_operator'
+    assert not provider.support_poi(poi_with_0_copy)
 
     invalid_poi = {}
     assert not provider.support_poi(invalid_poi)

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/cykleo_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/cykleo_test.py
@@ -45,6 +45,17 @@ poi = {
         'id': 'poi_type:amenity:bicycle_rental'
     }
 }
+poi_with_0 = {
+    'properties': {
+        'network': network,
+        'operator': 'Cykleo',
+        'ref': '02'
+    },
+    'poi_type': {
+        'name': 'station vls',
+        'id': 'poi_type:amenity:bicycle_rental'
+    }
+}
 
 
 def parking_space_availability_cykleo_support_poi_test():
@@ -60,6 +71,16 @@ def parking_space_availability_cykleo_support_poi_test():
     assert not provider.support_poi(poi)
     poi['properties']['operator'] = 'Bad_operator'
     assert not provider.support_poi(poi)
+
+    # same test with "02" in id, not "2"
+    assert provider.support_poi(poi_with_0)
+    poi_with_0['properties']['operator'] = 'Bad_operator'
+    assert not provider.support_poi(poi_with_0)
+    poi_with_0['properties']['operator'] = 'JCDecaux'
+    poi_with_0['properties']['network'] = 'Bad_network'
+    assert not provider.support_poi(poi_with_0)
+    poi['properties']['operator'] = 'Bad_operator'
+    assert not provider.support_poi(poi_with_0)
 
     invalid_poi = {}
     assert not provider.support_poi(invalid_poi)
@@ -88,8 +109,11 @@ def parking_space_availability_cykleo_get_informations_test():
     provider = CykleoProvider('http://bob', network, 'big', 'big', {'CYKLEO'})
     provider._call_webservice = MagicMock(return_value=webservice_response)
     assert provider.get_informations(poi) == Stands(2, 4)
+    assert provider.get_informations(poi_with_0) == Stands(2, 4)
     provider._call_webservice = MagicMock(return_value=None)
     assert provider.get_informations(poi) is None
+    assert provider.get_informations(poi_with_0) is None
+
     invalid_poi = {}
     assert provider.get_informations(invalid_poi) is None
 
@@ -114,6 +138,7 @@ def available_classic_bike_count_only_test():
     provider = CykleoProvider('http://bob', network, 'big', 'big', {'CYKLEO'})
     provider._call_webservice = MagicMock(return_value=webservice_response)
     assert provider.get_informations(poi) == Stands(2, 1)
+    assert provider.get_informations(poi_with_0) == Stands(2, 1)
 
 
 def available_electric_bike_count_only_test():
@@ -136,6 +161,7 @@ def available_electric_bike_count_only_test():
     provider = CykleoProvider('http://bob', network, 'big', 'big', {'CYKLEO'})
     provider._call_webservice = MagicMock(return_value=webservice_response)
     assert provider.get_informations(poi) == Stands(2, 1)
+    assert provider.get_informations(poi_with_0) == Stands(2, 1)
 
 
 def witout_available_dock_count_test():
@@ -157,3 +183,4 @@ def witout_available_dock_count_test():
     provider = CykleoProvider('http://bob', network, 'big', 'big', {'CYKLEO'})
     provider._call_webservice = MagicMock(return_value=webservice_response)
     assert not provider.get_informations(poi)
+    assert not provider.get_informations(poi_with_0)


### PR DESCRIPTION
Previously, if in OSM we had a station tagged "02" instead of "2"; Navitia couldn't find the station in Cykleo's feed.

JIRA: https://jira.canaltp.fr/browse/NAVITIAII-2330