### PR TITLE
Expose the configuration file parameters into the helper page

### DIFF
--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -41,12 +41,17 @@ www.navitia.io
 #include "utils/zmq.h"
 #include "utils/functions.h" //navitia::absolute_path function
 
-static void show_usage(const std::string& name)
+static void show_usage(const std::string& name, const boost::program_options::options_description& descr)
 {
     std::cerr << "Usage:\n"
               << "\t" << name << " --help\t\tShow this message.\n"
               << "\t" << name << " [config_file]\tSpecify the path of the configuration file "
-              << "(default: kraken.ini in the current path)"
+              << "(default: kraken.ini in the current path) \n\n"
+              << "Configuration file (kraken.ini) can have the following parameter: \n"
+              << descr
+              << "\n"
+              << "Parameters from the configuration file can also be declared by environment variable like: \n"
+              << "\t KRAKEN_GENERAL_instance_name=<inst_name>"
               << std::endl;
 }
 
@@ -64,7 +69,8 @@ int main(int argn, char** argv){
     if(argn > 1){
         std::string arg = argv[1];
         if(arg == "-h" || arg == "--help"){
-            show_usage(argv[0]);
+            auto opt_desc = navitia::kraken::get_options_description();
+            show_usage(argv[0], opt_desc);
             return 0;
         }else{
             // The first argument is the path to the configuration file


### PR DESCRIPTION
`./kraken --help` now displays configuration file options :
 
```
Usage:
        ./kraken/kraken --help          Show this message.
        ./kraken/kraken [config_file]   Specify the path of the configuration file (default: kraken.ini in the current path) 

Configuration file (kraken.ini) can have the following parameter: 
Allowed options:
  --GENERAL.database arg (=data.nav.lz4)
                                        path to the data file
  --GENERAL.zmq_socket arg              path to the zmq socket used for 
                                        receiving resquest
  --GENERAL.instance_name arg           name of the instance
  --GENERAL.nb_threads arg (=1)         number of workers threads
  --GENERAL.is_realtime_enabled arg (=0)
                                        enable loading of realtime data
  --GENERAL.is_realtime_add_enabled arg (=0)
                                        enable loading of realtime data that 
                                        add stop_times or trips
  --GENERAL.kirin_timeout arg (=60000)  timeout in ms for loading realtime data
                                        from kirin
  --GENERAL.kirin_retry_timeout arg (=300000)
                                        timeout in ms before retrying to load 
                                        realtime data
  --GENERAL.slow_request_duration arg (=1000)
                                        request running a least this number of 
                                        milliseconds are logged
  --GENERAL.display_contributors arg (=0)
                                        display all contributors in feed 
                                        publishers
  --GENERAL.raptor_cache_size arg (=10) maximum number of stored raptor caches
  --GENERAL.log_level arg               log level of kraken
  --GENERAL.log_format arg (=[%D{%y-%m-%d %H:%M:%S,%q}] [%p] [%x] - %m %b:%L  %n)
                                        log format
  --GENERAL.metrics_binding arg         IP:PORT to serving metrics in http
  --BROKER.host arg (=localhost)        host of rabbitmq
  --BROKER.port arg (=5672)             port of rabbitmq
  --BROKER.username arg (=guest)        username for rabbitmq
  --BROKER.password arg (=guest)        password for rabbitmq
  --BROKER.vhost arg (=/)               vhost for rabbitmq
  --BROKER.exchange arg (=navitia)      exchange used in rabbitmq
  --BROKER.rt_topics arg                list of realtime topic for this 
                                        instance
  --BROKER.timeout arg (=100)           timeout for maintenance worker in 
                                        millisecond
  --BROKER.sleeptime arg (=1)           sleeptime for maintenance worker in 
                                        second
  --CHAOS.database arg                  Chaos database connection string

Parameters from the configuration file can also be declared by environment variable like: 
         KRAKEN_GENERAL_instance_name=<inst_name>

```