### PR TITLE
Jormun: refacto initialization to add newrelic and gevent

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -43,20 +43,6 @@ from jormungandr.new_relic import record_custom_parameter
 from jormungandr.authentication import get_user, get_token, get_app_name, get_used_coverages
 import six
 
-if rest_api.app.config.get('PATCH_WITH_GEVENT_SOCKET', False):
-    logger = logging.getLogger('jormungandr.patch_gevent')
-    logger.info("Attention! You'are patching requests.packages.urllib3.connection.connection.socket with gevent.socket,"
-                "parallel http/https calling by requests is activated")
-    # This line replaces the gevent.monkey.patch_socket()
-    # Note that "monkey_patch" only patches on http request because we want asynchronisation on that,
-    # but we don't want that for reddis because it may cause performance regression
-    import requests
-    import gevent.socket
-    requests.packages.urllib3.connection.connection.socket = gevent.socket
-
-    from gevent import monkey
-    monkey.patch_ssl()
-
 @rest_api.representation("text/jsonp")
 @rest_api.representation("application/jsonp")
 def output_jsonp(data, code, headers=None):

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -28,6 +28,8 @@ PUBLIC = boolean(os.getenv('JORMUNGANDR_IS_PUBLIC', True))
 #message returned on authentication request
 HTTP_BASIC_AUTH_REALM = os.getenv('JORMUNGANDR_HTTP_BASIC_AUTH_REALM', 'Token Required')
 
+NEWRELIC_CONFIG_PATH = os.getenv('JORMUNGANDR_NEWRELIC_CONFIG_PATH', None)
+
 from jormungandr.logging_utils import IdFilter
 
 log_level = os.getenv('JORMUNGANDR_LOG_LEVEL', 'DEBUG')

--- a/source/jormungandr/jormungandr/init.py
+++ b/source/jormungandr/jormungandr/init.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# coding=utf-8
+
+# Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+import logging
+import os, sys
+
+"""
+    Import in this module should be done as late as possible to prevent side effect with the monkey patching
+"""
+
+def load_configuration(app):
+    app.config.from_object('jormungandr.default_settings')
+    if 'JORMUNGANDR_CONFIG_FILE' in os.environ:
+        app.config.from_envvar('JORMUNGANDR_CONFIG_FILE')
+
+def logger(app):
+    if 'LOGGER' in app.config:
+        logging.config.dictConfig(app.config['LOGGER'])
+    else:  # Default is std out
+        handler = logging.StreamHandler(stream=sys.stdout)
+        app.logger.addHandler(handler)
+        app.logger.setLevel('INFO')
+
+def patch_http():
+    logger = logging.getLogger(__name__)
+    logger.info(
+        "Warning! You'are patching socket with gevent, parallel http/https calling by requests is activated"
+    )
+
+    from gevent import monkey
+    monkey.patch_ssl()
+    monkey.patch_socket()
+

--- a/source/jormungandr/jormungandr/new_relic.py
+++ b/source/jormungandr/jormungandr/new_relic.py
@@ -30,6 +30,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
 import flask
+import os
 
 try:
     from newrelic import agent
@@ -37,6 +38,16 @@ except ImportError:
     logger = logging.getLogger(__name__)
     logger.exception('failure while importing newrelic')
     agent = None
+
+
+def init(config):
+    if not agent or not config:
+        return
+    if os.path.exists(config):
+        agent.initialize(config)
+    else:
+        logging.getLogger(__name__).error('%s doesn\'t exist, newrelic disabled', config)
+
 
 
 def record_exception():


### PR DESCRIPTION
This moves some of the crap in __init__ to functions in init.py
It also gives us the ability to initialize newrelic directly from jormungandr.
Finally, we are now monkeypatching all sockets with gevent and not just request, this shouldn't have any negative performance impact as jormungandr is now executed with only one thread, so every request has a dedicated process and do not have to fight with another request for some CPU time inside a python process