### PR TITLE
Kraken: add ptref shortcut between physical_mode and jpps

### DIFF
--- a/source/ptreferential/ptref_graph.cpp
+++ b/source/ptreferential/ptref_graph.cpp
@@ -73,6 +73,7 @@ Jointures::Jointures() {
     // PhysicalMode => {VehicleJourney, JourneyPattern}
     boost::add_edge(vertex_map.at(Type_e::VehicleJourney), vertex_map.at(Type_e::PhysicalMode), g);
     boost::add_edge(vertex_map.at(Type_e::JourneyPattern), vertex_map.at(Type_e::PhysicalMode), Edge(0.9), g);
+    boost::add_edge(vertex_map.at(Type_e::JourneyPatternPoint), vertex_map.at(Type_e::PhysicalMode), Edge(1.8), g);
 
     // À partir d'une ligne on peut avoir ses modes commerciaux, compagnies, réseaux et routes
     boost::add_edge(vertex_map.at(Type_e::CommercialMode), vertex_map.at(Type_e::Line), g);

--- a/source/routing/journey_pattern_container.cpp
+++ b/source/routing/journey_pattern_container.cpp
@@ -59,6 +59,7 @@ void JourneyPatternContainer::load(const nt::PT_Data& pt_data) {
     jps_from_route.assign(pt_data.routes);
     jp_from_vj.assign(pt_data.vehicle_journeys);
     jps_from_phy_mode.assign(pt_data.physical_modes);
+    jpps_from_phy_mode.assign(pt_data.physical_modes);
     for (const auto* route: pt_data.routes) {
         for (const auto& vj: route->discrete_vehicle_journey_list) { add_vj(*vj); }
         for (const auto& vj: route->frequency_vehicle_journey_list) { add_vj(*vj); }
@@ -199,6 +200,7 @@ JpIdx JourneyPatternContainer::make_jp(const JpKey& key) {
     for (const auto& jpp_key: key.jpp_keys) {
         jp.jpps.push_back(make_jpp(jp_idx, jpp_key.sp_idx, order++));
     }
+    jpps_from_phy_mode[jp.phy_mode_idx].insert(jpps_from_phy_mode[jp.phy_mode_idx].end(), jp.jpps.begin(), jp.jpps.end());
     jps.push_back(std::move(jp));
     return jp_idx;
 }

--- a/source/routing/journey_pattern_container.h
+++ b/source/routing/journey_pattern_container.h
@@ -114,6 +114,9 @@ struct JourneyPatternContainer {
     const IdxMap<type::PhysicalMode, std::vector<JpIdx>>& get_jps_from_phy_mode() const {
         return jps_from_phy_mode;
     }
+    const IdxMap<type::PhysicalMode, std::vector<JppIdx>>& get_jpps_from_phy_mode() const {
+        return jpps_from_phy_mode;
+    }
     const IdxMap<type::VehicleJourney, JpIdx>& get_jp_from_vj() const {
         return jp_from_vj;
     }
@@ -179,6 +182,7 @@ private:
     IdxMap<type::Route, std::vector<JpIdx>> jps_from_route;
     IdxMap<type::VehicleJourney, JpIdx> jp_from_vj;
     IdxMap<type::PhysicalMode, std::vector<JpIdx>> jps_from_phy_mode;
+    IdxMap<type::PhysicalMode, std::vector<JppIdx>> jpps_from_phy_mode;
 
     template<typename VJ> void add_vj(const VJ&);
     template<typename VJ> static JpKey make_key(const VJ&);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -734,6 +734,11 @@ Data::get_target_by_one_source(Type_e source, Type_e target,
     }
     if (target == Type_e::JourneyPatternPoint) {
         switch (source) {
+        case Type_e::PhysicalMode:
+            for (const auto& jpp: jp_container.get_jpps_from_phy_mode()[routing::PhyModeIdx(source_idx)]){
+                result.insert(jpp.val);
+            }
+            break;
         case Type_e::StopPoint:
             for (const auto& jpp: dataRaptor->jpps_from_sp[routing::SpIdx(source_idx)]) {
                 result.insert(jpp.idx.val); //TODO use bulk insert ?

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -705,7 +705,7 @@ void PbCreator::Filler::fill_pb_object(const nt::Calendar* cal, pbnavitia::Calen
         auto pb_period = pb_cal->add_active_periods();
         pb_period->set_begin(gd::to_iso_string(p.begin()));
         pb_period->set_end(gd::to_iso_string(p.end()));
-    }    
+    }
     fill(cal->exceptions, pb_cal->mutable_exceptions());
 }
 


### PR DESCRIPTION
Coverage with a lot of jpp (like se) still had very long route_schedules.

getting the journey_pattern_points from the physical mode bus on `se` coverage: 

|  before | after  |
|-----------|--------|
| 5s        | 30ms |