### PR TITLE
doc: tell mkvirtualenv to use python 2

### DIFF
--- a/source/jormungandr/readme.md
+++ b/source/jormungandr/readme.md
@@ -12,8 +12,7 @@ In the Norse mythology, Jörmungandr is a sea serpent that grew so large that it
 
 ```sh
 cd navitia/source/jormungandr
-mkvirtualenv jormungandr
-pip install -r requirements.txt -r requirements_dev.txt -U
+mkvirtualenv -r requirements_dev.txt -p /usr/bin/python2 jormungandr 
 ```
 
 # Configure


### PR DESCRIPTION
By default, `mkvirtualenv` now uses python 3 when setting up an environment. It doesn't work so well with Jormun....