### PR TITLE
Jormun: add tests on endpoint /vj with timezones

### DIFF
--- a/source/jormungandr/jormungandr/tests/authentication_test.py
+++ b/source/jormungandr/jormungandr/tests/authentication_test.py
@@ -57,7 +57,7 @@ def get_token_basic_auth_unicode_test():
     base64 doesn't seems to like unicode, it doesn't matter since our token are always in ascii (uuid).
     But we want a clean error, not a 500
     """
-    key = base64.encodestring(b'maclé:').strip()
+    key = base64.encodestring(u'maclé:'.encode('utf-8')).strip()
     with app.test_request_context('/', headers={'Authorization': 'BASIC {}'.format(key)}):
         with pytest.raises(Unauthorized):
             get_token()

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 # Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
@@ -59,7 +61,7 @@ class TestPlaces(AbstractTestFixture):
         assert response['places'][0]['name'] == "Condom (03430)"
 
     def test_places_invalid_encoding(self):
-        _, status = self.query_no_assert(b'/v1/coverage/main_routing_test/places/?q=ch\xe2teau')
+        _, status = self.query_no_assert(u'/v1/coverage/main_routing_test/places/?q=ch\xe2teau'.encode('utf-8'))
         assert status != 500
 
     def test_places_do_not_loose_precision(self):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -577,7 +577,7 @@ class TestPtRef(AbstractTestFixture):
         assert get_not_null(pt_objs[0], 'name') == 'base_network line:Ça roule'
 
     def test_query_with_strange_char(self):
-        q = b'stop_points/stop_point:stop_with name bob \" , é'
+        q = u'stop_points/stop_point:stop_with name bob \" , é'.encode('utf-8')
         encoded_q = quote(q)
         response = self.query_region(encoded_q)
 
@@ -609,7 +609,8 @@ class TestPtRef(AbstractTestFixture):
     def test_journey_with_strange_char(self):
         # we use an encoded url to be able to check the links
         query = 'journeys?from={}&to={}&datetime=20140105T070000'.format(
-            quote_plus(b'stop_with name bob \" , é'), quote_plus(b'stop_area:stop1')
+            quote_plus(u'stop_with name bob \" , é'.encode('utf-8')),
+            quote_plus(u'stop_area:stop1'.encode('utf-8')),
         )
         response = self.query_region(query, display=True)
 
@@ -675,7 +676,8 @@ class TestPtRef(AbstractTestFixture):
         params['since'] = '20140105T111500+0000'
         params['until'] = '20140105T121000-0000'
         response, code = self.query_no_assert(
-            'v1/coverage/main_ptref_test/vehicle_journeys?{}'.format(urlencode(params, doseq=True)))
+            'v1/coverage/main_ptref_test/vehicle_journeys?{}'.format(urlencode(params, doseq=True))
+        )
         assert code == 404
         assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -30,6 +30,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from six.moves.urllib.parse import quote, quote_plus
 from .check_utils import journey_basic_query
+from six.moves.urllib.parse import urlencode
 from .tests_mechanism import dataset, AbstractTestFixture
 from .check_utils import *
 from six.moves import range
@@ -634,6 +635,47 @@ class TestPtRef(AbstractTestFixture):
             "v1/coverage/main_ptref_test/vehicle_journeys?since=20140109T070000"
         )
 
+        assert code == 404
+        assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
+
+    def test_vj_period_filter_with_tz(self):
+        '''
+        testing that using TZ is OK (+0130 means TZ +1h30min)
+        Note: This is especially usefull as Kirin now uses it
+        '''
+
+        # first check it's OK with no TZ
+        params = {'since': '20140105T111500', 'until': '20140105T121000', 'headsign': 'vj1'}
+        response = self.query_region('vehicle_journeys?{}'.format(urlencode(params, doseq=True)))
+        vjs = get_not_null(response, 'vehicle_journeys')
+        assert 'vj1' in (vj['id'] for vj in vjs)
+
+        # check using the actual TZ (Europe/Paris so UTC+1)
+        params['since'] = '20140105T111500+0100'
+        params['until'] = '20140105T121000+0100'
+        response = self.query_region('vehicle_journeys?{}'.format(urlencode(params, doseq=True)))
+        vjs = get_not_null(response, 'vehicle_journeys')
+        assert 'vj1' in (vj['id'] for vj in vjs)
+
+        # check converting time correctly to UTC
+        params['since'] = '20140105T101500+0000'
+        params['until'] = '20140105T111000+0000'
+        response = self.query_region('vehicle_journeys?{}'.format(urlencode(params, doseq=True)))
+        vjs = get_not_null(response, 'vehicle_journeys')
+        assert 'vj1' in (vj['id'] for vj in vjs)
+
+        # check converting time correctly to 2 random TZ
+        params['since'] = '20140105T034500-0630'
+        params['until'] = '20140105T192500+0815'
+        response = self.query_region('vehicle_journeys?{}'.format(urlencode(params, doseq=True)))
+        vjs = get_not_null(response, 'vehicle_journeys')
+        assert 'vj1' in (vj['id'] for vj in vjs)
+
+        # check putting time in UTC with a mistake returns no VJ as it's then out of VJ's period
+        params['since'] = '20140105T111500+0000'
+        params['until'] = '20140105T121000-0000'
+        response, code = self.query_no_assert(
+            'v1/coverage/main_ptref_test/vehicle_journeys?{}'.format(urlencode(params, doseq=True)))
         assert code == 404
         assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
 

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -89,25 +89,32 @@ class InstanceConfig(object):
 
 
 def load_instance_config(instance_name):
+    def b(unicode):
+        """
+        convert unicode to bytestring
+        """
+        return unicode.encode('utf-8')
+
     confspec = []
-    confspec.append(b'[instance]')
-    confspec.append(b'source-directory = string()')
-    confspec.append(b'backup-directory = string()')
-    confspec.append(b'target-file = string()')
-    confspec.append(b'exchange = string(default="navitia")')
-    confspec.append(b'synonyms_file = string(default="")')
-    confspec.append(b'aliases_file = string(default="")')
-    confspec.append(b'name = string()')
-    confspec.append(b'is-free = boolean(default=False)')
 
-    confspec.append(b'[database]')
-    confspec.append(b'host = string()')
-    confspec.append(b'dbname = string()')
-    confspec.append(b'username = string()')
-    confspec.append(b'password = string()')
-    confspec.append(b'port = string(default="5432")')
+    confspec.append(b(u'[instance]'))
+    confspec.append(b(u'source-directory = string()'))
+    confspec.append(b(u'backup-directory = string()'))
+    confspec.append(b(u'target-file = string()'))
+    confspec.append(b(u'exchange = string(default="navitia")'))
+    confspec.append(b(u'synonyms_file = string(default="")'))
+    confspec.append(b(u'aliases_file = string(default="")'))
+    confspec.append(b(u'name = string()'))
+    confspec.append(b(u'is-free = boolean(default=False)'))
 
-    ini_file = b'%s/%s.ini' % (os.path.realpath(current_app.config['INSTANCES_DIR']), instance_name)
+    confspec.append(b(u'[database]'))
+    confspec.append(b(u'host = string()'))
+    confspec.append(b(u'dbname = string()'))
+    confspec.append(b(u'username = string()'))
+    confspec.append(b(u'password = string()'))
+    confspec.append(b(u'port = string(default="5432")'))
+
+    ini_file = b(u'%s/%s.ini') % (os.path.realpath(current_app.config['INSTANCES_DIR']), instance_name)
     if not os.path.isfile(ini_file):
         raise ValueError("File doesn't exists or is not a file %s" % ini_file)
 


### PR DESCRIPTION
"Fix" part of https://github.com/CanalTP/kirin/issues/157

It ensures that Navitia correctly handles requests from Kirin that now sometimes use timezones in the form +0130 (for a timezone that is 1h30min "east of" UTC)