### PR TITLE
Jormun: Distributed refacto before breaking the whole thingy

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -33,44 +33,58 @@ from jormungandr.scenarios import new_default
 from jormungandr.utils import PeriodExtremity
 from jormungandr.street_network.street_network import StreetNetworkPathType
 from jormungandr.scenarios.helper_classes import *
+from jormungandr.scenarios.helper_classes.complete_pt_journey import wait_and_get_pt_journeys
 from jormungandr.scenarios.utils import fill_uris, switch_back_to_ridesharing
 from jormungandr.new_relic import record_custom_parameter
 
 
-class Scenario(new_default.Scenario):
-    def __init__(self):
-        super(Scenario, self).__init__()
+class Distributed:
+    def __init__(self, future_manager, request, instance, krakens_call):
+        self.future_manager = future_manager
+        self.request = request
+        self.instance = instance
+        self.krakens_call = krakens_call
+        self.requested_orig_obj = None
+        self.requested_dest_obj = None
+        self.streetnetwork_path_pool = None
+        self.orig_fallback_durations_pool = None
+        self.dest_fallback_durations_pool = None
+        self.orig_places_free_access = None
+        self.dest_places_free_access = None
+        self.pt_journey_pool = None
 
-    @staticmethod
-    def _compute_all(future_manager, request, instance, krakens_call):
+    def _compute_all(self):
         """
         For all krakens_call, call the kraken and aggregate the responses
 
         return the list of all responses
         """
+        future_manager = self.future_manager
+        request = self.request
+        instance = self.instance
 
         logger = logging.getLogger(__name__)
         logger.debug('request datetime: %s', request['datetime'])
 
-        requested_dep_modes = {mode for mode, _ in krakens_call}
-        requested_arr_modes = {mode for _, mode in krakens_call}
+        requested_dep_modes = {mode for mode, _ in self.krakens_call}
+        requested_arr_modes = {mode for _, mode in self.krakens_call}
 
         logger.debug('requesting places by uri orig: %s dest %s', request['origin'], request['destination'])
 
         requested_orig = PlaceByUri(future_manager=future_manager, instance=instance, uri=request['origin'])
         requested_dest = PlaceByUri(future_manager=future_manager, instance=instance, uri=request['destination'])
 
-        requested_orig_obj = get_entry_point_or_raise(requested_orig, request['origin'])
-        requested_dest_obj = get_entry_point_or_raise(requested_dest, request['destination'])
+        self.requested_orig_obj = get_entry_point_or_raise(requested_orig, request['origin'])
+        self.requested_dest_obj = get_entry_point_or_raise(requested_dest, request['destination'])
 
-        streetnetwork_path_pool = StreetNetworkPathPool(future_manager=future_manager, instance=instance)
+        self.streetnetwork_path_pool = StreetNetworkPathPool(future_manager=future_manager, instance=instance)
         period_extremity = PeriodExtremity(request['datetime'], request['clockwise'])
 
         # we launch direct path asynchronously
         for mode in requested_dep_modes:
-            streetnetwork_path_pool.add_async_request(
-                requested_orig_obj=requested_orig_obj,
-                requested_dest_obj=requested_dest_obj,
+            self.streetnetwork_path_pool.add_async_request(
+                requested_orig_obj=self.requested_orig_obj,
+                requested_dest_obj=self.requested_dest_obj,
                 mode=mode,
                 period_extremity=period_extremity,
                 request=request,
@@ -81,9 +95,9 @@ class Scenario(new_default.Scenario):
         # we return all direct path without pt
         if request['max_duration'] == 0:
             return [
-                streetnetwork_path_pool.wait_and_get(
-                    requested_orig_obj=requested_orig_obj,
-                    requested_dest_obj=requested_dest_obj,
+                self.streetnetwork_path_pool.wait_and_get(
+                    requested_orig_obj=self.requested_orig_obj,
+                    requested_dest_obj=self.requested_dest_obj,
                     mode=mode,
                     request=request,
                     period_extremity=period_extremity,
@@ -95,12 +109,12 @@ class Scenario(new_default.Scenario):
         # We'd like to get the duration of a direct path to do some optimizations in ProximitiesByCrowflyPool and
         # FallbackDurationsPool.
         # Note :direct_paths_by_mode is a dict of mode vs future of a direct paths, this line is not blocking
-        direct_paths_by_mode = streetnetwork_path_pool.get_all_direct_paths()
+        direct_paths_by_mode = self.streetnetwork_path_pool.get_all_direct_paths()
 
         orig_proximities_by_crowfly = ProximitiesByCrowflyPool(
             future_manager=future_manager,
             instance=instance,
-            requested_place_obj=requested_orig_obj,
+            requested_place_obj=self.requested_orig_obj,
             modes=requested_dep_modes,
             request=request,
             direct_paths_by_mode=direct_paths_by_mode,
@@ -110,68 +124,61 @@ class Scenario(new_default.Scenario):
         dest_proximities_by_crowfly = ProximitiesByCrowflyPool(
             future_manager=future_manager,
             instance=instance,
-            requested_place_obj=requested_dest_obj,
+            requested_place_obj=self.requested_dest_obj,
             modes=requested_arr_modes,
             request=request,
             direct_paths_by_mode=direct_paths_by_mode,
             max_nb_crowfly_by_mode=request['max_nb_crowfly_by_mode'],
         )
 
-        orig_places_free_access = PlacesFreeAccess(
-            future_manager=future_manager, instance=instance, requested_place_obj=requested_orig_obj
+        self.orig_places_free_access = PlacesFreeAccess(
+            future_manager=future_manager, instance=instance, requested_place_obj=self.requested_orig_obj
         )
-        dest_places_free_access = PlacesFreeAccess(
-            future_manager=future_manager, instance=instance, requested_place_obj=requested_dest_obj
+        self.dest_places_free_access = PlacesFreeAccess(
+            future_manager=future_manager, instance=instance, requested_place_obj=self.requested_dest_obj
         )
 
-        orig_fallback_durations_pool = FallbackDurationsPool(
+        self.orig_fallback_durations_pool = FallbackDurationsPool(
             future_manager=future_manager,
             instance=instance,
-            requested_place_obj=requested_orig_obj,
+            requested_place_obj=self.requested_orig_obj,
             modes=requested_dep_modes,
             proximities_by_crowfly_pool=orig_proximities_by_crowfly,
-            places_free_access=orig_places_free_access,
+            places_free_access=self.orig_places_free_access,
             direct_paths_by_mode=direct_paths_by_mode,
             request=request,
             direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK,
         )
 
-        dest_fallback_durations_pool = FallbackDurationsPool(
+        self.dest_fallback_durations_pool = FallbackDurationsPool(
             future_manager=future_manager,
             instance=instance,
-            requested_place_obj=requested_dest_obj,
+            requested_place_obj=self.requested_dest_obj,
             modes=requested_arr_modes,
             proximities_by_crowfly_pool=dest_proximities_by_crowfly,
-            places_free_access=dest_places_free_access,
+            places_free_access=self.dest_places_free_access,
             direct_paths_by_mode=direct_paths_by_mode,
             request=request,
             direct_path_type=StreetNetworkPathType.ENDING_FALLBACK,
         )
 
-        pt_journey_pool = PtJourneyPool(
-            future_manager=future_manager,
-            instance=instance,
-            requested_orig_obj=requested_orig_obj,
-            requested_dest_obj=requested_dest_obj,
-            streetnetwork_path_pool=streetnetwork_path_pool,
-            krakens_call=krakens_call,
-            orig_fallback_durations_pool=orig_fallback_durations_pool,
-            dest_fallback_durations_pool=dest_fallback_durations_pool,
-            request=request,
+        self.pt_journey_pool = PtJourneyPool(
+            future_manager=self.future_manager,
+            instance=self.instance,
+            requested_orig_obj=self.requested_orig_obj,
+            requested_dest_obj=self.requested_dest_obj,
+            streetnetwork_path_pool=self.streetnetwork_path_pool,
+            krakens_call=self.krakens_call,
+            orig_fallback_durations_pool=self.orig_fallback_durations_pool,
+            dest_fallback_durations_pool=self.dest_fallback_durations_pool,
+            request=self.request,
         )
 
-        completed_pt_journeys = wait_and_complete_pt_journey(
-            future_manager=future_manager,
-            requested_orig_obj=requested_orig_obj,
-            requested_dest_obj=requested_dest_obj,
-            pt_journey_pool=pt_journey_pool,
-            streetnetwork_path_pool=streetnetwork_path_pool,
-            orig_places_free_access=orig_places_free_access,
-            dest_places_free_access=dest_places_free_access,
-            orig_fallback_durations_pool=orig_fallback_durations_pool,
-            dest_fallback_durations_pool=dest_fallback_durations_pool,
-            request=request,
+        self.pt_journeys = wait_and_get_pt_journeys(
+            self.pt_journey_pool, self.streetnetwork_path_pool.has_valid_direct_paths()
         )
+
+        completed_pt_journeys = self.finalise_journeys()
 
         # At the stage, all types of journeys have been computed thus we build the final result here
         res = []
@@ -186,11 +193,35 @@ class Scenario(new_default.Scenario):
         # completed_pt_journeys may contain None and res must be a list of protobuf journey
         res.extend((j for j in completed_pt_journeys if j))
 
-        check_final_results_or_raise(res, orig_fallback_durations_pool, dest_fallback_durations_pool)
+        check_final_results_or_raise(res, self.orig_fallback_durations_pool, self.dest_fallback_durations_pool)
 
         for r in res:
             fill_uris(r)
         return res
+
+    def finalise_journeys(self):
+
+        completed_pt_journeys = wait_and_complete_pt_journey(
+            future_manager=self.future_manager,
+            requested_orig_obj=self.requested_orig_obj,
+            requested_dest_obj=self.requested_dest_obj,
+            pt_journey_pool=self.pt_journey_pool,
+            streetnetwork_path_pool=self.streetnetwork_path_pool,
+            orig_places_free_access=self.orig_places_free_access,
+            dest_places_free_access=self.dest_places_free_access,
+            orig_fallback_durations_pool=self.orig_fallback_durations_pool,
+            dest_fallback_durations_pool=self.dest_fallback_durations_pool,
+            request=self.request,
+            pt_journeys=self.pt_journeys,
+        )
+
+        return completed_pt_journeys
+
+
+class Scenario(new_default.Scenario):
+    def __init__(self):
+        super(Scenario, self).__init__()
+        self._scenario = None
 
     def call_kraken(self, request_type, request, instance, krakens_call):
         record_custom_parameter('scenario', 'distributed')
@@ -206,8 +237,8 @@ class Scenario(new_default.Scenario):
         """
         try:
             with FutureManager() as future_manager:
-                res = self._compute_all(future_manager, request, instance, krakens_call)
-                return res
+                self._scenario = Distributed(future_manager, request, instance, krakens_call)
+                return self._scenario._compute_all()
         except PtException as e:
             return [e.get()]
         except EntryPointException as e:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -155,114 +155,104 @@ def _extend_journey(pt_journey, fallback_dp, fallback_period_extremity):
     _extend_pt_sections_with_fallback_sections(pt_journey, aligned_fallback)
 
 
-def _build_from(
-    requested_orig_obj,
-    pt_journeys,
-    dep_mode,
-    streetnetwork_path_pool,
-    orig_accessible_by_crowfly,
-    orig_fallback_durations_pool,
-    request,
-):
+def _get_fallback_logic(fallback_type):
+    if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:
+        return BeginningFallback()
 
-    accessibles_by_crowfly = orig_accessible_by_crowfly.wait_and_get()
-    fallback_durations = orig_fallback_durations_pool.wait_and_get(dep_mode)
+    if fallback_type == StreetNetworkPathType.ENDING_FALLBACK:
+        return EndingFallback()
+
+    raise EntryPointException(
+        "Unknown fallback type : {}".format(fallback_type), response_pb2.Error.unknown_object
+    )
+
+
+class BeginningFallback:
+    def get_pt_boundaries(self, pt_journey):
+        return pt_journey.sections[0].origin, pt_journey.departure_date_time, False
+
+    def get_section_datetime(self, pt_journey):
+        return pt_journey.sections[0].begin_date_time
+
+    def get_crowfly_datetime(self, pt_datetime, fallback_duration):
+        return pt_datetime - fallback_duration
+
+    def route_params(self, origin, dest):
+        return origin, dest
+
+    def set_fallback_datetime(self, pt_journey):
+        pt_journey.departure_date_time = self.get_section_datetime(pt_journey)
+
+
+class EndingFallback:
+    def get_pt_boundaries(self, pt_journey):
+        return pt_journey.sections[-1].destination, pt_journey.arrival_date_time, True
+
+    def get_section_datetime(self, pt_journey):
+        return pt_journey.sections[-1].end_date_time
+
+    def get_crowfly_datetime(self, pt_datetime, fallback_duration):
+        return pt_datetime + fallback_duration
+
+    def route_params(self, origin, dest):
+        return dest, origin
+
+    def set_fallback_datetime(self, pt_journey):
+        pt_journey.arrival_date_time = self.get_section_datetime(pt_journey)
+
+
+def _build_fallback(
+    requested_obj,
+    pt_journeys,
+    mode,
+    streetnetwork_path_pool,
+    obj_accessible_by_crowfly,
+    fallback_durations_pool,
+    request,
+    fallback_type,
+):
+    accessibles_by_crowfly = obj_accessible_by_crowfly.wait_and_get()
+    fallback_durations = fallback_durations_pool.wait_and_get(mode)
+    fallback_logic = _get_fallback_logic(fallback_type)
 
     for pt_journey in pt_journeys.journeys:
-        pt_origin = pt_journey.sections[0].origin
+        pt_obj, pt_datetime, represent_start = fallback_logic.get_pt_boundaries(pt_journey)
+        section_datetime = fallback_logic.get_section_datetime(pt_journey)
 
-        fallback_period_extremity = PeriodExtremity(pt_journey.departure_date_time, False)
-        # extend the journey with the fallback routing path
-        direct_path_type = StreetNetworkPathType.BEGINNING_FALLBACK
-        fallback_dp = streetnetwork_path_pool.wait_and_get(
-            requested_orig_obj, pt_origin, dep_mode, fallback_period_extremity, direct_path_type, request=request
-        )
+        if requested_obj.uri != pt_obj.uri:
 
-        if requested_orig_obj.uri != pt_origin.uri:
-            if pt_origin.uri in accessibles_by_crowfly.odt:
-                pt_journey.sections[0].origin.CopyFrom(requested_orig_obj)
-            elif _is_crowfly_needed(
-                pt_origin.uri, fallback_durations, accessibles_by_crowfly.crowfly, fallback_dp
-            ):
-                crowfly_departure_dt = (
-                    pt_journey.departure_date_time - fallback_durations[pt_origin.uri].duration
-                )
-                pt_journey.sections.extend(
-                    [
-                        _create_crowfly(
-                            pt_journey,
-                            requested_orig_obj,
-                            pt_origin,
-                            crowfly_departure_dt,
-                            pt_journey.sections[0].begin_date_time,
-                            dep_mode,
-                        )
-                    ]
-                )
+            if pt_obj.uri in accessibles_by_crowfly.odt:
+                pt_obj.CopyFrom(requested_obj)
             else:
                 # extend the journey with the fallback routing path
-                _extend_journey(pt_journey, fallback_dp, fallback_period_extremity)
+                fallback_period_extremity = PeriodExtremity(pt_datetime, represent_start)
+                crowfly_origin, crowfly_destination = fallback_logic.route_params(requested_obj, pt_obj)
+
+                fallback_dp = streetnetwork_path_pool.wait_and_get(
+                    crowfly_origin,
+                    crowfly_destination,
+                    mode,
+                    fallback_period_extremity,
+                    fallback_type,
+                    request=request,
+                )
+
+                if _is_crowfly_needed(
+                    pt_obj.uri, fallback_durations, accessibles_by_crowfly.crowfly, fallback_dp
+                ):
+                    fallback_duration = fallback_durations[pt_obj.uri].duration
+                    crowfly_dt = fallback_logic.get_crowfly_datetime(pt_datetime, fallback_duration)
+                    begin, end = fallback_logic.route_params(crowfly_dt, section_datetime)
+
+                    pt_journey.sections.extend(
+                        [_create_crowfly(pt_journey, crowfly_origin, crowfly_destination, begin, end, mode)]
+                    )
+                else:
+                    _extend_journey(pt_journey, fallback_dp, fallback_period_extremity)
 
         pt_journey.sections.sort(SectionSorter())
-        pt_journey.departure_date_time = pt_journey.sections[0].begin_date_time
+        fallback_logic.set_fallback_datetime(pt_journey)
 
-    return pt_journeys
-
-
-def _build_to(
-    requested_dest_obj,
-    pt_journeys,
-    arr_mode,
-    streetnetwork_path_pool,
-    dest_accessible_by_crowfly,
-    dest_fallback_durations_pool,
-    request,
-):
-
-    accessibles_by_crowfly = dest_accessible_by_crowfly.wait_and_get()
-    fallback_durations = dest_fallback_durations_pool.wait_and_get(arr_mode)
-
-    for pt_journey in pt_journeys.journeys:
-        pt_destination = pt_journey.sections[-1].destination
-        last_section_end = pt_journey.sections[-1].end_date_time
-
-        if requested_dest_obj.uri != pt_destination.uri:
-            fallback_period_extremity = PeriodExtremity(pt_journey.arrival_date_time, True)
-            # extend the journey with the fallback routing path
-            direct_path_type = StreetNetworkPathType.ENDING_FALLBACK
-            fallback_dp = streetnetwork_path_pool.wait_and_get(
-                pt_destination,
-                requested_dest_obj,
-                arr_mode,
-                fallback_period_extremity,
-                direct_path_type,
-                request=request,
-            )
-            if pt_destination.uri in accessibles_by_crowfly.odt:
-                pt_journey.sections[-1].destination.CopyFrom(requested_dest_obj)
-            elif _is_crowfly_needed(
-                pt_destination.uri, fallback_durations, accessibles_by_crowfly.crowfly, fallback_dp
-            ):
-                crowfly_arrival_dt = (
-                    pt_journey.arrival_date_time + fallback_durations[pt_destination.uri].duration
-                )
-                pt_journey.sections.extend(
-                    [
-                        _create_crowfly(
-                            pt_journey,
-                            pt_destination,
-                            requested_dest_obj,
-                            last_section_end,
-                            crowfly_arrival_dt,
-                            arr_mode,
-                        )
-                    ]
-                )
-            else:
-                _extend_journey(pt_journey, fallback_dp, fallback_period_extremity)
-
-        pt_journey.sections.sort(SectionSorter())
-        pt_journey.arrival_date_time = pt_journey.sections[-1].end_date_time
     return pt_journeys
 
 
@@ -369,7 +359,7 @@ def complete_pt_journey(
 
     logger.debug("building pt journey starts with %s and ends with %s", dep_mode, arr_mode)
 
-    pt_journeys = _build_from(
+    pt_journeys = _build_fallback(
         requested_orig_obj,
         pt_journeys,
         dep_mode,
@@ -377,9 +367,10 @@ def complete_pt_journey(
         orig_places_free_access,
         orig_fallback_durations_pool,
         request=request,
+        fallback_type=StreetNetworkPathType.BEGINNING_FALLBACK,
     )
 
-    pt_journeys = _build_to(
+    pt_journeys = _build_fallback(
         requested_dest_obj,
         pt_journeys,
         arr_mode,
@@ -387,6 +378,7 @@ def complete_pt_journey(
         dest_places_free_access,
         dest_fallback_durations_pool,
         request=request,
+        fallback_type=StreetNetworkPathType.ENDING_FALLBACK,
     )
 
     logger.debug("finish building pt journey starts with %s and ends with %s", dep_mode, arr_mode)

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -474,6 +474,10 @@ def get_qualified_journeys(responses):
     return (j for r in responses for j in r.journeys if not to_be_deleted(j))
 
 
+def num_qualifed_journeys(responses):
+    return sum(1 for j in get_qualified_journeys(responses))
+
+
 def get_all_journeys(responses):
     """
     :param responses: protobuf

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -288,6 +288,36 @@ def journey_pairs_gen(list_responses):
     return itertools.combinations(jf.get_qualified_journeys(list_responses), 2)
 
 
+def test_get_qualified_journeys():
+    responses = [response_pb2.Response()]
+    journey1 = responses[0].journeys.add()
+    journey1.tags.append("a_tag")
+
+    journey2 = responses[0].journeys.add()
+    journey2.tags.append("to_delete")
+
+    journey3 = responses[0].journeys.add()
+    journey3.tags.append("another_tag")
+    journey3.tags.append("to_delete")
+
+    for qualified in jf.get_qualified_journeys(responses):
+        assert qualified.tags[0] == 'a_tag'
+
+
+def test_num_qualifed_journeys():
+    responses = [response_pb2.Response()]
+    journey1 = responses[0].journeys.add()
+    journey1.tags.append("a_tag")
+
+    journey2 = responses[0].journeys.add()
+    journey2.tags.append("to_delete")
+
+    journey3 = responses[0].journeys.add()
+    journey3.tags.append("another_tag")
+
+    assert jf.num_qualifed_journeys(responses) == 2
+
+
 def test_journeys_equality_test_almost_same_journeys():
     """
     test the are_equals method, applied to different journeys, but with meaningless differences


### PR DESCRIPTION
I've just prepared the codebase for the upcoming changes, where the journeys will be attached a crowfly before being filtered. Only then, fallbacks will be computed.

The only change in the business logic is that we are now waiting on the pt_journeys in the `call_kraken` **before** computing the fallbacks.

There is a new function in the scenario (`Scenario.finalise_journeys()`) that will be moved after the filtering.
