### PR TITLE
Kraken & Tyr : Syslog for Ed binaries within Tyr

### DIFF
--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -51,7 +51,7 @@ www.navitia.io
 #include "tests/utils_test.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(regex_toknize_without_tests){
     BOOST_CHECK(vec.find("centre") != vec.end());
     BOOST_CHECK(vec.find("commercial") != vec.end());
     BOOST_CHECK(vec.find("de") != vec.end());
-    BOOST_CHECK(vec.find("soie") != vec.end());    
+    BOOST_CHECK(vec.find("soie") != vec.end());
 }
 
 BOOST_AUTO_TEST_CASE(regex_synonyme_gare_sncf_tests){
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(parse_find_with_name_in_vector_test){
     vec.insert("jau");
     res = ac.find(vec);
     expected = {0};
-    BOOST_CHECK_EQUAL_COLLECTIONS(res.begin(), res.end(), expected.begin(), expected.end());    
+    BOOST_CHECK_EQUAL_COLLECTIONS(res.begin(), res.end(), expected.begin(), expected.end());
 }
 
 /*
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(autocompletesynonym_and_weight_test){
         std::set<std::string> ghostwords;
         std::vector<std::string> admins;
         std::string admin_uri;
-        int nbmax = 10;        
+        int nbmax = 10;
         synonyms["st"]="saint";
         synonyms["ste"]="sainte";
         synonyms["cc"]="centre commercial";

--- a/source/calendar/tests/calendar_api_test.cpp
+++ b/source/calendar/tests/calendar_api_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -56,7 +56,7 @@ static boost::gregorian::date date(std::string str) {
 }
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -69,7 +69,7 @@ end_application_daily_hour = 18h00
 active_days = 11111111
 */
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -41,7 +41,7 @@ www.navitia.io
 #include "routing/raptor_utils.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
@@ -378,9 +378,9 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
             boost::gregorian::date_period("20150826"_d, "20150926"_d));
     BOOST_CHECK_EQUAL(data.pt_data->datasets[0]->realtime_level == nt::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(data.pt_data->datasets[0]->system, "obiti");
-    
+
     // accepted side-effect (no link) as ntfs_v5 fixture does not contain datasets.txt, which is now required
-    BOOST_CHECK(data.pt_data->vehicle_journeys[0]->dataset == nullptr); 
+    BOOST_CHECK(data.pt_data->vehicle_journeys[0]->dataset == nullptr);
 
     BOOST_REQUIRE_EQUAL(data.pt_data->networks.size(), 1);
     BOOST_CHECK_EQUAL(data.pt_data->codes.get_codes(data.pt_data->networks[0]),
@@ -409,7 +409,7 @@ BOOST_FIXTURE_TEST_CASE(osm_pois_id_should_match_mimir_naming, ArgsFixture)
     ));
 }
 
-BOOST_FIXTURE_TEST_CASE(poi2ed_pois_uri_should_match_mimir_naming, ArgsFixture) 
+BOOST_FIXTURE_TEST_CASE(poi2ed_pois_uri_should_match_mimir_naming, ArgsFixture)
 {
     navitia::type::Data data;
     BOOST_REQUIRE_NO_THROW(data.load_nav(input_file_paths.at("poi_file")););

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -183,7 +183,8 @@ int ed2nav(int argc, const char * argv[])
          "database connection parameters: host=localhost user=navitia dbname=navitia password=navitia")
         ("cities-connection-string", po::value<std::string>(&cities_connection_string)->default_value(""),
          "cities database connection parameters: host=localhost user=navitia dbname=cities password=navitia")
-        ("active_syslog,l", "Active log redirection in local syslog");
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -195,13 +196,11 @@ int ed2nav(int argc, const char * argv[])
         return 0;
     }
 
-    if(vm.count("active_syslog")){
-        init_logger(true);
-    } else {
-        init_logger();
-    }
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
-    navitia::init_signal_handling();
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -162,8 +162,6 @@ struct FindAdminWithCities {
 
 int ed2nav(int argc, const char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
     std::string output, connection_string, region_name, cities_connection_string;
     double min_non_connected_graph_ratio;
     po::options_description desc("Allowed options");
@@ -184,7 +182,8 @@ int ed2nav(int argc, const char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
          "database connection parameters: host=localhost user=navitia dbname=navitia password=navitia")
         ("cities-connection-string", po::value<std::string>(&cities_connection_string)->default_value(""),
-         "cities database connection parameters: host=localhost user=navitia dbname=cities password=navitia");
+         "cities database connection parameters: host=localhost user=navitia dbname=cities password=navitia")
+        ("active_syslog,l", "Active log redirection in local syslog");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -196,6 +195,13 @@ int ed2nav(int argc, const char * argv[])
         return 0;
     }
 
+    if(vm.count("active_syslog")){
+        init_logger(true);
+    } else {
+        init_logger();
+    }
+    auto logger = log4cplus::Logger::getInstance("log");
+    navitia::init_signal_handling();
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -183,7 +183,7 @@ int ed2nav(int argc, const char * argv[])
          "database connection parameters: host=localhost user=navitia dbname=navitia password=navitia")
         ("cities-connection-string", po::value<std::string>(&cities_connection_string)->default_value(""),
          "cities database connection parameters: host=localhost user=navitia dbname=cities password=navitia")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/fare2ed.cpp
+++ b/source/ed/fare2ed.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -51,9 +51,6 @@ namespace ed {
 
 int fare2ed(int argc, const char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
-
     std::string connection_string, fare_dir;
     po::options_description desc("Allowed options");
     desc.add_options()
@@ -62,7 +59,9 @@ int fare2ed(int argc, const char * argv[])
         ("config-file", po::value<std::string>(), "Path to configuration file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
          "Connection parameters to database: host=localhost user=navitia dbname=navitia password=navitia")
-        ("fare,f", po::value<std::string>(&fare_dir)->required(), "Directory of fare files");
+        ("fare,f", po::value<std::string>(&fare_dir)->required(), "Directory of fare files")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -72,6 +71,12 @@ int fare2ed(int argc, const char * argv[])
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/fare2ed.cpp
+++ b/source/ed/fare2ed.cpp
@@ -60,7 +60,7 @@ int fare2ed(int argc, const char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
          "Connection parameters to database: host=localhost user=navitia dbname=navitia password=navitia")
         ("fare,f", po::value<std::string>(&fare_dir)->required(), "Directory of fare files")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/fare2ed.cpp
+++ b/source/ed/fare2ed.cpp
@@ -75,7 +75,7 @@ int fare2ed(int argc, const char * argv[])
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("fare2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -49,9 +49,6 @@ namespace pt = boost::posix_time;
 
 int main(int argc, char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
-
     std::string input, date, connection_string,
                 fare_dir;
     double simplify_tolerance;
@@ -68,7 +65,9 @@ int main(int argc, char * argv[])
         ("config-file", po::value<std::string>(), "Path to configuration file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost "
-             "user=navitia dbname=navitia password=navitia");
+             "user=navitia dbname=navitia password=navitia")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -78,6 +77,12 @@ int main(int argc, char * argv[])
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -81,7 +81,7 @@ int main(int argc, char * argv[])
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("fusio2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){

--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -66,7 +66,7 @@ int main(int argc, char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost "
              "user=navitia dbname=navitia password=navitia")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/geopal2ed.cpp
+++ b/source/ed/geopal2ed.cpp
@@ -56,7 +56,7 @@ int main(int argc, char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost user=navitia "
              "dbname=navitia password=navitia")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/geopal2ed.cpp
+++ b/source/ed/geopal2ed.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -46,9 +46,6 @@ namespace pt = boost::posix_time;
 
 int main(int argc, char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
-
     std::string input, connection_string;
     po::options_description desc("Allowed options");
     desc.add_options()
@@ -58,7 +55,9 @@ int main(int argc, char * argv[])
         ("config-file", po::value<std::string>(), "Path to config file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost user=navitia "
-             "dbname=navitia password=navitia");
+             "dbname=navitia password=navitia")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -68,6 +67,12 @@ int main(int argc, char * argv[])
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/geopal2ed.cpp
+++ b/source/ed/geopal2ed.cpp
@@ -71,7 +71,7 @@ int main(int argc, char * argv[])
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("geopal2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -47,9 +47,6 @@ namespace pt = boost::posix_time;
 
 int main(int argc, char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
-
     std::string input, date, connection_string;
     double simplify_tolerance;
     po::options_description desc("Allowed options");
@@ -64,7 +61,9 @@ int main(int argc, char * argv[])
         ("config-file", po::value<std::string>(), "Path to a config file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
             "Database connection parameters: host=localhost user=navitia"
-            " dbname=navitia password=navitia");
+            " dbname=navitia password=navitia")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
 
     po::variables_map vm;
@@ -75,6 +74,12 @@ int main(int argc, char * argv[])
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -78,7 +78,7 @@ int main(int argc, char * argv[])
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("gtfs2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -62,7 +62,7 @@ int main(int argc, char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
             "Database connection parameters: host=localhost user=navitia"
             " dbname=navitia password=navitia")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
 

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -977,7 +977,7 @@ int osm2ed(int argc, const char** argv) {
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("osm2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("help") || (! vm.count("input") && ! vm.count("poi-type"))) {

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -960,7 +960,7 @@ int osm2ed(int argc, const char** argv) {
              " dbname=navitia password=navitia")
         ("poi-type,p", po::value<std::string>(&json_poi_types),
                        "a json string describing poi_types and rules to build them from OSM tags")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -22,7 +22,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -945,8 +945,6 @@ void OSMCache::flag_nodes() {
 }
 
 int osm2ed(int argc, const char** argv) {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
     pt::ptime start;
     std::string input, connection_string, json_poi_types;
 
@@ -961,18 +959,26 @@ int osm2ed(int argc, const char** argv) {
              "Database connection parameters: host=localhost user=navitia"
              " dbname=navitia password=navitia")
         ("poi-type,p", po::value<std::string>(&json_poi_types),
-                       "a json string describing poi_types and rules to build them from OSM tags");
+                       "a json string describing poi_types and rules to build them from OSM tags")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
 
     start = pt::microsec_clock::local_time();
-   
+
     if(vm.count("version")){
         std::cout << argv[0] << " " << navitia::config::project_version << " "
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("help") || (! vm.count("input") && ! vm.count("poi-type"))) {
         std::cout << "Reads an OSM file and inserts it into a ed database" << std::endl;
@@ -998,8 +1004,8 @@ int osm2ed(int argc, const char** argv) {
 
     if (! vm.count("poi-type")) {
         json_poi_types = ed::connectors::DEFAULT_JSON_POI_TYPES;
-    } 
-    
+    }
+
     po::notify(vm);
     const ed::connectors::PoiTypeParams poi_params(json_poi_types);
 

--- a/source/ed/poi2ed.cpp
+++ b/source/ed/poi2ed.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -47,9 +47,6 @@ namespace pt = boost::posix_time;
 
 int main(int argc, char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
-
     std::string input, connection_string;
     po::options_description desc("Allowed options");
     desc.add_options()
@@ -59,7 +56,9 @@ int main(int argc, char * argv[])
         ("config-file", po::value<std::string>(), "Configuration file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost user=navitia"
-             " dbname=navitia password=navitia");
+             " dbname=navitia password=navitia")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -69,6 +68,12 @@ int main(int argc, char * argv[])
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/poi2ed.cpp
+++ b/source/ed/poi2ed.cpp
@@ -72,7 +72,7 @@ int main(int argc, char * argv[])
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("poi2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){

--- a/source/ed/poi2ed.cpp
+++ b/source/ed/poi2ed.cpp
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost user=navitia"
              " dbname=navitia password=navitia")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/synonym2ed.cpp
+++ b/source/ed/synonym2ed.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -47,9 +47,6 @@ namespace pt = boost::posix_time;
 
 int main(int argc, char * argv[])
 {
-    navitia::init_app();
-    auto logger = log4cplus::Logger::getInstance("log");
-
     std::string input, connection_string;
     po::options_description desc("Allowed options");
     desc.add_options()
@@ -59,7 +56,9 @@ int main(int argc, char * argv[])
         ("config-file", po::value<std::string>(), "Path to config file")
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost user=navitia"
-             " dbname=navitia password=navitia");
+             " dbname=navitia password=navitia")
+        ("local_syslog", "Active log redirection within local syslog")
+        ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -69,6 +68,12 @@ int main(int argc, char * argv[])
                   << navitia::config::navitia_build_type << std::endl;
         return 0;
     }
+
+    // Construct logger and signal handling
+    std::string log_comment = "";
+    if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
+    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){
         std::ifstream stream;

--- a/source/ed/synonym2ed.cpp
+++ b/source/ed/synonym2ed.cpp
@@ -57,7 +57,7 @@ int main(int argc, char * argv[])
         ("connection-string", po::value<std::string>(&connection_string)->required(),
              "Database connection parameters: host=localhost user=navitia"
              " dbname=navitia password=navitia")
-        ("local_syslog", "Active log redirection within local syslog")
+        ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name");
 
     po::variables_map vm;

--- a/source/ed/synonym2ed.cpp
+++ b/source/ed/synonym2ed.cpp
@@ -72,7 +72,7 @@ int main(int argc, char * argv[])
     // Construct logger and signal handling
     std::string log_comment = "";
     if (vm.count("log_comment")) { log_comment = vm["log_comment"].as<std::string>(); }
-    navitia::init_app("ed2nav", "DEBUG", vm.count("local_syslog"), log_comment);
+    navitia::init_app("synonym2ed", "DEBUG", vm.count("local_syslog"), log_comment);
     auto logger = log4cplus::Logger::getInstance("log");
 
     if(vm.count("config-file")){

--- a/source/ed/tests/associated_calendar_test.cpp
+++ b/source/ed/tests/associated_calendar_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -39,7 +39,7 @@ www.navitia.io
 using namespace ed;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ed/tests/ed2nav_test.cpp
+++ b/source/ed/tests/ed2nav_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2018, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -36,22 +36,22 @@ www.navitia.io
 #include "utils/logger.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
-BOOST_AUTO_TEST_CASE(ed2nav_with_no_param_should_start_without_throwing) 
+BOOST_AUTO_TEST_CASE(ed2nav_with_no_param_should_start_without_throwing)
 {
     const char* argv [] = { "ed2nav_test" };
     BOOST_CHECK_NO_THROW(ed::ed2nav(1, argv));
 }
 
-BOOST_AUTO_TEST_CASE(should_throw_on_bad_connection_string) 
+BOOST_AUTO_TEST_CASE(should_throw_on_bad_connection_string)
 {
-    const char* argv [] = { 
-    	"ed2nav_test", 
-    	"--connection-string=\"blahblah\"" 
+    const char* argv [] = {
+    	"ed2nav_test",
+    	"--connection-string=\"blahblah\""
     };
     BOOST_CHECK_THROW(ed::ed2nav(2, argv), std::exception);
 }

--- a/source/ed/tests/fare2ed_test.cpp
+++ b/source/ed/tests/fare2ed_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2018, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -36,22 +36,22 @@ www.navitia.io
 #include "utils/logger.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
-BOOST_AUTO_TEST_CASE(fare2ed_with_no_param_should_start_without_throwing) 
+BOOST_AUTO_TEST_CASE(fare2ed_with_no_param_should_start_without_throwing)
 {
     const char* argv [] = { "fare2ed_test" };
     BOOST_CHECK_NO_THROW(ed::fare2ed(1, argv));
 }
 
-BOOST_AUTO_TEST_CASE(should_throw_on_bad_connection_string) 
+BOOST_AUTO_TEST_CASE(should_throw_on_bad_connection_string)
 {
-    const char* argv [] = { 
-    	"fare2ed_test", 
-    	"--connection-string=\"blahblah\"" 
+    const char* argv [] = {
+    	"fare2ed_test",
+    	"--connection-string=\"blahblah\""
     };
     BOOST_CHECK_THROW(ed::fare2ed(2, argv), std::exception);
 }

--- a/source/ed/tests/fare_parser_test.cpp
+++ b/source/ed/tests/fare_parser_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -37,7 +37,7 @@ www.navitia.io
 #include "utils/base64_encode.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -43,7 +43,7 @@ www.navitia.io
 namespace bg = boost::gregorian;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(sync_ntfs) {
     BOOST_REQUIRE_EQUAL(data.stop_points.size(), 8);
     BOOST_CHECK_EQUAL(data.lines[0]->name, "ligne A Flexible");
     BOOST_CHECK_EQUAL(data.lines[0]->uri, "l1");
-    BOOST_CHECK_EQUAL(data.lines[0]->text_color, "FFD700");    
+    BOOST_CHECK_EQUAL(data.lines[0]->text_color, "FFD700");
     BOOST_REQUIRE_EQUAL(data.routes.size(), 4);
 
     navitia::type::hasProperties has_properties;
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE(sync_ntfs) {
     BOOST_CHECK_EQUAL(data.datasets[0]->validation_period, boost::gregorian::date_period("20150826"_d, "20150926"_d));
     BOOST_CHECK_EQUAL(data.datasets[0]->realtime_level == nt::RTLevel::Base, true);
     BOOST_CHECK_EQUAL(data.datasets[0]->system, "obiti");
-    
+
     // accepted side-effect (no link) as ntfs_v5 fixture does not contain datasets.txt, which is now required
     BOOST_CHECK(data.vehicle_journeys[0]->dataset == nullptr);
 

--- a/source/ed/tests/gtfsparser_test.cpp
+++ b/source/ed/tests/gtfsparser_test.cpp
@@ -39,7 +39,7 @@ www.navitia.io
 #include "utils/csv.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ed/tests/osm2ed_test.cpp
+++ b/source/ed/tests/osm2ed_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2018, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -36,38 +36,38 @@ www.navitia.io
 #include "ed/osm2ed.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
 using namespace ed::connectors;
 
-BOOST_AUTO_TEST_CASE(osm2ed_with_no_param_should_start_without_throwing) 
+BOOST_AUTO_TEST_CASE(osm2ed_with_no_param_should_start_without_throwing)
 {
     const char* argv [] = { "osm2ed_test" };
     BOOST_CHECK_NO_THROW(osm2ed(1, argv));
 }
 
-BOOST_AUTO_TEST_CASE(poi_uri_should_construct_based_on_id) 
+BOOST_AUTO_TEST_CASE(poi_uri_should_construct_based_on_id)
 {
     ed::types::Poi poi("123456");
     BOOST_CHECK_EQUAL(poi.uri, "poi:123456");
 }
 
-BOOST_AUTO_TEST_CASE(osm_poi_id_node_should_match_mimirs_one) 
+BOOST_AUTO_TEST_CASE(osm_poi_id_node_should_match_mimirs_one)
 {
     OsmPoi osm_poi(OsmObjectType::Node, 123456);
     BOOST_CHECK_EQUAL(osm_poi.uri, "poi:osm:node:123456");
 }
 
-BOOST_AUTO_TEST_CASE(osm_poi_id_way_should_match_mimirs_one) 
+BOOST_AUTO_TEST_CASE(osm_poi_id_way_should_match_mimirs_one)
 {
     OsmPoi osm_poi(OsmObjectType::Way, 123456);
     BOOST_CHECK_EQUAL( osm_poi.uri, "poi:osm:way:123456");
 }
 
-BOOST_AUTO_TEST_CASE(osm_poi_id_relation_should_match_mimirs_one) 
+BOOST_AUTO_TEST_CASE(osm_poi_id_relation_should_match_mimirs_one)
 {
     OsmPoi osm_poi(OsmObjectType::Relation, 123456);
     BOOST_CHECK_EQUAL(osm_poi.uri, "poi:osm:relation:123456");

--- a/source/ed/tests/osm_tags_reader_test.cpp
+++ b/source/ed/tests/osm_tags_reader_test.cpp
@@ -41,7 +41,7 @@ www.navitia.io
 #include "tests/utils_test.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ed/tests/poi2ed_test.cpp
+++ b/source/ed/tests/poi2ed_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2018, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -38,7 +38,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized() { init_logger(); }
+    logger_initialized() { navitia::init_logger(); }
 };
 
 BOOST_GLOBAL_FIXTURE(logger_initialized);
@@ -46,15 +46,15 @@ BOOST_GLOBAL_FIXTURE(logger_initialized);
 using namespace ed::connectors;
 
 namespace {
-    class ArgsFixture 
+    class ArgsFixture
     {
     public:
-        ArgsFixture() 
+        ArgsFixture()
         {
             auto& master = boost::unit_test::framework::master_test_suite();
 
             BOOST_REQUIRE_MESSAGE(
-                master.argc > 1, 
+                master.argc > 1,
                 "Missing parameter - The test needs a path to a directory containing your POI's files");
 
             poi_dir_path = master.argv[1];

--- a/source/ed/tests/route_main_destination_test.cpp
+++ b/source/ed/tests/route_main_destination_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -35,7 +35,7 @@ www.navitia.io
 #include "ed/types.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ed/tests/shift_stop_times.cpp
+++ b/source/ed/tests/shift_stop_times.cpp
@@ -37,7 +37,7 @@ www.navitia.io
 #include <string>
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -41,7 +41,7 @@ www.navitia.io
 #include "type/pb_converter.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/fare/tests/fare_test.cpp
+++ b/source/fare/tests/fare_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -41,7 +41,7 @@ www.navitia.io
 #include <boost/spirit/include/phoenix_operator.hpp>
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -43,7 +43,7 @@ www.navitia.io
 #include <boost/graph/detail/adjacency_list.hpp>
 
 struct logger_initialized {
-    logger_initialized() { init_logger(); }
+    logger_initialized() { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -77,9 +77,9 @@ int main(int argn, char** argv){
     auto log_level = conf.log_level();
     auto log_format = conf.log_format();
     if(log_level && log_format){
-        init_logger(*log_level, *log_format);
+        navitia::init_logger("kraken", *log_level, false, *log_format);
     }else{
-        init_logger(conf_file);
+        navitia::init_logger(conf_file);
     }
 
     DataManager<navitia::type::Data> data_manager;

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -43,7 +43,7 @@ www.navitia.io
 #include "type/pb_converter.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/kraken/tests/disruption_periods_test.cpp
+++ b/source/kraken/tests/disruption_periods_test.cpp
@@ -40,7 +40,7 @@ www.navitia.io
 using btp = boost::posix_time::time_period;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
@@ -307,12 +307,12 @@ BOOST_FIXTURE_TEST_CASE(journey_inside_pub_period_inside_application, disruption
 if ptref is queried inside the publication period, but after the application period, we display the impact
 and it's status is 'past'
 [-------------------------------------------------------------------|-----------------]  production period
-                                                                    |               
-                                                Impact              |             
+                                                                    |
+                                                Impact              |
                                     <-------------------------------|-->                 publication period
-                                                                    |          
+                                                                    |
                                                      (------------) |                    application period
-                                                                    |            
+                                                                    |
                                                                    now
 
  */

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -48,7 +48,7 @@ www.navitia.io
 #include <boost/algorithm/string/classification.hpp>
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -44,7 +44,7 @@ www.navitia.io
 #include "type/pb_converter.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/kraken/tests/worker_test.cpp
+++ b/source/kraken/tests/worker_test.cpp
@@ -43,7 +43,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/proximity_list/tests/test.cpp
+++ b/source/proximity_list/tests/test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -43,7 +43,7 @@ using namespace navitia::type;
 using namespace navitia::proximitylist;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ptreferential/tests/ptref_companies_test.cpp
+++ b/source/ptreferential/tests/ptref_companies_test.cpp
@@ -45,7 +45,7 @@ www.navitia.io
 using namespace navitia::ptref;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/ptreferential/tests/ptref_odt_level_test.cpp
+++ b/source/ptreferential/tests/ptref_odt_level_test.cpp
@@ -44,7 +44,7 @@ www.navitia.io
 using namespace navitia::ptref;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/co2_emission_test.cpp
+++ b/source/routing/tests/co2_emission_test.cpp
@@ -40,7 +40,7 @@ www.navitia.io
 #include "type/pb_converter.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/disruptions_test.cpp
+++ b/source/routing/tests/disruptions_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -37,7 +37,7 @@ www.navitia.io
 #include "kraken/worker.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/frequency_raptor_test.cpp
+++ b/source/routing/tests/frequency_raptor_test.cpp
@@ -38,7 +38,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized() { init_logger(); }
+    logger_initialized() { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/heat_map_test.cpp
+++ b/source/routing/tests/heat_map_test.cpp
@@ -49,7 +49,7 @@ www.navitia.io
 #include <iostream>
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/isochrone_test.cpp
+++ b/source/routing/tests/isochrone_test.cpp
@@ -47,7 +47,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/journey_test.cpp
+++ b/source/routing/tests/journey_test.cpp
@@ -41,7 +41,7 @@ using namespace navitia;
 using namespace routing;
 
 struct logger_initialized {
-    logger_initialized() { init_logger(); }
+    logger_initialized() { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -37,7 +37,7 @@ www.navitia.io
 #include "tests/utils_test.h"
 
 struct logger_initialized {
-    logger_initialized() { init_logger(); }
+    logger_initialized() { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -38,7 +38,7 @@ www.navitia.io
 #include "tests/utils_test.h"
 
 struct logger_initialized {
-    logger_initialized() { init_logger(); }
+    logger_initialized() { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -44,7 +44,7 @@ www.navitia.io
 #include "type/pb_converter.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
@@ -3374,7 +3374,7 @@ BOOST_FIXTURE_TEST_CASE(night_bus_filter_should_be_order_agnostic, Night_bus_fix
 BOOST_FIXTURE_TEST_CASE(night_bus_filter_change_parameters, Night_bus_fixture)
 {
     // With the default parameters, the request departure is 08:00
-    // The max_pseudo_duration is 7h, so journeys departing after 15:00 are deleted 
+    // The max_pseudo_duration is 7h, so journeys departing after 15:00 are deleted
     nr::NightBusFilter::Params filter_params = get_default_filter_params();
     {
         nr::RAPTOR::Journeys journeys = {j1, j2};

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -40,7 +40,7 @@ www.navitia.io
 #include "kraken/make_disruption_from_chaos.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/time_tables/tests/passages_test.cpp
+++ b/source/time_tables/tests/passages_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -37,7 +37,7 @@ www.navitia.io
 #include "time_tables/passages.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -44,7 +44,7 @@ www.navitia.io
 namespace ntt = navitia::timetables;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/type/tests/associated_calendar_test.cpp
+++ b/source/type/tests/associated_calendar_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -36,7 +36,7 @@ www.navitia.io
 #include "type/pt_data.h"
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/type/tests/comments_test.cpp
+++ b/source/type/tests/comments_test.cpp
@@ -44,7 +44,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/type/tests/create_vj_test.cpp
+++ b/source/type/tests/create_vj_test.cpp
@@ -44,7 +44,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(create_vj_test) {
     sts.at(1).departure_time = 8300;
     vp.days = year("0000000" "0000110");
     const auto* rt_vj = mvj->create_discrete_vj("rt", nt::RTLevel::RealTime, vp, base_vj->route, sts, pt_data);
-    
+
     BOOST_CHECK_EQUAL(base_vj->base_validity_pattern()->days, year("0011111" "0011111"));
     BOOST_CHECK_EQUAL(base_vj->adapted_validity_pattern()->days, year("0011011" "0011011"));
     BOOST_CHECK_EQUAL(base_vj->rt_validity_pattern()->days, year("0011011" "0011001"));

--- a/source/type/tests/fill_pb_object_tests.cpp
+++ b/source/type/tests/fill_pb_object_tests.cpp
@@ -43,7 +43,7 @@ www.navitia.io
 using namespace navitia::type;
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -45,7 +45,7 @@ www.navitia.io
 
 
 struct logger_initialized {
-    logger_initialized()   { init_logger(); }
+    logger_initialized()   { navitia::init_logger(); }
 };
 BOOST_GLOBAL_FIXTURE( logger_initialized );
 

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -171,6 +171,9 @@ def fusio2ed(self, instance_config, filename, job_id, dataset_uid):
         connection_string = make_connection_string(instance_config)
         params.append("--connection-string")
         params.append(connection_string)
+        params.append("--local_syslog")
+        params.append("--log_comment")
+        params.append(instance_config.name)
         res = None
         with collect_metric('fusio2ed', job, dataset_uid):
             res = launch_exec("fusio2ed", params, logger)
@@ -207,6 +210,9 @@ def gtfs2ed(self, instance_config, gtfs_filename, job_id, dataset_uid):
         connection_string = make_connection_string(instance_config)
         params.append("--connection-string")
         params.append(connection_string)
+        params.append("--local_syslog")
+        params.append("--log_comment")
+        params.append(instance_config.name)
         res = None
         with collect_metric('gtfs2ed', job, dataset_uid):
             res = launch_exec("gtfs2ed", params, logger)
@@ -241,6 +247,9 @@ def osm2ed(self, instance_config, osm_filename, job_id, dataset_uid):
         if poi_types_json:
             args.append('-p')
             args.append(u'{}'.format(poi_types_json))
+            args.append("--local_syslog")
+            args.append("--log_comment")
+            args.append(instance_config.name)
 
         with collect_metric('osm2ed', job, dataset_uid):
             res = launch_exec('osm2ed',
@@ -268,10 +277,14 @@ def geopal2ed(self, instance_config, filename, job_id, dataset_uid):
 
         connection_string = make_connection_string(instance_config)
         res = None
+        params = ["-i", working_directory]
+        params.append("--connection-string")
+        params.append(connection_string)
+        params.append("--local_syslog")
+        params.append("--log_comment")
+        params.append(instance_config.name)
         with collect_metric('geopal2ed', job, dataset_uid):
-            res = launch_exec('geopal2ed',
-                    ["-i", working_directory, "--connection-string", connection_string],
-                    logger)
+            res = launch_exec('geopal2ed', params, logger)
         if res != 0:
             #@TODO: exception
             raise ValueError('geopal2ed failed')
@@ -294,10 +307,14 @@ def poi2ed(self, instance_config, filename, job_id, dataset_uid):
 
         connection_string = make_connection_string(instance_config)
         res = None
+        params = ["-i", working_directory]
+        params.append("--connection-string")
+        params.append(connection_string)
+        params.append("--local_syslog")
+        params.append("--log_comment")
+        params.append(instance_config.name)
         with collect_metric('poi2ed', job, dataset_uid):
-            res = launch_exec('poi2ed',
-                    ["-i", working_directory, "--connection-string", connection_string],
-                    logger)
+            res = launch_exec('poi2ed', params, logger)
         if res != 0:
             #@TODO: exception
             raise ValueError('poi2ed failed')
@@ -319,10 +336,14 @@ def synonym2ed(self, instance_config, filename, job_id, dataset_uid):
     try:
         connection_string = make_connection_string(instance_config)
         res = None
+        params = ["-i", filename]
+        params.append("--connection-string")
+        params.append(connection_string)
+        params.append("--local_syslog")
+        params.append("--log_comment")
+        params.append(instance_config.name)
         with collect_metric('synonym2ed', job, dataset_uid):
-            res = launch_exec('synonym2ed',
-                    ["-i", filename, "--connection-string", connection_string],
-                    logger)
+            res = launch_exec('synonym2ed', params, logger)
         if res != 0:
             #@TODO: exception
             raise ValueError('synonym2ed failed')
@@ -468,6 +489,8 @@ def ed2nav(self, instance_config, job_id, custom_output_dir):
             argv.extend(["--cities-connection-string", current_app.config['CITIES_DATABASE_URI']])
         if instance.full_sn_geometries:
             argv.extend(['--full_street_network_geometries'])
+            argv.extend(['--local_syslog'])
+            argv.extend(["--log_comment", instance_config.name])
 
         res = None
         with collect_metric('ed2nav', job, None):
@@ -495,10 +518,13 @@ def fare2ed(self, instance_config, filename, job_id, dataset_uid):
 
         working_directory = unzip_if_needed(filename)
 
-        res = launch_exec("fare2ed", ['-f', working_directory,
-                                      '--connection-string',
-                                      make_connection_string(instance_config)],
-                          logger)
+        params = ["-f", working_directory]
+        params.append("--connection-string")
+        params.append(make_connection_string(instance_config))
+        params.append("--local_syslog")
+        params.append("--log_comment")
+        params.append(instance_config.name)
+        res = launch_exec("fare2ed", params, logger)
         if res != 0:
             #@TODO: exception
             raise ValueError('fare2ed failed')


### PR DESCRIPTION
This PR aims to update the **navitia logger**.

Currently, we have no redirection log for ed binaries in Syslog. This is a real problem when a ed binary is called in Tyr and failed.
We have no way to view correctly logs (in the temporal order).

Moreover, this PR add an extra optional field in output log, like the **coverage name**

_Example in syslog_ for a Ed binary :

```
Sep 11 16:50:09 par-lap06 ed2nav: [fr-idf] [32099] [INFO] [] - Building uri maps data.cpp:379
Sep 11 16:50:09 par-lap06 ed2nav: [fr-idf] [32099] [INFO] [] - Building autocomplete data.cpp:381
Sep 11 16:50:09 par-lap06 ed2nav: [fr-idf] [32099] [INFO] [] - #011 Building admins: 99ms data.cpp:385
```

The logger changes are in utils : https://github.com/CanalTP/utils/pull/70

I hope that will be usefull for maintenance

Sorry, but I needed to update a lot of tests with _navitia::logger_, it's not comfortable for the reading... :cry: 