### PR TITLE
kraken: Compute projected_centroid of at binarisation

### DIFF
--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -197,7 +197,7 @@ nt::MultiLineString Way::make_multiline(const Graph& graph) const {
 
 
 // returns the centroid projected on the way
-nt::GeographicalCoord Way::projected_centroid(const Graph& graph) const {
+void Way::compute_projected_centroid(const Graph& graph) {
     const auto multiline = make_multiline(graph);
 
     nt::GeographicalCoord centroid;
@@ -208,7 +208,7 @@ nt::GeographicalCoord Way::projected_centroid(const Graph& graph) const {
                         "Can't find the centroid of the way: " << this->name);
     }
 
-    return nt::project(multiline, centroid);
+    this->_projected_centroid = nt::project(multiline, centroid);
 }
 
 /** Recherche du némuro le plus proche à des coordonnées
@@ -373,6 +373,12 @@ void GeoRef::init() {
         }
     }
     offsets[nt::Mode_e::CarNoPark] = offsets[nt::Mode_e::Car];
+}
+
+void GeoRef::build_centroid(){
+    for(auto way: this->ways){
+        way->compute_projected_centroid(this->graph);
+    }
 }
 
 void GeoRef::build_proximity_list(){

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -147,15 +147,17 @@ public:
     std::vector< HouseNumber > house_number_right;
     std::vector< std::pair<vertex_t, vertex_t> > edges;
     std::vector<nt::LineString> geoms;
+    nt::GeographicalCoord _projected_centroid;
 
     void add_house_number(const HouseNumber&);
     nt::GeographicalCoord nearest_coord(const int, const Graph&) const;
     // returns {house_number, distance}, return {-1, x} if not found
     std::pair<int, double> nearest_number(const nt::GeographicalCoord&) const;
-    nt::GeographicalCoord projected_centroid(const Graph&) const;
+    nt::GeographicalCoord projected_centroid(const Graph&) const {return this->_projected_centroid;};
+    void compute_projected_centroid(const Graph&);
     nt::MultiLineString make_multiline(const Graph&) const;
     template<class Archive> void serialize(Archive & ar, const unsigned int) {
-      ar & idx & name & comment & uri & way_type & admin_list & house_number_left & house_number_right & edges & geoms;
+      ar & idx & name & comment & uri & way_type & admin_list & house_number_left & house_number_right & edges & geoms & _projected_centroid;
     }
     std::string get_label() const;
 
@@ -297,6 +299,7 @@ struct GeoRef {
     /// Chargement de la liste map code externe idx sur poitype et poi
     void build_poitypes_map();
     void build_pois_map();
+    void build_centroid();
 
     /// Recherche d'une adresse avec un numéro en utilisant Autocomplete
     std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> find_ways(const std::string & str, const int nbmax, const int search_type,std::function<bool(nt::idx_t)> keep_element, const std::set<std::string>& ghostwords) const;

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -61,7 +61,7 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace type {
 
-const unsigned int Data::data_version = 68; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 69; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     _last_rt_data_loaded(boost::posix_time::not_a_date_time),
@@ -353,7 +353,7 @@ find_matching_calendar(const Data&, const std::string& name, const ValidityPatte
 void Data::complete(){
     auto logger = log4cplus::Logger::getInstance("log");
     pt::ptime start;
-    int admin, sort, autocomplete;
+    int admin, sort, autocomplete, centroid;
 
     build_grid_validity_pattern();
     //build_associated_calendar(); read from database
@@ -373,6 +373,11 @@ void Data::complete(){
     pt_data->sort_and_index();
     sort = (pt::microsec_clock::local_time() - start).total_milliseconds();
 
+    LOG4CPLUS_INFO(logger, "Building centroid");
+    start = pt::microsec_clock::local_time();
+    geo_ref->build_centroid();
+    centroid = (pt::microsec_clock::local_time() - start).total_milliseconds();
+
     start = pt::microsec_clock::local_time();
     LOG4CPLUS_INFO(logger, "Building proximity list");
     build_proximity_list();
@@ -384,6 +389,7 @@ void Data::complete(){
 
     LOG4CPLUS_INFO(logger, "\t Building admins: " << admin << "ms");
     LOG4CPLUS_INFO(logger, "\t Sorting data: " << sort << "ms");
+    LOG4CPLUS_INFO(logger, "\t Building  centroid of ways: " << centroid << "ms");
     LOG4CPLUS_INFO(logger, "\t Building autocomplete " << autocomplete << "ms");
 }
 


### PR DESCRIPTION
This greatly improve performances of autocompletion, we gain arround 50% in response time from kraken.
This is the first optimization of kraken autocompletion