### PR TITLE
Distributed: Add filter for finalized journeys

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -289,6 +289,13 @@ class Scenario(new_default.Scenario):
         try:
             with FutureManager() as future_manager:
                 self._scenario.finalise_journeys(future_manager, request, responses, context, instance, is_debug)
+
+                from jormungandr.scenarios import journey_filter
+
+                # At this point, we should have every details on the journeys.
+                # We refilter again(again and again...)
+                journey_filter.filter_detailed_journeys(responses, request)
+
         except Exception as e:
             final_e = FinaliseException(e)
             return [final_e.get()]

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -378,15 +378,10 @@ def similar_journeys_generator(journey, pt_functor):
     for idx, s in enumerate(journey.sections):
         if s.type == response_pb2.PUBLIC_TRANSPORT:
             yield pt_functor(s)
-        elif s.type == response_pb2.STREET_NETWORK:
-            # special case, we don't want to consider the walking section after/before parking a car
-            # so CAR / PARK / WALK / PT is equivalent to CAR / PARK / PT
-            if is_walk_after_parking(journey, idx):
-                continue
+        elif s.type == response_pb2.STREET_NETWORK and is_walk_after_parking(journey, idx):
+            continue
+        elif s.type in (response_pb2.STREET_NETWORK, response_pb2.CROW_FLY):
             yield 'sn:%s' % s.street_network.mode
-        elif s.type == response_pb2.CROW_FLY and s.street_network.mode == response_pb2.Ridesharing:
-            # crowfly in ridesharing must be distinct from crowfly in walking
-            yield "sn:{}".format(s.street_network.mode)
 
 
 def similar_journeys_vj_generator(journey):

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -525,6 +525,26 @@ def apply_final_journey_filters(response_list, instance, request):
     _filter_too_much_connections(journeys, instance, request)
 
 
+def filter_detailed_journeys(responses, request):
+    journey_generator = get_qualified_journeys
+    if request.get('debug', False):
+        journey_generator = get_all_journeys
+
+    journeys = journey_generator(responses)
+
+    min_bike = request.get('_min_bike', None)
+    min_car = request.get('_min_car', None)
+    orig_modes = request.get('origin_mode', [])
+    dest_modes = request.get('destination_mode', [])
+
+    too_heavy_journey_filter = FilterTooShortHeavyJourneys(
+        min_bike=min_bike, min_car=min_car, orig_modes=orig_modes, dest_modes=dest_modes
+    )
+    f_wrapped = filter_wrapper(is_debug=request.get('debug', False), filter_obj=too_heavy_journey_filter)
+
+    [f_wrapped(j) for j in journeys]
+
+
 def _get_worst_similar(j1, j2, request):
     """
     Decide which is the worst journey between 2 similar journeys.

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -998,6 +998,10 @@ class Scenario(simple.Scenario):
 
         self.finalise_journeys(request, responses, distributed_context, instance, api_request['debug'])
 
+        # At this point, we should have every details on the journeys.
+        # We refilter again(again and again...)
+        journey_filter.filter_detailed_journeys(responses, request)
+
         pb_resp = merge_responses(responses, api_request['debug'])
 
         sort_journeys(pb_resp, instance.journey_order, api_request['clockwise'])

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -998,10 +998,6 @@ class Scenario(simple.Scenario):
 
         self.finalise_journeys(request, responses, distributed_context, instance, api_request['debug'])
 
-        # At this point, we should have every details on the journeys.
-        # We refilter again(again and again...)
-        journey_filter.filter_detailed_journeys(responses, request)
-
         pb_resp = merge_responses(responses, api_request['debug'])
 
         sort_journeys(pb_resp, instance.journey_order, api_request['clockwise'])

--- a/source/jormungandr/tests/routing_tests.py
+++ b/source/jormungandr/tests/routing_tests.py
@@ -99,6 +99,12 @@ class TestJourneysDefault(JourneyCommon, AbstractTestFixture):
         """
         pass
 
+    def test_journeys_too_short_heavy_mode_fallback_filter(self):
+        """
+        This new feature is not supported in default
+        """
+        pass
+
 
 @config()
 class TestJourneysNoRegionDefault(JourneysNoRegion, AbstractTestFixture):

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -76,7 +76,7 @@ class TestJourneysDistributedWithMock(JourneyMinBikeMinCar, NewDefaultScenarioAb
         # journey count = 18 / direct_path_call_count = 26 / routing_matrix_call_count = 20
         # get_directpath_count_by_mode(response, 'walking') == 5
         # get_directpath_count_by_mode(response, 'bike') == 5
-        assert len(response["journeys"]) == 10
+        assert len(response["journeys"]) == 13
         assert sn_service.direct_path_call_count == 6
         assert sn_service.routing_matrix_call_count == 4
         assert get_directpath_count_by_mode(response, 'walking') == 1


### PR DESCRIPTION
Some journeys are not filtered because with the fake crowflies, there was no enough detailed information for the filter, especially when it concerns a car fallback returned by Kraken(car + park + walking...) 

We re-apply some filters which need more details than other filters...