### PR TITLE
Jomungandr: Rollback to celery and kombu 4.0.2 

### DIFF
--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -1446,7 +1446,6 @@ void EdPersistor::insert_prices(const ed::Data& data) {
             tickets.tickets.front().ticket.caption,
             tickets.tickets.front().ticket.comment
         };
-        LOG4CPLUS_INFO(logger, "ticket : " << boost::algorithm::join(values, ","));
         this->lotus.insert(values);
     }
     this->lotus.finish_bulk_insert();

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -19,7 +19,7 @@ psycopg2
 pyzmq==15.4.0
 redis==3.0.1
 six==1.10.0
-kombu==4.2.1
+kombu==4.0.2
 python-dateutil==2.5.3
 pytz==2013.9
 retrying==1.3.3

--- a/source/jormungandr/requirements_dev.txt
+++ b/source/jormungandr/requirements_dev.txt
@@ -8,3 +8,4 @@ pytest-cov==2.5.1
 requests-mock==1.0.0
 flex==6.10.0
 jsonschema==2.6.0
+pytest-timeout==1.3.3

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -17,10 +17,10 @@ aniso8601==0.82
 anyjson==0.3.3
 argparse==1.2.1
 billiard==3.5.0.4
-celery==4.2.1
+celery==4.0.2
 configobj==5.0.6
 itsdangerous==0.24
-kombu==4.2.1
+kombu==4.0.2
 protobuf
 psycopg2
 pydns==2.3.6

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -205,7 +205,13 @@ def send_to_mimir(instance, filename):
 def update_data():
     for instance in models.Instance.query_existing().all():
         current_app.logger.debug("Update data of : {}".format(instance.name))
-        instance_config = load_instance_config(instance.name)
+        instance_config = None
+        try:
+            instance_config = load_instance_config(instance.name)
+        except:
+            current_app.logger.exception("impossible to load instance configuration for %s", instance.name)
+            # Do not stop the task if only one instance is missing
+            continue
         files = glob.glob(instance_config.source_directory + "/*")
         if files:
             import_data(files, instance, backup_file=True)


### PR DESCRIPTION
Kombu 4.1 and later are bugged: if rabbitmq is down they will block until the end of time...
celery/kombu#902

The last two commit are some minor fixes that don't really have anything to do with this and that should both have their own PR, but at least it will help jenkins a bit. So read by commit!