### PR TITLE
CMake: Clean for cmake prefix install

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -24,7 +24,7 @@ project(Kraken)
 
 # List of directories to search for CMake modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules")
-set(CMAKE_INSTALL_PREFIX "/usr/bin/")
+set(CMAKE_INSTALL_PREFIX "/usr")
 
 # project version,
 # get git revision as the version number

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -24,6 +24,7 @@ project(Kraken)
 
 # List of directories to search for CMake modules
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules")
+set(CMAKE_INSTALL_PREFIX "/usr/bin/")
 
 # project version,
 # get git revision as the version number

--- a/source/cities/CMakeLists.txt
+++ b/source/cities/CMakeLists.txt
@@ -4,12 +4,11 @@ SET(BOOST_LIBS ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
 add_executable(cities cities.cpp)
 target_link_libraries(cities transportation_data_import connectors types ${PQXX_LIB} ${OSMPBF} pb_lib utils
     ${BOOST_LIBS} log4cplus z protobuf)
-INSTALL_TARGETS(/usr/bin/ cities)
-
-INSTALL_FILES(/usr/share/navitia/cities/alembic FILES alembic.ini alembic/env.py)
+install(TARGETS cities DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES alembic.ini alembic/env.py DESTINATION /usr/share/navitia/cities/alembic)
 
 FILE(GLOB
     alembic_cities
     alembic/versions/*.py
     )
-INSTALL_FILES(/usr/share/navitia/cities/alembic/versions FILES ${alembic_cities})
+install(FILES ${alembic_cities} DESTINATION /usr/share/navitia/cities/alembic/versions)

--- a/source/cities/CMakeLists.txt
+++ b/source/cities/CMakeLists.txt
@@ -4,11 +4,11 @@ SET(BOOST_LIBS ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
 add_executable(cities cities.cpp)
 target_link_libraries(cities transportation_data_import connectors types ${PQXX_LIB} ${OSMPBF} pb_lib utils
     ${BOOST_LIBS} log4cplus z protobuf)
-install(TARGETS cities DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(FILES alembic.ini alembic/env.py DESTINATION /usr/share/navitia/cities/alembic)
+install(TARGETS cities DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+install(FILES alembic.ini alembic/env.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/cities/alembic)
 
 FILE(GLOB
     alembic_cities
     alembic/versions/*.py
     )
-install(FILES ${alembic_cities} DESTINATION /usr/share/navitia/cities/alembic/versions)
+install(FILES ${alembic_cities} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/cities/alembic/versions)

--- a/source/cmake_modules/ThirdParty.cmake
+++ b/source/cmake_modules/ThirdParty.cmake
@@ -33,7 +33,6 @@ include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/")
 #
 # prometheus-cpp
 #
-# We want to deactivate prometheus lib if CMake version < 2.8.12.2
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/core/include/")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/pull/include/")
 #prometheus-cpp cmake will refuse to build if the CMAKE_INSTALL_PREFIX is empty

--- a/source/cmake_modules/ThirdParty.cmake
+++ b/source/cmake_modules/ThirdParty.cmake
@@ -34,31 +34,12 @@ include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/")
 # prometheus-cpp
 #
 # We want to deactivate prometheus lib if CMake version < 2.8.12.2
-if("${CMAKE_VERSION}" VERSION_GREATER 2.8.12.1)
-
-
-    include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/core/include/")
-    include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/pull/include/")
-    #prometheus-cpp cmake will refuse to build if the CMAKE_INSTALL_PREFIX is empty
-    #setting it before will have side effects on how we build packages
-    set(ENABLE_PUSH OFF CACHE INTERNAL "" FORCE)
-    add_subdirectory(third_party/prometheus-cpp)
-
-    message("-- Add prometheus in third party")
-
-    set(ENABLE_PROMETHEUS ON)
-    # Flag activation for code define
-    add_definitions(-DENABLE_PROMETHEUS=1)
-
-else()
-    message("-- CMake version < 2.8.12.2, Skip prometheus in third party")
-    message(DEPRECATION " ${CMAKE_OS_NAME} ${CMAKE_OS_VERSION} is no longer maintained for navitia project")
-
-    set(ENABLE_PROMETHEUS OFF)
-    # Flag activation for code define (=0)
-    add_definitions(-DENABLE_PROMETHEUS=0)
-
-endif()
+include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/core/include/")
+include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/pull/include/")
+#prometheus-cpp cmake will refuse to build if the CMAKE_INSTALL_PREFIX is empty
+#setting it before will have side effects on how we build packages
+set(ENABLE_PUSH OFF CACHE INTERNAL "" FORCE)
+add_subdirectory(third_party/prometheus-cpp)
 
 # Reactivate warnings flags
 set(CMAKE_CXX_FLAGS ${TMP_FLAG})

--- a/source/cmake_modules/ThirdParty.cmake
+++ b/source/cmake_modules/ThirdParty.cmake
@@ -21,7 +21,6 @@ set(BUILD_API_DOCS OFF CACHE BOOL "don't build doc of librabbimq-c")
 set(BUILD_EXAMPLES OFF CACHE BOOL "don't build example of librabbimq-c")
 set(BUILD_TOOLS OFF CACHE BOOL "don't build tool of librabbimq-c")
 set(BUILD_TESTS OFF CACHE BOOL "don't build tests of librabbimq-c")
-set(CMAKE_INSTALL_PREFIX "")
 set(Rabbitmqc_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/third_party/librabbitmq-c/librabbitmq/")
 add_subdirectory(third_party/librabbitmq-c)
 add_subdirectory(third_party/SimpleAmqpClient)
@@ -42,7 +41,6 @@ if("${CMAKE_VERSION}" VERSION_GREATER 2.8.12.1)
     include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp/pull/include/")
     #prometheus-cpp cmake will refuse to build if the CMAKE_INSTALL_PREFIX is empty
     #setting it before will have side effects on how we build packages
-    set(CMAKE_INSTALL_PREFIX "/")
     set(ENABLE_PUSH OFF CACHE INTERNAL "" FORCE)
     add_subdirectory(third_party/prometheus-cpp)
 

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -51,11 +51,11 @@ target_link_libraries(poi2ed transportation_data_import connectors)
 add_executable(synonym2ed synonym2ed.cpp)
 target_link_libraries(synonym2ed transportation_data_import connectors)
 
-SET(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
-INSTALL_TARGETS(/usr/bin/ ${ED_TARGETS_TO_INSTALL})
+set(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
+install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 add_custom_target(ed_executables DEPENDS ${ED_TARGETS_TO_INSTALL})
 
-# Ed integration tests with docker, build with the docker_test target 
+# Ed integration tests with docker, build with the docker_test target
 # and not with the default target not to have a strong docker dependency
 add_subdirectory(docker_tests EXCLUDE_FROM_ALL)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -52,7 +52,7 @@ add_executable(synonym2ed synonym2ed.cpp)
 target_link_libraries(synonym2ed transportation_data_import connectors)
 
 set(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
-install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 
 add_custom_target(ed_executables DEPENDS ${ED_TARGETS_TO_INSTALL})
 

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -29,5 +29,5 @@ target_link_libraries(kraken workers types proximitylist
     ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} protobuf)
 add_dependencies(kraken protobuf_files)
 
-install(TARGETS kraken DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(TARGETS kraken DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 add_subdirectory(tests)

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -41,5 +41,5 @@ target_link_libraries(kraken workers types proximitylist
     ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} protobuf)
 add_dependencies(kraken protobuf_files)
 
-INSTALL_TARGETS(/usr/bin/ kraken)
+install(TARGETS kraken DESTINATION ${CMAKE_INSTALL_PREFIX})
 add_subdirectory(tests)

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -10,23 +10,11 @@ add_library(rt_handling realtime.cpp)
 add_dependencies(rt_handling protobuf_files)
 target_link_libraries(rt_handling data pb_lib protobuf)
 
-# Add Prometheus
-if(ENABLE_PROMETHEUS)
-  set(PROMETHEUS_SOURCES metrics.cpp)
-  message("-- Add Prometheus sources in kraken")
-else(ENABLE_PROMETHEUS)
-  message("-- Skip Prometheus sources in kraken")
-endif(ENABLE_PROMETHEUS)
-
-add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp ${PROMETHEUS_SOURCES})
+add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp metrics.cpp)
 add_dependencies(workers protobuf_files)
 target_link_libraries(workers apply_disruption make_disruption_from_chaos rt_handling ${PQXX_LIB}
   SimpleAmqpClient disruption_api calendar_api ptreferential autocomplete georef
-  routing time_tables tcmalloc)
-
-if(ENABLE_PROMETHEUS)
-  target_link_libraries(workers prometheus-cpp-core prometheus-cpp-pull)
-endif(ENABLE_PROMETHEUS)
+  routing time_tables tcmalloc prometheus-cpp-core prometheus-cpp-pull)
 
 add_library(fill_disruption_from_database fill_disruption_from_database.cpp)
 target_link_libraries(fill_disruption_from_database make_disruption_from_chaos data types pb_lib

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -38,7 +38,6 @@ www.navitia.io
 
 #include "type/type.pb.h"
 
-#if ENABLE_PROMETHEUS
 #include <prometheus/exposer.h>
 #include <prometheus/counter.h>
 
@@ -48,25 +47,17 @@ class Registry;
 class Counter;
 class Histogram;
 }
-#endif
 
 namespace navitia {
 class Metrics: boost::noncopyable {
 
-// This stub is for retro compatibility
-#if ENABLE_PROMETHEUS
-    protected:
-        std::unique_ptr<prometheus::Exposer> exposer;
-        std::shared_ptr<prometheus::Registry> registry;
-        std::map<pbnavitia::API, prometheus::Histogram*> request_histogram;
-    public:
-        Metrics(const boost::optional<std::string>& endpoint, const std::string& coverage);
-        void observe_api(pbnavitia::API api, double duration) const;
-#else
-    public:
-        Metrics(const boost::optional<std::string>&, const std::string&) {}
-        void observe_api(pbnavitia::API, double) const {}
-#endif
+protected:
+    std::unique_ptr<prometheus::Exposer> exposer;
+    std::shared_ptr<prometheus::Registry> registry;
+    std::map<pbnavitia::API, prometheus::Histogram*> request_histogram;
+public:
+    Metrics(const boost::optional<std::string>& endpoint, const std::string& coverage);
+    void observe_api(pbnavitia::API api, double duration) const;
 };
 
 }

--- a/source/scripts/CMakeLists.txt
+++ b/source/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
-INSTALL_PROGRAMS(/usr/share/navitia/ed/scripts FILES update_db.sh)
-INSTALL_PROGRAMS(/usr/share/navitiacommon/scripts FILES init_db.sh)
+install(FILES update_db.sh DESTINATION /usr/share/navitia/ed/scripts)
+install(FILES init_db.sh DESTINATION /usr/share/navitiacommon/scripts)
 
-INSTALL_PROGRAMS(/usr/share/jormungandr/scripts FILES createinstance.sh)
+install(FILES createinstance.sh DESTINATION /usr/share/jormungandr/scripts)
 

--- a/source/scripts/CMakeLists.txt
+++ b/source/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
-install(FILES update_db.sh DESTINATION /usr/share/navitia/ed/scripts)
-install(FILES init_db.sh DESTINATION /usr/share/navitiacommon/scripts)
+install(FILES update_db.sh DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/ed/scripts)
+install(FILES init_db.sh DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitiacommon/scripts)
 
-install(FILES createinstance.sh DESTINATION /usr/share/jormungandr/scripts)
+install(FILES createinstance.sh DESTINATION ${CMAKE_INSTALL_PREFIX}/share/jormungandr/scripts)
 

--- a/source/sql/CMakeLists.txt
+++ b/source/sql/CMakeLists.txt
@@ -1,10 +1,10 @@
-INSTALL_FILES(/usr/share/navitia/ed/script FILES alembic.ini alembic/env.py)
-INSTALL_FILES(/usr/share/navitia/ed/sql FILES ed/02-migration.sql)
+install(FILES alembic.ini alembic/env.py DESTINATION /usr/share/navitia/ed/script)
+install(FILES ed/02-migration.sql DESTINATION /usr/share/navitia/ed/sql)
 
-INSTALL_FILES(/usr/share/navitia/ed/alembic FILES alembic.ini alembic/env.py)
+install(FILES alembic.ini alembic/env.py DESTINATION /usr/share/navitia/ed/alembic)
 
 FILE(GLOB
     alembic_ed
     alembic/versions/*.py
     )
-INSTALL_FILES(/usr/share/navitia/ed/alembic/versions FILES ${alembic_ed})
+install(FILES ${alembic_ed} DESTINATION /usr/share/navitia/ed/alembic/versions)

--- a/source/sql/CMakeLists.txt
+++ b/source/sql/CMakeLists.txt
@@ -1,10 +1,10 @@
-install(FILES alembic.ini alembic/env.py DESTINATION /usr/share/navitia/ed/script)
-install(FILES ed/02-migration.sql DESTINATION /usr/share/navitia/ed/sql)
+install(FILES alembic.ini alembic/env.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/ed/script)
+install(FILES ed/02-migration.sql DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/ed/sql)
 
-install(FILES alembic.ini alembic/env.py DESTINATION /usr/share/navitia/ed/alembic)
+install(FILES alembic.ini alembic/env.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/ed/alembic)
 
 FILE(GLOB
     alembic_ed
     alembic/versions/*.py
     )
-install(FILES ${alembic_ed} DESTINATION /usr/share/navitia/ed/alembic/versions)
+install(FILES ${alembic_ed} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/ed/alembic/versions)


### PR DESCRIPTION
**Topic** : Clean the CMake:

- Using _CMAKE_INSTALL_PREFIX_ (_1st commit_)
   There were a lot of deprecated CMake functions used (install_targets, install_files).
   These old functions do not work with the _CMAKE_INSTALL_PREFIX_

- Remove compatibility for Debian 7 because it is now deprecated for navitia (_2nd commit_)
   Prometheus stub is now useless (This simplifies the code).

I tested the package building on:
- `Debian 8 (OK)`
- `Ubuntu 16.4 (OK)`

**Extra** : I am sad because Gcc version on debian 8 is 4.9.2... Must wait debian 9 for C++14 full support within Gcc.