### PR TITLE
Jormun: slight modification to timeo to make it easy for gomeo

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -226,8 +226,8 @@ def next_passage_for_route_point_test():
                   service_args={'a': 'bobette', 'b': '12'})
 
     mock_requests = MockRequests({
-        'http://bob.com/tata?a=bobette&b=12&StopDescription=?StopTimeoCode=stop_tutu&LineTimeoCode'
-        '=line_toto&Way=route_tata&NextStopTimeNumber=5&StopTimeType=TR;':
+        'http://bob.com/tata?a=bobette&b=12&StopDescription=?StopTimeType=TR&LineTimeoCode'
+        '=line_toto&Way=route_tata&NextStopTimeNumber=5&StopTimeoCode=stop_tutu;':
         (mock_good_timeo_response(), 200)
     })
 

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -208,12 +208,14 @@ class Timeo(RealtimeProxy):
             .format(dt=self._timestamp_to_date(from_dt).strftime('%Y-%m-%dT%H:%M:%S')) \
             if from_dt else ''
 
+        #We want to have StopTimeType as it make parsing of the request way easier
+        #for alternative implementation of timeo since w<e can ignore this params
         stop_id_url = ("StopDescription=?"
-                       "StopTimeoCode={stop}"
+                       "StopTimeType={data_freshness}"
                        "&LineTimeoCode={line}"
                        "&Way={route}"
                        "&NextStopTimeNumber={count}"
-                       "&StopTimeType={data_freshness}{dt};").format(stop=stop,
+                       "&StopTimeoCode={stop}{dt};").format(stop=stop,
                                                                  line=line,
                                                                  route=route,
                                                                  count=count,

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -209,7 +209,7 @@ class Timeo(RealtimeProxy):
             if from_dt else ''
 
         #We want to have StopTimeType as it make parsing of the request way easier
-        #for alternative implementation of timeo since w<e can ignore this params
+        #for alternative implementation of timeo since we can ignore this params
         stop_id_url = ("StopDescription=?"
                        "StopTimeType={data_freshness}"
                        "&LineTimeoCode={line}"


### PR DESCRIPTION
Timeo use a non standard way of formatting parameters: `StopDescription`
is an "object" that contains params between the `?` and `;`. As you can
guess there is not a single implementation of something like this.
Standard implementation will consider that the value of
`StopDescription` end after the next `&`, so we "loose" the first
params.
This PR put `StopTimeType` in first position since it's the less useful
parameter of all, since for us it is obvious that we call timeo to get
realtime data. Doing so make it very easy for [goemo](https://github.com/kinnou02/gomeo)
to parse the query.