### PR TITLE
tests: rewrite line section tests in order to check all disruptions

### DIFF
--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -28,12 +28,11 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from collections import deque, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from functools import partial
 from future.moves.itertools import zip_longest
 import json
 from jormungandr.scenarios.qualifier import compare_field, reverse_compare_field
-from navitiacommon import request_pb2, response_pb2
 from navitiacommon.parser_args_type import UnsignedInteger
 from datetime import datetime
 import logging

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -29,7 +29,17 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 from .tests_mechanism import AbstractTestFixture, dataset
-from .check_utils import *
+from .check_utils import (
+    get_not_null,
+    get_all_element_disruptions,
+    get_disruptions,
+    is_valid_line,
+    is_valid_disruption,
+    is_valid_network,
+    is_valid_stop_area,
+    is_valid_line_report,
+    s_coord,
+)
 import jmespath
 
 
@@ -676,9 +686,9 @@ class TestDisruptionsLineSections(AbstractTestFixture):
     def test_line_reports(self):
         response = self.query_region("line_reports?_current_datetime=20170103T120000")
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 2
+        assert len(disruptions) == 3
         line_reports = get_not_null(response, 'line_reports')
-        assert len(line_reports) == 1
+        assert len(line_reports) == 2
         is_valid_line_report(line_reports[0])
         assert line_reports[0]['line']['id'] == 'line:1'
         assert len(line_reports[0]['pt_objects']) == 5
@@ -689,15 +699,18 @@ class TestDisruptionsLineSections(AbstractTestFixture):
         assert line_reports[0]['pt_objects'][4]['id'] == 'F_1'
         for pt_object in line_reports[0]['pt_objects']:
             assert pt_object['embedded_type'] == 'stop_point'
-            assert len(pt_object['stop_point']['links']) == (2 if pt_object['id'] == 'E_1' else 1)
+            assert len(pt_object['stop_point']['links']) == (
+                2 if pt_object['id'] in ['A_1', 'E_1', 'F_1'] else 1
+            )
             if pt_object['id'] != 'F_1':
                 assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
         assert (
             line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id']
             == 'line_section_on_line_1_other_effect'
         )
+        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_2'
         assert (
-            line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id']
+            line_reports[0]['pt_objects'][4]['stop_point']['links'][1]['id']
             == 'line_section_on_line_1_other_effect'
         )
 
@@ -712,9 +725,9 @@ class TestDisruptionsLineSections(AbstractTestFixture):
             "line_reports?_current_datetime=20170101T120000" "&since=20170104T130000&until=20170106T000000"
         )
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 2
+        assert len(disruptions) == 3
         line_reports = get_not_null(response, 'line_reports')
-        assert len(line_reports) == 1
+        assert len(line_reports) == 2
         is_valid_line_report(line_reports[0])
         assert line_reports[0]['line']['id'] == 'line:1'
         assert len(line_reports[0]['pt_objects']) == 5
@@ -725,24 +738,27 @@ class TestDisruptionsLineSections(AbstractTestFixture):
         assert line_reports[0]['pt_objects'][4]['id'] == 'F_1'
         for pt_object in line_reports[0]['pt_objects']:
             assert pt_object['embedded_type'] == 'stop_point'
-            assert len(pt_object['stop_point']['links']) == (2 if pt_object['id'] == 'E_1' else 1)
+            assert len(pt_object['stop_point']['links']) == (
+                2 if pt_object['id'] in ['A_1', 'E_1', 'F_1'] else 1
+            )
             if pt_object['id'] != 'F_1':
                 assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
         assert (
             line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id']
             == 'line_section_on_line_1_other_effect'
         )
+        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_2'
         assert (
-            line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id']
+            line_reports[0]['pt_objects'][4]['stop_point']['links'][1]['id']
             == 'line_section_on_line_1_other_effect'
         )
 
     def test_line_reports_with_since_intersects_application_period(self):
         response = self.query_region("line_reports?_current_datetime=20170101T120000&since=20170104T130000")
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 2
+        assert len(disruptions) == 3
         line_reports = get_not_null(response, 'line_reports')
-        assert len(line_reports) == 1
+        assert len(line_reports) == 2
         is_valid_line_report(line_reports[0])
         assert line_reports[0]['line']['id'] == 'line:1'
         assert len(line_reports[0]['pt_objects']) == 5
@@ -753,15 +769,18 @@ class TestDisruptionsLineSections(AbstractTestFixture):
         assert line_reports[0]['pt_objects'][4]['id'] == 'F_1'
         for pt_object in line_reports[0]['pt_objects']:
             assert pt_object['embedded_type'] == 'stop_point'
-            assert len(pt_object['stop_point']['links']) == (2 if pt_object['id'] == 'E_1' else 1)
+            assert len(pt_object['stop_point']['links']) == (
+                2 if pt_object['id'] in ['A_1', 'E_1', 'F_1'] else 1
+            )
             if pt_object['id'] != 'F_1':
                 assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
         assert (
             line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id']
             == 'line_section_on_line_1_other_effect'
         )
+        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_2'
         assert (
-            line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id']
+            line_reports[0]['pt_objects'][4]['stop_point']['links'][1]['id']
             == 'line_section_on_line_1_other_effect'
         )
 

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -704,15 +704,13 @@ class TestDisruptionsLineSections(AbstractTestFixture):
             )
             if pt_object['id'] != 'F_1':
                 assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
-        assert (
-            line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id']
-            == 'line_section_on_line_1_other_effect'
-        )
-        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_2'
-        assert (
-            line_reports[0]['pt_objects'][4]['stop_point']['links'][1]['id']
-            == 'line_section_on_line_1_other_effect'
-        )
+        links = [l['id'] for l in line_reports[0]['pt_objects'][3]['stop_point']['links']]
+        for d in ['line_section_on_line_1_other_effect']:
+            assert d in links
+
+        links = [l['id'] for l in line_reports[0]['pt_objects'][4]['stop_point']['links']]
+        for d in ['line_section_on_line_1_other_effect', 'line_section_on_line_2']:
+            assert d in links
 
     def test_line_reports_with_current_datetime_outof_application_period(self):
         # without since/until we use since=production_date.begin and until = production_date.end
@@ -743,15 +741,14 @@ class TestDisruptionsLineSections(AbstractTestFixture):
             )
             if pt_object['id'] != 'F_1':
                 assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
-        assert (
-            line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id']
-            == 'line_section_on_line_1_other_effect'
-        )
-        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_2'
-        assert (
-            line_reports[0]['pt_objects'][4]['stop_point']['links'][1]['id']
-            == 'line_section_on_line_1_other_effect'
-        )
+
+        links = [l['id'] for l in line_reports[0]['pt_objects'][3]['stop_point']['links']]
+        for d in ['line_section_on_line_1_other_effect']:
+            assert d in links
+
+        links = [l['id'] for l in line_reports[0]['pt_objects'][4]['stop_point']['links']]
+        for d in ['line_section_on_line_1_other_effect', 'line_section_on_line_2']:
+            assert d in links
 
     def test_line_reports_with_since_intersects_application_period(self):
         response = self.query_region("line_reports?_current_datetime=20170101T120000&since=20170104T130000")
@@ -774,15 +771,13 @@ class TestDisruptionsLineSections(AbstractTestFixture):
             )
             if pt_object['id'] != 'F_1':
                 assert pt_object['stop_point']['links'][0]['id'] == 'line_section_on_line_1'
-        assert (
-            line_reports[0]['pt_objects'][3]['stop_point']['links'][1]['id']
-            == 'line_section_on_line_1_other_effect'
-        )
-        assert line_reports[0]['pt_objects'][4]['stop_point']['links'][0]['id'] == 'line_section_on_line_2'
-        assert (
-            line_reports[0]['pt_objects'][4]['stop_point']['links'][1]['id']
-            == 'line_section_on_line_1_other_effect'
-        )
+        links = [l['id'] for l in line_reports[0]['pt_objects'][3]['stop_point']['links']]
+        for d in ['line_section_on_line_1_other_effect']:
+            assert d in links
+
+        links = [l['id'] for l in line_reports[0]['pt_objects'][4]['stop_point']['links']]
+        for d in ['line_section_on_line_1_other_effect', 'line_section_on_line_2']:
+            assert d in links
 
     def test_line_reports_with_since_until_outof_application_period(self):
         response = self.query_region(

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -27,10 +27,15 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
-import logging
-
 from .tests_mechanism import AbstractTestFixture, dataset
-from .check_utils import *
+from .check_utils import (
+    ObjGetter,
+    has_disruption,
+    get_not_null,
+    is_valid_line_section_disruption,
+    get_used_vj,
+    get_all_element_disruptions,
+)
 
 
 # Looking for (identifiable) objects impacted by 'disruptions' inputed
@@ -50,28 +55,31 @@ def impacted_ids(disruptions):
             id = obj.impacted_object['links'][0]['id']
         return id
 
-    return set(get_id(o) for o in disruptions['line_section_on_line_1'])
+    ids = set()
+    for label, d in disruptions.iteritems():
+        ids.update(set(get_id(o) for o in d))
+
+    return ids
 
 
 @dataset({"line_sections_test": {}})
 class TestLineSections(AbstractTestFixture):
     def default_query(self, q, **kwargs):
-        """query navitia with a current date in the publication period of the impacts"""
+        """
+        query navitia with a current date in the publication period of the impacts
+        """
         return self.query_region('{}?_current_datetime=20170101T100000'.format(q), **kwargs)
 
-    def has_disruption(self, q, object_get, disruption_uri, **kwargs):
-        r = self.default_query(q, **kwargs)
-        return has_disruption(r, object_get, disruption_uri)
-
     def has_disruption(self, object_get, disruption_uri):
-        """Little helper calling the detail of an object and checking it's disruptions"""
+        """
+        Little helper calling the detail of an object and checking it's disruptions
+        """
         r = self.default_query('{col}/{uri}'.format(col=object_get.collection, uri=object_get.uri))
         return has_disruption(r, object_get, disruption_uri)
 
     def has_tf_disruption(self, q, disruption):
         """
-        checks a disruption is present in traffic report response to
-        the request provided
+        checks a disruption is present in traffic report response to the request provided
         """
         r = self.default_query(q)
 
@@ -101,6 +109,10 @@ class TestLineSections(AbstractTestFixture):
 
         return False
 
+    def has_dis(self, q, disruption_label):
+        r = self.default_query(q)
+        return disruption_label in (d['disruption_id'] for d in r['disruptions'])
+
     def test_line_section_structure(self):
         r = self.default_query('stop_points/C_1')
 
@@ -111,30 +123,101 @@ class TestLineSections(AbstractTestFixture):
         """
         the line section disruption is not linked to a stop area, we cannot directly find our disruption
         """
-        assert not self.has_disruption(ObjGetter('stop_areas', 'A'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_areas', 'B'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_areas', 'C'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_areas', 'D'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_areas', 'E'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_areas', 'F'), 'line_section_on_line_1')
+        for disruption_label in [
+            'line_section_on_line_1',
+            'line_section_on_line_1_other_effect',
+            'line_section_on_line_2',
+        ]:
+            for stop_area in ['A', 'B', 'C', 'D', 'E', 'F']:
+                assert not self.has_disruption(ObjGetter('stop_areas', stop_area), disruption_label)
 
     def test_on_stop_points(self):
         """
         the line section disruption should be linked to the impacted stop_points
         """
-        assert not self.has_disruption(ObjGetter('stop_points', 'A_1'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_points', 'B_1'), 'line_section_on_line_1')
-        assert self.has_disruption(ObjGetter('stop_points', 'C_1'), 'line_section_on_line_1')
-        assert self.has_disruption(ObjGetter('stop_points', 'D_1'), 'line_section_on_line_1')
-        assert self.has_disruption(ObjGetter('stop_points', 'E_1'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('stop_points', 'F_1'), 'line_section_on_line_1')
+        # line_section_on_line_1
+        scenario = {
+            'A_1': False,
+            'A_2': False,
+            'B_1': False,
+            'B_2': False,
+            'C_1': True,
+            'C_2': False,
+            'C_3': False,
+            'D_1': True,
+            'D_2': False,
+            'D_3': True,
+            'E_1': True,
+            'E_2': False,
+            'F_1': False,
+            'F_2': False,
+        }
+        for stop_point, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'line_section_on_line_1')
+
+        # line_section_on_line_1_other_effect
+        scenario = {
+            'A_1': False,
+            'A_2': False,
+            'B_1': False,
+            'B_2': False,
+            'C_1': False,
+            'C_2': False,
+            'C_3': False,
+            'D_1': False,
+            'D_2': False,
+            'D_3': False,
+            'E_1': True,
+            'E_2': False,
+            'F_1': True,
+            'F_2': False,
+        }
+        for stop_point, result in scenario.iteritems():
+            assert result == self.has_disruption(
+                ObjGetter('stop_points', stop_point), 'line_section_on_line_1_other_effect'
+            )
+
+        # line_section_on_line_2
+        scenario = {
+            'A_1': False,
+            'A_2': False,
+            'B_1': True,
+            'B_2': False,
+            'C_1': False,
+            'C_2': False,
+            'C_3': False,
+            'D_1': False,
+            'D_2': False,
+            'D_3': False,
+            'E_1': False,
+            'E_2': False,
+            'F_1': True,
+            'F_2': False,
+        }
+        for stop_point, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'line_section_on_line_2')
 
     def test_on_vehicle_journeys(self):
         """
         the line section disruption should be linked to the impacted vehicle journeys
         """
-        assert self.has_disruption(ObjGetter('vehicle_journeys', 'vj:1:1'), 'line_section_on_line_1')
-        assert not self.has_disruption(ObjGetter('vehicle_journeys', 'vj:1:2'), 'line_section_on_line_1')
+
+        # line_section_on_line_1
+        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': False, 'vj:2': False, 'vj:3': False}
+        for vj, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'line_section_on_line_1')
+
+        # line_section_on_line_1_other_effect
+        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': False, 'vj:2': False, 'vj:3': False}
+        for vj, result in scenario.iteritems():
+            assert result == self.has_disruption(
+                ObjGetter('vehicle_journeys', vj), 'line_section_on_line_1_other_effect'
+            )
+
+        # line_section_on_line_2
+        scenario = {'vj:1:1': False, 'vj:1:2': False, 'vj:1:3': False, 'vj:2': True, 'vj:3': False}
+        for vj, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'line_section_on_line_2')
 
     def test_traffic_reports_on_stop_areas(self):
         """
@@ -165,54 +248,101 @@ class TestLineSections(AbstractTestFixture):
                 ObjGetter('stop_areas', sa),
             )
 
-    def test_traffic_reports_on_networks(self):
-        def has_dis(q):
-            r = self.default_query(q)
-            return 'line_section_on_line_1' in (d['disruption_id'] for d in r['disruptions'])
+        # line_section_on_line_2
+        scenario = {'A': False, 'B': True, 'C': False, 'D': False, 'E': False, 'F': True}
 
-        assert has_dis('networks/base_network/traffic_reports')
-        assert not has_dis('networks/network:other/traffic_reports')
+        for sa, result in scenario.iteritems():
+            assert result == self.has_tf_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa), 'line_section_on_line_2'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa), 'line_section_on_line_2', ObjGetter('stop_areas', sa)
+            )
+
+    def test_traffic_reports_on_networks(self):
+        for disruption_label in [
+            'line_section_on_line_1',
+            'line_section_on_line_1_other_effect',
+            'line_section_on_line_2',
+        ]:
+            assert self.has_dis('networks/base_network/traffic_reports', disruption_label)
+            assert not self.has_dis('networks/network:other/traffic_reports', disruption_label)
+
         r = self.default_query('traffic_reports')
-        assert len(r['traffic_reports']) == 1  # only one network (base_network) is disrupted
-        assert len(r['traffic_reports'][0]['stop_areas']) == 4
+        # only one network (base_network) is disrupted
+        assert len(r['traffic_reports']) == 1
+        assert len(r['traffic_reports'][0]['stop_areas']) == 5
         for sa in r['traffic_reports'][0]['stop_areas']:
-            assert len(sa['links']) == (2 if sa['id'] == 'E' else 1)
+            assert len(sa['links']) == (2 if sa['id'] in ['A', 'E', 'F'] else 1)
 
     def test_traffic_reports_on_lines(self):
         """
         we should be able to find the related line section disruption with /traffic_report
         """
 
-        # line_section_on_line_1
-        assert self.has_tf_disruption('lines/line:1/traffic_reports', 'line_section_on_line_1')
-        assert self.has_tf_linked_disruption(
-            'lines/line:1/traffic_reports', 'line_section_on_line_1', ObjGetter('lines', 'line:1')
-        )
+        # The commented results are not working for now, in those cases, the disruption affects at least 1 stop
+        # of the line whereas the line itself is not concerned (the disrupted routes are linked to other lines)
 
-        assert not self.has_tf_disruption('lines/line:2/traffic_reports', 'line_section_on_line_1')
+        # line_section_on_line_1
+        scenario = {
+            'line:1': True,
+            'line:2': False,
+            # 'line:3': False
+        }
+
+        for line, result in scenario.iteritems():
+            assert result == self.has_tf_disruption(
+                'lines/{}/traffic_reports'.format(line), 'line_section_on_line_1'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'lines/{}/traffic_reports'.format(line), 'line_section_on_line_1', ObjGetter('lines', line)
+            )
+
+        # there is no link between line:3 and the disruption
         assert not self.has_tf_linked_disruption(
-            'lines/line:2/traffic_reports', 'line_section_on_line_1', ObjGetter('lines', 'line:2')
+            'lines/line:3/traffic_reports', 'line_section_on_line_1', ObjGetter('lines', 'line:3')
         )
 
         # line_section_on_line_1_other_effect
-        assert self.has_tf_disruption('lines/line:1/traffic_reports', 'line_section_on_line_1_other_effect')
-        assert self.has_tf_linked_disruption(
-            'lines/line:1/traffic_reports', 'line_section_on_line_1_other_effect', ObjGetter('lines', 'line:1')
-        )
+        scenario = {
+            'line:1': True,
+            # 'line:2': False,
+            'line:3': False,
+        }
 
-        # There is a disruption and it affects 1 stop of the line
-        # whereas the line itself is not concerned (the
-        # disrupted routes are linked to other lines)
-        #
-        # This test doesn't work with the actual behavior
-        # assert not self.has_tf_disruption(
-        #     'lines/line:2/traffic_reports',
-        #     'line_section_on_line_1_other_effect',
-        # )
+        for line, result in scenario.iteritems():
+            assert result == self.has_tf_disruption(
+                'lines/{}/traffic_reports'.format(line), 'line_section_on_line_1_other_effect'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'lines/{}/traffic_reports'.format(line),
+                'line_section_on_line_1_other_effect',
+                ObjGetter('lines', line),
+            )
 
-        # At least, the disruption and the line are not linked
+        # there is no link between line:2 and the disruption
         assert not self.has_tf_linked_disruption(
             'lines/line:2/traffic_reports', 'line_section_on_line_1_other_effect', ObjGetter('lines', 'line:2')
+        )
+
+        # line_section_on_line_2
+        scenario = {
+            # 'line:1': False,
+            'line:2': True,
+            'line:3': False,
+        }
+
+        for line, result in scenario.iteritems():
+            assert result == self.has_tf_disruption(
+                'lines/{}/traffic_reports'.format(line), 'line_section_on_line_2'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'lines/{}/traffic_reports'.format(line), 'line_section_on_line_2', ObjGetter('lines', line)
+            )
+
+        # there is no link between line:1 and the disruption
+        assert not self.has_tf_linked_disruption(
+            'lines/line:1/traffic_reports', 'line_section_on_line_2', ObjGetter('lines', 'line:1')
         )
 
     def test_traffic_reports_on_routes(self):
@@ -221,34 +351,78 @@ class TestLineSections(AbstractTestFixture):
         we display the disruption even if the route has not been directly impacted
         """
 
-        def has_dis(q):
-            r = self.default_query(q)
-            return 'line_section_on_line_1' in (d['disruption_id'] for d in r['disruptions'])
+        # line_section_on_line_1
+        # route 3 has been impacted by the line section but it has no stoppoint
+        # in the line section so in this case we do not display the disruption
+        scenario = {
+            'route:line:1:1': True,
+            'route:line:1:2': False,
+            'route:line:1:3': False,
+            'route:line:2:1': False,
+            'route:line:3:1': True,
+        }
 
-        assert has_dis('routes/route:line:1:1/traffic_reports')
-        assert not has_dis('routes/route:line:1:2/traffic_reports')
-        # route 3 has been impacted by the line section but it has no stoppoint in the line section
-        # so in this case we do not display the disruption
-        assert not has_dis('routes/route:line:1:3/traffic_reports')
+        for route, result in scenario.iteritems():
+            assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'line_section_on_line_1')
+
+        # line_section_on_line_1_other_effect
+        scenario = {
+            'route:line:1:1': True,
+            'route:line:1:2': False,
+            'route:line:1:3': True,
+            'route:line:2:1': True,
+            'route:line:3:1': False,
+        }
+
+        for route, result in scenario.iteritems():
+            assert result == self.has_dis(
+                'routes/{}/traffic_reports'.format(route), 'line_section_on_line_1_other_effect'
+            )
+
+        # line_section_on_line_2
+        scenario = {
+            'route:line:1:1': True,
+            'route:line:1:2': False,
+            'route:line:1:3': True,
+            'route:line:2:1': True,
+            'route:line:3:1': False,
+        }
+
+        for route, result in scenario.iteritems():
+            assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'line_section_on_line_2')
 
     def test_traffic_reports_on_vjs(self):
         """
         for /traffic_reports on vjs it's a bit the same as the lines
         we display a line section disruption if it impacts the stops of the vj
         """
+        # line_section_on_line_1
+        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': False, 'vj:2': False, 'vj:3': True}
 
-        def has_dis(q):
-            r = self.default_query(q)
-            return 'line_section_on_line_1' in (d['disruption_id'] for d in r['disruptions'])
+        for vj, result in scenario.iteritems():
+            assert result == self.has_dis(
+                'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_1'
+            )
 
-        assert has_dis('vehicle_journeys/vj:1:1/traffic_reports')
-        assert not has_dis('vehicle_journeys/vj:1:2/traffic_reports')
-        assert not has_dis('vehicle_journeys/vj:1:3/traffic_reports')
+        # line_section_on_line_1_other_effect
+        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': True, 'vj:2': True, 'vj:3': False}
+
+        for vj, result in scenario.iteritems():
+            assert result == self.has_dis(
+                'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_1_other_effect'
+            )
+
+        # line_section_on_line_2
+        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': True, 'vj:2': True, 'vj:3': False}
+
+        for vj, result in scenario.iteritems():
+            assert result == self.has_dis(
+                'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_2'
+            )
 
     def test_traffic_reports_on_stop_points(self):
         """
-        for /traffic_reports on stop_points
-        there is a line section disruption link if it impacts the stop_point
+        for /traffic_reports on stop_points there is a line section disruption link if it impacts the stop_point
         """
 
         # line_section_on_line_1
@@ -259,8 +433,10 @@ class TestLineSections(AbstractTestFixture):
             'B_2': False,
             'C_1': True,
             'C_2': False,
+            'C_3': False,
             'D_1': True,
             'D_2': False,
+            'D_3': True,
             'E_1': True,
             'E_2': False,
             'F_1': False,
@@ -285,8 +461,10 @@ class TestLineSections(AbstractTestFixture):
             'B_2': False,
             'C_1': False,
             'C_2': False,
+            'C_3': False,
             'D_1': False,
             'D_2': False,
+            'D_3': False,
             'E_1': True,
             'E_2': False,
             'F_1': True,
@@ -303,6 +481,34 @@ class TestLineSections(AbstractTestFixture):
                 ObjGetter('stop_areas', sp[0]),
             )
 
+        # line_section_on_line_2
+        scenario = {
+            'A_1': False,
+            'A_2': False,
+            'B_1': True,
+            'B_2': False,
+            'C_1': False,
+            'C_2': False,
+            'C_3': False,
+            'D_1': False,
+            'D_2': False,
+            'D_3': False,
+            'E_1': False,
+            'E_2': False,
+            'F_1': True,
+            'F_2': False,
+        }
+
+        for sp, result in scenario.iteritems():
+            assert result == self.has_tf_disruption(
+                'stop_points/{}/traffic_reports'.format(sp), 'line_section_on_line_2'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_points/{}/traffic_reports'.format(sp),
+                'line_section_on_line_2',
+                ObjGetter('stop_areas', sp[0]),
+            )
+
     def test_journeys_use_vj_impacted_by_line_section(self):
         """
         for /journeys, we should display a line section disruption only if we use an impacted section
@@ -312,7 +518,8 @@ class TestLineSections(AbstractTestFixture):
         In this test we leave at 08:00 so we'll use vj:1:1 (that is impacted) during the application
         period of the impact
         """
-        date = '20170102T080000'  # with this departure time we should take 'vj:1:1' that is impacted
+        # with this departure time we should take 'vj:1:1' that is impacted
+        date = '20170102T080000'
         current = '_current_datetime=20170101T080000'
 
         def journey_query(_from, to):
@@ -326,43 +533,91 @@ class TestLineSections(AbstractTestFixture):
             self.is_valid_journey_response(r, q)
             return r
 
+        # A -> B
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+
         # if we do not use an impacted section we shouldn't see the impact
         r = journeys(_from='A', to='B')
-        assert get_used_vj(r) == [['vj:1:1']]  # we check the used vj to be certain we took an impacted vj
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['journeys'], r)
+        # we check the used vj to be certain we took an impacted vj
+        assert get_used_vj(r) == [['vj:1:1']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert not impacted_ids(d)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
 
+        # A -> C
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         # 'C' is part of the impacted section, it's the first stop,
         # so A->C use an impacted section
         r = journeys(_from='A', to='C')
         assert get_used_vj(r) == [['vj:1:1']]
-        disrupts = get_all_element_disruptions(r['journeys'], r)
-        assert impacted_ids(disrupts) == {'vj:1:1'}
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_ids(d) == {'vj:1:1'}
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
 
+        # B -> C
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         # same for B->C
         r = journeys(_from='B', to='C')
         assert get_used_vj(r) == [['vj:1:1']]
-        disrupts = get_all_element_disruptions(r['journeys'], r)
-        assert 'line_section_on_line_1' in disrupts
-        assert impacted_ids(disrupts) == {'vj:1:1'}
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_ids(d) == {'vj:1:1'}
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
 
+        # C -> D
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         r = journeys(_from='C', to='D')
         assert get_used_vj(r) == [['vj:1:1']]
-        disrupts = get_all_element_disruptions(r['journeys'], r)
-        assert 'line_section_on_line_1' in disrupts
-        assert impacted_ids(disrupts) == {'vj:1:1'}
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_ids(d) == {'vj:1:1'}
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
 
+        # D -> F
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': True,
+            'line_section_on_line_2': False,
+        }
         r = journeys(_from='D', to='F')
         assert get_used_vj(r) == [['vj:1:1']]
-        disrupts = get_all_element_disruptions(r['journeys'], r)
-        assert 'line_section_on_line_1' in disrupts
-        assert impacted_ids(disrupts) == {'vj:1:1'}
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_ids(d) == {'vj:1:1'}
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
 
+        # A -> F
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': True,
+            'line_section_on_line_2': False,
+        }
         # this journey passes over the impacted section but does not stop (or transfer) on it
         # as such it isn't impacted
         r = journeys(_from='A', to='F')
         assert get_used_vj(r) == [['vj:1:1']]
-        disrupts = get_all_element_disruptions(r['journeys'], r)
-        assert 'line_section_on_line_1' not in disrupts
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_ids(d) == {'vj:1:1'}
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
 
     def test_journeys_use_vj_not_impacted_by_line_section(self):
         """
@@ -373,7 +628,8 @@ class TestLineSections(AbstractTestFixture):
         In this test we leave at 09:00 so we'll use vj:1:2 (that is not impacted because not part of an
         impacted route) during the application period of the impact
         """
-        date = '20170102T090000'  # with this departure time we should take 'vj:1:2' that is impacted
+        # with this departure time we should take 'vj:1:2' that is impacted
+        date = '20170102T090000'
         current = '_current_datetime=20170101T080000'
 
         def journey_query(_from, to):
@@ -387,21 +643,58 @@ class TestLineSections(AbstractTestFixture):
             self.is_valid_journey_response(r, q)
             return r
 
+        # A -> F
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         r = journeys(_from='A', to='F')
-        assert get_used_vj(r) == [['vj:1:2']]  # we check the used vj to be certain we took the right vj
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['journeys'], r)
+        # we check the used vj to be certain we took the right vj
+        assert get_used_vj(r) == [['vj:1:2']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
+        # C -> D
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         r = journeys(_from='C', to='D')
         assert get_used_vj(r) == [['vj:1:2']]
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['journeys'], r)
+        d = get_all_element_disruptions(r['journeys'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
+        # B -> E
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         r = journeys(_from='B', to='E')
         assert get_used_vj(r) == [['vj:1:2']]
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['journeys'], r)
+        d = get_all_element_disruptions(r['journeys'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
+        # C -> A
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
         r = journeys(_from='C', to='A')
         assert get_used_vj(r) == [['vj:3']]
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['journeys'], r)
+        d = get_all_element_disruptions(r['journeys'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
     def test_stop_schedule_impacted_by_line_section(self):
         """
@@ -410,32 +703,80 @@ class TestLineSections(AbstractTestFixture):
         cur = '_current_datetime=20170101T100000'
         dt = 'from_datetime=20170101T080000'
         fresh = 'data_freshness=base_schedule'
-        r = self.query_region('stop_areas/A/stop_schedules?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['stop_schedules'], r)
+        query = 'stop_areas/{sa}/stop_schedules?{cur}&{d}&{f}'
 
-        r = self.query_region('stop_areas/B/stop_schedules?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['stop_schedules'], r)
-
-        r = self.query_region('stop_areas/C/stop_schedules?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # A
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='A', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['stop_schedules'], r)
-        assert 'line_section_on_line_1' in d
-        assert impacted_ids(d) == {
-            'vj:1:1'
-        }  # the impact is linked in the response only to the stop_schedule.datetime
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
-        r = self.query_region('stop_areas/D/stop_schedules?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # B
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': True,
+        }
+        r = self.query_region(query.format(sa='B', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['stop_schedules'], r)
-        assert 'line_section_on_line_1' in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert impacted_ids(d) == {'vj:2'}
+
+        # C
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='C', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['stop_schedules'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        # the impact is linked in the response only to the stop_schedule.datetime
         assert impacted_ids(d) == {'vj:1:1'}
 
-        r = self.query_region('stop_areas/E/stop_schedules?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # D
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='D', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['stop_schedules'], r)
-        assert 'line_section_on_line_1' in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
         assert impacted_ids(d) == {'vj:1:1'}
 
-        r = self.query_region('stop_areas/F/stop_schedules?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # E
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': True,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='E', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['stop_schedules'], r)
-        assert 'line_section_on_line_1' not in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert impacted_ids(d) == {'vj:1:1'}
+
+        # F
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='F', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['stop_schedules'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
     def test_departures_impacted_by_line_section(self):
         """
@@ -444,41 +785,138 @@ class TestLineSections(AbstractTestFixture):
         cur = '_current_datetime=20170101T100000'
         dt = 'from_datetime=20170101T080000'
         fresh = 'data_freshness=base_schedule'
-        r = self.query_region('stop_areas/A/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['departures'], r)
+        query = 'stop_areas/{sa}/departures?{cur}&{d}&{f}'
 
-        r = self.query_region('stop_areas/B/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
-        assert 'line_section_on_line_1' not in get_all_element_disruptions(r['departures'], r)
-
-        r = self.query_region('stop_areas/C/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # A
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='A', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        assert 'line_section_on_line_1' in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
+
+        # B
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': True,
+        }
+        r = self.query_region(query.format(sa='B', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['departures'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert impacted_ids(d) == {'vj:2'}
+
+        # C
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='C', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['departures'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
         # the impact is linked in the response to the stop point and the vj
         assert impacted_ids(d) == {'vj:1:1'}
 
-        r = self.query_region('stop_areas/D/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # D
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='D', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        assert 'line_section_on_line_1' in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
         assert impacted_ids(d) == {'vj:1:1'}
 
-        r = self.query_region('stop_areas/E/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # E
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': True,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='E', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        assert 'line_section_on_line_1' in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
         assert impacted_ids(d) == {'vj:1:1'}
 
-        r = self.query_region('stop_areas/F/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        # F
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(sa='F', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        assert 'line_section_on_line_1' not in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
 
     def test_route_schedule_impacted_by_line_section(self):
         cur = '_current_datetime=20170101T100000'
         dt = 'from_datetime=20170101T080000'
         fresh = 'data_freshness=base_schedule'
-        r = self.query_region('lines/line:1/departures?{cur}&{d}&{f}'.format(cur=cur, d=dt, f=fresh))
+        query = 'lines/{l}/departures?{cur}&{d}&{f}'
+
+        # line:1
+        scenario = {
+            'line_section_on_line_1': True,
+            'line_section_on_line_1_other_effect': True,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(l='line:1', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        assert 'line_section_on_line_1' in d
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
         assert impacted_ids(d) == {'vj:1:1'}
 
+        # line:2
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': True,
+        }
+        r = self.query_region(query.format(l='line:2', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['departures'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert impacted_ids(d) == {'vj:2'}
+
+        # line:3
+        scenario = {
+            'line_section_on_line_1': False,
+            'line_section_on_line_1_other_effect': False,
+            'line_section_on_line_2': False,
+        }
+        r = self.query_region(query.format(l='line:3', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['departures'], r)
+        for disruption, result in scenario.iteritems():
+            assert result == (disruption in d)
+        assert not impacted_ids(d)
+
     def test_line_impacted_by_line_section(self):
-        assert self.has_disruption(ObjGetter('lines', 'line:1'), 'line_section_on_line_1')
-        assert self.has_disruption(ObjGetter('lines', 'line:1'), 'line_section_on_line_1_other_effect')
+        # line_section_on_line_1
+        scenario = {'line:1': True, 'line:2': False, 'line:3': False}
+
+        for line, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('lines', line), 'line_section_on_line_1')
+
+        # line_section_on_line_1_other_effect
+        scenario = {'line:1': True, 'line:2': False, 'line:3': False}
+
+        for line, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('lines', line), 'line_section_on_line_1_other_effect')
+
+        # line_section_on_line_2
+        scenario = {'line:1': False, 'line:2': True, 'line:3': False}
+
+        for line, result in scenario.iteritems():
+            assert result == self.has_disruption(ObjGetter('lines', line), 'line_section_on_line_2')

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -36,6 +36,7 @@ from .check_utils import (
     get_used_vj,
     get_all_element_disruptions,
 )
+import pytest
 
 
 # Looking for (identifiable) objects impacted by 'disruptions' inputed
@@ -56,7 +57,7 @@ def impacted_ids(disruptions):
         return id
 
     ids = set()
-    for label, d in disruptions.iteritems():
+    for d in disruptions.values():
         ids.update(set(get_id(o) for o in d))
 
     return ids
@@ -280,14 +281,14 @@ class TestLineSections(AbstractTestFixture):
         we should be able to find the related line section disruption with /traffic_report
         """
 
-        # The commented results are not working for now, in those cases, the disruption affects at least 1 stop
-        # of the line whereas the line itself is not concerned (the disrupted routes are linked to other lines)
+        # some of the tests are failing and are runned in the next function named
+        # test_failing_traffic_reports_on_lines
 
         # line_section_on_line_1
         scenario = {
             'line:1': True,
             'line:2': False,
-            # 'line:3': False
+            # 'line:3': False,
         }
 
         for line, result in scenario.iteritems():
@@ -345,21 +346,47 @@ class TestLineSections(AbstractTestFixture):
             'lines/line:1/traffic_reports', 'line_section_on_line_2', ObjGetter('lines', 'line:1')
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="the disruption affects at least 1 stop of the line whereas the line itself is not impacted",
+        raises=AssertionError,
+    )
+    def test_failing_traffic_reports_on_lines(self):
+        """
+            specific cases for lines where the actual behavior is undesirable
+        """
+
+        assert not self.has_tf_disruption(
+            'lines/line:3/traffic_reports',
+            'line_section_on_line_1'
+        )
+
+        assert not self.has_tf_disruption(
+            'lines/line:2/traffic_reports',
+            'line_section_on_line_1_other_effect'
+        )
+
+        assert not self.has_tf_disruption(
+            'lines/line:3/traffic_reports',
+            'line_section_on_line_2'
+        )
+
     def test_traffic_reports_on_routes(self):
         """
         for routes since we display the impacts on all the stops (but we do not display a route object)
         we display the disruption even if the route has not been directly impacted
         """
 
+        # some of the tests are failing and are runned in the next function named
+        # test_failing_traffic_reports_on_routes
+
         # line_section_on_line_1
-        # route 3 has been impacted by the line section but it has no stoppoint
-        # in the line section so in this case we do not display the disruption
         scenario = {
             'route:line:1:1': True,
             'route:line:1:2': False,
             'route:line:1:3': False,
             'route:line:2:1': False,
-            'route:line:3:1': True,
+            # 'route:line:3:1': False,
         }
 
         for route, result in scenario.iteritems():
@@ -370,7 +397,7 @@ class TestLineSections(AbstractTestFixture):
             'route:line:1:1': True,
             'route:line:1:2': False,
             'route:line:1:3': True,
-            'route:line:2:1': True,
+            # 'route:line:2:1': False,
             'route:line:3:1': False,
         }
 
@@ -381,9 +408,9 @@ class TestLineSections(AbstractTestFixture):
 
         # line_section_on_line_2
         scenario = {
-            'route:line:1:1': True,
+            # 'route:line:1:1': False,
             'route:line:1:2': False,
-            'route:line:1:3': True,
+            # 'route:line:1:3': False,
             'route:line:2:1': True,
             'route:line:3:1': False,
         }
@@ -391,13 +418,52 @@ class TestLineSections(AbstractTestFixture):
         for route, result in scenario.iteritems():
             assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'line_section_on_line_2')
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="The disruptions shouldn't be displayed if only the stop point is impacted but not the route point",
+        raises=AssertionError,
+    )
+    def test_failing_traffic_reports_on_routes(self):
+        """
+            specific cases for routes where the actual behavior is undesirable
+        """
+
+        assert not self.has_dis(
+            'routes/route:line:3:1/traffic_reports',
+            'line_section_on_line_1'
+        )
+
+        assert not self.has_dis(
+            'routes/route:line:2:1/traffic_reports',
+            'line_section_on_line_1_other_effect'
+        )
+
+        assert not self.has_dis(
+            'routes/route:line:1:1/traffic_reports',
+            'line_section_on_line_2'
+        )
+
+        assert not self.has_dis(
+            'routes/route:line:1:3/traffic_reports',
+            'line_section_on_line_2'
+        )
+
     def test_traffic_reports_on_vjs(self):
         """
         for /traffic_reports on vjs it's a bit the same as the lines
         we display a line section disruption if it impacts the stops of the vj
         """
+        # some of the tests are failing and are runned in the next function named
+        # test_failing_traffic_reports_on_vjs
+
         # line_section_on_line_1
-        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': False, 'vj:2': False, 'vj:3': True}
+        scenario = {
+            'vj:1:1': True,
+            'vj:1:2': False,
+            'vj:1:3': False,
+            'vj:2': False,
+            # 'vj:3': False,
+        }
 
         for vj, result in scenario.iteritems():
             assert result == self.has_dis(
@@ -405,7 +471,13 @@ class TestLineSections(AbstractTestFixture):
             )
 
         # line_section_on_line_1_other_effect
-        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': True, 'vj:2': True, 'vj:3': False}
+        scenario = {
+            'vj:1:1': True,
+            'vj:1:2': False,
+            'vj:1:3': True,
+            # 'vj:2': False,
+            'vj:3': False,
+        }
 
         for vj, result in scenario.iteritems():
             assert result == self.has_dis(
@@ -413,12 +485,45 @@ class TestLineSections(AbstractTestFixture):
             )
 
         # line_section_on_line_2
-        scenario = {'vj:1:1': True, 'vj:1:2': False, 'vj:1:3': True, 'vj:2': True, 'vj:3': False}
+        scenario = {
+            # 'vj:1:1': False,
+            'vj:1:2': False,
+            # 'vj:1:3': False,
+            'vj:2': True,
+            'vj:3': False,
+        }
 
         for vj, result in scenario.iteritems():
             assert result == self.has_dis(
                 'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_2'
             )
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="The disruptions shouldn't be displayed if only the stop point is impacted but not the route point",
+        raises=AssertionError,
+    )
+    def test_failing_traffic_reports_on_vjs(self):
+        """
+            specific cases for vjs where the actual behavior is undesirable
+        """
+
+        assert not self.has_dis(
+            'vehicle_journeys/vj:3/traffic_reports',
+            'line_section_on_line_1'
+        )
+        assert not self.has_dis(
+            'vehicle_journeys/vj:2/traffic_reports',
+            'line_section_on_line_1_other_effect'
+        )
+        assert not self.has_dis(
+            'vehicle_journeys/vj:1:1/traffic_reports',
+            'line_section_on_line_2'
+        )
+        assert not self.has_dis(
+            'vehicle_journeys/vj:1:3/traffic_reports',
+            'line_section_on_line_2'
+        )
 
     def test_traffic_reports_on_stop_points(self):
         """
@@ -696,169 +801,88 @@ class TestLineSections(AbstractTestFixture):
             assert result == (disruption in d)
         assert not impacted_ids(d)
 
-    def test_stop_schedule_impacted_by_line_section(self):
-        """
-        For /stop_schedules we display a line section impact if the stoppoint is part of a line section impact
-        """
-        cur = '_current_datetime=20170101T100000'
-        dt = 'from_datetime=20170101T080000'
-        fresh = 'data_freshness=base_schedule'
-        query = 'stop_areas/{sa}/stop_schedules?{cur}&{d}&{f}'
-
-        # A
-        scenario = {
-            'line_section_on_line_1': False,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='A', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['stop_schedules'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert not impacted_ids(d)
-
-        # B
-        scenario = {
-            'line_section_on_line_1': False,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': True,
-        }
-        r = self.query_region(query.format(sa='B', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['stop_schedules'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert impacted_ids(d) == {'vj:2'}
-
-        # C
-        scenario = {
-            'line_section_on_line_1': True,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='C', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['stop_schedules'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        # the impact is linked in the response only to the stop_schedule.datetime
-        assert impacted_ids(d) == {'vj:1:1'}
-
-        # D
-        scenario = {
-            'line_section_on_line_1': True,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='D', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['stop_schedules'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert impacted_ids(d) == {'vj:1:1'}
-
-        # E
-        scenario = {
-            'line_section_on_line_1': True,
-            'line_section_on_line_1_other_effect': True,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='E', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['stop_schedules'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert impacted_ids(d) == {'vj:1:1'}
-
-        # F
-        scenario = {
-            'line_section_on_line_1': False,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='F', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['stop_schedules'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert not impacted_ids(d)
-
-    def test_departures_impacted_by_line_section(self):
+    def test_stops_schedules_and_departures_impacted_by_line_section(self):
         """
         For /departures we display a line section impact if the stoppoint is part of a line section impact
         """
         cur = '_current_datetime=20170101T100000'
         dt = 'from_datetime=20170101T080000'
         fresh = 'data_freshness=base_schedule'
-        query = 'stop_areas/{sa}/departures?{cur}&{d}&{f}'
+        query = 'stop_areas/{sa}/{q}?{cur}&{d}&{f}'
 
-        # A
-        scenario = {
-            'line_section_on_line_1': False,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='A', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert not impacted_ids(d)
+        for q in ['departures', 'stop_schedules']:
+            # A
+            scenario = {
+                'line_section_on_line_1': False,
+                'line_section_on_line_1_other_effect': False,
+                'line_section_on_line_2': False,
+            }
+            r = self.query_region(query.format(sa='A', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.iteritems():
+                assert result == (disruption in d)
+            assert not impacted_ids(d)
 
-        # B
-        scenario = {
-            'line_section_on_line_1': False,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': True,
-        }
-        r = self.query_region(query.format(sa='B', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert impacted_ids(d) == {'vj:2'}
+            # B
+            scenario = {
+                'line_section_on_line_1': False,
+                'line_section_on_line_1_other_effect': False,
+                'line_section_on_line_2': True,
+            }
+            r = self.query_region(query.format(sa='B', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.iteritems():
+                assert result == (disruption in d)
+            assert impacted_ids(d) == {'vj:2'}
 
-        # C
-        scenario = {
-            'line_section_on_line_1': True,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='C', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        # the impact is linked in the response to the stop point and the vj
-        assert impacted_ids(d) == {'vj:1:1'}
+            # C
+            scenario = {
+                'line_section_on_line_1': True,
+                'line_section_on_line_1_other_effect': False,
+                'line_section_on_line_2': False,
+            }
+            r = self.query_region(query.format(sa='C', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.iteritems():
+                assert result == (disruption in d)
+            # the impact is linked in the response to the stop point and the vj
+            assert impacted_ids(d) == {'vj:1:1'}
 
-        # D
-        scenario = {
-            'line_section_on_line_1': True,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='D', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert impacted_ids(d) == {'vj:1:1'}
+            # D
+            scenario = {
+                'line_section_on_line_1': True,
+                'line_section_on_line_1_other_effect': False,
+                'line_section_on_line_2': False,
+            }
+            r = self.query_region(query.format(sa='D', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.iteritems():
+                assert result == (disruption in d)
+            assert impacted_ids(d) == {'vj:1:1'}
 
-        # E
-        scenario = {
-            'line_section_on_line_1': True,
-            'line_section_on_line_1_other_effect': True,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='E', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert impacted_ids(d) == {'vj:1:1'}
+            # E
+            scenario = {
+                'line_section_on_line_1': True,
+                'line_section_on_line_1_other_effect': True,
+                'line_section_on_line_2': False,
+            }
+            r = self.query_region(query.format(sa='E', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.iteritems():
+                assert result == (disruption in d)
+            assert impacted_ids(d) == {'vj:1:1'}
 
-        # F
-        scenario = {
-            'line_section_on_line_1': False,
-            'line_section_on_line_1_other_effect': False,
-            'line_section_on_line_2': False,
-        }
-        r = self.query_region(query.format(sa='F', cur=cur, d=dt, f=fresh))
-        d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
-            assert result == (disruption in d)
-        assert not impacted_ids(d)
+            # F
+            scenario = {
+                'line_section_on_line_1': False,
+                'line_section_on_line_1_other_effect': False,
+                'line_section_on_line_2': False,
+            }
+            r = self.query_region(query.format(sa='F', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.iteritems():
+                assert result == (disruption in d)
+            assert not impacted_ids(d)
 
     def test_route_schedule_impacted_by_line_section(self):
         cur = '_current_datetime=20170101T100000'

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -120,6 +120,14 @@ int main(int argc, const char* const argv[]) {
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_2")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                              .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                              .on_line_section("line:2", "B", "F", {"route:line:2:1"})
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1_other_effect")
                               .severity(nt::disruption::Effect::OTHER_EFFECT)
                               .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -120,20 +120,20 @@ int main(int argc, const char* const argv[]) {
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_2")
-                              .severity(nt::disruption::Effect::NO_SERVICE)
-                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
-                              .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
-                              .on_line_section("line:2", "B", "F", {"route:line:2:1"})
-                              .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
-
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1_other_effect")
                               .severity(nt::disruption::Effect::OTHER_EFFECT)
                               .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
                               .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
                               .on_line_section("line:1", "E", "F", {"route:line:1:1", "route:line:1:3"})
                               .on_line_section("line:1", "F", "E", {"route:line:1:1", "route:line:1:3"})
+                              .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_2")
+                              .severity(nt::disruption::Effect::NO_SERVICE)
+                              .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                              .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                              .on_line_section("line:2", "B", "F", {"route:line:2:1"})
                               .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 


### PR DESCRIPTION
Hi,

This is a small PR I would like to make in order to add all missing checks in existing functions of line_sections_test in jormungandr.
I also rewrited some details for pep8 compliance and I used black tool in order to be sure that the code style is OK.

The final goal behind that is in a second PR I'm about to make where I remove DumpLineSectionMessage (yes...) So I need clearer tests in order to see all the changes and discuss them with you.

Thank you.