### PR TITLE
Tyr: "correctly" handle error in async command

### DIFF
--- a/source/tyr/tyr/command/import_last_autocomplete_dataset.py
+++ b/source/tyr/tyr/command/import_last_autocomplete_dataset.py
@@ -32,7 +32,7 @@ from tyr import tasks
 import logging
 from tyr import manager
 
-from tyr.helper import wait_and_raise
+from tyr.helper import wait_or_raise
 
 
 @manager.command
@@ -52,7 +52,7 @@ def import_last_autocomplete_dataset(instance_name, wait=True):
     logger.info('we reimport the last dataset of autocomplete %s, composed of: %s', instance_name, files)
     future, _ = tasks.import_autocomplete(files, instance, backup_file=False)
     if wait and future:
-        wait_and_raise(future)
+        wait_or_raise(future)
 
     logger.info('last datasets reimport finished for %s', instance_name)
 
@@ -76,7 +76,7 @@ def import_last_stop_dataset(instance_name, wait=True):
         _file = files[0]
         future = tasks.import_in_mimir(_file, instance)
         if wait and future:
-            wait_and_raise(future)
+            wait_or_raise(future)
         logger.info('last datasets reimport finished for %s', instance.name)
     else:
         logger.info('No file to reimport to mimir the last dataset of %s', instance.name)

--- a/source/tyr/tyr/command/import_last_autocomplete_dataset.py
+++ b/source/tyr/tyr/command/import_last_autocomplete_dataset.py
@@ -32,6 +32,8 @@ from tyr import tasks
 import logging
 from tyr import manager
 
+from tyr.helper import wait_and_raise
+
 
 @manager.command
 def import_last_autocomplete_dataset(instance_name, wait=True):
@@ -50,7 +52,7 @@ def import_last_autocomplete_dataset(instance_name, wait=True):
     logger.info('we reimport the last dataset of autocomplete %s, composed of: %s', instance_name, files)
     future, _ = tasks.import_autocomplete(files, instance, backup_file=False)
     if wait and future:
-        future.wait()
+        wait_and_raise(future)
 
     logger.info('last datasets reimport finished for %s', instance_name)
 
@@ -74,7 +76,7 @@ def import_last_stop_dataset(instance_name, wait=True):
         _file = files[0]
         future = tasks.import_in_mimir(_file, instance)
         if wait and future:
-            future.wait()
+            wait_and_raise(future)
         logger.info('last datasets reimport finished for %s', instance.name)
     else:
         logger.info('No file to reimport to mimir the last dataset of %s', instance.name)

--- a/source/tyr/tyr/command/import_last_dataset.py
+++ b/source/tyr/tyr/command/import_last_dataset.py
@@ -31,7 +31,7 @@ from navitiacommon import models
 from tyr import tasks
 import logging
 from tyr import manager
-from tyr.helper import get_instance_logger
+from tyr.helper import get_instance_logger, wait_and_raise
 
 
 @manager.command
@@ -65,4 +65,4 @@ def import_last_dataset(
         custom_output_dir=custom_output_dir,
     )
     if not nowait and future:
-        future.wait()
+        wait_and_raise(future)

--- a/source/tyr/tyr/command/import_last_dataset.py
+++ b/source/tyr/tyr/command/import_last_dataset.py
@@ -31,7 +31,7 @@ from navitiacommon import models
 from tyr import tasks
 import logging
 from tyr import manager
-from tyr.helper import get_instance_logger, wait_and_raise
+from tyr.helper import get_instance_logger, wait_or_raise
 
 
 @manager.command
@@ -65,4 +65,4 @@ def import_last_dataset(
         custom_output_dir=custom_output_dir,
     )
     if not nowait and future:
-        wait_and_raise(future)
+        wait_or_raise(future)

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -42,7 +42,7 @@ import sys
 import tempfile
 
 
-def wait_and_raise(async_result):
+def wait_or_raise(async_result):
     """
     wait for the end of an async task.
     Reraise the exception from the task in case of an error

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -32,6 +32,7 @@ import logging
 import logging.config
 import uuid
 import celery
+from celery.exceptions import TimeoutError
 
 from configobj import ConfigObj, flatten_errors
 from validate import Validator
@@ -39,6 +40,22 @@ from flask import current_app
 import os
 import sys
 import tempfile
+
+
+def wait_and_raise(async_result):
+    """
+    wait for the end of an async task.
+    Reraise the exception from the task in case of an error
+    """
+    # wait() will only throw exception at the start of the call
+    # if the worker raise an exception once the waiting has started the exception isn't raised by wait
+    # so we do a periodic polling on wait...
+    while True:
+        try:
+            async_result.wait(timeout=5)
+            return  # wait ended, we stop the endless loop
+        except TimeoutError:
+            pass  # everything is fine: let's poll!
 
 
 def configure_logger(app):


### PR DESCRIPTION
celery is  bit funny and doesn't seems to raise exception raised by a
worker like it should. More precisely it doesn't raise once the wait as
began, but before starting blocking if the worker have encountered an
exception, wait will raise it...
So I poll on wait to get the exception...