### PR TITLE
clean up tcmalloc linking

### DIFF
--- a/source/cities/CMakeLists.txt
+++ b/source/cities/CMakeLists.txt
@@ -3,7 +3,7 @@ SET(BOOST_LIBS ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
 
 add_executable(cities cities.cpp)
 target_link_libraries(cities transportation_data_import connectors types ${PQXX_LIB} ${OSMPBF} pb_lib utils
-    ${BOOST_LIBS} log4cplus z protobuf)
+    ${BOOST_LIBS} log4cplus z protobuf tcmalloc)
 install(TARGETS cities DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(FILES alembic.ini alembic/env.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/cities/alembic)
 

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -17,7 +17,7 @@ FIND_LIBRARY(OSMPBF osmpbf)
 add_library(osm2ed_lib osm2ed.cpp)
 add_executable(osm2ed osm2ed_main.cpp)
 target_link_libraries(osm2ed osm2ed_lib transportation_data_import ed connectors types ${PQXX_LIB} ${OSMPBF}
-  pb_lib utils ${BOOST_LIBS} log4cplus z protobuf)
+  pb_lib utils ${BOOST_LIBS} log4cplus z protobuf tcmalloc)
 
 
 
@@ -25,31 +25,30 @@ add_library(transportation_data_import ed_persistor.cpp)
 target_link_libraries(transportation_data_import ed fare types ${PQXX_LIB} data utils ${BOOST_LIBS} log4cplus)
 
 add_executable(gtfs2ed gtfs2ed.cpp)
-target_link_libraries(gtfs2ed transportation_data_import connectors)
+target_link_libraries(gtfs2ed transportation_data_import connectors tcmalloc)
 
 add_executable(fusio2ed fusio2ed.cpp)
-target_link_libraries(fusio2ed transportation_data_import connectors)
+target_link_libraries(fusio2ed transportation_data_import connectors tcmalloc)
 
 add_library(fare2ed_lib fare2ed.cpp)
 add_executable(fare2ed fare2ed_main.cpp)
-target_link_libraries(fare2ed fare2ed_lib transportation_data_import connectors)
+target_link_libraries(fare2ed fare2ed_lib transportation_data_import connectors tcmalloc)
 
 add_library(ed2nav_lib ed2nav.cpp ed_reader.cpp)
 add_executable(ed2nav ed2nav_main.cpp)
-target_link_libraries(ed2nav ed2nav_lib types connectors ${PQXX_LIB} data georef routing fare pb_lib utils autocomplete ${BOOST_LIBS} log4cplus protobuf)
+target_link_libraries(ed2nav ed2nav_lib types connectors ${PQXX_LIB} data georef routing fare pb_lib utils autocomplete ${BOOST_LIBS} log4cplus protobuf tcmalloc)
 
 add_subdirectory(tests)
 add_subdirectory(connectors)
 
 add_executable(geopal2ed geopal2ed.cpp)
+target_link_libraries(geopal2ed transportation_data_import connectors tcmalloc)
 
-target_link_libraries(geopal2ed transportation_data_import connectors)
 add_executable(poi2ed poi2ed.cpp)
-
-target_link_libraries(poi2ed transportation_data_import connectors)
+target_link_libraries(poi2ed transportation_data_import connectors tcmalloc)
 
 add_executable(synonym2ed synonym2ed.cpp)
-target_link_libraries(synonym2ed transportation_data_import connectors)
+target_link_libraries(synonym2ed transportation_data_import connectors tcmalloc)
 
 set(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/source/ed/connectors/CMakeLists.txt
+++ b/source/ed/connectors/CMakeLists.txt
@@ -17,6 +17,6 @@ SET(SOURCE_LIB
 )
 
 add_library(connectors ${SOURCE_LIB})
-target_link_libraries(connectors ${PROJ} tcmalloc)
+target_link_libraries(connectors ${PROJ})
 
 

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp metrics.
 add_dependencies(workers protobuf_files)
 target_link_libraries(workers apply_disruption make_disruption_from_chaos rt_handling ${PQXX_LIB}
   SimpleAmqpClient disruption_api calendar_api ptreferential autocomplete georef
-  routing time_tables tcmalloc prometheus-cpp-core prometheus-cpp-pull)
+  routing time_tables prometheus-cpp-core prometheus-cpp-pull)
 
 add_library(fill_disruption_from_database fill_disruption_from_database.cpp)
 target_link_libraries(fill_disruption_from_database make_disruption_from_chaos data types pb_lib
@@ -26,7 +26,7 @@ target_link_libraries(kraken workers types proximitylist
     rabbitmq-static log4cplus ${Boost_THREAD_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
     ${Boost_REGEX_LIBRARY} ${Boost_CHRONO_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} protobuf)
+    ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} protobuf tcmalloc)
 add_dependencies(kraken protobuf_files)
 
 install(TARGETS kraken DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ ADD_BOOST_TEST(apply_disruption_test)
 add_executable(direct_path_test direct_path_test.cpp)
 target_link_libraries(direct_path_test workers make_disruption_from_chaos apply_disruption
   ed data types routing fare pb_lib thermometer georef
-  autocomplete utils  ${BOOST_LIBS} log4cplus pthread protobuf)
+  autocomplete utils  ${BOOST_LIBS} log4cplus pthread protobuf tcmalloc)
 ADD_BOOST_TEST(direct_path_test)
 
 add_executable(disruption_periods_test disruption_periods_test.cpp)

--- a/source/routing/tests/CMakeLists.txt
+++ b/source/routing/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ ADD_BOOST_TEST(next_stop_time_test)
 add_executable(disruptions_test disruptions_test.cpp)
 target_link_libraries(disruptions_test ed data types routing fare pb_lib thermometer georef
   autocomplete utils workers
-  ${BOOST_LIBS} log4cplus pthread protobuf)
+  ${BOOST_LIBS} log4cplus pthread protobuf tcmalloc)
 ADD_BOOST_TEST(disruptions_test)
 
 add_executable(co2_emission_test co2_emission_test.cpp)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(ALL_LIBS workers ed disruption_api calendar_api time_tables types autocomplete proximitylist
     ptreferential time_tables data routing fare types georef utils SimpleAmqpClient
-    rabbitmq-static log4cplus tcmalloc ${Boost_LIBRARIES} protobuf)
+    rabbitmq-static log4cplus tcmalloc ${Boost_LIBRARIES} protobuf tcmalloc)
 
 # every tests will produce an executable used in jormungandr integration tests
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -92,7 +92,7 @@ endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 SET_SOURCE_FILES_PROPERTIES(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS ${PROTO_CMAKE_CXX_FLAGS})
 
 add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
-target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY} tcmalloc)
+target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY})
 
 add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp validity_pattern.cpp type_utils.cpp)
 target_link_libraries(types ptreferential utils pb_lib protobuf)


### PR DESCRIPTION
With this PR only final executable are linked to tcmalloc, not the
library. This make it easier to choose another allocator later.