### PR TITLE
Kraken: fix schedules for lines not circulating on two consecutive days or more

### DIFF
--- a/source/routing/get_stop_times.cpp
+++ b/source/routing/get_stop_times.cpp
@@ -59,7 +59,7 @@ std::vector<datetime_stop_time> get_stop_times(const routing::StopEvent stop_eve
         }
         auto st = next_st.next_stop_time(stop_event, jpp_idx,
                                          dt, clockwise, rt_level,
-                                         accessibilite_params.vehicle_properties, true);
+                                         accessibilite_params.vehicle_properties, true, max_dt);
         if (st.first) {
             next_requested_dt.push({jpp_idx, st.first, st.second});
         }
@@ -86,7 +86,7 @@ std::vector<datetime_stop_time> get_stop_times(const routing::StopEvent stop_eve
         auto next_dt = best_jpp_dt.dt + (clockwise ? 1 : -1);
         auto st = next_st.next_stop_time(stop_event, best_jpp_dt.jpp,
                                          next_dt, clockwise, rt_level,
-                                         accessibilite_params.vehicle_properties, true);
+                                         accessibilite_params.vehicle_properties, true, max_dt);
         if (st.first) {
             next_requested_dt.push({best_jpp_dt.jpp, st.first, st.second});
         }

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -133,15 +133,18 @@ next_valid_discrete(const StopEvent stop_event,
         }
     }
 
-    //if none was found, we try again the next day
-    date++;
-    for (const auto* st: dataRaptor.next_stop_time_data.stop_time_range_forward(jpp_idx, stop_event)) {
-        assert(dataRaptor.jp_container.get_jpp(*st) == jpp_idx);
-        const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->boarding_time : st->alighting_time;
-        const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
-        if (bound < cur_dt) { return {nullptr, DateTimeUtils::inf}; }
-        if (is_valid(st, date, true, rt_level, vehicle_props)) {
-            return {st, cur_dt};
+    const auto st_range = dataRaptor.next_stop_time_data.stop_time_range_forward(jpp_idx, stop_event);
+    //if none was found, we try again until we crossed the bound
+    while(DateTimeUtils::date(bound) > date) {
+        date++;
+        for (const auto* st: st_range) {
+            assert(dataRaptor.jp_container.get_jpp(*st) == jpp_idx);
+            const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->boarding_time : st->alighting_time;
+            const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
+            if (bound < cur_dt) { return {nullptr, DateTimeUtils::inf}; }
+            if (is_valid(st, date, true, rt_level, vehicle_props)) {
+                return {st, cur_dt};
+            }
         }
     }
 
@@ -153,30 +156,17 @@ static std::pair<const type::StopTime*, DateTime>
 next_valid_frequency(const StopEvent stop_event,
         const dataRAPTOR& dataRaptor,
         const JppIdx jpp_idx,
-        const DateTime dt,
+        DateTime dt,
         const type::RTLevel rt_level,
-        const type::VehicleProperties &vehicle_props) {
+        const type::VehicleProperties &vehicle_props,
+        const DateTime bound) {
     // to find the next frequency VJ, for the moment we loop through all frequency VJ of the JP
     // and for each jp, get compute the datetime on the jpp
     const auto& jpp = dataRaptor.jp_container.get(jpp_idx);
     const auto& jp = dataRaptor.jp_container.get(jpp.jp_idx);
     std::pair<const type::StopTime*, DateTime> best = {nullptr, DateTimeUtils::inf};
-    for (const auto& freq_vj: jp.freq_vjs) {
-        const auto& st = freq_vj->stop_time_list[jpp.order];
 
-        if (! freq_vj->accessible(vehicle_props)) { continue; }
-        if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
-        if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
-
-        const auto next_dt = get_next_stop_time(stop_event, dt, *freq_vj, st, rt_level);
-
-        if (next_dt < best.second) {
-            best = {&st, next_dt};
-        }
-    }
-
-    if (best.first == nullptr) {
-        const auto next_date = DateTimeUtils::set(DateTimeUtils::date(dt) + 1, 0);
+    do {
         for (const auto& freq_vj: jp.freq_vjs) {
             const auto& st = freq_vj->stop_time_list[jpp.order];
 
@@ -184,13 +174,14 @@ next_valid_frequency(const StopEvent stop_event,
             if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
             if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
-            const auto next_dt = get_next_stop_time(stop_event, next_date, *freq_vj, st, rt_level);
-
-            if (next_dt < best.second) {
+            const auto next_dt = get_next_stop_time(stop_event, dt, *freq_vj, st, rt_level);
+            if (next_dt < best.second && next_dt <= bound) {
                 best = {&st, next_dt};
             }
         }
-    }
+        dt = DateTimeUtils::set(DateTimeUtils::date(dt) + 1, 0);
+    } while(best.first == nullptr && dt < bound);
+
     return best;
 }
 
@@ -198,35 +189,15 @@ static std::pair<const type::StopTime*, DateTime>
 previous_valid_frequency(const StopEvent stop_event,
         const dataRAPTOR& dataRaptor,
         const JppIdx jpp_idx,
-        const DateTime dt,
+        DateTime dt,
         const type::RTLevel rt_level,
-        const type::VehicleProperties &vehicle_props) {
+        const type::VehicleProperties &vehicle_props,
+        const DateTime bound) {
     const auto& jpp = dataRaptor.jp_container.get(jpp_idx);
     const auto& jp = dataRaptor.jp_container.get(jpp.jp_idx);
     std::pair<const type::StopTime*, DateTime> best = {nullptr, DateTimeUtils::not_valid};
-    for (const auto& freq_vj: jp.freq_vjs) {
-        const auto& st = freq_vj->stop_time_list[jpp.order];
 
-        if (! freq_vj->accessible(vehicle_props)) { continue; }
-        if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
-        if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
-
-        const auto previous_dt = get_previous_stop_time(stop_event, dt, *freq_vj, st, rt_level);
-
-        if (previous_dt == DateTimeUtils::not_valid) {
-            continue;
-        }
-        if (best.second == DateTimeUtils::not_valid || previous_dt > best.second) {
-            best = {&st, previous_dt};
-        }
-    }
-
-    if (best.first == nullptr) {
-        auto date = DateTimeUtils::date(dt);
-        if (date == 0) {
-            return best;
-        }
-        const auto previous_date = DateTimeUtils::set(date - 1, DateTimeUtils::SECONDS_PER_DAY - 1);
+    do {
         for (const auto& freq_vj: jp.freq_vjs) {
             const auto& st = freq_vj->stop_time_list[jpp.order];
 
@@ -234,17 +205,22 @@ previous_valid_frequency(const StopEvent stop_event,
             if (stop_event == StopEvent::pick_up && ! st.pick_up_allowed()) { continue; }
             if (stop_event == StopEvent::drop_off && ! st.drop_off_allowed()) { continue; }
 
-            const auto previous_dt = get_previous_stop_time(stop_event, previous_date, *freq_vj,
-                    st, rt_level);
+            const auto previous_dt = get_previous_stop_time(stop_event, dt, *freq_vj, st, rt_level);
 
-            if (previous_dt == DateTimeUtils::not_valid) {
+            if (previous_dt == DateTimeUtils::not_valid || previous_dt < bound) {
                 continue;
             }
             if (best.second == DateTimeUtils::not_valid || previous_dt > best.second) {
                 best = {&st, previous_dt};
             }
         }
-    }
+        auto date = DateTimeUtils::date(dt);
+        if (date == 0) {
+            return best;
+        }
+        dt = DateTimeUtils::set(date - 1, DateTimeUtils::SECONDS_PER_DAY - 1);
+    } while(best.first == nullptr && dt > bound);
+
     return best;
 }
 
@@ -271,14 +247,21 @@ previous_valid_discrete(const StopEvent stop_event,
         return {nullptr, DateTimeUtils::not_valid};
     }
 
-    --date;
-    for (const auto* st: dataRaptor.next_stop_time_data.stop_time_range_backward(jpp_idx, stop_event)) {
-        assert(dataRaptor.jp_container.get_jpp(*st) == jpp_idx);
-        const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->boarding_time : st->alighting_time;
-        const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
-        if (bound > cur_dt) { return {nullptr, DateTimeUtils::not_valid}; }
-        if (is_valid(st, date, false, rt_level, vehicle_props)) {
-            return {st, cur_dt};
+    const auto st_range = dataRaptor.next_stop_time_data.stop_time_range_backward(jpp_idx, stop_event);
+    //if none was found, we try again until we crossed the bound
+    while(DateTimeUtils::date(bound) < date) {
+        date--;
+        for (const auto *st: st_range) {
+            assert(dataRaptor.jp_container.get_jpp(*st) == jpp_idx);
+            const uint32_t hour = (stop_event == StopEvent::pick_up) ? st->boarding_time : st->alighting_time;
+            const DateTime cur_dt = DateTimeUtils::set(date, DateTimeUtils::hour(hour));
+            if (bound > cur_dt) { return {nullptr, DateTimeUtils::not_valid}; }
+            if (is_valid(st, date, false, rt_level, vehicle_props)) {
+                return {st, cur_dt};
+            }
+        }
+        if (date == 0) {
+            return {nullptr, DateTimeUtils::not_valid};
         }
     }
 
@@ -292,14 +275,18 @@ NextStopTime::earliest_stop_time(const StopEvent stop_event,
         const type::RTLevel rt_level,
         const type::VehicleProperties& vehicle_props,
         const bool check_freq,
-        const DateTime bound) const
+        const boost::optional<DateTime>& bound) const
 {
-    const auto first_discrete_st_pair =
-            next_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
+    DateTime next_dep_bound = bound ? *bound : DateTimeUtils::set(DateTimeUtils::date(dt) + 2, 0);
+    // Limit the next bound to the end production date
+    next_dep_bound = std::min(next_dep_bound,
+                              DateTimeUtils::set(data.meta->production_date.length().days(), 0));
+    const auto first_discrete_st_pair = next_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt,
+                                                            rt_level,vehicle_props, next_dep_bound);
 
     if (check_freq) {
-        const auto first_frequency_st_pair =
-                next_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props);
+        const auto first_frequency_st_pair = next_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt,
+                                                                  rt_level, vehicle_props, next_dep_bound);
 
         if (first_frequency_st_pair.second < first_discrete_st_pair.second) {
             return first_frequency_st_pair;
@@ -316,14 +303,16 @@ NextStopTime::tardiest_stop_time(const StopEvent stop_event,
         const type::RTLevel rt_level,
         const type::VehicleProperties& vehicle_props,
         const bool check_freq,
-        const DateTime bound) const
+        const boost::optional<DateTime>& bound) const
 {
-    const auto first_discrete_st_pair =
-            previous_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props, bound);
+    auto cur_date = DateTimeUtils::date(dt);
+    const DateTime prev_dep_bound = bound ? *bound : (cur_date < 2 ? 0 : DateTimeUtils::set(cur_date - 2, 0));
+    const auto first_discrete_st_pair = previous_valid_discrete(stop_event, *data.dataRaptor, jpp_idx, dt,
+                                                                rt_level, vehicle_props, prev_dep_bound);
 
     if (check_freq) {
-        const auto first_frequency_st_pair =
-                previous_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt, rt_level, vehicle_props);
+        const auto first_frequency_st_pair = previous_valid_frequency(stop_event, *data.dataRaptor, jpp_idx, dt,
+                                                                      rt_level, vehicle_props, prev_dep_bound);
         // since the default value is DateTimeUtils::not_valid (== DateTimeUtils::max)
         // we need to check first that they are
         if (first_discrete_st_pair.second == DateTimeUtils::not_valid) {

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -163,10 +163,10 @@ struct NextStopTime {
                    const boost::optional<DateTime>& bound = boost::none) const {
         if (clockwise) {
             return earliest_stop_time(stop_event, jpp_idx, dt, rt_level, vehicle_props,
-                                      check_freq, bound ? *bound : DateTimeUtils::inf);
+                                      check_freq, bound);
         } else {
             return tardiest_stop_time(stop_event, jpp_idx, dt, rt_level, vehicle_props,
-                                      check_freq, bound ? *bound : DateTimeUtils::min);
+                                      check_freq, bound);
         }
     }
 
@@ -181,7 +181,7 @@ struct NextStopTime {
                        const type::RTLevel rt_level,
                        const type::VehicleProperties& vehicle_props,
                        const bool check_freq = true,
-                       const DateTime bound = DateTimeUtils::inf) const;
+                       const boost::optional<DateTime>& bound = boost::none) const;
 
     /// Next backward stop time for a given datetime (dt).  Look for
     /// the first stop_time arriving before dt on the journey pattern
@@ -194,7 +194,7 @@ struct NextStopTime {
                        const type::RTLevel rt_level,
                        const type::VehicleProperties& vehicle_props,
                        const bool check_freq = true,
-                       const DateTime bound = DateTimeUtils::min) const;
+                       const boost::optional<DateTime>& bound = boost::none) const;
 
 private:
     const type::Data& data;

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -290,12 +290,12 @@ private:
 };
 
 DateTime get_next_stop_time(const StopEvent stop_event,
-                            DateTime dt,
+                            const DateTime dt,
                             const type::FrequencyVehicleJourney& freq_vj,
                             const type::StopTime& st,
                             const type::RTLevel rt_level = type::RTLevel::Base);
 DateTime get_previous_stop_time(const StopEvent stop_event,
-                                DateTime dt,
+                                const DateTime dt,
                                 const type::FrequencyVehicleJourney& freq_vj,
                                 const type::StopTime& st,
                                 const type::RTLevel rt_level = type::RTLevel::Base);

--- a/source/routing/tests/next_stop_time_test.cpp
+++ b/source/routing/tests/next_stop_time_test.cpp
@@ -2233,6 +2233,20 @@ BOOST_AUTO_TEST_CASE(next_stop_time_with_distant_bounds) {
     uint32_t dt;
 
     {
+        // A bound in the past give no results
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure - 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test, nt::RTLevel::Base,
+                                                      nt::VehicleProperties(), false, DateTimeUtils::set(0, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp1, dt_test, nt::RTLevel::Base,
+                                                      nt::VehicleProperties(), false, DateTimeUtils::set(0, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
         // By default we only look for today and tomorrow so no results
         DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
         std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,

--- a/source/routing/tests/next_stop_time_test.cpp
+++ b/source/routing/tests/next_stop_time_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "routing/next_stop_time.h"
 #include "routing/dataraptor.h"
 #include "ed/build_helper.h"
+#include "tests/utils_test.h"
 #include "type/type.h"
 #include "type/pt_data.h"
 #include "type/datetime.h"
@@ -2205,4 +2206,416 @@ BOOST_FIXTURE_TEST_CASE(test_get_next_dep_overnight_midnight_case, midnight_freq
     auto next_dt = get_next_stop_time(StopEvent::pick_up, dt, vj, st);
 
     BOOST_REQUIRE_EQUAL(next_dt, DateTimeUtils::set(1, 17 * 60 * 60 + 30));
+}
+
+/*
+ * To be able to return stop_schedules requests with duration of multiple days we need to check that earliest
+ * stop time is able to search further than the next day.
+ * This is a line circulating only on sundays.
+ */
+BOOST_AUTO_TEST_CASE(next_stop_time_with_distant_bounds) {
+    ed::builder b("20180107");
+    DateTime sp1_departure = "10:00:00"_t;
+    DateTime sp2_arrival = "10:30:00"_t;
+    std::string spa1 = "stop1";
+    std::string spa2 = "stop2";
+    b.vj("A", "10000001", "")(spa1, sp1_departure, sp1_departure)
+                             (spa2, sp2_arrival, sp2_arrival);
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_uri();
+    b.data->build_raptor();
+    NextStopTime next_st(*b.data);
+
+    auto jpp1 = get_first_jpp_idx(b, spa1);
+    auto jpp2 = get_first_jpp_idx(b, spa2);
+    const type::StopTime *st;
+    uint32_t dt;
+
+    {
+        // By default we only look for today and tomorrow so no results
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // Looking for the next 6 days should yield no results too
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test, nt::RTLevel::Base,
+                                                      nt::VehicleProperties(), false, DateTimeUtils::set(7, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test, nt::RTLevel::Base,
+                                                      nt::VehicleProperties(), false, DateTimeUtils::set(7, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // Looking for the next 7 days but with a bound just before the departure should yield no results too
+        // Even if we are going to look for a departure on the right day we should ignore it with the bound
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(7, sp1_departure - 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(7, sp2_arrival - 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // Looking for the next 7 days with a bound on the dot should work.
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(7, sp1_departure));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp1_departure);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(7, sp2_arrival));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp2_arrival);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        // Look for a departure today and in the next 7 days should return the departure from the next sunday
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(8, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp1_departure);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(8, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp2_arrival);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        // By default we only look today and yesterday so no results
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                        nt::RTLevel::Base, nt::VehicleProperties());
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // Looking for the previous 6 days should yield no results too
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(1, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(1, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // Looking for the previous 7 days but with a bound just after the departure should yield no results too
+        // Even if we are going to look for a departure on the right day we should ignore it with the bound
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(0, sp1_departure + 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(0, sp2_arrival + 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // Looking for the previous 7 days but with a bound on the dot.
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(0, sp1_departure));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp1_departure);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(0, sp2_arrival));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp2_arrival);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        // Look for a departure today and the previous 7 days should return the departure from the first sunday
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(0, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp1_departure);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), false,
+                                                      DateTimeUtils::set(0, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->departure_time, sp2_arrival);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(freq_next_stop_time_with_distant_bounds) {
+    ed::builder b("20180107");
+    DateTime sp1_departure = "10:00:00"_t;
+    DateTime sp2_arrival = "10:30:00"_t;
+    DateTime start_time = sp1_departure;
+    DateTime end_time = "11:00:00"_t;
+    uint32_t headway_sec = 3600;
+    std::string spa1 = "stop1";
+    std::string spa2 = "stop2";
+    b.frequency_vj("A", start_time, end_time, headway_sec, "", "10000001")(spa1, sp1_departure)
+                                                                          (spa2, sp2_arrival);
+
+    b.finish();
+    b.data->pt_data->index();
+    b.data->build_uri();
+    b.data->build_raptor();
+    NextStopTime next_st(*b.data);
+
+    auto jpp1 = get_first_jpp_idx(b, spa1);
+    auto jpp2 = get_first_jpp_idx(b, spa2);
+    const type::StopTime *st;
+    DateTime dt;
+
+    {
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp1_departure + headway_sec));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp2_arrival + headway_sec));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        // Looking for a departure just after the end of the frequency without bound. No result because by
+        // default we only check on today and the next day.
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // No departure until saturday either
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(7, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(7, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // With a bound just before the start of the frequency no results
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(7, sp1_departure - 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(7, sp2_arrival - 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        // With a bound on the start of the frequency we have one
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(7, sp1_departure));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(7, sp2_arrival));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(0, sp1_departure + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(8, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(0, sp2_arrival + headway_sec + 1);
+        std::tie(st, dt) = next_st.earliest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(8, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure + headway_sec - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp1_departure));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival + headway_sec - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(7, sp2_arrival));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true);
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(1, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(1, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(0, sp1_departure + headway_sec + 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(0, sp2_arrival + headway_sec + 1));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::inf);
+        BOOST_REQUIRE(st == nullptr);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(0, sp1_departure + headway_sec));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp1_departure + headway_sec));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(0, sp2_arrival + headway_sec));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp2_arrival + headway_sec));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
+    {
+        DateTime dt_test = DateTimeUtils::set(7, sp1_departure - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::pick_up, jpp1, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(0, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp1_departure + headway_sec));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa1);
+
+        dt_test = DateTimeUtils::set(7, sp2_arrival - 1);
+        std::tie(st, dt) = next_st.tardiest_stop_time(StopEvent::drop_off, jpp2, dt_test,
+                                                      nt::RTLevel::Base, nt::VehicleProperties(), true,
+                                                      DateTimeUtils::set(0, 0));
+        BOOST_CHECK_EQUAL(dt, DateTimeUtils::set(0, sp2_arrival + headway_sec));
+        BOOST_REQUIRE(st != nullptr);
+        BOOST_CHECK_EQUAL(st->stop_point->stop_area->name, spa2);
+    }
 }

--- a/source/type/datetime.h
+++ b/source/type/datetime.h
@@ -60,11 +60,11 @@ namespace DateTimeUtils{
         return date * SECONDS_PER_DAY + time_of_day;
     }
 
-    inline uint32_t hour(navitia::DateTime datetime) {
+    inline uint32_t hour(const navitia::DateTime datetime) {
         return datetime%SECONDS_PER_DAY;
     }
 
-    inline uint32_t date(navitia::DateTime datetime) {
+    inline uint32_t date(const navitia::DateTime datetime) {
         return datetime/SECONDS_PER_DAY;
     }
 


### PR DESCRIPTION
This is following issue #2279.

This problem is occurring on stop/route_schedules with a duration of multiple days. Our use case is that we want to know which lines have a service on the next seven days at a certain stop. So we ask stop_schedules the next 2 departures in the next 7 days.
Some of our lines have routes only active on Saturdays or Sundays, so when we test it at the beginning of the week, we have no results.

After @TeXitoi's answer I took the safe approach, not wanting to impact anything performance-wise. I used the already existing bound for next/previous_valid_discrete (I added it to the frequency functions).
It's not just used to stop searching after a certain bound now, I also use it to determine how far into the future I need to go. For example next_valid_discrete will search on the current day and increment the date until we pass the bound as long as we have not found the next stop time.

If the bound is not set, I set it to DateTime(dt.date + 2, 0). It's kind of "random", but it's to emulate the current behavior. I don't know if there is a more elegant way to do it. I've added a bunch of tests too.

Let me know if that's seems an OK way to fix it, if I miss something or if I need to change / add anything.