### PR TITLE
Jormungandr: Fix min bound datetime

### DIFF
--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -90,16 +90,17 @@ class JourneyCommon(object):
         """ datetime is > 1970y """
 
         query_out_of_production_bound = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
-            from_coord="0.0000898312;0.0000898312",
-            to_coord="0.00188646;0.00071865",
-            datetime="19700101T000000",
+            from_coord="0.0000898312;0.0000898312", to_coord="0.00188646;0.00071865", datetime="19700101T000000"
         )
 
         response, status = self.query_region(query_out_of_production_bound, check=False)
 
         assert status != 200, "the response should not be valid"
         check_best(response)
-        assert response['message'] == 'parameter \"datetime\" invalid: Unable to parse datetime, date is too early!\ndatetime description: Date and time to go/arrive (see `datetime_represents`).\nNote: the datetime must be in the coverage’s publication period.'
+        assert (
+            response['message']
+            == 'parameter \"datetime\" invalid: Unable to parse datetime, date is too early!\ndatetime description: Date and time to go/arrive (see `datetime_represents`).\nNote: the datetime must be in the coverage’s publication period.'
+        )
 
         # and no journey is to be provided
         assert 'journeys' not in response or len(response['journeys']) == 0

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
@@ -66,7 +67,7 @@ class JourneyCommon(object):
 
         self.check_context(response)
 
-    def test_error_on_journeys(self):
+    def test_error_on_journeys_out_of_bounds(self):
         """ if we got an error with kraken, an error should be returned"""
 
         query_out_of_production_bound = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
@@ -81,6 +82,24 @@ class JourneyCommon(object):
         check_best(response)
         assert response['error']['id'] == "date_out_of_bounds"
         assert response['error']['message'] == "date is not in data production period"
+
+        # and no journey is to be provided
+        assert 'journeys' not in response or len(response['journeys']) == 0
+
+    def test_error_on_journeys_too_early(self):
+        """ datetime is > 1970y """
+
+        query_out_of_production_bound = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+            from_coord="0.0000898312;0.0000898312",
+            to_coord="0.00188646;0.00071865",
+            datetime="19700101T000000",
+        )
+
+        response, status = self.query_region(query_out_of_production_bound, check=False)
+
+        assert status != 200, "the response should not be valid"
+        check_best(response)
+        assert response['message'] == 'parameter \"datetime\" invalid: Unable to parse datetime, date is too early!\ndatetime description: Date and time to go/arrive (see `datetime_represents`).\nNote: the datetime must be in the coverage’s publication period.'
 
         # and no journey is to be provided
         assert 'journeys' not in response or len(response['journeys']) == 0

--- a/source/navitiacommon/navitiacommon/parser_args_type.py
+++ b/source/navitiacommon/navitiacommon/parser_args_type.py
@@ -235,7 +235,7 @@ class DateTimeFormat(CustomSchemaType):
         """
         try:
             d = _parse_input_date(value)
-            if d.year < 1970:
+            if d.year <= 1970:
                 raise ValueError('date is too early!')
 
             return d


### PR DESCRIPTION
Currently, when a request is created with `datetime=19700101T001900`, an exception is raised :
```
Stack trace
exceptions:ValueError: Value out of range: -2460
```
A conversion function doesn't like the `19700101`...

I think it is the most tiny PR of the world :earth_africa: 