### PR TITLE
Jormun: Expose configuration file pattern for selecting json to be loaded at runtime

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -86,6 +86,7 @@ else:
 from jormungandr.instance_manager import InstanceManager
 
 i_manager = InstanceManager(instances_dir=app.config.get('INSTANCES_DIR', None),
+                            instance_filename_pattern=app.config.get('INSTANCES_FILENAME_PATTERN', '*.json'),
                             start_ping=app.config.get('START_MONITORING_THREAD', True))
 i_manager.initialisation()
 

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -8,6 +8,10 @@ from flask_restful.inputs import boolean
 # path of the configuration file for each instances
 INSTANCES_DIR = os.getenv('JORMUNGANDR_INSTANCES_DIR', '/etc/jormungandr.d')
 
+# Patern that matches Jormungandr configuration files
+# ex: '*.json' will match all json files within "INSTANCES_DIR" directory
+INSTANCES_FILENAME_PATTERN = os.getenv('JORMUNGANDR_INSTANCES_FILENAME_PATTERN', '*.json')
+
 # Start the thread at startup, True in production, False for test environments
 START_MONITORING_THREAD = boolean(os.getenv('JORMUNGANDR_START_MONITORING_THREAD', True))
 

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -80,9 +80,9 @@ class InstanceManager(object):
     a kraken instance's id is associated to a zmq socket and possibly some custom configuration
     """
 
-    def __init__(self, instances_dir=None, start_ping=False):
-        # loads all .json files found in INSTANCES_DIR
-        self.configuration_files = glob.glob(instances_dir + '/*.json') if instances_dir else []
+    def __init__(self, instances_dir=None, instance_filename_pattern='*.json', start_ping=False):
+        # loads all json files found in 'instances_dir' that matches 'instance_filename_pattern'
+        self.configuration_files = glob.glob(instances_dir + '/' + instance_filename_pattern) if instances_dir else []
         self.start_ping = start_ping
         self.instances = {}
         self.context = zmq.Context()


### PR DESCRIPTION
This is useful to only load a specific set of configuration files, when running Jormun with an INSTANCES_DIR that contains multiple json files. 
