### PR TITLE
Jormun: Fix count on /departures with realtime proxies

### DIFF
--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -303,6 +303,9 @@ class MixedSchedule(object):
             return cmp(p1.stop_date_time.departure_date_time, p2.stop_date_time.departure_date_time)
 
         resp.next_departures.sort(comparator)
+        count = request['count']
+        if len(resp.next_departures) > count and rt_proxy:
+            del resp.next_departures[count:]
 
         # handle pagination :
         # If real time information exist, we have to change pagination score.

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -304,7 +304,7 @@ class MixedSchedule(object):
 
         resp.next_departures.sort(comparator)
         count = request['count']
-        if len(resp.next_departures) > count and rt_proxy:
+        if len(resp.next_departures) > count:
             del resp.next_departures[count:]
 
         # handle pagination :

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -342,6 +342,35 @@ class TestDepartures(AbstractTestFixture):
         for stop_sched in response['stop_schedules']:
             assert len(stop_sched['date_times']) == 2
 
+    def test_departures_count(self):
+        """
+        test that count parameter is correctly taken into account when using realtime proxies
+        We search for departures on C:vj1: C:S0 -> 11:30, C:S1 -> 12:30, C:S2 -> 13:30
+        So we got departures for the route points of the line C to the stops C:S0, C:S1, C:S2
+        So there is two departures:
+        Base_schedule:
+          - C:S0 -> 11:30
+          - C:S1 -> 12:30
+
+        In realtime C:S1 has no departure, but C:S0 got another one, so still two departures:
+          - C:S0 -> 11:32:42
+          - C:S0 -> 11:42:42
+
+        When we set count to 1 we want only one departure (the first one)
+        """
+        query = 'vehicle_journeys/C:vj1/departures?from_datetime=20160102T1000&count=100&_current_datetime=20160102T1000'
+        response = self.query_region(query, display=True)
+
+        assert "departures" in response
+        assert len(response["departures"]) == 2
+
+        query = 'vehicle_journeys/C:vj1/departures?from_datetime=20160102T1000&count=1&_current_datetime=20160102T1000'
+        response_count = self.query_region(query)
+
+        assert "departures" in response_count
+        assert len(response_count["departures"]) == 1
+        assert response_count["departures"] == response["departures"][:1]
+
 
 MOCKED_PROXY_CONF = [
     {

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -347,7 +347,7 @@ class TestDepartures(AbstractTestFixture):
         test that count parameter is correctly taken into account when using realtime proxies
         We search for departures on C:vj1: C:S0 -> 11:30, C:S1 -> 12:30, C:S2 -> 13:30
         So we got departures for the route points of the line C to the stops C:S0, C:S1, C:S2
-        So there is two departures:
+        So there are two departures:
         Base_schedule:
           - C:S0 -> 11:30
           - C:S1 -> 12:30


### PR DESCRIPTION
This is a follow-up on https://github.com/CanalTP/navitia/pull/2645
The count parameter wasn't used correctly on departures when realtime
proxies were involved.
This adds a post action that will enforce the count, so we never get more
than `count` departure.

We could change the realtime proxies to let them know about the
differences between /departures and /stop_schedules to optimize calls
made to external services. It's a lot of change that I won't make it for
now.

JIRA: https://jira.kisio.org/browse/NAVITIAII-2638