### PR TITLE
Alembic : add missing dependency - psycopg2_2.7.4

### DIFF
--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -5,4 +5,4 @@ MarkupSafe==0.18
 SQLAlchemy==1.0.4
 Shapely==1.3.0
 alembic==0.6.2
-psycopg2==2.7.4
+psycopg2

--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -5,3 +5,4 @@ MarkupSafe==0.18
 SQLAlchemy==1.0.4
 Shapely==1.3.0
 alembic==0.6.2
+psycopg2==2.7.4


### PR DESCRIPTION
Add missing dependency to psycorpg2 used by alembic when creating Postgres scheme.