### PR TITLE
Ed: Add codes in companies

### DIFF
--- a/fixtures/ed/ntfs/companies.txt
+++ b/fixtures/ed/ntfs/companies.txt
@@ -1,1 +1,3 @@
 company_id,company_name,company_address_name,company_address_number,company_address_type,company_url,company_mail,company_phone,company_fax,contributor_id
+COMP:A,"company_name_A",,,,,,,,contributor_id_a
+COMP:B,"company_name_B",,,,,,,,contributor_id_b

--- a/fixtures/ed/ntfs/object_codes.txt
+++ b/fixtures/ed/ntfs/object_codes.txt
@@ -20,4 +20,8 @@ stop_point,SP:J,navitia1,J
 route,route_1,navitia1,route_1
 route,route_2,navitia1,route_2
 route,route_3,navitia1,route_3
+route,route_4,navitia1,route_4
 line,11,navitia1,11
+company,COMP:A,navitia1,A
+company,COMP:A,navitia1,B
+company,COMP:B,navitia1,A

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -295,7 +295,7 @@ void RouteFusioHandler::handle_line(Data& data, const csv_row& row, bool) {
         LOG4CPLUS_WARN(logger, "Route orphan " + row[route_id_c]);
         return;
     }
-    ed::types::Route* ed_route = new ed::types::Route();    
+    ed::types::Route* ed_route = new ed::types::Route();
     ed_route->line = ed_line;
     ed_route->uri = row[route_id_c];
 
@@ -768,7 +768,7 @@ void DatasetFusioHandler::init(Data&){
     end_date_c = csv.get_pos_col("dataset_end_date");
     type_c = csv.get_pos_col("dataset_type");
     desc_c = csv.get_pos_col("dataset_desc");
-    system_c = csv.get_pos_col("dataset_system");    
+    system_c = csv.get_pos_col("dataset_system");
 }
 
 void DatasetFusioHandler::handle_line(Data& data, const csv_row& row, bool is_first_line){
@@ -1188,7 +1188,7 @@ void StopPropertiesFusioHandler::handle_line(Data&, const csv_row& row, bool is_
 }
 
 void ObjectPropertiesFusioHandler::init(Data &){
-    object_id_c = csv.get_pos_col("object_id"); 
+    object_id_c = csv.get_pos_col("object_id");
     object_type_c = csv.get_pos_col("object_type");
     property_name_c = csv.get_pos_col("object_property_name");
     property_value_c = csv.get_pos_col("object_property_value");
@@ -1693,6 +1693,11 @@ void ObjectCodesFusioHandler::handle_line(Data& data, const csv_row& row, bool) 
     } else if (object_type == "stop_point"){
         const auto& it_object = gtfs_data.stop_map.find(row[object_uri_c]);
         if(it_object != gtfs_data.stop_map.end()){
+            data.add_object_code(it_object->second, row[code_c], key);
+        }
+    } else if (object_type == "company"){
+        const auto& it_object = gtfs_data.company_map.find(row[object_uri_c]);
+        if(it_object != gtfs_data.company_map.end()){
             data.add_object_code(it_object->second, row[code_c], key);
         }
     } else {

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -115,7 +115,30 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     BOOST_REQUIRE_EQUAL(data.lines.size(), 4);
     BOOST_REQUIRE_EQUAL(data.routes.size(), 4);
 
-    //chekc comments
+    // object_codes
+    BOOST_REQUIRE_EQUAL(data.object_codes.size(), 21);
+    // routes
+    for (uint i = 0; i < data.routes.size(); ++i) {
+        auto obj_codes_routes_map = data.object_codes[ed::types::make_pt_object(data.routes[i])];
+        BOOST_REQUIRE_EQUAL(obj_codes_routes_map.size(), 1);
+        for (const auto obj_codes : obj_codes_routes_map) {
+            BOOST_CHECK_EQUAL(obj_codes.second[0], "route_" + std::to_string(i + 1));
+        }
+    }
+    // companies
+    auto obj_codes_map = data.object_codes[ed::types::make_pt_object(data.companies[0])];
+    BOOST_REQUIRE_EQUAL(obj_codes_map.size(), 1);
+    for (const auto obj_codes : obj_codes_map) {
+        BOOST_CHECK_EQUAL(obj_codes.second[0], "A");
+        BOOST_CHECK_EQUAL(obj_codes.second[1], "B");
+    }
+    obj_codes_map = data.object_codes[ed::types::make_pt_object(data.companies[1])];
+    BOOST_REQUIRE_EQUAL(obj_codes_map.size(), 1);
+    for (const auto obj_codes : obj_codes_map) {
+        BOOST_CHECK_EQUAL(obj_codes.second[0], "A");
+    }
+
+    // check comments
     BOOST_REQUIRE_EQUAL(data.comment_by_id.size(), 2);
     BOOST_CHECK_EQUAL(data.comment_by_id["bob"], "bob is in the kitchen");
     BOOST_CHECK_EQUAL(data.comment_by_id["bobette"], "test comment");

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -173,6 +173,30 @@ class TestEndPoint(AbstractTestFixture):
         assert response['geo_status']['street_network_sources'] == []
         assert response['geo_status']['poi_sources'] == []
 
+    def test_companies(self):
+        response = self.query('/v1/coverage/main_ptref_test/companies', display=True)
+        self.check_context(response)
+        assert len(response['companies']) == 2
+
+        # Company 1
+        assert response['companies'][0]['name'] == 'CMP1'
+        assert response['companies'][0]['id'] == 'CMP1'
+
+        # Codes for Company 1
+        assert len(response['companies'][0]['codes']) == 3
+        for idx, code in enumerate(response['companies'][0]['codes']):
+            assert code['type'] == 'cmp1_code_key_' + str(idx)
+            assert code['value'] == 'cmp1_code_value_' + str(idx)
+
+        # company 2
+        assert response['companies'][1]['name'] == 'CMP2'
+        assert response['companies'][1]['id'] == 'CMP2'
+
+        # Codes for Company 2
+        assert len(response['companies'][1]['codes']) == 1
+        assert response['companies'][1]['codes'][0]['type'] == 'cmp2_code_key_0'
+        assert response['companies'][1]['codes'][0]['value'] == 'cmp2_code_value_0'
+
     def test_lines_context(self):
         response = self.query('/v1/coverage/main_routing_test/lines', display=True)
         self.check_context(response)

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -478,23 +478,6 @@ class TestPtRef(AbstractTestFixture):
 
         self._test_links(response, 'stop_points')
 
-    def test_company_default_depth(self):
-        """default depth is 1"""
-        response = self.query_region("companies")
-
-        companies = get_not_null(response, 'companies')
-
-        for company in companies:
-            is_valid_company(company, depth_check=1)
-
-        # we check afterward that we have the right data
-        # we know there is only one vj in the dataset
-        assert len(companies) == 1
-        company = companies[0]
-        assert company['id'] == 'CMP1'
-
-        self._test_links(response, 'companies')
-
     def test_simple_crow_fly(self):
         journey_basic_query = "journeys?from=9;9.001&to=stop_area%3Astop2&datetime=20140105T000000"
         response = self.query_region(journey_basic_query)

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -118,6 +118,28 @@ struct data_set {
         for (auto r: b.lines["line:Ça roule"]->route_list) {
             r->destination = b.sas.find("stop_area:stop1")->second;
         }
+
+        // Company added
+        navitia::type::Company* cmp1 = new navitia::type::Company();
+        cmp1->line_list.push_back(b.lines["line:A"]);
+        b.data->pt_data->companies.push_back(cmp1);
+        cmp1->idx = b.data->pt_data->companies.size();
+        cmp1->name = "CMP1";
+        cmp1->uri = "CMP1";
+        b.lines["line:A"]->company_list.push_back(cmp1);
+        navitia::type::Company* cmp2 = new navitia::type::Company();
+        cmp2->line_list.push_back(b.lines["line:A"]);
+        b.data->pt_data->companies.push_back(cmp2);
+        cmp2->idx = b.data->pt_data->companies.size();
+        cmp2->name = "CMP2";
+        cmp2->uri = "CMP2";
+        b.lines["line:A"]->company_list.push_back(cmp2);
+        b.lines["line:A"]->text_color = "FFD700";
+
+        b.data->pt_data->codes.add(b.data->pt_data->companies[0], "cmp1_code_key_0", "cmp1_code_value_0");
+        b.data->pt_data->codes.add(b.data->pt_data->companies[0], "cmp1_code_key_1", "cmp1_code_value_1");
+        b.data->pt_data->codes.add(b.data->pt_data->companies[0], "cmp1_code_key_2", "cmp1_code_value_2");
+        b.data->pt_data->codes.add(b.data->pt_data->companies[1], "cmp2_code_key_0", "cmp2_code_value_0");
         b.data->pt_data->codes.add(b.lines["line:A"], "external_code", "A");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeB", "B");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeB", "Bise");
@@ -129,6 +151,7 @@ struct data_set {
         navitia::type::VehicleJourney* vj = b.data->pt_data->vehicle_journeys_map["vj1"];
         vj->base_validity_pattern()->add(boost::gregorian::from_undelimited_string("20140101"),
                                   boost::gregorian::from_undelimited_string("20140111"), monday_cal->week_pattern);
+        vj->company = cmp1;
 
         //we add some comments
         auto& comments = b.data->pt_data->comments;
@@ -148,17 +171,6 @@ struct data_set {
                 .on(nt::Type_e::StopArea, "stop_area:stop1")
                 .application_periods(btp("20140101T000000"_dt, "20140120T235959"_dt))
                 .publish(btp("20140101T000000"_dt, "20140120T235959"_dt));
-       // Company added
-        navitia::type::Company* cmp = new navitia::type::Company();
-        cmp->line_list.push_back(b.lines["line:A"]);
-        vj->company = cmp;
-        b.data->pt_data->companies.push_back(cmp);
-        cmp->idx = b.data->pt_data->companies.size();
-        cmp->name = "CMP1";
-        cmp->uri = "CMP1";
-        b.lines["line:A"]->company_list.push_back(cmp);
-
-        b.lines["line:A"]->text_color = "FFD700";
         // LineGroup added
         navitia::type::LineGroup* lg = new navitia::type::LineGroup();
         lg->name = "A group";


### PR DESCRIPTION
Purpose : Add `codes` list in company
Everything was good except the loading with fusio2ed binary...
Swagger is already OK

Example with a real data (SNCF NTFS) :
![company](https://user-images.githubusercontent.com/32099204/48208588-7183b000-e373-11e8-8d29-7cb2ccfaddfa.png)


A commit for each step :

- Add object code for company type in fusio2ed
- Add Ed unit test
- Add integration test for `/companies` entry point. Take the opportunity to test `codes` with company
- Avoid duplicate test / erase old test
