### PR TITLE
Ed: Remove stop point coordinates from journey geometry

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -244,8 +244,6 @@ nt::VehicleJourney* VJ::make() {
 VJ& VJ::st_shape(const navitia::type::LineString& shape) {
     assert(shape.size() >= 2);
     assert(stop_times.size() >= 2);
-    assert(stop_times.back().st.stop_point->coord == shape.back());
-    assert(stop_times.at(stop_times.size() - 2).st.stop_point->coord == shape.front());
     auto s = boost::make_shared<navitia::type::LineString>(shape);
     stop_times.back().st.shape_from_prev = s;
     return *this;

--- a/source/ed/tests/jpp_shape_test.cpp
+++ b/source/ed/tests/jpp_shape_test.cpp
@@ -56,6 +56,7 @@ static std::ostream& operator<<(std::ostream& os, const navitia::type::LineStrin
 //             |
 //             |   + F
 //           P +
+//               + G
 // 0.001 ~= 100m
 static const navitia::type::GeographicalCoord M(0.010,0.020);
 static const navitia::type::GeographicalCoord N(0.010,0.015);
@@ -63,10 +64,13 @@ static const navitia::type::GeographicalCoord O(0.015,0.015);
 static const navitia::type::GeographicalCoord P(0.015,0.010);
 static const navitia::type::GeographicalCoord A(0.011,0.021);
 static const navitia::type::GeographicalCoord B(0.012,0.016);
+static const navitia::type::GeographicalCoord Bproj(0.012,0.015);
 static const navitia::type::GeographicalCoord C(0.013,0.016);
 static const navitia::type::GeographicalCoord D(0.016,0.017);
 static const navitia::type::GeographicalCoord E(0.017,0.016);
 static const navitia::type::GeographicalCoord F(0.017,0.011);
+static const navitia::type::GeographicalCoord Fproj(0.015,0.011);
+static const navitia::type::GeographicalCoord G(0.016,0.009);
 static const navitia::type::LineString shape = {M, N, O, P};
 static const navitia::type::LineString rshape = {P, O, N, M};
 
@@ -94,13 +98,19 @@ BOOST_AUTO_TEST_CASE(create_shape) {
     shape_eq(D, E, LS({D, E}));
 
     // nearest segment and point on segment: using the common point
-    shape_eq(B, D, LS({B, O, D}));
+    // Dproj == O
+    shape_eq(B, D, LS({Bproj, O}));
 
     // 2 nearest segments are adjacent: using the common point
-    shape_eq(B, F, LS({B, O, F}));
+    shape_eq(B, F, LS({Bproj, O, Fproj}));
 
     // A->F, a long path
-    shape_eq(A, F, LS({A, M, N, O, F}));
+    // Aproj == M
+    shape_eq(A, F, LS({M, N, O, Fproj}));
+
+    // A->G, whole path
+    // Aproj == M
+    shape_eq(A, G, LS({M, N, O, P}));
 }
 
 /*


### PR DESCRIPTION
Hi,

As discussed with @eturck, we wanted to change the geometries of a journey by removing the small lines drawn between the route path and the stop points.

![before_geom](https://user-images.githubusercontent.com/2248947/35445833-2d6496ec-02b3-11e8-83aa-f54929177897.png)

We agreed on keeping only the first and last stop point coordinates of each route in a journey as it fit well with the whole geometry.

![after_geom](https://user-images.githubusercontent.com/2248947/35445834-2f7cc0da-02b3-11e8-9e8c-217b5cf6e895.png)

_In order to make it, I just removed completly the stop point coordinates from the shape generation in ED. I kept only first and last coordinates in raptor_api._

_Edit: Now the stop points aren't removed but are projected on the shape._

Tell me if it's ok ! Thank you.