### PR TITLE
Jormun : Fix min/max nb journey schema's type

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/parsers.py
+++ b/source/jormungandr/jormungandr/interfaces/parsers.py
@@ -70,18 +70,3 @@ class DateTimeFormat(CustomSchemaType):
 
     def schema(self):
         return TypeSchema(type=str, metadata={'format': 'date-time'})
-
-
-class UnsignedInteger(CustomSchemaType):
-    def __call__(self, value):
-        try:
-            d = int(value)
-            if d < 0:
-                raise ValueError('invalid positive int')
-
-            return d
-        except ValueError as e:
-            raise ValueError("Unable to evaluate, {}".format(e))
-
-    def schema(self):
-        return TypeSchema(type=int, metadata={'minimum': 0})

--- a/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
@@ -47,11 +47,11 @@ from jormungandr.interfaces.v1.fields import (
 from jormungandr.timezone import set_request_timezone
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.utils import date_to_timestamp
-from jormungandr.interfaces.parsers import UnsignedInteger
 from jormungandr.interfaces.v1.journey_common import JourneyCommon
 from jormungandr.interfaces.v1.fields import DateTime
 from jormungandr.interfaces.v1.serializer.api import GraphicalIsrochoneSerializer
 from jormungandr.interfaces.v1.decorators import get_serializer
+from navitiacommon.parser_args_type import UnsignedInteger
 
 graphical_isochrone = {
     "geojson": JsonString(),

--- a/source/jormungandr/jormungandr/interfaces/v1/HeatMap.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/HeatMap.py
@@ -46,11 +46,11 @@ from jormungandr.interfaces.v1.fields import (
 from jormungandr.timezone import set_request_timezone
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.utils import date_to_timestamp
-from jormungandr.interfaces.parsers import UnsignedInteger
 from jormungandr.interfaces.v1.journey_common import JourneyCommon
 from jormungandr.interfaces.v1.fields import DateTime, context
 from jormungandr.interfaces.v1.serializer.api import HeatMapSerializer
 from jormungandr.interfaces.v1.decorators import get_serializer
+from navitiacommon.parser_args_type import UnsignedInteger
 
 heat_map = {
     "heat_matrix": JsonString(),

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -68,7 +68,7 @@ from navitiacommon import default_values
 from jormungandr.interfaces.v1.journey_common import JourneyCommon, compute_possible_region
 from jormungandr.parking_space_availability.parking_places_manager import ManageParkingPlaces
 import six
-from navitiacommon.parser_args_type import BooleanType, OptionValue
+from navitiacommon.parser_args_type import BooleanType, OptionValue, UnsignedInteger, PositiveInteger
 from jormungandr.interfaces.common import add_poi_infos_types, handle_poi_infos
 
 f_datetime = "%Y%m%dT%H%M%S"
@@ -471,12 +471,12 @@ class Journeys(JourneyCommon):
         )
         parser_get.add_argument(
             "min_nb_journeys",
-            type=inputs.natural,
+            type=UnsignedInteger(),
             help='Minimum number of different suggested journeys, must be >= 0',
         )
         parser_get.add_argument(
             "max_nb_journeys",
-            type=inputs.positive,
+            type=PositiveInteger(),
             help='Maximum number of different suggested journeys, must be > 0',
         )
         parser_get.add_argument("_max_extra_second_pass", type=int, dest="max_extra_second_pass", hidden=True)

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -58,12 +58,7 @@ from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.serializer import api, pt
 from datetime import datetime, timedelta
 from jormungandr.interfaces.argument import ArgumentDoc
-from jormungandr.interfaces.parsers import (
-    DateTimeFormat,
-    default_count_arg_type,
-    depth_argument,
-    UnsignedInteger,
-)
+from jormungandr.interfaces.parsers import DateTimeFormat, default_count_arg_type, depth_argument
 from jormungandr.interfaces.v1.errors import ManageError
 from flask_restful.inputs import natural
 from jormungandr.interfaces.v1.fields import disruption_marshaller, NonNullList, NonNullNested
@@ -74,7 +69,7 @@ from copy import deepcopy
 from navitiacommon import response_pb2
 from jormungandr.exceptions import InvalidArguments
 import six
-from navitiacommon.parser_args_type import BooleanType, OptionValue
+from navitiacommon.parser_args_type import BooleanType, OptionValue, UnsignedInteger
 
 
 class Schedules(ResourceUri, ResourceUtc):

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -36,7 +36,7 @@ from jormungandr.interfaces.argument import ArgumentDoc
 from datetime import datetime
 from jormungandr.resources_utils import ResourceUtc
 from jormungandr.interfaces.v1.transform_id import transform_id
-from jormungandr.interfaces.parsers import float_gt_0, UnsignedInteger
+from jormungandr.interfaces.parsers import float_gt_0
 from flask_restful import reqparse, abort
 import logging
 from jormungandr.exceptions import RegionNotFound
@@ -52,6 +52,7 @@ from navitiacommon.parser_args_type import (
     BooleanType,
     OptionValue,
     DescribedOptionValue,
+    UnsignedInteger,
 )
 
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -34,12 +34,12 @@ from future.moves.itertools import zip_longest
 import json
 from jormungandr.scenarios.qualifier import compare_field, reverse_compare_field
 from navitiacommon import request_pb2, response_pb2
+from navitiacommon.parser_args_type import UnsignedInteger
 from datetime import datetime
 import logging
 import re
 from shapely.geometry import shape
 import sys
-from jormungandr.interfaces.parsers import UnsignedInteger
 from six.moves.urllib.parse import unquote
 import six
 

--- a/source/jormungandr/tests/graphical_isochrones_tests.py
+++ b/source/jormungandr/tests/graphical_isochrones_tests.py
@@ -303,7 +303,10 @@ class TestGraphicalIsochrone(AbstractTestFixture):
         normal_response, error_code = self.query_no_assert(q)
 
         assert error_code == 400
-        assert 'Unable to evaluate, invalid positive int' in normal_response['message']
+        assert (
+            'Unable to evaluate, invalid unsigned int\nmax_duration description: Maximum duration of journeys in secondes.\nReally useful when computing an isochrone.'
+            in normal_response['message']
+        )
 
         p = "v1/coverage/main_routing_test/isochrones?datetime={}&from={}&max_duration={}"
         p = p.format('20120614T080000', s_coord, 'toto')

--- a/source/jormungandr/tests/heat_maps_tests.py
+++ b/source/jormungandr/tests/heat_maps_tests.py
@@ -174,7 +174,10 @@ class TestHeatMap(AbstractTestFixture):
         normal_response, error_code = self.query_no_assert(q)
 
         assert error_code == 400
-        assert 'Unable to evaluate, invalid positive int' in normal_response['message']
+        assert (
+            'Unable to evaluate, invalid unsigned int\nmax_duration description: Maximum duration of journeys in secondes.\nReally useful when computing an isochrone.'
+            in normal_response['message']
+        )
 
         p = "v1/coverage/main_routing_test/isochrones?datetime={}&from={}&max_duration={}"
         p = p.format('20120614T080000', s_coord, 'toto')

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -1013,7 +1013,10 @@ class JourneyCommon(object):
 
             response = self.query_region(query, check=False)
             assert response[1] == 400
-            assert "max_nb_journeys must be a positive integer" in response[0]['message']
+            assert (
+                'parameter "max_nb_journeys" invalid: Unable to evaluate, invalid positive int\nmax_nb_journeys description: Maximum number of different suggested journeys, must be > 0'
+                in response[0]['message']
+            )
 
         query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}&min_nb_journeys={min_nb_journeys}".format(
             from_sa="stopA", to_sa="stopB", datetime="20120614T223000", min_nb_journeys=int(-42)
@@ -1021,7 +1024,10 @@ class JourneyCommon(object):
 
         response = self.query_region(query, check=False)
         assert response[1] == 400
-        assert "min_nb_journeys must be a non-negative integer" in response[0]['message']
+        assert (
+            'parameter "min_nb_journeys" invalid: Unable to evaluate, invalid unsigned int\nmin_nb_journeys description: Minimum number of different suggested journeys, must be >= 0'
+            in response[0]['message']
+        )
 
 
 @dataset({"main_stif_test": {}})

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -100,6 +100,29 @@ class SchemaChecker:
                 raise
             return obj, collect_all_errors(e)
 
+    def check_schema_parameters_structure(self, url):
+        """
+        Test the schema's parameters types
+        """
+        response = self.get_api_schema(url)
+
+        params = get_params(response)
+
+        assert len(params) > 1
+
+        for name, param in params.iteritems():
+            assert param.has_key('name')
+            assert param.has_key('description')
+            assert param.has_key('type')
+
+            assert type(param['name']) is unicode
+            assert type(param['description']) is unicode
+
+            assert any(
+                param['type'] == t
+                for t in ['integer', 'number', 'float', 'string', 'unicode', 'boolean', 'array']
+            )
+
 
 @dataset({"main_routing_test": {}, "main_autocomplete_test": {}})
 class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
@@ -299,6 +322,9 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
     def test_geo_status(self):
         query = '/v1/coverage/main_routing_test/_geo_status'
         self._check_schema(query)
+
+    def test_journeys_schema_parameters(self):
+        self.check_schema_parameters_structure('v1/coverage/main_routing_test/journeys?schema=true')
 
 
 @dataset({"main_ptref_test": {}})

--- a/source/navitiacommon/navitiacommon/parser_args_type.py
+++ b/source/navitiacommon/navitiacommon/parser_args_type.py
@@ -185,3 +185,33 @@ class CoordFormat(CustomSchemaType):
 
     def schema(self):
         return TypeSchema(type=str, metadata={'pattern': '.*;.*'})
+
+
+class UnsignedInteger(CustomSchemaType):
+    def __call__(self, value):
+        try:
+            d = int(value)
+            if d < 0:
+                raise ValueError('invalid unsigned int')
+
+            return d
+        except ValueError as e:
+            raise ValueError("Unable to evaluate, {}".format(e))
+
+    def schema(self):
+        return TypeSchema(type=int, metadata={'minimum': 0})
+
+
+class PositiveInteger(CustomSchemaType):
+    def __call__(self, value):
+        try:
+            d = int(value)
+            if d <= 0:
+                raise ValueError('invalid positive int')
+
+            return d
+        except ValueError as e:
+            raise ValueError("Unable to evaluate, {}".format(e))
+
+    def schema(self):
+        return TypeSchema(type=int, metadata={'minimum': 1})


### PR DESCRIPTION
`min_nb_journey` and `max_nb_journey`'s types are exposed in the schema as `type: <function natural at 0x7f3b670b7ed8>` which is not ideal for the front...

This PR fixes the type using `UnsignedInteger` & `PositiveInteger` to define them as `type: int`.