### PR TITLE
Jormun: Schema structure testing

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
@@ -79,8 +79,15 @@ class GraphicalIsochrone(JourneyCommon):
     def __init__(self):
         super(GraphicalIsochrone, self).__init__(output_type_serializer=GraphicalIsrochoneSerializer)
         parser_get = self.parsers["get"]
-        parser_get.add_argument("min_duration", type=UnsignedInteger(), default=0)
-        parser_get.add_argument("boundary_duration[]", type=UnsignedInteger(), action="append")
+        parser_get.add_argument(
+            "min_duration", type=UnsignedInteger(), default=0, help="Minimum travel duration"
+        )
+        parser_get.add_argument(
+            "boundary_duration[]",
+            type=UnsignedInteger(),
+            action="append",
+            help="To provide multiple duration parameters",
+        )
 
     @get_serializer(serpy=GraphicalIsrochoneSerializer, marshall=graphical_isochrones)
     @ManageError()

--- a/source/jormungandr/jormungandr/interfaces/v1/HeatMap.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/HeatMap.py
@@ -74,7 +74,7 @@ class HeatMap(JourneyCommon):
     def __init__(self):
         super(HeatMap, self).__init__(output_type_serializer=HeatMapSerializer)
         parser_get = self.parsers["get"]
-        parser_get.add_argument("resolution", type=UnsignedInteger(), default=500)
+        parser_get.add_argument("resolution", type=UnsignedInteger(), default=500, help="Sampling resolution")
 
     @get_serializer(serpy=HeatMapSerializer, marshall=heat_maps)
     @ManageError()

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -85,7 +85,7 @@ class Schedules(ResourceUri, ResourceUtc):
         self.endpoint = endpoint
         self.parsers["get"] = reqparse.RequestParser(argument_class=ArgumentDoc)
         parser_get = self.parsers["get"]
-        parser_get.add_argument("filter", type=six.text_type)
+        parser_get.add_argument("filter", type=six.text_type, help="use to filter PT objects")
         parser_get.add_argument(
             "from_datetime",
             type=DateTimeFormat(),
@@ -104,7 +104,7 @@ class Schedules(ResourceUri, ResourceUtc):
             default=3600 * 24,
             help="Maximum duration between datetime and the retrieved stop time",
         )
-        parser_get.add_argument("depth", type=DepthArgument(), default=2)
+        parser_get.add_argument("depth", type=DepthArgument(), default=2, help="The depth of your object")
         parser_get.add_argument(
             "count", type=default_count_arg_type, default=10, help="Number of schedules per page"
         )

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -30,11 +30,10 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 
 import json
 import logging
-
-from flex.exceptions import ValidationError
-
-from tests.tests_mechanism import dataset, AbstractTestFixture
 import flex
+from flex.exceptions import ValidationError
+from tests.tests_mechanism import dataset, AbstractTestFixture
+from itertools import chain, ifilter
 
 
 def get_params(schema):
@@ -340,8 +339,7 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
             other_param = any(elem in path for elem in ['{id}', '{uri}'])
             return '{region}' in path and not other_param
 
-        urls = list(filter(endpoints_with_no_param, paths))
-        urls.extend(list(filter(endpoints_with_only_region_param, paths)))
+        urls = chain(ifilter(endpoints_with_no_param, paths), ifilter(endpoints_with_only_region_param, paths))
 
         for u in urls:
             url = '/v1' + u.format(region='main_routing_test') + '?schema=true'


### PR DESCRIPTION
We now ensure that an endpoint referenced in the schema has its parameters defined with: 
- A name
- A description
- A type (that can be: 'integer', 'number', 'float', 'string', 'unicode', 'boolean' or 'array') 

I'm only testing endpoints with no or just the `{region}` parameter (eg. `/v1/coverage/{lon}:{lat}/journeys` isn't tested but `/v1/coverage/{region}/journeys` is ! ).