### PR TITLE
Protobuf: fix failing ridesharing test with protobuf 2.6

### DIFF
--- a/source/jormungandr/tests/instant_system_new_default_routing_tests.py
+++ b/source/jormungandr/tests/instant_system_new_default_routing_tests.py
@@ -108,7 +108,7 @@ INSTANCE_SYSTEM_RESPONSE = {
                             }
                         },
                         "price": {
-                            "amount": 170,
+                            "amount": 170.0,
                             "currency": "EUR"
                         },
                         "vehicle": {


### PR DESCRIPTION
The behavior between protobuf 3 and protobuf 2.6 isn't the same when
setting an integer into a float field.
In protobuf 2.6 it will stay an int
and as such we loose the decimal in the output.
In protobuf 3, it is cast to a float and we have the decimal in the
output.
So, long story short, let use float in the test and not be bothered with
this.

Fix: #2360
Also protobuf 2.6 is not recommended for production usage as it has some memory leak.