### PR TITLE
raptor: increase number of try in raptor for journeys without transfers

### DIFF
--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -235,5 +235,35 @@ void make_pathes(PbCreator& pb_creator,
                  const uint32_t free_radius_from = 0,
                  const uint32_t free_radius_to = 0);
 
+/**
+ * @brief This function determine the breaking condition that depends on nb of found journeys,
+ * min_nb_journeys and time frame.
+ *
+ * @details
+ *
+ *   requested_datetime           requested_datetime + timeframe_duration
+ *   -------[--------------------------------------------]-------------------------->
+ *                  minimal period to explore
+ *
+ * timeframe_limit (request_date_secs + timeframe_duration):
+ *          The end datetime of original request's timeframe (we have to explore at minimum this period)
+ *
+ *                   min_nb_journeys is set?
+ *                    /               \
+ *                   / Y               \ N
+ *          timeframe is set?        timeframe is set?
+ *            /       \                  /     \
+ *           / Y       \ N              / Y      \ N
+ *       Case 1      Case 2          Case 3     Case 4
+ *
+ *
+ */
+bool keep_going(const uint32_t total_nb_journeys,
+                       const uint32_t nb_try,
+                       const bool clockwise,
+                       const DateTime request_date_secs,
+                       const boost::optional<uint32_t>& min_nb_journeys,
+                       const boost::optional<DateTime>& timeframe_limit,
+                       const uint32_t max_transfers);
 } // namespace routing
 } // namespace navitia


### PR DESCRIPTION
When requesting journeys with min_nb_journeys or timeframe_duration we
loop in kraken to find most of the journeys in one call. To prevent
infinite loop we limit to 100 iterations. This PR increases the maximum
of iteration when the request doesn't allow any transfers
(max_transfers=0) as this type of journeys is very fast to compute and
is mostly used to build time schedules between two stops.

This PR also adds a lot of unit test for the `keep_going` function