### PR TITLE
autocomplete: bug on longest common substring

### DIFF
--- a/source/autocomplete/autocomplete.h
+++ b/source/autocomplete/autocomplete.h
@@ -331,7 +331,7 @@ struct Autocomplete
         auto global_score = word_quality_list.at(position).score;
 
         const auto& indexed_str = indexed_string.at(position);
-        auto lcs_and_pos = longest_common_substring(str, indexed_str);
+        auto lcs_and_pos = longest_common_substring(strip_accents_and_lower(str), indexed_str);
 
         return std::make_tuple(
             global_score,

--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -1941,3 +1941,54 @@ BOOST_AUTO_TEST_CASE(longuest_substring_test_2) {
     BOOST_CHECK_EQUAL(res.first, std::string("ligne").size());
     BOOST_CHECK_EQUAL(res.second, 10); // position of the end of 'ligne' in str2
 }
+
+// The second scores should be of the length of the string
+// Check that there is no extra space and case is not taken into account
+BOOST_AUTO_TEST_CASE(autocomplete_test_stop_area_longest_substring) {
+    std::vector<std::string> admins;
+    std::vector<navitia::type::Type_e> type_filter;
+    ed::builder b("20180201");
+    b.sa("Jean Jaurès", 0, 0);
+
+    b.data->pt_data->index();
+    Admin* ad = new Admin;
+    ad->name = "Toulouse";
+    ad->uri = "admin:fr:31555";
+    ad->level = 8;
+    ad->postal_codes.push_back("31000");
+    ad->idx = 0;
+    b.data->geo_ref->admins.push_back(ad);
+    b.manage_admin();
+    b.build_autocomplete();
+
+    type_filter.push_back(navitia::type::Type_e::StopArea);
+    auto * data_ptr = b.data.get();
+
+    std::string search("Jean Jaurès Toulouse");
+    std::string search_low = data_ptr->pt_data->stop_area_autocomplete.strip_accents_and_lower(search);
+
+    // No accents, one less byte
+    BOOST_REQUIRE_EQUAL(search.size(), search_low.size() + 1);
+
+    {
+        navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+        navitia::autocomplete::autocomplete(pb_creator, search, type_filter , 1, 5, admins, 0, *(b.data));
+        pbnavitia::Response resp = pb_creator.get_response();
+
+        BOOST_REQUIRE_EQUAL(resp.places_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.places(0).scores_size(), 3);
+        // The search is done on the lower case without accent string so the results are on this length
+        BOOST_REQUIRE_EQUAL(resp.places(0).scores(1), search_low.size());
+        BOOST_REQUIRE_EQUAL(resp.places(0).scores(2), (search_low.size() - 1) * - 1);
+    }
+    {
+        navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+        navitia::autocomplete::autocomplete(pb_creator, search_low, type_filter , 1, 5, admins, 0, *(b.data));
+        pbnavitia::Response resp = pb_creator.get_response();
+
+        BOOST_REQUIRE_EQUAL(resp.places_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.places(0).scores_size(), 3);
+        BOOST_REQUIRE_EQUAL(resp.places(0).scores(1), search_low.size());
+        BOOST_REQUIRE_EQUAL(resp.places(0).scores(2), (search_low.size() - 1) * - 1);
+    }
+}

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -73,7 +73,7 @@ void PT_Data::build_autocomplete(const navitia::georef::GeoRef & georef){
             for( navitia::georef::Admin* admin : sa->admin_list){
                 if (admin->level ==8){key +=" " + admin->name;}
             }
-            this->stop_area_autocomplete.add_string(sa->name + " " + key, sa->idx, georef.ghostwords, georef.synonyms);
+            this->stop_area_autocomplete.add_string(sa->name + key, sa->idx, georef.ghostwords, georef.synonyms);
         }
     }
     this->stop_area_autocomplete.build();


### PR DESCRIPTION
Hello.

A small thing I came across while playing with places.
When I was inputing "Jean Jaurès Toulouse", which is the exact name of one of our main stop_area I had a bad longest common substring (I looked at scores in the pbf).
This was caused by two things:
- When building the stop_area autocomplete an extra space was added. I had a better lcs when inputing "Jean Jaurès  Toulouse" (2 spaces) because of this,
- The lcs was comparing the raw input to the indexed string which is the name of the stop_area in lowercase without any accents. I transform the raw input with the same method before getting the lcs now.