### PR TITLE
kraken: ignore envvar not defined for kraken

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -94,6 +94,14 @@ static std::string env_parser(std::string env){
     }
     boost::algorithm::replace_first(env, "KRAKEN_", "");
     boost::algorithm::replace_first(env, "_", ".");
+    if(!boost::algorithm::starts_with(env, "GENERAL")
+            && !boost::algorithm::starts_with(env, "BROKER")
+            && !boost::algorithm::starts_with(env, "CHAOS")){
+        //it doesn't look like one of our var, we ignore it
+        //docker and kubernetes define a lot of env var starting by kraken when deploying kraken
+        //and boost po will abort startup if unknown var are present
+        return "";
+    }
     return env;
 }
 


### PR DESCRIPTION
Kubernetes defines a lot of environment variables for each service.
For example if a service "kraken-default" exist the following envvar (it may not be the exact naming, but you get the idea) will exist inside each pod:
  - KRAKEN_DEFAULT_SERVICE_PORT
  - KRAKEN_DEFAULT_SERVICE_HOST
  - and a few others like that

Obviously these variables aren't used by kraken, but boost program options will consider it as an error if they are present.
We still have to not define service named "kraken-general", "kraken-broker" or "kraken-chaos", but it seems pretty unlikely that we will do that.