### PR TITLE
Jormun: add a memory cache layer and migration to flask_caching

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -35,7 +35,7 @@ import logging.config
 import os
 from flask import Flask, got_request_exception
 from flask_restful import Api
-from flask_cache import Cache
+from flask_caching import Cache
 from flask_cors import CORS
 import sys
 import six
@@ -86,6 +86,7 @@ from navitiacommon.models import db
 
 db.init_app(app)
 cache = Cache(app, config=app.config['CACHE_CONFIGURATION'])
+memory_cache = Cache(app, config=app.config['MEMORY_CACHE_CONFIGURATION'])
 
 if app.config['AUTOCOMPLETE_SYSTEMS'] is not None:
     global_autocomplete = {k: utils.create_object(v) for k, v in app.config['AUTOCOMPLETE_SYSTEMS'].items()}

--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -39,7 +39,7 @@ from jormungandr.exceptions import RegionNotFound
 import datetime
 import base64
 from navitiacommon.models import User, Instance, Key
-from jormungandr import cache, app as current_app
+from jormungandr import cache, memory_cache, app as current_app
 
 
 def authentication_required(func):
@@ -105,6 +105,7 @@ def get_token():
         return auth
 
 
+@memory_cache.memoize(current_app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 30))
 @cache.memoize(current_app.config['CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 300))
 def has_access(region, api, abort, user):
     """
@@ -139,6 +140,7 @@ def has_access(region, api, abort, user):
             return False
 
 
+@memory_cache.memoize(current_app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 30))
 @cache.memoize(current_app.config['CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 300))
 def cache_get_user(token):
     """
@@ -148,11 +150,13 @@ def cache_get_user(token):
     return User.get_from_token(token, datetime.datetime.now())
 
 
+@memory_cache.memoize(current_app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 30))
 @cache.memoize(current_app.config['CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 300))
 def cache_get_key(token):
     return Key.get_by_token(token)
 
 
+@memory_cache.memoize(current_app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 30))
 @cache.memoize(current_app.config['CACHE_CONFIGURATION'].get('TIMEOUT_AUTHENTICATION', 300))
 def get_all_available_instances(user):
     """

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -89,7 +89,7 @@ STAT_CIRCUIT_BREAKER_MAX_FAIL = int(os.getenv('JORMUNGANDR_STAT_CIRCUIT_BREAKER_
 # the circuit breaker retries after this timeout (in seconds)
 STAT_CIRCUIT_BREAKER_TIMEOUT_S = int(os.getenv('JORMUNGANDR_STAT_CIRCUIT_BREAKER_TIMEOUT_S', 60))
 
-# Cache configuration, see https://pythonhosted.org/Flask-Cache/ for more information
+# Cache configuration, see https://pythonhosted.org/Flask-Caching/ for more information
 default_cache = {
     'CACHE_TYPE': 'null',  # by default cache is not activated
     'TIMEOUT_PTOBJECTS': 600,
@@ -100,6 +100,17 @@ default_cache = {
 }
 
 CACHE_CONFIGURATION = json.loads(os.getenv('JORMUNGANDR_CACHE_CONFIGURATION', '{}')) or default_cache
+
+
+default_memory_cache = {
+    'CACHE_TYPE': 'null',  # by default cache is not activated
+    'TIMEOUT_AUTHENTICATION': 30,
+    'TIMEOUT_PARAMS': 30,
+}
+
+MEMORY_CACHE_CONFIGURATION = (
+    json.loads(os.getenv('JORMUNGANDR_MEMORY_CACHE_CONFIGURATION', '{}')) or default_memory_cache
+)
 
 # List of enabled modules
 MODULES = {

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -45,7 +45,7 @@ import logging
 from .exceptions import DeadSocketException
 from navitiacommon import models
 from importlib import import_module
-from jormungandr import cache, app, global_autocomplete
+from jormungandr import cache, memory_cache, app, global_autocomplete
 from shapely import wkt
 from shapely.geos import ReadingError
 from shapely import geometry
@@ -169,6 +169,7 @@ class Instance(object):
     def __repr__(self):
         return 'instance.{}'.format(self.name)
 
+    @memory_cache.memoize(app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_PARAMS', 30))
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_PARAMS', 300))
     def _get_models(self):
         if app.config['DISABLE_DATABASE']:

--- a/source/jormungandr/jormungandr/travelers_profile.py
+++ b/source/jormungandr/jormungandr/travelers_profile.py
@@ -28,7 +28,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from jormungandr import app, cache
+from jormungandr import app, cache, memory_cache
 from navitiacommon import models
 from navitiacommon.default_traveler_profile_params import (
     default_traveler_profile_params,
@@ -108,6 +108,7 @@ class TravelerProfile(object):
         list(map(override, arg_2_profile_attr))
 
     @classmethod
+    @memory_cache.memoize(app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_PARAMS', 30))
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_PARAMS', 300))
     def make_traveler_profile(cls, coverage, traveler_type):
         """
@@ -140,6 +141,7 @@ class TravelerProfile(object):
         )
 
     @classmethod
+    @memory_cache.memoize(app.config['MEMORY_CACHE_CONFIGURATION'].get('TIMEOUT_PARAMS', 30))
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_PARAMS', 300))
     def get_profiles_by_coverage(cls, coverage):
         traveler_profiles = []

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -35,7 +35,7 @@ future==0.15.2
 zeep==1.1.0
 --no-binary=gevent,greenlet #the wheel is built against python 2.7.4 and debian is on 2.7.3 :(
 gevent==1.1.2
-Flask-Cache==0.13.1
+Flask-Caching==1.4.0
 git+https://github.com/canaltp/serpy.git@ctp
 python-json-logger==0.1.7
 jmespath==0.9.3


### PR DESCRIPTION
Flask_cache is unmaintained since 2014, it has been forked and maintained has flask_caching.
This PR also add a new cache instance named `memory_cache` that aims to
provide a first layer of cache that is faster (but local) than the
traditional `cache` that is (most of the time) backed by a redis.

The `memory_cache` is only used to reduce load on the database and as
such isn't used for realtime proxies. This is mostly due to the fact
that the priviligied backend for this cache will be the [uwsgi
cache](https://uwsgi-docs.readthedocs.io/en/latest/Caching.html) that
require to be configured with a maximum number of item and doesn't
provide both LRU and time based expiration at the same time.