### PR TITLE
Doc: removing unused stop location_type=3

### DIFF
--- a/documentation/ntfs/ntfs_changelog_fr.md
+++ b/documentation/ntfs/ntfs_changelog_fr.md
@@ -59,3 +59,5 @@
     * les fichiers contributors.txt et datasets.txt sont obligatoires, ainsi que le lien entre "trip" et "dataset_id"
     * le champ "comment_value" est renommé "comment_name" (conformité avec le code)
     * les valeurs de comment_type changent
+* Version 0.7.2 du 30/10/2018
+    * dans le fichier stops.txt, suppresion du "location_type = 3" qui n'est pas utilisé

--- a/documentation/ntfs/ntfs_fr.md
+++ b/documentation/ntfs/ntfs_fr.md
@@ -333,7 +333,6 @@ equipment_id | chaine | Optionnel | Identifiant de la propriété accessibilité
         0 ou non spécifié - Arrêt physique (objet stop_point)
         1 - Zone d'arrêt (objet stop_area)
         2 - Zone géographique (pour le TAD zonal de type "adressse à adresse", objet stop_zone)
-        3 - Commune
 
 ### stop_times.txt (requis)
 Colonne | Type | Contrainte | Commentaire


### PR DESCRIPTION
location_type = 3 is not used in fusio2ed and is not provided in actual NTFS.
This PR proposes to remove this unused value.