### PR TITLE
tyr: create a new job to manage data injection towards mimir

### DIFF
--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -374,7 +374,7 @@ class Instance(db.Model):
         return the n last dataset of each family type loaded for this instance
         """
         query = db.session.query(func.distinct(DataSet.family_type)) \
-            .filter(Instance.id == self.id)
+            .filter(Instance.id == self.id, DataSet.family_type != 'mimir')
         if family_type:
             query = query.filter(DataSet.family_type == family_type)
 

--- a/source/tyr/tests/integration/dataset_test.py
+++ b/source/tyr/tests/integration/dataset_test.py
@@ -36,7 +36,6 @@ def create_basic_job_with_data_sets():
         models.db.session.commit()
 
 
-#@pytest.fixture
 def add_job_with_data_set_mimir(create_basic_job_with_data_sets):
     with app.app_context():
         # we also create 1 job with a dataset for mimir

--- a/source/tyr/tests/integration/dataset_test.py
+++ b/source/tyr/tests/integration/dataset_test.py
@@ -1,0 +1,132 @@
+from __future__ import absolute_import, print_function, unicode_literals, division
+from tests.check_utils import api_get
+import pytest
+from navitiacommon import models
+from tyr import app
+
+@pytest.fixture
+def create_basic_job_with_data_sets():
+    with app.app_context():
+        instance = models.Instance('fr')
+        models.db.session.add(instance)
+        models.db.session.commit()
+
+        job = models.Job()
+        job.instance = instance
+
+        # we also create 2 datasets, one for fusio, one for synonym
+        for i, dset_type in enumerate(['fusio', 'synonym']):
+            dataset = models.DataSet()
+            dataset.type = dset_type
+            dataset.family_type = dataset.type
+            if dataset.type == 'fusio':
+                dataset.family_type = 'pt'
+            dataset.name = '/path/to/dataset_{}'.format(i)
+            models.db.session.add(dataset)
+
+            job.data_sets.append(dataset)
+
+        job.state = 'done'
+        models.db.session.add(job)
+        models.db.session.commit()
+
+
+@pytest.fixture
+def create_jobs_with_three_data_sets():
+    with app.app_context():
+        instance = models.Instance('fr')
+        models.db.session.add(instance)
+        models.db.session.commit()
+
+        job = models.Job()
+        job.instance = instance
+
+        # we also create 2 datasets, one for fusio, one for synonym
+        for i, dset_type in enumerate(['fusio', 'synonym']):
+            dataset = models.DataSet()
+            dataset.type = dset_type
+            dataset.family_type = dataset.type
+            if dataset.type == 'fusio':
+                dataset.family_type = 'pt'
+            dataset.name = '/path/to/dataset_{}'.format(i)
+            models.db.session.add(dataset)
+            job.data_sets.append(dataset)
+        job.state = 'done'
+        models.db.session.add(job)
+        models.db.session.commit()
+
+        # we also create 1 job with a dataset for mimir
+        job = models.Job()
+        job.instance = instance
+        dataset = models.DataSet()
+        dataset.family_type = 'mimir'
+        dataset.type = 'stop2mimir'
+        dataset.name = '/path/to/dataset_3'
+        models.db.session.add(dataset)
+        job.data_sets.append(dataset)
+
+        job.state = 'done'
+        models.db.session.add(job)
+
+        models.db.session.commit()
+
+
+def test_basic_datasets(create_basic_job_with_data_sets):
+    """
+    we query the loaded datasets of fr
+    we loaded 2 datasets, one for pt, one for synonym
+    """
+    resp = api_get('/v0/instances/fr/last_datasets')
+
+    assert len(resp) == 2
+    fusio = next((d for d in resp if d['type'] == 'fusio'), None)
+    assert fusio
+    assert fusio['family_type'] == 'pt'
+    assert fusio['name'] == '/path/to/dataset_0'
+
+    synonym = next((d for d in resp if d['type'] == 'synonym'), None)
+    assert synonym
+    assert synonym['family_type'] == 'synonym'
+    assert synonym['name'] == '/path/to/dataset_1'
+
+    #There is only one job
+    resp = api_get('/v0/jobs/fr')
+    assert len(resp['jobs']) == 1
+
+
+def test_datasets_with_mimir(create_jobs_with_three_data_sets):
+
+    """
+    we query the loaded datasets of fr
+    we loaded 3 datasets, 1 in a job with two data_sets (pt and synonym)
+    another job with a data_set having family_type 'mimir'
+    In last_datasets we return a data_set per family_type except 'mimir'.
+    """
+    resp = api_get('/v0/instances/fr/last_datasets')
+
+    assert len(resp) == 2
+    fusio = next((d for d in resp if d['type'] == 'fusio'), None)
+    assert fusio
+    assert fusio['family_type'] == 'pt'
+    assert fusio['name'] == '/path/to/dataset_0'
+
+    synonym = next((d for d in resp if d['type'] == 'synonym'), None)
+    assert synonym
+    assert synonym['family_type'] == 'synonym'
+    assert synonym['name'] == '/path/to/dataset_1'
+
+    #we have two jobs: one with 1 data_set and another with 2 data_sets
+    resp = api_get('/v0/jobs/fr')
+    assert len(resp['jobs']) == 2
+    job_with_pt = resp['jobs'][1]['data_sets']
+    assert job_with_pt[0]['family_type'] == 'pt'
+    assert job_with_pt[0]['name'] == '/path/to/dataset_0'
+    assert job_with_pt[0]['type'] == 'fusio'
+    assert job_with_pt[1]['family_type'] == 'synonym'
+    assert job_with_pt[1]['name'] == '/path/to/dataset_1'
+    assert job_with_pt[1]['type'] == 'synonym'
+
+    job_with_mimir = resp['jobs'][0]['data_sets']
+    assert job_with_mimir[0]['family_type'] == 'mimir'
+    assert job_with_mimir[0]['name'] == '/path/to/dataset_3'
+    assert job_with_mimir[0]['type'] == 'stop2mimir'

--- a/source/tyr/tests/integration/dataset_test.py
+++ b/source/tyr/tests/integration/dataset_test.py
@@ -9,6 +9,7 @@ def get_instance_from_db(name=None):
     with app.app_context():
         return models.Instance.get_by_name(name=name)
 
+
 @pytest.fixture
 def create_basic_job_with_data_sets():
     with app.app_context():

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -606,6 +606,8 @@ def stops2mimir(self, instance_config, input, job_id=None, dataset_uid=None):
             # stops2mimir have to be non-blocking.
             # @TODO : Find a way to raise error without breaking celery tasks chain
             logger.error('stops2mimir failed')
+            if job_id:
+                job.state = 'failed'
     except:
         logger.exception('')
         if job_id:
@@ -640,6 +642,8 @@ def ntfs2mimir(self, instance_config, input, job_id=None, dataset_uid=None):
             # ntfs2mimir have to be non-blocking.
             # @TODO : Find a way to raise error without breaking celery tasks chain
             logger.error('ntfs2mimir failed')
+            if job_id:
+                job.state = 'failed'
     except:
         logger.exception('')
         if job_id:

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -608,6 +608,7 @@ def stops2mimir(self, instance_config, input, job_id=None, dataset_uid=None):
             logger.error('stops2mimir failed')
             if job_id:
                 job.state = 'failed'
+                models.db.session.commit()
     except:
         logger.exception('')
         if job_id:
@@ -644,6 +645,7 @@ def ntfs2mimir(self, instance_config, input, job_id=None, dataset_uid=None):
             logger.error('ntfs2mimir failed')
             if job_id:
                 job.state = 'failed'
+                models.db.session.commit()
     except:
         logger.exception('')
         if job_id:

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -293,7 +293,10 @@ def import_in_mimir(_file, instance, async=True):
     """
     current_app.logger.debug("Import pt data to mimir")
     instance_config = load_instance_config(instance.name)
-    action = stops2mimir.si(instance_config, _file)
+    if instance.import_ntfs_in_mimir:
+        action = ntfs2mimir.si(instance_config, _file)
+    if instance.import_stops_in_mimir and not instance.import_ntfs_in_mimir:
+        action = stops2mimir.si(instance_config, _file)
     if async:
         return action.delay()
     else:

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -172,10 +172,6 @@ def send_to_mimir(instance, filename):
     models.db.session.add(job)
     models.db.session.commit()
 
-    # We pass the job id to each tasks, but job need to be commited for having an id
-    for action in actions:
-        action.kwargs['job_id'] = job.id
-
     # Import ntfs in Mimir
     if instance.import_ntfs_in_mimir:
         actions.append(ntfs2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -55,7 +55,8 @@ def finish_job(job_id):
     use for mark a job as done after all the required task has been executed
     """
     job = models.Job.query.get(job_id)
-    job.state = 'done'
+    if job.state != 'failed':
+        job.state = 'done'
     models.db.session.commit()
 
 
@@ -130,19 +131,63 @@ def import_data(files, instance, backup_file, async=True, reload=True, custom_ou
         # Reload kraken with new data after binarisation (New .nav.lz4)
         if reload:
             actions.append(reload_data.si(instance_config, job.id))
-        # Import ntfs in Mimir
-        if dataset.family_type == 'pt' and instance.import_ntfs_in_mimir:
-            actions.append(ntfs2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
-        # Import stops in Mimir
-        if dataset.family_type == 'pt' and instance.import_stops_in_mimir and not instance.import_ntfs_in_mimir:
-            # if we are loading pt data we might want to load the stops to autocomplete
-            actions.append(stops2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
+
+        for dataset in job.data_sets:
+            if dataset.family_type == 'pt':
+                actions.extend(send_to_mimir(instance, dataset.name))
+
         actions.append(finish_job.si(job.id))
         if async:
             return chain(*actions).delay()
         else:
             # all job are run in sequence and import_data will only return when all the jobs are finish
             return chain(*actions).apply()
+
+
+def send_to_mimir(instance, filename):
+    """
+    :param instance: instance to receive the data
+    :param filename: file to inject towards mimir
+
+    - create a job with a data_set
+    - data injection towards mimir(stops2mimir, ntfs2mimir)
+
+    returns action list
+    """
+    actions = []
+    job = models.Job()
+    instance_config = load_instance_config(instance.name)
+    job.instance = instance
+    job.state = 'pending'
+
+    dataset = models.DataSet()
+    dataset.family_type = 'mimir'
+    dataset.type = 'stops2mimir'
+
+    #currently the name of a dataset is the path to it
+    dataset.name = filename
+    models.db.session.add(dataset)
+    job.data_sets.append(dataset)
+
+    models.db.session.add(job)
+    models.db.session.commit()
+
+    # Import ntfs in Mimir
+    if instance.import_ntfs_in_mimir:
+        actions.append(ntfs2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
+
+    # We pass the job id to each tasks, but job need to be commited for having an id
+    for action in actions:
+        action.kwargs['job_id'] = job.id
+
+    # Import stops in Mimir
+    # if we are loading pt data we might want to load the stops to autocomplete
+    if instance.import_stops_in_mimir and not instance.import_ntfs_in_mimir:
+        actions.append(stops2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
+
+    actions.append(finish_job.si(job.id))
+
+    return actions
 
 
 @celery.task()

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -162,7 +162,7 @@ def send_to_mimir(instance, filename):
 
     dataset = models.DataSet()
     dataset.family_type = 'mimir'
-    dataset.type = 'stops2mimir'
+    dataset.type = 'fusio'
 
     #currently the name of a dataset is the path to it
     dataset.name = filename
@@ -172,13 +172,13 @@ def send_to_mimir(instance, filename):
     models.db.session.add(job)
     models.db.session.commit()
 
-    # Import ntfs in Mimir
-    if instance.import_ntfs_in_mimir:
-        actions.append(ntfs2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
-
     # We pass the job id to each tasks, but job need to be commited for having an id
     for action in actions:
         action.kwargs['job_id'] = job.id
+
+    # Import ntfs in Mimir
+    if instance.import_ntfs_in_mimir:
+        actions.append(ntfs2mimir.si(instance_config, filename, job.id, dataset_uid=dataset.uid))
 
     # Import stops in Mimir
     # if we are loading pt data we might want to load the stops to autocomplete


### PR DESCRIPTION
- Ticket: https://jira.canaltp.fr/browse/NAVP-813

- For a data_set with family_type = 'pt' and an instance with  export to mimir activated, we create a new job and a data_set with family_type = 'mimir', and name = file path of source job (job with 'pt'). 
    
- In the function last_datasets the data_set with family_type = 'mimir' is excluded for backward compatibility of other apis. The function last_datasets is used many times.

- in the api "jobs" all the jobs and data_sets are listed with status of each job.

TODO:
- [x]  wait for dev deploy to be up