### PR TITLE
Kraken: Disambiguision of the fetched branch in the retrocompat script

### DIFF
--- a/source/scripts/check_retrocompat.sh
+++ b/source/scripts/check_retrocompat.sh
@@ -22,8 +22,9 @@ model_files=(
     "source/type/validity_pattern.h"
 )
 
-diff_filenames=`git diff --name-only $branch_to` # List the updated files
 
+fetch_remote_branch=`git fetch origin $branch_to` # Make sure we are up to date with the remote for the diff
+diff_filenames=`git diff --name-only origin/$branch_to` # List the updated files
 num_model_files=${#model_files[@]}
 modified_model_files=()
 

--- a/source/scripts/check_retrocompat.sh
+++ b/source/scripts/check_retrocompat.sh
@@ -23,7 +23,6 @@ model_files=(
 )
 
 
-fetch_remote_branch=`git fetch origin $branch_to` # Make sure we are up to date with the remote for the diff
 diff_filenames=`git diff --name-only origin/$branch_to` # List the updated files
 num_model_files=${#model_files[@]}
 modified_model_files=()


### PR DESCRIPTION
When running the retrocompat script, jenkins was complaining about the diff branch being ambiguous

```log
++ git diff --name-only dev
fatal: ambiguous argument 'dev': unknown revision or path not in the working tree.
```

This is fixed by using the remote:
```sh
git diff --name-only origin/dev
```
