### PR TITLE
Kraken: Fix adapted validity pattern with disruption

### DIFF
--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2312,6 +2312,20 @@ BOOST_AUTO_TEST_CASE(test_disruption_on_line_then_stop_point) {
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
+    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Y'a plus qu'a attendre ton train")
+                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
+                              .on(nt::Type_e::Line, "A")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Un peu de patience...")
+                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
+                              .on(nt::Type_e::StopPoint, "stopA2")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
     BOOST_CHECK_MESSAGE(
             ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "11110111"),
             vj1->rt_validity_pattern()->days);
@@ -2325,6 +2339,14 @@ BOOST_AUTO_TEST_CASE(test_disruption_on_line_then_stop_point) {
     */
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Penguins on fire at Montparnasse")
                               .severity(nt::disruption::Effect::NO_SERVICE)
+                              .on(nt::Type_e::Line, "B")
+                              .on(nt::Type_e::StopPoint, "stopB2")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Prends ton mal en patience")
+                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
                               .on(nt::Type_e::Line, "B")
                               .on(nt::Type_e::StopPoint, "stopB2")
                               .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
@@ -2356,15 +2378,29 @@ BOOST_AUTO_TEST_CASE(test_disruption_on_stop_point_then_line) {
     * Then, we make sure that the real time validity pattern has been disabled
     *
     */
-    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Fire at Montparnasse")
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Fire at Montparnasse")
                               .severity(nt::disruption::Effect::NO_SERVICE)
                               .on(nt::Type_e::StopPoint, "stopA2")
                               .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Line A : penguins on the line")
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Line A : penguins on the line")
                               .severity(nt::disruption::Effect::NO_SERVICE)
+                              .on(nt::Type_e::Line, "A")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Un peu de patience...")
+                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
+                              .on(nt::Type_e::StopPoint, "stopA2")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Y'a plus qu'a attendre ton train")
+                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
                               .on(nt::Type_e::Line, "A")
                               .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                               .get_disruption(),
@@ -2373,11 +2409,17 @@ BOOST_AUTO_TEST_CASE(test_disruption_on_stop_point_then_line) {
     BOOST_CHECK_MESSAGE(
             ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "11110111"),
             vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(vj1->adapted_validity_pattern()->days.to_string(), "11110111"),
+            vj1->adapted_validity_pattern()->days);
 
-    auto rt_vj1 = b.data->pt_data->vehicle_journeys_map["vj:1:RealTime:0:Fire at Montparnasse"];
+    auto rt_vj1 = b.data->pt_data->vehicle_journeys_map["vj:1:Adapted:0:Fire at Montparnasse"];
     BOOST_CHECK_MESSAGE(
             ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00000000"),
             rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->adapted_validity_pattern()->days.to_string(), "00000000"),
+            rt_vj1->adapted_validity_pattern()->days);
 
    /*
     * For VJ2
@@ -2386,19 +2428,93 @@ BOOST_AUTO_TEST_CASE(test_disruption_on_stop_point_then_line) {
     * Then, we make sure that the real time validity pattern has been disabled
     *
     */
-    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Penguins on fire at Montparnasse")
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Penguins on fire at Montparnasse")
                               .severity(nt::disruption::Effect::NO_SERVICE)
                               .on(nt::Type_e::StopPoint, "stopB2")
                               .on(nt::Type_e::Line, "B")
                               .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Prends ton mal en patience")
+                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
+                              .on(nt::Type_e::StopPoint, "stopB2")
+                              .on(nt::Type_e::Line, "B")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
     BOOST_CHECK_MESSAGE(
             ba::ends_with(vj2->rt_validity_pattern()->days.to_string(), "11110111"),
             vj2->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(vj2->adapted_validity_pattern()->days.to_string(), "11110111"),
+            vj2->adapted_validity_pattern()->days);
 
-    auto rt_vj2 = b.data->pt_data->vehicle_journeys_map["vj:2:RealTime:0:Penguins on fire at Montparnasse"];
+    auto rt_vj2 = b.data->pt_data->vehicle_journeys_map["vj:2:Adapted:0:Penguins on fire at Montparnasse"];
     BOOST_CHECK_MESSAGE(
             ba::ends_with(rt_vj2->rt_validity_pattern()->days.to_string(), "00000000"),
             rt_vj2->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj2->adapted_validity_pattern()->days.to_string(), "00000000"),
+            rt_vj2->adapted_validity_pattern()->days);
+}
+
+BOOST_AUTO_TEST_CASE(repro_disruption_error) {
+    ed::builder b("20120614");
+    auto* vj1 = b.vj("A").uri("vj:1")("stopA1", "10:00"_t)("stopA2", "11:00"_t)("stopA3", "12:00"_t).make();
+    //auto* vj2 = b.vj("B").uri("vj:2")("stopB1", "10:00"_t)("stopB2", "11:00"_t)("stopB3", "12:00"_t).make();
+
+    b.generate_dummy_basis();
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    b.data->meta->production_date = bg::date_period("20120614"_d, 7_days);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Penguins on fire at Montparnasse")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .on(nt::Type_e::StopPoint, "stopA2")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(vj1->base_validity_pattern()->days.to_string(), "11111111"),
+            vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(vj1->adapted_validity_pattern()->days.to_string(), "11110111"),
+            vj1->adapted_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "11110111"),
+            vj1->rt_validity_pattern()->days);
+
+    auto rt_vj1 = b.data->pt_data->vehicle_journeys_map["vj:1:Adapted:0:Penguins on fire at Montparnasse"];
+
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->base_validity_pattern()->days.to_string(), "00000000"),
+            rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->adapted_validity_pattern()->days.to_string(), "00001000"),
+            rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00001000"),
+            rt_vj1->rt_validity_pattern()->days);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "coffee spilled on the line")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .on(nt::Type_e::Line, "A")
+                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->base_validity_pattern()->days.to_string(), "00000000"),
+            rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->adapted_validity_pattern()->days.to_string(), "00000000"),
+            rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(
+            ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00000000"),
+            rt_vj1->rt_validity_pattern()->days);
 }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2362,7 +2362,6 @@ BOOST_AUTO_TEST_CASE(test_realtime_disruption_on_line_then_stop_point) {
 BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
     ed::builder b("20120614");
     auto* vj1 = b.vj("A").uri("vj:1")("stopA1", "10:00"_t)("stopA2", "11:00"_t)("stopA3", "12:00"_t).make();
-    //auto* vj2 = b.vj("B").uri("vj:2")("stopB1", "10:00"_t)("stopB2", "11:00"_t)("stopB3", "12:00"_t).make();
 
     b.generate_dummy_basis();
     b.finish();

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2312,20 +2312,6 @@ BOOST_AUTO_TEST_CASE(test_realtime_disruption_on_line_then_stop_point) {
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Y'a plus qu'a attendre ton train")
-                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                              .on(nt::Type_e::Line, "A")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Un peu de patience...")
-                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                              .on(nt::Type_e::StopPoint, "stopA2")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
     BOOST_CHECK_MESSAGE(
             ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "11110111"),
             vj1->rt_validity_pattern()->days);
@@ -2339,14 +2325,6 @@ BOOST_AUTO_TEST_CASE(test_realtime_disruption_on_line_then_stop_point) {
     */
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Penguins on fire at Montparnasse")
                               .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on(nt::Type_e::Line, "B")
-                              .on(nt::Type_e::StopPoint, "stopB2")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Prends ton mal en patience")
-                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
                               .on(nt::Type_e::Line, "B")
                               .on(nt::Type_e::StopPoint, "stopB2")
                               .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2279,7 +2279,7 @@ BOOST_AUTO_TEST_CASE(significant_delay_on_stop_point_dont_remove_it) {
     BOOST_CHECK_EQUAL(res[0].items[0].stop_times.size(), 2);
 }
 
-BOOST_AUTO_TEST_CASE(test_disruption_on_line_then_stop_point) {
+BOOST_AUTO_TEST_CASE(test_realtime_disruption_on_line_then_stop_point) {
     ed::builder b("20120614");
     auto* vj1 = b.vj("A").uri("vj:1")("stopA1", "10:00"_t)("stopA2", "11:00"_t)("stopA3", "12:00"_t).make();
     auto* vj2 = b.vj("B").uri("vj:2")("stop1B", "10:00"_t)("stopB2", "11:00"_t)("stopB3", "12:00"_t).make();
@@ -2359,108 +2359,7 @@ BOOST_AUTO_TEST_CASE(test_disruption_on_line_then_stop_point) {
 
 }
 
-BOOST_AUTO_TEST_CASE(test_disruption_on_stop_point_then_line) {
-    ed::builder b("20120614");
-    auto* vj1 = b.vj("A").uri("vj:1")("stopA1", "10:00"_t)("stopA2", "11:00"_t)("stopA3", "12:00"_t).make();
-    auto* vj2 = b.vj("B").uri("vj:2")("stopB1", "10:00"_t)("stopB2", "11:00"_t)("stopB3", "12:00"_t).make();
-
-    b.generate_dummy_basis();
-    b.finish();
-    b.data->pt_data->sort_and_index();
-    b.data->build_raptor();
-    b.data->build_uri();
-    b.data->meta->production_date = bg::date_period("20120614"_d, 7_days);
-
-    /*
-    * For VJ1
-    *
-    * Let's apply 2 disruption on 2 objects types (stop point then line)
-    * Then, we make sure that the real time validity pattern has been disabled
-    *
-    */
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Fire at Montparnasse")
-                              .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on(nt::Type_e::StopPoint, "stopA2")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Line A : penguins on the line")
-                              .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on(nt::Type_e::Line, "A")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Un peu de patience...")
-                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                              .on(nt::Type_e::StopPoint, "stopA2")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Y'a plus qu'a attendre ton train")
-                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                              .on(nt::Type_e::Line, "A")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "11110111"),
-            vj1->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(vj1->adapted_validity_pattern()->days.to_string(), "11110111"),
-            vj1->adapted_validity_pattern()->days);
-
-    auto rt_vj1 = b.data->pt_data->vehicle_journeys_map["vj:1:Adapted:0:Fire at Montparnasse"];
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00000000"),
-            rt_vj1->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(rt_vj1->adapted_validity_pattern()->days.to_string(), "00000000"),
-            rt_vj1->adapted_validity_pattern()->days);
-
-   /*
-    * For VJ2
-    *
-    * Let's apply only 1 disruption on the same objects types (stop point then line)
-    * Then, we make sure that the real time validity pattern has been disabled
-    *
-    */
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Penguins on fire at Montparnasse")
-                              .severity(nt::disruption::Effect::NO_SERVICE)
-                              .on(nt::Type_e::StopPoint, "stopB2")
-                              .on(nt::Type_e::Line, "B")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Prends ton mal en patience")
-                              .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                              .on(nt::Type_e::StopPoint, "stopB2")
-                              .on(nt::Type_e::Line, "B")
-                              .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(vj2->rt_validity_pattern()->days.to_string(), "11110111"),
-            vj2->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(vj2->adapted_validity_pattern()->days.to_string(), "11110111"),
-            vj2->adapted_validity_pattern()->days);
-
-    auto rt_vj2 = b.data->pt_data->vehicle_journeys_map["vj:2:Adapted:0:Penguins on fire at Montparnasse"];
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(rt_vj2->rt_validity_pattern()->days.to_string(), "00000000"),
-            rt_vj2->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(
-            ba::ends_with(rt_vj2->adapted_validity_pattern()->days.to_string(), "00000000"),
-            rt_vj2->adapted_validity_pattern()->days);
-}
-
-BOOST_AUTO_TEST_CASE(repro_disruption_error) {
+BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
     ed::builder b("20120614");
     auto* vj1 = b.vj("A").uri("vj:1")("stopA1", "10:00"_t)("stopA2", "11:00"_t)("stopA3", "12:00"_t).make();
     //auto* vj2 = b.vj("B").uri("vj:2")("stopB1", "10:00"_t)("stopB2", "11:00"_t)("stopB3", "12:00"_t).make();

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -396,12 +396,16 @@ bool VehicleJourney::has_landing() const{
 namespace {
 template <typename F>
 static bool concerns_base_at_period(const VehicleJourney& vj,
+                                    const RTLevel rt_level,
                                     const std::vector<bt::time_period>& periods,
                                     const F& fun,
                                     bool check_past_midnight = true) {
     bool intersect = false;
-    // we only need to check on the base canceled vp
-    ValidityPattern concerned_vp = vj.get_base_canceled_validity_pattern();
+
+    ValidityPattern concerned_vp = *vj.validity_patterns[rt_level];
+    // We shift the vlidity pattern to get the base one (from adapted or realtime)
+    concerned_vp.days >>= vj.shift;
+
     for (const auto& period: periods) {
         //we can impact a vj with a departure the day before who past midnight
         namespace bg = boost::gregorian;
@@ -638,7 +642,7 @@ void MetaVehicleJourney::cancel_vj(RTLevel level,
                     return true; // we don't want to stop
                 };
 
-                if (concerns_base_at_period(*vj, periods, vp_modifier)) {
+                if (concerns_base_at_period(*vj, vp_level, periods, vp_modifier)) {
                     vj->validity_patterns[vp_level] = pt_data.get_or_create_validity_pattern(tmp_vp);
                 }
             }
@@ -1028,7 +1032,7 @@ VehicleJourney::get_impacts() const {
         auto vp_functor = [&] (const unsigned) {
             return false; // we don't need to carry on when we find a day concerned
         };
-        if (concerns_base_at_period(*this, impact->application_periods, vp_functor, false)) {
+        if (concerns_base_at_period(*this, realtime_level, impact->application_periods, vp_functor, false)) {
             result.push_back(impact);
         }
     }
@@ -1136,7 +1140,7 @@ EntryPoint::EntryPoint(const Type_e type, const std::string &uri, int access_dur
             this->coordinates.set_lon(coord.first);
             this->coordinates.set_lat(coord.second);
         } catch (const navitia::wrong_coordinate&) {
-            LOG4CPLUS_INFO(log4cplus::Logger::getInstance("logger"), 
+            LOG4CPLUS_INFO(log4cplus::Logger::getInstance("logger"),
                            "uri " << uri << " partialy match coordinate, cannot work");
             this->coordinates.set_lon(0);
             this->coordinates.set_lat(0);


### PR DESCRIPTION
We were not using the right disruption freshness level when trying to match a disruption with a VJ.