### PR TITLE
kraken: Exclude way without edge from the autocomplete

### DIFF
--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -739,21 +739,11 @@ BOOST_AUTO_TEST_CASE(autocomplete_functional_test_admin_SA_and_Address_test) {
     b.sa("Napoleon III", 0, 0);
     b.sa("MPT kerfeunteun", 0, 0);
     b.data->pt_data->index();
-    Way* w = new Way;
-    w->idx = 0;
-    w->name = "rue DU TREGOR";
-    w->uri = w->name;
-    b.data->geo_ref->ways.push_back(w);
-    w = new navitia::georef::Way;
-    w->name = "rue VIS";
-    w->uri = w->name;
-    w->idx = 1;
-    b.data->geo_ref->ways.push_back(w);
-    w = new navitia::georef::Way;
-    w->idx = 2;
-    w->name = "quai NEUF";
-    w->uri = w->name;
-    b.data->geo_ref->ways.push_back(w);
+
+
+    b.add_way("rue DU TREGOR", "");
+    b.add_way("rue VIS", "");
+    b.add_way("quai NEUF", "");
 
     Admin* ad = new Admin;
     ad->name = "Quimper";
@@ -1347,12 +1337,8 @@ BOOST_AUTO_TEST_CASE(autocomplete_with_multi_postal_codes_testAA) {
     ad->idx = 0;
     b.data->geo_ref->admins.push_back(ad);
 
-    navitia::georef::Way* w = new navitia::georef::Way();
-    w->idx = 0;
-    w->name = "Sante";
-    w->uri = w->name;
+    auto w = b.add_way("Sante", "");
     w->admin_list.push_back(ad);
-    b.data->geo_ref->ways.push_back(w);
 
     ad = new Admin();
     ad->name = "Tours";
@@ -1364,12 +1350,8 @@ BOOST_AUTO_TEST_CASE(autocomplete_with_multi_postal_codes_testAA) {
     ad->idx = 1;
     b.data->geo_ref->admins.push_back(ad);
 
-    w = new navitia::georef::Way();
-    w->idx = 1;
-    w->name = "Sante";
-    w->uri = w->name;
+    w = b.add_way("Sante", "");
     w->admin_list.push_back(ad);
-    b.data->geo_ref->ways.push_back(w);
 
     b.build_autocomplete();
     type_filter.push_back(navitia::type::Type_e::Address);
@@ -1459,7 +1441,7 @@ BOOST_AUTO_TEST_CASE(autocomplete_with_ghostword_test) {
     std::vector<navitia::type::Type_e> type_filter;
     ed::builder b("20140614");
     autocomplete_map synonyms;
-     std::set<std::string> ghostwords;
+    std::set<std::string> ghostwords;
 
     synonyms["cc"]="centre commercial";
     synonyms["hotel de ville"]="mairie";
@@ -1500,19 +1482,11 @@ BOOST_AUTO_TEST_CASE(autocomplete_with_ghostword_test) {
     ad->idx = 0;
     b.data->geo_ref->admins.push_back(ad);
 
-    navitia::georef::Way* w = new navitia::georef::Way();
-    w->idx = 0;
-    w->name = "place de la Gare";
-    w->uri = w->name;
+    auto w = b.add_way("place de la Gare", "");
     w->admin_list.push_back(ad);
-    b.data->geo_ref->ways.push_back(w);
 
-    w = new navitia::georef::Way();
-    w->idx = 1;
-    w->name = "rue de la Garenne";
-    w->uri = w->name;
+    w = b.add_way("rue de la Garenne", "");
     w->admin_list.push_back(ad);
-    b.data->geo_ref->ways.push_back(w);
 
     //Create a new StopArea
     navitia::type::StopArea* sa = new navitia::type::StopArea();

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -820,4 +820,33 @@ void builder::finish() {
     data->build_autocomplete();
     data->compute_labels();
 }
+
+static navitia::georef::vertex_t init_vertex(navitia::georef::GeoRef& georef){
+    navitia::georef::Vertex v;
+    v.coord.set_lon(0);
+    v.coord.set_lat(0);
+    return boost::add_vertex(v, georef.graph);
+}
+
+navitia::georef::Way* builder::add_way(const std::string& name, const std::string& way_type){
+    if (vertex_a == boost::none) {
+        vertex_a = init_vertex(*this->data->geo_ref);
+    }
+    if (vertex_b == boost::none) {
+        vertex_b = init_vertex(*this->data->geo_ref);
+    }
+    navitia::georef::Way* w = new navitia::georef::Way;
+    w->idx = this->data->geo_ref->ways.size();
+    w->name = name;
+    w->way_type = way_type;
+    w->uri = name;
+    navitia::georef::Edge e;
+    e.way_idx = w->idx;
+    boost::add_edge(*this->vertex_a, *this->vertex_b, e, this->data->geo_ref->graph);
+    w->edges.push_back(std::make_pair(*this->vertex_a, *this->vertex_b));
+    this->data->geo_ref->ways.push_back(w);
+    return w;
+
+}
+
 }

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -840,6 +840,7 @@ navitia::georef::Way* builder::add_way(const std::string& name, const std::strin
     w->name = name;
     w->way_type = way_type;
     w->uri = name;
+    //associate the way to an edge to make them "searchable" in the autocomplete
     navitia::georef::Edge e;
     e.way_idx = w->idx;
     boost::add_edge(*this->vertex_a, *this->vertex_b, e, this->data->geo_ref->graph);

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -226,6 +226,7 @@ struct builder {
     std::unique_ptr<navitia::type::Data> data = std::make_unique<navitia::type::Data>();
     navitia::georef::GeoRef street_network;
 
+    //lazy init of vertexes used when creating ways with add_way
     boost::optional<navitia::georef::vertex_t> vertex_a;
     boost::optional<navitia::georef::vertex_t> vertex_b;
 

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -38,6 +38,8 @@ www.navitia.io
 #include "type/message.h"
 #include "type/rt_level.h"
 #include <memory>
+#include <boost/optional.hpp>
+
 
 /** Ce connecteur permet de faciliter la construction d'un réseau en code
  *
@@ -224,6 +226,9 @@ struct builder {
     std::unique_ptr<navitia::type::Data> data = std::make_unique<navitia::type::Data>();
     navitia::georef::GeoRef street_network;
 
+    boost::optional<navitia::georef::vertex_t> vertex_a;
+    boost::optional<navitia::georef::vertex_t> vertex_b;
+
     /// 'date' is the beggining date of all the validity patterns
     builder(const std::string & date,
             const std::string& publisher_name = "canal tp",
@@ -302,6 +307,8 @@ struct builder {
     void manage_admin();
     void build_autocomplete();
     void fill_missing_destinations();
+
+    navitia::georef::Way* add_way(const std::string& name, const std::string& way_type);
 };
 
 }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -407,6 +407,7 @@ void GeoRef::build_autocomplete_list(){
     for (Way* way: ways) {
         ++pos;
         if (way->name.empty()) { continue; }
+        //skip way without edges as we don't kwow where they are (no coordinate)
         if (way->edges.empty()) { continue; }
         if (auto admin = find_city_admin(way->admin_list)) {
             // @TODO:

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -407,6 +407,7 @@ void GeoRef::build_autocomplete_list(){
     for (Way* way: ways) {
         ++pos;
         if (way->name.empty()) { continue; }
+        if (way->edges.empty()) { continue; }
         if (auto admin = find_city_admin(way->admin_list)) {
             // @TODO:
             // For each object admin we have one element in the dictionnary of admins.

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -1033,6 +1033,8 @@ BOOST_AUTO_TEST_CASE(coord){
     BOOST_CHECK_EQUAL(result, -1);
 
 }
+
+
 // Test de autocomplete
 BOOST_AUTO_TEST_CASE(build_autocomplete_test){
     ed::builder b = {"20140614"};
@@ -1041,48 +1043,19 @@ BOOST_AUTO_TEST_CASE(build_autocomplete_test){
     int nbmax = 10;
     std::set<std::string> ghostwords;
 
-    auto* way = new navitia::georef::Way;
-    way->idx = 0;
-    way->name = "jeanne d'arc";
-    way->way_type = "rue";
-    b.data->geo_ref->ways.push_back(way);
-
-    way = new navitia::georef::Way;
-    way->idx = 1;
-    way->name = "jean jaures";
-    way->way_type = "place";
-    b.data->geo_ref->ways.push_back(way);
-
-    way = new navitia::georef::Way;
-    way->idx = 2;
-    way->name = "jean paul gaultier paris";
-    way->way_type = "rue";
-    b.data->geo_ref->ways.push_back(way);
-
-    way = new navitia::georef::Way;
-    way->idx = 3;
-    way->name = "jean jaures";
-    way->way_type = "avenue";
-    b.data->geo_ref->ways.push_back(way);
-
-    way = new navitia::georef::Way;
-    way->idx = 4;
-    way->name = "poniatowski";
-    way->way_type = "boulevard";
-    b.data->geo_ref->ways.push_back(way);
-
-    way = new navitia::georef::Way;
-    way->idx = 5;
-    way->name = "pente de Bray";
-    way->way_type = "";
-    b.data->geo_ref->ways.push_back(way);
+    b.add_way("jeanne d'arc", "rue");
+    b.add_way("jean jaures", "place");
+    b.add_way("jean paul gaultier paris", "rue");
+    b.add_way("jean jaures", "avenue");
+    b.add_way("poniatowski", "boulevard");
+    b.add_way("pente de Bray", "");
 
     /*
    (2,4)       (2,4)       (2,18)       (2,54)
      4           4           18           54
    */
 
-    way = new navitia::georef::Way;
+    auto way = new navitia::georef::Way;
     way->idx = 6;
     way->name = "jean jaures";
     way->way_type = "rue";


### PR DESCRIPTION
We may have some Way that don't have any edges because we removed small unconnected connexes component.
When we return such way their coordinates are (0,0) and they don't have id