### PR TITLE
Jormun: ridesharing crowfly is never equivalent to another crowfly

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -366,28 +366,37 @@ def is_walk_after_parking(journey, idx_section):
     return False
 
 
-def similar_journeys_vj_generator(journey):
+def similar_pt_section_vj(section):
+    return 'pt:%s' % section.pt_display_informations.uris.vehicle_journey
+
+
+def similar_pt_section_line(section):
+    return "pt:{}".format(section.pt_display_informations.uris.line)
+
+
+def similar_journeys_generator(journey, pt_functor):
     for idx, s in enumerate(journey.sections):
         if s.type == response_pb2.PUBLIC_TRANSPORT:
-            yield 'pt:%s' % s.pt_display_informations.uris.vehicle_journey
+            yield pt_functor(s)
         elif s.type == response_pb2.STREET_NETWORK:
             # special case, we don't want to consider the walking section after/before parking a car
             # so CAR / PARK / WALK / PT is equivalent to CAR / PARK / PT
             if is_walk_after_parking(journey, idx):
                 continue
             yield 'sn:%s' % s.street_network.mode
+        elif s.type == response_pb2.CROW_FLY and s.street_network.mode == response_pb2.Ridesharing:
+            # crowfly in ridesharing must be distinct from crowfly in walking
+            yield "sn:{}".format(s.street_network.mode)
+
+
+def similar_journeys_vj_generator(journey):
+    for v in similar_journeys_generator(journey, similar_pt_section_vj):
+        yield v
 
 
 def similar_journeys_line_generator(journey):
-    for idx, s in enumerate(journey.sections):
-        if s.type == response_pb2.PUBLIC_TRANSPORT:
-            yield "pt:{}".format(s.pt_display_informations.uris.line)
-        elif s.type == response_pb2.STREET_NETWORK:
-            # special case, we don't want to consider the walking section after/before parking a car
-            # so CAR / PARK / WALK / PT is equivalent to CAR / PARK / PT
-            if is_walk_after_parking(journey, idx):
-                continue
-            yield "sn:{}".format(s.street_network.mode)
+    for v in similar_journeys_generator(journey, similar_pt_section_line):
+        yield v
 
 
 def shared_section_generator(journey):

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_compare_tests.py
@@ -615,6 +615,24 @@ def test_similar_journeys_bss_park():
     assert jf.compare(journey1, journey2, jf.similar_journeys_vj_generator)
 
 
+def test_similar_journeys_crowfly_rs():
+    """
+    We have to consider a journey with
+    CROWFLY WALK to be different than CROWFLY Ridesharing
+    """
+    journey1 = response_pb2.Journey()
+    journey1.sections.add()
+    journey1.sections[-1].type = response_pb2.CROW_FLY
+    journey1.sections[-1].street_network.mode = response_pb2.Walking
+
+    journey2 = response_pb2.Journey()
+    journey2.sections.add()
+    journey2.sections[-1].type = response_pb2.CROW_FLY
+    journey2.sections[-1].street_network.mode = response_pb2.Ridesharing
+
+    assert not jf.compare(journey1, journey2, jf.similar_journeys_vj_generator)
+
+
 def test_departure_sort():
     """
     we want to sort by departure hour, then by duration


### PR DESCRIPTION
This change the similar_journey_filter to prevent a journey with a
ridesharing crowfly to remove a journey with a walking crowfly.
Also refacto a bit the generators to factorize the streetnetwork part

JIRA: https://jira.kisio.org/browse/NAVP-1077