### PR TITLE
jormun: Round second of datetime before calling realtime proxy to improve cachability

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -40,7 +40,36 @@ import datetime
 import hashlib
 import logging
 import six
+import math
 
+
+def floor_datetime(dt, step):
+    """
+    floor the second of a datetime to the nearest multiple of step
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 0), 15)
+    datetime.datetime(2018, 1, 1, 10, 10)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 12), 15)
+    datetime.datetime(2018, 1, 1, 10, 10)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 29), 15)
+    datetime.datetime(2018, 1, 1, 10, 10, 15)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 30), 15)
+    datetime.datetime(2018, 1, 1, 10, 10, 30)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 59), 15)
+    datetime.datetime(2018, 1, 1, 10, 10, 45)
+
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10), 30)
+    datetime.datetime(2018, 1, 1, 10, 10)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 59), 30)
+    datetime.datetime(2018, 1, 1, 10, 10, 30)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 59), 60)
+    datetime.datetime(2018, 1, 1, 10, 10)
+
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 28), 1)
+    datetime.datetime(2018, 1, 1, 10, 10, 28)
+    >>> floor_datetime(datetime.datetime(2018, 1, 1, 10, 10, 59), 1)
+    datetime.datetime(2018, 1, 1, 10, 10, 59)
+    """
+    return dt.replace(second=int(math.floor(dt.second/float(step))*step), microsecond=0)
 
 class RealtimeProxyError(RuntimeError):
     pass

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -34,7 +34,7 @@ from flask import logging
 import pybreaker
 import requests as requests
 from jormungandr import cache, app
-from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError
+from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError, floor_datetime
 from jormungandr.schedule import RealTimePassage
 import xml.etree.ElementTree as et
 import aniso8601
@@ -108,6 +108,7 @@ class Siri(RealtimeProxy):
         self.instance = instance
         self.breaker = pybreaker.CircuitBreaker(fail_max=app.config.get('CIRCUIT_BREAKER_MAX_SIRI_FAIL', 5),
                                                 reset_timeout=app.config.get('CIRCUIT_BREAKER_SIRI_TIMEOUT_S', 60))
+        self.step = kwargs.get('step', 30)
 
     def __repr__(self):
         """
@@ -223,7 +224,7 @@ class Siri(RealtimeProxy):
             </GetStopMonitoring>
           </x:Body>
         </x:Envelope>
-        """.format(dt=datetime.utcfromtimestamp(dt).isoformat(),
+        """.format(dt=floor_datetime(datetime.utcfromtimestamp(dt), self.step).isoformat(),
                    count=count,
                    RequestorRef=self.requestor_ref,
                    MessageIdentifier=message_identifier,

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -108,7 +108,8 @@ class Siri(RealtimeProxy):
         self.instance = instance
         self.breaker = pybreaker.CircuitBreaker(fail_max=app.config.get('CIRCUIT_BREAKER_MAX_SIRI_FAIL', 5),
                                                 reset_timeout=app.config.get('CIRCUIT_BREAKER_SIRI_TIMEOUT_S', 60))
-        self.step = kwargs.get('step', 30)
+        # A step is applied on from_datetime to discretize calls and allow caching them
+        self.from_datetime_step = kwargs.get('from_datetime_step', app.config['CACHE_CONFIGURATION'].get('TIMEOUT_SIRI', 60))
 
     def __repr__(self):
         """
@@ -224,7 +225,7 @@ class Siri(RealtimeProxy):
             </GetStopMonitoring>
           </x:Body>
         </x:Envelope>
-        """.format(dt=floor_datetime(datetime.utcfromtimestamp(dt), self.step).isoformat(),
+        """.format(dt=floor_datetime(datetime.utcfromtimestamp(dt), self.from_datetime_step).isoformat(),
                    count=count,
                    RequestorRef=self.requestor_ref,
                    MessageIdentifier=message_identifier,

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
@@ -40,7 +40,7 @@ from jormungandr.tests.utils_test import MockResponse, MockRequests
 
 
 def make_request_test():
-    siri = Siri(id='tata', service_url='http://bob.com/', requestor_ref='Stibada')
+    siri = Siri(id='tata', service_url='http://bob.com/', requestor_ref='Stibada', from_datetime_step=30)
 
     request = siri._make_request(dt=_timestamp("12:00"), count=2, monitoring_ref='Tri:SP:toto:LOC')
 

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
@@ -53,6 +53,14 @@ def make_request_test():
     assert root.find('.//siri:RequestTimestamp', ns).text == '2016-02-07T12:00:00'
     assert root.find('.//siri:RequestorRef', ns).text == 'Stibada'
 
+    request = siri._make_request(dt=_timestamp("12:00:12"), count=2, monitoring_ref='Tri:SP:toto:LOC')
+    root = et.fromstring(request)
+    assert root.find('.//siri:RequestTimestamp', ns).text == '2016-02-07T12:00:00'
+
+    request = siri._make_request(dt=_timestamp("12:00:33"), count=2, monitoring_ref='Tri:SP:toto:LOC')
+    root = et.fromstring(request)
+    assert root.find('.//siri:RequestTimestamp', ns).text == '2016-02-07T12:00:30'
+
 
 def mock_good_response():
     return """<?xml version="1.0"?>

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -66,7 +66,8 @@ def make_url_count_and_dt_test():
     same as make_url_test but with a count and a from_dt
     """
     timeo = Timeo(id='tata', timezone='UTC', service_url='http://bob.com/tata',
-                  service_args={'a': 'bobette', 'b': '12'})
+                  service_args={'a': 'bobette', 'b': '12'},
+                  from_datetime_step=30)
 
     url = timeo._make_url(MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu'),
                           count=2, from_dt=_timestamp("12:00"))

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -84,6 +84,15 @@ def make_url_count_and_dt_test():
     assert 'NextStopTimeNumber=2' in url
     assert 'NextStopReferenceTime=2016-02-07T12:00:00' in url
 
+    #same as before we only update the seconds of dt
+    url = timeo._make_url(MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu'),
+            count=2, from_dt=_timestamp("12:00:04"))
+    assert 'NextStopReferenceTime=2016-02-07T12:00:00' in url
+
+    url = timeo._make_url(MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu'),
+            count=2, from_dt=_timestamp("12:00:59"))
+    assert 'NextStopReferenceTime=2016-02-07T12:00:30' in url
+
 
 def make_url_invalid_code_test():
     """

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -73,7 +73,8 @@ class Timeo(RealtimeProxy):
         fail_max = kwargs.get('circuit_breaker_max_fail', app.config['CIRCUIT_BREAKER_MAX_TIMEO_FAIL'])
         reset_timeout = kwargs.get('circuit_breaker_reset_timeout', app.config['CIRCUIT_BREAKER_TIMEO_TIMEOUT_S'])
         self.breaker = pybreaker.CircuitBreaker(fail_max=fail_max, reset_timeout=reset_timeout)
-        self.step = kwargs.get('step', 30)
+        # A step is applied on from_datetime to discretize calls and allow caching them
+        self.from_datetime_step = kwargs.get('from_datetime_step', app.config['CACHE_CONFIGURATION'].get('TIMEOUT_TIMEO', 60))
 
         # Note: if the timezone is not know, pytz raise an error
         self.timezone = pytz.timezone(timezone)
@@ -220,7 +221,7 @@ class Timeo(RealtimeProxy):
 
         # if a custom datetime is provided we give it to timeo but we round it to improve cachability
         dt_param = '&NextStopReferenceTime={dt}'\
-            .format(dt=floor_datetime(self._timestamp_to_date(from_dt), self.step).strftime('%Y-%m-%dT%H:%M:%S')) \
+            .format(dt=floor_datetime(self._timestamp_to_date(from_dt), self.from_datetime_step).strftime('%Y-%m-%dT%H:%M:%S')) \
             if from_dt else ''
 
         #We want to have StopTimeType as it make parsing of the request way easier

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -34,7 +34,7 @@ import pybreaker
 import pytz
 import requests as requests
 from jormungandr import cache, app
-from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError
+from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError, floor_datetime
 from jormungandr.schedule import RealTimePassage
 from datetime import datetime, time
 from navitiacommon.ratelimit import RateLimiter, FakeRateLimiter
@@ -73,6 +73,7 @@ class Timeo(RealtimeProxy):
         fail_max = kwargs.get('circuit_breaker_max_fail', app.config['CIRCUIT_BREAKER_MAX_TIMEO_FAIL'])
         reset_timeout = kwargs.get('circuit_breaker_reset_timeout', app.config['CIRCUIT_BREAKER_TIMEO_TIMEOUT_S'])
         self.breaker = pybreaker.CircuitBreaker(fail_max=fail_max, reset_timeout=reset_timeout)
+        self.step = kwargs.get('step', 30)
 
         # Note: if the timezone is not know, pytz raise an error
         self.timezone = pytz.timezone(timezone)
@@ -217,9 +218,9 @@ class Timeo(RealtimeProxy):
         # timeo can only handle items_per_schedule if it's < 5
         count = min(count or 5, 5)# if no value defined we ask for 5 passages
 
-        # if a custom datetime is provided we give it to timeo
+        # if a custom datetime is provided we give it to timeo but we round it to improve cachability
         dt_param = '&NextStopReferenceTime={dt}'\
-            .format(dt=self._timestamp_to_date(from_dt).strftime('%Y-%m-%dT%H:%M:%S')) \
+            .format(dt=floor_datetime(self._timestamp_to_date(from_dt), self.step).strftime('%Y-%m-%dT%H:%M:%S')) \
             if from_dt else ''
 
         #We want to have StopTimeType as it make parsing of the request way easier


### PR DESCRIPTION
The cache key used with realtime proxy contains the url called, so it
does contains the datetime with the seconds, it makes cache only working
for one second, that's not very good...
This PR round the second to a multiple of 30, giving us 30 seconds of
cache, this is also configurable with the `step` parameter.

We may want to rename this params as it's not very clear what it does
based on it's name, so if you have an idea I take it.