### PR TITLE
Kraken: Remove constness for erasing list iterator...

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1282,8 +1282,8 @@ void filter_late_journeys(RAPTOR::Journeys & journeys,
 
     const auto & best = get_best_journey(journeys, params.clockwise);
 
-    auto it = journeys.cbegin();
-    while(it != journeys.cend()) {
+    auto it = journeys.begin();
+    while(it != journeys.end()) {
         const auto & journey = *it;
         if(best != journey && is_way_later(journey, best, params)) {
             it = journeys.erase(it);


### PR DESCRIPTION
On Debian 7, std::list::erase over a const iterator isn't implemented... 