### PR TITLE
Jormungandr: Disable uwsgi timer waiting for proper fix

### DIFF
--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -183,20 +183,19 @@ class InstanceManager(object):
                 break
 
     def init_socket_reaper(self):
-        try:
-            from uwsgidecorators import timer
+        # Disable uwsgi for now
+        # try:
+        #    from uwsgidecorators import timer
 
-            logging.getLogger(__name__).info("spawning a socket reaper with  uwsgi timer")
+        #    logging.getLogger(__name__).info("spawning a socket reaper with  uwsgi timer")
 
-            @timer(self.reaper_interval, target='active-workers')
-            def reaper_timer(signal):
-                self.socket_reaper_thread(disable_gevent=True)
+        #    @timer(self.reaper_interval, target='active-workers')
+        #    def reaper_timer(signal):
+        #        self.socket_reaper_thread(disable_gevent=True)
 
-        except ImportError:
-            logging.getLogger(__name__).info(
-                "uwsgi timers not available, falling back to gevent for socket reaper"
-            )
-            gevent.spawn_later(self.reaper_interval, self.socket_reaper_thread)
+        # except ImportError:
+        logging.getLogger(__name__).info("uwsgi timers not available, falling back to gevent for socket reaper")
+        gevent.spawn_later(self.reaper_interval, self.socket_reaper_thread)
 
     def socket_reaper_thread(self, disable_gevent=False):
         for instance in self.instances.values():

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -183,7 +183,7 @@ class InstanceManager(object):
                 break
 
     def init_socket_reaper(self):
-        # Disable uwsgi for now
+        # Disable uwsgi timers for now
         # try:
         #    from uwsgidecorators import timer
 


### PR DESCRIPTION
uwsgi has a undocumented limit on the number of timer than can be
created in a uwsgi "context", set to 64, after that creating the timer
will raise an exception that terminate all uwsgi processes.
The current implementation of transient socket create one timer per
uwsgi process.
We learned the hard way that this limit exist when our uwsgi in
production started to die at startup...

This doesn't fix the problems, it only disable uwsgi timers to let me
some time for finding a real solution.

This will be hotfixed in 2.68.2