### PR TITLE
Jormun: remove a useless log

### DIFF
--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -141,14 +141,15 @@ autocomplete_backend = 'kraken'
 
 def get_value_or_default(attr, instance, instance_name):
     if not instance or getattr(instance, attr, None) == None:
-        logger = logging.getLogger(__name__)
         value = getattr(sys.modules[__name__], attr)
-        logger.warn(
-            'instance %s not found in db, we use the default value (%s) for the param %s',
-            instance_name,
-            value,
-            attr,
-        )
+        if not instance:
+            logger = logging.getLogger(__name__)
+            logger.warn(
+                'instance %s not found in db, we use the default value (%s) for the param %s',
+                instance_name,
+                value,
+                attr,
+            )
         return value
     else:
         return getattr(instance, attr)


### PR DESCRIPTION
Jormungandr logs a warning if it doesn't find a coverage in its database
and use the default value defined in the code. This log was also written
when the requested value was `None`.
This PR isolate the test for the log and only write it if the instance
isn't in the database: this should never happen in production.