### PR TITLE
kraken: Manages added_for_detour in advance

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1387,6 +1387,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
                     arrival=tstamp("20120614T080102"),
                     departure=tstamp("20120614T080102"),
                     arrival_skipped=True,
+                    departure_skipped=True,
                     is_detour=True,
                     message='deleted for detour',
                 ),
@@ -1420,7 +1421,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
 
         assert bool(impacted_stops[1]['is_detour']) is True
         assert impacted_stops[1]['cause'] == 'deleted for detour'
-        assert impacted_stops[1]['departure_status'] == 'unchanged'
+        assert impacted_stops[1]['departure_status'] == 'deleted'
         assert impacted_stops[1]['arrival_status'] == 'deleted'
 
         assert bool(impacted_stops[2]['is_detour']) is True
@@ -1428,7 +1429,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
         assert impacted_stops[2]['departure_status'] == 'added'
         assert impacted_stops[2]['arrival_status'] == 'added'
 
-        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&direct_path=none".format(
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
             from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
         )
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1360,8 +1360,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
         """
         1. create a new_stop_time at C to replace existing one at A so that we have A deleted_for_detour
         and C added_for_detour with arrival time < to arrival time of A (deleted)
-        2. Kraken rejects this disruption and is a BUG. Adjust this test after correction in kraken
-        For details see: https://jira.kisio.org/browse/NAVP-1118
+        2. Kraken accepts this disruption
         """
         disruptions_before = self.query_region('disruptions?_current_datetime=20120614T080000')
         nb_disruptions_before = len(disruptions_before['disruptions'])
@@ -1407,7 +1406,51 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
 
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == nb_disruptions_before
+        assert len(disrupts['disruptions']) == nb_disruptions_before + 1
+        assert has_the_disruption(disrupts, 'stop_time_with_detour')
+        last_disrupt = disrupts['disruptions'][-1]
+        assert last_disrupt['severity']['effect'] == 'DETOUR'
+
+        # Verify impacted objects
+        assert len(last_disrupt['impacted_objects']) == 1
+        impacted_stops = last_disrupt['impacted_objects'][0]['impacted_stops']
+        assert len(impacted_stops) == 3
+        assert bool(impacted_stops[0]['is_detour']) is False
+        assert impacted_stops[0]['cause'] == 'on time'
+
+        assert bool(impacted_stops[1]['is_detour']) is True
+        assert impacted_stops[1]['cause'] == 'deleted for detour'
+        assert impacted_stops[1]['departure_status'] == 'unchanged'
+        assert impacted_stops[1]['arrival_status'] == 'deleted'
+
+        assert bool(impacted_stops[2]['is_detour']) is True
+        assert impacted_stops[2]['cause'] == 'added for detour'
+        assert impacted_stops[2]['departure_status'] == 'added'
+        assert impacted_stops[2]['arrival_status'] == 'added'
+
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+            from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
+        )
+
+        # Query with data_freshness=base_schedule
+        base_journey_query = B_C_query + "&data_freshness=base_schedule&_current_datetime=20120614T080000"
+
+        # There is no public transport from B to C
+        response = self.query_region(base_journey_query)
+        assert len(response['journeys']) == 1
+        assert response['journeys'][0]['type'] == 'non_pt_walk'
+        assert 'data_freshness' not in response['journeys'][0]['sections'][0]  # means it's base_schedule
+
+        # Query with data_freshness=realtime
+        base_journey_query = B_C_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
+
+        # There is a public transport from B to C with realtime
+        response = self.query_region(base_journey_query)
+        assert len(response['journeys']) == 2
+        assert response['journeys'][0]['status'] == 'DETOUR'
+        assert response['journeys'][0]['sections'][0]['type'] == 'public_transport'
+        assert response['journeys'][0]['sections'][0]['data_freshness'] == 'realtime'
+        assert has_the_disruption(response, 'stop_time_with_detour')
 
 
 def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None, effect=None):

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1428,7 +1428,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
         assert impacted_stops[2]['departure_status'] == 'added'
         assert impacted_stops[2]['arrival_status'] == 'added'
 
-        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
+        B_C_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}&direct_path=none".format(
             from_coord='stop_point:stopB', to_coord='stop_point:stopC', datetime='20120614T080000'
         )
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -111,7 +111,7 @@ static bool check_trip_update(const transit_realtime::TripUpdate& trip_update) {
                 return false;
             }
             // we don't update for a deleted stop_time for departure
-            if (!is_deleted(st.departure())) {
+            if (!is_deleted(st.departure()) && !is_deleted(st.arrival())) {
                 last_st_dep = departure_time;
             }
         }
@@ -156,7 +156,7 @@ static bool check_disruption(const nt::disruption::Disruption& disruption) {
                 return false;
             }
             // we don't update for a deleted stop_time on departure
-            if (!dep_deleted) {
+            if (!dep_deleted && !arr_deleted) {
                 last_st = st;
             }
         }

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -152,7 +152,7 @@ static bool check_disruption(const nt::disruption::Disruption& disruption) {
             bool dep_deleted = in(stu.departure_status,
                     {StopTimeUpdate::Status::DELETED, StopTimeUpdate::Status::DELETED_FOR_DETOUR});
             if (! dep_deleted) {
-                if (last_stop_event_time && *last_stop_event_time > st.departure_time) {
+                if (last_stop_event_time > st.departure_time) {
                     LOG4CPLUS_WARN(log, "stop time " << st << " is not correctly ordered regarding departure");
                     return false;
                 }

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2460,10 +2460,8 @@ BOOST_AUTO_TEST_CASE(add_new_with_earlier_arrival_and_delete_existingstop_time_i
 
     // Delete the stop_time at B (delete_for_detour) followed by a new stop_time added
     // at B_bis (added_for_detour) and C unchanged.
-    // Since the arrival time of newly added stop_time is earlier than deleted, this disruption
-    // is rejected by kraken (BUG)
-    // TODO XFAIL: Update this test after correction in kraken
-    // For details see: https://jira.kisio.org/browse/NAVP-1118
+    // the arrival time of newly added stop_time is earlier than deleted, and this
+    // feature works well.
     transit_realtime::TripUpdate just_new_stop = ntest::make_delay_message("vj:1",
             "20171101",
             {
@@ -2477,7 +2475,7 @@ BOOST_AUTO_TEST_CASE(add_new_with_earlier_arrival_and_delete_existingstop_time_i
 
     b.make();
 
-    // Since the disruption is rejected by kraken, no impact is added.
+    // Same verifications as in the test above
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2481,6 +2481,18 @@ BOOST_AUTO_TEST_CASE(add_new_with_earlier_arrival_and_delete_existingstop_time_i
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 3);
-    BOOST_CHECK_EQUAL(res.impacts_size(), 0);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 4);
+    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts(0).severity().effect(), pbnavitia::Severity_Effect_DETOUR);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).stop_point().uri(), "stop_point:B_bis");
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects_size(), 1);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops_size(), 4);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(0).is_detour(), false);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(0).departure_status(), pbnavitia::StopTimeUpdateStatus::UNCHANGED);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(1).is_detour(), true);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(1).departure_status(), pbnavitia::StopTimeUpdateStatus::DELETED);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(2).is_detour(), true);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(2).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).is_detour(), false);
+    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).departure_status(), pbnavitia::StopTimeUpdateStatus::UNCHANGED);
 }


### PR DESCRIPTION
In a trip_update, 

1. we have a stop_time replaced by another stop_time with arrival or departure time < to  the one deleted.

2. the added stop_time appears after the  deleted one in gtfs-rt.

Kraken rejected the gtfs-rt.

Correction: For a deleted stop_time, no verification is made on arrival and departure time with the previous stop_time.

Blocked by: https://github.com/CanalTP/navitia/pull/2620
Review needed from : https://github.com/CanalTP/navitia/pull/2626/commits/2f88a0635679426105c5f9cff51efa2dfba16590

