### PR TITLE
Kraken: Manage adding of StopTime in realtime

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -64,6 +64,7 @@ UpdatedStopTime = make_namedtuple(
     message=None,
     departure_skipped=False,
     arrival_skipped=False,
+    is_added=False,
 )
 
 
@@ -737,6 +738,83 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
         # no realtime flags on route_schedules yet
 
 
+MAIN_ROUTING_TEST_SETTING = {
+    'main_routing_test': {
+        'kraken_args': [
+            '--BROKER.rt_topics=' + rt_topic,
+            'spawn_maintenance_worker',
+            '--GENERAL.is_realtime_add_enabled=1',
+        ]
+    }
+}
+
+
+@dataset(MAIN_ROUTING_TEST_SETTING)
+class TestKirinOnNewStopTime(MockKirinDisruptionsFixture):
+    def test_add_one_stop_time_at_the_end(self):
+        """
+        bla bla bla new_stop_time bla bla bla
+        """
+        disruptions_before = self.query_region('disruptions?_current_datetime=20120614T080000')
+        nb_disruptions_before = len(disruptions_before['disruptions'])
+
+        # New disruption same as base schedule
+        self.send_mock(
+            "vjA",
+            "20120614",
+            'modified',
+            [
+                UpdatedStopTime(
+                    "stop_point:stopB",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    arrival=tstamp("20120614T080100"),
+                    departure=tstamp("20120614T080100"),
+                    message='on time',
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopA",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    arrival=tstamp("20120614T080102"),
+                    departure=tstamp("20120614T080102"),
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopC",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080104"),
+                    departure=tstamp("20120614T080104"),
+                ),
+            ],
+            disruption_id='new_stop_time',
+        )
+
+        def has_the_disruption(response):
+            return len([d['id'] for d in response['disruptions'] if d['id'] == 'new_stop_time']) != 0
+
+        # We have a new diruption
+        disruptions_after = self.query_region('disruptions?_current_datetime=20120614T080000')
+        assert nb_disruptions_before + 1 == len(disruptions_after['disruptions'])
+        assert has_the_disruption(disruptions_after)
+
+        journey_query = journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
+        response = self.query_region(journey_query)
+        assert has_the_disruption(response)
+        self.is_valid_journey_response(response, journey_query)
+        assert response['journeys'][0]['sections'][1]['data_freshness'] == 'realtime'
+
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+            from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
+        )
+        journey_query = B_C_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
+        response = self.query_region(journey_query)
+        assert has_the_disruption(response)
+        self.is_valid_journey_response(response, journey_query)
+        assert response['journeys'][0]['sections'][0]['data_freshness'] == 'realtime'
+
+
 def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None):
     feed_message = gtfs_realtime_pb2.FeedMessage()
     feed_message.header.gtfs_realtime_version = '1.0'
@@ -764,16 +842,18 @@ def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], 
             stop_time_update.departure.time = st.departure
             stop_time_update.departure.delay = st.departure_delay
 
-            def get_relationship(is_skipped):
+            def get_relationship(is_skipped=False, is_added=False):
                 if is_skipped:
                     return gtfs_realtime_pb2.TripUpdate.StopTimeUpdate.SKIPPED
+                if is_added:
+                    return gtfs_realtime_pb2.TripUpdate.StopTimeUpdate.ADDED
                 return gtfs_realtime_pb2.TripUpdate.StopTimeUpdate.SCHEDULED
 
             stop_time_update.arrival.Extensions[kirin_pb2.stop_time_event_relationship] = get_relationship(
-                st.arrival_skipped
+                st.arrival_skipped, st.is_added
             )
             stop_time_update.departure.Extensions[kirin_pb2.stop_time_event_relationship] = get_relationship(
-                st.departure_skipped
+                st.departure_skipped, st.is_added
             )
             if st.message:
                 stop_time_update.Extensions[kirin_pb2.stoptime_message] = st.message

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -30,6 +30,9 @@
 # Note: the tests_mechanism should be the first
 # import for the conf to be loaded correctly when only this test is ran
 from __future__ import absolute_import
+
+from copy import deepcopy
+
 from datetime import datetime
 import uuid
 from tests.tests_mechanism import dataset
@@ -738,22 +741,26 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
         # no realtime flags on route_schedules yet
 
 
-MAIN_ROUTING_TEST_SETTING = {
+MAIN_ROUTING_TEST_SETTING_NO_ADD = {
     'main_routing_test': {
         'kraken_args': [
             '--BROKER.rt_topics=' + rt_topic,
             'spawn_maintenance_worker',
-            '--GENERAL.is_realtime_add_enabled=1',
-        ]
+        ]  # also check that by 'default is_realtime_add_enabled=0'
     }
 }
+
+
+MAIN_ROUTING_TEST_SETTING = deepcopy(MAIN_ROUTING_TEST_SETTING_NO_ADD)
+MAIN_ROUTING_TEST_SETTING['main_routing_test']['kraken_args'].append('--GENERAL.is_realtime_add_enabled=1')
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING)
 class TestKirinOnNewStopTime(MockKirinDisruptionsFixture):
     def test_add_one_stop_time_at_the_end(self):
         """
-        bla bla bla new_stop_time bla bla bla
+        creating a new_stop_time to add a final stop in C
+        test that a new journey is possible from B to C
         """
         disruptions_before = self.query_region('disruptions?_current_datetime=20120614T080000')
         nb_disruptions_before = len(disruptions_before['disruptions'])
@@ -794,7 +801,7 @@ class TestKirinOnNewStopTime(MockKirinDisruptionsFixture):
         def has_the_disruption(response):
             return len([d['id'] for d in response['disruptions'] if d['id'] == 'new_stop_time']) != 0
 
-        # We have a new diruption
+        # We have a new disruption
         disruptions_after = self.query_region('disruptions?_current_datetime=20120614T080000')
         assert nb_disruptions_before + 1 == len(disruptions_after['disruptions'])
         assert has_the_disruption(disruptions_after)
@@ -808,11 +815,102 @@ class TestKirinOnNewStopTime(MockKirinDisruptionsFixture):
         B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
             from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
         )
-        journey_query = B_C_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
-        response = self.query_region(journey_query)
+        base_journey_query = B_C_query + "&data_freshness=base_schedule&_current_datetime=20120614T080000"
+        response = self.query_region(base_journey_query)
+        assert not has_the_disruption(response)
+        self.is_valid_journey_response(response, base_journey_query)
+        assert len(response['journeys']) == 1  # check we only have one journey
+        assert 'data_freshness' not in response['journeys'][0]['sections'][0]  # means it's base_schedule
+
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+            from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
+        )
+        rt_journey_query = B_C_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
+        response = self.query_region(rt_journey_query)
         assert has_the_disruption(response)
-        self.is_valid_journey_response(response, journey_query)
+        self.is_valid_journey_response(response, rt_journey_query)
+        assert len(response['journeys']) == 2  # check there's a new journey possible
         assert response['journeys'][0]['sections'][0]['data_freshness'] == 'realtime'
+        assert 'data_freshness' not in response['journeys'][1]['sections'][0]  # means it's base_schedule
+
+
+@dataset(MAIN_ROUTING_TEST_SETTING_NO_ADD)
+class TestKrakenNoAdd(MockKirinDisruptionsFixture):
+    def test_no_rt_add_possible(self):
+        """
+        trying to add new_stop_time without allowing it in kraken
+        test that it is ignored
+        (same test as test_add_one_stop_time_at_the_end(), different result expected)
+        """
+        disruptions_before = self.query_region('disruptions?_current_datetime=20120614T080000')
+        nb_disruptions_before = len(disruptions_before['disruptions'])
+
+        # New disruption same as base schedule
+        self.send_mock(
+            "vjA",
+            "20120614",
+            'modified',
+            [
+                UpdatedStopTime(
+                    "stop_point:stopB",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    arrival=tstamp("20120614T080100"),
+                    departure=tstamp("20120614T080100"),
+                    message='on time',
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopA",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    arrival=tstamp("20120614T080102"),
+                    departure=tstamp("20120614T080102"),
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopC",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080104"),
+                    departure=tstamp("20120614T080104"),
+                ),
+            ],
+            disruption_id='new_stop_time',
+        )
+
+        def has_the_disruption(response):
+            return len([d['id'] for d in response['disruptions'] if d['id'] == 'new_stop_time']) != 0
+
+        # No new disruption
+        disruptions_after = self.query_region('disruptions?_current_datetime=20120614T080000')
+        assert nb_disruptions_before == len(disruptions_after['disruptions'])
+        assert not has_the_disruption(disruptions_after)
+
+        journey_query = journey_basic_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
+        response = self.query_region(journey_query)
+        assert not has_the_disruption(response)
+        self.is_valid_journey_response(response, journey_query)
+        assert response['journeys'][0]['sections'][1]['data_freshness'] == 'base_schedule'
+
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+            from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
+        )
+        base_journey_query = B_C_query + "&data_freshness=base_schedule&_current_datetime=20120614T080000"
+        response = self.query_region(base_journey_query)
+        assert not has_the_disruption(response)
+        self.is_valid_journey_response(response, base_journey_query)
+        assert len(response['journeys']) == 1  # check we only have one journey
+        assert 'data_freshness' not in response['journeys'][0]['sections'][0]  # means it's base_schedule
+
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+            from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
+        )
+        rt_journey_query = B_C_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
+        response = self.query_region(rt_journey_query)
+        assert not has_the_disruption(response)
+        self.is_valid_journey_response(response, rt_journey_query)
+        assert len(response['journeys']) == 1  # check there's no new journey possible
+        assert 'data_freshness' not in response['journeys'][0]['sections'][0]  # means it's base_schedule
 
 
 def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None):

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -476,7 +476,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
 };
 
 static bool is_modifying_effect(nt::disruption::Effect e) {
-    // check is the effect needs to modify the model
+    // check if the effect needs to modify the model
     return in(e, {nt::disruption::Effect::NO_SERVICE,
                   nt::disruption::Effect::SIGNIFICANT_DELAYS,
                   nt::disruption::Effect::MODIFIED_SERVICE,

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -155,8 +155,9 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             LOG4CPLUS_TRACE(log, "canceling " << mvj->uri);
             mvj->cancel_vj(rt_level, impact->application_periods, pt_data, r);
             mvj->push_unique_impact(impact);
-        } else if ((impact->severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS ||
-                   impact->severity->effect == nt::disruption::Effect::DETOUR) &&
+        } else if (in(impact->severity->effect, {nt::disruption::Effect::SIGNIFICANT_DELAYS,
+                                                 nt::disruption::Effect::MODIFIED_SERVICE,
+                                                 nt::disruption::Effect::DETOUR}) &&
                    // we don't want to apply delay or detour without stoptime's information
                    // if there is no stoptimes it should be modeled as a NO_SERVICE
                    // else it is something else, like for example a SIGNIFICANT_DELAYS on a line
@@ -192,7 +193,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             }
             if (! mvj->get_base_vj().empty()) {
                 vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
-                vj->name = mvj->get_base_vj().at(0)->name; 
+                vj->name = mvj->get_base_vj().at(0)->name;
             } else {
                 // If we set nothing for physical_mode, it'll crash when building raptor
                 vj->physical_mode = pt_data.physical_modes[0];
@@ -440,7 +441,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                     vj->route,
                     std::move(new_stop_times),
                     pt_data);
-            
+
             LOG4CPLUS_TRACE(log,  "new_vj: "<< new_vj->uri << " is created");
 
             if (! mvj->get_base_vj().empty()) {
@@ -478,6 +479,7 @@ static bool is_modifying_effect(nt::disruption::Effect e) {
     // check is the effect needs to modify the model
     return in(e, {nt::disruption::Effect::NO_SERVICE,
                   nt::disruption::Effect::SIGNIFICANT_DELAYS,
+                  nt::disruption::Effect::MODIFIED_SERVICE,
                   nt::disruption::Effect::DETOUR});
 }
 
@@ -553,7 +555,7 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
         // it with an empty vector.
         decltype(mvj->modified_by) modified_by_moved;
         boost::swap(modified_by_moved, mvj->modified_by);
-        
+
         for(const auto& wptr: modified_by_moved) {
             if (auto share_ptr = wptr.lock()){
                 disruptions_collection.insert(share_ptr);

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -482,7 +482,7 @@ static bool is_modifying_effect(nt::disruption::Effect e) {
 }
 
 void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact,
-                         nt::PT_Data& pt_data, const nt::MetaData& meta) {
+                  nt::PT_Data& pt_data, const nt::MetaData& meta) {
     if (! is_modifying_effect(impact->severity->effect)) {
         return;
     }
@@ -647,8 +647,9 @@ void delete_disruption(const std::string& disruption_id,
     LOG4CPLUS_DEBUG(log, "disruption " << disruption_id << " deleted");
 }
 
-void apply_disruption(const type::disruption::Disruption& disruption, nt::PT_Data& pt_data,
-                    const navitia::type::MetaData &meta) {
+void apply_disruption(const type::disruption::Disruption& disruption,
+                      nt::PT_Data& pt_data,
+                      const navitia::type::MetaData &meta) {
     LOG4CPLUS_DEBUG(log4cplus::Logger::getInstance("log"), "applying disruption: " << disruption.uri);
     for (const auto& impact: disruption.get_impacts()) {
         apply_impact(impact, pt_data, meta);

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -58,6 +58,8 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("GENERAL.nb_threads", po::value<int>()->default_value(1), "number of workers threads")
         ("GENERAL.is_realtime_enabled", po::value<bool>()->default_value(false),
                                         "enable loading of realtime data")
+        ("GENERAL.is_realtime_add_enabled", po::value<bool>()->default_value(false),
+                                        "enable loading of realtime data that add stop_times or trips")
         ("GENERAL.kirin_timeout", po::value<int>()->default_value(60000),
                                   "timeout in ms for loading realtime data from kirin")
         ("GENERAL.kirin_retry_timeout", po::value<int>()->default_value(5*60*1000),
@@ -157,6 +159,10 @@ int Configuration::nb_threads() const{
 
 bool Configuration::is_realtime_enabled() const{
     return this->vm["GENERAL.is_realtime_enabled"].as<bool>();
+}
+
+bool Configuration::is_realtime_add_enabled() const{
+    return this->vm["GENERAL.is_realtime_add_enabled"].as<bool>();
 }
 
 int Configuration::kirin_timeout() const{

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -56,6 +56,7 @@ namespace navitia { namespace kraken{
             int broker_timeout() const;
             int broker_sleeptime() const;
             bool is_realtime_enabled() const;
+            bool is_realtime_add_enabled() const;
             int kirin_timeout() const;
             int kirin_retry_timeout() const;
             bool display_contributors() const;

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -187,7 +187,8 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
                 handle_realtime(entity.id(),
                                 navitia::from_posix_timestamp(feed_message.header().timestamp()),
                                 entity.trip_update(),
-                                *data);
+                                *data,
+                                conf.is_realtime_add_enabled());
             } else {
                 LOG4CPLUS_WARN(logger, "unsupported gtfs rt feed");
             }

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -268,7 +268,7 @@ create_disruption(const std::string& id,
     auto log = log4cplus::Logger::getInstance("realtime");
 
     if (! is_realtime_add_enabled && is_added_service(trip_update)) {
-        LOG4CPLUS_TRACE(log, "Disruption is ADDING service and realtime-adding is disabled: ignoring it");
+        LOG4CPLUS_DEBUG(log, "Disruption is ADDING service and realtime-adding is disabled: ignoring it");
         return nullptr;
     }
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -207,10 +207,11 @@ get_status(const transit_realtime::TripUpdate_StopTimeEvent& event,
     }
 }
 
-static bool is_realtime_add(const transit_realtime::TripUpdate& trip_update) {
+static bool is_added_service(const transit_realtime::TripUpdate& trip_update) {
     namespace trt = transit_realtime;
     auto log = log4cplus::Logger::getInstance("realtime");
 
+    // adding a trip is adding service
     if (trip_update.trip().schedule_relationship() == trt::TripDescriptor_ScheduleRelationship_ADDED) {
         LOG4CPLUS_TRACE(log, "Disruption has ADDITIONAL_SERVICE effect");
         return true;
@@ -218,6 +219,7 @@ static bool is_realtime_add(const transit_realtime::TripUpdate& trip_update) {
     else if (trip_update.trip().schedule_relationship() == trt::TripDescriptor_ScheduleRelationship_SCHEDULED
                 && trip_update.stop_time_update_size()) {
         for (const auto& st: trip_update.stop_time_update()) {
+            // adding a stop_time event (adding departure or/and arrival) is adding service
             if (get_relationship(st.departure(), st) ==
                         trt::TripUpdate_StopTimeUpdate_ScheduleRelationship_ADDED
                     || get_relationship(st.arrival(), st) ==
@@ -240,7 +242,7 @@ create_disruption(const std::string& id,
     namespace trt = transit_realtime;
     auto log = log4cplus::Logger::getInstance("realtime");
 
-    if (! is_realtime_add_enabled && is_realtime_add(trip_update)) {
+    if (! is_realtime_add_enabled && is_added_service(trip_update)) {
         LOG4CPLUS_TRACE(log, "Disruption is ADDING service and realtime-adding is disabled: ignoring it");
         return nullptr;
     }

--- a/source/kraken/realtime.h
+++ b/source/kraken/realtime.h
@@ -38,5 +38,6 @@ namespace navitia {
 void handle_realtime(const std::string& id,
                      const boost::posix_time::ptime& timestamp,
                      const transit_realtime::TripUpdate&,
-                     const type::Data&);
+                     const type::Data&,
+                     const bool is_realtime_add_enabled = false);
 }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE(stop_point_no_service_with_shift) {
             ntest::DelayedTimeStop("stop2", "20120617T0105"_pts).delay(55_min),
             ntest::DelayedTimeStop("stop3", "20120617T0205"_pts).delay(80_min),
         });
-    navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data);
+    navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data, true);
 
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "111011"),
             vj1->rt_validity_pattern()->days);
@@ -834,7 +834,7 @@ BOOST_AUTO_TEST_CASE(test_shift_of_a_disrupted_delayed_train) {
             ntest::DelayedTimeStop("stop2", "20120618T0005"_pts).delay(23_h + 50_min),
             ntest::DelayedTimeStop("stop3", "20120618T0100"_pts).delay(24_h),
         });
-    navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data);
+    navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data, true);
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "000000"),
@@ -960,7 +960,7 @@ BOOST_AUTO_TEST_CASE(disrupted_stop_point_then_delayed) {
             ntest::DelayedTimeStop("stop3", "20120618T0100"_pts).delay(48_h),
         });
 
-    navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data);
+    navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -754,9 +754,9 @@ BOOST_AUTO_TEST_CASE(stop_point_no_service_with_shift) {
     b.data->meta->production_date = bg::date_period(bg::date(2012,6,14), bg::days(7));
 
     auto trip_update = ntest::make_delay_message("vj:1", "20120616", {
-            ntest::DelayedTimeStop("stop1", "20120617T0005"_pts).delay(65_min),
-            ntest::DelayedTimeStop("stop2", "20120617T0105"_pts).delay(55_min),
-            ntest::DelayedTimeStop("stop3", "20120617T0205"_pts).delay(80_min),
+            ntest::RTStopTime("stop1", "20120617T0005"_pts).delay(65_min),
+            ntest::RTStopTime("stop2", "20120617T0105"_pts).delay(55_min),
+            ntest::RTStopTime("stop3", "20120617T0205"_pts).delay(80_min),
         });
     navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data, true);
 
@@ -830,9 +830,9 @@ BOOST_AUTO_TEST_CASE(test_shift_of_a_disrupted_delayed_train) {
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
 
     auto trip_update = ntest::make_delay_message("vj:1", "20120616", {
-            ntest::DelayedTimeStop("stop1", "20120617T2300"_pts).delay(24_h),
-            ntest::DelayedTimeStop("stop2", "20120618T0005"_pts).delay(23_h + 50_min),
-            ntest::DelayedTimeStop("stop3", "20120618T0100"_pts).delay(24_h),
+            ntest::RTStopTime("stop1", "20120617T2300"_pts).delay(24_h),
+            ntest::RTStopTime("stop2", "20120618T0005"_pts).delay(23_h + 50_min),
+            ntest::RTStopTime("stop3", "20120618T0100"_pts).delay(24_h),
         });
     navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data, true);
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
@@ -956,8 +956,8 @@ BOOST_AUTO_TEST_CASE(disrupted_stop_point_then_delayed) {
     BOOST_REQUIRE_EQUAL(vj->shift, 1);
 
     auto trip_update = ntest::make_delay_message("vj:1", "20120616", {
-            ntest::DelayedTimeStop("stop2", "20120618T0015"_pts).delay(48_h),
-            ntest::DelayedTimeStop("stop3", "20120618T0100"_pts).delay(48_h),
+            ntest::RTStopTime("stop2", "20120618T0015"_pts).delay(48_h),
+            ntest::RTStopTime("stop3", "20120618T0100"_pts).delay(48_h),
         });
 
     navitia::handle_realtime("bob", "20120616T1337"_dt, trip_update, *b.data, true);

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
 
     // we should not have created any objects save for one validity_pattern
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 1);
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     BOOST_REQUIRE_EQUAL(disruption->contributor, "cow.owner");
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
 
     // we should not have created any objects save for one validity_pattern
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 1);
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(train_cancellation_on_unused_day) {
     transit_realtime::TripUpdate trip_update = make_cancellation_message("vj:1", "20150929");
     const auto& pt_data = b.data->pt_data;
 
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
 
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("bob", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("bob", timestamp, trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
     BOOST_CHECK_EQUAL(stus[1].cause, "birds on the tracks");
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("bob", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("bob", timestamp, trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
 
     // we add a third time the same message but with a different id, it should not change anything
     // but for the number of impacts in the meta vj
-    navitia::handle_realtime("bobette", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("bobette", timestamp, trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -317,8 +317,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_vj_cleaned_up) {
                     DelayedTimeStop("stop2", "20150928T0910"_pts).delay(9_min)
             });
     b.data->build_uri();
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 }
@@ -354,7 +354,7 @@ BOOST_AUTO_TEST_CASE(two_different_delays_on_same_vj) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime(feed_id, timestamp, trip_update_1, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update_1, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -387,7 +387,7 @@ BOOST_AUTO_TEST_CASE(two_different_delays_on_same_vj) {
     }
 
     // we add a second time the realtime message
-    navitia::handle_realtime(feed_id_1, timestamp, trip_update_2, *b.data);
+    navitia::handle_realtime(feed_id_1, timestamp, trip_update_2, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(train_pass_midnight_delayed) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -461,7 +461,7 @@ BOOST_AUTO_TEST_CASE(train_pass_midnight_delayed) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(add_two_delay_disruption) {
     auto vj_A = pt_data->vehicle_journeys.at(0);
     BOOST_CHECK_EQUAL(vj_A->base_validity_pattern(), vj_A->rt_validity_pattern());
 
-    navitia::handle_realtime(feed_id, timestamp, trip_update_A, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update_A, *b.data, true);
 
     // We should have 3 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 3);
@@ -532,7 +532,7 @@ BOOST_AUTO_TEST_CASE(add_two_delay_disruption) {
     BOOST_CHECK_NE(vj_A->base_validity_pattern(), vj_A->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime(feed_id_1, timestamp, trip_update_B, *b.data);
+    navitia::handle_realtime(feed_id_1, timestamp, trip_update_B, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 2);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 2);
@@ -591,7 +591,7 @@ BOOST_AUTO_TEST_CASE(add_blocking_disruption_and_delay_disruption) {
     auto vj_A = pt_data->vehicle_journeys.at(0);
     BOOST_CHECK_EQUAL(vj_A->base_validity_pattern(), vj_A->rt_validity_pattern());
 
-    navitia::handle_realtime(feed_id, timestamp, trip_update_A, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, trip_update_A, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -688,7 +688,7 @@ BOOST_AUTO_TEST_CASE(invalid_delay) {
     BOOST_REQUIRE_EQUAL(pt_data->disruption_holder.nb_disruptions(), 0);
     BOOST_REQUIRE_EQUAL(vj->meta_vj->get_impacts().size(), 0);
 
-    navitia::handle_realtime(feed_id, timestamp, wrong_st_order, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, wrong_st_order, *b.data, true);
 
     //there should be no disruption added
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
@@ -704,7 +704,7 @@ BOOST_AUTO_TEST_CASE(invalid_delay) {
                     DelayedTimeStop("stop2", "20150928T0910"_pts, "20150928T0900"_pts).arrival_delay(9_min)
             });
 
-    navitia::handle_realtime(feed_id, timestamp, dep_before_arr, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, dep_before_arr, *b.data, true);
 
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
     BOOST_REQUIRE_EQUAL(pt_data->disruption_holder.nb_disruptions(), 0);
@@ -719,7 +719,7 @@ BOOST_AUTO_TEST_CASE(invalid_delay) {
                     DelayedTimeStop("stop2", "20150927T0300"_pts).delay(18_h)
             });
 
-    navitia::handle_realtime(feed_id, timestamp, wrong_first_st, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, wrong_first_st, *b.data, true);
 
     //there should be no disruption added
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
@@ -753,7 +753,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1DayD0", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("delay1DayD0", timestamp, trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -764,7 +764,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("delay1DayD0_bis", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("delay1DayD0_bis", timestamp, trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -820,7 +820,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_pass_midnight_day_after) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1DayPassMidnightD0", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("delay1DayPassMidnightD0", timestamp, trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -831,7 +831,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_pass_midnight_day_after) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("delay1DayPassMidnightD0_bis", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("delay1DayPassMidnightD0_bis", timestamp, trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_one_hour) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -911,7 +911,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_one_hour) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("delay1HourD0", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("delay1HourD0", timestamp, second_trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -980,7 +980,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_back_to_normal) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -991,7 +991,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_back_to_normal) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("backToNormalD0", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("backToNormalD0", timestamp, second_trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -1060,7 +1060,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_one_hour_on_next_day) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -1071,7 +1071,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_one_hour_on_next_day) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("delay1HourD1", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("delay1HourD1", timestamp, second_trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -1134,7 +1134,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_cancel) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay1DayD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -1145,7 +1145,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_cancel) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("cancelD0", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("cancelD0", timestamp, second_trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -1203,7 +1203,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_day_after_cancel) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay1dayD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay1dayD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -1214,7 +1214,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_day_after_cancel) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("cancelD1", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("cancelD1", timestamp, second_trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -1266,7 +1266,7 @@ BOOST_AUTO_TEST_CASE(train_canceled_first_day_then_cancel_second_day) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("cancelD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("cancelD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 1);
@@ -1279,7 +1279,7 @@ BOOST_AUTO_TEST_CASE(train_canceled_first_day_then_cancel_second_day) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("cancelD1", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("cancelD1", timestamp, second_trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->lines.size(), 1);
@@ -1338,7 +1338,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_10_hours_then_canceled) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("delay10HoursD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay10HoursD0", timestamp, first_trip_update, *b.data, true);
 
     // We should have 2 vj
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -1349,7 +1349,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_10_hours_then_canceled) {
     BOOST_CHECK_NE(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
     // we add a second time the realtime message, it should not change anything
-    navitia::handle_realtime("cancelD0", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("cancelD0", timestamp, second_trip_update, *b.data, true);
 
 
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -1412,7 +1412,7 @@ BOOST_AUTO_TEST_CASE(get_impacts_on_vj) {
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 1);
     BOOST_CHECK_EQUAL(vj->get_impacts().size(), 0);
 
-    navitia::handle_realtime("delay1hourD0", timestamp, first_trip_update, *b.data);
+    navitia::handle_realtime("delay1hourD0", timestamp, first_trip_update, *b.data, true);
 
     // get vj realtime for d0 and check it's on day 0
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 2);
@@ -1425,7 +1425,7 @@ BOOST_AUTO_TEST_CASE(get_impacts_on_vj) {
     BOOST_REQUIRE_EQUAL(vj_rt_d0->get_impacts().size(), 1);
     BOOST_CHECK_EQUAL(vj_rt_d0->get_impacts()[0]->uri, "delay1hourD0");
 
-    navitia::handle_realtime("delay2hourD1", timestamp, second_trip_update, *b.data);
+    navitia::handle_realtime("delay2hourD1", timestamp, second_trip_update, *b.data, true);
 
     // get vj realtime for d1 and check it's on day 1
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 3);
@@ -1441,7 +1441,7 @@ BOOST_AUTO_TEST_CASE(get_impacts_on_vj) {
     BOOST_REQUIRE_EQUAL(vj_rt_d1->get_impacts().size(), 1);
     BOOST_CHECK_EQUAL(vj_rt_d1->get_impacts()[0]->uri, "delay2hourD1");
 
-    navitia::handle_realtime("cancelD3", timestamp, third_trip_update, *b.data);
+    navitia::handle_realtime("cancelD3", timestamp, third_trip_update, *b.data, true);
 
     BOOST_REQUIRE_EQUAL(pt_data->vehicle_journeys.size(), 3);
     BOOST_REQUIRE_EQUAL(vj->get_impacts().size(), 3);
@@ -1469,8 +1469,8 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys) {
             DelayedTimeStop("stop2", "20150929T1010"_pts).delay(1_h)
         });
     transit_realtime::TripUpdate trip_update_vj3 = make_cancellation_message("vj:3", "20150928");
-    navitia::handle_realtime("trip_update_vj2", timestamp, trip_update_vj2, *b.data);
-    navitia::handle_realtime("trip_update_vj3", timestamp, trip_update_vj3, *b.data);
+    navitia::handle_realtime("trip_update_vj2", timestamp, trip_update_vj2, *b.data, true);
+    navitia::handle_realtime("trip_update_vj3", timestamp, trip_update_vj3, *b.data, true);
 
     auto * data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::posix_time::from_iso_string("20150928T0830"), null_time_period);
@@ -1494,7 +1494,7 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys_no_base) {
             DelayedTimeStop("stop1", "20150928T0910"_pts).delay(69_min),
             DelayedTimeStop("stop2", "20150929T1010"_pts).delay(69_min)
         });
-    navitia::handle_realtime("trip_update", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("trip_update", timestamp, trip_update, *b.data, true);
     auto * data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::posix_time::from_iso_string("20150928T0830"), null_time_period);
     navitia::disruption::traffic_reports(pb_creator, *b.data,
@@ -1531,7 +1531,7 @@ BOOST_AUTO_TEST_CASE(unknown_stop_point) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime(feed_id, timestamp, bad_trip_update, *b.data);
+    navitia::handle_realtime(feed_id, timestamp, bad_trip_update, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 1);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -1605,9 +1605,9 @@ BOOST_AUTO_TEST_CASE(ordered_delay_message_test) {
     auto vj = pt_data->vehicle_journeys.front();
     BOOST_CHECK_EQUAL(vj->base_validity_pattern(), vj->rt_validity_pattern());
 
-    navitia::handle_realtime("feed_42", "20150101T1337"_dt, trip_update_1, *b.data);
-    navitia::handle_realtime("feed_43", "20150101T1338"_dt, trip_update_2, *b.data);
-    navitia::handle_realtime("feed_44", "20150101T1339"_dt, trip_update_3, *b.data);
+    navitia::handle_realtime("feed_42", "20150101T1337"_dt, trip_update_1, *b.data, true);
+    navitia::handle_realtime("feed_43", "20150101T1338"_dt, trip_update_2, *b.data, true);
+    navitia::handle_realtime("feed_44", "20150101T1339"_dt, trip_update_3, *b.data, true);
 
     BOOST_CHECK_EQUAL(pt_data->vehicle_journeys.size(), 2);
     BOOST_CHECK_EQUAL(pt_data->routes.size(), 1);
@@ -1679,7 +1679,7 @@ BOOST_AUTO_TEST_CASE(delays_with_boarding_alighting_times) {
                     DelayedTimeStop("stop_point:30", "20170102T084000"_pts, "20170102T084100"_pts).delay(10_min),
                     DelayedTimeStop("stop_point:40", "20170102T085000"_pts, "20170102T085100"_pts).delay(10_min)
             });
-    navitia::handle_realtime("feed", "20170101T1337"_dt, trip_update_1, *b.data);
+    navitia::handle_realtime("feed", "20170101T1337"_dt, trip_update_1, *b.data, true);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1740,7 +1740,7 @@ BOOST_AUTO_TEST_CASE(delays_on_lollipop_with_boarding_alighting_times) {
                     DelayedTimeStop("stop_point:20", "20170102T082000"_pts, "20170102T082100"_pts),
                     DelayedTimeStop("stop_point:10", "20170102T084000"_pts, "20170102T084100"_pts).delay(10_min),
             });
-    navitia::handle_realtime("feed", "20170101T1337"_dt, trip_update_1, *b.data);
+    navitia::handle_realtime("feed", "20170101T1337"_dt, trip_update_1, *b.data, true);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1788,7 +1788,7 @@ BOOST_AUTO_TEST_CASE(simple_skipped_stop) {
                     DelayedTimeStop("B", "20170101T082000"_pts).skipped(),
                     DelayedTimeStop("C", "20170101T083000"_pts),
             });
-    navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_1, *b.data);
+    navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_1, *b.data, true);
 
     navitia::routing::RAPTOR raptor(*(b.data));
 
@@ -1857,7 +1857,7 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
                     DelayedTimeStop("C", "20170101T083000"_pts).skipped(),
                     DelayedTimeStop("D", "20170101T084000"_pts),
             });
-    navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_1, *b.data);
+    navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_1, *b.data, true);
 
     auto trip_update_2 = ntest::make_delay_message("vj:1",
             "20170101",
@@ -1867,7 +1867,7 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
                     DelayedTimeStop("C", "20170101T083500"_pts).delay(5_min),
                     DelayedTimeStop("D", "20170101T084000"_pts),
             });
-    navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_2, *b.data);
+    navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_2, *b.data, true);
     b.data->build_raptor();
     navitia::routing::RAPTOR raptor(*(b.data));
 
@@ -1963,7 +1963,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_and_on_time) {
             });
     b.data->build_uri();
 
-    navitia::handle_realtime("bob", timestamp, trip_update, *b.data);
+    navitia::handle_realtime("bob", timestamp, trip_update, *b.data, true);
 
     const auto& pt_data = b.data->pt_data;
     pt_data->sort_and_index();
@@ -2042,7 +2042,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_3_times_different_id) {
             });
     b.data->build_uri();
 
-    navitia::handle_realtime("bob1", timestamp, trip_update1, *b.data);
+    navitia::handle_realtime("bob1", timestamp, trip_update1, *b.data, true);
 
     transit_realtime::TripUpdate trip_update2 = ntest::make_delay_message("vj:1",
             "20150928",
@@ -2052,7 +2052,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_3_times_different_id) {
             });
     b.data->build_uri();
 
-    navitia::handle_realtime("bob2", timestamp, trip_update2, *b.data);
+    navitia::handle_realtime("bob2", timestamp, trip_update2, *b.data, true);
 
     transit_realtime::TripUpdate trip_update3 = ntest::make_delay_message("vj:1",
             "20150928",
@@ -2062,7 +2062,7 @@ BOOST_AUTO_TEST_CASE(train_delayed_3_times_different_id) {
             });
     b.data->build_uri();
 
-    navitia::handle_realtime("bob3", timestamp, trip_update2, *b.data);
+    navitia::handle_realtime("bob3", timestamp, trip_update2, *b.data, true);
 
     const auto& pt_data = b.data->pt_data;
     pt_data->sort_and_index();
@@ -2107,7 +2107,7 @@ BOOST_AUTO_TEST_CASE(teleportation_train_2_delays_check_disruptions) {
             });
     b.data->build_uri();
 
-    navitia::handle_realtime("late-01", timestamp, trip_update1, *b.data);
+    navitia::handle_realtime("late-01", timestamp, trip_update1, *b.data, true);
 
     transit_realtime::TripUpdate trip_update2 = ntest::make_delay_message("vj:1",
             "20171102",
@@ -2117,7 +2117,7 @@ BOOST_AUTO_TEST_CASE(teleportation_train_2_delays_check_disruptions) {
             });
     b.data->build_uri();
 
-    navitia::handle_realtime("late-02", timestamp, trip_update2, *b.data);
+    navitia::handle_realtime("late-02", timestamp, trip_update2, *b.data, true);
 
     const auto& pt_data = b.data->pt_data;
     pt_data->sort_and_index();

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -51,7 +51,7 @@ BOOST_GLOBAL_FIXTURE( logger_initialized );
 namespace nt = navitia::type;
 namespace pt = boost::posix_time;
 namespace ntest = navitia::test;
-using ntest::DelayedTimeStop;
+using ntest::RTStopTime;
 
 static const std::string feed_id = "42";
 static const std::string feed_id_1 = "44";
@@ -225,8 +225,8 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
     transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts).delay(9_min),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(9_min)
+                    RTStopTime("stop1", "20150928T0810"_pts).delay(9_min),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(9_min)
             });
     b.data->build_uri();
 
@@ -313,8 +313,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_vj_cleaned_up) {
     transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts).delay(9_min),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(9_min)
+                    RTStopTime("stop1", "20150928T0810"_pts).delay(9_min),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(9_min)
             });
     b.data->build_uri();
     navitia::handle_realtime(feed_id, timestamp, trip_update, *b.data, true);
@@ -331,17 +331,17 @@ BOOST_AUTO_TEST_CASE(two_different_delays_on_same_vj) {
     transit_realtime::TripUpdate trip_update_1 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(9_min),
-                    DelayedTimeStop("stop3", "20150928T1001"_pts)
+                    RTStopTime("stop1", "20150928T0810"_pts),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(9_min),
+                    RTStopTime("stop3", "20150928T1001"_pts)
             });
 
     transit_realtime::TripUpdate trip_update_2 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(9_min),
-                    DelayedTimeStop("stop3", "20150928T1030"_pts).delay(29_min)
+                    RTStopTime("stop1", "20150928T0810"_pts),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(9_min),
+                    RTStopTime("stop3", "20150928T1030"_pts).delay(29_min)
             });
     b.data->build_uri();
 
@@ -434,8 +434,8 @@ BOOST_AUTO_TEST_CASE(train_pass_midnight_delayed) {
     transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T2330"_pts).delay(30_min),
-                    DelayedTimeStop("stop2", "20150929T0025"_pts).delay(30_min)
+                    RTStopTime("stop1", "20150928T2330"_pts).delay(30_min),
+                    RTStopTime("stop2", "20150929T0025"_pts).delay(30_min)
             });
     b.data->build_uri();
 
@@ -498,15 +498,15 @@ BOOST_AUTO_TEST_CASE(add_two_delay_disruption) {
     transit_realtime::TripUpdate trip_update_A = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T2330"_pts).delay(30_min),
-                    DelayedTimeStop("stop2", "20150929T0025"_pts).delay(30_min)
+                    RTStopTime("stop1", "20150928T2330"_pts).delay(30_min),
+                    RTStopTime("stop2", "20150929T0025"_pts).delay(30_min)
             });
 
     transit_realtime::TripUpdate trip_update_B = ntest::make_delay_message("vj:2",
             "20150928",
             {
-                    DelayedTimeStop("stop3", "20150928T2230"_pts).delay(30_min),
-                    DelayedTimeStop("stop4", "20150928T2300"_pts).delay(30_min)
+                    RTStopTime("stop3", "20150928T2230"_pts).delay(30_min),
+                    RTStopTime("stop4", "20150928T2300"_pts).delay(30_min)
             });
 
     b.data->build_uri();
@@ -578,8 +578,8 @@ BOOST_AUTO_TEST_CASE(add_blocking_disruption_and_delay_disruption) {
     transit_realtime::TripUpdate trip_update_A = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts).delay(10_min),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(10_min)
+                    RTStopTime("stop1", "20150928T0810"_pts).delay(10_min),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(10_min)
             });
     b.data->build_uri();
 
@@ -679,8 +679,8 @@ BOOST_AUTO_TEST_CASE(invalid_delay) {
             "20150928",
             {
                     //stop1 is after stop2, it's not valid
-                    DelayedTimeStop("stop1", "20150928T1000"_pts).delay(2_h),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(10_min)
+                    RTStopTime("stop1", "20150928T1000"_pts).delay(2_h),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(10_min)
             });
 
     const auto& pt_data = b.data->pt_data;
@@ -699,9 +699,9 @@ BOOST_AUTO_TEST_CASE(invalid_delay) {
     transit_realtime::TripUpdate dep_before_arr = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts).delay(10_min),
+                    RTStopTime("stop1", "20150928T0810"_pts).delay(10_min),
                     //departure is before arrival, it's not valid too
-                    DelayedTimeStop("stop2", "20150928T0910"_pts, "20150928T0900"_pts).arrival_delay(9_min)
+                    RTStopTime("stop2", "20150928T0910"_pts, "20150928T0900"_pts).arrival_delay(9_min)
             });
 
     navitia::handle_realtime(feed_id, timestamp, dep_before_arr, *b.data, true);
@@ -714,9 +714,9 @@ BOOST_AUTO_TEST_CASE(invalid_delay) {
     transit_realtime::TripUpdate wrong_first_st = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150926T0800"_pts, "20150927T0200"_pts).arrival_delay(10_min)
+                    RTStopTime("stop1", "20150926T0800"_pts, "20150927T0200"_pts).arrival_delay(10_min)
                                                                                       .departure_delay(18_h),
-                    DelayedTimeStop("stop2", "20150927T0300"_pts).delay(18_h)
+                    RTStopTime("stop2", "20150927T0300"_pts).delay(18_h)
             });
 
     navitia::handle_realtime(feed_id, timestamp, wrong_first_st, *b.data, true);
@@ -739,8 +739,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after) {
     transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T0610"_pts).delay(9_min),
-                    DelayedTimeStop("stop2", "20150929T0710"_pts).delay(9_min)
+                    RTStopTime("stop1", "20150929T0610"_pts).delay(9_min),
+                    RTStopTime("stop2", "20150929T0710"_pts).delay(9_min)
             });
     b.data->build_uri();
 
@@ -806,8 +806,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_pass_midnight_day_after) {
     transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T1710"_pts).delay(9_h),
-                    DelayedTimeStop("stop2", "20150930T0110"_pts).delay(16_h)
+                    RTStopTime("stop1", "20150929T1710"_pts).delay(9_h),
+                    RTStopTime("stop2", "20150930T0110"_pts).delay(16_h)
             });
     b.data->build_uri();
 
@@ -880,14 +880,14 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_one_hour) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T0710"_pts).delay(23_h),
-                    DelayedTimeStop("stop2", "20150929T0810"_pts).delay(23_h)
+                    RTStopTime("stop1", "20150929T0710"_pts).delay(23_h),
+                    RTStopTime("stop2", "20150929T0810"_pts).delay(23_h)
             });
     transit_realtime::TripUpdate second_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0901"_pts).delay(24_h),
-                    DelayedTimeStop("stop2", "20150928T1001"_pts).delay(24_h)
+                    RTStopTime("stop1", "20150928T0901"_pts).delay(24_h),
+                    RTStopTime("stop2", "20150928T1001"_pts).delay(24_h)
             });
     b.data->build_uri();
 
@@ -960,14 +960,14 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_back_to_normal) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T0710"_pts).delay(23_h),
-                    DelayedTimeStop("stop2", "20150929T0810"_pts).delay(23_h)
+                    RTStopTime("stop1", "20150929T0710"_pts).delay(23_h),
+                    RTStopTime("stop2", "20150929T0810"_pts).delay(23_h)
             });
     transit_realtime::TripUpdate second_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0801"_pts),
-                    DelayedTimeStop("stop2", "20150928T0901"_pts)
+                    RTStopTime("stop1", "20150928T0801"_pts),
+                    RTStopTime("stop2", "20150928T0901"_pts)
             });
     b.data->build_uri();
 
@@ -1040,14 +1040,14 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_one_hour_on_next_day) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T0710"_pts).delay(23_h),
-                    DelayedTimeStop("stop2", "20150929T0810"_pts).delay(23_h)
+                    RTStopTime("stop1", "20150929T0710"_pts).delay(23_h),
+                    RTStopTime("stop2", "20150929T0810"_pts).delay(23_h)
             });
     transit_realtime::TripUpdate second_trip_update = ntest::make_delay_message("vj:1",
             "20150929",
             {
-                    DelayedTimeStop("stop1", "20150929T0901"_pts).delay(25_h),
-                    DelayedTimeStop("stop2", "20150929T1001"_pts).delay(25_h)
+                    RTStopTime("stop1", "20150929T0901"_pts).delay(25_h),
+                    RTStopTime("stop2", "20150929T1001"_pts).delay(25_h)
             });
     b.data->build_uri();
 
@@ -1120,8 +1120,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_cancel) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T0610"_pts).delay(22_h),
-                    DelayedTimeStop("stop2", "20150929T0710"_pts).delay(22_h)
+                    RTStopTime("stop1", "20150929T0610"_pts).delay(22_h),
+                    RTStopTime("stop2", "20150929T0710"_pts).delay(22_h)
             });
     transit_realtime::TripUpdate second_trip_update = make_cancellation_message("vj:1", "20150928");
     b.data->build_uri();
@@ -1188,8 +1188,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_day_after_then_day_after_cancel) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150929T0610"_pts).delay(22_h),
-                    DelayedTimeStop("stop2", "20150929T0710"_pts).delay(22_h)
+                    RTStopTime("stop1", "20150929T0610"_pts).delay(22_h),
+                    RTStopTime("stop2", "20150929T0710"_pts).delay(22_h)
             });
     transit_realtime::TripUpdate second_trip_update = make_cancellation_message("vj:1", "20150929");
     b.data->build_uri();
@@ -1323,8 +1323,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_10_hours_then_canceled) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T1801"_pts).delay(10_h),
-                    DelayedTimeStop("stop2", "20150928T1901"_pts).delay(10_h)
+                    RTStopTime("stop1", "20150928T1801"_pts).delay(10_h),
+                    RTStopTime("stop2", "20150928T1901"_pts).delay(10_h)
             });
     transit_realtime::TripUpdate second_trip_update = make_cancellation_message("vj:1", "20150928");
     b.data->build_uri();
@@ -1394,14 +1394,14 @@ BOOST_AUTO_TEST_CASE(get_impacts_on_vj) {
     transit_realtime::TripUpdate first_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0910"_pts).delay(1_h),
-                    DelayedTimeStop("stop2", "20150928T1010"_pts).delay(1_h)
+                    RTStopTime("stop1", "20150928T0910"_pts).delay(1_h),
+                    RTStopTime("stop2", "20150928T1010"_pts).delay(1_h)
             });
     transit_realtime::TripUpdate second_trip_update = ntest::make_delay_message("vj:1",
             "20150929",
             {
-                    DelayedTimeStop("stop1", "20150929T1010"_pts).delay(2_h),
-                    DelayedTimeStop("stop2", "20150929T1110"_pts).delay(2_h)
+                    RTStopTime("stop1", "20150929T1010"_pts).delay(2_h),
+                    RTStopTime("stop2", "20150929T1110"_pts).delay(2_h)
             });
     transit_realtime::TripUpdate third_trip_update = make_cancellation_message("vj:1", "20150930");
 
@@ -1465,8 +1465,8 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys) {
         "vj:2",
         "20150928",
         {
-            DelayedTimeStop("stop1", "20150928T0910"_pts).delay(1_h),
-            DelayedTimeStop("stop2", "20150929T1010"_pts).delay(1_h)
+            RTStopTime("stop1", "20150928T0910"_pts).delay(1_h),
+            RTStopTime("stop2", "20150929T1010"_pts).delay(1_h)
         });
     transit_realtime::TripUpdate trip_update_vj3 = make_cancellation_message("vj:3", "20150928");
     navitia::handle_realtime("trip_update_vj2", timestamp, trip_update_vj2, *b.data, true);
@@ -1491,8 +1491,8 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys_no_base) {
         "vj:1",
         "20150928",
         {
-            DelayedTimeStop("stop1", "20150928T0910"_pts).delay(69_min),
-            DelayedTimeStop("stop2", "20150929T1010"_pts).delay(69_min)
+            RTStopTime("stop1", "20150928T0910"_pts).delay(69_min),
+            RTStopTime("stop2", "20150929T1010"_pts).delay(69_min)
         });
     navitia::handle_realtime("trip_update", timestamp, trip_update, *b.data, true);
     auto * data_ptr = b.data.get();
@@ -1515,9 +1515,9 @@ BOOST_AUTO_TEST_CASE(unknown_stop_point) {
     transit_realtime::TripUpdate bad_trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts).delay(9_min),
-                    DelayedTimeStop("stop_unknown_toto", "20150928T0910"_pts).delay(9_min), // <--- bad
-                    DelayedTimeStop("stop3", "20150928T1001"_pts).delay(9_min)
+                    RTStopTime("stop1", "20150928T0810"_pts).delay(9_min),
+                    RTStopTime("stop_unknown_toto", "20150928T0910"_pts).delay(9_min), // <--- bad
+                    RTStopTime("stop3", "20150928T1001"_pts).delay(9_min)
             });
 
     b.data->build_uri();
@@ -1576,23 +1576,23 @@ BOOST_AUTO_TEST_CASE(ordered_delay_message_test) {
     auto trip_update_1 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0801"_pts),
-                    DelayedTimeStop("stop2", "20150928T0910"_pts).delay(9_min),
-                    DelayedTimeStop("stop3", "20150928T1001"_pts)
+                    RTStopTime("stop1", "20150928T0801"_pts),
+                    RTStopTime("stop2", "20150928T0910"_pts).delay(9_min),
+                    RTStopTime("stop3", "20150928T1001"_pts)
             });
     auto trip_update_2 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts),
-                    DelayedTimeStop("stop2", "20150928T0920"_pts).delay(19_min),
-                    DelayedTimeStop("stop3", "20150928T1001"_pts)
+                    RTStopTime("stop1", "20150928T0810"_pts),
+                    RTStopTime("stop2", "20150928T0920"_pts).delay(19_min),
+                    RTStopTime("stop3", "20150928T1001"_pts)
             });
     auto trip_update_3 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("stop1", "20150928T0810"_pts),
-                    DelayedTimeStop("stop2", "20150928T0925"_pts).delay(26_min),
-                    DelayedTimeStop("stop3", "20150928T1001"_pts)
+                    RTStopTime("stop1", "20150928T0810"_pts),
+                    RTStopTime("stop2", "20150928T0925"_pts).delay(26_min),
+                    RTStopTime("stop3", "20150928T1001"_pts)
             });
     b.data->build_uri();
 
@@ -1674,10 +1674,10 @@ BOOST_AUTO_TEST_CASE(delays_with_boarding_alighting_times) {
     auto trip_update_1 = ntest::make_delay_message("vj:1",
             "20170102",
             {
-                    DelayedTimeStop("stop_point:10", "20170102T081000"_pts, "20170102T081100"_pts),
-                    DelayedTimeStop("stop_point:20", "20170102T082000"_pts, "20170102T082100"_pts),
-                    DelayedTimeStop("stop_point:30", "20170102T084000"_pts, "20170102T084100"_pts).delay(10_min),
-                    DelayedTimeStop("stop_point:40", "20170102T085000"_pts, "20170102T085100"_pts).delay(10_min)
+                    RTStopTime("stop_point:10", "20170102T081000"_pts, "20170102T081100"_pts),
+                    RTStopTime("stop_point:20", "20170102T082000"_pts, "20170102T082100"_pts),
+                    RTStopTime("stop_point:30", "20170102T084000"_pts, "20170102T084100"_pts).delay(10_min),
+                    RTStopTime("stop_point:40", "20170102T085000"_pts, "20170102T085100"_pts).delay(10_min)
             });
     navitia::handle_realtime("feed", "20170101T1337"_dt, trip_update_1, *b.data, true);
 
@@ -1736,9 +1736,9 @@ BOOST_AUTO_TEST_CASE(delays_on_lollipop_with_boarding_alighting_times) {
     auto trip_update_1 = ntest::make_delay_message("vj:1",
             "20170102",
             {
-                    DelayedTimeStop("stop_point:10", "20170102T081000"_pts, "20170102T081100"_pts),
-                    DelayedTimeStop("stop_point:20", "20170102T082000"_pts, "20170102T082100"_pts),
-                    DelayedTimeStop("stop_point:10", "20170102T084000"_pts, "20170102T084100"_pts).delay(10_min),
+                    RTStopTime("stop_point:10", "20170102T081000"_pts, "20170102T081100"_pts),
+                    RTStopTime("stop_point:20", "20170102T082000"_pts, "20170102T082100"_pts),
+                    RTStopTime("stop_point:10", "20170102T084000"_pts, "20170102T084100"_pts).delay(10_min),
             });
     navitia::handle_realtime("feed", "20170101T1337"_dt, trip_update_1, *b.data, true);
 
@@ -1784,9 +1784,9 @@ BOOST_AUTO_TEST_CASE(simple_skipped_stop) {
     auto trip_update_1 = ntest::make_delay_message("vj:1",
             "20170101",
             {
-                    DelayedTimeStop("A", "20170101T081000"_pts),
-                    DelayedTimeStop("B", "20170101T082000"_pts).skipped(),
-                    DelayedTimeStop("C", "20170101T083000"_pts),
+                    RTStopTime("A", "20170101T081000"_pts),
+                    RTStopTime("B", "20170101T082000"_pts).skipped(),
+                    RTStopTime("C", "20170101T083000"_pts),
             });
     navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_1, *b.data, true);
 
@@ -1852,20 +1852,20 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
     auto trip_update_1 = ntest::make_delay_message("vj:1",
             "20170101",
             {
-                    DelayedTimeStop("A", "20170101T081000"_pts),
-                    DelayedTimeStop("B", "20170101T082000"_pts).departure_skipped(),
-                    DelayedTimeStop("C", "20170101T083000"_pts).skipped(),
-                    DelayedTimeStop("D", "20170101T084000"_pts),
+                    RTStopTime("A", "20170101T081000"_pts),
+                    RTStopTime("B", "20170101T082000"_pts).departure_skipped(),
+                    RTStopTime("C", "20170101T083000"_pts).skipped(),
+                    RTStopTime("D", "20170101T084000"_pts),
             });
     navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_1, *b.data, true);
 
     auto trip_update_2 = ntest::make_delay_message("vj:1",
             "20170101",
             {
-                    DelayedTimeStop("A", "20170101T081000"_pts),
-                    DelayedTimeStop("B", "20170101T082000"_pts).departure_skipped(),
-                    DelayedTimeStop("C", "20170101T083500"_pts).delay(5_min),
-                    DelayedTimeStop("D", "20170101T084000"_pts),
+                    RTStopTime("A", "20170101T081000"_pts),
+                    RTStopTime("B", "20170101T082000"_pts).departure_skipped(),
+                    RTStopTime("C", "20170101T083500"_pts).delay(5_min),
+                    RTStopTime("D", "20170101T084000"_pts),
             });
     navitia::handle_realtime("feed", "20170101T0337"_dt, trip_update_2, *b.data, true);
     b.data->build_raptor();
@@ -1955,11 +1955,11 @@ BOOST_AUTO_TEST_CASE(train_delayed_and_on_time) {
     transit_realtime::TripUpdate trip_update = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("A", "20150928T0805"_pts).delay(5_min),
-                    DelayedTimeStop("B", "20150928T0900"_pts).delay(0_min),
-                    DelayedTimeStop("C", "20150928T1000"_pts).delay(0_min),
-                    DelayedTimeStop("D", "20150928T1105"_pts).delay(5_min),
-                    DelayedTimeStop("E", "20150928T1200"_pts).delay(0_min)
+                    RTStopTime("A", "20150928T0805"_pts).delay(5_min),
+                    RTStopTime("B", "20150928T0900"_pts).delay(0_min),
+                    RTStopTime("C", "20150928T1000"_pts).delay(0_min),
+                    RTStopTime("D", "20150928T1105"_pts).delay(5_min),
+                    RTStopTime("E", "20150928T1200"_pts).delay(0_min)
             });
     b.data->build_uri();
 
@@ -2037,8 +2037,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_3_times_different_id) {
     transit_realtime::TripUpdate trip_update1 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("A", "20150928T0801"_pts).delay(1_min),
-                    DelayedTimeStop("B", "20150928T0900"_pts).delay(0_min)
+                    RTStopTime("A", "20150928T0801"_pts).delay(1_min),
+                    RTStopTime("B", "20150928T0900"_pts).delay(0_min)
             });
     b.data->build_uri();
 
@@ -2047,8 +2047,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_3_times_different_id) {
     transit_realtime::TripUpdate trip_update2 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("A", "20150928T0805"_pts).delay(5_min),
-                    DelayedTimeStop("B", "20150928T0900"_pts).delay(0_min)
+                    RTStopTime("A", "20150928T0805"_pts).delay(5_min),
+                    RTStopTime("B", "20150928T0900"_pts).delay(0_min)
             });
     b.data->build_uri();
 
@@ -2057,8 +2057,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_3_times_different_id) {
     transit_realtime::TripUpdate trip_update3 = ntest::make_delay_message("vj:1",
             "20150928",
             {
-                    DelayedTimeStop("A", "20150928T0802"_pts).delay(2_min),
-                    DelayedTimeStop("B", "20150928T0900"_pts).delay(0_min)
+                    RTStopTime("A", "20150928T0802"_pts).delay(2_min),
+                    RTStopTime("B", "20150928T0900"_pts).delay(0_min)
             });
     b.data->build_uri();
 
@@ -2102,8 +2102,8 @@ BOOST_AUTO_TEST_CASE(teleportation_train_2_delays_check_disruptions) {
     transit_realtime::TripUpdate trip_update1 = ntest::make_delay_message("vj:1",
             "20171101",
             {
-                    DelayedTimeStop("A", "20171101T0801"_pts).delay(1_min),
-                    DelayedTimeStop("B", "20171101T0801"_pts).delay(1_min)
+                    RTStopTime("A", "20171101T0801"_pts).delay(1_min),
+                    RTStopTime("B", "20171101T0801"_pts).delay(1_min)
             });
     b.data->build_uri();
 
@@ -2112,8 +2112,8 @@ BOOST_AUTO_TEST_CASE(teleportation_train_2_delays_check_disruptions) {
     transit_realtime::TripUpdate trip_update2 = ntest::make_delay_message("vj:1",
             "20171102",
             {
-                    DelayedTimeStop("A", "20171102T0802"_pts).delay(2_min),
-                    DelayedTimeStop("B", "20171102T0802"_pts).delay(2_min)
+                    RTStopTime("A", "20171102T0802"_pts).delay(2_min),
+                    RTStopTime("B", "20171102T0802"_pts).delay(2_min)
             });
     b.data->build_uri();
 
@@ -2207,10 +2207,10 @@ BOOST_AUTO_TEST_CASE(add_new_stop_time_in_the_trip) {
     transit_realtime::TripUpdate just_new_stop = ntest::make_delay_message("vj:1",
             "20171101",
             {
-                    DelayedTimeStop("stop_point:A", "20171101T0800"_pts),
-                    DelayedTimeStop("stop_point:B", "20171101T0830"_pts),
-                    DelayedTimeStop("stop_point:B_bis", "20171101T0845"_pts).added(),
-                    DelayedTimeStop("stop_point:C", "20171101T0900"_pts),
+                    RTStopTime("stop_point:A", "20171101T0800"_pts),
+                    RTStopTime("stop_point:B", "20171101T0830"_pts),
+                    RTStopTime("stop_point:B_bis", "20171101T0845"_pts).added(),
+                    RTStopTime("stop_point:C", "20171101T0900"_pts),
             });
 
     navitia::handle_realtime("add_new_stop_time_in_the_trip", timestamp, just_new_stop, *b.data, true);
@@ -2230,10 +2230,10 @@ BOOST_AUTO_TEST_CASE(add_new_stop_time_in_the_trip) {
     transit_realtime::TripUpdate delay_and_new_stop = ntest::make_delay_message("vj:1",
             "20171101",
             {
-                    DelayedTimeStop("stop_point:A", "20171101T0805"_pts).delay(5_min),
-                    DelayedTimeStop("stop_point:B", "20171101T0830"_pts),
-                    DelayedTimeStop("stop_point:B_bis", "20171101T0845"_pts).added(),
-                    DelayedTimeStop("stop_point:C", "20171101T0905"_pts).delay(5_min),
+                    RTStopTime("stop_point:A", "20171101T0805"_pts).delay(5_min),
+                    RTStopTime("stop_point:B", "20171101T0830"_pts),
+                    RTStopTime("stop_point:B_bis", "20171101T0845"_pts).added(),
+                    RTStopTime("stop_point:C", "20171101T0905"_pts).delay(5_min),
             });
 
     navitia::handle_realtime("add_new_stop_time_in_the_trip", timestamp, delay_and_new_stop, *b.data, true);
@@ -2253,10 +2253,10 @@ BOOST_AUTO_TEST_CASE(add_new_stop_time_in_the_trip) {
     transit_realtime::TripUpdate new_stop_at_the_end = ntest::make_delay_message("vj:1",
             "20171101",
             {
-                    DelayedTimeStop("stop_point:A", "20171101T0800"_pts),
-                    DelayedTimeStop("stop_point:B", "20171101T0830"_pts),
-                    DelayedTimeStop("stop_point:C", "20171101T0905"_pts),
-                    DelayedTimeStop("stop_point:D", "20171101T1000"_pts).added()
+                    RTStopTime("stop_point:A", "20171101T0800"_pts),
+                    RTStopTime("stop_point:B", "20171101T0830"_pts),
+                    RTStopTime("stop_point:C", "20171101T0905"_pts),
+                    RTStopTime("stop_point:D", "20171101T1000"_pts).added()
             });
 
     navitia::handle_realtime("add_new_stop_time_in_the_trip", timestamp, new_stop_at_the_end, *b.data, true);

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -39,6 +39,7 @@ struct DelayedTimeStop {
     std::string _msg = "birds on the tracks";
     bool _departure_skipped = false;
     bool _arrival_skipped = false;
+    bool _is_added = false;
     DelayedTimeStop(const std::string& n, int arrival_time, int departure_time):
         _stop_name(n), _arrival_time(arrival_time), _departure_time(departure_time) {}
     DelayedTimeStop(const std::string& n, int time):
@@ -50,6 +51,7 @@ struct DelayedTimeStop {
     DelayedTimeStop& arrival_skipped() { _arrival_skipped = true; return *this; }
     DelayedTimeStop& departure_skipped() { _departure_skipped = true; return *this; }
     DelayedTimeStop& skipped() { return arrival_skipped().departure_skipped(); }
+    DelayedTimeStop& added() { _is_added = true; return *this; }
 };
 
 inline transit_realtime::TripUpdate
@@ -76,11 +78,15 @@ make_delay_message(const std::string& vj_uri,
         departure->set_time(delayed_st._departure_time);
         departure->set_delay(delayed_st._departure_delay.total_seconds());
         auto skipped = transit_realtime::TripUpdate_StopTimeUpdate_ScheduleRelationship_SKIPPED;
+        auto added = transit_realtime::TripUpdate_StopTimeUpdate_ScheduleRelationship_ADDED;
         if (delayed_st._departure_skipped) {
             departure->SetExtension(kirin::stop_time_event_relationship, skipped);
         }
         if (delayed_st._arrival_skipped) {
             arrival->SetExtension(kirin::stop_time_event_relationship, skipped);
+        }
+        if(delayed_st._is_added) {
+            arrival->SetExtension(kirin::stop_time_event_relationship, added);
         }
     }
 

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -30,7 +30,7 @@ inline uint64_t to_posix_timestamp(const std::string& str) {
     return navitia::to_posix_timestamp(boost::posix_time::from_iso_string(str));
 }
 
-struct DelayedTimeStop {
+struct RTStopTime {
     std::string _stop_name;
     int _arrival_time = 0;
     int _departure_time = 0;
@@ -40,24 +40,24 @@ struct DelayedTimeStop {
     bool _departure_skipped = false;
     bool _arrival_skipped = false;
     bool _is_added = false;
-    DelayedTimeStop(const std::string& n, int arrival_time, int departure_time):
+    RTStopTime(const std::string& n, int arrival_time, int departure_time):
         _stop_name(n), _arrival_time(arrival_time), _departure_time(departure_time) {}
-    DelayedTimeStop(const std::string& n, int time):
+    RTStopTime(const std::string& n, int time):
         _stop_name(n), _arrival_time(time), _departure_time(time) {}
 
-    DelayedTimeStop& arrival_delay(navitia::time_duration delay) { _arrival_delay = delay; return *this; }
-    DelayedTimeStop& departure_delay(navitia::time_duration delay) { _departure_delay = delay; return *this; }
-    DelayedTimeStop& delay(navitia::time_duration delay) { return arrival_delay(delay).departure_delay(delay); }
-    DelayedTimeStop& arrival_skipped() { _arrival_skipped = true; return *this; }
-    DelayedTimeStop& departure_skipped() { _departure_skipped = true; return *this; }
-    DelayedTimeStop& skipped() { return arrival_skipped().departure_skipped(); }
-    DelayedTimeStop& added() { _is_added = true; return *this; }
+    RTStopTime& arrival_delay(navitia::time_duration delay) { _arrival_delay = delay; return *this; }
+    RTStopTime& departure_delay(navitia::time_duration delay) { _departure_delay = delay; return *this; }
+    RTStopTime& delay(navitia::time_duration delay) { return arrival_delay(delay).departure_delay(delay); }
+    RTStopTime& arrival_skipped() { _arrival_skipped = true; return *this; }
+    RTStopTime& departure_skipped() { _departure_skipped = true; return *this; }
+    RTStopTime& skipped() { return arrival_skipped().departure_skipped(); }
+    RTStopTime& added() { _is_added = true; return *this; }
 };
 
 inline transit_realtime::TripUpdate
 make_delay_message(const std::string& vj_uri,
         const std::string& start_date,
-        const std::vector<DelayedTimeStop>& delayed_time_stops) {
+        const std::vector<RTStopTime>& delayed_time_stops) {
     transit_realtime::TripUpdate trip_update;
     auto trip = trip_update.mutable_trip();
     trip->set_trip_id(vj_uri);

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -21,7 +21,7 @@ inline void handle_realtime_test(const std::string& id,
                                  const transit_realtime::TripUpdate& trip_update,
                                  const type::Data& data,
                                  std::unique_ptr<navitia::routing::RAPTOR>& raptor) {
-    navitia::handle_realtime(id, timestamp, trip_update, data);
+    navitia::handle_realtime(id, timestamp, trip_update, data,true);
     data.dataRaptor->load(*data.pt_data);
     raptor = std::make_unique<navitia::routing::RAPTOR>(data);
 }

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -103,29 +103,29 @@ struct departure_board_fixture {
         sp_ptr = b.data->pt_data->stop_points_map["S43"];
         b.data->pt_data->codes.add(sp_ptr, "Kisio数字", "Kisio数字_C:S43");
 
-        using ntest::DelayedTimeStop;
+        using ntest::RTStopTime;
         // we delay all A's vjs by 7mn (to be able to test whether it's base schedule or realtime data)
         auto trip_update1 = ntest::make_delay_message("A:vj1", "20160101", {
-                DelayedTimeStop("A:s", "20160101T0807"_pts).delay(7_min),
-                DelayedTimeStop("S1", "20160101T0907"_pts).delay(7_min),
-                DelayedTimeStop("S2", "20160101T1007"_pts).delay(7_min),
-                DelayedTimeStop("A:e", "20160101T1107"_pts).delay(7_min),
+                RTStopTime("A:s", "20160101T0807"_pts).delay(7_min),
+                RTStopTime("S1", "20160101T0907"_pts).delay(7_min),
+                RTStopTime("S2", "20160101T1007"_pts).delay(7_min),
+                RTStopTime("A:e", "20160101T1107"_pts).delay(7_min),
             });
         navitia::handle_realtime("delay_vj1", "20160101T1337"_dt, trip_update1, *b.data, true);
 
         auto trip_update2 = ntest::make_delay_message("A:vj2", "20160101", {
-                DelayedTimeStop("A:s", "20160101T0907"_pts).delay(7_min),
-                DelayedTimeStop("S1", "20160101T1007"_pts).delay(7_min),
-                DelayedTimeStop("S2", "20160101T1107"_pts).delay(7_min),
-                DelayedTimeStop("A:e", "20160101T1207"_pts).delay(7_min),
+                RTStopTime("A:s", "20160101T0907"_pts).delay(7_min),
+                RTStopTime("S1", "20160101T1007"_pts).delay(7_min),
+                RTStopTime("S2", "20160101T1107"_pts).delay(7_min),
+                RTStopTime("A:e", "20160101T1207"_pts).delay(7_min),
             });
         navitia::handle_realtime("delay_vj2", "20160101T1337"_dt, trip_update2, *b.data, true);
 
         auto trip_update3 = ntest::make_delay_message("A:vj3", "20160101", {
-                DelayedTimeStop("A:s", "20160101T1007"_pts).delay(7_min),
-                DelayedTimeStop("S1", "20160101T1107"_pts).delay(7_min),
-                DelayedTimeStop("S2", "20160101T1207"_pts).delay(7_min),
-                DelayedTimeStop("A:e", "20160101T1307"_pts).delay(7_min),
+                RTStopTime("A:s", "20160101T1007"_pts).delay(7_min),
+                RTStopTime("S1", "20160101T1107"_pts).delay(7_min),
+                RTStopTime("S2", "20160101T1207"_pts).delay(7_min),
+                RTStopTime("A:e", "20160101T1307"_pts).delay(7_min),
             });
         navitia::handle_realtime("delay_vj3", "20160101T1337"_dt, trip_update3, *b.data, true);
 
@@ -147,9 +147,9 @@ struct departure_board_fixture {
         //
         //
         auto trip_update = ntest::make_delay_message("vjP:1", "20160103", {
-                DelayedTimeStop("stopP1", "20160103T2340"_pts),
-                DelayedTimeStop("stopP2", "20160104T0008"_pts, "20160104T0010"_pts).delay(4_min),
-                DelayedTimeStop("stopP3", "20160104T0017"_pts).delay(4_min),
+                RTStopTime("stopP1", "20160103T2340"_pts),
+                RTStopTime("stopP2", "20160104T0008"_pts, "20160104T0010"_pts).delay(4_min),
+                RTStopTime("stopP3", "20160104T0017"_pts).delay(4_min),
             });
         navitia::handle_realtime("bib", "20160101T1337"_dt, trip_update, *b.data, true);
 
@@ -171,9 +171,9 @@ struct departure_board_fixture {
         //
         // 21m
         auto trip_update_q = ntest::make_delay_message("vjQ:1", "20160103", {
-                DelayedTimeStop("stopQ1", "20160104T0001"_pts).delay(21_min),
-                DelayedTimeStop("stopQ2", "20160104T0005"_pts, "20160104T0006"_pts).delay(21_min),
-                DelayedTimeStop("stopQ3", "20160104T0016"_pts).delay(21_min),
+                RTStopTime("stopQ1", "20160104T0001"_pts).delay(21_min),
+                RTStopTime("stopQ2", "20160104T0005"_pts, "20160104T0006"_pts).delay(21_min),
+                RTStopTime("stopQ3", "20160104T0016"_pts).delay(21_min),
             });
         navitia::handle_realtime("Q", "20160101T1337"_dt, trip_update_q, *b.data, true);
         b.data->build_raptor();

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -111,7 +111,7 @@ struct departure_board_fixture {
                 DelayedTimeStop("S2", "20160101T1007"_pts).delay(7_min),
                 DelayedTimeStop("A:e", "20160101T1107"_pts).delay(7_min),
             });
-        navitia::handle_realtime("delay_vj1", "20160101T1337"_dt, trip_update1, *b.data);
+        navitia::handle_realtime("delay_vj1", "20160101T1337"_dt, trip_update1, *b.data, true);
 
         auto trip_update2 = ntest::make_delay_message("A:vj2", "20160101", {
                 DelayedTimeStop("A:s", "20160101T0907"_pts).delay(7_min),
@@ -119,7 +119,7 @@ struct departure_board_fixture {
                 DelayedTimeStop("S2", "20160101T1107"_pts).delay(7_min),
                 DelayedTimeStop("A:e", "20160101T1207"_pts).delay(7_min),
             });
-        navitia::handle_realtime("delay_vj2", "20160101T1337"_dt, trip_update2, *b.data);
+        navitia::handle_realtime("delay_vj2", "20160101T1337"_dt, trip_update2, *b.data, true);
 
         auto trip_update3 = ntest::make_delay_message("A:vj3", "20160101", {
                 DelayedTimeStop("A:s", "20160101T1007"_pts).delay(7_min),
@@ -127,7 +127,7 @@ struct departure_board_fixture {
                 DelayedTimeStop("S2", "20160101T1207"_pts).delay(7_min),
                 DelayedTimeStop("A:e", "20160101T1307"_pts).delay(7_min),
             });
-        navitia::handle_realtime("delay_vj3", "20160101T1337"_dt, trip_update3, *b.data);
+        navitia::handle_realtime("delay_vj3", "20160101T1337"_dt, trip_update3, *b.data, true);
 
 
         //
@@ -151,7 +151,7 @@ struct departure_board_fixture {
                 DelayedTimeStop("stopP2", "20160104T0008"_pts, "20160104T0010"_pts).delay(4_min),
                 DelayedTimeStop("stopP3", "20160104T0017"_pts).delay(4_min),
             });
-        navitia::handle_realtime("bib", "20160101T1337"_dt, trip_update, *b.data);
+        navitia::handle_realtime("bib", "20160101T1337"_dt, trip_update, *b.data, true);
 
         //
         //      20160103                    |    20160104
@@ -175,7 +175,7 @@ struct departure_board_fixture {
                 DelayedTimeStop("stopQ2", "20160104T0005"_pts, "20160104T0006"_pts).delay(21_min),
                 DelayedTimeStop("stopQ3", "20160104T0016"_pts).delay(21_min),
             });
-        navitia::handle_realtime("Q", "20160101T1337"_dt, trip_update_q, *b.data);
+        navitia::handle_realtime("Q", "20160101T1337"_dt, trip_update_q, *b.data, true);
         b.data->build_raptor();
         b.data->build_uri();
     }

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -249,8 +249,8 @@ struct StopTimeUpdate {
         DELETED,
         DELAYED
     };
-    Status departure_status;
-    Status arrival_status;
+    Status departure_status{Status::UNCHANGED};
+    Status arrival_status{Status::UNCHANGED};
     StopTimeUpdate() {}
     StopTimeUpdate(const StopTime& st, const std::string& c, Status dep_status, Status arr_status):
         stop_time(st), cause(c), departure_status(dep_status), arrival_status(arr_status) {}

--- a/source/type/validity_pattern.cpp
+++ b/source/type/validity_pattern.cpp
@@ -30,6 +30,7 @@ www.navitia.io
 #include "validity_pattern.h"
 #include <log4cplus/logger.h>
 #include <log4cplus/loggingmacros.h>
+#include "utils/exception.h"
 #include "datetime.h"
 
 namespace navitia {


### PR DESCRIPTION
* Manage adding of stop time in realtime (https://jira.kisio.org/browse/NAVP-1047)
* New conf param to ignore realtime add (https://jira.kisio.org/browse/NAVP-1038)

TODO:

- [x] adapt tests so they test with realtime add allowed (first commit tests nothing is broken when it's forbidden)
- [x] deployment PR (fabric + conf)
- [x] add tests on that ? Maybe following the tests on realtime add (from #2579 )