### PR TITLE
Kraken:Maintenance_worker thread interuption

### DIFF
--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -102,7 +102,9 @@ int main(int argn, char** argv){
     try{
         lb.bind(zmq_socket, "inproc://workers");
     }catch(zmq::error_t& e){
-        LOG4CPLUS_ERROR(logger, "zmq::socket_t::bind() failure: " << e.what());
+        LOG4CPLUS_ERROR(logger, "zmq::socket_t::bind( "<< zmq_socket << " ) failure: " << e.what());
+        threads.interrupt_all();
+        threads.join_all();
         return 1;
     }
 

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -37,6 +37,7 @@ www.navitia.io
 #include "type/pt_data.h"
 #include <boost/algorithm/string/join.hpp>
 #include <boost/optional.hpp>
+#include <boost/thread/thread.hpp>
 #include <sys/stat.h>
 #include <signal.h>
 #include <SimpleAmqpClient/Envelope.h>
@@ -252,6 +253,7 @@ void MaintenanceWorker::listen_rabbitmq(){
     LOG4CPLUS_INFO(logger, "start event loop");
     data_manager.get_data()->is_connected_to_rabbitmq = true;
     while(true){
+        boost::this_thread::interruption_point();
         auto now = pt::microsec_clock::universal_time();
         //We don't want to try to load realtime data every second
         if(now > this->next_try_realtime_loading){


### PR DESCRIPTION
Add interruption point to the maintenance worker thread to prevent the application from badly crashing when unwinding the stack from the main and maintenance_worker threads.

This happened when zmq cannot bind !