### PR TITLE
Configure codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,34 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 1
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2
+        base: auto
+    patch:
+      default:
+        target: 25%
+        threshold: null
+        base: auto
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
This is based on the default config, there is only two changes:
  - Increase of threshold to two percent, since sometime our coverage
  vary randomly...
  - Lower patch code coverage requirements to 25%, to prevent the red
  cross effect