### PR TITLE
Doc: debug schema inconsistent on impacted_section.routes

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -214,7 +214,7 @@ class ImpactedStopSerializer(PbNestedSerializer):
 class ImpactedSectionSerializer(PbNestedSerializer):
     f = PtObjectSerializer(label='from', attr='from')
     to = PtObjectSerializer()
-    routes = jsonschema.MethodField(schema_type=lambda: RouteSerializer(Many=True))
+    routes = jsonschema.MethodField(schema_type=lambda: RouteSerializer(many=True))
 
     def get_routes(self, obj):
         return RouteSerializer(obj.routes, display_none=False, many=True).data

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -561,7 +561,7 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
 
         # some disruption are loaded on the dataset though
         nb_pre_loaded_disruption = len(get_not_null(self.query_region('disruptions'), 'disruptions'))
-        assert nb_pre_loaded_disruption == 9
+        assert nb_pre_loaded_disruption == 10
 
         self.send_mock("blocking_line_disruption", "A",
                        "line", blocking=True)

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -569,25 +569,25 @@ class TestDisruptions(AbstractTestFixture):
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 9
+        assert len(disruptions) == 10
 
         #filtering disruptions on line A
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions?forbidden_uris[]=A")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 4
+        assert len(disruptions) == 5
 
         # for retrocompatibility purpose forbidden_id[] is the same
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions?forbidden_id[]=A")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 4
+        assert len(disruptions) == 5
 
         # when we forbid another id, we find again all our disruptions
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions?forbidden_id[]=bloubliblou")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 9
+        assert len(disruptions) == 10
 
     def test_line_reports(self):
         response = self.query_region("line_reports?_current_datetime=20120801T000000")

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -906,7 +906,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         response = self.query_region('disruptions')
 
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 9
+        assert len(disruptions) == 10
         for d in disruptions:
             is_valid_disruption(d)
 

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -190,6 +190,9 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
     def test_networks_schema(self):
         self._check_schema('/v1/coverage/main_routing_test/networks')
 
+    def test_disruptions_schema(self):
+        self._check_schema('/v1/coverage/main_routing_test/disruptions')
+
     def test_journeys_schema(self):
         self._check_schema('/v1/coverage/main_routing_test/journeys?'
                            'from=0.001527130369323005;0.0004491559909773545&'

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -691,6 +691,13 @@ struct routing_api_data {
                 .severity("foo")
                 .on(nt::Type_e::Line, "C")
                 .msg("try again", nt::disruption::ChannelType::sms);
+
+        disruption_maker.impact()
+                .uri("too_bad_line_section_B_stop_B_route_B3")
+                .application_periods(boost::posix_time::time_period("20120826T060000"_dt, "20120830T120000"_dt))
+                .severity("disruption")
+                .on_line_section("B", "stopB", "stopB", {"B:3"})
+                .msg("try again", nt::disruption::ChannelType::sms);
     }
 
     int AA = 0;


### PR DESCRIPTION
`impacted_section.routes` is a list (and should be) in the API, but was a simple object in swagger.