### PR TITLE
Kraken: Realtime,Take into account companies into new VJ

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -182,6 +182,12 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 r,
                 std::move(stoptimes),
                 pt_data);
+            if (!impact->company_id.empty()) {
+                auto company = pt_data.companies_map[impact->company_id];
+                if (company) {
+                    vj->company = company;
+                }
+            }
             LOG4CPLUS_TRACE(log, "New vj has been created " << vj->uri);
             // Use the corresponding base stop_time for boarding and alighting duration
             for(auto& st: vj->stop_time_list) {

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -186,6 +186,8 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 auto company = pt_data.companies_map[impact->company_id];
                 if (company) {
                     vj->company = company;
+                } else {
+                    LOG4CPLUS_WARN(log, "[disruption] Associate company into new VJ. Company doesn't exist with id : " << impact->company_id);
                 }
             }
             LOG4CPLUS_TRACE(log, "New vj has been created " << vj->uri);

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -309,6 +309,9 @@ create_disruption(const std::string& id,
         impact->uri = disruption.uri;
         impact->created_at = timestamp;
         impact->updated_at = timestamp;
+        if (trip_update.trip().HasExtension(kirin::company_id)) {
+            impact->company_id = trip_update.trip().GetExtension(kirin::company_id);
+        }
         if (trip_update.HasExtension(kirin::trip_message)) {
             impact->messages.push_back(create_message(trip_update.GetExtension(kirin::trip_message)));
         }

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -57,10 +57,12 @@ struct RTStopTime {
 inline transit_realtime::TripUpdate
 make_delay_message(const std::string& vj_uri,
         const std::string& start_date,
-        const std::vector<RTStopTime>& delayed_time_stops) {
+        const std::vector<RTStopTime>& delayed_time_stops,
+        const std::string& company_id = "") {
     transit_realtime::TripUpdate trip_update;
     auto trip = trip_update.mutable_trip();
     trip->set_trip_id(vj_uri);
+    trip->SetExtension(kirin::company_id, company_id);
     // start_date is used to disambiguate trips that are very late, cf:
     // https://github.com/CanalTP/chaos-proto/blob/master/gtfs-realtime.proto#L459
     trip->set_start_date(start_date);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -61,7 +61,7 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace type {
 
-const unsigned int Data::data_version = 68; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 69; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -303,7 +303,7 @@ struct Impact {
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
-        ar & uri & created_at & updated_at & application_periods
+        ar & uri & company_id & created_at & updated_at & application_periods
            & severity & _informed_entities & messages & disruption
            & aux_info;
     }

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -282,6 +282,7 @@ struct AuxInfoForMetaVJ {
 struct Impact {
     using SharedImpact = boost::shared_ptr<Impact>;
     std::string uri;
+    std::string company_id;
     boost::posix_time::ptime created_at;
     boost::posix_time::ptime updated_at;
 


### PR DESCRIPTION
Work objective : Take into account `Companies` inside new VJ, when a Real Time perturbation arrives.
Reading by commits is more easily

With love, Ben :unicorn: 