### PR TITLE
Kraken: update "last_rt_data_loaded" on each update even if Data hasn't changed

### DIFF
--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -196,10 +196,16 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         data->pt_data->clean_weak_impacts();
         LOG4CPLUS_INFO(logger, "rebuilding data raptor");
         data->build_raptor(conf.raptor_cache_size());
-        data->last_rt_data_loaded = pt::microsec_clock::universal_time();
+        data->set_last_rt_data_loaded(pt::microsec_clock::universal_time());
         data_manager.set_data(std::move(data));
         LOG4CPLUS_INFO(logger, "data updated " << envelopes.size() << " disruption applied in "
                                                << pt::microsec_clock::universal_time() - begin);
+    } else if (envelopes.size() > 0) {
+        // we didn't had to update Data because there is no change but we want to track that realtime data
+        // is being processed as it should because "nothing has changed" isn't the same thing
+        // than "I don't known what's happening"
+        auto current_data = data_manager.get_data();
+        current_data->set_last_rt_data_loaded(pt::microsec_clock::universal_time());
     }
 }
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -248,7 +248,11 @@ void Worker::status() {
     status->set_loaded(d->loaded);
     status->set_last_load_status(d->last_load_succeeded);
     status->set_last_load_at(pt::to_iso_string(d->last_load_at));
-    status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded));
+    //make a copy of shared_ptr to use it locally
+    auto last_rt_data_loaded = std::atomic_load(&d->last_rt_data_loaded);
+    if(last_rt_data_loaded){
+        status->set_last_rt_data_loaded(pt::to_iso_string(*d->last_rt_data_loaded));
+    }
     status->set_nb_threads(conf.nb_threads());
     status->set_is_connected_to_rabbitmq(d->is_connected_to_rabbitmq);
     status->set_disruption_error(d->disruption_error);

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -248,11 +248,7 @@ void Worker::status() {
     status->set_loaded(d->loaded);
     status->set_last_load_status(d->last_load_succeeded);
     status->set_last_load_at(pt::to_iso_string(d->last_load_at));
-    //make a copy of shared_ptr to use it locally
-    auto last_rt_data_loaded = std::atomic_load(&d->last_rt_data_loaded);
-    if(last_rt_data_loaded){
-        status->set_last_rt_data_loaded(pt::to_iso_string(*d->last_rt_data_loaded));
-    }
+    status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded()));
     status->set_nb_threads(conf.nb_threads());
     status->set_is_connected_to_rabbitmq(d->is_connected_to_rabbitmq);
     status->set_disruption_error(d->disruption_error);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -75,7 +75,8 @@ Data::Data(size_t data_identifier) :
             [&](const GeographicalCoord &c, georef::AdminRtree& admin_tree){
             return geo_ref->find_admins(c, admin_tree);
             }),
-    last_load_succeeded(false)
+    last_load_succeeded(false),
+    last_rt_data_loaded(std::make_shared<const pt::ptime>(pt::not_a_date_time))
 {
     loaded = false;
     is_connected_to_rabbitmq = false;
@@ -852,6 +853,11 @@ void Data::clone_from(const Data& from) {
     std::thread write([&]() {boost::archive::binary_oarchive oa(p.out); oa << from;});
     { boost::archive::binary_iarchive ia(p.in); ia >> *this; }
     write.join();
+}
+
+void Data::set_last_rt_data_loaded(const boost::posix_time::ptime& p) const{
+    auto ptr = std::make_shared<const boost::posix_time::ptime>(p);
+    std::atomic_store(&this->last_rt_data_loaded, ptr);
 }
 
 }} //namespace navitia::type

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -42,6 +42,13 @@ www.navitia.io
 #include "utils/obj_factory.h"
 #include "georef/adminref.h"
 
+// workaround missing "is_trivially_copyable" in g++ < 5.0
+#if __GNUG__ && __GNUC__ < 5
+#define IS_TRIVIALLY_COPYABLE(T) __has_trivial_copy(T)
+#else
+#define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
+#endif
+
 //forward declare
 namespace navitia {
     namespace georef {
@@ -122,7 +129,7 @@ struct ContainerTrait<type::MetaVehicleJourney> {
   */
 class Data : boost::noncopyable{
 
-    static_assert(std::is_trivially_copyable<const boost::posix_time::ptime>::value, "ptime isn't is_trivially_copyable and can't be used with std::atomic");
+    static_assert(IS_TRIVIALLY_COPYABLE(const boost::posix_time::ptime), "ptime isn't is_trivially_copyable and can't be used with std::atomic");
     mutable std::atomic<const boost::posix_time::ptime> _last_rt_data_loaded; //datetime of the last Real Time loaded data
 public:
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -185,7 +185,7 @@ public:
     // UTC
     boost::posix_time::ptime last_load_at;
 
-    boost::posix_time::ptime last_rt_data_loaded; //datetime of the last Real Time loaded data
+    mutable std::shared_ptr<const boost::posix_time::ptime> last_rt_data_loaded; //datetime of the last Real Time loaded data
 
     // This object is the only field mutated in this object. As it is
     // thread safe to mutate it, we mark it as mutable.  Maybe we can
@@ -264,6 +264,8 @@ public:
 
     // Deep clone from the given Data.
     void clone_from(const Data&);
+
+    void set_last_rt_data_loaded(const boost::posix_time::ptime&) const;
 private:
     /** Get similar validitypattern **/
     ValidityPattern* get_similar_validity_pattern(ValidityPattern* vp) const;

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -121,6 +121,9 @@ struct ContainerTrait<type::MetaVehicleJourney> {
   * peut même (sur des disques lents) accélerer le chargement).
   */
 class Data : boost::noncopyable{
+
+    static_assert(std::is_trivially_copyable<const boost::posix_time::ptime>::value, "ptime isn't is_trivially_copyable and can't be used with std::atomic");
+    mutable std::atomic<const boost::posix_time::ptime> _last_rt_data_loaded; //datetime of the last Real Time loaded data
 public:
 
     static const unsigned int data_version; //< Data version number. *INCREMENT* in cpp file
@@ -185,7 +188,6 @@ public:
     // UTC
     boost::posix_time::ptime last_load_at;
 
-    mutable std::shared_ptr<const boost::posix_time::ptime> last_rt_data_loaded; //datetime of the last Real Time loaded data
 
     // This object is the only field mutated in this object. As it is
     // thread safe to mutate it, we mark it as mutable.  Maybe we can
@@ -266,6 +268,7 @@ public:
     void clone_from(const Data&);
 
     void set_last_rt_data_loaded(const boost::posix_time::ptime&) const;
+    const boost::posix_time::ptime last_rt_data_loaded() const;
 private:
     /** Get similar validitypattern **/
     ValidityPattern* get_similar_validity_pattern(ValidityPattern* vp) const;


### PR DESCRIPTION
Has stated in the code:
we didn't had to update Data because there is no change but we want to track that realtime data
is being processed as it should because "nothing has changed" isn't the same thing
than "I don't known what's happening"

This will prevent monitoring to think that something is broken because
we don't update our data