### PR TITLE
Tyr: add gevent as a dependency

### DIFF
--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -33,3 +33,5 @@ retrying==1.3.3
 ujson==1.35
 jsonschema==2.5.1
 python-dateutil==2.5.3
+gevent==1.3.7
+psycogreen==1.0

--- a/source/tyr/tyr/__init__.py
+++ b/source/tyr/tyr/__init__.py
@@ -27,8 +27,22 @@
 # IRC #navitia on freenode
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
-
 from __future__ import absolute_import, print_function, division
+
+try:
+    import uwsgi
+
+    # if we are in web context we monkey patch for gevent
+    # We don't want to enable gevent in celery workers
+    from gevent import monkey
+
+    monkey.patch_all()
+    import psycogreen.gevent
+
+    psycogreen.gevent.patch_psycopg()
+except ImportError:
+    pass
+
 from flask import Flask
 import flask_restful
 from tyr.helper import configure_logger, make_celery


### PR DESCRIPTION
Monkey patch tyr with gevent to handle request asynchronously.
The monkey patching is done only on the webservice to not impact celery workers.

As always with async it doesn't make thing faster but it increases concurrency, very slow request will only sightly impact fast requests done at the same time.
With threads (the current configuration) the fast requests were suffering from the latency of the slow requests.

Once this is merged we will have to merge https://github.com/CanalTP/navitia_deployment_conf/pull/509