### PR TITLE
jormun: stop reporting bragi error as newrelic exception

### DIFF
--- a/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
+++ b/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
@@ -75,7 +75,7 @@ class AbstractAutocomplete(six.with_metaclass(ABCMeta, object)):
         pass
 
     def record_status(self, status, exc=None):
-        data = {'type': type(self).__name__, 'status': status}
+         data = {'type': self.__class__.__name__, 'status': status}
         if exc is not None:
             data["cause"] = str(exc)
         record_custom_event('autocomplete_status', data)

--- a/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
+++ b/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
@@ -75,7 +75,7 @@ class AbstractAutocomplete(six.with_metaclass(ABCMeta, object)):
         pass
 
     def record_status(self, status, exc=None):
-         data = {'type': self.__class__.__name__, 'status': status}
+        data = {'type': self.__class__.__name__, 'status': status}
         if exc is not None:
             data["cause"] = str(exc)
         record_custom_event('autocomplete_status', data)


### PR DESCRIPTION
When bragi is a bit slow there is a lot of timeout on the reverse done
for /journeys, currently these timeout are reported to newrelic as
exceptions even if they do not cause the response to be on error.
This behavior is a bit misleading for operation people that see 20-30%
of error in newrelic while in fact it's just that the reverse is
failing: it's not that bad.

This PR create a new type of events in newrelic to track
`GeocodeJsonUnavailable` errors (timeouts, 503, etc...), other kind
of errors (`GeocodeJsonError`) are still reported as exception.

The newrelic event is `autocomplete_status`, is has the following
properties:
  - status: `ok`/`unavailable`/`error`
  - type: geocodejson or kraken
  - cause: exception message in case of status being `unavailable` or `error`