### PR TITLE
jormun: handle SIRI errors appropriately

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -198,7 +198,12 @@ class Siri(RealtimeProxy):
             # Status is false: there is a problem, but we may have a valid response too...
             # Lets log whats happening
             error_condition = stop_monitoring_delivery.find('.//siri:ErrorCondition', ns)
-            if error_condition and list(error_condition):
+            if error_condition is not None and list(error_condition):
+                if error_condition.find('.//siri:NoInfoForTopicError', ns) is not None:
+                    # There is no data, we might be at the end of the service
+                    # OR the SIRI server doesn't update it's own data: their is no way to known
+                    # let's say it's normal and not log nor return base_schedule data
+                    return
                 # Log the error returned by SIRI, the is a node for the normalized error code
                 # and another node that hold the description
                 code = " ".join([e.tag for e in list(error_condition) if 'Description' not in e.tag])

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -228,8 +228,11 @@ class Siri(RealtimeProxy):
             cur_route = visit.find('.//siri:DirectionName', ns).text
             if route != cur_route:
                 continue
+            # TODO? we should ignore MonitoredCall with a DepartureStatus set to "Cancelled"
             cur_destination = visit.find('.//siri:DestinationName', ns).text
             cur_dt = visit.find('.//siri:ExpectedDepartureTime', ns).text
+            # TODO? fallback on siri:AimedDepartureTime is there is not ExpectedDepartureTime
+            # In that case we may want to set realtime to False
             cur_dt = aniso8601.parse_datetime(cur_dt)
             next_passages.append(RealTimePassage(cur_dt, cur_destination))
 

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -201,7 +201,7 @@ class Siri(RealtimeProxy):
             if error_condition is not None and list(error_condition):
                 if error_condition.find('.//siri:NoInfoForTopicError', ns) is not None:
                     # There is no data, we might be at the end of the service
-                    # OR the SIRI server doesn't update it's own data: their is no way to known
+                    # OR the SIRI server doesn't update it's own data: there is no way to known
                     # let's say it's normal and not log nor return base_schedule data
                     return
                 # Log the error returned by SIRI, the is a node for the normalized error code

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
@@ -122,6 +122,35 @@ def mock_good_response():
     """
 
 
+def mock_error_response():
+    return """<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns1:GetStopMonitoringResponse xmlns:ns1="http://wsdl.siri.org.uk">
+      <ServiceDeliveryInfo xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri">
+        <ns5:ResponseTimestamp>2018-12-31T09:11:27.681+01:00</ns5:ResponseTimestamp>
+        <ns5:ProducerRef>Orleans</ns5:ProducerRef>
+        <ns5:ResponseMessageIdentifier>Orleans:SM:RQ:630908</ns5:ResponseMessageIdentifier>
+        <ns5:RequestMessageRef>IDontCare</ns5:RequestMessageRef>
+      </ServiceDeliveryInfo>
+      <Answer xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri">
+        <ns5:StopMonitoringDelivery>
+          <ns5:ResponseTimestamp>2018-12-31T09:11:27.681+01:00</ns5:ResponseTimestamp>
+          <ns5:RequestMessageRef>IDontCare</ns5:RequestMessageRef>
+          <ns5:Status>false</ns5:Status>
+          <ns5:ErrorCondition>
+            <ns5:NoInfoForTopicError/>
+            <ns5:Description>Pas de donn&#xE9;e</ns5:Description>
+          </ns5:ErrorCondition>
+        </ns5:StopMonitoringDelivery>
+      </Answer>
+      <AnswerExtension xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri"/>
+    </ns1:GetStopMonitoringResponse>
+  </soap:Body>
+</soap:Envelope>
+    """
+
+
 def next_passage_for_route_point_test():
     """
     test the whole next_passage_for_route_point
@@ -152,6 +181,24 @@ def next_passage_for_route_point_failure_test():
 
     with requests_mock.Mocker() as m:
         m.post('http://bob.com/', text=mock_good_response(), status_code=404)
+        passages = siri.next_passage_for_route_point(route_point, from_dt=_timestamp("12:00"), count=2)
+        assert m.called
+
+        assert passages is None
+
+
+def next_passage_for_route_point_error_test():
+    """
+    test the whole next_passage_for_route_point
+
+    the siri's response contains a error, we should get 'None'
+    """
+    siri = Siri(id='tata', service_url='http://bob.com/', requestor_ref='Stibada')
+
+    route_point = MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu')
+
+    with requests_mock.Mocker() as m:
+        m.post('http://bob.com/', text=mock_error_response(), status_code=404)
         passages = siri.next_passage_for_route_point(route_point, from_dt=_timestamp("12:00"), count=2)
         assert m.called
 

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
@@ -62,6 +62,70 @@ def make_request_test():
     assert root.find('.//siri:RequestTimestamp', ns).text == '2016-02-07T12:00:30'
 
 
+def mock_good_with_error_response():
+    return """<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns1:GetStopMonitoringResponse xmlns:ns1="http://wsdl.siri.org.uk">
+      <ServiceDeliveryInfo xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri">
+        <ns5:ResponseTimestamp>2017-03-02T11:27:09.886+01:00</ns5:ResponseTimestamp>
+        <ns5:ProducerRef>Orleans</ns5:ProducerRef>
+        <ns5:ResponseMessageIdentifier>Orleans:SM:RQ:331</ns5:ResponseMessageIdentifier>
+        <ns5:RequestMessageRef>StopMonitoringClient:Test:0</ns5:RequestMessageRef>
+      </ServiceDeliveryInfo>
+      <Answer xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri">
+        <ns5:StopMonitoringDelivery version="1.3">
+          <ns5:ResponseTimestamp>2017-03-02T11:27:09.886+01:00</ns5:ResponseTimestamp>
+          <ns5:RequestMessageRef>StopMonitoringClient:Test:0</ns5:RequestMessageRef>
+          <ns5:Status>false</ns5:Status>
+          <ns5:ErrorCondition>
+            <ns5:ParametersIgnoredError/>
+            <ns5:Description>...</ns5:Description>
+          </ns5:ErrorCondition>
+          <ns5:MonitoredStopVisit>
+            <ns5:RecordedAtTime>2017-03-02T03:30:34.000+01:00</ns5:RecordedAtTime>
+            <ns5:ItemIdentifier>Orleans:ItemId::268517466:LOC</ns5:ItemIdentifier>
+            <ns5:MonitoringRef>Orleans:StopPoint:BP:TJDARC1:LOC</ns5:MonitoringRef>
+            <ns5:MonitoredVehicleJourney>
+              <ns5:LineRef>line_toto</ns5:LineRef>
+              <ns5:FramedVehicleJourneyRef>
+                <ns5:DataFrameRef>Orleans:Version:3:LOC</ns5:DataFrameRef>
+                <ns5:DatedVehicleJourneyRef>Orleans:VehicleJourney::B_R_175_10_B09_5_11:06:00:LOC</ns5:DatedVehicleJourneyRef>
+              </ns5:FramedVehicleJourneyRef>
+              <ns5:JourneyPatternRef>Orleans:JourneyPattern::B_R_175:LOC</ns5:JourneyPatternRef>
+              <ns5:PublishedLineName>G. POMPIDOU - CLOS DU HAMEAU</ns5:PublishedLineName>
+              <ns5:DirectionName>route_tata</ns5:DirectionName>
+              <ns5:VehicleFeatureRef/>
+              <ns5:DestinationRef>stop_destination</ns5:DestinationRef>
+              <ns5:DestinationName>Georges Pompidou</ns5:DestinationName>
+              <ns5:Monitored>false</ns5:Monitored>
+              <ns5:MonitoredCall>
+                <ns5:StopPointRef>stop_tutu</ns5:StopPointRef>
+                <ns5:Order>15</ns5:Order>
+                <ns5:StopPointName>Jeanne d'Arc</ns5:StopPointName>
+                <ns5:VehicleAtStop>false</ns5:VehicleAtStop>
+                <ns5:PlatformTraversal>false</ns5:PlatformTraversal>
+                <ns5:DestinationDisplay>GEORGES POMPIDOU</ns5:DestinationDisplay>
+                <ns5:AimedArrivalTime>2016-03-29T13:30:00.000+00:00</ns5:AimedArrivalTime>
+                <ns5:ExpectedArrivalTime>2016-03-29T13:37:00.000+00:00</ns5:ExpectedArrivalTime>
+                <ns5:ArrivalStatus>noReport</ns5:ArrivalStatus>
+                <ns5:ArrivalPlatformName/>
+                <ns5:AimedDepartureTime>2016-03-29T13:30:00.000+00:00</ns5:AimedDepartureTime>
+                <ns5:ExpectedDepartureTime>2016-03-29T13:37:00.000+00:00</ns5:ExpectedDepartureTime>
+                <ns5:DepartureStatus>noReport</ns5:DepartureStatus>
+                <ns5:DeparturePlatformName/>
+              </ns5:MonitoredCall>
+            </ns5:MonitoredVehicleJourney>
+          </ns5:MonitoredStopVisit>
+        </ns5:StopMonitoringDelivery>
+      </Answer>
+      <AnswerExtension xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri"/>
+    </ns1:GetStopMonitoringResponse>
+  </soap:Body>
+</soap:Envelope>
+    """
+
+
 def mock_good_response():
     return """<?xml version="1.0"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
@@ -203,6 +267,23 @@ def next_passage_for_route_point_error_test():
         assert m.called
 
         assert passages is None
+
+
+def next_passage_for_route_point_good_response_with_error_test():
+    """
+    mock the http call to return a good response that also contain an error, we should get some next_passages
+    """
+    siri = Siri(id='tata', service_url='http://bob.com/', requestor_ref='Stibada')
+    route_point = MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu')
+
+    with requests_mock.Mocker() as m:
+        m.post('http://bob.com/', text=mock_good_with_error_response())
+        passages = siri._get_next_passage_for_route_point(
+            route_point, from_dt=_timestamp("12:00"), current_dt=_timestamp("12:00"), count=1
+        )
+        assert m.called
+        assert len(passages) == 1
+        assert passages[0].datetime == datetime.datetime(2016, 3, 29, 13, 37, tzinfo=pytz.UTC)
 
 
 def status_test():

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
@@ -187,6 +187,35 @@ def mock_good_response():
 
 
 def mock_error_response():
+    return """<?xml version="1.0" encoding="ISO-8859-1"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ns1:GetStopMonitoringResponse xmlns:ns1="http://wsdl.siri.org.uk">
+      <ServiceDeliveryInfo xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri">
+        <ns5:ResponseTimestamp>2019-01-02T07:57:03.919+01:00</ns5:ResponseTimestamp>
+        <ns5:ProducerRef>Orleans</ns5:ProducerRef>
+        <ns5:ResponseMessageIdentifier>Orleans:SM:RQ:423078</ns5:ResponseMessageIdentifier>
+        <ns5:RequestMessageRef>IDontCare</ns5:RequestMessageRef>
+      </ServiceDeliveryInfo>
+      <Answer xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri">
+        <ns5:StopMonitoringDelivery>
+          <ns5:ResponseTimestamp>2019-01-02T07:57:03.919+01:00</ns5:ResponseTimestamp>
+          <ns5:RequestMessageRef>IDontCare</ns5:RequestMessageRef>
+          <ns5:Status>false</ns5:Status>
+          <ns5:ErrorCondition>
+            <ns5:OtherError/>
+            <ns5:Description>[BAD_ID] MonitoringRef (00052200)</ns5:Description>
+          </ns5:ErrorCondition>
+        </ns5:StopMonitoringDelivery>
+      </Answer>
+      <AnswerExtension xmlns:ns2="http://www.ifopt.org.uk/acsb" xmlns:ns3="http://datex2.eu/schema/1_0/1_0" xmlns:ns4="http://www.ifopt.org.uk/ifopt" xmlns:ns5="http://www.siri.org.uk/siri"/>
+    </ns1:GetStopMonitoringResponse>
+  </soap:Body>
+</soap:Envelope>
+    """
+
+
+def mock_no_data_response():
     return """<?xml version="1.0"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
   <soap:Body>
@@ -262,11 +291,29 @@ def next_passage_for_route_point_error_test():
     route_point = MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu')
 
     with requests_mock.Mocker() as m:
-        m.post('http://bob.com/', text=mock_error_response(), status_code=404)
+        m.post('http://bob.com/', text=mock_error_response(), status_code=200)
         passages = siri.next_passage_for_route_point(route_point, from_dt=_timestamp("12:00"), count=2)
         assert m.called
 
         assert passages is None
+
+
+def next_passage_for_route_point_no_data_test():
+    """
+    test the whole next_passage_for_route_point
+
+    the siri's response contains a error of type NoInfoForTopicError: there is no next departure
+    """
+    siri = Siri(id='tata', service_url='http://bob.com/', requestor_ref='Stibada')
+
+    route_point = MockRoutePoint(route_id='route_tata', line_id='line_toto', stop_id='stop_tutu')
+
+    with requests_mock.Mocker() as m:
+        m.post('http://bob.com/', text=mock_no_data_response(), status_code=200)
+        passages = siri.next_passage_for_route_point(route_point, from_dt=_timestamp("12:00"), count=2)
+        assert m.called
+
+        assert passages == []
 
 
 def next_passage_for_route_point_good_response_with_error_test():


### PR DESCRIPTION
# Error management
Every SIRI response contains a status that may indicate an error, or not...
From the official documentation
[the SIRI IDF profil 2.4](http://www.normes-donnees-tc.org/format-dechange/donnees-temps-reel/)

> Pour les services fonctionnels, le champ facultatif « Status » sera toujours
> présent et égal à « true » si la requête a été traitée normalement et à
> « false » sinon (dans le cas des abonnements, un éventuel problème
> détecté, comme une indisponibilité temporaire, donnera lieu à l'émission
> d'une notification sans données, mais signalant le problème). Ce champ
> signale qu'un problème a été rencontré, et non qu'il n'y a pas de réponse : il
> peut donc être positionné à « false » alors qu'une information est bien
> retournée.

So, if there is some departures we keep them, else if status is false
it's an error, and finally if status is true but without departure we
assume there is no more departure for today.

There is one standardized error that we might have to consider
`siri:NoInfoForTopicError`, it's description is the following:

> La requête est valide, mais aucune donnée correspondante n'est disponible sur le serveur.

Kinda fuzzy...

The profil has a paragraphe dedicated to the end of service for a line:

> ### Note concernant les cas ou il n'y a pas ou plus d'information:
> S'il n'y a de réponse à une requête « Stop monitoring » car elle intervient après le
> dernier passage de la journée, le producteur doit dans la mesure du possible fournir
> une information via le service « General message ». Il est donc recommandé que le
> client, s'il n'obtient pas de réponse au « Stop monitoring », fasse dans la foulée une
> requête au « General message ».
>
> Dans le cas des déviations : pour les arrêts non desservis, il conviendra aussi de
> fournir une information via le service « General message » (la réponse à « Stop
> monitoring n'est toutefois pas forcément vide si la déviation est temporaire »).

And by GeneralMessage they mean the extended one used in "Ile de France"
that allow to associate a textual message to an object, the normalized
one doesn't provide any information about the "impacted" object.
GeneralMessage is used for unstructured data as stated by the profile:

> il faut rappeler que ce service n’est pas le service de gestion de perturbation :
> il est conçu pour pouvoir diffuser les informations non structurées de perturbation,
> dans un premier temps, en attendant la définition finale du service SIRI Situation
> Exchange

From what I can see `siri:NoInfoForTopicError` is returned after the end of service, 
so ignore this error and will not try to return base_schedule data so no departure in that case.

should fix https://jira.kisio.org/browse/NAVITIAII-2634

# Possible Improvement
## Ignore Canceled Departure 
We should ignore MonitoredCall with a DepartureStatus set to "Cancelled"
as stated in the Profil:

> ### Note concernant les annulations de passage :
> Concernant les informations permettant d'indiquer l'annulation d'un passage il est
> précisé que:
> - Mode requête:
>    - La réponse positionne à « Cancelled » le champ « ArrivalStatus »
>    et/ou « DepartureStatus » dans « MonitoredCall » jusqu’à l’heure d’arrivée théorique
>    - Puis aucune information n'est plus fournie pour cette course

## Use Aimed Departure Time  
Currently we only use the ExpectedDepartureTime, if a MonitoredCall is
provided without ExpectedDepartureTime it won't be present in the
navitia response. The profile state that AimedDepartureTime should
contains the theorical departure time for the day if there no realtime
data:

> SIRI propose plusieurs niveaux d'information sur les heures de passage:
> - Aimed(Departure/Arrival)Time : Heure d'arrivée ou de départ théorique. Il
> s'agit là de l'heure planifiée (figurant dans les fichiers horaires). Il peut aussi
> s'agir de l'horaire replanifié du matin s’il est disponible (horaire commandé).
> - Actual(Departure/Arrival)Time : Heure d'arrivée ou de départ effectivement
> mesurée (et donc disponible uniquement après le départ ou l’arrivée du
> véhicule).
> - Expected(Departure/Arrival)Time : Heure d'arrivée ou de départ calculée par
> le SAE sur la base de la progression du véhicule et du commandé (ou
> modifié en cours d'exploitation).