### PR TITLE
jormun: Sytral realtime based on sytral-rt

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -144,6 +144,9 @@ CIRCUIT_BREAKER_CAR_PARK_TIMEOUT_S = 60  # the circuit breaker retries after thi
 CIRCUIT_BREAKER_MAX_CLEVERAGE_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_CLEVERAGE_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 
+CIRCUIT_BREAKER_MAX_SYTRAL_FAIL = 4  # max instance call failures before stopping attempt
+CIRCUIT_BREAKER_SYTRAL_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
+
 CIRCUIT_BREAKER_MAX_VALHALLA_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_VALHALLA_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -159,10 +159,8 @@ class Sytral(RealtimeProxy):
         if not url:
             return None
         r = self._call(url)
-        if not r:
-            return None
 
-        if r.status_code != 200:
+        if r.status_code != requests.codes.ok:
             logging.getLogger(__name__).error(
                 'sytralrt RT service unavailable, impossible to query : {}'.format(r.url),
                 extra={'rt_system_id': unicode(self.rt_system_id)},

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -1,0 +1,183 @@
+# coding=utf-8
+
+# Copyright (c) 2001-2016, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, division
+from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, RealtimeProxyError
+from flask import logging
+import pybreaker
+import pytz
+import requests as requests
+from jormungandr import cache, app
+from jormungandr.schedule import RealTimePassage
+import aniso8601
+
+
+class Sytral(RealtimeProxy):
+    """
+    class managing calls to sytral-rt service providing real-time next passages
+
+    """
+
+    def __init__(
+        self,
+        id,
+        service_url,
+        object_id_tag="source",
+        destination_id_tag="source",
+        instance=None,
+        timeout=2,
+        **kwargs
+    ):
+        self.service_url = service_url
+        self.timeout = timeout  # timeout in seconds
+        self.rt_system_id = id
+        self.object_id_tag = object_id_tag
+        self.destination_id_tag = destination_id_tag
+        self.instance = instance
+        self.breaker = pybreaker.CircuitBreaker(
+            fail_max=app.config['CIRCUIT_BREAKER_MAX_SYTRAL_FAIL'],
+            reset_timeout=app.config['CIRCUIT_BREAKER_SYTRAL_TIMEOUT_S'],
+        )
+        # TODO create a logger (with rt_system_id) and use it everywhere
+
+    def __repr__(self):
+        """
+         used as the cache key. we use the rt_system_id to share the cache between servers in production
+        """
+        try:
+            return self.rt_system_id.encode('utf-8', 'backslashreplace')
+        except:
+            return self.rt_system_id
+
+    @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_SYTRAL', 30))
+    def _call(self, url):
+        """
+        http call to sytralRT
+        """
+        logging.getLogger(__name__).debug(
+            'systralRT RT service , call url : {}'.format(url),
+            extra={'rt_system_id': unicode(self.rt_system_id)},
+        )
+        try:
+            return self.breaker.call(requests.get, url, timeout=self.timeout)
+        except pybreaker.CircuitBreakerError as e:
+            logging.getLogger(__name__).error(
+                'systralRT RT service dead, using base ' 'schedule (error: {}'.format(e),
+                extra={'rt_system_id': unicode(self.rt_system_id)},
+            )
+            raise RealtimeProxyError('circuit breaker open')
+        except requests.Timeout as t:
+            logging.getLogger(__name__).error(
+                'systralRT RT service timeout, using base ' 'schedule (error: {}'.format(t),
+                extra={'rt_system_id': unicode(self.rt_system_id)},
+            )
+            raise RealtimeProxyError('timeout')
+        except Exception as e:
+            logging.getLogger(__name__).exception(
+                'systralRT RT error, using base schedule', extra={'rt_system_id': unicode(self.rt_system_id)}
+            )
+            raise RealtimeProxyError(str(e))
+
+    def _make_url(self, route_point):
+        """
+        The url returns something like a departure on a stop point
+        """
+
+        stop_id = route_point.fetch_stop_id(self.object_id_tag)
+
+        if not stop_id:
+            # one a the id is missing, we'll not find any realtime
+            logging.getLogger(__name__).debug(
+                'missing realtime id for {obj}: stop code={s}'.format(obj=route_point, s=stop_id),
+                extra={'rt_system_id': unicode(self.rt_system_id)},
+            )
+            self.record_internal_failure('missing id')
+            return None
+
+        url = "{base_url}?stop_id={stop_id}".format(base_url=self.service_url, stop_id=stop_id)
+
+        return url
+
+    def _get_dt(self, datetime_str):
+        dt = aniso8601.parse_datetime(datetime_str)
+
+        utc_dt = dt.astimezone(pytz.utc)
+
+        return utc_dt
+
+    def _get_passages(self, route_point, resp):
+        logging.getLogger(__name__).debug(
+            'sytralrt response: {}'.format(resp), extra={'rt_system_id': unicode(self.rt_system_id)}
+        )
+
+        line_code = route_point.fetch_line_id(self.object_id_tag)
+
+        departures = resp.get('departures', [])
+        next_passages = []
+        for next_expected_st in departures:
+            if line_code != next_expected_st['line']:
+                continue
+            dt = self._get_dt(next_expected_st['datetime'])
+            direction = next_expected_st.get('direction_name')
+            is_real_time = next_expected_st.get('type') == 'E'
+            next_passage = RealTimePassage(dt, direction, is_real_time)
+            next_passages.append(next_passage)
+
+        return next_passages
+
+    def _get_next_passage_for_route_point(
+        self, route_point, count=None, from_dt=None, current_dt=None, duration=None
+    ):
+        url = self._make_url(route_point)
+        if not url:
+            return None
+        r = self._call(url)
+        if not r:
+            return None
+
+        if r.status_code != 200:
+            logging.getLogger(__name__).error(
+                'sytralrt RT service unavailable, impossible to query : {}'.format(r.url),
+                extra={'rt_system_id': unicode(self.rt_system_id)},
+            )
+            raise RealtimeProxyError('non 200 response')
+
+        return self._get_passages(route_point, r.json())
+
+    def status(self):
+        return {
+            'id': unicode(self.rt_system_id),
+            'timeout': self.timeout,
+            'circuit_breaker': {
+                'current_state': self.breaker.current_state,
+                'fail_counter': self.breaker.fail_counter,
+                'reset_timeout': self.breaker.reset_timeout,
+            },
+        }

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -32,9 +32,10 @@ from __future__ import absolute_import
 from datetime import datetime
 import pytz
 from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy
-from jormungandr.schedule import RealTimePassage
+from jormungandr.schedule import RealTimePassage, RoutePoint
 from jormungandr.utils import date_to_timestamp as d2t
 from six.moves import map
+from navitiacommon.type_pb2 import Route
 
 
 class CustomProxy(RealtimeProxy):
@@ -136,3 +137,28 @@ def filter_filter_dt_duration_test(mocker):
 
     r = proxy.next_passage_for_route_point(None, from_dt=d2t(dt("10:00")), duration=3600)
     assert list(map(get_dt, r)) == [dt("10:00"), dt("11:00")]
+
+
+def test_route_point_get_code():
+    r = Route()
+    c = r.codes.add()
+    c.value = "foo"
+    c.type = "source"
+
+    c = r.codes.add()
+    c.value = "bar"
+    c.type = "extcode"
+
+    assert RoutePoint._get_all_codes(r, "source") == ["foo"]
+    assert RoutePoint._get_all_codes(r, "extcode") == ["bar"]
+    # add a duplicate, this happen in real life...
+    c = r.codes.add()
+    c.value = "foo"
+    c.type = "source"
+    assert RoutePoint._get_all_codes(r, "source") == ["foo"]
+
+    # source has two different values(think fusion)
+    c = r.codes.add()
+    c.value = "foo3"
+    c.type = "source"
+    assert RoutePoint._get_all_codes(r, "source") == ["foo", "foo3"]

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_test.py
@@ -151,7 +151,7 @@ def test_route_point_get_code():
 
     assert RoutePoint._get_all_codes(r, "source") == ["foo"]
     assert RoutePoint._get_all_codes(r, "extcode") == ["bar"]
-    # add a duplicate, this happen in real life...
+    # add a duplicate, this happens in real life...
     c = r.codes.add()
     c.value = "foo"
     c.type = "source"

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
@@ -1,0 +1,307 @@
+# coding=utf-8
+# Copyright (c) 2001-2016, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+# the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, division
+import mock
+from jormungandr.realtime_schedule.sytral import Sytral
+import validators
+import datetime
+import pytz
+import pytest
+
+
+def make_url_test():
+    sytral = Sytral(id='tata', service_url='http://bob.com/')
+
+    url = sytral._make_url(MockRoutePoint(line_code='line_toto', stop_id='stop_tutu'))
+
+    # it should be a valid url
+    assert validators.url(url)
+
+    assert url == 'http://bob.com/?stop_id=stop_tutu'
+
+
+def make_url_invalid_code_test():
+    """
+    test make_url when RoutePoint does not have a mandatory code
+
+    we should not get any url
+    """
+    sytral = Sytral(id='tata', service_url='http://bob.com/')
+
+    url = sytral._make_url(MockRoutePoint(line_code='line_toto', stop_id=None))
+
+    assert url is None
+
+
+class MockResponse(object):
+    def __init__(self, data, status_code, url, *args, **kwargs):
+        self.data = data
+        self.status_code = status_code
+        self.url = url
+
+    def json(self):
+        return self.data
+
+
+class MockRequests(object):
+    def __init__(self, responses):
+        self.responses = responses
+
+    def get(self, url, *args, **kwargs):
+        return MockResponse(self.responses[url][0], self.responses[url][1], url)
+
+
+@pytest.fixture(scope="module")
+def mock_good_response():
+    return {
+        "departures": [
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:37:15+02:00",
+                "type": "E",
+                "line": "05",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:38:15+02:00",
+                "type": "E",
+                "line": "04",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:45:35+02:00",
+                "type": "E",
+                "line": "05",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:49:35+02:00",
+                "type": "E",
+                "line": "04",
+                "stop": "42",
+            },
+        ]
+    }
+
+
+@pytest.fixture(scope="module")
+def mock_empty_response():
+    return {}
+
+
+@pytest.fixture(scope="module")
+def mock_no_departure_response():
+    return {"departures": []}
+
+
+@pytest.fixture(scope="module")
+def mock_missing_line_response():
+    return {
+        "departures": [
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:38:15+02:00",
+                "type": "E",
+                "line": "04",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:49:35+02:00",
+                "type": "E",
+                "line": "04",
+                "stop": "42",
+            },
+        ]
+    }
+
+
+@pytest.fixture(scope="module")
+def mock_theoric_response():
+    return {
+        "departures": [
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:37:15+01:00",
+                "type": "T",
+                "line": "05",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:38:15+01:00",
+                "type": "E",
+                "line": "04",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:45:35+01:00",
+                "type": "E",
+                "line": "05",
+                "stop": "42",
+            },
+            {
+                "direction_id": "3341",
+                "direction_name": "Piscine Chambéry",
+                "datetime": "2016-04-11T14:49:35+01:00",
+                "type": "E",
+                "line": "04",
+                "stop": "42",
+            },
+        ]
+    }
+
+
+class MockRoutePoint(object):
+    def __init__(self, *args, **kwars):
+        self._hardcoded_line_code = kwars['line_code']
+        self._hardcoded_stop_id = kwars['stop_id']
+
+    def fetch_stop_id(self, object_id_tag):
+        return self._hardcoded_stop_id
+
+    def fetch_line_id(self, object_id_tag):
+        return self._hardcoded_line_code
+
+
+def next_passage_for_route_point_test(mock_good_response):
+    """
+    test the whole next_passage_for_route_point
+    mock the http call to return a good response, we should get some next_passages
+    """
+    sytral = Sytral(id='tata', service_url='http://bob.com/')
+
+    mock_requests = MockRequests({'http://bob.com/?stop_id=42': (mock_good_response, 200)})
+
+    route_point = MockRoutePoint(line_code='05', stop_id='42')
+
+    with mock.patch('requests.get', mock_requests.get):
+        passages = sytral.next_passage_for_route_point(route_point)
+
+        assert len(passages) == 2
+
+        assert passages[0].datetime == datetime.datetime(2016, 4, 11, 12, 37, 15, tzinfo=pytz.UTC)
+        assert passages[0].is_real_time
+        assert passages[1].datetime == datetime.datetime(2016, 4, 11, 12, 45, 35, tzinfo=pytz.UTC)
+        assert passages[1].is_real_time
+
+
+def next_passage_for_empty_response_test(mock_empty_response):
+    """
+    test the whole next_passage_for_route_point
+    mock the http call to return a empty response, we should get None
+    """
+    sytral = Sytral(id='tata', service_url='http://bob.com/')
+
+    mock_requests = MockRequests({'http://bob.com/?stop_id=42': (mock_empty_response, 500)})
+
+    route_point = MockRoutePoint(line_code='05', stop_id='42')
+
+    with mock.patch('requests.get', mock_requests.get):
+        passages = sytral.next_passage_for_route_point(route_point)
+
+        assert passages is None
+
+
+def next_passage_for_no_departures_response_test(mock_no_departure_response):
+    """
+    test the whole next_passage_for_route_point
+    mock the http call to return a response without any departures, we should get no departure
+    """
+    sytral = Sytral(id='tata', service_url='http://bob.com/')
+
+    mock_requests = MockRequests({'http://bob.com/?stop_id=42': (mock_no_departure_response, 200)})
+
+    route_point = MockRoutePoint(line_code='05', stop_id='42')
+
+    with mock.patch('requests.get', mock_requests.get):
+        passages = sytral.next_passage_for_route_point(route_point)
+
+        assert passages == []
+
+
+def next_passage_for_missing_line_response_test(mock_missing_line_response):
+    """
+    test the whole next_passage_for_route_point
+    mock the http call to return a response without wanted line  we should get no departure
+    """
+    sytral = Sytral(id='tata', service_url='http://bob.com/', service_args={'a': 'bobette', 'b': '12'})
+
+    mock_requests = MockRequests({'http://bob.com/?stop_id=42': (mock_missing_line_response, 200)})
+
+    route_point = MockRoutePoint(line_code='05', stop_id='42')
+
+    with mock.patch('requests.get', mock_requests.get):
+        passages = sytral.next_passage_for_route_point(route_point)
+
+        assert passages == []
+
+
+def next_passage_with_theoric_time_response_test(mock_theoric_response):
+    """
+    test the whole next_passage_for_route_point
+    mock the http call to return a response with a theoric time we should get one departure
+    """
+    sytral = Sytral(id='tata', service_url='http://bob.com/', service_args={'a': 'bobette', 'b': '12'})
+
+    mock_requests = MockRequests({'http://bob.com/?stop_id=42': (mock_theoric_response, 200)})
+
+    route_point = MockRoutePoint(line_code='05', stop_id='42')
+
+    with mock.patch('requests.get', mock_requests.get):
+        passages = sytral.next_passage_for_route_point(route_point)
+
+        assert len(passages) == 2
+
+        assert passages[0].datetime == datetime.datetime(2016, 4, 11, 13, 37, 15, tzinfo=pytz.UTC)
+        assert not passages[0].is_real_time
+        assert passages[1].datetime == datetime.datetime(2016, 4, 11, 13, 45, 35, tzinfo=pytz.UTC)
+        assert passages[1].is_real_time
+
+
+def status_test():
+    sytral = Sytral(
+        id=u'tata-é$~#@"*!\'`§èû', service_url='http://bob.com/', service_args={'a': 'bobette', 'b': '12'}
+    )
+    status = sytral.status()
+    assert status['id'] == u"tata-é$~#@\"*!'`§èû"

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -119,7 +119,7 @@ class RoutePoint(object):
 
     @staticmethod
     def _get_all_codes(obj, object_id_tag):
-        return [c.value for c in obj.codes if c.type == object_id_tag]
+        return list({c.value for c in obj.codes if c.type == object_id_tag})
 
     def _get_code(self, obj, object_id_tag):
         tags = self._get_all_codes(obj, object_id_tag)

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1353,6 +1353,7 @@ def new_default_pagination_journey_comparator(clockwise):
 def has_the_disruption(response, disrupt_id):
     return any([d['id'] for d in response['disruptions'] if d['id'] == disrupt_id])
 
+
 def get_departure(dep, sp_uri, line_code):
     """ small helper that extract the information from a route point departures """
     return [

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1352,3 +1352,26 @@ def new_default_pagination_journey_comparator(clockwise):
 
 def has_the_disruption(response, disrupt_id):
     return any([d['id'] for d in response['disruptions'] if d['id'] == disrupt_id])
+
+def get_departure(dep, sp_uri, line_code):
+    """ small helper that extract the information from a route point departures """
+    return [
+        {
+            'rt': r['stop_date_time']['data_freshness'] == 'realtime',
+            'dt': r['stop_date_time']['departure_date_time'],
+        }
+        for r in dep
+        if r['stop_point']['id'] == sp_uri and r['route']['line']['code'] == line_code
+    ]
+
+
+def get_schedule(scs, sp_uri, line_code):
+    """ small helper that extract the information from a route point stop schedule """
+    return [
+        {'rt': r['data_freshness'] == 'realtime', 'dt': r['date_time']}
+        for r in next(
+            rp_sched['date_times']
+            for rp_sched in scs
+            if rp_sched['stop_point']['id'] == sp_uri and rp_sched['route']['line']['code'] == line_code
+        )
+    ]

--- a/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_cleverage_integration_tests.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import mock
 
 from jormungandr.tests.utils_test import MockRequests
-from tests.check_utils import get_not_null
+from tests.check_utils import get_not_null, get_departure, get_schedule
 from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
@@ -50,30 +50,6 @@ MOCKED_PROXY_CONF = [
         },
     }
 ]
-
-
-def _get_departure(dep, sp_uri, line_code):
-    """ small helper that extract the information from a route point departures """
-    return [
-        {
-            'rt': r['stop_date_time']['data_freshness'] == 'realtime',
-            'dt': r['stop_date_time']['departure_date_time'],
-        }
-        for r in dep
-        if r['stop_point']['id'] == sp_uri and r['route']['line']['code'] == line_code
-    ]
-
-
-def _get_schedule(scs, sp_uri, line_code):
-    """ small helper that extract the information from a route point stop schedule """
-    return [
-        {'rt': r['data_freshness'] == 'realtime', 'dt': r['date_time']}
-        for r in next(
-            rp_sched['date_times']
-            for rp_sched in scs
-            if rp_sched['stop_point']['id'] == sp_uri and rp_sched['route']['line']['code'] == line_code
-        )
-    ]
 
 
 @dataset({'multiple_schedules': {'instance_config': {'realtime_proxies': MOCKED_PROXY_CONF}}})
@@ -155,7 +131,7 @@ class TestCleverageSchedules(AbstractTestFixture):
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
             # 2016-01-02 08:17:00
-            assert _get_schedule(scs, 'SP_1', 'code A') == [
+            assert get_schedule(scs, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': True, 'dt': '20160102T091717'},
             ]
@@ -164,7 +140,7 @@ class TestCleverageSchedules(AbstractTestFixture):
             response = self.query_region(query)
             dep = get_not_null(response, 'departures')
             assert len(dep) == 2
-            assert _get_departure(dep, 'SP_1', 'code A') == [
+            assert get_departure(dep, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': True, 'dt': '20160102T091717'},
             ]
@@ -236,7 +212,7 @@ class TestCleverageSchedules(AbstractTestFixture):
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
             # 2016-01-02 08:17:00
-            assert _get_schedule(scs, 'SP_1', 'code A') == [
+            assert get_schedule(scs, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': False, 'dt': '20160102T091717'},
             ]
@@ -245,7 +221,7 @@ class TestCleverageSchedules(AbstractTestFixture):
             response = self.query_region(query)
             dep = get_not_null(response, 'departures')
             assert len(dep) == 2
-            assert _get_departure(dep, 'SP_1', 'code A') == [
+            assert get_departure(dep, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': False, 'dt': '20160102T091717'},
             ]

--- a/source/jormungandr/tests/proxy_realtime_sytral_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_sytral_integration_tests.py
@@ -33,7 +33,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 import mock
 
 from jormungandr.tests.utils_test import MockRequests
-from tests.check_utils import get_not_null
+from tests.check_utils import get_not_null, get_departure, get_schedule
 from .tests_mechanism import AbstractTestFixture, dataset
 
 MOCKED_PROXY_CONF = [
@@ -49,30 +49,6 @@ MOCKED_PROXY_CONF = [
         },
     }
 ]
-
-
-def _get_departure(dep, sp_uri, line_code):
-    """ small helper that extract the information from a route point departures """
-    return [
-        {
-            'rt': r['stop_date_time']['data_freshness'] == 'realtime',
-            'dt': r['stop_date_time']['departure_date_time'],
-        }
-        for r in dep
-        if r['stop_point']['id'] == sp_uri and r['route']['line']['code'] == line_code
-    ]
-
-
-def _get_schedule(scs, sp_uri, line_code):
-    """ small helper that extract the information from a route point stop schedule """
-    return [
-        {'rt': r['data_freshness'] == 'realtime', 'dt': r['date_time']}
-        for r in next(
-            rp_sched['date_times']
-            for rp_sched in scs
-            if rp_sched['stop_point']['id'] == sp_uri and rp_sched['route']['line']['code'] == line_code
-        )
-    ]
 
 
 @dataset({'multiple_schedules': {'instance_config': {'realtime_proxies': MOCKED_PROXY_CONF}}})
@@ -121,7 +97,7 @@ class TestSytralSchedules(AbstractTestFixture):
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
             # 2016-01-02 08:17:00
-            assert _get_schedule(scs, 'SP_1', 'code A') == [
+            assert get_schedule(scs, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': True, 'dt': '20160102T091717'},
             ]
@@ -130,7 +106,7 @@ class TestSytralSchedules(AbstractTestFixture):
             response = self.query_region(query)
             dep = get_not_null(response, 'departures')
             assert len(dep) == 2
-            assert _get_departure(dep, 'SP_1', 'code A') == [
+            assert get_departure(dep, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': True, 'dt': '20160102T091717'},
             ]
@@ -169,7 +145,7 @@ class TestSytralSchedules(AbstractTestFixture):
             scs = get_not_null(response, 'stop_schedules')
             assert len(scs) == 1
             # 2016-01-02 08:17:00
-            assert _get_schedule(scs, 'SP_1', 'code A') == [
+            assert get_schedule(scs, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': False, 'dt': '20160102T091717'},
             ]
@@ -178,7 +154,7 @@ class TestSytralSchedules(AbstractTestFixture):
             response = self.query_region(query)
             dep = get_not_null(response, 'departures')
             assert len(dep) == 2
-            assert _get_departure(dep, 'SP_1', 'code A') == [
+            assert get_departure(dep, 'SP_1', 'code A') == [
                 {'rt': True, 'dt': '20160102T081717'},
                 {'rt': False, 'dt': '20160102T091717'},
             ]


### PR DESCRIPTION
Realtime departures for sytral, this use sytral-rt: https://github.com/CanalTP/sytralrt you should review that too before merging this PR. Sytral realtime data are provided as csv file over ftp (it's also the case for parking and equipments), It would be difficult to integrate this directly on jormungandr as it doesn't have any kind of background job and each process (around 1000 in production) is totally independent.

This connector is based on the cleverage one as we got mostly the same
information. It has the same drawback of not being able to distinguish
between the departure of two route of the same line at the same
stop_point.

The second commit isn't directly related to the sytral connector, I suggest reading each commit separately.