### PR TITLE
jormun: Fix missing schedules in SIRI realtime connector

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -61,7 +61,7 @@ class Siri(RealtimeProxy):
                     <siri:RequestTimestamp>{datetime}</siri:RequestTimestamp>
                     <siri:MessageIdentifier>IDontCare</siri:MessageIdentifier>
                     <siri:MonitoringRef>{stop_code}</siri:MonitoringRef>
-                    <siri:MaximumStopVisits>{nb_desired}</siri:MaximumStopVisits>
+                    <siri:MinimumStopVisitsPerLine>{nb_desired}</siri:MinimumStopVisitsPerLine>
                 </Request>
                 <RequestExtension xmlns=""/>
             </GetStopMonitoring>
@@ -232,7 +232,7 @@ class Siri(RealtimeProxy):
                 <siri:RequestTimestamp>{dt}</siri:RequestTimestamp>
                 <siri:MessageIdentifier>{MessageIdentifier}</siri:MessageIdentifier>
                 <siri:MonitoringRef>{MonitoringRef}</siri:MonitoringRef>
-                <siri:MaximumStopVisits>{count}</siri:MaximumStopVisits>
+                <siri:MinimumStopVisitsPerLine>{count}</siri:MinimumStopVisitsPerLine>
               </Request>
               <RequestExtension xmlns=""/>
             </GetStopMonitoring>

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/siri_test.py
@@ -49,7 +49,7 @@ def make_request_test():
     ns = {'siri': 'http://www.siri.org.uk/siri'}
 
     assert root.find('.//siri:MonitoringRef', ns).text == 'Tri:SP:toto:LOC'
-    assert root.find('.//siri:MaximumStopVisits', ns).text == '2'
+    assert root.find('.//siri:MinimumStopVisitsPerLine', ns).text == '2'
     assert root.find('.//siri:RequestTimestamp', ns).text == '2016-02-07T12:00:00'
     assert root.find('.//siri:RequestorRef', ns).text == 'Stibada'
 


### PR DESCRIPTION
FIX https://jira.kisio.org/browse/NAVITIAII-2638

When doing a stop_schedules on stop_points with multiple lines, some
lines/routes will have no next departures while there is some on the
SIRI server.

This is because we call SIRI one time per stop_point as each route point
will do the same query that will have been cached.
In this query we asked for `item_per_schedules` results **at most**.
So lets say we have a stop_point with five lines, we call it once
and ask for five schedules: best case, we have one schedule per
line, sadly we do not live in wonderland, and we will get departures for
only a few of these lines as it's very unlikely that they run at the same
frequency.

In fact SIRI can have the same behavior than navitia, it's possible to
do a "departures" call by asking for at most N departures with the
parameter `siri:MaximumStopVisits` or to do a "stop_schedules" call with
the parameter `siri:MinimumStopVisitsPerLine`.
This is the changed proposed by this PR: we always ask for at least N
departures per line for each stop_point that we have to call, it makes
`/stop_schedules` happy as we will have departures for everyone.

But... this totally messes `/departures`, if we take the same example than
before: one stop_point with 5 lines, and we want 5 departures, we will
in fact get 25 departures in the response, that's not great (it's
somehow already the case as soon as a request is done on a stop_area
with multiple stop_points) but we will have gap in the schedules, if one
line passes every two minutes while another is scheduled every ten
minutes we will have departures for the first line for the next ten
minutes while for the other we will have fifty minutes of departures, In
these forty minutes difference we will not get the departures for the
first line.

SIRI is only used on Orléans. On this coverage, stop_schedules is
used twenty time more than departures, so for an hotfix it will do ...

We could use the parameter `siri:LineRef` to filter per line, but it
will have more or less the same effect on departures and will
**greatly** increase the request made to SIRI.