### PR TITLE
Tyr: add poi_types json configuration management to mimir autocomplete

### DIFF
--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -747,14 +747,18 @@ class AutocompleteParameter(db.Model, TimestampMixin):
     poi = db.Column(db.Enum(*poi_source_types, name='source_poi'), nullable=True)
     admin = db.Column(db.Enum(*admin_source_types, name='source_admin'), nullable=True)
     admin_level = db.Column(ARRAY(db.Integer), nullable=False)
+    poi_types_json = db.Column(db.Text, nullable=True)
 
-    def __init__(self, name=None, street=None, address=None, poi=None, admin=None, admin_level=None):
+    def __init__(
+        self, name=None, street=None, address=None, poi=None, admin=None, admin_level=None, poi_types_json=None
+    ):
         self.name = name
         self.street = street
         self.address = address
         self.poi = poi
         self.admin = admin
         self.admin_level = admin_level
+        self.poi_types_json = poi_types_json
 
     def main_dir(self, root_path):
         return os.path.join(root_path, self.name)

--- a/source/tyr/migrations/versions/3f620c440544_autocomplete_poi_types.py
+++ b/source/tyr/migrations/versions/3f620c440544_autocomplete_poi_types.py
@@ -1,0 +1,22 @@
+"""add poi_types_json to mimir autocomplete params in tyr
+
+Revision ID: 3f620c440544
+Revises: e632d689de5
+Create Date: 2018-11-22 09:35:17.988985
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3f620c440544'
+down_revision = 'e632d689de5'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('autocomplete_parameter', sa.Column('poi_types_json', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('autocomplete_parameter', 'poi_types_json')

--- a/source/tyr/readme.md
+++ b/source/tyr/readme.md
@@ -724,13 +724,20 @@ instance:
 
 If you want to change something on poi types you have to POST again all the json (previous AND new poi types):
     
-    curl 'http://localhost:5000/v0/instances/fr-bre/poi_types' -X POST -H 'content-type: application/json' -d '{"poi_types": [{"id": "pdv", "name": "Point de vente"},],"rules": [{"osm_tags_filters": [{"key": "amenity:park", "value": "yes"}, {"key": "amenity", "value": "shop"}], "poi_type_id": "pdv"}]}'
+    curl 'http://localhost:5000/v0/instances/fr-bre/poi_types' -X POST -H 'content-type: application/json' -d '{"poi_types": [{"id": "amenity:bicycle_rental", "name": "Station VLS"}, {"id": "amenity:parking", "name": "Parking"}, {"id": "pdv", "name": "Point de vente"}],"rules": [{"osm_tags_filters": [{"key": "amenity", "value": "bicycle_rental"}], "poi_type_id": "amenity:bicycle_rental"}, {"osm_tags_filters": [{"key": "amenity", "value": "parking"}], "poi_type_id": "amenity:parking"}, {"osm_tags_filters": [{"key": "amenity:park", "value": "yes"}, {"key": "amenity", "value": "shop"}], "poi_type_id": "pdv"}]}'
 
 Any update requires a complete POST because the order of the rules matters, so no PUT is allowed on a partial object.
 
 Finally if you want to delete a poi_type you just have to use the DELETE action:
 
     curl 'http://localhost:5000/v0/instances/fr-bre/poi_types' -X DELETE
+
+
+The same way, you can decide what types of POI should be extracted for a "general" autocomplete region:
+
+    curl "http://localhost:5000/v0/autocomplete_parameters/france/poi_types"
+
+GET, POST and DELETE verbs are available in the exact same way, for the same functionality, with Mimir in background.
 
 #### Migrate from POI to OSM
 

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest==3.7.2
 python-dateutil==2.5.3
 mock==1.0.1
 clingon==0.1.4
+jmespath==0.9.3

--- a/source/tyr/tyr/api.py
+++ b/source/tyr/tyr/api.py
@@ -58,11 +58,13 @@ api.add_resource(
 
 api.add_resource(resources.BillingPlan, '/v0/billing_plans/', '/v0/billing_plans/<int:billing_plan_id>')
 
-api.add_resource(resources.PoiType, '/v0/instances/<string:instance_name>/poi_types')
+api.add_resource(resources.InstancePoiType, '/v0/instances/<string:instance_name>/poi_types')
 
 api.add_resource(
     resources.AutocompleteParameter, '/v0/autocomplete_parameters/', '/v0/autocomplete_parameters/<string:name>'
 )
+
+api.add_resource(resources.AutocompletePoiType, '/v0/autocomplete_parameters/<string:name>/poi_types')
 
 api.add_resource(resources.InstanceDataset, '/v0/instances/<instance_name>/last_datasets')
 

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -614,6 +614,12 @@ def osm2mimir(self, autocomplete_instance, filename, job_id, dataset_uid):
         params.append('--import-way')
     if autocomplete_instance.poi == 'OSM':
         params.append('--import-poi')
+        if autocomplete_instance.poi_types_json:
+            poi_types_file_name = '{}/poi-types.json'.format(os.path.dirname(working_directory))
+            with open(poi_types_file_name, 'w') as f:
+                f.write(autocomplete_instance.poi_types_json)
+            params.append('--poi-config')
+            params.append(poi_types_file_name)
     params.append('--dataset')
     params.append(autocomplete_instance.name)
     try:

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -107,7 +107,36 @@ class Job(flask_restful.Resource):
         return {'message': 'OK'}, 200
 
 
-class PoiType(flask_restful.Resource):
+def _validate_poi_types_json(poi_types_json):
+    try:
+        validate(poi_types_json, poi_type_conf_format)
+    except ValidationError as e:
+        abort(400, status="error", message='{}'.format(parse_error(e)))
+
+    poi_types_map = {}
+    for p in poi_types_json.get('poi_types', []):
+        if p.get('id') in poi_types_map:
+            abort(400, status="error", message='POI type id {} is defined multiple times'.format(p.get('id')))
+        poi_types_map[p.get('id')] = p.get('name')
+
+    if not 'amenity:parking' in poi_types_map or not 'amenity:bicycle_rental' in poi_types_map:
+        abort(
+            400,
+            status="error",
+            message='The 2 POI types id=amenity:parking and id=amenity:bicycle_rental must be defined',
+        )
+
+    for r in poi_types_json.get('rules', []):
+        pt_id = r.get('poi_type_id')
+        if not pt_id in poi_types_map:
+            abort(
+                400,
+                status="error",
+                message='Using an undefined POI type id ({}) forbidden in rules'.format(pt_id),
+            )
+
+
+class InstancePoiType(flask_restful.Resource):
     def get(self, instance_name):
         instance = models.Instance.query_existing().filter_by(name=instance_name).first_or_404()
         poi_types = '{}'
@@ -123,36 +152,7 @@ class PoiType(flask_restful.Resource):
             abort(400, status="error", message='Incorrect json provided')
 
         try:
-            try:
-                validate(poi_types_json, poi_type_conf_format)
-            except ValidationError as e:
-                abort(400, status="error", message='{}'.format(parse_error(e)))
-
-            poi_types_map = {}
-            for p in poi_types_json.get('poi_types', []):
-                if p.get('id') in poi_types_map:
-                    abort(
-                        400,
-                        status="error",
-                        message='POI type id {} is defined multiple times'.format(p.get('id')),
-                    )
-                poi_types_map[p.get('id')] = p.get('name')
-
-            if not 'amenity:parking' in poi_types_map or not 'amenity:bicycle_rental' in poi_types_map:
-                abort(
-                    400,
-                    status="error",
-                    message='The 2 POI types id=amenity:parking and id=amenity:bicycle_rental must be defined',
-                )
-
-            for r in poi_types_json.get('rules', []):
-                pt_id = r.get('poi_type_id')
-                if not pt_id in poi_types_map:
-                    abort(
-                        400,
-                        status="error",
-                        message='Using an undefined POI type id ({}) forbidden in rules'.format(pt_id),
-                    )
+            _validate_poi_types_json(poi_types_json)
 
             poi_types = models.PoiTypeJson(
                 json.dumps(poi_types_json, ensure_ascii=False).encode('utf-8', 'backslashreplace'), instance
@@ -176,7 +176,46 @@ class PoiType(flask_restful.Resource):
             logging.exception("fail")
             raise
 
-        return '', 204
+        return json.loads('{}'), 204
+
+
+class AutocompletePoiType(flask_restful.Resource):
+    def get(self, name):
+        autocomplete_param = models.AutocompleteParameter.query.filter_by(name=name).first_or_404()
+        poi_types = '{}'
+        if autocomplete_param.poi_types_json:
+            poi_types = autocomplete_param.poi_types_json
+        return json.loads(poi_types)
+
+    def post(self, name):
+        autocomplete_param = models.AutocompleteParameter.query.filter_by(name=name).first_or_404()
+        try:
+            poi_types_json = request.get_json(silent=False)
+        except:
+            abort(400, status="error", message='Incorrect json provided')
+
+        try:
+            _validate_poi_types_json(poi_types_json)
+            autocomplete_param.poi_types_json = json.dumps(poi_types_json, ensure_ascii=False).encode(
+                'utf-8', 'backslashreplace'
+            )
+            db.session.commit()
+        except Exception:
+            logging.exception("fail")
+            raise
+
+        return json.loads(autocomplete_param.poi_types_json), 200
+
+    def delete(self, name):
+        autocomplete_param = models.AutocompleteParameter.query.filter_by(name=name).first_or_404()
+        try:
+            autocomplete_param.poi_types_json = None
+            db.session.commit()
+        except Exception:
+            logging.exception("fail")
+            raise
+
+        return json.loads('{}'), 204
 
 
 class Instance(flask_restful.Resource):

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -108,17 +108,26 @@ class Job(flask_restful.Resource):
 
 
 def _validate_poi_types_json(poi_types_json):
+    """
+    poi_types configuration must follow some rules so that the binarisation is OK.
+    It's checked at bina, but tyr must also reject broken config directly so that the user knows.
+    """
+
+    # Check that the conf is a valid json
     try:
         validate(poi_types_json, poi_type_conf_format)
     except ValidationError as e:
         abort(400, status="error", message='{}'.format(parse_error(e)))
 
+    # Check that poi_type.id defined are unique
     poi_types_map = {}
     for p in poi_types_json.get('poi_types', []):
         if p.get('id') in poi_types_map:
             abort(400, status="error", message='POI type id {} is defined multiple times'.format(p.get('id')))
         poi_types_map[p.get('id')] = p.get('name')
 
+    # Check that poi_type.id 'amenity:parking' and 'amenity:bicycle_rental' are defined.
+    # Those are mandatory as they are used for journey processing (BSS and car).
     if not 'amenity:parking' in poi_types_map or not 'amenity:bicycle_rental' in poi_types_map:
         abort(
             400,
@@ -126,6 +135,7 @@ def _validate_poi_types_json(poi_types_json):
             message='The 2 POI types id=amenity:parking and id=amenity:bicycle_rental must be defined',
         )
 
+    # Check that rules to affect poi_types to OSM object are using a poi_type.id defined in "poi_types" list.
     for r in poi_types_json.get('rules', []):
         pt_id = r.get('poi_type_id')
         if not pt_id in poi_types_map:


### PR DESCRIPTION
At bina, a file containing POI conf will be created in the backup directory, to be passed to osm2mimir.

- [x] Some tests added on tyr's API
- [x] Hand-tested for full chain

JIRA: https://jira.kisio.org/browse/NAVP-1085