### PR TITLE
Kraken: Fix clang compilation

### DIFF
--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -194,7 +194,7 @@ static std::vector<Autocomplete<nt::idx_t>::fl_quality> complete(const type::Dat
                         d.geo_ref->word_weight,
                         nbmax, valid_admin_ptr(d.pt_data->stop_areas, admin_ptr), d.geo_ref->ghostwords);
             }
-            if(main_stop_area_weight_factor != 1.0){
+            if(main_stop_area_weight_factor != 1.0f){
                 auto main_stop_areas = get_main_stop_areas(d);
                 for(auto& r: result){
                     if(main_stop_areas.count(d.pt_data->stop_areas[r.idx]->uri)){

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -383,7 +383,7 @@ void autocomplete(navitia::PbCreator& pb_creator,
 
 
     std::vector<AutocompleteResult> results;
-    for(const auto group: build_type_groups(filter)){
+    for(const auto& group: build_type_groups(filter)){
         for(nt::Type_e type : group) {
             //search for candidate
             auto found = complete(d, type, q, admin_ptr, nb_items_to_search, search_type, main_stop_area_weight_factor);

--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -300,8 +300,8 @@ BOOST_FIXTURE_TEST_CASE(Test5, Params) {
 struct DisruptedNetwork {
     ed::builder b;
     navitia::PbCreator pb_creator;
-    const ptime since = "20180102T060000"_dt;
-    const ptime until = "20180103T060000"_dt;
+    const boost::posix_time::ptime since = "20180102T060000"_dt;
+    const boost::posix_time::ptime until = "20180103T060000"_dt;
 
     DisruptedNetwork() : b("20180101") {
         b.vj_with_network("network_1","line_1")

--- a/source/ed/connectors/conv_coord.cpp
+++ b/source/ed/connectors/conv_coord.cpp
@@ -93,7 +93,7 @@ navitia::type::GeographicalCoord ConvCoord::convert_to(navitia::type::Geographic
     }
     double x = coord.lon();
     double y = coord.lat();
-    pj_transform(this->origin.proj_pj, this->destination.proj_pj, 1, 1,&x, &y, NULL);
+    pj_transform(this->origin.proj_pj, this->destination.proj_pj, 1, 1,&x, &y, nullptr);
     coord.set_lon(x);
     coord.set_lat(y);
     if(this->destination.is_degree){

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -332,8 +332,8 @@ void RouteFusioHandler::handle_line(Data& data, const csv_row& row, bool) {
 
 void TransfersFusioHandler::init(Data& d) {
     TransfersGtfsHandler::init(d);
-    real_time_c = csv.get_pos_col("real_min_transfer_time"),
-            property_id_c = csv.get_pos_col("property_id");
+    real_time_c = csv.get_pos_col("real_min_transfer_time");
+    property_id_c = csv.get_pos_col("property_id");
     // TODO equipment_id NTFSv0.4: remove property_id when we stop to support NTFSv0.3
     if (property_id_c == -1){
         property_id_c = csv.get_pos_col("equipment_id");
@@ -1006,14 +1006,15 @@ void LineGroupLinksFusioHandler::handle_line(Data& data, const csv_row& row, boo
 }
 
 void CompanyFusioHandler::init(Data&) {
-    id_c = csv.get_pos_col("company_id"), name_c = csv.get_pos_col("company_name"),
-            company_address_name_c = csv.get_pos_col("company_address_name"),
-            company_address_number_c = csv.get_pos_col("company_address_number"),
-            company_address_type_c = csv.get_pos_col("company_address_type"),
-            company_url_c = csv.get_pos_col("company_url"),
-            company_mail_c = csv.get_pos_col("company_mail"),
-            company_phone_c = csv.get_pos_col("company_phone"),
-            company_fax_c = csv.get_pos_col("company_fax");
+    id_c = csv.get_pos_col("company_id");
+    name_c = csv.get_pos_col("company_name");
+    company_address_name_c = csv.get_pos_col("company_address_name");
+    company_address_number_c = csv.get_pos_col("company_address_number");
+    company_address_type_c = csv.get_pos_col("company_address_type");
+    company_url_c = csv.get_pos_col("company_url");
+    company_mail_c = csv.get_pos_col("company_mail");
+    company_phone_c = csv.get_pos_col("company_phone");
+    company_fax_c = csv.get_pos_col("company_fax");
 }
 
 void CompanyFusioHandler::handle_line(Data& data, const csv_row& row, bool is_first_line) {

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -950,7 +950,7 @@ void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
 
 void StopTimeGtfsHandler::init(Data&) {
     LOG4CPLUS_INFO(logger, "reading stop times");
-    id_c = csv.get_pos_col("trip_id"),
+    trip_c = csv.get_pos_col("trip_id");
     arrival_c = csv.get_pos_col("arrival_time");
     departure_c = csv.get_pos_col("departure_time");
     stop_c = csv.get_pos_col("stop_id");
@@ -1027,15 +1027,15 @@ std::vector<nm::StopTime*> StopTimeGtfsHandler::handle_line(Data& data, const cs
         return {};
     }
 
-    auto vj_it = gtfs_data.tz.vj_by_name.lower_bound(row[id_c]);
+    auto vj_it = gtfs_data.tz.vj_by_name.lower_bound(row[trip_c]);
     if(vj_it == gtfs_data.tz.vj_by_name.end()) {
-        LOG4CPLUS_WARN(logger, "Impossible to find the vehicle_journey '" << row[id_c] << "'");
+        LOG4CPLUS_WARN(logger, "Impossible to find the vehicle_journey '" << row[trip_c] << "'");
         return {};
     }
     std::vector<nm::StopTime*> stop_times;
 
     //the validity pattern may have been split because of DST, so we need to create one vj for each
-    for (auto vj_end_it = gtfs_data.tz.vj_by_name.upper_bound(row[id_c]); vj_it != vj_end_it; ++vj_it) {
+    for (auto vj_end_it = gtfs_data.tz.vj_by_name.upper_bound(row[trip_c]); vj_it != vj_end_it; ++vj_it) {
 
         nm::StopTime* stop_time = new nm::StopTime();
 

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -308,7 +308,7 @@ void StopsGtfsHandler::finish(Data& data) {
                     "the stop area " + sa_sps.first  + " has not been found for the stop points :  ";
             for(auto sp : sa_sps.second) {
                 error_message += sp->uri;
-                sp->stop_area = 0;
+                sp->stop_area = nullptr;
             }
             LOG4CPLUS_WARN(logger, error_message);
         }

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -278,18 +278,18 @@ void StopsGtfsHandler::init(Data& data) {
     // we allocate with values sized for the Île-de-France
     data.stop_points.reserve(56000);
     data.stop_areas.reserve(13000);
-    id_c = csv.get_pos_col("stop_id"),
-            code_c = csv.get_pos_col("stop_code"),
-            lat_c = csv.get_pos_col("stop_lat"),
-            lon_c = csv.get_pos_col("stop_lon"),
-            zone_c = csv.get_pos_col("zone_id"),
-            type_c = csv.get_pos_col("location_type"),
-            parent_c = csv.get_pos_col("parent_station"),
-            name_c = csv.get_pos_col("stop_name"),
-            desc_c = csv.get_pos_col("stop_desc"),
-            wheelchair_c = csv.get_pos_col("wheelchair_boarding"),
-            platform_c = csv.get_pos_col("platform_code"),
-            timezone_c = csv.get_pos_col("stop_timezone");
+    id_c = csv.get_pos_col("stop_id");
+    code_c = csv.get_pos_col("stop_code");
+    lat_c = csv.get_pos_col("stop_lat");
+    lon_c = csv.get_pos_col("stop_lon");
+    zone_c = csv.get_pos_col("zone_id");
+    type_c = csv.get_pos_col("location_type");
+    parent_c = csv.get_pos_col("parent_station");
+    name_c = csv.get_pos_col("stop_name");
+    desc_c = csv.get_pos_col("stop_desc");
+    wheelchair_c = csv.get_pos_col("wheelchair_boarding");
+    platform_c = csv.get_pos_col("platform_code");
+    timezone_c = csv.get_pos_col("stop_timezone");
     if (code_c == -1) {
         code_c = id_c;
     }
@@ -471,11 +471,14 @@ StopsGtfsHandler::stop_point_and_area StopsGtfsHandler::handle_line(Data& data, 
 }
 
 void RouteGtfsHandler::init(Data&) {
-    id_c = csv.get_pos_col("route_id"), short_name_c = csv.get_pos_col("route_short_name"),
-            long_name_c = csv.get_pos_col("route_long_name"), type_c = csv.get_pos_col("route_type"),
-            desc_c = csv.get_pos_col("route_desc"),
-            color_c = csv.get_pos_col("route_color"), agency_c = csv.get_pos_col("agency_id"),
-            text_color_c = csv.get_pos_col("route_text_color");
+    id_c = csv.get_pos_col("route_id");
+    short_name_c = csv.get_pos_col("route_short_name");
+    long_name_c = csv.get_pos_col("route_long_name");
+    type_c = csv.get_pos_col("route_type");
+    desc_c = csv.get_pos_col("route_desc");
+    color_c = csv.get_pos_col("route_color");
+    agency_c = csv.get_pos_col("agency_id");
+    text_color_c = csv.get_pos_col("route_text_color");
 }
 
 nm::Line* RouteGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
@@ -538,9 +541,9 @@ void RouteGtfsHandler::finish(Data& data) {
 }
 
 void TransfersGtfsHandler::init(Data&) {
-    from_c = csv.get_pos_col("from_stop_id"),
-            to_c = csv.get_pos_col("to_stop_id"),
-            time_c = csv.get_pos_col("min_transfer_time");
+    from_c = csv.get_pos_col("from_stop_id");
+        to_c = csv.get_pos_col("to_stop_id");
+        time_c = csv.get_pos_col("min_transfer_time");
 }
 
 void TransfersGtfsHandler::finish(Data& data) {
@@ -626,11 +629,16 @@ void TransfersGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
 void CalendarGtfsHandler::init(Data& data) {
     data.validity_patterns.reserve(10000);
 
-    id_c = csv.get_pos_col("service_id"), monday_c = csv.get_pos_col("monday"),
-            tuesday_c = csv.get_pos_col("tuesday"), wednesday_c = csv.get_pos_col("wednesday"),
-            thursday_c = csv.get_pos_col("thursday"), friday_c = csv.get_pos_col("friday"),
-            saturday_c = csv.get_pos_col("saturday"), sunday_c = csv.get_pos_col("sunday"),
-            start_date_c = csv.get_pos_col("start_date"), end_date_c = csv.get_pos_col("end_date");
+    id_c = csv.get_pos_col("service_id");
+    monday_c = csv.get_pos_col("monday");
+    tuesday_c = csv.get_pos_col("tuesday");
+    wednesday_c = csv.get_pos_col("wednesday");
+    thursday_c = csv.get_pos_col("thursday");
+    friday_c = csv.get_pos_col("friday");
+    saturday_c = csv.get_pos_col("saturday");
+    sunday_c = csv.get_pos_col("sunday");
+    start_date_c = csv.get_pos_col("start_date");
+    end_date_c = csv.get_pos_col("end_date");
 }
 
 void CalendarGtfsHandler::finish(Data& data) {
@@ -754,8 +762,9 @@ void split_validity_pattern_over_dst(Data& data, GtfsData& gtfs_data) {
 }
 
 void CalendarDatesGtfsHandler::init(Data&) {
-    id_c = csv.get_pos_col("service_id"), date_c = csv.get_pos_col("date"),
-            e_type_c = csv.get_pos_col("exception_type");
+    id_c = csv.get_pos_col("service_id");
+    date_c = csv.get_pos_col("date");
+    e_type_c = csv.get_pos_col("exception_type");
 }
 
 void CalendarDatesGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
@@ -942,12 +951,12 @@ void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
 void StopTimeGtfsHandler::init(Data&) {
     LOG4CPLUS_INFO(logger, "reading stop times");
     id_c = csv.get_pos_col("trip_id"),
-            arrival_c = csv.get_pos_col("arrival_time"),
-            departure_c = csv.get_pos_col("departure_time"),
-            stop_c = csv.get_pos_col("stop_id"),
-            stop_seq_c = csv.get_pos_col("stop_sequence"),
-            pickup_c = csv.get_pos_col("pickup_type"),
-            drop_off_c = csv.get_pos_col("drop_off_type");
+    arrival_c = csv.get_pos_col("arrival_time");
+    departure_c = csv.get_pos_col("departure_time");
+    stop_c = csv.get_pos_col("stop_id");
+    stop_seq_c = csv.get_pos_col("stop_sequence");
+    pickup_c = csv.get_pos_col("pickup_type");
+    drop_off_c = csv.get_pos_col("drop_off_type");
 }
 
 void StopTimeGtfsHandler::finish(Data& data) {
@@ -1068,8 +1077,10 @@ std::vector<nm::StopTime*> StopTimeGtfsHandler::handle_line(Data& data, const cs
 }
 
 void FrequenciesGtfsHandler::init(Data&) {
-    trip_id_c = csv.get_pos_col("trip_id"), start_time_c = csv.get_pos_col("start_time"),
-    end_time_c = csv.get_pos_col("end_time"), headway_secs_c = csv.get_pos_col("headway_secs");
+    trip_id_c = csv.get_pos_col("trip_id");
+    start_time_c = csv.get_pos_col("start_time");
+    end_time_c = csv.get_pos_col("end_time");
+    headway_secs_c = csv.get_pos_col("headway_secs");
 }
 
 void FrequenciesGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -340,7 +340,7 @@ struct TripsGtfsHandler : public GenericHandler {
 };
 struct StopTimeGtfsHandler : public GenericHandler {
     StopTimeGtfsHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int id_c, arrival_c,
+    int trip_c, arrival_c,
     departure_c, stop_c,
     stop_seq_c, pickup_c,
     drop_off_c;

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -739,7 +739,7 @@ void EdPersistor::insert_stop_points(const std::vector<types::StopPoint*>& stop_
         values.push_back(sp->name);
         values.push_back("POINT(" + std::to_string(sp->coord.lon()) + " " + std::to_string(sp->coord.lat()) + ")");
         values.push_back(sp->fare_zone);
-        if(sp->stop_area != NULL){
+        if(sp->stop_area != nullptr){
             values.push_back(std::to_string(sp->stop_area->idx));
         }else{
             values.push_back(lotus.null_value);
@@ -772,13 +772,13 @@ void EdPersistor::insert_lines(const std::vector<types::Line*>& lines){
         values.push_back(line->name);
         values.push_back(line->color);
         values.push_back(line->code);
-        if(line->commercial_mode != NULL){
+        if(line->commercial_mode != nullptr){
             values.push_back(std::to_string(line->commercial_mode->idx));
         }else{
             values.push_back(lotus.null_value);
         }
 
-        if(line->network != NULL){
+        if(line->network != nullptr){
             values.push_back(std::to_string(line->network->idx));
         } else {
             LOG4CPLUS_INFO(logger, "Line " + line->uri + " ignored because it doesn't "
@@ -868,7 +868,7 @@ void EdPersistor::insert_routes(const std::vector<types::Route*>& routes){
         values.push_back(std::to_string(route->idx));
         values.push_back(navitia::encode_uri(route->uri));
         values.push_back(route->name);
-        if(route->line != NULL){
+        if(route->line != nullptr){
             values.push_back(std::to_string(route->line->idx));
         }else{
             values.push_back(lotus.null_value);
@@ -959,7 +959,7 @@ void EdPersistor::insert_stop_times(const std::vector<types::StopTime*>& stop_ti
             values.push_back(std::to_string(stop->shape_from_prev->idx));
         }
 
-        if(stop->vehicle_journey != NULL){
+        if(stop->vehicle_journey != nullptr){
             values.push_back(std::to_string(stop->vehicle_journey->idx));
         }else{
             values.push_back(lotus.null_value);
@@ -1023,12 +1023,12 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(navitia::encode_uri(vj->uri));
         values.push_back(vj->name);
 
-        if(vj->validity_pattern != NULL){
+        if(vj->validity_pattern != nullptr){
             values.push_back(std::to_string(vj->validity_pattern->idx));
         }else{
             values.push_back(lotus.null_value);
         }
-        if (vj->dataset != NULL){
+        if (vj->dataset != nullptr){
             values.push_back(std::to_string(vj->dataset->idx));
         }else{
             values.push_back(lotus.null_value);
@@ -1037,12 +1037,12 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(std::to_string(vj->end_time));
         values.push_back(std::to_string(vj->headway_secs));
 
-        if(vj->adapted_validity_pattern != NULL){
+        if(vj->adapted_validity_pattern != nullptr){
             values.push_back(std::to_string(vj->adapted_validity_pattern->idx));
         }else{
             values.push_back(std::to_string(vj->validity_pattern->idx));
         }
-        if(vj->company != NULL){
+        if(vj->company != nullptr){
             values.push_back(std::to_string(vj->company->idx));
         }else{
             values.push_back(lotus.null_value);
@@ -1050,7 +1050,7 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(std::to_string(vj->route->idx));
         values.push_back(std::to_string(vj->physical_mode->idx));
 
-        if(vj->theoric_vehicle_journey != NULL){
+        if(vj->theoric_vehicle_journey != nullptr){
             values.push_back(std::to_string(vj->theoric_vehicle_journey->idx));
         }else{
             //@TODO WTF??

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -694,7 +694,7 @@ void EdReader::fill_validity_patterns(nt::Data& data, pqxx::work& work){
 
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
-        nt::ValidityPattern* validity_pattern = NULL;
+        nt::ValidityPattern* validity_pattern = nullptr;
         validity_pattern = new nt::ValidityPattern(data.meta->production_date.begin(), const_it["days"].as<std::string>());
 
         validity_pattern->idx = data.pt_data->validity_patterns.size();
@@ -1293,7 +1293,7 @@ void EdReader::fill_house_numbers(navitia::type::Data& data, pqxx::work& work){
             hn.coord.set_lon(const_it["lon"].as<double>());
             hn.coord.set_lat(const_it["lat"].as<double>());
             navitia::georef::Way* way = this->way_map[const_it["way_id"].as<idx_t>()];
-            if (way != NULL){
+            if (way != nullptr){
                 way->add_house_number(hn);
             }
         }
@@ -1812,9 +1812,9 @@ void EdReader::build_rel_way_admin(navitia::type::Data&, pqxx::work& work){
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         navitia::georef::Way* way = this->way_map[const_it["way_id"].as<idx_t>()];
-        if (way != NULL){
+        if (way != nullptr){
             navitia::georef::Admin* admin = this->admin_map[const_it["admin_id"].as<idx_t>()];
-            if (admin != NULL){
+            if (admin != nullptr){
                 way->admin_list.push_back(admin);
             }
         }
@@ -1826,9 +1826,9 @@ void EdReader::build_rel_admin_admin(navitia::type::Data&, pqxx::work& work){
     pqxx::result result = work.exec(request);
     for(auto const_it = result.begin(); const_it != result.end(); ++const_it){
         navitia::georef::Admin* admin_master = this->admin_map[const_it["master_admin_id"].as<idx_t>()];
-        if (admin_master != NULL){
+        if (admin_master != nullptr){
             navitia::georef::Admin* admin = this->admin_map[const_it["admin_id"].as<idx_t>()];
-            if ((admin != NULL)){
+            if ((admin != nullptr)){
                 admin_master->admin_list.push_back(admin);
             }
         }

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -121,20 +121,20 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     for (uint i = 0; i < data.routes.size(); ++i) {
         auto obj_codes_routes_map = data.object_codes[ed::types::make_pt_object(data.routes[i])];
         BOOST_REQUIRE_EQUAL(obj_codes_routes_map.size(), 1);
-        for (const auto obj_codes : obj_codes_routes_map) {
+        for (const auto& obj_codes : obj_codes_routes_map) {
             BOOST_CHECK_EQUAL(obj_codes.second[0], "route_" + std::to_string(i + 1));
         }
     }
     // companies
     auto obj_codes_map = data.object_codes[ed::types::make_pt_object(data.companies[0])];
     BOOST_REQUIRE_EQUAL(obj_codes_map.size(), 1);
-    for (const auto obj_codes : obj_codes_map) {
+    for (const auto& obj_codes : obj_codes_map) {
         BOOST_CHECK_EQUAL(obj_codes.second[0], "A");
         BOOST_CHECK_EQUAL(obj_codes.second[1], "B");
     }
     obj_codes_map = data.object_codes[ed::types::make_pt_object(data.companies[1])];
     BOOST_REQUIRE_EQUAL(obj_codes_map.size(), 1);
-    for (const auto obj_codes : obj_codes_map) {
+    for (const auto& obj_codes : obj_codes_map) {
         BOOST_CHECK_EQUAL(obj_codes.second[0], "A");
     }
 

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -41,9 +41,9 @@ bool PhysicalMode::operator<(const PhysicalMode& other) const {
 }
 
 bool Line::operator<(const Line& other) const {
-    if(this->commercial_mode == NULL && other.commercial_mode != NULL){
+    if(this->commercial_mode == nullptr && other.commercial_mode != nullptr){
         return true;
-    }else if(other.commercial_mode == NULL && this->commercial_mode != NULL){
+    }else if(other.commercial_mode == nullptr && this->commercial_mode != nullptr){
         return false;
     }
     if(this->commercial_mode == other.commercial_mode){

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -228,7 +228,6 @@ struct Line : public Header, Nameable {
 
 struct LineGroup : public Header, Nameable {
     const static nt::Type_e type = nt::Type_e::LineGroup;
-    std::string name;
     Line* main_line;
 
     bool operator<(const LineGroup & other) const;

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -94,7 +94,7 @@ struct StopPointConnection: public Header, hasProperties {
     int max_duration;
     ConnectionType connection_kind;
 
-    StopPointConnection() : departure(NULL), destination(NULL), display_duration(0), duration(0),
+    StopPointConnection() : departure(nullptr), destination(nullptr), display_duration(0), duration(0),
         max_duration(0), connection_kind(ConnectionType::Default){}
 
    bool operator<(const StopPointConnection& other) const;

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_stops_different_hours) {
 
     test_vjs_indexes(b.data->pt_data->vehicle_journeys);
 
-    auto get_adapted = [&b](const nt::VehicleJourney* vj, int nb_adapted_vj) {
+    auto get_adapted = [](const nt::VehicleJourney* vj, int nb_adapted_vj) {
         BOOST_REQUIRE_EQUAL(vj->meta_vj->get_adapted_vj().size(), nb_adapted_vj);
         return vj->meta_vj->get_adapted_vj().back().get();
     };

--- a/source/time_tables/tests/thermometer.cpp
+++ b/source/time_tables/tests/thermometer.cpp
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(t10) {
 
 
 BOOST_AUTO_TEST_CASE(t12) {
-    srand(time(NULL));
+    srand(time(nullptr));
     Thermometer t;
     std::vector<vector_idx> req;
     req.push_back({4,5,6});

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -40,6 +40,7 @@ www.navitia.io
 #include "utils/serialization_atomic.h"
 #include "data_exceptions.h"
 #include "utils/obj_factory.h"
+#include "utils/ptime.h"
 #include "georef/adminref.h"
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
@@ -129,8 +130,8 @@ struct ContainerTrait<type::MetaVehicleJourney> {
   */
 class Data : boost::noncopyable{
 
-    static_assert(IS_TRIVIALLY_COPYABLE(const boost::posix_time::ptime), "ptime isn't is_trivially_copyable and can't be used with std::atomic");
-    mutable std::atomic<const boost::posix_time::ptime> _last_rt_data_loaded; //datetime of the last Real Time loaded data
+    static_assert(IS_TRIVIALLY_COPYABLE(navitia::ptime), "ptime isn't is_trivially_copyable and can't be used with std::atomic");
+    mutable std::atomic<navitia::ptime> _last_rt_data_loaded; //datetime of the last Real Time loaded data
 public:
 
     static const unsigned int data_version; //< Data version number. *INCREMENT* in cpp file

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -715,9 +715,9 @@ void MetaVehicleJourney::push_unique_impact(const boost::shared_ptr<disruption::
     }
 }
 
-static_data * static_data::instance = 0;
+static_data * static_data::instance = nullptr;
 static_data * static_data::get() {
-    if (instance == 0) {
+    if (instance == nullptr) {
         static_data* temp = new static_data();
 
         boost::assign::insert(temp->types_string)

--- a/source/vptranslator/vptranslator.cpp
+++ b/source/vptranslator/vptranslator.cpp
@@ -42,14 +42,6 @@ static std::ostream& operator<<(std::ostream& os, const std::set<T>& s) {
     for (;it != end; ++it) { os << ", " << *it; }
     return os << "}";
 }
-template<typename T>
-static std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
-    os << "[";
-    auto it = v.cbegin(), end = v.cend();
-    if (it != end) { os << *it++; }
-    for (; it != end; ++it) { os << ", " << *it; }
-    return os << "]";
-}
 }
 
 namespace navitia {


### PR DESCRIPTION
Fixes Clang < 5.0 compilation (after that, there seems to be a boost bug: https://github.com/boostorg/serialization/issues/119).

Should be easier to read by commit.

Last 4 ones are more important (:warning:):
* remove shadowing (2 commits)
* remove useless code
* fix atomic<ptime> use with clang

TODO (`do_not_merge` labels that): 
- [x] merge https://github.com/CanalTP/utils/pull/72 and update the submodule in that PR