### PR TITLE
Jormun: fix missing feed publisher

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -771,7 +771,7 @@ def merge_responses(responses, debug):
             fp
             for fp in r.feed_publishers
             if fp.id not in initial_feed_publishers
-            and (debug or all('to_delete' not in j.tags for j in r.journeys))
+            and (debug or any('to_delete' not in j.tags for j in r.journeys))
         )
 
         # handle impacts

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -771,7 +771,7 @@ def merge_responses(responses, debug):
             fp
             for fp in r.feed_publishers
             if fp.id not in initial_feed_publishers
-            and (debug or any('to_delete' not in j.tags for j in r.journeys))
+            and (debug or len(responses) == 1 or all('to_delete' not in j.tags for j in r.journeys))
         )
 
         # handle impacts

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -771,7 +771,7 @@ def merge_responses(responses, debug):
             fp
             for fp in r.feed_publishers
             if fp.id not in initial_feed_publishers
-            and (debug or len(responses) == 1 or all('to_delete' not in j.tags for j in r.journeys))
+            and (debug or any('to_delete' not in j.tags for j in r.journeys))
         )
 
         # handle impacts

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -312,25 +312,15 @@ def merge_responses_feed_publishers_test():
     merged_response = new_default.merge_responses(r, False)
     assert len(merged_response.feed_publishers) == 2
 
-    # The 2nd journey is to be deleted so its feed publisher won't be exposed
+    # The 2nd journey is to be deleted, the feed publisher should still be exposed
     resp2.journeys.add().tags.extend(['to_delete'])
     merged_response = new_default.merge_responses(r, False)
-    assert len(merged_response.feed_publishers) == 1
+    assert len(merged_response.feed_publishers) == 2
     assert merged_response.feed_publishers[0].id == 'Bobby'
 
     # With 'debug=True', the journey to delete is exposed and so is its feed publisher
     merged_response = new_default.merge_responses(r, True)
     assert len(merged_response.feed_publishers) == 2
-
-    resp3 = response_pb2.Response()
-    fp3 = resp3.feed_publishers.add()
-    fp3.id = "Bobbybette"
-    resp3.journeys.add()
-    resp3.journeys.add().tags.extend(['to_delete'])
-    r = [resp3]
-    merged_response = new_default.merge_responses(r, False)
-    assert len(merged_response.feed_publishers) == 1
-    assert merged_response.feed_publishers[0].id == 'Bobbybette'
 
 
 def add_pt_sections(journey):

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -301,11 +301,11 @@ def merge_responses_feed_publishers_test():
     resp1 = response_pb2.Response()
     fp1 = resp1.feed_publishers.add()
     fp1.id = "Bobby"
-    resp1.journeys.add()
+    j1 = resp1.journeys.add()
     resp2 = response_pb2.Response()
     fp2 = resp2.feed_publishers.add()
     fp2.id = "Bobbette"
-    resp2.journeys.add()
+    j2 = resp2.journeys.add()
     r = [resp1, resp2]
 
     # The feed publishers of both journeys are exposed
@@ -317,6 +317,12 @@ def merge_responses_feed_publishers_test():
     merged_response = new_default.merge_responses(r, False)
     assert len(merged_response.feed_publishers) == 2
     assert merged_response.feed_publishers[0].id == 'Bobby'
+
+    # All journeys are tagged as 'to_delete', no feed publishers should be exposed
+    j1.tags.extend(['to_delete'])
+    j2.tags.extend(['to_delete'])
+    merged_response = new_default.merge_responses([resp1, resp2], False)
+    assert len(merged_response.feed_publishers) == 0
 
     # With 'debug=True', the journey to delete is exposed and so is its feed publisher
     merged_response = new_default.merge_responses(r, True)

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -322,6 +322,16 @@ def merge_responses_feed_publishers_test():
     merged_response = new_default.merge_responses(r, True)
     assert len(merged_response.feed_publishers) == 2
 
+    resp3 = response_pb2.Response()
+    fp3 = resp3.feed_publishers.add()
+    fp3.id = "Bobbybette"
+    resp3.journeys.add()
+    resp3.journeys.add().tags.extend(['to_delete'])
+    r = [resp3]
+    merged_response = new_default.merge_responses(r, False)
+    assert len(merged_response.feed_publishers) == 1
+    assert merged_response.feed_publishers[0].id == 'Bobbybette'
+
 
 def add_pt_sections(journey):
     section = journey.sections.add()


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVITIAII-2570

The feed_publisher is missing when requesting journeys.


According to the old code, we accept the feed_publisher returned by kraken when ALL journeys are NOT tagged as `to_delete`(tagged/filtered by jormun).

Now consider the following request(i suggest to do it twice, with and without debug=true):

http://api.navitia.io/v1/journeys?from=3.05719%3B50.63871&to=3.04797%3B50.6211&datetime=20180827T080000&datetime_represents=departure&forbidden_uris%5B%5D=physical_mode%3ALongDistanceTrain&forbidden_uris%5B%5D=physical_mode%3ATrain&forbidden_uris%5B%5D=physical_mode%3ATaxi&forbidden_uris%5B%5D=physical_mode%3ABoat&forbidden_uris%5B%5D=physical_mode%3AFerry&forbidden_uris%5B%5D=physical_mode%3AAir&forbidden_uris%5B%5D=physical_mode%3ACar&forbidden_uris%5B%5D=physical_mode%3ATrolleybus

With debug, the feed_publishers appear! 

The tricky thing here is that kraken has returned 4 journeys, one of these are filtered(a.k.a tagged as `to_delete`), the M1 journey is deleted because it looks like the another very much(kraken returned that journey because from the point of view front pareto, it makes sense). When dealing with the feed_publisher, we just omit them because there is one journey among 4 is tagged as `to_delete`.

So is it ok that replace `all` by `any` in this case?