### PR TITLE
cmake: fix broken build after #2363

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -147,5 +147,5 @@ add_subdirectory(third_party/librabbitmq-c)
 add_subdirectory(third_party/SimpleAmqpClient)
 #prometheus-cpp cmake will refuse to build if the CMAKE_INSTALL_PREFIX is empty
 #setting it before will have side effects on how we build packages
-SET(CMAKE_INSTALL_PREFIX "/usr/local")
+SET(CMAKE_INSTALL_PREFIX "/")
 add_subdirectory(third_party/prometheus-cpp)


### PR DESCRIPTION
It isn't pretty but the install prefix has some effect during the
configure (when running cmake) and also after in the install target.
If we want to keep a pretty install prefix we would have to update every
.install file from the debian packages. I would prefer not having to do
so.