### PR TITLE
Utils: Diff against commit's ancestor

### DIFF
--- a/source/scripts/check_retrocompat.sh
+++ b/source/scripts/check_retrocompat.sh
@@ -23,7 +23,7 @@ model_files=(
 )
 
 
-diff_filenames=`git diff --name-only origin/$branch_to` # List the updated files
+diff_filenames=`git diff --name-only $(git merge-base HEAD origin/$branch_to)` # List the updated files
 num_model_files=${#model_files[@]}
 modified_model_files=()
 

--- a/source/scripts/check_retrocompat.sh
+++ b/source/scripts/check_retrocompat.sh
@@ -23,7 +23,7 @@ model_files=(
 )
 
 
-diff_filenames=`git diff --name-only $(git merge-base HEAD origin/$branch_to)` # List the updated files
+diff_filenames=`git diff --name-only HEAD^)` # List the updated files
 num_model_files=${#model_files[@]}
 modified_model_files=()
 


### PR DESCRIPTION
Make sure we diff the current branch with its forking point. 
This avoids finding differences in files that havent't been touched when the forking point isn't up to date with `origin/dev`