### PR TITLE
Fix get_base_stop_time

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -32,7 +32,7 @@ www.navitia.io
 #include "utils/logger.h"
 #include "utils/map_find.h"
 #include "type/datetime.h"
-#include "type/type_utils.h"
+#include "type/type.h"
 
 #include <boost/make_shared.hpp>
 #include <boost/variant/static_visitor.hpp>
@@ -230,7 +230,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             LOG4CPLUS_TRACE(log, "New vj has been created " << vj->uri);
             // Use the corresponding base stop_time for boarding and alighting duration
             for(auto& st: vj->stop_time_list) {
-                const auto base_st = get_base_stop_time(&st);
+                const auto base_st = st.get_base_stop_time();
                 if(base_st) {
                     st.boarding_time = st.departure_time - base_st->get_boarding_duration();
                     st.alighting_time = st.arrival_time + base_st->get_alighting_duration();

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2394,4 +2394,3 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
             ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00000000"),
             rt_vj1->rt_validity_pattern()->days);
 }
-

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -73,7 +73,7 @@ make_cancellation_message(const std::string& vj_uri, const std::string& date) {
     return trip_update;
 }
 
-pbnavitia::Response compute_iti(
+static pbnavitia::Response compute_iti(
     const ed::builder& b,
     const char* datetime, 
     const std::string& from, 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1,32 +1,32 @@
-//  Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
-// 
-// This file is part of Navitia,
-//     the software to build cool stuff with public transport.
-// 
-// Hope you'll enjoy and contribute to this project,
-//     powered by Canal TP (www.canaltp.fr).
-// Help us simplify mobility and open public transport:
-//     a non ending quest to the responsive locomotion way of traveling!
-// 
-// LICENCE: This program is free software; you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-// 
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Affero General Public License for more details.
-// 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
-// 
-// Stay tuned using
-// twitter @navitia
-// IRC #navitia on freenode
-// https://groups.google.com/d/forum/navitia
-// www.navitia.io
-//
+/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE test_realtime

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1,32 +1,32 @@
-/* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
-
-This file is part of Navitia,
-    the software to build cool stuff with public transport.
-
-Hope you'll enjoy and contribute to this project,
-    powered by Canal TP (www.canaltp.fr).
-Help us simplify mobility and open public transport:
-    a non ending quest to the responsive locomotion way of traveling!
-
-LICENCE: This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-Stay tuned using
-twitter @navitia
-IRC #navitia on freenode
-https://groups.google.com/d/forum/navitia
-www.navitia.io
-*/
+//  Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
+// 
+// This file is part of Navitia,
+//     the software to build cool stuff with public transport.
+// 
+// Hope you'll enjoy and contribute to this project,
+//     powered by Canal TP (www.canaltp.fr).
+// Help us simplify mobility and open public transport:
+//     a non ending quest to the responsive locomotion way of traveling!
+// 
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+// 
+// Stay tuned using
+// twitter @navitia
+// IRC #navitia on freenode
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+//
 
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE test_realtime
@@ -51,6 +51,9 @@ BOOST_GLOBAL_FIXTURE( logger_initialized );
 namespace nt = navitia::type;
 namespace pt = boost::posix_time;
 namespace ntest = navitia::test;
+namespace tr = transit_realtime;
+namespace ptref = navitia::ptref;
+
 using ntest::RTStopTime;
 
 static const std::string feed_id = "42";
@@ -70,6 +73,28 @@ make_cancellation_message(const std::string& vj_uri, const std::string& date) {
     return trip_update;
 }
 
+pbnavitia::Response compute_iti(
+    const ed::builder& b,
+    const char* datetime, 
+    const std::string& from, 
+    const std::string& to,
+    const navitia::type::RTLevel level) 
+{
+    navitia::type::EntryPoint origin(b.data->get_type_of_id(from), from);
+    navitia::type::EntryPoint destination(b.data->get_type_of_id(to), to);
+
+    navitia::PbCreator pb_creator(b.data.get(), "20171101T073000"_dt, null_time_period);
+
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    make_response(pb_creator, raptor, origin, destination,
+            { ntest::to_posix_timestamp(datetime) },
+            true, navitia::type::AccessibiliteParams(), {}, {},
+            sn_worker, level, 2_min);
+
+    return  pb_creator.get_response();
+}
 
 BOOST_AUTO_TEST_CASE(simple_train_cancellation) {
     ed::builder b("20150928");
@@ -2544,4 +2569,65 @@ BOOST_AUTO_TEST_CASE(add_new_with_earlier_arrival_and_delete_existingstop_time_i
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(2).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).is_detour(), false);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).departure_status(), pbnavitia::StopTimeUpdateStatus::UNCHANGED);
+}
+
+BOOST_AUTO_TEST_CASE(should_get_base_stoptime_with_realtime_added_stop_time) {
+    ed::builder b("20171101");
+
+    b.sa("A");
+    b.sa("B");
+    b.sa("C");
+    b.sa("D");
+
+    b.vj("L1").uri("vj:1")
+        ("stop_point:A", "08:10"_t)
+        ("stop_point:C", "08:30"_t)
+        ("stop_point:D", "08:40"_t);
+    b.make();
+ 
+    tr::TripUpdate add_stop = ntest::make_delay_message("vj:1", "20171101", {
+        RTStopTime("stop_point:A", "20171101T0810"_pts),
+        RTStopTime("stop_point:B", "20171101T0820"_pts).added(),
+        RTStopTime("stop_point:C", "20171101T0830"_pts),
+        RTStopTime("stop_point:D", "20171101T0840"_pts),
+    });
+
+    navitia::handle_realtime("add_new_stop", timestamp, add_stop, *b.data, true);
+    b.make();
+
+    auto res = compute_iti(b, "20171101T080000", "A", "D", nt::RTLevel::RealTime);
+    
+    BOOST_REQUIRE_EQUAL(res.impacts_size(), 1);
+    BOOST_REQUIRE_EQUAL(res.impacts(0).impacted_objects_size(), 1);
+
+    const auto & stop_time_updates = res.impacts(0).impacted_objects(0).impacted_stops();
+    BOOST_REQUIRE_EQUAL(stop_time_updates.size(), 4);
+
+    const auto & stop_time_A = stop_time_updates.Get(0);
+    BOOST_CHECK_EQUAL(stop_time_A.stop_point().uri(), "stop_point:A");
+    BOOST_CHECK_EQUAL(stop_time_A.base_stop_time().arrival_time(), "08:10"_t);
+    BOOST_CHECK_EQUAL(stop_time_A.base_stop_time().departure_time() ,"08:10"_t);
+    BOOST_CHECK_EQUAL(stop_time_A.amended_stop_time().arrival_time(), "08:10"_t);
+    BOOST_CHECK_EQUAL(stop_time_A.amended_stop_time().departure_time(), "08:10"_t);
+
+    const auto & stop_time_B = stop_time_updates.Get(1);
+    BOOST_CHECK_EQUAL(stop_time_B.stop_point().uri(), "stop_point:B");
+    BOOST_CHECK_MESSAGE(stop_time_B.base_stop_time().arrival_time() == "00:00"_t, "Base stop time doesn't exist for added stop time");
+    BOOST_CHECK_MESSAGE(stop_time_B.base_stop_time().departure_time() == "00:00"_t, "Base stop time doesn't exist for added stop time");
+    BOOST_CHECK_EQUAL(stop_time_B.amended_stop_time().arrival_time(), "08:20"_t);
+    BOOST_CHECK_EQUAL(stop_time_B.amended_stop_time().departure_time(), "08:20"_t);
+
+    const auto & stop_time_C = stop_time_updates.Get(2);
+    BOOST_CHECK_EQUAL(stop_time_C.stop_point().uri(), "stop_point:C");
+    BOOST_CHECK_EQUAL(stop_time_C.base_stop_time().arrival_time(), "08:30"_t);
+    BOOST_CHECK_EQUAL(stop_time_C.base_stop_time().departure_time() ,"08:30"_t);
+    BOOST_CHECK_EQUAL(stop_time_C.amended_stop_time().arrival_time(), "08:30"_t);
+    BOOST_CHECK_EQUAL(stop_time_C.amended_stop_time().departure_time(), "08:30"_t);
+
+    const auto & stop_time_D = stop_time_updates.Get(3);
+    BOOST_CHECK_EQUAL(stop_time_D.stop_point().uri(), "stop_point:D");
+    BOOST_CHECK_EQUAL(stop_time_D.base_stop_time().arrival_time(), "08:40"_t);
+    BOOST_CHECK_EQUAL(stop_time_D.base_stop_time().departure_time() ,"08:40"_t);
+    BOOST_CHECK_EQUAL(stop_time_D.amended_stop_time().arrival_time(), "08:40"_t);
+    BOOST_CHECK_EQUAL(stop_time_D.amended_stop_time().departure_time(), "08:40"_t);
 }

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1750,20 +1750,19 @@ BOOST_AUTO_TEST_CASE(delays_on_lollipop_with_boarding_alighting_times) {
     vj = b.get<nt::VehicleJourney>("vj:1:modified:0:feed");
     BOOST_CHECK_END_VP(vj->rt_validity_pattern(), "0000010");
     BOOST_CHECK_END_VP(vj->base_validity_pattern(), "0000000");
-    // The realtime vj should have all 3 stop_times but lose the boarding / alighting time on stop_point:10
-    // since it's a lollipop vj and it can't find the base_st
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().departure_time, "08:11"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().boarding_time, "08:11"_t);
-    // SHOULD BE : BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().boarding_time, "08:06"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).departure_time, "08:21"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:21"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).arrival_time, "08:40"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).alighting_time, "08:40"_t);
-    // SHOULD BE : BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).alighting_time, "08:46"_t);
+
+    // The realtime vj should have all 3 stop_times 
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(0).stop_point->uri, "stop_point:10");
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(0).departure_time, "08:11"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(0).boarding_time, "08:06"_t); // Boarding time is 5 min (300s) before departure 
+    
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).departure_time, "08:21"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:21"_t);
+
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "stop_point:10");
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).arrival_time, "08:40"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).alighting_time, "08:45"_t); // Alighting time is 5 min (300s) after arrival
 }
 
 BOOST_AUTO_TEST_CASE(simple_skipped_stop) {

--- a/source/routing/benchmark_raptor_cache.cpp
+++ b/source/routing/benchmark_raptor_cache.cpp
@@ -56,7 +56,7 @@ struct Demand {
     nt::AccessibiliteParams accessibilite_params;
 };
 
-void compute(std::vector<Demand> demands, boost::progress_display& show_progress, const type::Data& data){
+static void compute(std::vector<Demand> demands, boost::progress_display& show_progress, const type::Data& data){
 
     std::random_shuffle(demands.begin(), demands.end());
     std::vector<const CachedNextStopTime*> results;

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -178,7 +178,7 @@ void passages(PbCreator& pb_creator,
         passage->mutable_stop_date_time()->set_arrival_date_time(navitia::to_posix_timestamp(arrival_dt));
 
         //find base datetime
-        auto base_st = get_base_stop_time(dt_stop_time.second);
+        auto base_st = dt_stop_time.second->get_base_stop_time();
         if (base_st != nullptr) {
             auto base_departure_dt = get_date_time(vis.stop_event(), dt_stop_time.second, base_st,
                                                    base_ptime, true);

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -39,8 +39,9 @@ www.navitia.io
 namespace pt = boost::posix_time;
 namespace bg = boost::gregorian;
 
-
-namespace navitia { namespace type { namespace disruption {
+namespace navitia { 
+namespace type { 
+namespace disruption {
 
 std::vector<ImpactedVJ>
 get_impacted_vehicle_journeys(const LineSection& ls,
@@ -443,47 +444,6 @@ void DisruptionHolder::forget_vj(const VehicleJourney* vj) {
     }
 }
 
-namespace detail {
-
-const StopTime* AuxInfoForMetaVJ::get_base_stop_time(const StopTimeUpdate& stu) const {
-    //TODO check effect when available, we can do this only for UPDATED
-    auto* vj = stu.stop_time.vehicle_journey;
-    auto log = log4cplus::Logger::getInstance("log");
-    if (! vj) {
-        LOG4CPLUS_WARN(log, "impossible to find corresponding base stoptime "
-                            "since the stoptime update is not yet associated to a vj");
-        return nullptr;
-    }
-
-    const auto* base_vj = vj->get_corresponding_base();
-
-    if (! base_vj) {
-        return nullptr;
-    }
-
-    size_t idx = 0;
-    for (const auto& stop_update: stop_times) {
-        // TODO check stop_update effect not to consider added stops
-        if (&stop_update != &stu) {
-            idx ++;
-            continue;
-        }
-        if (idx >= base_vj->stop_time_list.size()) {
-            LOG4CPLUS_WARN(log, "The stoptime update list of " << base_vj->meta_vj->uri <<
-                                " is not consistent with the list of stoptimes");
-            return nullptr;
-        }
-        const auto& base_st = base_vj->stop_time_list[idx];
-        if (stu.stop_time.stop_point != base_st.stop_point) {
-            LOG4CPLUS_WARN(log, "The stoptime update list of " << base_vj->meta_vj->uri <<
-                                " is not consistent with the list of stoptimes, stoppoint are different");
-            return nullptr;
-        }
-        return &base_st;
-    }
-
-    return nullptr;
-}
-}
-
-}}}//namespace
+} // namespace discruption
+} // namespace type
+} // namespace navitia

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -271,8 +271,6 @@ inline bool operator<(StopTimeUpdate::Status a, StopTimeUpdate::Status b) {
 namespace detail {
 struct AuxInfoForMetaVJ {
     std::vector<StopTimeUpdate> stop_times;
-    // get the corresponding stoptime in the base vj. return null if nothing found
-    const StopTime* get_base_stop_time(const StopTimeUpdate&) const;
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -133,7 +133,7 @@ struct PbCreator::Filler::PtObjVisitor: public boost::static_visitor<> {
                                                            impacted_stop->mutable_amended_stop_time());
 
             // we need to get the base stoptime
-            const auto* base_st = impact.aux_info.get_base_stop_time(stu);
+            const auto* base_st = stu.stop_time.get_base_stop_time();
             if (base_st) {
                 filler.copy(0, DumpMessage::No).fill_pb_object(base_st, impacted_stop->mutable_base_stop_time());
             }
@@ -1397,7 +1397,7 @@ void PbCreator::Filler::fill_pb_object(const StopTimeCalendar* stop_time_calenda
         //for calendar we don't want to have a date
         rs_date_time->set_date(navitia::to_int_date(navitia::to_posix_time(stop_time_calendar->date_time, *pb_creator.data)));
 
-        if (auto base_st = get_base_stop_time(stop_time_calendar->stop_time)) {
+        if (auto base_st = stop_time_calendar->stop_time->get_base_stop_time()) {
             auto base_dt = get_date_time(routing::StopEvent::pick_up,
                                          stop_time_calendar->stop_time,
                                          base_st,

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -196,7 +196,7 @@ const StopTime* StopTime::get_base_stop_time() const {
     // We get the rank of the stop_stime in the current VJ, and 
     // return the one with same rank in the base VJ. 
     // There are limitations if:
-    //   * the lollopop's node (stop_point B) is added before 
+    //   * the lollipop's node (stop_point B) is added before
     //          ie. Base VJ:     A - B - C - B - D
     //              RT VJ:   B - A - B - C - B - D 
     //   * the first stop time of the node is deleted
@@ -223,7 +223,8 @@ const StopTime* StopTime::get_base_stop_time() const {
     }
 
     auto logger = log4cplus::Logger::getInstance("log");
-    LOG4CPLUS_DEBUG(logger, "Ignored stop_time " << stop_point->uri << ":" << departure_time << ": impossible to match exactly one base stop_time");
+    LOG4CPLUS_DEBUG(logger, "Ignored stop_time " << stop_point->uri << ":" << departure_time
+                            << ": impossible to match exactly one base stop_time");
     return nullptr;
 }
 

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -205,7 +205,7 @@ const StopTime* StopTime::get_base_stop_time() const {
     // TODO - Use Levenshtein (edit) distance to handle those cases properly
     size_t rank_current_vj = 0;
     for (const auto& st : vehicle_journey->stop_time_list) {
-        if (&st == this) {
+        if (st.has_similar_timings(*this)) {
             break;
         }
         if (stop_point == st.stop_point) {
@@ -214,7 +214,7 @@ const StopTime* StopTime::get_base_stop_time() const {
     }
 
     for (const auto& base_st: base_vj->stop_time_list) {
-        if (stop_point == base_st.stop_point) {
+        if(stop_point->idx == base_st.stop_point->idx) {
             if(rank_current_vj == 0) {
                 return &base_st;
             }
@@ -225,6 +225,12 @@ const StopTime* StopTime::get_base_stop_time() const {
     auto logger = log4cplus::Logger::getInstance("log");
     LOG4CPLUS_DEBUG(logger, "Ignored stop_time " << stop_point->uri << ":" << departure_time << ": impossible to match exactly one base stop_time");
     return nullptr;
+}
+
+bool StopTime::has_similar_timings(const StopTime& st) const {
+    return arrival_time == st.arrival_time
+        && departure_time == st.departure_time
+        && stop_point->idx == st.stop_point->idx;
 }
 
 bool FrequencyVehicleJourney::is_valid(int day, const RTLevel rt_level) const {

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -205,7 +205,7 @@ const StopTime* StopTime::get_base_stop_time() const {
     // TODO - Use Levenshtein (edit) distance to handle those cases properly
     size_t rank_current_vj = 0;
     for (const auto& st : vehicle_journey->stop_time_list) {
-        if (st.has_similar_timings(*this)) {
+        if (st.is_similar(*this)) {
             break;
         }
         if (stop_point == st.stop_point) {
@@ -228,7 +228,7 @@ const StopTime* StopTime::get_base_stop_time() const {
     return nullptr;
 }
 
-bool StopTime::has_similar_timings(const StopTime& st) const {
+bool StopTime::is_similar(const StopTime& st) const {
     return arrival_time == st.arrival_time
         && departure_time == st.departure_time
         && stop_point->idx == st.stop_point->idx;

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -759,7 +759,8 @@ struct StopTime {
 
     //  Check if a stop time has similar hours of departure/arrival/alighting/boarding_time etc...
     //  We don't want to rely on properties that might change with real time object.
-    bool has_similar_timings(const StopTime& st) const;
+    //  Note : This is usefull in the case of a StopTimeUpdate that owns a partially constructed Stop Time.
+    bool is_similar(const StopTime& st) const;
 
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
             ar & arrival_time & departure_time & boarding_time & alighting_time & vehicle_journey

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -757,6 +757,10 @@ struct StopTime {
 
     const StopTime* get_base_stop_time() const;
 
+    //  Check if a stop time has similar hours of departure/arrival/alighting/boarding_time etc...
+    //  We don't want to rely on properties that might change with real time object.
+    bool has_similar_timings(const StopTime& st) const;
+
     template<class Archive> void serialize(Archive & ar, const unsigned int ) {
             ar & arrival_time & departure_time & boarding_time & alighting_time & vehicle_journey
             & stop_point & shape_from_prev & properties & local_traffic_zone;

--- a/source/type/type_utils.cpp
+++ b/source/type/type_utils.cpp
@@ -38,29 +38,6 @@ namespace nt = navitia::type;
 namespace bt = boost::posix_time;
 namespace navitia {
 
-const nt::StopTime* get_base_stop_time(const nt::StopTime* st_orig) {
-    const nt::StopTime* st_base = nullptr;
-    size_t nb_st_found = 0;
-    if (st_orig == nullptr || st_orig->vehicle_journey == nullptr) { return nullptr; }
-    auto base_vj = st_orig->vehicle_journey->get_corresponding_base();
-    if (base_vj == nullptr) { return nullptr; }
-
-    if (st_orig->vehicle_journey == base_vj) { return st_orig; }
-    for (const auto& st_it : base_vj->stop_time_list) {
-        if (st_orig->stop_point == st_it.stop_point) {
-            st_base = &st_it;
-            ++nb_st_found;
-        }
-    }
-    //TODO handle lolipop vj, bob-commerce-commerce-bobito vj...
-    if (nb_st_found != 1) {
-        auto logger = log4cplus::Logger::getInstance("log");
-        LOG4CPLUS_DEBUG(logger, "Ignored stop_time finding: impossible to match exactly one base stop_time");
-        return nullptr;
-    }
-    return st_base;
-}
-
 /**
  * Compute base passage from amended passage, knowing amended and base stop-times
  */

--- a/source/type/type_utils.h
+++ b/source/type/type_utils.h
@@ -35,8 +35,6 @@ www.navitia.io
 
 namespace navitia {
 
-const type::StopTime* get_base_stop_time(const type::StopTime* st_orig);
-
 /**
  * Compute base passage from amended passage, knowing amended and base stop-times
  */


### PR DESCRIPTION
Fix base arrival/departure times that were missing after adding a new stop_time in a disruption.

3 Different implementations of `get_base_stop_time` have been found.... but [only 1 survived !](http://gph.is/1KVPGOF) 

We keep the one in [type.cpp#L178-L198](https://github.com/CanalTP/navitia/blob/14364090fa3d7cca705c48874184221ca3cfdee3/source/type/type.cpp#L178-L198) that fixes our issue. 

[#NAVP-1131](https://jira.kisio.org/browse/NAVP-1131)