### PR TITLE
kraken: fix tests that were failling without tcmalloc

### DIFF
--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -3303,8 +3303,8 @@ namespace {
             ("B1", "22:00"_t, "22:00"_t)("C1", "23:00"_t, "23:00"_t);
 
         nt::PT_Data & d = *b.data->pt_data;
-        auto stl1 = d.vehicle_journeys[0]->stop_time_list;
-        auto stl2 = d.vehicle_journeys[1]->stop_time_list;
+        const auto& stl1 = d.vehicle_journeys[0]->stop_time_list;
+        const auto& stl2 = d.vehicle_journeys[1]->stop_time_list;
 
         nr::Journey j1;
         j1.sections.push_back(nr::Journey::Section(


### PR DESCRIPTION
In these tests we were making a copy of the stop_time_list that was
freed before being used, so...
tcmalloc was hiding the problem since this chunk of memory was only mark
has available