### PR TITLE
Jormun: Cache timezone

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -126,7 +126,7 @@ if rest_api.app.config.get('ACTIVATE_PROFILING'):
     rest_api.app.logger.warning('=======================================================')
     from werkzeug.contrib.profiler import ProfilerMiddleware
     rest_api.app.config['PROFILE'] = True
-    f = open('/tmp/profiler.log', 'a')
-    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/tmp/profile')
+    f = open('/home/xiaolong/profiler/profiler.log', 'a')
+    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/home/xiaolong/profiler/')
 
 index(rest_api)

--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -126,7 +126,7 @@ if rest_api.app.config.get('ACTIVATE_PROFILING'):
     rest_api.app.logger.warning('=======================================================')
     from werkzeug.contrib.profiler import ProfilerMiddleware
     rest_api.app.config['PROFILE'] = True
-    f = open('/home/xiaolong/profiler/profiler.log', 'a')
-    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/home/xiaolong/profiler/')
+    f = open('/tmp/profiler.log', 'a')
+    rest_api.app.wsgi_app = ProfilerMiddleware(rest_api.app.wsgi_app, f, restrictions=[80], profile_dir='/tmp/profile')
 
 index(rest_api)

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -190,7 +190,7 @@ class complete_links(object):
     def get_links(self, data):
         queue = deque()
         result = {"notes": [], "exceptions": []}
-        queue.extend(list(data.values()))
+        queue.extend(data.values())
         while queue:
             elem = queue.pop()
             if isinstance(elem, (list, tuple)):
@@ -203,10 +203,9 @@ class complete_links(object):
                         result[collect].append(link)
                     # Delete all items from link not in expected_keys
                     del_keys = set(elem.keys()).difference(self.EXPECTED_ITEMS)
-                    if len(del_keys):
-                        list(map(elem.pop, del_keys))
+                    list(map(elem.pop, del_keys))
                 else:
-                    queue.extend(list(elem.values()))
+                    queue.extend(elem.values())
         return result
 
     def __call__(self, f):

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -192,7 +192,7 @@ class Schedules(ResourceUri, ResourceUtc):
             self.endpoint = "previous" + self.endpoint[4:]
 
         # Add timezone in request for availability in greenlet
-        args['timezone'] = timezone.get_timezone()
+        args['timezone'] = timezone.get_timezone(request.id)
 
         self._register_interpreted_parameters(args)
         return i_manager.dispatch(args, self.endpoint,

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -32,6 +32,7 @@ from copy import deepcopy
 import datetime
 import logging
 from flask.globals import g
+from flask import request
 import pytz
 from jormungandr.interfaces.v1.make_links import create_internal_link, create_external_link
 from jormungandr.interfaces.v1.serializer import pt, base
@@ -126,7 +127,6 @@ class DateTime(fields.Raw):
         return self.format(value)
 
     def format(self, value):
-        from flask import request
         return timestamp_to_str(value, request.id)
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -126,7 +126,8 @@ class DateTime(fields.Raw):
         return self.format(value)
 
     def format(self, value):
-        return timestamp_to_str(value)
+        from flask import request
+        return timestamp_to_str(value, request.id)
 
 
 class Links(fields.Raw):

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -303,13 +303,11 @@ class add_id_links(generate_links):
         if hasattr(data, 'keys'):
             if "id" in data and "type" in data:
                 self.data.add(data["type"])
-            if "id" in data and ("href" not in data) and collection_name:
+            elif "id" in data and ("href" not in data) and collection_name:
                 self.data.add(collection_name)
-            for key, value in data.items():
-                self.get_objets(value, key)
-        if isinstance(data, (list, tuple)):
-            for item in data:
-                self.get_objets(item, collection_name)
+            [self.get_objets(value, key)for key, value in data.iteritems() if hasattr(value, '__iter__')]
+        elif hasattr(data, '__iter__'):
+            [self.get_objets(value, collection_name) for value in data if hasattr(value, '__iter__')]
 
 
 class clean_links(object):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -321,13 +321,13 @@ class BetaEndpointsSerializer(serpy.Serializer):
                            schema_type=str, display_none=True)
 
 def make_notes(notes):
-    return [{"type": "notes",
+    return ({"type": "notes",
              "rel": "notes",
              "category": "comment",
              "id": value.uri,
              "value": value.note,
              "internal": True}
-            for value in notes]
+            for value in notes)
 
 
 class NestedDictGenericField(DictGenericSerializer, NestedPropertyField):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -28,6 +28,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 from datetime import datetime
+from itertools import chain
 from flask import request
 from jormungandr.interfaces.v1.serializer.base import PbNestedSerializer, EnumField, EnumListField
 from jormungandr.interfaces.v1.serializer import pt, jsonschema, base
@@ -37,17 +38,20 @@ from jormungandr.interfaces.v1.make_links import create_internal_link
 from jormungandr.interfaces.v1.serializer.jsonschema.fields import TimeOrDateTimeType
 from jormungandr.utils import timestamp_to_str
 
+LINK_ATTRS_NAMES = ("line", "company", "vehicle_journey", "route", "commercial_mode", "physical_mode", "physical_mode",
+
+                    "network")
 def _get_links(obj):
     display_info = obj.pt_display_informations
     uris = display_info.uris
-    l = [("line", uris.line),
-         ("company", uris.company),
-         ("vehicle_journey", uris.vehicle_journey),
-         ("route", uris.route),
-         ("commercial_mode", uris.commercial_mode),
-         ("physical_mode", uris.physical_mode),
-         ("network", uris.network)]
-    return [{"type": k, "id": v} for k, v in l if v != ""] + base.make_notes(display_info.notes)
+
+    def gen(attr_uris):
+        for attr_name in LINK_ATTRS_NAMES:
+            attr = getattr(attr_uris, attr_name, "")
+            if attr != "":
+                yield {"type": attr_name, "id": attr}
+    return list(chain(gen(uris), base.make_notes(display_info.notes)))
+
 
 
 class PassageSerializer(PbNestedSerializer):
@@ -69,10 +73,10 @@ class DateTimeTypeSerializer(PbNestedSerializer):
     data_freshness = EnumField(attr="realtime_level", display_none=True)
 
     def get_links(self, obj):
-        disruption_links = [create_internal_link(_type="disruption", rel="disruptions", id=uri)
-                            for uri in obj.impact_uris]
         properties_links = pt.make_properties_links(obj.properties)
-        return properties_links + disruption_links
+        properties_links.extend(create_internal_link(_type="disruption", rel="disruptions", id=uri)
+                                for uri in obj.impact_uris)
+        return properties_links
 
     def get_date_time(self, obj):
         __date_time_null_value__ = 2**64 - 1

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -78,7 +78,8 @@ class DateTimeTypeSerializer(PbNestedSerializer):
         if obj.time == __date_time_null_value__:
             return ""
         if obj.HasField('date'):
-            return timestamp_to_str(obj.date + obj.time)
+            from flask import request
+            return timestamp_to_str(obj.date + obj.time, request.id)
         return datetime.utcfromtimestamp(obj.time).strftime('%H%M%S')
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -28,6 +28,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 from datetime import datetime
+from flask import request
 from jormungandr.interfaces.v1.serializer.base import PbNestedSerializer, EnumField, EnumListField
 from jormungandr.interfaces.v1.serializer import pt, jsonschema, base
 from jormungandr.interfaces.v1.serializer.fields import LinkSchema, MultiLineStringField
@@ -78,7 +79,6 @@ class DateTimeTypeSerializer(PbNestedSerializer):
         if obj.time == __date_time_null_value__:
             return ""
         if obj.HasField('date'):
-            from flask import request
             return timestamp_to_str(obj.date + obj.time, request.id)
         return datetime.utcfromtimestamp(obj.time).strftime('%H%M%S')
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
@@ -56,7 +56,8 @@ class DateTimeField(PbField, DateTimeType):
     custom date format from timestamp
     """
     def to_value(self, value):
-        return timestamp_to_str(value)
+        from flask import request
+        return timestamp_to_str(value, request.id)
 
 
 class DateTimeDictField(Field, DateTimeType):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
@@ -66,7 +66,6 @@ class DateTimeDictField(Field, DateTimeType):
     """
     def to_value(self, value):
         return timestamp_to_str(value) if value else None
-        super(DateTimeDictField, self).__init__(schema_type=str, schema_metadata=schema_metadata, **kwargs)
 
 
 class PeriodSerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/time.py
@@ -30,6 +30,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import serpy
 from datetime import datetime
+from flask import request
 from jormungandr.interfaces.v1.serializer.base import PbField, PbNestedSerializer, NestedPbField
 from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field, TimeType, DateTimeType
 from jormungandr.utils import timestamp_to_str
@@ -56,7 +57,6 @@ class DateTimeField(PbField, DateTimeType):
     custom date format from timestamp
     """
     def to_value(self, value):
-        from flask import request
         return timestamp_to_str(value, request.id)
 
 

--- a/source/jormungandr/jormungandr/scenarios/destineo.py
+++ b/source/jormungandr/jormungandr/scenarios/destineo.py
@@ -45,6 +45,7 @@ import itertools
 from jormungandr.utils import pb_del_if, timestamp_to_str
 from six.moves import filter
 from six.moves import range
+from flask import request
 
 non_pt_types = ['non_pt_walk', 'non_pt_bike', 'non_pt_bss']
 
@@ -415,7 +416,7 @@ class Scenario(default.Scenario):
         if not journeys:
             return None
         next_journey = max(journeys, key=lambda j: j.departure_date_time)
-        params['datetime'] = timestamp_to_str(next_journey.departure_date_time + 60)
+        params['datetime'] = timestamp_to_str(next_journey.departure_date_time + 60, request.id)
         params['datetime_represents'] = 'departure'
         add_link(resp, rel='next', **params)
 
@@ -424,7 +425,7 @@ class Scenario(default.Scenario):
         if not journeys:
             return None
         next_journey = max(journeys, key=lambda j: j.arrival_date_time)
-        params['datetime'] = timestamp_to_str(next_journey.arrival_date_time - 60)
+        params['datetime'] = timestamp_to_str(next_journey.arrival_date_time - 60, request.id)
         params['datetime_represents'] = 'arrival'
         add_link(resp, rel='prev', **params)
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -360,7 +360,6 @@ class Scenario(object):
     def _add_prev_link(self, resp, params, clockwise):
         prev_dt = self.previous_journey_datetime(resp.journeys, clockwise)
         if prev_dt is not None:
-            from flask import request
             params['datetime'] = timestamp_to_str(prev_dt, request.id)
             params['datetime_represents'] = 'arrival'
             add_link(resp, rel='prev', **params)

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -360,31 +360,37 @@ class Scenario(object):
     def _add_prev_link(self, resp, params, clockwise):
         prev_dt = self.previous_journey_datetime(resp.journeys, clockwise)
         if prev_dt is not None:
-            params['datetime'] = timestamp_to_str(prev_dt)
+            from flask import request
+            params['datetime'] = timestamp_to_str(prev_dt, request.id)
             params['datetime_represents'] = 'arrival'
             add_link(resp, rel='prev', **params)
 
     def _add_next_link(self, resp, params, clockwise):
         next_dt = self.next_journey_datetime(resp.journeys, clockwise)
         if next_dt is not None:
-            params['datetime'] = timestamp_to_str(next_dt)
+            from flask import request
+            params['datetime'] = timestamp_to_str(next_dt, request.id)
             params['datetime_represents'] = 'departure'
             add_link(resp, rel='next', **params)
 
     def _add_first_last_links(self, resp, params):
         soonest_departure_ts = min(j.departure_date_time for j in resp.journeys)
-        soonest_departure = timestamp_to_datetime(soonest_departure_ts)
+        from flask import request
+        soonest_departure = timestamp_to_datetime(soonest_departure_ts, request.id)
         if soonest_departure:
             soonest_departure = soonest_departure.replace(hour=0, minute=0, second=0)
-            params['datetime'] = dt_to_str(soonest_departure)
+            from flask import request
+            params['datetime'] = dt_to_str(soonest_departure, request.id)
             params['datetime_represents'] = 'departure'
             add_link(resp, rel='first', **params)
 
         tardiest_arrival_ts = max(j.arrival_date_time for j in resp.journeys)
-        tardiest_arrival = timestamp_to_datetime(tardiest_arrival_ts)
+        from flask import request
+        tardiest_arrival = timestamp_to_datetime(tardiest_arrival_ts, request.id)
         if tardiest_arrival:
             tardiest_arrival = tardiest_arrival.replace(hour=23, minute=59, second=59)
-            params['datetime'] = dt_to_str(tardiest_arrival)
+            from flask import request
+            params['datetime'] = dt_to_str(tardiest_arrival, request.id)
             params['datetime_represents'] = 'arrival'
             add_link(resp, rel='last', **params)
 

--- a/source/jormungandr/jormungandr/stat_manager.py
+++ b/source/jormungandr/jormungandr/stat_manager.py
@@ -300,7 +300,7 @@ class StatManager(object):
         """
         init_journey(stat_journey)
 
-        tz = utils.get_timezone()
+        tz = utils.get_timezone(request.id)
         if 'requested_date_time' in resp_journey:
             stat_journey.requested_date_time = tz_str_to_utc_timestamp(resp_journey['requested_date_time'], tz)
 
@@ -356,7 +356,7 @@ class StatManager(object):
         """
         journey_request = stat_request.journey_request
         if hasattr(g, 'stat_interpreted_parameters') and g.stat_interpreted_parameters['original_datetime']:
-            tz = utils.get_timezone()
+            tz = utils.get_timezone(request.id)
             dt = g.stat_interpreted_parameters['original_datetime']
             if dt.tzinfo is None:
                 dt = tz.normalize(tz.localize(dt))
@@ -394,7 +394,7 @@ class StatManager(object):
         return result
 
     def fill_section(self, stat_section, resp_section, previous_section):
-        tz = utils.get_timezone()
+        tz = utils.get_timezone(request.id)
         if 'departure_date_time' in resp_section:
             stat_section.departure_date_time = tz_str_to_utc_timestamp(resp_section['departure_date_time'], tz)
 

--- a/source/jormungandr/jormungandr/timezone.py
+++ b/source/jormungandr/jormungandr/timezone.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import logging
 import pytz
 from flask import g, request
+import functools32
 from jormungandr.exceptions import TechnicalError, RegionNotFound
 
 def set_request_timezone(region):
@@ -65,8 +66,6 @@ def set_request_instance_timezone(instance):
 
     except RuntimeError:
         pass#working outside of an application context...
-
-import functools32
 
 
 @functools32.lru_cache(1)

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -49,6 +49,7 @@ import re
 import flask
 from contextlib import contextmanager
 import functools
+import functools32
 import sys
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -136,10 +137,8 @@ def str_datetime_utc_to_local(dt, timezone):
     else:
         utc_dt = datetime.utcnow()
     local = pytz.timezone(timezone)
-    from flask import request
     return dt_to_str(utc_dt.replace(tzinfo=pytz.UTC).astimezone(local), request.id)
 
-import functools32
 
 @functools32.lru_cache(2048)
 def timestamp_to_datetime(timestamp, req_id, tz=None):
@@ -162,7 +161,6 @@ def timestamp_to_datetime(timestamp, req_id, tz=None):
         return dt.astimezone(timezone)
     return None
 
-import functools32
 
 @functools32.lru_cache(2048)
 def dt_to_str(dt, req_id):

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -139,34 +139,34 @@ def str_datetime_utc_to_local(dt, timezone):
     local = pytz.timezone(timezone)
     return dt_to_str(utc_dt.replace(tzinfo=pytz.UTC).astimezone(local), request.id)
 
+MAXINT = 9223372036854775807
 
-@functools32.lru_cache(2048)
+@functools32.lru_cache(4096)
 def timestamp_to_datetime(timestamp, req_id, tz=None):
     """
     Convert a timestamp to datetime
     if timestamp > MAX_INT we return None
     """
-    maxint = 9223372036854775807
+
     # when a date is > 2038-01-19 03:14:07
     # we receive a timestamp = 18446744071562142720 (64 bits) > 9223372036854775807 (MAX_INT 32 bits)
     # And ValueError: timestamp out of range for platform time_t is raised
-    if timestamp >= maxint:
+    if timestamp >= MAXINT:
         return None
-
-    dt = datetime.utcfromtimestamp(timestamp)
 
     timezone = tz or get_timezone(req_id or request.id)
     if timezone:
-        dt = pytz.utc.localize(dt)
+        dt = pytz.utc.localize(datetime.utcfromtimestamp(timestamp))
         return dt.astimezone(timezone)
     return None
 
 
-@functools32.lru_cache(2048)
+@functools32.lru_cache(4096)
 def dt_to_str(dt, req_id):
     return dt.strftime(DATETIME_FORMAT)
 
-@functools32.lru_cache(2048)
+
+@functools32.lru_cache(4096)
 def timestamp_to_str(timestamp, req_id):
     dt = timestamp_to_datetime(timestamp, req_id)
     if dt:

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -38,3 +38,4 @@ Flask-Cache==0.13.1
 git+https://github.com/canaltp/serpy.git@ctp
 python-json-logger==0.1.7
 jmespath==0.9.3
+functools32


### PR DESCRIPTION
a "POTENTIAL" way to cache the timezone and timestamp str...

this boosts the /route_schedule api by about 30%, 
since this api is migrating to Gormun, this PR is not necessarily useful.

But it may open a way to improve the perf of other API's endpoints.

Note that I put the timezone in the `request` context because it makes more sense, then I added a request_id to the get_timezone function so it can be cached correctly 