### PR TITLE
Add dateutil dependency to navitiacommon, and link it from tyr

### DIFF
--- a/source/navitiacommon/requirements.txt
+++ b/source/navitiacommon/requirements.txt
@@ -1,1 +1,0 @@
-python-dateutil==2.5.3

--- a/source/navitiacommon/requirements.txt
+++ b/source/navitiacommon/requirements.txt
@@ -1,0 +1,1 @@
+python-dateutil==2.5.3

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -1,3 +1,4 @@
+-r ../navitiacommon/requirements.txt
 Flask==0.12.4
 Flask-Migrate==1.1.1
 git+https://github.com/CanalTP/flask-restful.git@76346f65ca12a8edb9b32688cdc192ad391fa686

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -1,4 +1,3 @@
--r ../navitiacommon/requirements.txt
 Flask==0.12.4
 Flask-Migrate==1.1.1
 git+https://github.com/CanalTP/flask-restful.git@76346f65ca12a8edb9b32688cdc192ad391fa686
@@ -33,3 +32,4 @@ wsgiref==0.1.2
 retrying==1.3.3
 ujson==1.35
 jsonschema==2.5.1
+python-dateutil==2.5.3


### PR DESCRIPTION
Proposal for splitting dependency requirements. 
As Tyr pulls navitiacommon, I want Tyr to relies on navitiacommon's dependencies; hence the new `requirements.txt` in navitiacommon.

This is a first step, but I would love to see all navitiacommon's requirements in the right files from now on :)