### PR TITLE
kraken: use disable_geojson in route_schedules

### DIFF
--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -430,7 +430,9 @@ void route_schedule(PbCreator& pb_creator, const std::string& filter,
                 pb_creator.fill(&st_calendar, pb_dt, max_depth);
             }
         }
-        pb_creator.fill(&route->shape, schedule->mutable_geojson(), 0);
+        if(!pb_creator.disable_geojson) {
+            pb_creator.fill(&route->shape, schedule->mutable_geojson(), 0);
+        }
 
         //Add additiona_informations in each route:
         if (stop_times.empty() && (rt_level != type::RTLevel::Base)) {


### PR DESCRIPTION
We serialize in protobuf, send it over the wire then deserialize it, then we choose to not use it, it's sad