### PR TITLE
Jormun: log request-id provided in the request

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -72,6 +72,7 @@ def access_log(response, *args, **kwargs):
         'path': request.path,
         'query_string': query_string,
         'status': response.status_code,
+        'external_request_id': request.headers.get('x-request-id'),
     }
     logger.info(u'"%(method)s %(path)s?%(query_string)s" %(status)s', d, extra=d)
     return response


### PR DESCRIPTION
If a client provide a request-id with the `x-request-id` header this one
will be logged. This will help to trace request between systems.
This external request id doesn't change our request id that is generated
by jormungandr at the start of a request as their is no easy way to
ensure that the provided id is unique.

This is only logged if json log is activated.

@thewhitewizard :gift: :santa: 