### PR TITLE
Kraken: Unicode parse bugfix

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -409,7 +409,6 @@ class Instance(object):
                 request.request_id = flask.request.id
             except RuntimeError:
                 # we aren't in a flask context, so there is no request
-                logger.info("we aren't in a flask context, so there is no request")
 
                 if 'flask_request_id' in kwargs:
                     request.request_id = kwargs['flask_request_id']

--- a/source/jormungandr/jormungandr/ptref.py
+++ b/source/jormungandr/jormungandr/ptref.py
@@ -62,10 +62,10 @@ class PtRef(object):
         req.ptref.count = 1
         req.ptref.start_page = 0
         req.ptref.depth = 1
-        req.ptref.filter = "stop_point.has_code({code_key}, {code_value})".\
+        req.ptref.filter = 'stop_point.has_code("{code_key}", "{code_value}")'.\
             format(code_key=code_key, code_value=code_value)
         if line_uri:
-            req.ptref.filter = req.ptref.filter + ' and line.uri={}'.format(line_uri)
+            req.ptref.filter = req.ptref.filter + ' and line.uri="{}"'.format(line_uri)
 
         result = self.instance.send_and_receive(req)
         if len(result.stop_points) == 0:

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -187,7 +187,7 @@ class TestBasicAuthentication(AbstractTestAuthentication):
 
     def test_auth_required(self):
         """
-        if no token is given we are asked to log in (code 401) and a chalenge is sent (header WWW-Authenticate)
+        if no token is given we are asked to log in (code 401) and a challenge is sent (header WWW-Authenticate)
         """
         response_obj = self.app.get('/v1/coverage')
         assert response_obj.status_code == 401
@@ -195,7 +195,7 @@ class TestBasicAuthentication(AbstractTestAuthentication):
 
     def test_status_code(self):
         """
-        We query the api with user 1 who have access to the main routintg test and not to the departure board
+        We query the api with user 1 who have access to the main routing test and not to the departure board
         """
         requests_status_codes = [
             ('/v1/coverage/main_routing_test', 200),

--- a/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
@@ -38,11 +38,11 @@ from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigital",
-        "id": "KisioDigital",
+        "object_id_tag": "KisioDigitalisé",
+        "id": "KisioDigitalisé",
         "class": "jormungandr.realtime_schedule.cleverage.Cleverage",
         "args": {
-            "destination_id_tag": "KisioDigital",
+            "destination_id_tag": "KisioDigitalisé",
             "timezone": "UTC",
             "service_url": "http://XXXX",
             "timeout": 15,
@@ -90,7 +90,7 @@ class TestCleverageSchedules(AbstractTestFixture):
                 ([
                  {
                      "name": "Lianes 5",
-                     "code": "KisioDigital A",
+                     "code": "KisioDigitalisé A",
                      "type": "Bus",
                      "schedules": [
                          {
@@ -167,7 +167,7 @@ class TestCleverageSchedules(AbstractTestFixture):
                 ([
                  {
                      "name": "Lianes 5",
-                     "code": "KisioDigital A",
+                     "code": "KisioDigitalisé A",
                      "type": "Bus",
                      "schedules": [
                          {

--- a/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
@@ -38,11 +38,11 @@ from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigitalisé",
-        "id": "KisioDigitalisé",
+        "object_id_tag": "Kisio数字",
+        "id": "Kisio数字",
         "class": "jormungandr.realtime_schedule.cleverage.Cleverage",
         "args": {
-            "destination_id_tag": "KisioDigitalisé",
+            "destination_id_tag": "Kisio数字",
             "timezone": "UTC",
             "service_url": "http://XXXX",
             "timeout": 15,
@@ -90,7 +90,7 @@ class TestCleverageSchedules(AbstractTestFixture):
                 ([
                  {
                      "name": "Lianes 5",
-                     "code": "KisioDigitalisé A",
+                     "code": "Kisio数字 A",
                      "type": "Bus",
                      "schedules": [
                          {
@@ -167,7 +167,7 @@ class TestCleverageSchedules(AbstractTestFixture):
                 ([
                  {
                      "name": "Lianes 5",
-                     "code": "KisioDigitalisé A",
+                     "code": "Kisio数字 A",
                      "type": "Bus",
                      "schedules": [
                          {

--- a/source/jormungandr/tests/proxy_realtime_sirilite_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_sirilite_integration_tests.py
@@ -37,11 +37,11 @@ from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigital",
-        "id": "KisioDigital",
+        "object_id_tag": "KisioDigitalisé",
+        "id": "KisioDigitalisé",
         "class": "jormungandr.realtime_schedule.siri_lite.SiriLite",
         "args": {
-            "destination_id_tag": "KisioDigital",
+            "destination_id_tag": "KisioDigitalisé",
             "timezone": "Europe/Paris",
             "service_url": "http://siri.com?apikey=bob",
             "timeout": 15

--- a/source/jormungandr/tests/proxy_realtime_sirilite_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_sirilite_integration_tests.py
@@ -37,11 +37,11 @@ from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigitalisé",
-        "id": "KisioDigitalisé",
+        "object_id_tag": "Kisio数字",
+        "id": "Kisio数字",
         "class": "jormungandr.realtime_schedule.siri_lite.SiriLite",
         "args": {
-            "destination_id_tag": "KisioDigitalisé",
+            "destination_id_tag": "Kisio数字",
             "timezone": "Europe/Paris",
             "service_url": "http://siri.com?apikey=bob",
             "timeout": 15

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -38,8 +38,8 @@ from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigital",
-        "id": "KisioDigital",
+        "object_id_tag": "KisioDigitalisé",
+        "id": "KisioDigitalisé",
         "class": "jormungandr.realtime_schedule.synthese.Synthese",
         "args": {
             "timezone": "UTC",

--- a/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_synthese_integration_tests.py
@@ -38,8 +38,8 @@ from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigitalisé",
-        "id": "KisioDigitalisé",
+        "object_id_tag": "Kisio数字",
+        "id": "Kisio数字",
         "class": "jormungandr.realtime_schedule.synthese.Synthese",
         "args": {
             "timezone": "UTC",

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -42,7 +42,7 @@ from .check_utils import is_valid_stop_date_time, get_not_null
 
 MOCKED_PROXY_CONF = [
     {
-        "id": "KisioDigitalisé",
+        "id": "Kisio数字",
         "class": "tests.proxy_realtime_tests.MockedTestProxy",
         "args": {}
     }
@@ -68,13 +68,13 @@ class MockedTestProxy(realtime_proxy.RealtimeProxy):
         return next_passages
 
     def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
-        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigitalisé_C:S1":
+        if route_point.fetch_stop_id(self.object_id_tag) == "Kisio数字_C:S1":
             return []
 
         if route_point.fetch_stop_id(self.object_id_tag) == "AnotherSource_C:S1":
             return self._create_next_passages([("10:42:42", "l'infini"), ("11:42:42", "l'au dela")])
 
-        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigitalisé_C:S0":
+        if route_point.fetch_stop_id(self.object_id_tag) == "Kisio数字_C:S0":
             return self._create_next_passages([("11:32:42", "l'infini"), ("11:42:42", "l'au dela")])
 
         if route_point.pb_stop_point.uri == "S42":
@@ -296,7 +296,7 @@ class TestDepartures(AbstractTestFixture):
 
 MOCKED_PROXY_CONF = [
     {
-        "id": "KisioDigitalisé",
+        "id": "Kisio数字",
         "object_id_tag": "AnotherSource",
         "class": "tests.proxy_realtime_tests.MockedTestProxy",
         "args": {}
@@ -321,7 +321,7 @@ class TestDeparturesWithAnotherSource(AbstractTestFixture):
 
 MOCKED_PROXY_WITH_TIMEZONE_CONF = [
     {
-        "id": "KisioDigitalisé",
+        "id": "Kisio数字",
         "class": "tests.proxy_realtime_tests.MockedTestProxyWithTimezone",
         "args": {}
     }
@@ -334,7 +334,7 @@ class MockedTestProxyWithTimezone(MockedTestProxy):
 
     def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
 
-        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigitalisé_C:S0":
+        if route_point.fetch_stop_id(self.object_id_tag) == "Kisio数字_C:S0":
             return self._create_next_passages([("00:03:00", "l'infini"), ("00:04:00", "l'au dela")],
                                               year=2016, month=1, day=3,
                                               tzinfo=pytz.timezone("Europe/Paris"))
@@ -357,7 +357,7 @@ class TestDeparturesWithTimeZone(AbstractTestFixture):
 
 MOCKED_PROXY_WITH_CUSTOM_MERGING_CONF = [
     {
-        "id": "KisioDigitalisé",
+        "id": "Kisio数字",
         "class": "tests.proxy_realtime_tests.MockedTestProxyWithCustomMerging",
         "args": {}
     }

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -42,7 +42,7 @@ from .check_utils import is_valid_stop_date_time, get_not_null
 
 MOCKED_PROXY_CONF = [
     {
-        "id": "KisioDigital",
+        "id": "KisioDigitalisé",
         "class": "tests.proxy_realtime_tests.MockedTestProxy",
         "args": {}
     }
@@ -68,13 +68,13 @@ class MockedTestProxy(realtime_proxy.RealtimeProxy):
         return next_passages
 
     def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
-        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigital_C:S1":
+        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigitalisé_C:S1":
             return []
 
         if route_point.fetch_stop_id(self.object_id_tag) == "AnotherSource_C:S1":
             return self._create_next_passages([("10:42:42", "l'infini"), ("11:42:42", "l'au dela")])
 
-        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigital_C:S0":
+        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigitalisé_C:S0":
             return self._create_next_passages([("11:32:42", "l'infini"), ("11:42:42", "l'au dela")])
 
         if route_point.pb_stop_point.uri == "S42":
@@ -296,7 +296,7 @@ class TestDepartures(AbstractTestFixture):
 
 MOCKED_PROXY_CONF = [
     {
-        "id": "KisioDigital",
+        "id": "KisioDigitalisé",
         "object_id_tag": "AnotherSource",
         "class": "tests.proxy_realtime_tests.MockedTestProxy",
         "args": {}
@@ -321,7 +321,7 @@ class TestDeparturesWithAnotherSource(AbstractTestFixture):
 
 MOCKED_PROXY_WITH_TIMEZONE_CONF = [
     {
-        "id": "KisioDigital",
+        "id": "KisioDigitalisé",
         "class": "tests.proxy_realtime_tests.MockedTestProxyWithTimezone",
         "args": {}
     }
@@ -334,7 +334,7 @@ class MockedTestProxyWithTimezone(MockedTestProxy):
 
     def _get_next_passage_for_route_point(self, route_point, count=None, from_dt=None, current_dt=None, duration=None):
 
-        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigital_C:S0":
+        if route_point.fetch_stop_id(self.object_id_tag) == "KisioDigitalisé_C:S0":
             return self._create_next_passages([("00:03:00", "l'infini"), ("00:04:00", "l'au dela")],
                                               year=2016, month=1, day=3,
                                               tzinfo=pytz.timezone("Europe/Paris"))
@@ -357,7 +357,7 @@ class TestDeparturesWithTimeZone(AbstractTestFixture):
 
 MOCKED_PROXY_WITH_CUSTOM_MERGING_CONF = [
     {
-        "id": "KisioDigital",
+        "id": "KisioDigitalisé",
         "class": "tests.proxy_realtime_tests.MockedTestProxyWithCustomMerging",
         "args": {}
     }

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -106,13 +106,13 @@ class MockTimeo(Timeo):
                                 {
                                     "NextStop": "10:00:52",
                                     "Destination": "DIRECTION AA",
-                                    "Terminus": u"KisioDigitalisé_C:S43"
+                                    "Terminus": "KisioDigitalisé_C:S43"
 
                                 },
                                 {
                                     "NextStop": "10:13:52",
                                     "Destination": "DIRECTION AA",
-                                    "Terminus": u"KisioDigitalisé_C:S43"
+                                    "Terminus": "KisioDigitalisé_C:S43"
                                 }
                             ]
                         }

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -106,13 +106,13 @@ class MockTimeo(Timeo):
                                 {
                                     "NextStop": "10:00:52",
                                     "Destination": "DIRECTION AA",
-                                    "Terminus": "KisioDigitalisé_C:S43"
+                                    "Terminus": "Kisio数字_C:S43"
 
                                 },
                                 {
                                     "NextStop": "10:13:52",
                                     "Destination": "DIRECTION AA",
-                                    "Terminus": "KisioDigitalisé_C:S43"
+                                    "Terminus": "Kisio数字_C:S43"
                                 }
                             ]
                         }
@@ -127,11 +127,11 @@ class MockTimeo(Timeo):
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigitalisé",
-        "id": "KisioDigitalisé",
+        "object_id_tag": "Kisio数字",
+        "id": "Kisio数字",
         "class": "tests.proxy_realtime_timeo_integration_tests.MockTimeo",
         "args": {
-            "destination_id_tag": "KisioDigitalisé",
+            "destination_id_tag": "Kisio数字",
             "timezone": "Europe/Paris",
             "service_url": "http://XXXX",
             "timeout": 15,

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -106,13 +106,13 @@ class MockTimeo(Timeo):
                                 {
                                     "NextStop": "10:00:52",
                                     "Destination": "DIRECTION AA",
-                                    "Terminus": "KisioDigital_C:S43"
+                                    "Terminus": u"KisioDigitalisé_C:S43"
 
                                 },
                                 {
                                     "NextStop": "10:13:52",
                                     "Destination": "DIRECTION AA",
-                                    "Terminus": "KisioDigital_C:S43"
+                                    "Terminus": u"KisioDigitalisé_C:S43"
                                 }
                             ]
                         }
@@ -127,11 +127,11 @@ class MockTimeo(Timeo):
 
 MOCKED_PROXY_CONF = [
     {
-        "object_id_tag": "KisioDigital",
-        "id": "KisioDigital",
+        "object_id_tag": "KisioDigitalisé",
+        "id": "KisioDigitalisé",
         "class": "tests.proxy_realtime_timeo_integration_tests.MockTimeo",
         "args": {
-            "destination_id_tag": "KisioDigital",
+            "destination_id_tag": "KisioDigitalisé",
             "timezone": "Europe/Paris",
             "service_url": "http://XXXX",
             "timeout": 15,

--- a/source/tests/multiple_schedules.cpp
+++ b/source/tests/multiple_schedules.cpp
@@ -66,25 +66,25 @@ int main(int argc, const char* const argv[]) {
     b.get<nt::Line>("B")->code = "code B";
     b.get<nt::Line>("C")->code = "code C";
 
-    b.get<nt::Line>("A")->properties["realtime_system"] = "KisioDigitalisé";
-    b.get<nt::Line>("B")->properties["realtime_system"] = "KisioDigitalisé";
-    b.get<nt::Line>("C")->properties["realtime_system"] = "KisioDigitalisé";
+    b.get<nt::Line>("A")->properties["realtime_system"] = "Kisio数字";
+    b.get<nt::Line>("B")->properties["realtime_system"] = "Kisio数字";
+    b.get<nt::Line>("C")->properties["realtime_system"] = "Kisio数字";
 
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_1"), "KisioDigitalisé", "syn_stoppoint1");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_11"), "KisioDigitalisé", "syn_stoppoint11");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_20"), "KisioDigitalisé", "syn_stoppoint20");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_21"), "KisioDigitalisé", "syn_stoppoint21");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_22"), "KisioDigitalisé", "syn_stoppoint22");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_31"), "KisioDigitalisé", "syn_stoppoint31");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_41"), "KisioDigitalisé", "syn_stoppoint41");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_1"), "Kisio数字", "syn_stoppoint1");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_11"), "Kisio数字", "syn_stoppoint11");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_20"), "Kisio数字", "syn_stoppoint20");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_21"), "Kisio数字", "syn_stoppoint21");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_22"), "Kisio数字", "syn_stoppoint22");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_31"), "Kisio数字", "syn_stoppoint31");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_41"), "Kisio数字", "syn_stoppoint41");
 
     auto r1 = b.get<nt::Route>("A1");
-    b.data->pt_data->codes.add(r1, "KisioDigitalisé", "syn_routeA1");
-    b.data->pt_data->codes.add(r1, "KisioDigitalisé", "syn_cute_routeA1");
+    b.data->pt_data->codes.add(r1, "Kisio数字", "syn_routeA1");
+    b.data->pt_data->codes.add(r1, "Kisio数字", "syn_cute_routeA1");
 
-    b.data->pt_data->codes.add(b.get<nt::Line>("A"), "KisioDigitalisé", "KisioDigitalisé A");
-    b.data->pt_data->codes.add(b.get<nt::Line>("B"), "KisioDigitalisé", "syn_lineB");
-    b.data->pt_data->codes.add(b.get<nt::Line>("C"), "KisioDigitalisé", "syn_lineC");
+    b.data->pt_data->codes.add(b.get<nt::Line>("A"), "Kisio数字", "Kisio数字 A");
+    b.data->pt_data->codes.add(b.get<nt::Line>("B"), "Kisio数字", "syn_lineB");
+    b.data->pt_data->codes.add(b.get<nt::Line>("C"), "Kisio数字", "syn_lineC");
 
     mock_kraken kraken(b, "multiple_schedules", argc, argv);
 

--- a/source/tests/multiple_schedules.cpp
+++ b/source/tests/multiple_schedules.cpp
@@ -66,25 +66,25 @@ int main(int argc, const char* const argv[]) {
     b.get<nt::Line>("B")->code = "code B";
     b.get<nt::Line>("C")->code = "code C";
 
-    b.get<nt::Line>("A")->properties["realtime_system"] = "KisioDigital";
-    b.get<nt::Line>("B")->properties["realtime_system"] = "KisioDigital";
-    b.get<nt::Line>("C")->properties["realtime_system"] = "KisioDigital";
+    b.get<nt::Line>("A")->properties["realtime_system"] = "KisioDigitalisé";
+    b.get<nt::Line>("B")->properties["realtime_system"] = "KisioDigitalisé";
+    b.get<nt::Line>("C")->properties["realtime_system"] = "KisioDigitalisé";
 
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_1"), "KisioDigital", "syn_stoppoint1");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_11"), "KisioDigital", "syn_stoppoint11");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_20"), "KisioDigital", "syn_stoppoint20");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_21"), "KisioDigital", "syn_stoppoint21");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_22"), "KisioDigital", "syn_stoppoint22");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_31"), "KisioDigital", "syn_stoppoint31");
-    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_41"), "KisioDigital", "syn_stoppoint41");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_1"), "KisioDigitalisé", "syn_stoppoint1");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_11"), "KisioDigitalisé", "syn_stoppoint11");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_20"), "KisioDigitalisé", "syn_stoppoint20");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_21"), "KisioDigitalisé", "syn_stoppoint21");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_22"), "KisioDigitalisé", "syn_stoppoint22");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_31"), "KisioDigitalisé", "syn_stoppoint31");
+    b.data->pt_data->codes.add(b.get<nt::StopPoint>("SP_41"), "KisioDigitalisé", "syn_stoppoint41");
 
     auto r1 = b.get<nt::Route>("A1");
-    b.data->pt_data->codes.add(r1, "KisioDigital", "syn_routeA1");
-    b.data->pt_data->codes.add(r1, "KisioDigital", "syn_cute_routeA1");
+    b.data->pt_data->codes.add(r1, "KisioDigitalisé", "syn_routeA1");
+    b.data->pt_data->codes.add(r1, "KisioDigitalisé", "syn_cute_routeA1");
 
-    b.data->pt_data->codes.add(b.get<nt::Line>("A"), "KisioDigital", "KisioDigital A");
-    b.data->pt_data->codes.add(b.get<nt::Line>("B"), "KisioDigital", "syn_lineB");
-    b.data->pt_data->codes.add(b.get<nt::Line>("C"), "KisioDigital", "syn_lineC");
+    b.data->pt_data->codes.add(b.get<nt::Line>("A"), "KisioDigitalisé", "KisioDigitalisé A");
+    b.data->pt_data->codes.add(b.get<nt::Line>("B"), "KisioDigitalisé", "syn_lineB");
+    b.data->pt_data->codes.add(b.get<nt::Line>("C"), "KisioDigitalisé", "syn_lineC");
 
     mock_kraken kraken(b, "multiple_schedules", argc, argv);
 

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -46,23 +46,23 @@ struct departure_board_fixture {
         b.vj("B").uri("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
 
         b.vj("C").uri("C:vj1")("C:S0", "11:30"_t)("C:S1", "12:30"_t)("C:S2", "13:30"_t);
-        b.lines.find("C")->second->properties["realtime_system"] = "KisioDigital";
+        b.lines.find("C")->second->properties["realtime_system"] = "KisioDigitalisé";
 
         // J is late
         b.vj("J")("S40", "11:00"_t)("S42", "12:00"_t)("S43", "13:00"_t);
-        b.lines.find("J")->second->properties["realtime_system"] = "KisioDigital";
+        b.lines.find("J")->second->properties["realtime_system"] = "KisioDigitalisé";
 
         b.vj("K")("S41", "08:59"_t)("S42", "09:59"_t)("S43", "10:59"_t);
         b.vj("K")("S41", "09:03"_t)("S42", "10:03"_t)("S43", "11:03"_t);
         b.vj("K")("S41", "09:06"_t)("S42", "10:06"_t)("S43", "11:06"_t);
         b.vj("K")("S41", "09:09"_t)("S42", "10:09"_t)("S43", "11:09"_t);
         b.vj("K")("S41", "09:19"_t)("S42", "10:19"_t)("S43", "11:19"_t);
-        b.lines.find("K")->second->properties["realtime_system"] = "KisioDigital";
+        b.lines.find("K")->second->properties["realtime_system"] = "KisioDigitalisé";
 
         b.vj("L")("S39", "09:02"_t)("S42", "10:02"_t)("S43", "11:02"_t);
         b.vj("L")("S39", "09:07"_t)("S42", "10:07"_t)("S43", "11:07"_t);
         b.vj("L")("S39", "09:11"_t)("S42", "10:11"_t)("S43", "11:11"_t);
-        b.lines.find("L")->second->properties["realtime_system"] = "KisioDigital";
+        b.lines.find("L")->second->properties["realtime_system"] = "KisioDigitalisé";
 
         b.vj("M","1111111")("M:s", "10:30"_t)("S11", "11:30"_t, "11:35"_t)("M:e", "12:30"_t);
         b.vj("P", "11111").uri("vjP:1")("stopP1", "23:40"_t)("stopP2", "24:04"_t, "24:06"_t)("stopP3", "24:13"_t);
@@ -95,13 +95,13 @@ struct departure_board_fixture {
         b.data->meta->production_date = bg::date_period(bg::date(2016,1,1), bg::days(5));
 
         sp_ptr = b.data->pt_data->stop_points_map["C:S0"];
-        b.data->pt_data->codes.add(sp_ptr, "KisioDigital", "KisioDigital_C:S0");
+        b.data->pt_data->codes.add(sp_ptr, "KisioDigitalisé", "KisioDigitalisé_C:S0");
         sp_ptr = b.data->pt_data->stop_points_map["C:S1"];
-        b.data->pt_data->codes.add(sp_ptr, "KisioDigital", "KisioDigital_C:S1");
+        b.data->pt_data->codes.add(sp_ptr, "KisioDigitalisé", "KisioDigitalisé_C:S1");
         b.data->pt_data->codes.add(sp_ptr, "AnotherSource", "AnotherSource_C:S1");
 
         sp_ptr = b.data->pt_data->stop_points_map["S43"];
-        b.data->pt_data->codes.add(sp_ptr, "KisioDigital", "KisioDigital_C:S43");
+        b.data->pt_data->codes.add(sp_ptr, "KisioDigitalisé", "KisioDigitalisé_C:S43");
 
         using ntest::DelayedTimeStop;
         // we delay all A's vjs by 7mn (to be able to test whether it's base schedule or realtime data)

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -46,23 +46,23 @@ struct departure_board_fixture {
         b.vj("B").uri("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
 
         b.vj("C").uri("C:vj1")("C:S0", "11:30"_t)("C:S1", "12:30"_t)("C:S2", "13:30"_t);
-        b.lines.find("C")->second->properties["realtime_system"] = "KisioDigitalisé";
+        b.lines.find("C")->second->properties["realtime_system"] = "Kisio数字";
 
         // J is late
         b.vj("J")("S40", "11:00"_t)("S42", "12:00"_t)("S43", "13:00"_t);
-        b.lines.find("J")->second->properties["realtime_system"] = "KisioDigitalisé";
+        b.lines.find("J")->second->properties["realtime_system"] = "Kisio数字";
 
         b.vj("K")("S41", "08:59"_t)("S42", "09:59"_t)("S43", "10:59"_t);
         b.vj("K")("S41", "09:03"_t)("S42", "10:03"_t)("S43", "11:03"_t);
         b.vj("K")("S41", "09:06"_t)("S42", "10:06"_t)("S43", "11:06"_t);
         b.vj("K")("S41", "09:09"_t)("S42", "10:09"_t)("S43", "11:09"_t);
         b.vj("K")("S41", "09:19"_t)("S42", "10:19"_t)("S43", "11:19"_t);
-        b.lines.find("K")->second->properties["realtime_system"] = "KisioDigitalisé";
+        b.lines.find("K")->second->properties["realtime_system"] = "Kisio数字";
 
         b.vj("L")("S39", "09:02"_t)("S42", "10:02"_t)("S43", "11:02"_t);
         b.vj("L")("S39", "09:07"_t)("S42", "10:07"_t)("S43", "11:07"_t);
         b.vj("L")("S39", "09:11"_t)("S42", "10:11"_t)("S43", "11:11"_t);
-        b.lines.find("L")->second->properties["realtime_system"] = "KisioDigitalisé";
+        b.lines.find("L")->second->properties["realtime_system"] = "Kisio数字";
 
         b.vj("M","1111111")("M:s", "10:30"_t)("S11", "11:30"_t, "11:35"_t)("M:e", "12:30"_t);
         b.vj("P", "11111").uri("vjP:1")("stopP1", "23:40"_t)("stopP2", "24:04"_t, "24:06"_t)("stopP3", "24:13"_t);
@@ -95,13 +95,13 @@ struct departure_board_fixture {
         b.data->meta->production_date = bg::date_period(bg::date(2016,1,1), bg::days(5));
 
         sp_ptr = b.data->pt_data->stop_points_map["C:S0"];
-        b.data->pt_data->codes.add(sp_ptr, "KisioDigitalisé", "KisioDigitalisé_C:S0");
+        b.data->pt_data->codes.add(sp_ptr, "Kisio数字", "Kisio数字_C:S0");
         sp_ptr = b.data->pt_data->stop_points_map["C:S1"];
-        b.data->pt_data->codes.add(sp_ptr, "KisioDigitalisé", "KisioDigitalisé_C:S1");
+        b.data->pt_data->codes.add(sp_ptr, "Kisio数字", "Kisio数字_C:S1");
         b.data->pt_data->codes.add(sp_ptr, "AnotherSource", "AnotherSource_C:S1");
 
         sp_ptr = b.data->pt_data->stop_points_map["S43"];
-        b.data->pt_data->codes.add(sp_ptr, "KisioDigitalisé", "KisioDigitalisé_C:S43");
+        b.data->pt_data->codes.add(sp_ptr, "Kisio数字", "Kisio数字_C:S43");
 
         using ntest::DelayedTimeStop;
         // we delay all A's vjs by 7mn (to be able to test whether it's base schedule or realtime data)


### PR DESCRIPTION
Only test for now (and a WIP commit to remember it).

The problem is the same as the one when calling:
v1/coverage/toto/stop_points?filter=stop_point.has_code(KisioDigitalis%C3%A9%2C%20KisioDigitalis_C%3AS43)
:arrow_right: this fails for parsing while the same call without accent success (or fails because no object is found)

Have to use quotes for this kind of query