### PR TITLE
Eitri, Tyr & docker tests: Launch even if docker can't reach server

### DIFF
--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,9 +1,9 @@
 future==0.13.1
-docker-py==1.10.6
+docker==3.4.1
 retrying==1.2.3
 psycopg2==2.4.5
 clingon==0.1.4
 GeoAlchemy2==0.2.4
 SQLAlchemy==1.0.4
 alembic==0.6.7
-requests==2.6.0
+requests==2.19.1

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -176,7 +176,7 @@ struct PathFinder {
     void dijkstra(const vertex_t source, const vertex_t target, const Visitor& visitor) {
         // Note: the predecessors have been updated in init
 
-        std::array<georef::vertex_t, 2> vertex {source, target};
+        std::array<georef::vertex_t, 2> vertex {{source, target}};
 
         // Fill color map in white before dijkstra
         std::fill(color.data.get(),

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -74,7 +74,7 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
     }
 }
 
-void Metrics::observe_api(pbnavitia::API api, float duration) const{
+void Metrics::observe_api(pbnavitia::API api, double duration) const{
     if(!registry) {
         return;
     }

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -61,11 +61,11 @@ class Metrics: boost::noncopyable {
         std::map<pbnavitia::API, prometheus::Histogram*> request_histogram;
     public:
         Metrics(const boost::optional<std::string>& endpoint, const std::string& coverage);
-        void observe_api(pbnavitia::API api, float duration) const;
+        void observe_api(pbnavitia::API api, double duration) const;
 #else
     public:
         Metrics(const boost::optional<std::string>&, const std::string&) {}
-        void observe_api(pbnavitia::API, float) const {}
+        void observe_api(pbnavitia::API, double) const {}
 #endif
 };
 

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-docker-py==1.6.0
+docker==3.4.1
 pytest==3.1.1
 python-dateutil==2.5.3
 mock==1.0.1


### PR DESCRIPTION
Allows to launch eitri or docker_test when not connected to internet.

This was hand-tested: launched `eitri` and `make docker_test` while offline.

TODO:

- [x] Check if we can even do smarter checks