### PR TITLE
Kraken: Fill disruption becomes optional on data load

### DIFF
--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -182,9 +182,18 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     const auto input_file = input_file_paths.at("ntfs_file");
     nt::Data data;
 
-    const auto res = data.load(input_file);
-
-    BOOST_REQUIRE(res);
+    bool failed = false;
+    try {
+        data.load_nav(input_file);
+    } catch(const navitia::data::data_loading_error& ex) {
+        failed = true;
+    }
+    try {
+        data.build_raptor();
+    } catch(const navitia::data::raptor_building_error& ex) {
+        failed = true;
+    }
+    BOOST_REQUIRE_EQUAL(failed, false);
 
     check_ntfs(data);
 
@@ -196,9 +205,19 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
 BOOST_FIXTURE_TEST_CASE(gtfs_test, ArgsFixture) {
     const auto input_file = input_file_paths.at("gtfs_google_example_file");
     navitia::type::Data data;
-    const auto res = data.load(input_file);
 
-    BOOST_REQUIRE(res);
+    bool failed = false;
+    try {
+        data.load_nav(input_file);
+    } catch(const navitia::data::data_loading_error& ex) {
+        failed = true;
+    }
+    try {
+        data.build_raptor();
+    } catch(const navitia::data::raptor_building_error& ex) {
+        failed = true;
+    }
+    BOOST_REQUIRE_EQUAL(failed, false);
 
     const auto& pt_data = *data.pt_data;
 
@@ -345,9 +364,18 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
     const auto input_file = input_file_paths.at("ntfs_v5_file");
     nt::Data data;
 
-    const auto res = data.load(input_file);
-
-    BOOST_REQUIRE(res);
+    bool failed = false;
+    try {
+        data.load_nav(input_file);
+    } catch(const navitia::data::data_loading_error& ex) {
+        failed = true;
+    }
+    try {
+        data.build_raptor();
+    } catch(const navitia::data::raptor_building_error& ex) {
+        failed = true;
+    }
+    BOOST_REQUIRE_EQUAL(failed, false);
 
     BOOST_REQUIRE_EQUAL(data.pt_data->lines.size(), 4);
     BOOST_REQUIRE_EQUAL(data.pt_data->routes.size(), 4);

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -185,14 +185,10 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     bool failed = false;
     try {
         data.load_nav(input_file);
-    } catch(const navitia::data::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error&) {
         failed = true;
     }
-    try {
-        data.build_raptor();
-    } catch(const navitia::data::raptor_building_error& ex) {
-        failed = true;
-    }
+    data.build_raptor();
     BOOST_REQUIRE_EQUAL(failed, false);
 
     check_ntfs(data);
@@ -209,14 +205,10 @@ BOOST_FIXTURE_TEST_CASE(gtfs_test, ArgsFixture) {
     bool failed = false;
     try {
         data.load_nav(input_file);
-    } catch(const navitia::data::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error&) {
         failed = true;
     }
-    try {
-        data.build_raptor();
-    } catch(const navitia::data::raptor_building_error& ex) {
-        failed = true;
-    }
+    data.build_raptor();
     BOOST_REQUIRE_EQUAL(failed, false);
 
     const auto& pt_data = *data.pt_data;
@@ -367,14 +359,10 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
     bool failed = false;
     try {
         data.load_nav(input_file);
-    } catch(const navitia::data::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error&) {
         failed = true;
     }
-    try {
-        data.build_raptor();
-    } catch(const navitia::data::raptor_building_error& ex) {
-        failed = true;
-    }
+    data.build_raptor();
     BOOST_REQUIRE_EQUAL(failed, false);
 
     BOOST_REQUIRE_EQUAL(data.pt_data->lines.size(), 4);

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -32,7 +32,7 @@ www.navitia.io
 
 #include "utils/logger.h"
 #include "utils/timer.h"
-#include "utils/exception.h"
+#include "type/data_exceptions.h"
 #ifndef NO_FORCE_MEMORY_RELEASE
 //by default we force the release of the memory after the reload of the data
 #include "gperftools/malloc_extension.h"
@@ -43,17 +43,6 @@ www.navitia.io
 #include <atomic>
 #include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
-
-//forward declare
-namespace navitia {
-    namespace type {
-        struct wrong_version;
-        struct data_loading_error;
-        struct disruptions_broken_connection;
-        struct disruptions_loading_error;
-        struct raptor_building_error;
-    }
-}
 
 template<typename Data>
 void data_deleter(const Data* data){
@@ -115,7 +104,7 @@ public:
         // load .nav.lz4
         try {
             data->load_nav(filename);
-        } catch(const navitia::type::data_loading_error& ex) {
+        } catch(const navitia::data::data_loading_error& ex) {
             data->loading = false;
             if (data->last_load) {
                 LOG4CPLUS_INFO(logger, "Data loading failed, we keep last loaded data");
@@ -128,9 +117,9 @@ public:
             bool load_disruptions_failed = false;
             try {
                 data->load_disruptions(*chaos_database, contributors);
-            } catch (const navitia::type::disruptions_broken_connection& ex){
+            } catch (const navitia::data::disruptions_broken_connection& ex){
 
-            } catch(const navitia::type::disruptions_loading_error& ex) {
+            } catch(const navitia::data::disruptions_loading_error& ex) {
                 load_disruptions_failed = true;
             }
 
@@ -139,8 +128,8 @@ public:
                 LOG4CPLUS_ERROR(logger, "Reload data: " << filename);
                 try {
                     data = create_data(data_identifier.load());
-                    data->load_nav(filename);
-                } catch(const navitia::type::data_loading_error& ex) {
+                    //data->load_nav(filename);
+                } catch(const navitia::data::data_loading_error& ex) {
                     data->loading = false;
                     return false;
                 }
@@ -150,7 +139,7 @@ public:
         // Build Raptor Data
         try {
             data->build_raptor(raptor_cache_size);
-        } catch(const navitia::type::raptor_building_error& ex) {
+        } catch(const navitia::data::raptor_building_error& ex) {
             data->loading = false;
             return false;
         }

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -96,6 +96,13 @@ public:
         ++ data_identifier;
         auto data = create_data(data_identifier.load());
         success = data->load(database, chaos_database, contributors, raptor_cache_size);
+
+        // If disruptions corruption is detected, reload data without this
+        if ((!success) && (data->disruptions_corruption_detected)) {
+            data = create_data(data_identifier.load());
+            success = data->load_without_disruptions(database, contributors, raptor_cache_size);
+        }
+
         if (success) {
             set_data(std::move(data));
         }

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -104,7 +104,7 @@ public:
         // load .nav.lz4
         try {
             data->load_nav(filename);
-        } catch(const navitia::data::data_loading_error& ex) {
+        } catch(const navitia::data::data_loading_error&) {
             data->loading = false;
             if (data->last_load_succeeded) {
                 LOG4CPLUS_INFO(logger, "Data loading failed, we keep last loaded data");
@@ -116,16 +116,16 @@ public:
         if (chaos_database != boost::none) {
             try {
                 data->load_disruptions(*chaos_database, contributors);
-            } catch (const navitia::data::disruptions_broken_connection& ex){
+            } catch (const navitia::data::disruptions_broken_connection&){
                 LOG4CPLUS_WARN(logger, "Load data without disruptions");
 
-            } catch(const navitia::data::disruptions_loading_error& ex) {
+            } catch(const navitia::data::disruptions_loading_error&) {
                 // Reload data .nav.lz4
                 LOG4CPLUS_ERROR(logger, "Reload data with disruptions: " << filename);
                 try {
                     data = create_data(data_identifier.load());
                     data->load_nav(filename);
-                } catch(const navitia::data::data_loading_error& ex) {
+                } catch(const navitia::data::data_loading_error&) {
                     data->loading = false;
                     return false;
                 }

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -127,7 +127,7 @@ public:
         if (chaos_database != boost::none) {
             bool load_disruptions_failed = false;
             try {
-                data->load_disruptions(chaos_database.value(), contributors);
+                data->load_disruptions(*chaos_database, contributors);
             } catch (const navitia::type::disruptions_broken_connection& ex){
 
             } catch(const navitia::type::disruptions_loading_error& ex) {

--- a/source/kraken/fill_disruption_from_database.cpp
+++ b/source/kraken/fill_disruption_from_database.cpp
@@ -48,7 +48,8 @@ void fill_disruption_from_database(const std::string& connection_string,
     try{
         conn = std::unique_ptr<pqxx::connection>(new pqxx::connection(connection_string));
     }catch(const pqxx::broken_connection& e){
-        throw navitia::exception(std::string("Unable to connect to chaos database"));
+        throw;
+        return;
     }
 
     try{
@@ -201,8 +202,12 @@ void fill_disruption_from_database(const std::string& connection_string,
         reader.finalize();
         LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), count.size() << " disruption(s) loaded");
 
-    }catch(const pqxx::pqxx_exception& e){
-        throw navitia::exception(std::string(e.base().what()));
+    } catch(const pqxx::pqxx_exception& e) {
+        throw;
+    } catch(const std::exception& ex) {
+        throw;
+    } catch(...) {
+        throw;
     }
 }
 

--- a/source/kraken/fill_disruption_from_database.cpp
+++ b/source/kraken/fill_disruption_from_database.cpp
@@ -47,158 +47,163 @@ void fill_disruption_from_database(const std::string& connection_string,
     std::unique_ptr<pqxx::connection> conn;
     try{
         conn = std::unique_ptr<pqxx::connection>(new pqxx::connection(connection_string));
-    }catch(const pqxx::pqxx_exception& e){
-        throw navitia::exception(std::string("Unable to connect to chaos database: ")
-                + std::string(e.base().what()));
+    }catch(const pqxx::broken_connection& e){
+        throw navitia::exception(std::string("Unable to connect to chaos database"));
     }
-    pqxx::work work(*conn, "loading disruptions");
 
-    size_t offset = 0,
-           items_per_request = 1000;
-    DisruptionDatabaseReader reader(pt_data, meta);
-    pqxx::result result;
-    std::string contributors_array = boost::algorithm::join(contributors, ", ");
-    LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), "Reading disruptions from database");
-    do{
+    try{
+        pqxx::work work(*conn, "loading disruptions");
+
+        size_t offset = 0,
+               items_per_request = 1000;
+        DisruptionDatabaseReader reader(pt_data, meta);
+        pqxx::result result;
+        std::string contributors_array = boost::algorithm::join(contributors, ", ");
+        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), "Reading disruptions from database");
+        do{
+            std::string request = (boost::format(
+                   "SELECT "
+                   // Disruptions field
+                   "     d.id as disruption_id, d.reference as disruption_reference, d.note as disruption_note,"
+                   "     d.status as disruption_status,"
+                   "     extract(epoch from d.start_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_start_publication_date,"
+                   "     extract(epoch from d.end_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_end_publication_date,"
+                   "     extract(epoch from d.created_at  AT TIME ZONE 'UTC') :: bigint as disruption_created_at,"
+                   "     extract(epoch from d.updated_at  AT TIME ZONE 'UTC') :: bigint as disruption_updated_at,"
+                   "     co.contributor_code as contributor,"
+                   // Cause fields
+                   "     c.id as cause_id, c.wording as cause_wording,"
+                   "     c.is_visible as cause_visible,"
+                   "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as cause_created_at,"
+                   "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as cause_updated_at,"
+                   // Category fields
+                   "     cat.name as category_name, cat.id as category_id,"
+                   "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as category_created_at,"
+                   "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as category_updated_at,"
+                   // Tag fields
+                   "     t.id as tag_id, t.name as tag_name, t.is_visible as tag_is_visible,"
+                   "     extract(epoch from t.created_at  AT TIME ZONE 'UTC') :: bigint as tag_created_at,"
+                   "     extract(epoch from t.updated_at  AT TIME ZONE 'UTC') :: bigint as tag_updated_at,"
+                   // Impact fields
+                   "     i.id as impact_id, i.status as impact_status, i.disruption_id as impact_disruption_id,"
+                   "     extract(epoch from i.created_at  AT TIME ZONE 'UTC') :: bigint as impact_created_at,"
+                   "     extract(epoch from i.updated_at  AT TIME ZONE 'UTC') :: bigint as impact_updated_at,"
+                   // Application period fields
+                   "     a.id as application_id,"
+                   "     extract(epoch from a.start_date  AT TIME ZONE 'UTC') :: bigint as application_start_date,"
+                   "     extract(epoch from a.end_date  AT TIME ZONE 'UTC') :: bigint as application_end_date,"
+                   // Severity fields
+                   "     s.id as severity_id, s.wording as severity_wording, s.color as severity_color,"
+                   "     s.is_visible as severity_is_visible, s.priority as severity_priority,"
+                   "     s.effect as severity_effect,"
+                   "     extract(epoch from s.created_at  AT TIME ZONE 'UTC') :: bigint as severity_created_at,"
+                   "     extract(epoch from s.updated_at  AT TIME ZONE 'UTC') :: bigint as severity_updated_at,"
+                   // Ptobject fields
+                   "     p.id as ptobject_id, p.type as ptobject_type, p.uri as ptobject_uri,"
+                   "     extract(epoch from p.created_at  AT TIME ZONE 'UTC') :: bigint as ptobject_created_at,"
+                   "     extract(epoch from p.updated_at  AT TIME ZONE 'UTC') :: bigint as ptobject_updated_at,"
+                   // Ptobject line_section optional fields
+                   "     ls_line.uri as ls_line_uri,"
+                   "     extract(epoch from ls_line.created_at  AT TIME ZONE 'UTC') :: bigint as ls_line_created_at,"
+                   "     extract(epoch from ls_line.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_line_updated_at,"
+                   "     ls_start.uri as ls_start_uri,"
+                   "     extract(epoch from ls_start.created_at  AT TIME ZONE 'UTC') :: bigint as ls_start_created_at,"
+                   "     extract(epoch from ls_start.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_start_updated_at,"
+                   "     ls_end.uri as ls_end_uri,"
+                   "     extract(epoch from ls_end.created_at  AT TIME ZONE 'UTC') :: bigint as ls_end_created_at,"
+                   "     extract(epoch from ls_end.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_end_updated_at,"
+                   "     ls_route.id AS ls_route_id,"
+                   "     ls_route.uri AS ls_route_uri,"
+                   "     extract(epoch from ls_route.created_at  AT TIME ZONE 'UTC') :: bigint as ls_route_created_at,"
+                   "     extract(epoch from ls_route.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_route_updated_at,"
+                   // Message fields
+                   "     m.id as message_id, m.text as message_text,"
+                   "     extract(epoch from m.created_at  AT TIME ZONE 'UTC') :: bigint as message_created_at,"
+                   "     extract(epoch from m.updated_at  AT TIME ZONE 'UTC') :: bigint as message_updated_at,"
+                   // Channel fields
+                   "     ch.id as channel_id, ch.name as channel_name,"
+                   "     ch.content_type as channel_content_type, ch.max_size as channel_max_size,"
+                   "     extract(epoch from ch.created_at  AT TIME ZONE 'UTC') :: bigint as channel_created_at,"
+                   "     extract(epoch from ch.updated_at  AT TIME ZONE 'UTC') :: bigint as channel_updated_at,"
+                   "     cht.id as channel_type_id, cht.name as channel_type,"
+                   // Property & Associate property fields
+                   "     adp.value as property_value, pr.key as property_key, pr.type as property_type"
+                   // Request
+                   "     FROM disruption AS d"
+                   "     JOIN contributor AS co ON d.contributor_id = co.id"
+                   "     JOIN cause AS c ON (c.id = d.cause_id)"
+                   "     LEFT JOIN category AS cat ON cat.id=c.category_id"
+                   "     LEFT JOIN associate_disruption_tag ON associate_disruption_tag.disruption_id = d.id"
+                   "     LEFT JOIN tag AS t ON associate_disruption_tag.tag_id = t.id"
+                   "     JOIN impact AS i ON i.disruption_id = d.id"
+                   "     JOIN application_periods AS a ON a.impact_id = i.id"
+                   "     JOIN severity AS s ON s.id = i.severity_id"
+                   "     JOIN associate_impact_pt_object ON associate_impact_pt_object.impact_id = i.id"
+                   "     JOIN pt_object AS p ON associate_impact_pt_object.pt_object_id = p.id"
+                   "     LEFT JOIN line_section ON p.id = line_section.object_id"
+                   "     LEFT JOIN pt_object AS ls_line ON line_section.line_object_id = ls_line.id"
+                   "     LEFT JOIN pt_object AS ls_start ON line_section.start_object_id = ls_start.id"
+                   "     LEFT JOIN pt_object AS ls_end ON line_section.end_object_id = ls_end.id"
+                   "     LEFT JOIN associate_line_section_route_object"
+                   "         ON associate_line_section_route_object.line_section_id = line_section.id"
+                   "     LEFT JOIN pt_object AS ls_route"
+                   "         ON associate_line_section_route_object.route_object_id = ls_route.id"
+                   "     LEFT JOIN message AS m ON m.impact_id = i.id"
+                   "     LEFT JOIN channel AS ch ON m.channel_id = ch.id"
+                   "     LEFT JOIN channel_type as cht on ch.id = cht.channel_id"
+                   "     LEFT JOIN associate_disruption_property adp ON adp.disruption_id = d.id"
+                   "     LEFT JOIN property pr ON pr.id = adp.property_id"
+                   "     WHERE "
+                   "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
+                   "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
+                   "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
+                   "     AND d.status = 'published'"
+                   "     AND i.status = 'published'"
+                   "     ORDER BY d.id, c.id, t.id, i.id, a.id, p.id, m.id, ch.id, cht.id"
+                   "     LIMIT %i OFFSET %i"
+                   " ;") %meta.production_date.end() % meta.production_date.begin() %meta.production_date.end()  % contributors_array % items_per_request % offset).str();
+            result = work.exec(request);
+            for (auto res : result) {
+                reader(res);
+            }
+
+            offset += result.size();
+            LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("sql"), request);
+        }while(result.size() > 0);
+
+        // counting disruptions & impacts in order to get real numbers
+        pqxx::result count;
+        int impact_count = 0;
         std::string request = (boost::format(
-               "SELECT "
-               // Disruptions field
-               "     d.id as disruption_id, d.reference as disruption_reference, d.note as disruption_note,"
-               "     d.status as disruption_status,"
-               "     extract(epoch from d.start_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_start_publication_date,"
-               "     extract(epoch from d.end_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_end_publication_date,"
-               "     extract(epoch from d.created_at  AT TIME ZONE 'UTC') :: bigint as disruption_created_at,"
-               "     extract(epoch from d.updated_at  AT TIME ZONE 'UTC') :: bigint as disruption_updated_at,"
-               "     co.contributor_code as contributor,"
-               // Cause fields
-               "     c.id as cause_id, c.wording as cause_wording,"
-               "     c.is_visible as cause_visible,"
-               "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as cause_created_at,"
-               "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as cause_updated_at,"
-               // Category fields
-               "     cat.name as category_name, cat.id as category_id,"
-               "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as category_created_at,"
-               "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as category_updated_at,"
-               // Tag fields
-               "     t.id as tag_id, t.name as tag_name, t.is_visible as tag_is_visible,"
-               "     extract(epoch from t.created_at  AT TIME ZONE 'UTC') :: bigint as tag_created_at,"
-               "     extract(epoch from t.updated_at  AT TIME ZONE 'UTC') :: bigint as tag_updated_at,"
-               // Impact fields
-               "     i.id as impact_id, i.status as impact_status, i.disruption_id as impact_disruption_id,"
-               "     extract(epoch from i.created_at  AT TIME ZONE 'UTC') :: bigint as impact_created_at,"
-               "     extract(epoch from i.updated_at  AT TIME ZONE 'UTC') :: bigint as impact_updated_at,"
-               // Application period fields
-               "     a.id as application_id,"
-               "     extract(epoch from a.start_date  AT TIME ZONE 'UTC') :: bigint as application_start_date,"
-               "     extract(epoch from a.end_date  AT TIME ZONE 'UTC') :: bigint as application_end_date,"
-               // Severity fields
-               "     s.id as severity_id, s.wording as severity_wording, s.color as severity_color,"
-               "     s.is_visible as severity_is_visible, s.priority as severity_priority,"
-               "     s.effect as severity_effect,"
-               "     extract(epoch from s.created_at  AT TIME ZONE 'UTC') :: bigint as severity_created_at,"
-               "     extract(epoch from s.updated_at  AT TIME ZONE 'UTC') :: bigint as severity_updated_at,"
-               // Ptobject fields
-               "     p.id as ptobject_id, p.type as ptobject_type, p.uri as ptobject_uri,"
-               "     extract(epoch from p.created_at  AT TIME ZONE 'UTC') :: bigint as ptobject_created_at,"
-               "     extract(epoch from p.updated_at  AT TIME ZONE 'UTC') :: bigint as ptobject_updated_at,"
-               // Ptobject line_section optional fields
-               "     ls_line.uri as ls_line_uri,"
-               "     extract(epoch from ls_line.created_at  AT TIME ZONE 'UTC') :: bigint as ls_line_created_at,"
-               "     extract(epoch from ls_line.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_line_updated_at,"
-               "     ls_start.uri as ls_start_uri,"
-               "     extract(epoch from ls_start.created_at  AT TIME ZONE 'UTC') :: bigint as ls_start_created_at,"
-               "     extract(epoch from ls_start.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_start_updated_at,"
-               "     ls_end.uri as ls_end_uri,"
-               "     extract(epoch from ls_end.created_at  AT TIME ZONE 'UTC') :: bigint as ls_end_created_at,"
-               "     extract(epoch from ls_end.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_end_updated_at,"
-               "     ls_route.id AS ls_route_id,"
-               "     ls_route.uri AS ls_route_uri,"
-               "     extract(epoch from ls_route.created_at  AT TIME ZONE 'UTC') :: bigint as ls_route_created_at,"
-               "     extract(epoch from ls_route.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_route_updated_at,"
-               // Message fields
-               "     m.id as message_id, m.text as message_text,"
-               "     extract(epoch from m.created_at  AT TIME ZONE 'UTC') :: bigint as message_created_at,"
-               "     extract(epoch from m.updated_at  AT TIME ZONE 'UTC') :: bigint as message_updated_at,"
-               // Channel fields
-               "     ch.id as channel_id, ch.name as channel_name,"
-               "     ch.content_type as channel_content_type, ch.max_size as channel_max_size,"
-               "     extract(epoch from ch.created_at  AT TIME ZONE 'UTC') :: bigint as channel_created_at,"
-               "     extract(epoch from ch.updated_at  AT TIME ZONE 'UTC') :: bigint as channel_updated_at,"
-               "     cht.id as channel_type_id, cht.name as channel_type,"
-               // Property & Associate property fields
-               "     adp.value as property_value, pr.key as property_key, pr.type as property_type"
-               // Request
-               "     FROM disruption AS d"
-               "     JOIN contributor AS co ON d.contributor_id = co.id"
-               "     JOIN cause AS c ON (c.id = d.cause_id)"
-               "     LEFT JOIN category AS cat ON cat.id=c.category_id"
-               "     LEFT JOIN associate_disruption_tag ON associate_disruption_tag.disruption_id = d.id"
-               "     LEFT JOIN tag AS t ON associate_disruption_tag.tag_id = t.id"
-               "     JOIN impact AS i ON i.disruption_id = d.id"
-               "     JOIN application_periods AS a ON a.impact_id = i.id"
-               "     JOIN severity AS s ON s.id = i.severity_id"
-               "     JOIN associate_impact_pt_object ON associate_impact_pt_object.impact_id = i.id"
-               "     JOIN pt_object AS p ON associate_impact_pt_object.pt_object_id = p.id"
-               "     LEFT JOIN line_section ON p.id = line_section.object_id"
-               "     LEFT JOIN pt_object AS ls_line ON line_section.line_object_id = ls_line.id"
-               "     LEFT JOIN pt_object AS ls_start ON line_section.start_object_id = ls_start.id"
-               "     LEFT JOIN pt_object AS ls_end ON line_section.end_object_id = ls_end.id"
-               "     LEFT JOIN associate_line_section_route_object"
-               "         ON associate_line_section_route_object.line_section_id = line_section.id"
-               "     LEFT JOIN pt_object AS ls_route"
-               "         ON associate_line_section_route_object.route_object_id = ls_route.id"
-               "     LEFT JOIN message AS m ON m.impact_id = i.id"
-               "     LEFT JOIN channel AS ch ON m.channel_id = ch.id"
-               "     LEFT JOIN channel_type as cht on ch.id = cht.channel_id"
-               "     LEFT JOIN associate_disruption_property adp ON adp.disruption_id = d.id"
-               "     LEFT JOIN property pr ON pr.id = adp.property_id"
-               "     WHERE "
-               "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
-               "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
-               "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
-               "     AND d.status = 'published'"
-               "     AND i.status = 'published'"
-               "     ORDER BY d.id, c.id, t.id, i.id, a.id, p.id, m.id, ch.id, cht.id"
-               "     LIMIT %i OFFSET %i"
-               " ;") %meta.production_date.end() % meta.production_date.begin() %meta.production_date.end()  % contributors_array % items_per_request % offset).str();
-        result = work.exec(request);
-        for (auto res : result) {
-            reader(res);
+           "SELECT DISTINCT ON (d.id) d.id, count(i)"
+           "   FROM disruption d"
+           "   LEFT JOIN impact i ON d.id = i.disruption_id"
+           "   JOIN contributor AS co ON d.contributor_id = co.id"
+           "   WHERE"
+           "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
+           "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
+           "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
+           "     AND d.status = 'published'"
+           "     AND i.status = 'published'"
+           "   GROUP BY d.id"
+           " ;") % meta.production_date.end() % meta.production_date.begin()
+                 % meta.production_date.end() % contributors_array
+       ).str();
+        count = work.exec(request);
+        for (auto ct: count) {
+            impact_count += ct[1].as<int>();
         }
 
-        offset += result.size();
-        LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("sql"), request);
-    }while(result.size() > 0);
+        LOG4CPLUS_INFO(
+            log4cplus::Logger::getInstance("Logger"),
+            "Loading " << count.size() << " disruption(s) with " << impact_count << " impact(s)"
+        );
+        reader.finalize();
+        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), count.size() << " disruption(s) loaded");
 
-    // counting disruptions & impacts in order to get real numbers
-    pqxx::result count;
-    int impact_count = 0;
-    std::string request = (boost::format(
-       "SELECT DISTINCT ON (d.id) d.id, count(i)"
-       "   FROM disruption d"
-       "   LEFT JOIN impact i ON d.id = i.disruption_id"
-       "   JOIN contributor AS co ON d.contributor_id = co.id"
-       "   WHERE"
-       "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
-       "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
-       "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
-       "     AND d.status = 'published'"
-       "     AND i.status = 'published'"
-       "   GROUP BY d.id"
-       " ;") % meta.production_date.end() % meta.production_date.begin()
-             % meta.production_date.end() % contributors_array
-   ).str();
-    count = work.exec(request);
-    for (auto ct: count) {
-        impact_count += ct[1].as<int>();
+    }catch(const pqxx::pqxx_exception& e){
+        throw navitia::exception(std::string(e.base().what()));
     }
-
-    LOG4CPLUS_INFO(
-        log4cplus::Logger::getInstance("Logger"),
-        "Loading " << count.size() << " disruption(s) with " << impact_count << " impact(s)"
-    );
-    reader.finalize();
-    LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), count.size() << " disruption(s) loaded");
 }
 
 void DisruptionDatabaseReader::finalize() {

--- a/source/kraken/fill_disruption_from_database.cpp
+++ b/source/kraken/fill_disruption_from_database.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -45,170 +45,156 @@ namespace navitia {
 void fill_disruption_from_database(const std::string& connection_string,
         type::PT_Data& pt_data, type::MetaData &meta, const std::vector<std::string>& contributors) {
     std::unique_ptr<pqxx::connection> conn;
-    try{
-        conn = std::unique_ptr<pqxx::connection>(new pqxx::connection(connection_string));
-    }catch(const pqxx::broken_connection& e){
-        throw;
-        return;
-    }
+    conn = std::unique_ptr<pqxx::connection>(new pqxx::connection(connection_string));
 
-    try{
-        pqxx::work work(*conn, "loading disruptions");
+    pqxx::work work(*conn, "loading disruptions");
 
-        size_t offset = 0,
-               items_per_request = 1000;
-        DisruptionDatabaseReader reader(pt_data, meta);
-        pqxx::result result;
-        std::string contributors_array = boost::algorithm::join(contributors, ", ");
-        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), "Reading disruptions from database");
-        do{
-            std::string request = (boost::format(
-                   "SELECT "
-                   // Disruptions field
-                   "     d.id as disruption_id, d.reference as disruption_reference, d.note as disruption_note,"
-                   "     d.status as disruption_status,"
-                   "     extract(epoch from d.start_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_start_publication_date,"
-                   "     extract(epoch from d.end_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_end_publication_date,"
-                   "     extract(epoch from d.created_at  AT TIME ZONE 'UTC') :: bigint as disruption_created_at,"
-                   "     extract(epoch from d.updated_at  AT TIME ZONE 'UTC') :: bigint as disruption_updated_at,"
-                   "     co.contributor_code as contributor,"
-                   // Cause fields
-                   "     c.id as cause_id, c.wording as cause_wording,"
-                   "     c.is_visible as cause_visible,"
-                   "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as cause_created_at,"
-                   "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as cause_updated_at,"
-                   // Category fields
-                   "     cat.name as category_name, cat.id as category_id,"
-                   "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as category_created_at,"
-                   "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as category_updated_at,"
-                   // Tag fields
-                   "     t.id as tag_id, t.name as tag_name, t.is_visible as tag_is_visible,"
-                   "     extract(epoch from t.created_at  AT TIME ZONE 'UTC') :: bigint as tag_created_at,"
-                   "     extract(epoch from t.updated_at  AT TIME ZONE 'UTC') :: bigint as tag_updated_at,"
-                   // Impact fields
-                   "     i.id as impact_id, i.status as impact_status, i.disruption_id as impact_disruption_id,"
-                   "     extract(epoch from i.created_at  AT TIME ZONE 'UTC') :: bigint as impact_created_at,"
-                   "     extract(epoch from i.updated_at  AT TIME ZONE 'UTC') :: bigint as impact_updated_at,"
-                   // Application period fields
-                   "     a.id as application_id,"
-                   "     extract(epoch from a.start_date  AT TIME ZONE 'UTC') :: bigint as application_start_date,"
-                   "     extract(epoch from a.end_date  AT TIME ZONE 'UTC') :: bigint as application_end_date,"
-                   // Severity fields
-                   "     s.id as severity_id, s.wording as severity_wording, s.color as severity_color,"
-                   "     s.is_visible as severity_is_visible, s.priority as severity_priority,"
-                   "     s.effect as severity_effect,"
-                   "     extract(epoch from s.created_at  AT TIME ZONE 'UTC') :: bigint as severity_created_at,"
-                   "     extract(epoch from s.updated_at  AT TIME ZONE 'UTC') :: bigint as severity_updated_at,"
-                   // Ptobject fields
-                   "     p.id as ptobject_id, p.type as ptobject_type, p.uri as ptobject_uri,"
-                   "     extract(epoch from p.created_at  AT TIME ZONE 'UTC') :: bigint as ptobject_created_at,"
-                   "     extract(epoch from p.updated_at  AT TIME ZONE 'UTC') :: bigint as ptobject_updated_at,"
-                   // Ptobject line_section optional fields
-                   "     ls_line.uri as ls_line_uri,"
-                   "     extract(epoch from ls_line.created_at  AT TIME ZONE 'UTC') :: bigint as ls_line_created_at,"
-                   "     extract(epoch from ls_line.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_line_updated_at,"
-                   "     ls_start.uri as ls_start_uri,"
-                   "     extract(epoch from ls_start.created_at  AT TIME ZONE 'UTC') :: bigint as ls_start_created_at,"
-                   "     extract(epoch from ls_start.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_start_updated_at,"
-                   "     ls_end.uri as ls_end_uri,"
-                   "     extract(epoch from ls_end.created_at  AT TIME ZONE 'UTC') :: bigint as ls_end_created_at,"
-                   "     extract(epoch from ls_end.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_end_updated_at,"
-                   "     ls_route.id AS ls_route_id,"
-                   "     ls_route.uri AS ls_route_uri,"
-                   "     extract(epoch from ls_route.created_at  AT TIME ZONE 'UTC') :: bigint as ls_route_created_at,"
-                   "     extract(epoch from ls_route.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_route_updated_at,"
-                   // Message fields
-                   "     m.id as message_id, m.text as message_text,"
-                   "     extract(epoch from m.created_at  AT TIME ZONE 'UTC') :: bigint as message_created_at,"
-                   "     extract(epoch from m.updated_at  AT TIME ZONE 'UTC') :: bigint as message_updated_at,"
-                   // Channel fields
-                   "     ch.id as channel_id, ch.name as channel_name,"
-                   "     ch.content_type as channel_content_type, ch.max_size as channel_max_size,"
-                   "     extract(epoch from ch.created_at  AT TIME ZONE 'UTC') :: bigint as channel_created_at,"
-                   "     extract(epoch from ch.updated_at  AT TIME ZONE 'UTC') :: bigint as channel_updated_at,"
-                   "     cht.id as channel_type_id, cht.name as channel_type,"
-                   // Property & Associate property fields
-                   "     adp.value as property_value, pr.key as property_key, pr.type as property_type"
-                   // Request
-                   "     FROM disruption AS d"
-                   "     JOIN contributor AS co ON d.contributor_id = co.id"
-                   "     JOIN cause AS c ON (c.id = d.cause_id)"
-                   "     LEFT JOIN category AS cat ON cat.id=c.category_id"
-                   "     LEFT JOIN associate_disruption_tag ON associate_disruption_tag.disruption_id = d.id"
-                   "     LEFT JOIN tag AS t ON associate_disruption_tag.tag_id = t.id"
-                   "     JOIN impact AS i ON i.disruption_id = d.id"
-                   "     JOIN application_periods AS a ON a.impact_id = i.id"
-                   "     JOIN severity AS s ON s.id = i.severity_id"
-                   "     JOIN associate_impact_pt_object ON associate_impact_pt_object.impact_id = i.id"
-                   "     JOIN pt_object AS p ON associate_impact_pt_object.pt_object_id = p.id"
-                   "     LEFT JOIN line_section ON p.id = line_section.object_id"
-                   "     LEFT JOIN pt_object AS ls_line ON line_section.line_object_id = ls_line.id"
-                   "     LEFT JOIN pt_object AS ls_start ON line_section.start_object_id = ls_start.id"
-                   "     LEFT JOIN pt_object AS ls_end ON line_section.end_object_id = ls_end.id"
-                   "     LEFT JOIN associate_line_section_route_object"
-                   "         ON associate_line_section_route_object.line_section_id = line_section.id"
-                   "     LEFT JOIN pt_object AS ls_route"
-                   "         ON associate_line_section_route_object.route_object_id = ls_route.id"
-                   "     LEFT JOIN message AS m ON m.impact_id = i.id"
-                   "     LEFT JOIN channel AS ch ON m.channel_id = ch.id"
-                   "     LEFT JOIN channel_type as cht on ch.id = cht.channel_id"
-                   "     LEFT JOIN associate_disruption_property adp ON adp.disruption_id = d.id"
-                   "     LEFT JOIN property pr ON pr.id = adp.property_id"
-                   "     WHERE "
-                   "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
-                   "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
-                   "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
-                   "     AND d.status = 'published'"
-                   "     AND i.status = 'published'"
-                   "     ORDER BY d.id, c.id, t.id, i.id, a.id, p.id, m.id, ch.id, cht.id"
-                   "     LIMIT %i OFFSET %i"
-                   " ;") %meta.production_date.end() % meta.production_date.begin() %meta.production_date.end()  % contributors_array % items_per_request % offset).str();
-            result = work.exec(request);
-            for (auto res : result) {
-                reader(res);
-            }
-
-            offset += result.size();
-            LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("sql"), request);
-        }while(result.size() > 0);
-
-        // counting disruptions & impacts in order to get real numbers
-        pqxx::result count;
-        int impact_count = 0;
+    size_t offset = 0,
+           items_per_request = 1000;
+    DisruptionDatabaseReader reader(pt_data, meta);
+    pqxx::result result;
+    std::string contributors_array = boost::algorithm::join(contributors, ", ");
+    LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), "Reading disruptions from database");
+    do{
         std::string request = (boost::format(
-           "SELECT DISTINCT ON (d.id) d.id, count(i)"
-           "   FROM disruption d"
-           "   LEFT JOIN impact i ON d.id = i.disruption_id"
-           "   JOIN contributor AS co ON d.contributor_id = co.id"
-           "   WHERE"
-           "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
-           "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
-           "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
-           "     AND d.status = 'published'"
-           "     AND i.status = 'published'"
-           "   GROUP BY d.id"
-           " ;") % meta.production_date.end() % meta.production_date.begin()
-                 % meta.production_date.end() % contributors_array
-       ).str();
-        count = work.exec(request);
-        for (auto ct: count) {
-            impact_count += ct[1].as<int>();
+               "SELECT "
+               // Disruptions field
+               "     d.id as disruption_id, d.reference as disruption_reference, d.note as disruption_note,"
+               "     d.status as disruption_status,"
+               "     extract(epoch from d.start_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_start_publication_date,"
+               "     extract(epoch from d.end_publication_date  AT TIME ZONE 'UTC') :: bigint as disruption_end_publication_date,"
+               "     extract(epoch from d.created_at  AT TIME ZONE 'UTC') :: bigint as disruption_created_at,"
+               "     extract(epoch from d.updated_at  AT TIME ZONE 'UTC') :: bigint as disruption_updated_at,"
+               "     co.contributor_code as contributor,"
+               // Cause fields
+               "     c.id as cause_id, c.wording as cause_wording,"
+               "     c.is_visible as cause_visible,"
+               "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as cause_created_at,"
+               "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as cause_updated_at,"
+               // Category fields
+               "     cat.name as category_name, cat.id as category_id,"
+               "     extract(epoch from c.created_at  AT TIME ZONE 'UTC') :: bigint as category_created_at,"
+               "     extract(epoch from c.updated_at  AT TIME ZONE 'UTC') :: bigint as category_updated_at,"
+               // Tag fields
+               "     t.id as tag_id, t.name as tag_name, t.is_visible as tag_is_visible,"
+               "     extract(epoch from t.created_at  AT TIME ZONE 'UTC') :: bigint as tag_created_at,"
+               "     extract(epoch from t.updated_at  AT TIME ZONE 'UTC') :: bigint as tag_updated_at,"
+               // Impact fields
+               "     i.id as impact_id, i.status as impact_status, i.disruption_id as impact_disruption_id,"
+               "     extract(epoch from i.created_at  AT TIME ZONE 'UTC') :: bigint as impact_created_at,"
+               "     extract(epoch from i.updated_at  AT TIME ZONE 'UTC') :: bigint as impact_updated_at,"
+               // Application period fields
+               "     a.id as application_id,"
+               "     extract(epoch from a.start_date  AT TIME ZONE 'UTC') :: bigint as application_start_date,"
+               "     extract(epoch from a.end_date  AT TIME ZONE 'UTC') :: bigint as application_end_date,"
+               // Severity fields
+               "     s.id as severity_id, s.wording as severity_wording, s.color as severity_color,"
+               "     s.is_visible as severity_is_visible, s.priority as severity_priority,"
+               "     s.effect as severity_effect,"
+               "     extract(epoch from s.created_at  AT TIME ZONE 'UTC') :: bigint as severity_created_at,"
+               "     extract(epoch from s.updated_at  AT TIME ZONE 'UTC') :: bigint as severity_updated_at,"
+               // Ptobject fields
+               "     p.id as ptobject_id, p.type as ptobject_type, p.uri as ptobject_uri,"
+               "     extract(epoch from p.created_at  AT TIME ZONE 'UTC') :: bigint as ptobject_created_at,"
+               "     extract(epoch from p.updated_at  AT TIME ZONE 'UTC') :: bigint as ptobject_updated_at,"
+               // Ptobject line_section optional fields
+               "     ls_line.uri as ls_line_uri,"
+               "     extract(epoch from ls_line.created_at  AT TIME ZONE 'UTC') :: bigint as ls_line_created_at,"
+               "     extract(epoch from ls_line.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_line_updated_at,"
+               "     ls_start.uri as ls_start_uri,"
+               "     extract(epoch from ls_start.created_at  AT TIME ZONE 'UTC') :: bigint as ls_start_created_at,"
+               "     extract(epoch from ls_start.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_start_updated_at,"
+               "     ls_end.uri as ls_end_uri,"
+               "     extract(epoch from ls_end.created_at  AT TIME ZONE 'UTC') :: bigint as ls_end_created_at,"
+               "     extract(epoch from ls_end.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_end_updated_at,"
+               "     ls_route.id AS ls_route_id,"
+               "     ls_route.uri AS ls_route_uri,"
+               "     extract(epoch from ls_route.created_at  AT TIME ZONE 'UTC') :: bigint as ls_route_created_at,"
+               "     extract(epoch from ls_route.updated_at  AT TIME ZONE 'UTC') :: bigint as ls_route_updated_at,"
+               // Message fields
+               "     m.id as message_id, m.text as message_text,"
+               "     extract(epoch from m.created_at  AT TIME ZONE 'UTC') :: bigint as message_created_at,"
+               "     extract(epoch from m.updated_at  AT TIME ZONE 'UTC') :: bigint as message_updated_at,"
+               // Channel fields
+               "     ch.id as channel_id, ch.name as channel_name,"
+               "     ch.content_type as channel_content_type, ch.max_size as channel_max_size,"
+               "     extract(epoch from ch.created_at  AT TIME ZONE 'UTC') :: bigint as channel_created_at,"
+               "     extract(epoch from ch.updated_at  AT TIME ZONE 'UTC') :: bigint as channel_updated_at,"
+               "     cht.id as channel_type_id, cht.name as channel_type,"
+               // Property & Associate property fields
+               "     adp.value as property_value, pr.key as property_key, pr.type as property_type"
+               // Request
+               "     FROM disruption AS d"
+               "     JOIN contributor AS co ON d.contributor_id = co.id"
+               "     JOIN cause AS c ON (c.id = d.cause_id)"
+               "     LEFT JOIN category AS cat ON cat.id=c.category_id"
+               "     LEFT JOIN associate_disruption_tag ON associate_disruption_tag.disruption_id = d.id"
+               "     LEFT JOIN tag AS t ON associate_disruption_tag.tag_id = t.id"
+               "     JOIN impact AS i ON i.disruption_id = d.id"
+               "     JOIN application_periods AS a ON a.impact_id = i.id"
+               "     JOIN severity AS s ON s.id = i.severity_id"
+               "     JOIN associate_impact_pt_object ON associate_impact_pt_object.impact_id = i.id"
+               "     JOIN pt_object AS p ON associate_impact_pt_object.pt_object_id = p.id"
+               "     LEFT JOIN line_section ON p.id = line_section.object_id"
+               "     LEFT JOIN pt_object AS ls_line ON line_section.line_object_id = ls_line.id"
+               "     LEFT JOIN pt_object AS ls_start ON line_section.start_object_id = ls_start.id"
+               "     LEFT JOIN pt_object AS ls_end ON line_section.end_object_id = ls_end.id"
+               "     LEFT JOIN associate_line_section_route_object"
+               "         ON associate_line_section_route_object.line_section_id = line_section.id"
+               "     LEFT JOIN pt_object AS ls_route"
+               "         ON associate_line_section_route_object.route_object_id = ls_route.id"
+               "     LEFT JOIN message AS m ON m.impact_id = i.id"
+               "     LEFT JOIN channel AS ch ON m.channel_id = ch.id"
+               "     LEFT JOIN channel_type as cht on ch.id = cht.channel_id"
+               "     LEFT JOIN associate_disruption_property adp ON adp.disruption_id = d.id"
+               "     LEFT JOIN property pr ON pr.id = adp.property_id"
+               "     WHERE "
+               "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
+               "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
+               "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
+               "     AND d.status = 'published'"
+               "     AND i.status = 'published'"
+               "     ORDER BY d.id, c.id, t.id, i.id, a.id, p.id, m.id, ch.id, cht.id"
+               "     LIMIT %i OFFSET %i"
+               " ;") %meta.production_date.end() % meta.production_date.begin() %meta.production_date.end()  % contributors_array % items_per_request % offset).str();
+        result = work.exec(request);
+        for (auto res : result) {
+            reader(res);
         }
 
-        LOG4CPLUS_INFO(
-            log4cplus::Logger::getInstance("Logger"),
-            "Loading " << count.size() << " disruption(s) with " << impact_count << " impact(s)"
-        );
-        reader.finalize();
-        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), count.size() << " disruption(s) loaded");
+        offset += result.size();
+        LOG4CPLUS_TRACE(log4cplus::Logger::getInstance("sql"), request);
+    }while(result.size() > 0);
 
-    } catch(const pqxx::pqxx_exception& e) {
-        throw;
-    } catch(const std::exception& ex) {
-        throw;
-    } catch(...) {
-        throw;
+    // counting disruptions & impacts in order to get real numbers
+    pqxx::result count;
+    int impact_count = 0;
+    std::string request = (boost::format(
+       "SELECT DISTINCT ON (d.id) d.id, count(i)"
+       "   FROM disruption d"
+       "   LEFT JOIN impact i ON d.id = i.disruption_id"
+       "   JOIN contributor AS co ON d.contributor_id = co.id"
+       "   WHERE"
+       "     (NOT (d.start_publication_date >= '%s' OR d.end_publication_date <= '%s')"
+       "     OR (d.start_publication_date<='%s' and d.end_publication_date IS NULL))"
+       "     AND co.contributor_code = ANY('{%s}')" // it's like a "IN" but won't crash if empty"
+       "     AND d.status = 'published'"
+       "     AND i.status = 'published'"
+       "   GROUP BY d.id"
+       " ;") % meta.production_date.end() % meta.production_date.begin()
+             % meta.production_date.end() % contributors_array
+   ).str();
+    count = work.exec(request);
+    for (auto ct: count) {
+        impact_count += ct[1].as<int>();
     }
+
+    LOG4CPLUS_INFO(
+        log4cplus::Logger::getInstance("Logger"),
+        "Loading " << count.size() << " disruption(s) with " << impact_count << " impact(s)"
+    );
+    reader.finalize();
+    LOG4CPLUS_INFO(log4cplus::Logger::getInstance("Logger"), count.size() << " disruption(s) loaded");
 }
 
 void DisruptionDatabaseReader::finalize() {

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -39,6 +39,7 @@ www.navitia.io
 #include "utils/init.h"
 #include "kraken_zmq.h"
 #include "utils/zmq.h"
+#include "utils/functions.h" //navitia::absolute_path function
 
 static void show_usage(const std::string& name)
 {
@@ -55,12 +56,8 @@ int main(int argn, char** argv){
 
     std::string::size_type posSlash = std::string(argv[0]).find_last_of( "\\/" );
     std::string application = std::string(argv[0]).substr(posSlash+1);
-    std::string path;
-    char buf[256];
-    if(getcwd(buf, sizeof(buf))){
-        path = std::string(buf) + "/";
-    }else{
-        perror("getcwd");
+    std::string path = navitia::absolute_path();
+    if (path.empty()) {
         return 1;
     }
     std::string conf_file;

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -52,7 +52,7 @@ namespace bg = boost::gregorian;
 namespace navitia {
 
 
-void MaintenanceWorker::load(){
+void MaintenanceWorker::load_data(){
     const std::string database = conf.databases_path();
     auto chaos_database = conf.chaos_database();
     auto contributors = conf.rt_topics();
@@ -62,7 +62,6 @@ void MaintenanceWorker::load(){
         data->is_realtime_loaded = false;
         data->meta->instance_name = conf.instance_name();
     }
-    load_realtime();
 }
 
 
@@ -115,13 +114,7 @@ void MaintenanceWorker::load_realtime(){
 void MaintenanceWorker::operator()(){
     LOG4CPLUS_INFO(logger, "Starting background thread");
 
-    try{
-        this->listen_rabbitmq();
-    }catch(const std::runtime_error& ex){
-        LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
-        data_manager.get_data()->is_connected_to_rabbitmq = false;
-        sleep(10);
-    }
+    // Main working loop
     while(true){
         try{
             this->init_rabbitmq();
@@ -145,7 +138,8 @@ void MaintenanceWorker::handle_task_in_batch(const std::vector<AmqpClient::Envel
         }
         switch(task.action()){
             case pbnavitia::RELOAD:
-                load();
+                this->load_data();
+                this->load_realtime();
                 // For now, we have only one type of task: reload_kraken. We don't want that this command
                 // is executed several times in stride for nothing.
                 return;
@@ -331,18 +325,12 @@ MaintenanceWorker::MaintenanceWorker(DataManager<type::Data>& data_manager, krak
         logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("background"))),
         conf(conf),
         next_try_realtime_loading(pt::microsec_clock::universal_time()){
-    try{
-        this->init_rabbitmq();
-    }catch(const std::runtime_error& ex){
-        LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
-        data_manager.get_data()->is_connected_to_rabbitmq = false;
-    }
-    try{
-        load();
-    }catch(const std::runtime_error& ex){
-        LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
-        data_manager.get_data()->is_connected_to_rabbitmq = false;
-    }
+
+    // Load Data (.nav, disruption Bdd, build raptor data)
+    this->load_data();
+
+    // Load Realtime
+    this->load_realtime();
 }
 
-}
+} // namespace navitia

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -83,7 +83,7 @@ class MaintenanceWorker{
 
         bool load_and_switch();
 
-        void load();
+        void load_data();
 
         void operator()();
 };

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -1,11 +1,11 @@
 #We use the BOOST_LIBS define is the parent
 SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 add_executable(data_manager_test data_manager_test.cpp)
-target_link_libraries(data_manager_test workers utils make_disruption_from_chaos log4cplus tcmalloc ${Boost_LIBRARIES})
+target_link_libraries(data_manager_test types utils log4cplus tcmalloc ${Boost_LIBRARIES})
 ADD_BOOST_TEST(data_manager_test)
 
 add_executable(data_manager_with_type_data_test data_manager_with_type_data_test.cpp)
-target_link_libraries(data_manager_with_type_data_test workers utils make_disruption_from_chaos log4cplus tcmalloc ${Boost_LIBRARIES})
+target_link_libraries(data_manager_with_type_data_test make_disruption_from_chaos workers log4cplus tcmalloc ${Boost_LIBRARIES})
 ADD_BOOST_TEST(data_manager_with_type_data_test)
 
 add_executable(disruption_reader_test disruption_reader_test.cpp)

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 #We use the BOOST_LIBS define is the parent
 SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 add_executable(data_manager_test data_manager_test.cpp)
-target_link_libraries(data_manager_test workers utils log4cplus tcmalloc ${Boost_LIBRARIES})
+target_link_libraries(data_manager_test workers utils make_disruption_from_chaos log4cplus tcmalloc ${Boost_LIBRARIES})
 ADD_BOOST_TEST(data_manager_test)
 
 add_executable(disruption_reader_test disruption_reader_test.cpp)

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -4,6 +4,10 @@ add_executable(data_manager_test data_manager_test.cpp)
 target_link_libraries(data_manager_test workers utils make_disruption_from_chaos log4cplus tcmalloc ${Boost_LIBRARIES})
 ADD_BOOST_TEST(data_manager_test)
 
+add_executable(data_manager_with_type_data_test data_manager_with_type_data_test.cpp)
+target_link_libraries(data_manager_with_type_data_test workers utils make_disruption_from_chaos log4cplus tcmalloc ${Boost_LIBRARIES})
+ADD_BOOST_TEST(data_manager_with_type_data_test)
+
 add_executable(disruption_reader_test disruption_reader_test.cpp)
 target_link_libraries(disruption_reader_test workers data types pb_lib utils log4cplus tcmalloc ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
 ADD_BOOST_TEST(disruption_reader_test)

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -42,14 +42,14 @@ namespace test {
 class Data {
     public:
 
-        void load_nav(const std::string& filename){}
-        void load_disruptions(const std::string& database,
-                              const std::vector<std::string>& contributors = {}){}
-        void build_raptor(size_t cache_size = 10){}
+        void load_nav(const std::string&){}
+        void load_disruptions(const std::string&,
+                              const std::vector<std::string>& = {}){}
+        void build_raptor(size_t){}
         mutable std::atomic<bool> loading;
         mutable std::atomic<bool> is_connected_to_rabbitmq;
         static bool load_status;
-        static bool last_load;
+        static bool last_load_succeeded;
         static bool destructor_called;
         size_t data_identifier;
 
@@ -60,7 +60,7 @@ class Data {
         ~Data(){Data::destructor_called = true;}
 };
 bool Data::load_status = true;
-bool Data::last_load = true;
+bool Data::last_load_succeeded = true;
 bool Data::destructor_called = false;
 
 } // namespace test
@@ -90,7 +90,7 @@ BOOST_FIXTURE_TEST_CASE(load, fixture) {
     // True because fake data don't failed
     BOOST_CHECK(data_manager.load("fake path"));
 
-    // Load OK, so the internal shared pointer change.
+    // Load OK, so the internal shared pointer changes.
     // Data has changed.
     BOOST_CHECK_NE(first_data, data_manager.get_data());
 }
@@ -101,7 +101,7 @@ BOOST_FIXTURE_TEST_CASE(destructor_called, fixture) {
         auto first_data = data_manager.get_data();
         // True because fake data don't failed
         BOOST_CHECK(data_manager.load("fake path"));
-        // Load OK, so the internal shared pointer change.
+        // Load OK, so the internal shared pointer changes.
         // Data has changed.
         BOOST_CHECK_NE(first_data, data_manager.get_data());
     }

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -45,8 +45,14 @@ class Data{
                   const size_t) {
             return load_status;
         }
+        bool load_without_disruptions(const std::string&,
+                                     const std::vector<std::string>&,
+                                     const size_t) {
+            return load_status;
+        }
         mutable std::atomic<bool> is_connected_to_rabbitmq;
         static bool load_status;
+        static bool disruptions_corruption_detected;
         static bool destructor_called;
         size_t data_identifier;
 
@@ -57,6 +63,7 @@ class Data{
         ~Data(){Data::destructor_called = true;}
 };
 bool Data::load_status = true;
+bool Data::disruptions_corruption_detected = false;
 bool Data::destructor_called = false;
 
 struct fixture{

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -133,8 +133,7 @@ BOOST_AUTO_TEST_CASE(load_failed) {
 
     // Load failed, so the internal shared pointer no change.
     // Data has not changed.
-    auto second_data = data_manager.get_data();
-    BOOST_CHECK_EQUAL(first_data, second_data);
+    BOOST_CHECK_EQUAL(first_data, data_manager.get_data());
 }
 
 BOOST_AUTO_TEST_CASE(destructor_called) {

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -30,10 +30,10 @@ www.navitia.io
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE data_manager_test
-#include <boost/test/unit_test.hpp>
-#include <boost/optional.hpp>
 
 #include "kraken/data_manager.h"
+
+#include <boost/test/unit_test.hpp>
 #include <atomic>
 
 namespace navitia { namespace type {
@@ -111,16 +111,14 @@ struct fixture{
     }
 };
 
-BOOST_FIXTURE_TEST_SUITE(s, fixture)
-
-BOOST_AUTO_TEST_CASE(get_data) {
+BOOST_FIXTURE_TEST_CASE(get_data, fixture) {
     DataManager<navitia::type::Data> data_manager;
     auto data = data_manager.get_data();
     BOOST_REQUIRE(data);
     BOOST_CHECK_EQUAL(navitia::type::Data::destructor_called, false);
 }
 
-BOOST_AUTO_TEST_CASE(load_failed) {
+BOOST_FIXTURE_TEST_CASE(load_failed, fixture) {
     DataManager<navitia::type::Data> data_manager;
     BOOST_CHECK(data_manager.get_data());
     auto first_data = data_manager.get_data();
@@ -136,7 +134,7 @@ BOOST_AUTO_TEST_CASE(load_failed) {
     BOOST_CHECK_EQUAL(first_data, data_manager.get_data());
 }
 
-BOOST_AUTO_TEST_CASE(destructor_called) {
+BOOST_FIXTURE_TEST_CASE(destructor_called, fixture) {
     DataManager<navitia::type::Data> data_manager;
     {
         auto first_data = data_manager.get_data();
@@ -149,7 +147,7 @@ BOOST_AUTO_TEST_CASE(destructor_called) {
     BOOST_CHECK(data_manager.get_data());
 }
 
-BOOST_AUTO_TEST_CASE(destructor_not_called) {
+BOOST_FIXTURE_TEST_CASE(destructor_not_called, fixture) {
     DataManager<navitia::type::Data> data_manager;
     {
         auto first_data = data_manager.get_data();
@@ -160,5 +158,3 @@ BOOST_AUTO_TEST_CASE(destructor_not_called) {
     BOOST_CHECK_EQUAL(navitia::type::Data::destructor_called, false);
     BOOST_CHECK(data_manager.get_data());
 }
-
-BOOST_AUTO_TEST_SUITE_END()

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -72,14 +72,16 @@ struct fixture{
     }
 };
 
-BOOST_FIXTURE_TEST_CASE(get_data, fixture) {
+BOOST_FIXTURE_TEST_SUITE(s, fixture)
+
+BOOST_AUTO_TEST_CASE(get_data) {
     DataManager<test::Data> data_manager;
     auto data = data_manager.get_data();
     BOOST_REQUIRE(data);
     BOOST_CHECK_EQUAL(test::Data::destructor_called, false);
 }
 
-BOOST_FIXTURE_TEST_CASE(load, fixture) {
+BOOST_AUTO_TEST_CASE(load) {
     DataManager<test::Data> data_manager;
     BOOST_CHECK(data_manager.get_data());
     auto first_data = data_manager.get_data();
@@ -95,7 +97,7 @@ BOOST_FIXTURE_TEST_CASE(load, fixture) {
     BOOST_CHECK_NE(first_data, data_manager.get_data());
 }
 
-BOOST_FIXTURE_TEST_CASE(destructor_called, fixture) {
+BOOST_AUTO_TEST_CASE(destructor_called) {
     DataManager<test::Data> data_manager;
     {
         auto first_data = data_manager.get_data();
@@ -111,7 +113,7 @@ BOOST_FIXTURE_TEST_CASE(destructor_called, fixture) {
     BOOST_CHECK(data_manager.get_data());
 }
 
-BOOST_FIXTURE_TEST_CASE(destructor_not_called, fixture) {
+BOOST_AUTO_TEST_CASE(destructor_not_called) {
     DataManager<test::Data> data_manager;
     {
         auto first_data = data_manager.get_data();
@@ -121,3 +123,5 @@ BOOST_FIXTURE_TEST_CASE(destructor_not_called, fixture) {
     BOOST_CHECK_EQUAL(test::Data::destructor_called, false);
     BOOST_CHECK(data_manager.get_data());
 }
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/source/kraken/tests/data_manager_with_type_data_test.cpp
+++ b/source/kraken/tests/data_manager_with_type_data_test.cpp
@@ -1,0 +1,121 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE data_manager_test
+#include <boost/test/unit_test.hpp>
+
+#include "kraken/data_manager.h"
+#include "type/data.h"
+
+static const std::string fake_data_file = "fake_data.nav.lz4";
+static const std::string fake_disruption_path = "fake_disruption_path";
+
+// We create a empty data with lz4 format in current directory.
+#define CREATE_FAKE_DATA(fake_file_name) \
+    navitia::type::Data data(0);         \
+    data.save(fake_data_file);           \
+
+// Absolute path
+std::string complete_path(const std::string file_name){
+    char buf[256];
+    if (getcwd(buf, sizeof(buf))) {
+        return std::string(buf) + "/" + file_name;
+    } else {
+        std::perror("getcwd");
+        return "";
+    }
+}
+
+// test sequence :
+// 1. load good data
+// 2. reload good data
+// 3. reload wrong data
+BOOST_AUTO_TEST_CASE(load_success) {
+
+    CREATE_FAKE_DATA(fake_data_file)
+
+    DataManager<navitia::type::Data> data_manager;
+    BOOST_CHECK(data_manager.get_data());
+    auto first_data = data_manager.get_data();
+
+    // Same pointer
+    BOOST_CHECK_EQUAL(first_data, data_manager.get_data());
+
+    // real data : Loading successed
+    BOOST_CHECK(data_manager.load(complete_path(fake_data_file)));
+
+    // Load success, so the internal shared pointer change.
+    auto second_data = data_manager.get_data();
+    BOOST_CHECK_NE(first_data, second_data);
+
+    // Same pointer
+    BOOST_CHECK_EQUAL(second_data, data_manager.get_data());
+
+    // When we reload a new data.
+    // real data : Loading successed
+    BOOST_CHECK(data_manager.load(complete_path(fake_data_file)));
+
+    // Load success, so the internal shared pointer change.
+    auto third_data = data_manager.get_data();
+    BOOST_CHECK_NE(second_data, third_data);
+
+    // Same pointer
+    BOOST_CHECK_EQUAL(third_data, data_manager.get_data());
+
+    // When we reload a new data.
+    // Fake data : Loading failed
+    BOOST_CHECK(!data_manager.load("wrong path"));
+
+    // Load failed, so the internal shared pointer no change.
+    // Data has not changed.
+    auto fourth_data = data_manager.get_data();
+    BOOST_CHECK_EQUAL(third_data, fourth_data);
+}
+
+BOOST_AUTO_TEST_CASE(load_failed) {
+
+    CREATE_FAKE_DATA(fake_data_file)
+
+    DataManager<navitia::type::Data> data_manager;
+    BOOST_CHECK(data_manager.get_data());
+    auto first_data = data_manager.get_data();
+
+    // Same pointer
+    BOOST_CHECK_EQUAL(first_data, data_manager.get_data());
+
+    // Fake data : Loading failed
+    BOOST_CHECK(!data_manager.load("wrong path"));
+
+    // Load failed, so the internal shared pointer no change.
+    // Data has not changed.
+    auto second_data = data_manager.get_data();
+    BOOST_CHECK_EQUAL(first_data, second_data);
+}

--- a/source/kraken/tests/data_manager_with_type_data_test.cpp
+++ b/source/kraken/tests/data_manager_with_type_data_test.cpp
@@ -40,9 +40,10 @@ static const std::string fake_data_file = "fake_data.nav.lz4";
 static const std::string fake_disruption_path = "fake_disruption_path";
 
 // We create a empty data with lz4 format in current directory.
-#define CREATE_FAKE_DATA(fake_file_name) \
-    navitia::type::Data data(0);         \
-    data.save(fake_data_file);           \
+static void create_fake_data(const std::string& fake_file_name){
+    navitia::type::Data data(0);
+    data.save(fake_file_name);
+}
 
 // Absolute path
 static std::string complete_path(const std::string file_name){
@@ -61,7 +62,7 @@ static std::string complete_path(const std::string file_name){
 // 3. reload wrong data
 BOOST_AUTO_TEST_CASE(load_success) {
 
-    CREATE_FAKE_DATA(fake_data_file)
+    create_fake_data(fake_data_file);
 
     DataManager<navitia::type::Data> data_manager;
     BOOST_CHECK(data_manager.get_data());
@@ -107,7 +108,7 @@ BOOST_AUTO_TEST_CASE(load_success) {
 
 BOOST_AUTO_TEST_CASE(load_failed) {
 
-    CREATE_FAKE_DATA(fake_data_file)
+    create_fake_data(fake_data_file);
 
     DataManager<navitia::type::Data> data_manager;
     BOOST_CHECK(data_manager.get_data());

--- a/source/kraken/tests/data_manager_with_type_data_test.cpp
+++ b/source/kraken/tests/data_manager_with_type_data_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 
 #include "kraken/data_manager.h"
 #include "type/data.h"
+#include "utils/functions.h" // absolute_path function
 
 static const std::string fake_data_file = "fake_data.nav.lz4";
 static const std::string fake_disruption_path = "fake_disruption_path";
@@ -43,17 +44,6 @@ static const std::string fake_disruption_path = "fake_disruption_path";
 static void create_fake_data(const std::string& fake_file_name){
     navitia::type::Data data(0);
     data.save(fake_file_name);
-}
-
-// Absolute path
-static std::string complete_path(const std::string file_name){
-    char buf[256];
-    if (getcwd(buf, sizeof(buf))) {
-        return std::string(buf) + "/" + file_name;
-    } else {
-        std::perror("getcwd");
-        return "";
-    }
 }
 
 // test sequence :
@@ -72,7 +62,7 @@ BOOST_AUTO_TEST_CASE(load_success) {
     BOOST_CHECK_EQUAL(first_data, data_manager.get_data());
 
     // real data : Loading successed
-    std::string fake_data_path = complete_path(fake_data_file);
+    std::string fake_data_path = navitia::absolute_path() + fake_data_file;
     BOOST_CHECK(data_manager.load(fake_data_path));
 
     // Load success, so the internal shared pointer changes.
@@ -97,7 +87,7 @@ BOOST_AUTO_TEST_CASE(load_success) {
     // Fake data : Loading failed
     BOOST_CHECK(!data_manager.load("wrong path"));
 
-    // Load failed, so the internal shared pointer no changes.
+    // Load failed, so the internal shared pointer does not changes.
     // Data has not changed.
     auto fourth_data = data_manager.get_data();
     BOOST_CHECK_EQUAL(third_data, fourth_data);
@@ -107,8 +97,6 @@ BOOST_AUTO_TEST_CASE(load_success) {
 }
 
 BOOST_AUTO_TEST_CASE(load_failed) {
-
-    create_fake_data(fake_data_file);
 
     DataManager<navitia::type::Data> data_manager;
     BOOST_CHECK(data_manager.get_data());

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -244,7 +244,7 @@ void Worker::status() {
     status->set_data_version(d->version);
     status->set_navitia_version(config::project_version);
     status->set_loaded(d->loaded);
-    status->set_last_load_status(d->last_load);
+    status->set_last_load_status(d->last_load_succeeded);
     status->set_last_load_at(pt::to_iso_string(d->last_load_at));
     status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded));
     status->set_nb_threads(conf.nb_threads());
@@ -339,7 +339,7 @@ void Worker::init_worker_data(const navitia::type::Data* data,
         planner = std::make_unique<routing::RAPTOR>(*data);
         street_network_worker = std::make_unique<georef::StreetNetwork>(*data->geo_ref);
         this->last_data_identifier = data->data_identifier;
-        LOG4CPLUS_INFO(logger, "Instanciate planner");        
+        LOG4CPLUS_INFO(logger, "Instanciate planner");
     }
     this->pb_creator.init(data, now, action_period, disable_geojson, disable_feedpublisher);
 }
@@ -544,7 +544,7 @@ void Worker::place_uri(const pbnavitia::PlaceUriRequest &request) {
         auto ep = type::EntryPoint(type::Type_e::Coord, request.uri());
         type::GeographicalCoord coord = ep.coordinates;
 
-        try{ 
+        try{
             auto address = this->pb_creator.data->geo_ref->nearest_addr(coord);
             const auto& way_coord = WayCoord(address.second, coord, address.first);
             pb_creator.fill(&way_coord, pb_creator.add_places(), request.depth());
@@ -560,7 +560,7 @@ void Worker::place_uri(const pbnavitia::PlaceUriRequest &request) {
         pb_creator.fill(it_sa->second, pb_creator.add_places(), request.depth());
     } else {
         auto it_sp = data->pt_data->stop_points_map.find(request.uri());
-        if(it_sp != data->pt_data->stop_points_map.end()) {            
+        if(it_sp != data->pt_data->stop_points_map.end()) {
             pb_creator.fill(it_sp->second, pb_creator.add_places(), request.depth());
         } else {
             auto it_poi = data->geo_ref->poi_map.find(request.uri());

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -249,6 +249,7 @@ void Worker::status() {
     status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded));
     status->set_nb_threads(conf.nb_threads());
     status->set_is_connected_to_rabbitmq(d->is_connected_to_rabbitmq);
+    status->set_disruption_error(d->disruption_error);
     status->set_status(get_string_status(d));
     status->set_is_realtime_loaded(d->is_realtime_loaded);
     for(const auto& contrib: this->conf.rt_topics()){

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -85,6 +85,7 @@ def monitor():
         response['last_load_status'] = resp.status.last_load_status
         response['loaded'] = resp.status.loaded
         response['is_connected_to_rabbitmq'] = resp.status.is_connected_to_rabbitmq
+        response['disruption_error'] = resp.status.disruption_error
         response['publication_date'] = resp.status.publication_date
         response['is_realtime_loaded'] = resp.status.is_realtime_loaded
 

--- a/source/routing/benchmark.cpp
+++ b/source/routing/benchmark.cpp
@@ -104,7 +104,8 @@ int main(int argc, char** argv){
     type::Data data;
     {
         Timer t("Chargement des données : " + file);
-        data.load(file);
+        data.load_nav(file);
+        data.build_raptor();
     }
     std::vector<PathDemand> demands;
 

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -178,7 +178,8 @@ int main(int argc, char** argv){
     type::Data data;
     {
         Timer t("Chargement des données : " + file);
-        data.load(file);
+        data.load_nav(file);
+        data.build_raptor();
     }
     std::vector<PathDemand> demands;
 

--- a/source/routing/routing_cli_utils.cpp
+++ b/source/routing/routing_cli_utils.cpp
@@ -49,9 +49,9 @@ namespace navitia { namespace cli {
         void compute_options::load(const std::string& file) {
             {
                 Timer t("Loading datafile : " + file);
-                data.load(file);
+                data.load_nav(file);
+                data.build_raptor();
             }
-            data.build_raptor();
             raptor = std::unique_ptr<nr::RAPTOR>(new nr::RAPTOR(data));
         }
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -143,6 +143,10 @@ add_executable(comments_test tests/comments_test.cpp)
 target_link_libraries(comments_test ed data types georef autocomplete utils ${BOOST_DEV_LIBS} log4cplus pb_lib protobuf)
 ADD_BOOST_TEST(comments_test)
 
+add_executable(data_test tests/data_test.cpp)
+target_link_libraries(data_test ed data types utils ${BOOST_DEV_LIBS} log4cplus)
+ADD_BOOST_TEST(data_test)
+
 add_executable(code_container_test tests/code_container_test.cpp)
 target_link_libraries(code_container_test ${BOOST_DEV_LIBS})
 ADD_BOOST_TEST(code_container_test)

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -90,6 +90,7 @@ add_dependencies(types protobuf_files)
 
 SET(DATA_SRC
     data.cpp
+    data_exceptions.cpp
     "${CMAKE_SOURCE_DIR}/third_party/lz4/lz4.c"
     pt_data.cpp
     headsign_handler.cpp

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -91,7 +91,7 @@ bool Data::load(const std::string& filename,
                 const size_t raptor_cache_size) {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     loading = true;
-    disruption_is_loaded = false;
+    disruption_error = false;
 
     // Load .nav
     try {
@@ -123,11 +123,12 @@ bool Data::load(const std::string& filename,
     if (chaos_database) {
         try {
             fill_disruption_from_database(*chaos_database, *pt_data, *meta, contributors);
-            disruption_is_loaded = true;
         } catch(const std::exception& ex) {
             LOG4CPLUS_WARN(logger, "Data disruptions loading failed: " << ex.what());
+            disruption_error = true;
         } catch(...) {
             LOG4CPLUS_WARN(logger, "Data disruptions loading failed");
+            disruption_error = true;
         }
     }
 

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -161,8 +161,8 @@ void Data::load_disruptions(const std::string& database,
         throw navitia::data::disruptions_loading_error("Disruptions loading error: " + std::string(ex.what()));
         disruption_error = true;
     } catch (...) {
-        LOG4CPLUS_ERROR(logger, "Disruptions loading error: ");
-        throw navitia::data::disruptions_loading_error("Disruptions loading error: ");
+        LOG4CPLUS_ERROR(logger, "Disruptions loading error");
+        throw navitia::data::disruptions_loading_error("Disruptions loading error");
         disruption_error = true;
     }
     LOG4CPLUS_DEBUG(logger, "Finished to load disruptions");

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -91,6 +91,7 @@ bool Data::load(const std::string& filename,
                 const size_t raptor_cache_size) {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     loading = true;
+    disruption_is_loaded = false;
 
     // Load .nav
     try {
@@ -107,18 +108,22 @@ bool Data::load(const std::string& filename,
     } catch(const wrong_version& ex) {
         LOG4CPLUS_ERROR(logger, "Cannot load data: " << ex.what());
         last_load = false;
+        return last_load;
     } catch(const std::exception& ex) {
         LOG4CPLUS_ERROR(logger, "Data loading failed: " << ex.what());
         last_load = false;
+        return last_load;
     } catch(...) {
         LOG4CPLUS_ERROR(logger, "Data loading failed");
         last_load = false;
+        return last_load;
 	}
 
     // Load Disruption (optionnal)
     if (chaos_database) {
         try {
             fill_disruption_from_database(*chaos_database, *pt_data, *meta, contributors);
+            disruption_is_loaded = true;
         } catch(const std::exception& ex) {
             LOG4CPLUS_WARN(logger, "Data disruptions loading failed: " << ex.what());
         } catch(...) {

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -121,7 +121,7 @@ bool Data::load(const std::string& filename,
         return last_load;
 	}
 
-    // Load Disruption (optionnal)
+    // Load Disruption (optional)
     if ((chaos_database) && (disruptions_corruption_detected == false)){
         try {
             fill_disruption_from_database(*chaos_database, *pt_data, *meta, contributors);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -148,22 +148,22 @@ void Data::load_disruptions(const std::string& database,
     try {
         fill_disruption_from_database(database, *pt_data, *meta, contributors);
         disruption_error = false;
-    } catch (const pqxx::broken_connection& ex){
+    } catch (const pqxx::broken_connection& ex) {
         LOG4CPLUS_WARN(logger, "Unable to connect to disruptions database: " << std::string(ex.what()));
         disruption_error = true;
         throw navitia::data::disruptions_broken_connection("Unable to connect to disruptions database: " + std::string(ex.what()));
-    } catch (const pqxx::pqxx_exception& ex){
+    } catch (const pqxx::pqxx_exception& ex) {
         LOG4CPLUS_ERROR(logger, "Disruptions loading error: " << std::string(ex.base().what()));
-        throw navitia::data::disruptions_loading_error("Disruptions loading error: " + std::string(ex.base().what()));
         disruption_error = true;
+        throw navitia::data::disruptions_loading_error("Disruptions loading error: " + std::string(ex.base().what()));
     } catch (const std::exception& ex) {
         LOG4CPLUS_ERROR(logger, "Disruptions loading error: " << std::string(ex.what()));
-        throw navitia::data::disruptions_loading_error("Disruptions loading error: " + std::string(ex.what()));
         disruption_error = true;
+        throw navitia::data::disruptions_loading_error("Disruptions loading error: " + std::string(ex.what()));
     } catch (...) {
         LOG4CPLUS_ERROR(logger, "Disruptions loading error");
-        throw navitia::data::disruptions_loading_error("Disruptions loading error");
         disruption_error = true;
+        throw navitia::data::disruptions_loading_error("Disruptions loading error");
     }
     LOG4CPLUS_DEBUG(logger, "Finished to load disruptions");
 }

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -61,7 +61,7 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace type {
 
-const unsigned int Data::data_version = 67; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 68; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     disruption_error(false),

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -48,7 +48,6 @@ www.navitia.io
 #include "third_party/eos_portable_archive/portable_oarchive.hpp"
 #include "lz4_filter/filter.h"
 #include "utils/functions.h"
-#include "utils/exception.h"
 #include "utils/threadbuf.h"
 
 #include "pt_data.h"
@@ -61,12 +60,6 @@ www.navitia.io
 namespace pt = boost::posix_time;
 
 namespace navitia { namespace type {
-
-wrong_version::~wrong_version() noexcept {}
-data_loading_error::~data_loading_error() noexcept {}
-disruptions_broken_connection::~disruptions_broken_connection() noexcept {}
-disruptions_loading_error::~disruptions_loading_error() noexcept {}
-raptor_building_error::~raptor_building_error() noexcept {}
 
 const unsigned int Data::data_version = 67; //< *INCREMENT* every time serialized data are modified
 
@@ -107,7 +100,7 @@ void Data::load_nav(const std::string& filename) {
 
     if (filename.empty()){
         LOG4CPLUS_ERROR(logger, "Data loading failed: Data path is empty");
-        throw data_loading_error("Data loading failed: Data path is empty");
+        throw navitia::data::data_loading_error("Data loading failed: Data path is empty");
     }
 
     try {
@@ -123,10 +116,10 @@ void Data::load_nav(const std::string& filename) {
                        % pt_data->stop_points.size());
     } catch (const std::exception& ex) {
         LOG4CPLUS_ERROR(logger, "Data loading failed: " + std::string(ex.what()));
-        throw data_loading_error("Data loading failed: " + std::string(ex.what()));
+        throw navitia::data::data_loading_error("Data loading failed: " + std::string(ex.what()));
     } catch (...) {
         LOG4CPLUS_ERROR(logger, "Data loading failed");
-        throw data_loading_error("Data loading failed");
+        throw navitia::data::data_loading_error("Data loading failed");
     }
     LOG4CPLUS_DEBUG(logger, "Finished to load nav");
 }
@@ -158,18 +151,18 @@ void Data::load_disruptions(const std::string& database,
     } catch (const pqxx::broken_connection& ex){
         LOG4CPLUS_WARN(logger, "Unable to connect to disruptions database: " << std::string(ex.what()));
         disruption_error = true;
-        throw disruptions_broken_connection("Unable to connect to disruptions database: " + std::string(ex.what()));
+        throw navitia::data::disruptions_broken_connection("Unable to connect to disruptions database: " + std::string(ex.what()));
     } catch (const pqxx::pqxx_exception& ex){
         LOG4CPLUS_ERROR(logger, "Disruptions loading error");
-        throw disruptions_loading_error("Disruptions loading error");
+        throw navitia::data::disruptions_loading_error("Disruptions loading error");
         disruption_error = true;
     } catch (const std::exception& ex) {
         LOG4CPLUS_ERROR(logger, "Disruptions loading error: " << std::string(ex.what()));
-        throw disruptions_loading_error("Disruptions loading error: " + std::string(ex.what()));
+        throw navitia::data::disruptions_loading_error("Disruptions loading error: " + std::string(ex.what()));
         disruption_error = true;
     } catch (...) {
         LOG4CPLUS_ERROR(logger, "Disruptions loading error: ");
-        throw disruptions_loading_error("Disruptions loading error: ");
+        throw navitia::data::disruptions_loading_error("Disruptions loading error: ");
         disruption_error = true;
     }
     LOG4CPLUS_DEBUG(logger, "Finished to load disruptions");
@@ -190,10 +183,10 @@ void Data::build_raptor(size_t cache_size) {
         dataRaptor->load(*this->pt_data, cache_size);
     } catch (const std::exception& ex) {
         LOG4CPLUS_ERROR(logger, "Data Raptor loading error: " << std::string(ex.what()));
-        throw disruptions_loading_error("Data Raptor loading error: " + std::string(ex.what()));
+        throw navitia::data::raptor_building_error("Data Raptor loading error: " + std::string(ex.what()));
     } catch(...) {
         LOG4CPLUS_ERROR(logger, "Data Raptor loading error: ");
-        throw disruptions_loading_error("Data Raptor loading error: ");
+        throw navitia::data::raptor_building_error("Data Raptor loading error: ");
     }
     LOG4CPLUS_DEBUG(logger, "Finished to build data Raptor");
 }

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -158,8 +158,8 @@ bool Data::load(const std::string& filename,
 }
 
 bool Data::load_without_disruptions(const std::string& filename,
-                                        const std::vector<std::string>& contributors,
-                                        const size_t raptor_cache_size) {
+                                    const std::vector<std::string>& contributors,
+                                    const size_t raptor_cache_size) {
    disruptions_corruption_detected = true;
    return this->load(filename, {}, contributors, raptor_cache_size);
    disruptions_corruption_detected = false;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -133,7 +133,7 @@ public:
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded
-    bool disruption_is_loaded; // disruption flag
+    bool disruption_error; // disruption error flag
     size_t data_identifier = 0;
 
     std::unique_ptr<MetaData> meta;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -133,7 +133,8 @@ public:
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded
-    bool disruption_error; // disruption error flag
+    std::atomic<bool> disruption_error; // disruption error flag
+    bool disruptions_corruption_detected;
     size_t data_identifier = 0;
 
     std::unique_ptr<MetaData> meta;
@@ -226,6 +227,11 @@ public:
               const boost::optional<std::string>& chaos_database = {},
               const std::vector<std::string>& contributors = {},
               const size_t raptor_cache_size = 10);
+
+    // Reload Data without disruption data
+    bool load_without_disruptions(const std::string & filename,
+                                 const std::vector<std::string>& contributors = {},
+                                 const size_t raptor_cache_size = 10);
 
     /** Sauvegarde les données */
     void save(const std::string & filename) const;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -230,8 +230,8 @@ public:
 
     // Reload Data without disruption data
     bool load_without_disruptions(const std::string & filename,
-                                 const std::vector<std::string>& contributors = {},
-                                 const size_t raptor_cache_size = 10);
+                                  const std::vector<std::string>& contributors = {},
+                                  const size_t raptor_cache_size = 10);
 
     /** Sauvegarde les données */
     void save(const std::string & filename) const;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -38,7 +38,7 @@ www.navitia.io
 #include "type/type.h"
 #include "utils/serialization_unique_ptr.h"
 #include "utils/serialization_atomic.h"
-#include "utils/exception.h"
+#include "data_exceptions.h"
 #include "utils/obj_factory.h"
 
 //forward declare
@@ -63,46 +63,6 @@ namespace navitia {
 
 namespace navitia { namespace type {
 
-// Wrong data version
-struct wrong_version : public navitia::exception {
-    wrong_version(const std::string& msg): navitia::exception(msg){}
-    wrong_version(const wrong_version&) = default;
-    wrong_version& operator=(const wrong_version&) = default;
-    virtual ~wrong_version() noexcept;
-};
-
-// Data loading exceptions handler
-struct data_loading_error : public navitia::exception {
-    data_loading_error(const std::string& msg): navitia::exception(msg){}
-    data_loading_error(const data_loading_error&) = default;
-    data_loading_error& operator=(const data_loading_error&) = default;
-    virtual ~data_loading_error() noexcept;
-};
-
-// Disruptions exceptions handler. Broken connection
-struct disruptions_broken_connection : public navitia::exception {
-    disruptions_broken_connection(const std::string& msg): navitia::exception(msg){}
-    disruptions_broken_connection(const disruptions_broken_connection&) = default;
-    disruptions_broken_connection& operator=(const disruptions_broken_connection&) = default;
-    virtual ~disruptions_broken_connection() noexcept;
-};
-
-// Disruptions exceptions handler. Loading error
-struct disruptions_loading_error : public navitia::exception {
-    disruptions_loading_error(const std::string& msg): navitia::exception(msg){}
-    disruptions_loading_error(const disruptions_loading_error&) = default;
-    disruptions_loading_error& operator=(const disruptions_loading_error&) = default;
-    virtual ~disruptions_loading_error() noexcept;
-};
-
-// Raptor building exceptions handler
-struct raptor_building_error : public navitia::exception {
-    raptor_building_error(const std::string& msg): navitia::exception(msg){}
-    raptor_building_error(const raptor_building_error&) = default;
-    raptor_building_error& operator=(const raptor_building_error&) = default;
-    virtual ~raptor_building_error() noexcept;
-};
-
 template<typename T>
 struct ContainerTrait {
     typedef std::vector<T*> vect_type;
@@ -110,7 +70,7 @@ struct ContainerTrait {
 };
 
 // specialization for impact
-// Instead of pure pointer, we can only get a weak_ptr when requesting impacts 
+// Instead of pure pointer, we can only get a weak_ptr when requesting impacts
 template<>
 struct ContainerTrait<type::disruption::Impact> {
     typedef std::vector<boost::weak_ptr<type::disruption::Impact>> vect_type;
@@ -247,7 +207,7 @@ public:
         if(this->version != data_version){
             unsigned int v = data_version;//sinon ca link pas...
             auto msg = boost::format("Warning data version don't match with the data version of kraken %u (current version: %d)") % version % v;
-            throw wrong_version(msg.str());
+            throw navitia::data::wrong_version(msg.str());
         }
         ar & pt_data & geo_ref & meta & fare & last_load_at & loaded & last_load & is_connected_to_rabbitmq
            & is_realtime_loaded;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -133,6 +133,7 @@ public:
     unsigned int version = 0; //< Version of loaded data
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded
+    bool disruption_is_loaded; // disruption flag
     size_t data_identifier = 0;
 
     std::unique_ptr<MetaData> meta;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -63,11 +63,44 @@ namespace navitia {
 
 namespace navitia { namespace type {
 
+// Wrong data version
 struct wrong_version : public navitia::exception {
     wrong_version(const std::string& msg): navitia::exception(msg){}
     wrong_version(const wrong_version&) = default;
     wrong_version& operator=(const wrong_version&) = default;
     virtual ~wrong_version() noexcept;
+};
+
+// Data loading exceptions handler
+struct data_loading_error : public navitia::exception {
+    data_loading_error(const std::string& msg): navitia::exception(msg){}
+    data_loading_error(const data_loading_error&) = default;
+    data_loading_error& operator=(const data_loading_error&) = default;
+    virtual ~data_loading_error() noexcept;
+};
+
+// Disruptions exceptions handler. Broken connection
+struct disruptions_broken_connection : public navitia::exception {
+    disruptions_broken_connection(const std::string& msg): navitia::exception(msg){}
+    disruptions_broken_connection(const disruptions_broken_connection&) = default;
+    disruptions_broken_connection& operator=(const disruptions_broken_connection&) = default;
+    virtual ~disruptions_broken_connection() noexcept;
+};
+
+// Disruptions exceptions handler. Loading error
+struct disruptions_loading_error : public navitia::exception {
+    disruptions_loading_error(const std::string& msg): navitia::exception(msg){}
+    disruptions_loading_error(const disruptions_loading_error&) = default;
+    disruptions_loading_error& operator=(const disruptions_loading_error&) = default;
+    virtual ~disruptions_loading_error() noexcept;
+};
+
+// Raptor building exceptions handler
+struct raptor_building_error : public navitia::exception {
+    raptor_building_error(const std::string& msg): navitia::exception(msg){}
+    raptor_building_error(const raptor_building_error&) = default;
+    raptor_building_error& operator=(const raptor_building_error&) = default;
+    virtual ~raptor_building_error() noexcept;
 };
 
 template<typename T>
@@ -134,7 +167,6 @@ public:
     std::atomic<bool> loaded; //< have the data been loaded ?
     std::atomic<bool> loading; //< Is the data being loaded
     std::atomic<bool> disruption_error; // disruption error flag
-    bool disruptions_corruption_detected;
     size_t data_identifier = 0;
 
     std::unique_ptr<MetaData> meta;
@@ -188,7 +220,7 @@ public:
     Indexes get_target_by_one_source(Type_e source, Type_e target, idx_t source_idx) const ;
 
 
-    bool last_load = true;
+    bool last_load;
     // UTC
     boost::posix_time::ptime last_load_at;
 
@@ -222,16 +254,11 @@ public:
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()
 
-    /** Charge les données et effectue les initialisations nécessaires */
-    bool load(const std::string & filename,
-              const boost::optional<std::string>& chaos_database = {},
-              const std::vector<std::string>& contributors = {},
-              const size_t raptor_cache_size = 10);
-
-    // Reload Data without disruption data
-    bool load_without_disruptions(const std::string & filename,
-                                  const std::vector<std::string>& contributors = {},
-                                  const size_t raptor_cache_size = 10);
+    // Loading methods
+    void load_nav(const std::string& filename);
+    void load_disruptions(const std::string& database,
+                          const std::vector<std::string>& contributors = {});
+    void build_raptor(size_t cache_size = 10);
 
     /** Sauvegarde les données */
     void save(const std::string & filename) const;
@@ -247,8 +274,6 @@ public:
     void build_proximity_list();
     /** Set admins*/
     void build_administrative_regions();
-    /** Construit les données raptor */
-    void build_raptor(size_t cache_size = 10);
 
     void build_associated_calendar();
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -180,7 +180,7 @@ public:
     Indexes get_target_by_one_source(Type_e source, Type_e target, idx_t source_idx) const ;
 
 
-    bool last_load;
+    bool last_load_succeeded;
     // UTC
     boost::posix_time::ptime last_load_at;
 
@@ -199,7 +199,7 @@ public:
 
     friend class boost::serialization::access;
     template<class Archive> void save(Archive & ar, const unsigned int) const {
-        ar & pt_data & geo_ref & meta & fare & last_load_at & loaded & last_load & is_connected_to_rabbitmq
+        ar & pt_data & geo_ref & meta & fare & last_load_at & loaded & last_load_succeeded & is_connected_to_rabbitmq
            & is_realtime_loaded;
     }
     template<class Archive> void load(Archive & ar, const unsigned int version) {
@@ -209,7 +209,7 @@ public:
             auto msg = boost::format("Warning data version don't match with the data version of kraken %u (current version: %d)") % version % v;
             throw navitia::data::wrong_version(msg.str());
         }
-        ar & pt_data & geo_ref & meta & fare & last_load_at & loaded & last_load & is_connected_to_rabbitmq
+        ar & pt_data & geo_ref & meta & fare & last_load_at & loaded & last_load_succeeded & is_connected_to_rabbitmq
            & is_realtime_loaded;
     }
     BOOST_SERIALIZATION_SPLIT_MEMBER()

--- a/source/type/data_exceptions.cpp
+++ b/source/type/data_exceptions.cpp
@@ -1,0 +1,11 @@
+#include "data_exceptions.h"
+
+namespace navitia { namespace data {
+
+wrong_version::~wrong_version() noexcept {}
+data_loading_error::~data_loading_error() noexcept {}
+disruptions_broken_connection::~disruptions_broken_connection() noexcept {}
+disruptions_loading_error::~disruptions_loading_error() noexcept {}
+raptor_building_error::~raptor_building_error() noexcept {}
+
+}} //namespace navitia::type

--- a/source/type/data_exceptions.h
+++ b/source/type/data_exceptions.h
@@ -35,40 +35,40 @@ www.navitia.io
 namespace navitia { namespace data {
 
 // Wrong data version
-struct wrong_version : public navitia::exception {
-    wrong_version(const std::string& msg): navitia::exception(msg){}
+struct wrong_version : public navitia::recoverable_exception {
+    wrong_version(const std::string& msg): navitia::recoverable_exception(msg){}
     wrong_version(const wrong_version&) = default;
     wrong_version& operator=(const wrong_version&) = default;
     virtual ~wrong_version() noexcept;
 };
 
 // Data loading exceptions handler
-struct data_loading_error : public navitia::exception {
-    data_loading_error(const std::string& msg): navitia::exception(msg){}
+struct data_loading_error : public navitia::recoverable_exception {
+    data_loading_error(const std::string& msg): navitia::recoverable_exception(msg){}
     data_loading_error(const data_loading_error&) = default;
     data_loading_error& operator=(const data_loading_error&) = default;
     virtual ~data_loading_error() noexcept;
 };
 
 // Disruptions exceptions handler. Broken connection
-struct disruptions_broken_connection : public navitia::exception {
-    disruptions_broken_connection(const std::string& msg): navitia::exception(msg){}
+struct disruptions_broken_connection : public navitia::recoverable_exception {
+    disruptions_broken_connection(const std::string& msg): navitia::recoverable_exception(msg){}
     disruptions_broken_connection(const disruptions_broken_connection&) = default;
     disruptions_broken_connection& operator=(const disruptions_broken_connection&) = default;
     virtual ~disruptions_broken_connection() noexcept;
 };
 
 // Disruptions exceptions handler. Loading error
-struct disruptions_loading_error : public navitia::exception {
-    disruptions_loading_error(const std::string& msg): navitia::exception(msg){}
+struct disruptions_loading_error : public navitia::recoverable_exception {
+    disruptions_loading_error(const std::string& msg): navitia::recoverable_exception(msg){}
     disruptions_loading_error(const disruptions_loading_error&) = default;
     disruptions_loading_error& operator=(const disruptions_loading_error&) = default;
     virtual ~disruptions_loading_error() noexcept;
 };
 
 // Raptor building exceptions handler
-struct raptor_building_error : public navitia::exception {
-    raptor_building_error(const std::string& msg): navitia::exception(msg){}
+struct raptor_building_error : public navitia::recoverable_exception {
+    raptor_building_error(const std::string& msg): navitia::recoverable_exception(msg){}
     raptor_building_error(const raptor_building_error&) = default;
     raptor_building_error& operator=(const raptor_building_error&) = default;
     virtual ~raptor_building_error() noexcept;

--- a/source/type/data_exceptions.h
+++ b/source/type/data_exceptions.h
@@ -1,0 +1,77 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+
+#include "utils/exception.h"
+
+namespace navitia { namespace data {
+
+// Wrong data version
+struct wrong_version : public navitia::exception {
+    wrong_version(const std::string& msg): navitia::exception(msg){}
+    wrong_version(const wrong_version&) = default;
+    wrong_version& operator=(const wrong_version&) = default;
+    virtual ~wrong_version() noexcept;
+};
+
+// Data loading exceptions handler
+struct data_loading_error : public navitia::exception {
+    data_loading_error(const std::string& msg): navitia::exception(msg){}
+    data_loading_error(const data_loading_error&) = default;
+    data_loading_error& operator=(const data_loading_error&) = default;
+    virtual ~data_loading_error() noexcept;
+};
+
+// Disruptions exceptions handler. Broken connection
+struct disruptions_broken_connection : public navitia::exception {
+    disruptions_broken_connection(const std::string& msg): navitia::exception(msg){}
+    disruptions_broken_connection(const disruptions_broken_connection&) = default;
+    disruptions_broken_connection& operator=(const disruptions_broken_connection&) = default;
+    virtual ~disruptions_broken_connection() noexcept;
+};
+
+// Disruptions exceptions handler. Loading error
+struct disruptions_loading_error : public navitia::exception {
+    disruptions_loading_error(const std::string& msg): navitia::exception(msg){}
+    disruptions_loading_error(const disruptions_loading_error&) = default;
+    disruptions_loading_error& operator=(const disruptions_loading_error&) = default;
+    virtual ~disruptions_loading_error() noexcept;
+};
+
+// Raptor building exceptions handler
+struct raptor_building_error : public navitia::exception {
+    raptor_building_error(const std::string& msg): navitia::exception(msg){}
+    raptor_building_error(const raptor_building_error&) = default;
+    raptor_building_error& operator=(const raptor_building_error&) = default;
+    virtual ~raptor_building_error() noexcept;
+};
+
+}} //namespace navitia::data

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -47,13 +47,8 @@ using namespace navitia;
 static const std::string fake_data_file = "fake_data.nav.lz4";
 static const std::string fake_disruption_path = "fake_disruption_path";
 
-// We create a empty data with lz4 format in current directory.
-#define CREATE_FAKE_DATA(fake_file_name) \
-    navitia::type::Data data(0);         \
-    data.save(fake_data_file);           \
-
 // Absolute path
-std::string complete_path(const std::string file_name){
+static std::string complete_path(const std::string file_name){
     char buf[256];
     if (getcwd(buf, sizeof(buf))) {
         return std::string(buf) + "/" + file_name;
@@ -65,38 +60,26 @@ std::string complete_path(const std::string file_name){
 
 BOOST_AUTO_TEST_CASE(load_data) {
 
-    CREATE_FAKE_DATA(fake_data_file)
+    navitia::type::Data data(0);
+    data.save(fake_data_file);
 
     // load .nav
     bool failed = false;
-    BOOST_CHECK_EQUAL(data.last_load, false);
+    BOOST_CHECK_EQUAL(data.last_load_succeeded, false);
     try {
         data.load_nav(complete_path(fake_data_file));
-    } catch(const navitia::data::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error&) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, false);
-    BOOST_CHECK_EQUAL(data.last_load, true);
+    BOOST_CHECK_EQUAL(data.last_load_succeeded, true);
     try {
         data.load_nav("wrong_path");
-    } catch(const navitia::data::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error&) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, true);
-    BOOST_CHECK_EQUAL(data.last_load, true);
-}
-
-BOOST_AUTO_TEST_CASE(load_data_fail) {
-    navitia::type::Data data(0);
-
-    // load .nav
-    bool failed = false;
-    try {
-        data.load_nav("wrong_path");
-    } catch(const navitia::data::data_loading_error& ex) {
-        failed = true;
-    }
-    BOOST_CHECK_EQUAL(failed, true);
+    BOOST_CHECK_EQUAL(data.last_load_succeeded, true);
 }
 
 BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
@@ -106,7 +89,7 @@ BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
     bool failed = false;
     try {
         data.load_disruptions(fake_disruption_path);
-    } catch(const navitia::data::disruptions_broken_connection& ex) {
+    } catch(const navitia::data::disruptions_broken_connection&) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, true);

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -37,8 +37,8 @@ www.navitia.io
 
 // Std
 #include <string>
-#include <stdio.h>
-#include <unistd.h>  // getcwd() definition
+
+#include "utils/functions.h" // absolute_path function
 
 // Data to test
 #include "type/data.h"
@@ -48,24 +48,13 @@ using namespace navitia;
 static const std::string fake_data_file = "fake_data.nav.lz4";
 static const std::string fake_disruption_path = "fake_disruption_path";
 
-// Absolute path
-static std::string complete_path(const std::string file_name){
-    char buf[256];
-    if (getcwd(buf, sizeof(buf))) {
-        return std::string(buf) + "/" + file_name;
-    } else {
-        std::perror("getcwd");
-        return "";
-    }
-}
-
 BOOST_AUTO_TEST_CASE(load_data) {
 
     navitia::type::Data data(0);
     data.save(fake_data_file);
 
     // load .nav
-    std::string fake_data_path = complete_path(fake_data_file);
+    std::string fake_data_path =  navitia::absolute_path() + fake_data_file;
     bool failed = false;
     BOOST_CHECK_EQUAL(data.last_load_succeeded, false);
     try {

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -38,7 +38,7 @@ www.navitia.io
 // Std
 #include <string>
 #include <fstream>
-#include <clocale>
+#include <cstdlib>
 
 // Data to test
 #include "type/data.h"
@@ -54,7 +54,7 @@ static const std::string fake_disruption_path = "fake_disruption_path";
 // [Exception] - std::runtime_error: locale::facet::_S_create_c_locale name not valid
 // sources : https://stackoverflow.com/questions/19405272/c-issues-with-boostfilesystem-on-server-localefacet-s-create-c-locale
 #define CREATE_FAKE_DATA(fake_file_name) \
-    std::setlocale(LC_ALL, "C");         \
+    setenv("LC_ALL", "C", 1);            \
     navitia::type::Data data(0);         \
     data.save(fake_data_file);           \
 

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -58,8 +58,10 @@ BOOST_AUTO_TEST_CASE(load_data) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
-                                + "/" + fake_data_file);
+    bool check_load = data.load(system_complete("fake_data.nav.lz4").string());
+    std::cout << "path : " << system_complete("fake_data.nav.lz4").string() << std::endl;
+    //bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
+    //                            + "/" + fake_data_file);
     BOOST_CHECK_EQUAL(check_load, true);
 }
 
@@ -74,8 +76,10 @@ BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
-                                + "/" + fake_data_file, fake_disruption_path);
+    //bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
+    //                            + "/" + fake_data_file, fake_disruption_path);
+    bool check_load = data.load(system_complete("fake_data.nav.lz4").string(),
+                                                fake_disruption_path);
     BOOST_CHECK_EQUAL(data.disruption_error, true);
     BOOST_CHECK_EQUAL(check_load, true);
 }
@@ -85,8 +89,9 @@ BOOST_AUTO_TEST_CASE(load_without_disruptions) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    bool check_load = data.load_without_disruptions(boost::filesystem::absolute(current_path()).string() \
-                                                    + "/" + fake_data_file);
+    bool check_load = data.load(system_complete("fake_data.nav.lz4").string());
+    //bool check_load = data.load_without_disruptions(boost::filesystem::absolute(current_path()).string() \
+    //                                                + "/" + fake_data_file);
     BOOST_CHECK_EQUAL(data.disruption_error, false);
     BOOST_CHECK_EQUAL(check_load, true);
 }

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -72,14 +72,14 @@ BOOST_AUTO_TEST_CASE(load_data) {
     BOOST_CHECK_EQUAL(data.last_load, false);
     try {
         data.load_nav(complete_path(fake_data_file));
-    } catch(const navitia::type::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error& ex) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, false);
     BOOST_CHECK_EQUAL(data.last_load, true);
     try {
         data.load_nav("wrong_path");
-    } catch(const navitia::type::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error& ex) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, true);
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(load_data_fail) {
     bool failed = false;
     try {
         data.load_nav("wrong_path");
-    } catch(const navitia::type::data_loading_error& ex) {
+    } catch(const navitia::data::data_loading_error& ex) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, true);
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
     bool failed = false;
     try {
         data.load_disruptions(fake_disruption_path);
-    } catch(const navitia::type::disruptions_broken_connection& ex) {
+    } catch(const navitia::data::disruptions_broken_connection& ex) {
         failed = true;
     }
     BOOST_CHECK_EQUAL(failed, true);

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 
 // Boost
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 
 // Std
 #include <string>
@@ -64,10 +65,11 @@ BOOST_AUTO_TEST_CASE(load_data) {
     data.save(fake_data_file);
 
     // load .nav
+    std::string fake_data_path = complete_path(fake_data_file);
     bool failed = false;
     BOOST_CHECK_EQUAL(data.last_load_succeeded, false);
     try {
-        data.load_nav(complete_path(fake_data_file));
+        data.load_nav(fake_data_path);
     } catch(const navitia::data::data_loading_error&) {
         failed = true;
     }
@@ -80,6 +82,9 @@ BOOST_AUTO_TEST_CASE(load_data) {
     }
     BOOST_CHECK_EQUAL(failed, true);
     BOOST_CHECK_EQUAL(data.last_load_succeeded, true);
+
+    // Clean fake file
+    boost::filesystem::remove(fake_data_path);
 }
 
 BOOST_AUTO_TEST_CASE(load_disruptions_fail) {

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -1,0 +1,80 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE data_test
+
+// Boost
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+
+// Std
+#include <string>
+#include <fstream>
+
+// Data to test
+#include "type/data.h"
+
+using namespace navitia;
+using namespace boost::filesystem;
+
+static const std::string fake_data_file = "fake_data.nav.lz4";
+static const std::string fake_disruption_path = "fake_disruption_path";
+
+BOOST_AUTO_TEST_CASE(load_data) {
+  navitia::type::Data data(0);
+
+  // We create a empty data with lz4 format
+  data.save(fake_data_file);
+
+  // Load fake data
+  bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
+  														+ "/" + fake_data_file);
+  BOOST_CHECK_EQUAL(check_load, true);
+}
+
+BOOST_AUTO_TEST_CASE(load_data_fail) {
+  navitia::type::Data data(0);
+  bool check_load = data.load("wrong_path");
+  BOOST_CHECK_EQUAL(check_load, false);
+}
+
+BOOST_AUTO_TEST_CASE(load_disruption_fail) {
+  navitia::type::Data data(0);
+
+  // We create a empty data with lz4 format
+  data.save(fake_data_file);
+
+  // Load fake data
+  bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
+  														+ "/" + fake_data_file, fake_disruption_path);
+  BOOST_CHECK_EQUAL(data.disruption_is_loaded, false);
+  BOOST_CHECK_EQUAL(check_load, true);
+}

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(load_data) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
+    bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
                                 + "/" + fake_data_file);
     BOOST_CHECK_EQUAL(check_load, true);
 }
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
+    bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
                                 + "/" + fake_data_file, fake_disruption_path);
     BOOST_CHECK_EQUAL(data.disruption_error, true);
     BOOST_CHECK_EQUAL(check_load, true);
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(load_without_disruptions) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    bool check_load = data.load_without_disruptions(boost::filesystem::canonical(current_path()).string() \
+    bool check_load = data.load_without_disruptions(boost::filesystem::absolute(current_path()).string() \
                                                     + "/" + fake_data_file);
     BOOST_CHECK_EQUAL(data.disruption_error, false);
     BOOST_CHECK_EQUAL(check_load, true);

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -48,33 +48,45 @@ using namespace boost::filesystem;
 static const std::string fake_data_file = "fake_data.nav.lz4";
 static const std::string fake_disruption_path = "fake_disruption_path";
 
+// We create a empty data with lz4 format in current directory
+#define CREATE_FAKE_DATA(fake_file_name) \
+    navitia::type::Data data(0);         \
+    data.save(fake_data_file);           \
+
 BOOST_AUTO_TEST_CASE(load_data) {
-  navitia::type::Data data(0);
 
-  // We create a empty data with lz4 format
-  data.save(fake_data_file);
+    CREATE_FAKE_DATA(fake_data_file)
 
-  // Load fake data
-  bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
-  														+ "/" + fake_data_file);
-  BOOST_CHECK_EQUAL(check_load, true);
+    // Load fake data
+    bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
+                                + "/" + fake_data_file);
+    BOOST_CHECK_EQUAL(check_load, true);
 }
 
 BOOST_AUTO_TEST_CASE(load_data_fail) {
-  navitia::type::Data data(0);
-  bool check_load = data.load("wrong_path");
-  BOOST_CHECK_EQUAL(check_load, false);
+    navitia::type::Data data(0);
+    bool check_load = data.load("wrong_path");
+    BOOST_CHECK_EQUAL(check_load, false);
 }
 
-BOOST_AUTO_TEST_CASE(load_disruption_fail) {
-  navitia::type::Data data(0);
+BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
 
-  // We create a empty data with lz4 format
-  data.save(fake_data_file);
+    CREATE_FAKE_DATA(fake_data_file)
 
-  // Load fake data
-  bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
-  														+ "/" + fake_data_file, fake_disruption_path);
-  BOOST_CHECK_EQUAL(data.disruption_error, true);
-  BOOST_CHECK_EQUAL(check_load, true);
+    // Load fake data
+    bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
+                                + "/" + fake_data_file, fake_disruption_path);
+    BOOST_CHECK_EQUAL(data.disruption_error, true);
+    BOOST_CHECK_EQUAL(check_load, true);
+}
+
+BOOST_AUTO_TEST_CASE(load_without_disruptions) {
+
+    CREATE_FAKE_DATA(fake_data_file)
+
+    // Load fake data
+    bool check_load = data.load_without_disruptions(boost::filesystem::canonical(current_path()).string() \
+                                                    + "/" + fake_data_file);
+    BOOST_CHECK_EQUAL(data.disruption_error, false);
+    BOOST_CHECK_EQUAL(check_load, true);
 }

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -38,6 +38,7 @@ www.navitia.io
 // Std
 #include <string>
 #include <fstream>
+#include <clocale>
 
 // Data to test
 #include "type/data.h"
@@ -50,6 +51,10 @@ static const std::string fake_disruption_path = "fake_disruption_path";
 
 // We create a empty data with lz4 format in current directory
 #define CREATE_FAKE_DATA(fake_file_name) \
+    // We have to set LC_ALL=C because you can fall on :
+    // [Exception] - std::runtime_error: locale::facet::_S_create_c_locale name not valid
+    // sources : https://stackoverflow.com/questions/19405272/c-issues-with-boostfilesystem-on-server-localefacet-s-create-c-locale
+    std::setlocale(LC_ALL, "C");         \
     navitia::type::Data data(0);         \
     data.save(fake_data_file);           \
 
@@ -59,9 +64,7 @@ BOOST_AUTO_TEST_CASE(load_data) {
 
     // Load fake data
     bool check_load = data.load(system_complete("fake_data.nav.lz4").string());
-    std::cout << "path : " << system_complete("fake_data.nav.lz4").string() << std::endl;
-    //bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
-    //                            + "/" + fake_data_file);
+
     BOOST_CHECK_EQUAL(check_load, true);
 }
 
@@ -76,8 +79,6 @@ BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
     CREATE_FAKE_DATA(fake_data_file)
 
     // Load fake data
-    //bool check_load = data.load(boost::filesystem::absolute(current_path()).string() \
-    //                            + "/" + fake_data_file, fake_disruption_path);
     bool check_load = data.load(system_complete("fake_data.nav.lz4").string(),
                                                 fake_disruption_path);
     BOOST_CHECK_EQUAL(data.disruption_error, true);
@@ -90,8 +91,7 @@ BOOST_AUTO_TEST_CASE(load_without_disruptions) {
 
     // Load fake data
     bool check_load = data.load(system_complete("fake_data.nav.lz4").string());
-    //bool check_load = data.load_without_disruptions(boost::filesystem::absolute(current_path()).string() \
-    //                                                + "/" + fake_data_file);
+
     BOOST_CHECK_EQUAL(data.disruption_error, false);
     BOOST_CHECK_EQUAL(check_load, true);
 }

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -75,6 +75,6 @@ BOOST_AUTO_TEST_CASE(load_disruption_fail) {
   // Load fake data
   bool check_load = data.load(boost::filesystem::canonical(current_path()).string() \
   														+ "/" + fake_data_file, fake_disruption_path);
-  BOOST_CHECK_EQUAL(data.disruption_is_loaded, false);
+  BOOST_CHECK_EQUAL(data.disruption_error, true);
   BOOST_CHECK_EQUAL(check_load, true);
 }

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -52,6 +52,7 @@ static const std::string fake_disruption_path = "fake_disruption_path";
 // We create a empty data with lz4 format in current directory.
 // We have to set LC_ALL=C because we can fall on :
 // [Exception] - std::runtime_error: locale::facet::_S_create_c_locale name not valid
+// When you create a absolute path, boost < 1.56 failed. 
 // sources : https://stackoverflow.com/questions/19405272/c-issues-with-boostfilesystem-on-server-localefacet-s-create-c-locale
 #define CREATE_FAKE_DATA(fake_file_name) \
     setenv("LC_ALL", "C", 1);            \

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -67,37 +67,47 @@ BOOST_AUTO_TEST_CASE(load_data) {
 
     CREATE_FAKE_DATA(fake_data_file)
 
-    // Load fake data
-    bool check_load = data.load(complete_path(fake_data_file));
-
-    BOOST_CHECK_EQUAL(check_load, true);
+    // load .nav
+    bool failed = false;
+    BOOST_CHECK_EQUAL(data.last_load, false);
+    try {
+        data.load_nav(complete_path(fake_data_file));
+    } catch(const navitia::type::data_loading_error& ex) {
+        failed = true;
+    }
+    BOOST_CHECK_EQUAL(failed, false);
+    BOOST_CHECK_EQUAL(data.last_load, true);
+    try {
+        data.load_nav("wrong_path");
+    } catch(const navitia::type::data_loading_error& ex) {
+        failed = true;
+    }
+    BOOST_CHECK_EQUAL(failed, true);
+    BOOST_CHECK_EQUAL(data.last_load, true);
 }
 
 BOOST_AUTO_TEST_CASE(load_data_fail) {
     navitia::type::Data data(0);
-    bool check_load = data.load("wrong_path");
-    BOOST_CHECK_EQUAL(check_load, false);
+
+    // load .nav
+    bool failed = false;
+    try {
+        data.load_nav("wrong_path");
+    } catch(const navitia::type::data_loading_error& ex) {
+        failed = true;
+    }
+    BOOST_CHECK_EQUAL(failed, true);
 }
 
 BOOST_AUTO_TEST_CASE(load_disruptions_fail) {
+    navitia::type::Data data(0);
 
-    CREATE_FAKE_DATA(fake_data_file)
-
-    // Load fake data
-    bool check_load = data.load(complete_path(fake_data_file),
-                                fake_disruption_path);
-
-    BOOST_CHECK_EQUAL(data.disruption_error, true);
-    BOOST_CHECK_EQUAL(check_load, true);
-}
-
-BOOST_AUTO_TEST_CASE(load_without_disruptions) {
-
-    CREATE_FAKE_DATA(fake_data_file)
-
-    // Load fake data
-    bool check_load = data.load(complete_path(fake_data_file));
-
-    BOOST_CHECK_EQUAL(data.disruption_error, false);
-    BOOST_CHECK_EQUAL(check_load, true);
+    // load disruptions
+    bool failed = false;
+    try {
+        data.load_disruptions(fake_disruption_path);
+    } catch(const navitia::type::disruptions_broken_connection& ex) {
+        failed = true;
+    }
+    BOOST_CHECK_EQUAL(failed, true);
 }

--- a/source/type/tests/data_test.cpp
+++ b/source/type/tests/data_test.cpp
@@ -49,11 +49,11 @@ using namespace boost::filesystem;
 static const std::string fake_data_file = "fake_data.nav.lz4";
 static const std::string fake_disruption_path = "fake_disruption_path";
 
-// We create a empty data with lz4 format in current directory
+// We create a empty data with lz4 format in current directory.
+// We have to set LC_ALL=C because we can fall on :
+// [Exception] - std::runtime_error: locale::facet::_S_create_c_locale name not valid
+// sources : https://stackoverflow.com/questions/19405272/c-issues-with-boostfilesystem-on-server-localefacet-s-create-c-locale
 #define CREATE_FAKE_DATA(fake_file_name) \
-    // We have to set LC_ALL=C because you can fall on :
-    // [Exception] - std::runtime_error: locale::facet::_S_create_c_locale name not valid
-    // sources : https://stackoverflow.com/questions/19405272/c-issues-with-boostfilesystem-on-server-localefacet-s-create-c-locale
     std::setlocale(LC_ALL, "C");         \
     navitia::type::Data data(0);         \
     data.save(fake_data_file);           \


### PR DESCRIPTION
The loading stops no longer when disruption is not loaded.

TODO:
- [ ]  wait for the beginning of a sprint for merge, to let it live... and maybe crash.