### PR TITLE
tyr: delete old jobs of discarded instance

### DIFF
--- a/source/navitiacommon/navitiacommon/models.py
+++ b/source/navitiacommon/navitiacommon/models.py
@@ -397,6 +397,10 @@ class Instance(db.Model):
         return cls.query.filter_by(discarded=False)
 
     @classmethod
+    def query_all(cls):
+        return cls.query
+
+    @classmethod
     def get_by_name(cls, name):
         res = cls.query_existing().filter_by(name=name).first()
         return res

--- a/source/tyr/tests/integration/purge_test.py
+++ b/source/tyr/tests/integration/purge_test.py
@@ -71,14 +71,6 @@ def create_job(creation_date, dataset_type, backup_dir):
     return job
 
 
-def add_data_set(job, creation_date, dataset_type, backup_dir):
-    dataset_backup_dir = tempfile.mkdtemp(dir=backup_dir)
-    dataset, metric = create_dataset(dataset_type, dataset_backup_dir)
-    job.data_sets.append(dataset)
-    job.metrics.append(metric)
-    return job
-
-
 def create_jobs_with_same_datasets(name, backup_dir):
     with app.app_context():
         job_list = []

--- a/source/tyr/tests/integration/purge_test.py
+++ b/source/tyr/tests/integration/purge_test.py
@@ -36,7 +36,7 @@ from datetime import datetime, timedelta
 
 from tyr import app, tasks
 from navitiacommon import models
-from tests.check_utils import api_get
+from tests.check_utils import api_get, api_delete
 try:
     import ConfigParser
 except:
@@ -68,6 +68,14 @@ def create_job(creation_date, dataset_type, backup_dir):
     job.created_at = creation_date
     models.db.session.add(job)
 
+    return job
+
+
+def add_data_set(job, creation_date, dataset_type, backup_dir):
+    dataset_backup_dir = tempfile.mkdtemp(dir=backup_dir)
+    dataset, metric = create_dataset(dataset_type, dataset_backup_dir)
+    job.data_sets.append(dataset)
+    job.metrics.append(metric)
     return job
 
 
@@ -154,8 +162,9 @@ def test_purge_old_jobs():
 @pytest.mark.usefixtures("init_instances_dir")
 def test_purge_old_jobs_no_delete():
     """
-    The jobs related to the instance are the only ones of their type.
-    So, even if they are older than the time limit, they won't be deleted
+    The jobs related to the instance are the only ones of their type(having one data_set par job).
+    So, even if they are older than the time limit, they won't be deleted and hence last_datasets
+    always contains a full set of valid data_sets
     """
     app.config['JOB_MAX_PERIOD_TO_KEEP'] = 1
 
@@ -184,7 +193,7 @@ def test_purge_old_jobs_no_delete():
 def test_purge_old_jobs_same_dataset():
     """
     An old job to be deleted uses the same dataset as one to keep.
-    So, delete the job in db but the dataset file on disc
+    So, delete the job keeping at least one in db but the dataset file on disc
     """
     app.config['JOB_MAX_PERIOD_TO_KEEP'] = 1
 
@@ -207,3 +216,34 @@ def test_purge_old_jobs_same_dataset():
 
     folders = set(glob.glob('{}/*'.format(backup_dir)))
     assert len(folders) == 1
+
+
+@pytest.mark.usefixtures("init_instances_dir")
+def test_purge_old_jobs_of_multi_instance():
+    """
+    We should delete jobs, data_sets as well as metrics of all instances
+    including discarded = True
+    """
+    app.config['JOB_MAX_PERIOD_TO_KEEP'] = 1
+
+    instance_name, backup_dir = init_test()
+    create_jobs_with_same_datasets(instance_name, backup_dir)
+
+    create_jobs_with_same_datasets('fr-discarded', backup_dir)
+
+    instances_resp = api_get('/v0/instances')
+    assert len(instances_resp) == 2
+
+    # Delete the second instance (discarded = True)
+    instances_resp = api_delete('/v0/instances/fr-discarded')
+    assert instances_resp['discarded'] is True
+
+    jobs_resp = api_get('/v0/jobs/fr-discarded')
+    assert len(jobs_resp['jobs']) == 3
+    jobs_resp = api_get('/v0/jobs/fr')
+    assert len(jobs_resp['jobs']) == 3
+    tasks.purge_jobs()
+    jobs_resp = api_get('/v0/jobs/fr-discarded')
+    assert len(jobs_resp['jobs']) == 1
+    jobs_resp = api_get('/v0/jobs/fr')
+    assert len(jobs_resp['jobs']) == 1

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -350,7 +350,8 @@ def purge_jobs(days_to_keep=None):
         days_to_keep = current_app.config.get('JOB_MAX_PERIOD_TO_KEEP', 60)
 
     time_limit = datetime.utcnow() - timedelta(days=int(days_to_keep))
-    instances = models.Instance.query_existing().all()
+    # Purge all instances (even discarded = true)
+    instances = models.Instance.query_all().all()
 
     logger = logging.getLogger(__name__)
     logger.info('Purge old jobs and datasets backup created before {}'.format(time_limit))


### PR DESCRIPTION
Ticket : https://jira.kisio.org/browse/NAVITIAII-2442

Note: old jobs with state <> 'done' or without any data_sets are cleaned with existing version