### PR TITLE
Ptref disruption by tags

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -345,7 +345,6 @@ class Scenario(object):
         return self.__on_ptref("impact", type_pb2.IMPACT, request, instance)
 
     def contributors(self, request, instance):
-
         return self.__on_ptref("contributors", type_pb2.CONTRIBUTOR, request, instance)
 
     def datasets(self, request, instance):

--- a/source/ptreferential/ptref_graph.cpp
+++ b/source/ptreferential/ptref_graph.cpp
@@ -1,8 +1,8 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -195,6 +195,10 @@ struct Eval: boost::static_visitor<Indexes> {
                     indexes.insert(l->idx);
                 }
             }
+        } else if (f.type == "disruption"
+                   && ((f.method == "tag"  && f.args.size() == 1)
+                    || (f.method == "tags" && f.args.size() >= 1))) {
+            indexes = get_impacts_by_tags(f.args, data);
         } else if ((f.method == "since" && f.args.size() == 1)
                    || (f.method == "until" && f.args.size() == 1)
                    || (f.method == "between" && f.args.size() == 2)) {
@@ -341,7 +345,7 @@ std::string make_request(const Type_e requested_type,
         ss << ')';
         res = ss.str();
     }
-        
+
     return res;
 }
 

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -93,7 +93,7 @@ struct PtRefGrammar: qi::grammar<Iterator, ast::Expr(), ascii::space_type> {
 
         ident = qi::lexeme[qi::alpha >> *(qi::alnum | qi::char_("_"))];
         str = qi::lexeme[+(qi::alnum | qi::char_("_.:;|-"))]
-            | qi::lexeme['"' > *(qi::char_ - qi::char_("\"\\") | ('\\' > qi::char_)) > '"'];
+            | qi::lexeme['"' > (*(qi::char_ - qi::char_("\"\\") | ('\\' > qi::char_))) > '"'];
     }
 
     // Pred

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -37,7 +37,6 @@ www.navitia.io
 #include "type/meta_data.h"
 #include "routing/dataraptor.h"
 
-#include <boost/range/adaptor/indexed.hpp>
 #include <boost/range/algorithm/find.hpp>
 #include <string>
 
@@ -145,12 +144,12 @@ Indexes get_impacts_by_tags(const std::vector<std::string> & tag_uris,
     Indexes result;
     const auto& w_impacts = d.pt_data->disruption_holder.get_weak_impacts();
 
-    for(const auto& w_impact : w_impacts | boost::adaptors::indexed(0)) {
-        auto impact = w_impact.value().lock();
+    for(size_t i=0; i<w_impacts.size(); i++) {
+        auto impact = w_impacts[i].lock();
         if(impact && impact->disruption) {
             for(const auto& tag : impact->disruption->tags) {
                 if(tag && boost::range::find(tag_uris, tag->uri) != tag_uris.end()) {
-                    result.insert(w_impact.index());
+                    result.insert(i);
                 }
             }
         }

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -42,7 +42,10 @@ type::Indexes get_corresponding(type::Indexes indexes,
                                 const type::Type_e to,
                                 const type::Data& data);
 type::Type_e type_by_caption(const std::string& type);
-type::Indexes get_indexes_by_impacts(const type::Type_e& type_e, const type::Data& d);
+type::Indexes get_indexes_by_impacts(const type::Type_e& type_e,
+                                     const type::Data& d);
+type::Indexes get_impacts_by_tags(const std::vector<std::string> & tag_uris,
+                                  const type::Data& d);
 type::Indexes filter_on_period(const type::Indexes& indexes,
                                const type::Type_e requested_type,
                                const boost::optional<boost::posix_time::ptime>& since,

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -397,7 +397,9 @@ public:
     void clean_weak_impacts();
     void forget_vj(const VehicleJourney*);
     const std::vector<boost::weak_ptr<Impact>>&
-    get_weak_impacts() const{ return weak_impacts;}
+        get_weak_impacts() const{ return weak_impacts;}
+    boost::weak_ptr<Impact> get_weak_impact(size_t id) const { return weak_impacts[id]; }
+    boost::shared_ptr<Impact> get_impact(size_t id) const { return weak_impacts[id].lock(); }
     // causes, severities and tags are a pool (weak_ptr because the owner ship
     // is in the linked disruption or impact)
     std::map<std::string, boost::weak_ptr<Cause>> causes; //to be wrapped

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io


### PR DESCRIPTION
A pt_ref request can now contain : `disruption.tag=my_tag` that returns a list of indexes referring to the disruptions with the specific tag.

I'm suggesting to add a syntax for querying multiple tags at once with `disruption.tags(my_tag1, my_tag2, <...>)`. With a similar behaviour to `disruption.tag=my_tag1 OR disruption.tag=my_tag2 OR <...>)` but with the benefits of parsing the disruptions only once with no AST parsing overhead.

## Limitation
There is a limitation though. We can only retrieve disruptions through the impacts in the model with: `make_query_ng(Type_e::Impact, "disruption.tag(TAG)")`. Links are missing in the data graph to resolve pt_objects from an impact. Thus, retrieving the lines affected by a disruption like `make_query_ng(Type_e::Line, "disruption.tag(TAG)")` will not work :cry: 