### PR TITLE
"migration" to c++14

### DIFF
--- a/source/cmake_modules/CompilationFlags.cmake
+++ b/source/cmake_modules/CompilationFlags.cmake
@@ -14,7 +14,7 @@ ENDIF(NOT CMAKE_BUILD_TYPE)
 # Gcc Release flags
 if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_GNUCXX_WARN_FLAGS "-Wall -Wextra -Woverloaded-virtual -Wundef -pedantic")
-    set(CMAKE_GNUCXX_COMMON_FLAGS "-std=c++0x -rdynamic -g")
+    set(CMAKE_GNUCXX_COMMON_FLAGS "-std=c++14 -rdynamic -g")
     set(CMAKE_CXX_FLAGS "${CMAKE_GNUCXX_COMMON_FLAGS} ${CMAKE_GNUCXX_WARN_FLAGS}")
     set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAG} --coverage -fprofile-arcs -ftest-coverage  -g")
     set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS} --coverage")


### PR DESCRIPTION
we can migrate to c++14 since we do not support debian 7 anymore