### PR TITLE
Remove specific filter for line sections

### DIFF
--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -95,16 +95,15 @@ struct LineReport {
     }
 
     void to_pb(navitia::PbCreator& pb_creator, const size_t depth) const {
-        const auto with_line_sections = DumpMessageOptions{DumpMessage::Yes, DumpLineSectionMessage::Yes};
         auto* report = pb_creator.add_line_reports();
-        pb_creator.fill(line, report->mutable_line(), depth-1, with_line_sections);
+        pb_creator.fill(line, report->mutable_line(), depth-1);
         if (line->has_applicable_message(pb_creator.now, pb_creator.action_period)) {
             pb_creator.fill(line, report->add_pt_objects(), 0);
         }
         pb_creator.fill(networks, report->mutable_pt_objects(), 0);
         pb_creator.fill(routes, report->mutable_pt_objects(), 0);
         pb_creator.fill(stop_areas, report->mutable_pt_objects(), 0);
-        pb_creator.fill(stop_points, report->mutable_pt_objects(), 0, with_line_sections);
+        pb_creator.fill(stop_points, report->mutable_pt_objects(), 0);
     }
 };
 

--- a/source/disruption/traffic_reports_api.cpp
+++ b/source/disruption/traffic_reports_api.cpp
@@ -368,7 +368,7 @@ void traffic_reports(navitia::PbCreator& pb_creator,
         for(const auto& impact: dist.network_disruptions){
             pb_creator.fill_message(impact, pb_network, depth-1);
         }
-        pb_creator.fill(dist.network, pb_network, depth, DumpMessageOptions{DumpMessage::No, DumpLineSectionMessage::No});
+        pb_creator.fill(dist.network, pb_network, depth, DumpMessageOptions{DumpMessage::No});
         for (const auto& line_item: dist.lines) {
             pbnavitia::Line* pb_line = pb_traffic_reports->add_lines();
             pb_creator.fill(line_item.first, pb_line, depth-1, DumpMessage::No);

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -49,13 +49,12 @@ static void extract_data(navitia::PbCreator& pb_creator,
                          const type::Indexes& rows,
                          const int depth) {
     pb_creator.action_period = data.meta->production_period();
-    const auto with_line_sections = DumpMessageOptions{DumpMessage::Yes, DumpLineSectionMessage::Yes};
     switch(requested_type){
     case Type_e::ValidityPattern:
         pb_creator.pb_fill(data.get_data<nt::ValidityPattern>(rows), depth);
         return;
     case Type_e::Line:
-        pb_creator.pb_fill(data.get_data<nt::Line>(rows), depth, with_line_sections);
+        pb_creator.pb_fill(data.get_data<nt::Line>(rows), depth);
         return;
     case Type_e::LineGroup:
         pb_creator.pb_fill(data.get_data<nt::LineGroup>(rows), depth);
@@ -69,7 +68,7 @@ static void extract_data(navitia::PbCreator& pb_creator,
         return;
         }
     case Type_e::StopPoint:
-        pb_creator.pb_fill(data.get_data<nt::StopPoint>(rows), depth, with_line_sections);
+        pb_creator.pb_fill(data.get_data<nt::StopPoint>(rows), depth);
         return;
     case Type_e::StopArea:
         pb_creator.pb_fill(data.get_data<nt::StopArea>(rows), depth);
@@ -107,7 +106,7 @@ static void extract_data(navitia::PbCreator& pb_creator,
         pb_creator.pb_fill(data.get_data<nt::StopPointConnection>(rows), depth);
         return;
     case Type_e::VehicleJourney:
-        pb_creator.pb_fill(data.get_data<nt::VehicleJourney>(rows), depth, with_line_sections);
+        pb_creator.pb_fill(data.get_data<nt::VehicleJourney>(rows), depth);
         return;
     case Type_e::Calendar:
         pb_creator.pb_fill(data.get_data<nt::Calendar>(rows), depth);

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -89,7 +89,13 @@ render(PbCreator& pb_creator,
         //Each schedule has a stop_point and a route
         const auto* stop_point = pb_creator.data->pt_data->stop_points[id_vec.first.second.val];
         const auto* route = pb_creator.data->pt_data->routes[id_vec.first.first.val];
-        pb_creator.fill(stop_point, schedule->mutable_stop_point(), depth);
+
+        pb_creator.fill(
+            stop_point,
+            schedule->mutable_stop_point(),
+            depth,
+            route
+        );
 
         auto m_route = schedule->mutable_route();
 

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -111,7 +111,7 @@ void fill_route_point(PbCreator& pb_creator,
                       const type::Route* route,
                       const type::StopPoint* stop_point,
                       T* pb) {
-    pb_creator.fill(stop_point, pb->mutable_stop_point(), depth);
+    pb_creator.fill(stop_point, pb->mutable_stop_point(), depth, route);
     const type::Line* line = route->line;
     auto m_route = pb->mutable_route();
     pb_creator.fill(route, m_route, 0);

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -399,7 +399,7 @@ void route_schedule(PbCreator& pb_creator, const std::string& filter,
             type::idx_t spidx=thermometer.get_thermometer()[i];
             const type::StopPoint* sp = pb_creator.data->pt_data->stop_points[spidx];
             pbnavitia::RouteScheduleRow* row = table->add_rows();
-            pb_creator.fill(sp, row->mutable_stop_point(), max_depth);
+            pb_creator.fill(sp, row->mutable_stop_point(), max_depth, route);
 
             for(unsigned int j=0; j<stop_times.size(); ++j) {
                 const auto& dt_stop_time  = matrix[i][j];

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -347,7 +347,6 @@ template<typename NAV, typename PB>
 void PbCreator::Filler::fill(NAV* nav_object, PB* pb_object) {
     if (nav_object == nullptr) { return; }
     DumpMessageOptions new_dump_options{dump_message_options};
-    new_dump_options.dump_line_section = DumpLineSectionMessage::No;
     copy(depth-1, new_dump_options).fill_pb_object(nav_object, get_sub_object(nav_object, pb_object));
 }
 template<typename NAV, typename F>
@@ -448,7 +447,7 @@ void PbCreator::Filler::fill_pb_object(const ng::Admin* adm, pbnavitia::Administ
     }
     if (depth > 1) {
         // for the admin we add the main stop area, but with the minimum vital information
-        auto minimum_filler = Filler(0, {DumpMessage::No, DumpLineSectionMessage::No}, pb_creator);
+        auto minimum_filler = Filler(0, {DumpMessage::No}, pb_creator);
         for (const auto& sa: adm->main_stop_areas) {
             auto* pb_sa = admin->add_main_stop_areas();
 
@@ -619,7 +618,7 @@ void PbCreator::Filler::fill_pb_object(const nt::Line* l, pbnavitia::Line* line)
         pb_property->set_value(property.second);
     }
 
-    if (dump_message_options ==  DumpMessageOptions{DumpMessage::Yes, DumpLineSectionMessage::Yes} ) {
+    if (dump_message_options ==  DumpMessageOptions{DumpMessage::Yes} ) {
         /*
          * Here we dump the impacts which impact LineSection.
          * We could have link the LineSection impact with the line, but that would change the code and

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -221,6 +221,20 @@ struct PbCreator {
     PbCreator(const PbCreator&) = delete;
     PbCreator& operator=(const PbCreator&) = delete;
 
+    template<typename P>
+    void fill(const nt::StopPoint* item, P* proto, int depth,
+              const nt::Route* route,
+              const DumpMessageOptions& dump_message_options=DumpMessageOptions{}) {
+        Filler(depth, dump_message_options, *this).fill_pb_object(item, proto, route);
+    }
+
+    template<typename P>
+    void fill(const nt::EntryPoint* item, P* proto, int depth,
+              const nt::Route* route,
+              const DumpMessageOptions& dump_message_options=DumpMessageOptions{}) {
+        Filler(depth, dump_message_options, *this).fill_pb_object(item, proto, route);
+    }
+
     template<typename N, typename P>
     void fill(const N& item, P* proto, int depth,
             const DumpMessageOptions& dump_message_options=DumpMessageOptions{}) {
@@ -252,9 +266,15 @@ struct PbCreator {
     void fill_co2_emission_by_mode(pbnavitia::Section* pb_section, const std::string& mode_uri);
     void fill_fare_section(pbnavitia::Journey* pb_journey, const fare::results& fare);
 
-    void fill_crowfly_section(const type::EntryPoint& origin, const type::EntryPoint& destination,
-                              const time_duration& crow_fly_duration, type::Mode_e mode,
-                              pt::ptime origin_time, pbnavitia::Journey* pb_journey);
+    void fill_crowfly_section(const type::EntryPoint& origin,
+                              const type::EntryPoint& destination,
+                              const time_duration& crow_fly_duration,
+                              type::Mode_e mode,
+                              pt::ptime origin_time,
+                              pbnavitia::Journey* pb_journey,
+                              const nt::Route* route = nullptr,
+                              const bool way = false);
+
 
     void fill_street_sections(const type::EntryPoint &ori_dest, const georef::Path & path,
                               pbnavitia::Journey* pb_journey, const pt::ptime departure,
@@ -333,6 +353,12 @@ private:
         template<typename NAV, typename F>
         void fill_with_creator(NAV* nav_object, F creator);
 
+        template<typename F>
+        void fill_with_creator(const nt::EntryPoint* nav_object, F creator, const nt::Route* route = nullptr);
+
+        template<typename F>
+        void fill_with_creator(const nt::StopPoint* nav_object, F creator, const nt::Route* route = nullptr);
+
         template<typename NAV, typename PB>
         void fill(const NAV& nav_object, PB* pb_object) {
             copy(depth-1, dump_message_options).fill_pb_object(nav_object, pb_object);
@@ -386,6 +412,8 @@ private:
         }
         // override fill_messages for journey sections to handle line sections impacts
         void fill_messages(const VjStopTimes*, pbnavitia::PtDisplayInfo*);
+        // override fill_messages for stop point to handle line sections impacts
+        void fill_messages(const nt::StopPoint*, pbnavitia::StopPoint*, const nt::Route* = nullptr);
 
         template <typename Target, typename Source>
         std::vector<Target*> ptref_indexes(const Source* nav_obj);
@@ -426,7 +454,7 @@ private:
         void fill_pb_object(const nt::Contributor*, pbnavitia::Contributor*);
         void fill_pb_object(const nt::Dataset*, pbnavitia::Dataset*);
         void fill_pb_object(const nt::StopArea*, pbnavitia::StopArea*);
-        void fill_pb_object(const nt::StopPoint*, pbnavitia::StopPoint*);
+        void fill_pb_object(const nt::StopPoint*, pbnavitia::StopPoint*, const nt::Route* = nullptr);
         void fill_pb_object(const nt::Company*, pbnavitia::Company*);
         void fill_pb_object(const nt::Network*, pbnavitia::Network*);
         void fill_pb_object(const nt::PhysicalMode*, pbnavitia::PhysicalMode*);
@@ -462,13 +490,15 @@ private:
         void fill_pb_object(const VjStopTimes*, pbnavitia::PtDisplayInfo*);
         void fill_pb_object(const nt::VehicleJourney*, pbnavitia::hasEquipments*);
         void fill_pb_object(const StopTimeCalendar*, pbnavitia::ScheduleStopTime*);
-        void fill_pb_object(const nt::EntryPoint*, pbnavitia::PtObject*);
+        void fill_pb_object(const nt::EntryPoint*, pbnavitia::PtObject*, const nt::Route* = nullptr);
         void fill_pb_object(const WayCoord*, pbnavitia::PtObject*);
         void fill_pb_object(const WayCoord*, pbnavitia::Address*);
 
         // Used for place
         template<typename T>
         void fill_pb_object(const T* value, pbnavitia::PtObject* pt_object);
+
+        void fill_pb_object(const nt::StopPoint*, pbnavitia::PtObject*, const nt::Route* = nullptr);
     };
     // Raptor api
     pbnavitia::Section* create_section(pbnavitia::Journey*, const ng::PathItem&, int);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -46,19 +46,12 @@ enum class DumpMessage: bool {
     No
 };
 
-enum class DumpLineSectionMessage: bool {
-    Yes,
-    No
-};
-
 struct DumpMessageOptions {
     DumpMessage dump_message;
-    DumpLineSectionMessage dump_line_section;
-    constexpr DumpMessageOptions(DumpMessage dump_message = DumpMessage::Yes,
-            DumpLineSectionMessage dump_line_section = DumpLineSectionMessage::No):
-                        dump_message(dump_message), dump_line_section(dump_line_section){}
+    constexpr DumpMessageOptions(DumpMessage dump_message = DumpMessage::Yes):
+        dump_message(dump_message){}
     constexpr bool operator==(const DumpMessageOptions& rhs) const {
-        return dump_message == rhs.dump_message && dump_line_section == rhs.dump_line_section;
+        return dump_message == rhs.dump_message;
     }
 };
 
@@ -387,9 +380,7 @@ private:
         void fill_messages(const nt::HasMessages* nav_obj, P* pb_obj){
             if (nav_obj == nullptr) {return ;}
             if (dump_message_options.dump_message == DumpMessage::No) { return; }
-            const bool dump_line_sections = dump_message_options.dump_line_section == DumpLineSectionMessage::Yes;
             for (const auto& message: nav_obj->get_applicable_messages(pb_creator.now, pb_creator.action_period)) {
-                if (!dump_line_sections && message->is_only_line_section()) { continue; }
                 fill_message(message, pb_obj);
             }
         }
@@ -495,7 +486,7 @@ pbnavitia::Response get_response(const std::vector<N*>& nt_objects, const nt::Da
                                  const DumpMessage dump_message = DumpMessage::Yes){
     PbCreator creator(&data, now, action_period, disable_geojson);
 
-    creator.pb_fill(nt_objects, depth, {dump_message, DumpLineSectionMessage::No});
+    creator.pb_fill(nt_objects, depth, {dump_message});
     return creator.get_response();
 }
 


### PR DESCRIPTION
Hi,

As discussed since some time now with @eturck and @kinnou02, we would like to suggest some changes about how the line sections are displayed in navitia. The main goal for us is to be able to see them in a request on `/lines/line:xx/stop_schedules` but in order to achieve this, we have to deal with the option "DumpLineSectionMessage". As you already know, doing this adds a lot of links between impacts messages and pb objects and make disruptions appear a lot more in services like journeys or stop schedules, departures...

We know that the discussion is still in progress for you but in order to make a first step, here is a PR where we try to do something :3 

To summarize what is in the changes:

- Remove DumpLineSectionMessage option (we may replace this by keeping the option and activating it with a parameter in the requests or whatever if we cannot agree on the changes)
- Try to fill the impacts messages for route points instead of stop points by adding the route in the fill_message function. This is useful to limit the links in the output to what is really impacted in a journey or in stop schedules
- Also add the route in fill_messages called for crow fly sections, for the same reason

The current work may be incomplete as I didn't manage very well with the crowfly sections and I think the tests lack some journeys with tranfers and multiple impacts with multiple lines. I'll work on this after the first comments.





