### PR TITLE
Git ignore files generated by Visual Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ debian/*.substvars
 debian/*.debhelper
 source/jormungandr/jormungandr/_version.py
 .cache
+.vscode


### PR DESCRIPTION
For the  Visual Code aficionados, tell git to ignore files generated by the IDE.