### PR TITLE
Jormun: correction crash use before define

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -980,7 +980,7 @@ The [isochrones](#isochrones) service exposes another response structure, which 
 | nop     | count                | int     | Fixed number of different journeys<br>More in multiple_journeys  |             |
 | nop     | max_nb_tranfers      | int     | Maximum number of transfers in each journey  | 10          |
 | nop     | min_nb_transfers     | int     | Minimum number of transfers in each journey  | 0           |
-| nop     | max_duration         | int     | Maximum duration of journeys in secondes. Really useful when computing an isochrone   | 10          |
+| nop     | max_duration         | int     | Maximum duration of journeys in secondes. Really useful when computing an isochrone   | 86400       |
 | nop     | disruption_active    | boolean | For compatibility use only.<br>If true the algorithm take the disruptions into account, and thus avoid disrupted public transport.<br>Rq: `disruption_active=true` = `data_freshness=realtime` <br>Use `data_freshness` parameter instead       |  False     |
 | nop     | wheelchair           | boolean | If true the traveler is considered to be using a wheelchair, thus only accessible public transport are used<br>be warned: many data are currently too faint to provide acceptable answers with this parameter on       | False       |
 | nop     | direct_path          | enum    | Specify if direct paths should be suggested.<br>possible values: <ul><li>indifferent</li><li>none</li><li>only</li></ul>      | indifferent |

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -255,6 +255,7 @@ class MixedSchedule(object):
                              _create_template_from_pb_route_point(rp))
                             for rp in resp.route_points)
 
+        rt_proxy = None
         for route_point, template in route_points.items():
             rt_proxy = self._get_realtime_proxy(route_point)
             if rt_proxy:


### PR DESCRIPTION
Sometimes this var could be undefined but used (15 lines below)

see: https://github.com/CanalTP/navitia/blob/dev/source/jormungandr/jormungandr/schedule.py#L273

Case of request out of production date was ending into crash


Also a small doc fix