### PR TITLE
Jormun: fix regression on coord format

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -296,7 +296,7 @@ class DoubleToStringField(Field):
 
     def to_value(self, value):
         # we don't want to loose precision while converting a double to string
-        return '%.16f' % value
+        return '%.16g' % value
 
 
 class DescribedField(LambdaField):


### PR DESCRIPTION
Not sure that `g` suffix is what we want  as it may output float
formatted with exponent.

> General format. For a given precision p >= 1, this rounds the number to p significant digits and then formats the result in either fixed-point format or in scientific notation, depending on its magnitude.
> from https://docs.python.org/2/library/string.html