### PR TITLE
Jormungandr: Journey filters optimization

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -126,7 +126,7 @@ if rest_api.app.config.get('ACTIVATE_PROFILING'):
     rest_api.app.logger.warning('=======================================================')
     from werkzeug.contrib.profiler import ProfilerMiddleware
     rest_api.app.config['PROFILE'] = True
-    f = open('/tmp/profiler.log', 'a')
-    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/tmp/profile')
+    f = open('/home/xiaolong/profiler/profiler', 'a')
+    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/home/xiaolong/profiler/')
 
 index(rest_api)

--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -126,7 +126,7 @@ if rest_api.app.config.get('ACTIVATE_PROFILING'):
     rest_api.app.logger.warning('=======================================================')
     from werkzeug.contrib.profiler import ProfilerMiddleware
     rest_api.app.config['PROFILE'] = True
-    f = open('/home/xiaolong/profiler/profiler', 'a')
-    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/home/xiaolong/profiler/')
+    f = open('/tmp/profiler.log', 'a')
+    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/tmp/profile')
 
 index(rest_api)

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -221,8 +221,15 @@ def filter_too_short_heavy_journeys(journey, request):
     """
     logger = logging.getLogger(__name__)
 
-    # early return
+    # Early return 1
+    # There are no bike/bss/car fallback
     if journey.durations.bike == journey.durations.car == 0:
+        return True
+
+    # Early return 2
+    # Durations of every mode are >= min
+    if journey.durations.bike >= request.get('_min_bike', float('inf')) and \
+            journey.durations.car >= request.get('_min_car', float('inf')):
         return True
 
     is_debug = request.get('debug', False)

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -33,7 +33,7 @@ import functools
 import datetime
 from jormungandr.scenarios.utils import compare, get_pseudo_duration, get_or_default, mode_weight
 from navitiacommon import response_pb2
-from jormungandr.utils import pb_del_if, compose
+from jormungandr.utils import pb_del_if, compose, portable_min
 
 
 def delete_journeys(responses, request):
@@ -358,7 +358,7 @@ def get_min_connections(journeys):
     if not journeys:
         return None
 
-    return min((get_nb_connections(j) for j in journeys if not to_be_deleted(j)), 0)
+    return portable_min((get_nb_connections(j) for j in journeys if not to_be_deleted(j)), default=0)
 
 
 def get_nb_connections(journey):
@@ -378,7 +378,7 @@ def get_min_waiting(journey):
     """
     Returns min waiting time in a journey
     """
-    return min((s.duration for s in journey.sections if s.type == response_pb2.WAITING), 0)
+    return portable_min((s.duration for s in journey.sections if s.type == response_pb2.WAITING), default=0)
 
 
 def way_later(request, journey1, journey2):
@@ -437,6 +437,7 @@ def _filter_too_long_journeys(responses, request):
             logger.debug("the journey {} is too long compared to {}, we delete it"
                          .format(j1.internal_id, j2.internal_id))
             mark_as_dead(j1, request, 'too_long', 'too_long_compared_to_{}'.format(j2.internal_id))
+
 
 def is_walk_after_parking(journey, idx_section):
     '''

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -185,6 +185,7 @@ def _filter_similar_journeys(journeys_pool, request, similar_journey_generator):
     """
 
     logger = logging.getLogger(__name__)
+    is_debug = request.get('debug')
     for j1, j2 in journeys_pool:
         if to_be_deleted(j1) or to_be_deleted(j2):
             continue
@@ -195,7 +196,7 @@ def _filter_similar_journeys(journeys_pool, request, similar_journey_generator):
                                                                                 j2.internal_id,
                                                                                 worst.internal_id))
 
-            mark_as_dead(worst, request, 'duplicate_journey', 'similar_to_{other}'
+            mark_as_dead(worst, is_debug, 'duplicate_journey', 'similar_to_{other}'
                           .format(other=j1.internal_id if worst == j2 else j2.internal_id))
 
 
@@ -295,12 +296,13 @@ def _filter_too_much_connections(journeys, instance, request):
     import itertools
     it1, it2 = itertools.tee(journeys, 2)
     min_connections = get_min_connections(it1)
+    is_debug = request.get('debug')
     if min_connections is not None:
         max_connections_allowed = max_additional_connections + min_connections
         for j in it2:
             if get_nb_connections(j) > max_connections_allowed:
                 logger.debug("the journey {} has a too much connections, we delete it".format(j.internal_id))
-                mark_as_dead(j, request, "too_much_connections")
+                mark_as_dead(j, is_debug, "too_much_connections")
 
 
 def filter_min_transfers(journey, is_debug, min_nb_transfers):
@@ -415,13 +417,14 @@ def _filter_too_long_journeys(responses, request):
                 and not to_be_deleted(j))
 
     logger = logging.getLogger(__name__)
+    is_debug = request.get('debug')
     for (j1, j2) in itertools.permutations(journeys, 2):
         if to_be_deleted(j1) or to_be_deleted(j2):
             continue
         if way_later(request, j1, j2):
             logger.debug("the journey {} is too long compared to {}, we delete it"
                          .format(j1.internal_id, j2.internal_id))
-            mark_as_dead(j1, request, 'too_long', 'too_long_compared_to_{}'.format(j2.internal_id))
+            mark_as_dead(j1, is_debug, 'too_long', 'too_long_compared_to_{}'.format(j2.internal_id))
 
 
 def is_walk_after_parking(journey, idx_section):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -438,6 +438,7 @@ def culling_journeys(resp, request):
 
     nb_journeys_must_have = len(idx_of_jrnys_must_keep)
     logger.debug("There are {0} journeys we must keep".format(nb_journeys_must_have))
+    is_debug = request.get('debug')
     if (request["max_nb_journeys"] - nb_journeys_must_have) <= 0:
         # At this point, max_nb_journeys is smaller than nb_journeys_must_have, we have to make choices
 
@@ -447,7 +448,7 @@ def culling_journeys(resp, request):
 
         # Here we mark all journeys as dead that are not must-have
         for jrny in _inverse_selection(candidates_pool, idx_of_jrnys_must_keep):
-             journey_filter.mark_as_dead(jrny, request, 'Filtered by max_nb_journeys')
+             journey_filter.mark_as_dead(jrny, is_debug, 'Filtered by max_nb_journeys')
 
         if request["max_nb_journeys"] == nb_journeys_must_have:
             logger.debug('max_nb_journeys equals to nb_journeys_must_have')
@@ -468,7 +469,7 @@ def culling_journeys(resp, request):
             sorted_by_type_journeys.extend(list_dict.get(t, []))
 
         for jrny in sorted_by_type_journeys[request["max_nb_journeys"]:]:
-            journey_filter.mark_as_dead(jrny, request, 'Filtered by max_nb_journeys')
+            journey_filter.mark_as_dead(jrny, is_debug, 'Filtered by max_nb_journeys')
 
         journey_filter.delete_journeys((resp,), request)
         return
@@ -517,7 +518,7 @@ def culling_journeys(resp, request):
 
     logger.debug('Removing non selected journeys')
     for jrny in candidates_pool[np.where(selection_matrix[the_best_index, :] == 0)]:
-        journey_filter.mark_as_dead(jrny, request, 'Filtered by max_nb_journeys')
+        journey_filter.mark_as_dead(jrny, is_debug, 'Filtered by max_nb_journeys')
 
     journey_filter.delete_journeys((resp,), request)
 
@@ -872,7 +873,7 @@ class Scenario(simple.Scenario):
         else:
             for j in pb_resp.journeys:
                 if 'ridesharing' in j.tags:
-                    journey_filter.mark_as_dead(j, api_request, 'no_matching_ridesharing_found')
+                    journey_filter.mark_as_dead(j, api_request.get('debug'), 'no_matching_ridesharing_found')
 
         journey_filter.delete_journeys((pb_resp,), api_request)
         type_journeys(pb_resp, api_request)

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -947,7 +947,7 @@ class Scenario(simple.Scenario):
 
         to do that we find ask the next (resp previous) query datetime
         """
-        vjs = [j for r in responses for j in r.journeys if not journey_filter.to_be_deleted(j)]
+        vjs = journey_filter.get_qualified_journeys(responses)
         if request["clockwise"]:
             request['datetime'] = self.next_journey_datetime(vjs, request["clockwise"])
         else:

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -824,15 +824,17 @@ class Scenario(simple.Scenario):
             journey_filter._filter_too_long_journeys(new_resp, request)
             if nb_journeys(new_resp) == 0:
                 # no new journeys found, we stop
+                # we still append the new_resp because there are journeys that a tagged as dead probably
                 responses.extend(new_resp)
                 break
 
             request = self.create_next_kraken_request(request, new_resp)
 
-            # we filter unwanted journeys by side effects
+            # we filter unwanted journeys
+            # note that filter_journeys returns a generator which will be evaluated later
             filtered_new_resp = journey_filter.filter_journeys(new_resp, instance, api_request)
 
-            #duplicate the iterator
+            # duplicate the generator
             tmp1, tmp2 = itertools.tee(filtered_new_resp)
             qualified_journeys = journey_filter.get_qualified_journeys(responses)
 
@@ -845,7 +847,8 @@ class Scenario(simple.Scenario):
             responses.extend(new_resp)  # we keep the error for building the response
 
             nb_qualified_journeys = nb_journeys(responses)
-            #We allow one more call to kraken if there is no valid journey.
+
+            # We allow one more call to kraken if there is no valid journey.
             if nb_qualified_journeys == 0:
                 min_journeys_calls = max(min_journeys_calls, 2)
 

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -810,10 +810,10 @@ class Scenario(simple.Scenario):
 
         responses = []
         nb_try = 0
-        nb_valid_journeys = nb_journeys(responses)
+        nb_qualified_journeys = nb_journeys(responses)
 
         while request is not None and \
-                ((nb_valid_journeys < min_asked_journeys and nb_try < min_asked_journeys)
+                ((nb_qualified_journeys < min_asked_journeys and nb_try < min_asked_journeys)
                  or nb_try < min_journeys_calls):
             nb_try = nb_try + 1
 
@@ -844,9 +844,9 @@ class Scenario(simple.Scenario):
 
             responses.extend(new_resp)  # we keep the error for building the response
 
-            nb_valid_journeys = nb_journeys(responses)
+            nb_qualified_journeys = nb_journeys(responses)
             #We allow one more call to kraken if there is no valid journey.
-            if nb_valid_journeys == 0:
+            if nb_qualified_journeys == 0:
                 min_journeys_calls = max(min_journeys_calls, 2)
 
         logger.debug('nb of call kraken: %i', nb_try)

--- a/source/jormungandr/jormungandr/scenarios/qualifier.py
+++ b/source/jormungandr/jormungandr/scenarios/qualifier.py
@@ -184,12 +184,7 @@ def choose_standard(journeys, best_criteria):
 
 #comparison of 2 fields. 0=>equality, 1=>1 better than 2
 def compare_minus(field_1, field_2):
-    if field_1 == field_2:
-        return 0
-    elif field_1 < field_2:
-        return 1
-    else:
-        return -1
+    return cmp(field_2, field_1)
 
 
 def compare_field(obj1, obj2, func):

--- a/source/jormungandr/jormungandr/scenarios/qualifier.py
+++ b/source/jormungandr/jormungandr/scenarios/qualifier.py
@@ -184,7 +184,9 @@ def choose_standard(journeys, best_criteria):
 
 #comparison of 2 fields. 0=>equality, 1=>1 better than 2
 def compare_minus(field_1, field_2):
-    return cmp(field_2, field_1)
+    # ordering-comparisons
+    # https://docs.python.org/3.4/whatsnew/3.0.html#ordering-comparisons
+    return (field_2 > field_1) - (field_2 < field_1)
 
 
 def compare_field(obj1, obj2, func):

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -637,7 +637,7 @@ def test_too_late_journeys():
     journey3.departure_date_time = 10000
     journey3.arrival_date_time = 13000
 
-    journey_filter._filter_too_long_journeys(responses, request)
+    journey_filter._filter_too_late_journeys(responses, request)
 
     assert 'to_delete' not in journey1.tags
     assert 'to_delete' not in journey2.tags
@@ -659,7 +659,7 @@ def test_not_too_late_journeys():
     journey2.departure_date_time = 3100
     journey2.arrival_date_time = 3200
 
-    journey_filter._filter_too_long_journeys(responses, request)
+    journey_filter._filter_too_late_journeys(responses, request)
 
     assert 'to_delete' not in journey1.tags
     assert 'to_delete' not in journey2.tags
@@ -695,7 +695,7 @@ def test_too_late_journeys_but_better_mode():
     walking.arrival_date_time = 1016070 # bss * 2 + 10
     walking.tags.append('walking')
 
-    journey_filter._filter_too_long_journeys(responses, request)
+    journey_filter._filter_too_late_journeys(responses, request)
 
     assert all('to_delete' not in j.tags for r in responses for j in r.journeys)
 
@@ -730,7 +730,7 @@ def test_too_late_journeys_and_worst_mode():
     car.arrival_date_time = 1016070 # bike * 2 + 10
     car.tags.append('car')
 
-    journey_filter._filter_too_long_journeys(responses, request)
+    journey_filter._filter_too_late_journeys(responses, request)
 
     assert ['to_delete' not in j.tags for r in responses for j in r.journeys].count(True) == 1
 
@@ -756,7 +756,7 @@ def test_not_too_late_journeys_non_clockwise():
     journey3.departure_date_time = 8000
     journey3.arrival_date_time = 9000
 
-    journey_filter._filter_too_long_journeys(responses, request)
+    journey_filter._filter_too_late_journeys(responses, request)
 
     assert 'to_delete' in journey1.tags
     assert 'to_delete' not in journey2.tags

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -877,14 +877,14 @@ def test_heavy_journey_bike():
     journey.sections.add()
     journey.sections[-1].type = response_pb2.STREET_NETWORK
     journey.sections[-1].street_network.mode = response_pb2.Bike
-    journey.sections[-1].duration = 15
+    journey.durations.bike = journey.sections[-1].duration = 15
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' not in journey.tags
 
     request['origin_mode'] = ['bike', 'walking']
-    journey.sections[-1].duration = 5
+    journey.durations.bike = journey.sections[-1].duration = 5
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
 
@@ -901,13 +901,13 @@ def test_heavy_journey_car():
     journey.sections.add()
     journey.sections[-1].type = response_pb2.STREET_NETWORK
     journey.sections[-1].street_network.mode = response_pb2.Car
-    journey.sections[-1].duration = 25
+    journey.durations.car = journey.sections[-1].duration = 25
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' not in journey.tags
 
-    journey.sections[-1].duration = 15
+    journey.durations.car = journey.sections[-1].duration = 15
     request['origin_mode'] = ['bike', 'walking']
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -985,6 +985,8 @@ def test_activate_deactivate_min_bike():
 
     # case 2: request without origin_mode
     journey.sections[-1].duration = 15
+    journey.durations.bike = 20
+
     request = {'_min_bike': 8, 'destination_mode': ['bike', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -993,6 +995,8 @@ def test_activate_deactivate_min_bike():
     # case 3: request without destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 5
+    journey.durations.bike = 20
+
     request = {'_min_bike': 8, 'origin_mode': ['bike', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1001,6 +1005,7 @@ def test_activate_deactivate_min_bike():
     # case 4: request without walking in origin_mode
     journey.sections[0].duration = 5
     journey.sections[-1].duration = 15
+    journey.durations.bike = 20
     request = {'_min_bike': 8, 'origin_mode': ['bike']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1009,6 +1014,7 @@ def test_activate_deactivate_min_bike():
     # case 5: request without walking in destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 5
+    journey.durations.bike = 20
     request = {'_min_bike': 8, 'destination_mode': ['bike']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1017,6 +1023,7 @@ def test_activate_deactivate_min_bike():
     # case 6: request with bike only in origin_mode destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 14
+    journey.durations.bike = 29
     request = {'_min_bike': 17, 'origin_mode': ['bike'], 'destination_mode': ['bike']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1025,6 +1032,7 @@ def test_activate_deactivate_min_bike():
     # case 7: request with walking in destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 5
+    journey.durations.bike = 20
     request = {'_min_bike': 8, 'destination_mode': ['bike', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1033,6 +1041,7 @@ def test_activate_deactivate_min_bike():
     # case 8: request with walking in origin_mode
     journey.sections[0].duration = 5
     journey.sections[-1].duration = 15
+    journey.durations.bike = 20
     request = {'_min_bike': 8, 'origin_mode': ['bike', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1041,6 +1050,7 @@ def test_activate_deactivate_min_bike():
     # case 9: request with bike in origin_mode and bike, walking in destination_mode
     journey.sections[0].duration = 5
     journey.sections[-1].duration = 7
+    journey.durations.bike = 12
     request = {'_min_bike': 8, 'origin_mode': ['bike'], 'destination_mode': ['bike', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1077,11 +1087,14 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].street_network.mode = response_pb2.Car
     journey.sections[-1].duration = 7
 
+    journey.durations.car = 12
     journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 2: request without origin_mode
     journey.sections[-1].duration = 15
+    journey.durations.car = 20
+
     request = {'_min_car': 8, 'destination_mode': ['car', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1090,6 +1103,7 @@ def test_activate_deactivate_min_car():
     # case 3: request without destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 5
+    journey.durations.car = 20
     request = {'_min_car': 8, 'origin_mode': ['car', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1098,6 +1112,7 @@ def test_activate_deactivate_min_car():
     # case 4: request without walking in origin_mode
     journey.sections[0].duration = 5
     journey.sections[-1].duration = 15
+    journey.durations.car = 20
     request = {'_min_car': 8, 'origin_mode': ['car']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1106,6 +1121,7 @@ def test_activate_deactivate_min_car():
     # case 5: request without walking in destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 5
+    journey.durations.car = 20
     request = {'_min_car': 8, 'destination_mode': ['car']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1114,6 +1130,7 @@ def test_activate_deactivate_min_car():
     # case 6: request with car only in origin_mode destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 14
+    journey.durations.car = 29
     request = {'_min_car': 17, 'origin_mode': ['car'], 'destination_mode': ['car']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1122,6 +1139,7 @@ def test_activate_deactivate_min_car():
     # case 7: request with walking in destination_mode
     journey.sections[0].duration = 15
     journey.sections[-1].duration = 5
+    journey.durations.car = 20
     request = {'_min_car': 8, 'destination_mode': ['car', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1130,6 +1148,7 @@ def test_activate_deactivate_min_car():
     # case 8: request with walking in origin_mode
     journey.sections[0].duration = 5
     journey.sections[-1].duration = 15
+    journey.durations.car = 20
     request = {'_min_car': 8, 'origin_mode': ['car', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)
@@ -1138,6 +1157,7 @@ def test_activate_deactivate_min_car():
     # case 9: request with bike in origin_mode and bike, walking in destination_mode
     journey.sections[0].duration = 5
     journey.sections[-1].duration = 7
+    journey.durations.car = 12
     request = {'_min_car': 8, 'origin_mode': ['car'], 'destination_mode': ['car', 'walking']}
 
     journey_filter.filter_too_short_heavy_journeys(journey, request)

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -863,8 +863,7 @@ def test_heavy_journey_walking():
     journey.sections[-1].street_network.mode = response_pb2.Walking
     journey.sections[-1].duration = 5
 
-
-    journey_filter._filter_too_short_heavy_journeys([journey], request)
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' not in journey.tags
 
@@ -880,14 +879,14 @@ def test_heavy_journey_bike():
     journey.sections[-1].street_network.mode = response_pb2.Bike
     journey.sections[-1].duration = 15
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' not in journey.tags
 
     request['origin_mode'] = ['bike', 'walking']
     journey.sections[-1].duration = 5
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' in journey.tags
 
@@ -904,14 +903,14 @@ def test_heavy_journey_car():
     journey.sections[-1].street_network.mode = response_pb2.Car
     journey.sections[-1].duration = 25
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' not in journey.tags
 
     journey.sections[-1].duration = 15
     request['origin_mode'] = ['bike', 'walking']
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' in journey.tags
 
@@ -945,7 +944,7 @@ def test_heavy_journey_bss():
     journey.sections[-1].street_network.mode = response_pb2.Walking
     journey.sections[-1].duration = 5
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
 
     assert 'to_delete' not in journey.tags
 
@@ -981,14 +980,14 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].street_network.mode = response_pb2.Bike
     journey.sections[-1].duration = 7
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 2: request without origin_mode
     journey.sections[-1].duration = 15
     request = {'_min_bike': 8, 'destination_mode': ['bike', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 3: request without destination_mode
@@ -996,7 +995,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 5
     request = {'_min_bike': 8, 'origin_mode': ['bike', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 4: request without walking in origin_mode
@@ -1004,7 +1003,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 15
     request = {'_min_bike': 8, 'origin_mode': ['bike']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 5: request without walking in destination_mode
@@ -1012,7 +1011,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 5
     request = {'_min_bike': 8, 'destination_mode': ['bike']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 6: request with bike only in origin_mode destination_mode
@@ -1020,7 +1019,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 14
     request = {'_min_bike': 17, 'origin_mode': ['bike'], 'destination_mode': ['bike']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 7: request with walking in destination_mode
@@ -1028,7 +1027,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 5
     request = {'_min_bike': 8, 'destination_mode': ['bike', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' in journey.tags
 
     # case 8: request with walking in origin_mode
@@ -1036,7 +1035,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 15
     request = {'_min_bike': 8, 'origin_mode': ['bike', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' in journey.tags
 
     # case 9: request with bike in origin_mode and bike, walking in destination_mode
@@ -1044,7 +1043,7 @@ def test_activate_deactivate_min_bike():
     journey.sections[-1].duration = 7
     request = {'_min_bike': 8, 'origin_mode': ['bike'], 'destination_mode': ['bike', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' in journey.tags
 
 def test_activate_deactivate_min_car():
@@ -1078,14 +1077,14 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].street_network.mode = response_pb2.Car
     journey.sections[-1].duration = 7
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 2: request without origin_mode
     journey.sections[-1].duration = 15
     request = {'_min_car': 8, 'destination_mode': ['car', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 3: request without destination_mode
@@ -1093,7 +1092,7 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 5
     request = {'_min_car': 8, 'origin_mode': ['car', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 4: request without walking in origin_mode
@@ -1101,7 +1100,7 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 15
     request = {'_min_car': 8, 'origin_mode': ['car']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 5: request without walking in destination_mode
@@ -1109,7 +1108,7 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 5
     request = {'_min_car': 8, 'destination_mode': ['car']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 6: request with car only in origin_mode destination_mode
@@ -1117,7 +1116,7 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 14
     request = {'_min_car': 17, 'origin_mode': ['car'], 'destination_mode': ['car']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' not in journey.tags
 
     # case 7: request with walking in destination_mode
@@ -1125,7 +1124,7 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 5
     request = {'_min_car': 8, 'destination_mode': ['car', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' in journey.tags
 
     # case 8: request with walking in origin_mode
@@ -1133,7 +1132,7 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 15
     request = {'_min_car': 8, 'origin_mode': ['car', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' in journey.tags
 
     # case 9: request with bike in origin_mode and bike, walking in destination_mode
@@ -1141,5 +1140,5 @@ def test_activate_deactivate_min_car():
     journey.sections[-1].duration = 7
     request = {'_min_car': 8, 'origin_mode': ['car'], 'destination_mode': ['car', 'walking']}
 
-    list(journey_filter._filter_too_short_heavy_journeys([journey], request))
+    journey_filter.filter_too_short_heavy_journeys(journey, request)
     assert 'to_delete' in journey.tags

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -219,7 +219,8 @@ def get_or_default(request, val, default):
     so here is a simple helper to get the default value is the key
     is not in the dict or if the value is None
     """
-    return request.get(val, default) or default
+    val = request.get(val, default)
+    return val if val is not None else default
 
 
 def updated_common_journey_request_with_default(request, instance):

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -66,8 +66,8 @@ def compare(obj1, obj2, compare_generator):
     from any values returned by the other generator
     """
     return all(a == b for a, b in zip_longest(compare_generator(obj1),
-                                                         compare_generator(obj2),
-                                                         fillvalue=object()))
+                                              compare_generator(obj2),
+                                              fillvalue=object()))
 
 
 def are_equals(journey1, journey2):

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -219,10 +219,7 @@ def get_or_default(request, val, default):
     so here is a simple helper to get the default value is the key
     is not in the dict or if the value is None
     """
-    val = request.get(val, default)
-    if val is not None:
-        return val
-    return default
+    return request.get(val, default) or default
 
 
 def updated_common_journey_request_with_default(request, instance):

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -48,7 +48,7 @@ from flask import request
 import re
 import flask
 from contextlib import contextmanager
-
+import functools
 
 DATETIME_FORMAT = "%Y%m%dT%H%M%S"
 
@@ -563,3 +563,36 @@ def copy_context_in_greenlet_stack(request_context):
     flask.globals._request_ctx_stack.push(request_context)
     yield
     flask.globals._request_ctx_stack.pop()
+
+
+def compose(*funs):
+    """
+    compose functions and return a callable object
+
+    example 1:
+    f(x) = x + 1
+    g(x) = 2*x
+
+    compose(f,g) = g(f(x)) = 2 * (x + 1 )
+
+    example 2:
+    f(a list of integer): returns multiples of 3
+    g(a list of integer): returns multiples of 5
+
+    compose(f,g): returns multiples of 3 AND 5
+
+    :param funs:
+    :return: a lambda
+
+    >>> c = compose(lambda x: x+1, lambda x: 2*x)
+    >>> c(42)
+    86
+
+    >>> f = lambda l: (x for x in l if x%3 == 0)
+    >>> g = lambda l: (x for x in l if x%5 == 0)
+    >>> c = compose(f, g)
+    >>> list(c(range(45)))
+    [0, 15, 30]
+    """
+    return lambda obj: functools.reduce(lambda prev, f: f(prev), funs, obj)
+

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -599,6 +599,31 @@ def compose(*funs):
     """
     return lambda obj: functools.reduce(lambda prev, f: f(prev), funs, obj)
 
+class ComposedFilter(object):
+    """
+    Compose several filters with convenient interfaces
+    All filters are evaluated lazily
+
+    >>> F = ComposedFilter()
+    >>> f = F.add_filter(lambda x: x % 2 == 0).add_filter(lambda x: x % 5 == 0).compile()
+    >>> list(f(range(40)))
+    [0, 10, 20, 30]
+    >>> list(f(range(20))) # we can reuse the composed filter
+    [0, 10]
+    >>> f = F.add_filter(lambda x: x % 3 == 0).compile() # we can continue on adding new filter
+    >>> list(f(range(40)))
+    [0, 30]
+    """
+    def __init__(self):
+        self.filters = []
+
+    def add_filter(self, pred):
+        self.filters.append(lambda iterable: (i for i in iterable if pred(i)))
+        return self
+
+    def compile(self):
+        return compose(*self.filters)
+
 
 def portable_min(*args, **kwargs):
     """

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -605,12 +605,12 @@ class ComposedFilter(object):
     All filters are evaluated lazily
 
     >>> F = ComposedFilter()
-    >>> f = F.add_filter(lambda x: x % 2 == 0).add_filter(lambda x: x % 5 == 0).compile()
+    >>> f = F.add_filter(lambda x: x % 2 == 0).add_filter(lambda x: x % 5 == 0).compose_filters()
     >>> list(f(range(40)))
     [0, 10, 20, 30]
     >>> list(f(range(20))) # we can reuse the composed filter
     [0, 10]
-    >>> f = F.add_filter(lambda x: x % 3 == 0).compile() # we can continue on adding new filter
+    >>> f = F.add_filter(lambda x: x % 3 == 0).compose_filters() # we can continue on adding new filter
     >>> list(f(range(40)))
     [0, 30]
     """
@@ -621,7 +621,7 @@ class ComposedFilter(object):
         self.filters.append(lambda iterable: (i for i in iterable if pred(i)))
         return self
 
-    def compile(self):
+    def compose_filters(self):
         return compose(*self.filters)
 
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -308,7 +308,7 @@ def realtime_level_to_pbf(level):
 #we can't use reverse(enumerate(list)) without creating a temporary
 #list, so we define our own reverse enumerate
 def reverse_enumerate(l):
-    return list(zip(list(range(len(l)-1, -1, -1)), reversed(l)))
+    return zip(xrange(len(l)-1, -1, -1), reversed(l))
 
 
 def pb_del_if(l, pred):

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -49,6 +49,9 @@ import re
 import flask
 from contextlib import contextmanager
 import functools
+import sys
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 
 DATETIME_FORMAT = "%Y%m%dT%H%M%S"
 
@@ -596,3 +599,27 @@ def compose(*funs):
     """
     return lambda obj: functools.reduce(lambda prev, f: f(prev), funs, obj)
 
+
+def portable_min(*args, **kwargs):
+    """
+    a portable min() for python2 which takes a default value when
+    the iterable is empty
+
+    >>> portable_min([1], default=42)
+    1
+    >>> portable_min([], default=42)
+    42
+    >>> portable_min(iter(()), default=43) # empty iterable
+    43
+
+    """
+    if PY2:
+        default = kwargs.pop('default', None)
+        try:
+            return min(*args, **kwargs)
+        except ValueError:
+            return default
+        except Exception:
+            raise
+    if PY3:
+        return min(*args, **kwargs)

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -1098,7 +1098,6 @@ class OnBasicRouting():
         """
         query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}&debug=true"\
             .format(from_sa="A", to_sa="D", datetime="20120614T080000")
-        print(query)
         response = self.query_region(query, display=True)
         check_best(response)
         #self.is_valid_journey_response(response, query)# linestring with 1 value (0,0)


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVP-861

I used the following request, with which kraken is called  99 times (i requested 100 journeys) for the benchmark
```bash
time curl 'http://localhost:5000/v1/coverage/stif/journeys?from=stop_area%3A0%3ASA%3A8768600&to=stop_area%3A0%3ASA%3A8775860&datetime=20180423T083802&count=100' > /dev/null
```
In this [loop:](https://github.com/CanalTP/navitia/pull/2404/files#diff-f050c03e2b24acf6b927fade7d249a87L813):


|   time used in   | C++(Kraken) | Python |
|--------|--------|--------|
| Before |    4.46s    | 3.44s        | 
| After  |      4.41s  |  0.13s      | 

another request, with which kraken is called for 30 times (100 journeys are requested, same as before)
```bash
time curl 'http://localhost:5000/v1/coverage/stif/journeys?from=2.284794%3B48.911762&to=2.37715%3B48.846781&count=100&datetime=20180423T083802&' > /dev/null
```

|   time used in     | C++(Kraken) | Python |
|--------|--------|--------|
| Before |   3.21s   | 1.2s        | 
| After  |     3.30s  |  0.15s      | 


