### PR TITLE
Kraken: prioritize main stop_area over the others stop_area

### DIFF
--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -227,7 +227,7 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
                 auto main_stop_areas = get_main_stop_areas(d);
                 for(auto& r: result){
                     if(main_stop_areas.count(d.pt_data->stop_areas[r.idx]->uri)){
-                        std::get<0>(r.scores) = std::get<0>(r.scores) * main_stop_area_weight_factor;
+                        std::get<0>(r.scores) *= main_stop_area_weight_factor;
                     }
                 }
             }

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -334,7 +334,6 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
     }
 
 
-
     //Sort the list of objects (sort by object type , score, quality and name)
     //delete unwanted objects at the end of the list
     auto compare_attributs = [](pbnavitia::PtObject a, pbnavitia::PtObject b)->bool {

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -194,7 +194,7 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
                                  const std::vector<std::string> &admins,
                                  int search_type,
                                  const navitia::type::Data &d,
-                                 float main_sa_weight_factor) {
+                                 float main_stop_area_weight_factor) {
 
     if (q.empty()) {
         pb_creator.fill_pb_error(pbnavitia::Error::bad_filter, "Autocomplete : value of q absent");
@@ -223,12 +223,12 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
                         d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr), d.geo_ref->ghostwords);
             }
-            if(main_sa_weight_factor != 1.0){
+            if(main_stop_area_weight_factor != 1.0){
                 std::cout << "boosting main SA" << std::endl;
                 auto main_stop_areas = get_main_stop_areas(d);
                 for(auto& r: result){
                     if(main_stop_areas.count(d.pt_data->stop_areas[r.idx]->uri)){
-                        std::get<0>(r.scores) = std::get<0>(r.scores) * main_sa_weight_factor;
+                        std::get<0>(r.scores) = std::get<0>(r.scores) * main_stop_area_weight_factor;
                     }
                 }
             }

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -224,7 +224,6 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
                         nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr), d.geo_ref->ghostwords);
             }
             if(main_stop_area_weight_factor != 1.0){
-                std::cout << "boosting main SA" << std::endl;
                 auto main_stop_areas = get_main_stop_areas(d);
                 for(auto& r: result){
                     if(main_stop_areas.count(d.pt_data->stop_areas[r.idx]->uri)){

--- a/source/autocomplete/autocomplete_api.h
+++ b/source/autocomplete/autocomplete_api.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -51,6 +51,7 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
                                  int nbmax,
                                  const std::vector <std::string> &admins,
                                  int search_type,
-                                 const type::Data &d);
+                                 const type::Data &d,
+                                 float main_sa_weight_factor=1.0);
 }
 }

--- a/source/autocomplete/autocomplete_api.h
+++ b/source/autocomplete/autocomplete_api.h
@@ -52,6 +52,6 @@ void autocomplete(navitia::PbCreator& pb_creator, const std::string &q,
                                  const std::vector <std::string> &admins,
                                  int search_type,
                                  const type::Data &d,
-                                 float main_sa_weight_factor=1.0);
+                                 float main_stop_area_weight_factor=1.0);
 }
 }

--- a/source/jormungandr/jormungandr/autocomplete/kraken.py
+++ b/source/jormungandr/jormungandr/autocomplete/kraken.py
@@ -69,7 +69,7 @@ class Kraken(AbstractAutocomplete):
         req.places.depth = request['depth']
         req.places.count = request['count']
         req.places.search_type = request['search_type']
-        req.places.main_stop_areas_weight_factor = request.get('_main_stop_areas_weight_factor', 1.0)
+        req.places.main_stop_area_weight_factor = request.get('_main_stop_area_weight_factor', 1.0)
         req._current_datetime = date_to_timestamp(request['_current_datetime'])
         req.disable_disruption = True
         if request["type[]"]:

--- a/source/jormungandr/jormungandr/autocomplete/kraken.py
+++ b/source/jormungandr/jormungandr/autocomplete/kraken.py
@@ -69,6 +69,7 @@ class Kraken(AbstractAutocomplete):
         req.places.depth = request['depth']
         req.places.count = request['count']
         req.places.search_type = request['search_type']
+        req.places.main_stop_areas_weight_factor = request.get('_main_stop_areas_weight_factor', 1.0)
         req._current_datetime = date_to_timestamp(request['_current_datetime'])
         req.disable_disruption = True
         if request["type[]"]:

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -110,6 +110,9 @@ class Places(ResourceUri):
             "search_type", type=int, default=0, hidden=True, help="Type of search: firstletter or type error"
         )
         self.parsers["get"].add_argument(
+            "_main_stop_areas_weight_factor", type=float, default=1.0, hidden=True, help="TODO"
+        )
+        self.parsers["get"].add_argument(
             "admin_uri[]",
             type=six.text_type,
             action="append",

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -110,7 +110,11 @@ class Places(ResourceUri):
             "search_type", type=int, default=0, hidden=True, help="Type of search: firstletter or type error"
         )
         self.parsers["get"].add_argument(
-            "_main_stop_areas_weight_factor", type=float, default=1.0, hidden=True, help="TODO"
+            "_main_stop_area_weight_factor",
+            type=float,
+            default=1.0,
+            hidden=True,
+            help="multiplicator for the weight of main stop area",
         )
         self.parsers["get"].add_argument(
             "admin_uri[]",

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -210,6 +210,21 @@ class TestPlaces(AbstractTestFixture):
         is_valid_places(response['places_nearby'])
         assert len(response['disruptions']) == 1
 
+    def test_main_stop_area_weight_factor(self):
+        response = self.query_region("places?type[]=stop_area&q=stop")
+        places = response['places']
+        assert len(places) == 3
+        assert places[0]['id'] == 'stopA'
+        assert places[1]['id'] == 'stopB'
+        assert places[2]['id'] == 'stopC'
+
+        response = self.query_region("places?type[]=stop_area&q=stop&_main_stop_area_weight_factor=5")
+        places = response['places']
+        assert len(places) == 3
+        assert places[0]['id'] == 'stopC'
+        assert places[1]['id'] == 'stopA'
+        assert places[2]['id'] == 'stopB'
+
     def test_disruptions_in_places(self):
         """check disruptions in places"""
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -353,7 +353,7 @@ void Worker::autocomplete(const pbnavitia::PlacesRequest & request) {
     navitia::autocomplete::autocomplete(this->pb_creator, request.q(),
                                         vector_of_pb_types(request), request.depth(),
                                         request.count(), vector_of_admins(request),
-                                        request.search_type(), *data, request.main_stop_areas_weight_factor());
+                                        request.search_type(), *data, request.main_stop_area_weight_factor());
 }
 
 void Worker::pt_object(const pbnavitia::PtobjectRequest & request) {

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -353,7 +353,7 @@ void Worker::autocomplete(const pbnavitia::PlacesRequest & request) {
     navitia::autocomplete::autocomplete(this->pb_creator, request.q(),
                                         vector_of_pb_types(request), request.depth(),
                                         request.count(), vector_of_admins(request),
-                                        request.search_type(), *data);
+                                        request.search_type(), *data, request.main_stop_areas_weight_factor());
 }
 
 void Worker::pt_object(const pbnavitia::PtobjectRequest & request) {

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -469,6 +469,9 @@ struct routing_api_data {
         b.data->pt_data->sort_and_index();
         b.data->build_raptor();
 
+        //add a main stop area to our admin
+        admin->main_stop_areas.push_back(b.data->pt_data->stop_areas_map["stopC"]);
+
         //Add a fare_zone in stop point A
         b.sps.begin()->second->fare_zone = "2";
 


### PR DESCRIPTION
With the change we reintroduce one of the rules used by navitia 1. :disappointed: 
It allows data administrators to increase the weight of some stop_area
by setting them as main stop_area.
This is a hack to make JLP happy: we need to find a better way to
implement this as `main stop_area` are used for admin to admin journeys
and geocoding.
You may want to set a coach station as the departure/arrival of a city
when doing long distance journeys, but it's a "minor" stop in the urban
network and even in the national network so you don't want to increase its visibility when doing geocoding.

The previous version of this change was always putting main stop area before, now it's more subtile, a new parameter has been added to the api: `_main_stop_area_weight_factor` that defines the factor to be applied to the weight/score of a stop_area that is a main stop area. 
The main advantage of this solution is that it won't impact any existing users since the default value is `1.0` so nothing new will be done.
It also lets us fine tune this factor to see the impacts, manual tests has been done with a value of `1.3` and provide some good result on the IdFM datasets.

- [x] Tests to come !