### PR TITLE
Kraken: display departures on stop_point used multiple times in lines

### DIFF
--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -399,7 +399,7 @@ class TestSwaggerSchemaDepartureBoard(AbstractTestFixture, SchemaChecker):
         )
 
         # we have some errors, but only on additional_informations
-        assert len(errors) == 9
+        assert len(errors) == 10
         for k, e in errors.items():
             assert k.endswith('additional_informations[0].type[0]')
             assert e == "Got value `None` of type `null`. Value must be of type(s): `(u'string',)`"

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -1696,8 +1696,8 @@ BOOST_AUTO_TEST_CASE(stop_schedule_on_partial_terminus) {
     b.data->build_raptor();
     b.data->pt_data->build_uri();
     auto * data_ptr = b.data.get();
-    // hacky way to set another terminus to have partial terminuses
-    data_ptr->pt_data->routes[0]->destination = data_ptr->pt_data->stop_areas[1];
+    // Set a different terminus on the route to have partial terminuses
+    data_ptr->pt_data->routes[0]->destination = b.sas.find("real terminus")->second;
 
     navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
     departure_board(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"), 86400, 3,
@@ -1708,6 +1708,7 @@ BOOST_AUTO_TEST_CASE(stop_schedule_on_partial_terminus) {
     auto stop_schedule = resp.stop_schedules(0);
     BOOST_CHECK_EQUAL(stop_schedule.stop_point().uri(), "stop3");
     BOOST_CHECK_EQUAL(stop_schedule.route().uri(), "A:0");
+    BOOST_CHECK_EQUAL(stop_schedule.route().direction().uri(), "real terminus");
     BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 0);
     BOOST_CHECK_EQUAL(stop_schedule.response_status(), pbnavitia::ResponseStatus::partial_terminus);
 
@@ -1720,6 +1721,7 @@ BOOST_AUTO_TEST_CASE(stop_schedule_on_partial_terminus) {
     stop_schedule = resp.stop_schedules(0);
     BOOST_CHECK_EQUAL(stop_schedule.stop_point().uri(), "stop3");
     BOOST_CHECK_EQUAL(stop_schedule.route().uri(), "A:0");
+    BOOST_CHECK_EQUAL(stop_schedule.route().direction().uri(), "real terminus");
     BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 0);
     BOOST_CHECK_EQUAL(stop_schedule.response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 }


### PR DESCRIPTION
Hello everyone,

This is to fix issue #2289. We have (well, we had, but it could come back one day) a line with the same first and last stop_point. When we did a departure_board on this stop_point, there were no date_times, and it was tagged as "terminus". It would be nice to have them :).

This PR makes some changes on this and also the way we flag terminus and partial terminus : 
- Change the check for is_last_stoptime. Before we were only checking if the stop_point of the stop_time was the same as the last stop_point of the vj. Now we check the order of the stop time instead.
- Change the way we flag terminus and partial_terminus.
  - Before
    - It was a terminus if the stop_area of the stop_point was the same as the destination of the route.
    - If not we were checking if all the stop_times were on the same stop_point as the last one of the journey_pattern they were on. If it was the case, it was a partial terminus.
    - Tagging as partial terminus meant we had stop_times to check. It was only the case when a calendar_id was passed. Otherwise, routing::get_stop_times return an empty set of pickup stop_times on terminuses and we could not check.
    - `terminus` had the priority over `no_departure_this_day` since the check is done before.
  - Now
    - To check if it's a terminus or partial terminus we need stop_times. For calendar we have them, otherwise if the pickup stop_times are empty, we request the dropoff stop_times.
    - If all stop_times are last stop_times (check on the order) we check if the stop_area of the stop_point is the destination of the route. If it is, it's a terminus, otherwise a partial_terminus.
    - Now partial terminus works for both calendar and non calendar requests.
    - `no_departure_this_day` has the priority over `terminus`. Since we need stop_times to output the `terminus` flag, if no dropoff stop_times are returned by get_stop_times we use `no_departure_this_day`.

The last commit make some changes on schema_tests.py. In `TestSwaggerSchemaDepartureBoard` there is a few changes on additional_informations (since it is where ResponseStatus is returned in the API).
I looked at all the difference, there were two cases : 
* The first one is now we output partial_terminuses. In https://github.com/CanalTP/navitia/blob/dev/source/time_tables/tests/departure_board_test_data.h#L344 we set the same destination for all the route (we overwrite some of them afterwards) so we have quite a few partial terminuses.
* Previously departure_board on StopR2 for the vj of line `R` defined here https://github.com/CanalTP/navitia/blob/dev/source/time_tables/tests/departure_board_test_data.h#L249 had a `terminus` tag. It isn't the case anymore, since we are not on the terminus of the vj. This one explains the additional error (another additional_informations at null).

Let me know if there is something to change or if you have any question. 