### PR TITLE
Ed: match stop_area and poi by using admin boundary if possible

### DIFF
--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -132,7 +132,7 @@ void EdReader::fill(navitia::type::Data& data, const double min_non_connected_gr
 
 void EdReader::fill_admins(navitia::type::Data& nav_data, pqxx::work& work){
     std::string request = "SELECT id, name, uri, comment, insee, level, ST_X(coord::geometry) as lon, "
-        "ST_Y(coord::geometry) as lat "
+        "ST_Y(coord::geometry) as lat, ST_asText(boundary) as boundary "
         "FROM georef.admin";
 
     pqxx::result result = work.exec(request);
@@ -145,6 +145,10 @@ void EdReader::fill_admins(navitia::type::Data& nav_data, pqxx::work& work){
         const_it["level"].to(admin->level);
         admin->coord.set_lon(const_it["lon"].as<double>());
         admin->coord.set_lat(const_it["lat"].as<double>());
+
+        if(!const_it["boundary"].is_null()){
+            boost::geometry::read_wkt(const_it["boundary"].as<std::string>(), admin->boundary);
+        }
 
         admin->idx = nav_data.geo_ref->admins.size();
 

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -40,6 +40,7 @@ namespace navitia {
 
     namespace georef {
         typedef boost::geometry::model::polygon<navitia::type::GeographicalCoord> polygon_type;
+        typedef boost::geometry::model::multi_polygon<polygon_type> multi_polygon_type;
 
         struct Admin : nt::Header, nt::Nameable {
             const static type::Type_e type = type::Type_e::Admin;
@@ -62,7 +63,7 @@ namespace navitia {
             std::string comment;
 
             nt::GeographicalCoord coord;
-            polygon_type boundary;
+            multi_polygon_type boundary;
             std::vector<const Admin*> admin_list;
             std::vector<const nt::StopArea*> main_stop_areas;
 

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -590,6 +590,16 @@ void GeoRef::project_stop_points(const std::vector<type::StopPoint*> &stop_point
 
 std::vector<Admin*> GeoRef::find_admins(const type::GeographicalCoord& coord) const {
     try {
+        std::vector<Admin*> result;
+        for(auto* admin: this->admins){
+            if(boost::geometry::within(coord, admin->boundary)){
+                result.push_back(admin);
+            }
+        }
+        if(!result.empty()){
+            return result;
+        }
+        //we didn't found any results with boundary, as a fallback we search for the admin o the closest way
         const auto& filter = [](const Way& w){return w.admin_list.empty();};
         return nearest_addr(coord, filter).second->admin_list;
     } catch (proximitylist::NotFound&) {


### PR DESCRIPTION
When OSM data is used we get the boundary of each admin, in that case
we want to use these boundaries to associate stop_points to an admin.

This doesn't use any kind of spacial indexes, so it might be slower than
before.

If we do not find any admin by using the boundary we still keep the old
approach as a fallback, so if there are no boundaries it works as before.


|coverage|before|before with cities|after|after with cities|
|---|-------------|---------------------|---------------------|----------------------|
|bordeaux| 7042ms| 6974ms | 417ms | 287ms |
|fr-idf| 70811ms | 50539ms | 153190ms| 118166ms|

Bordeaux has only a few admins, so the after result is very fast, also, no call to cities is done, so it has no effect on perf.
So funnily cities make the admin search faster...