### PR TITLE
Jormun: use a stack in place of a queue to store opened sockets

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -105,7 +105,7 @@ class Instance(object):
         autocomplete_type,
     ):
         self.geom = None
-        self._sockets = queue.Queue()
+        self._sockets = queue.LifoQueue()
         self.socket_path = zmq_socket
         self._scenario = None
         self._scenario_name = None


### PR DESCRIPTION
This change should reduce the number of connection opened to kraken as
unused connection will be closed by haproxy.