### PR TITLE
Jormungandr: rename pt_dataset to pt_dataset[]

### DIFF
--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -488,7 +488,7 @@ class GeocodeJson(AbstractAutocomplete):
     def basic_params(self, instances):
         if not instances:
             return {}
-        return {'pt_dataset': [i.name for i in instances]}
+        return {'pt_dataset[]': [i.name for i in instances]}
 
     def make_params(self, request, instances, timeout):
         params = self.basic_params(instances)

--- a/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
@@ -540,7 +540,7 @@ def bragi_make_params_with_instance_test():
     request = {"q": "aa", "count": 20}
 
     params = bragi.make_params(request=request, instances=[instance], timeout=1)
-    rsp = {'q': 'aa', 'limit': 20, 'pt_dataset': ['bib'], 'timeout': 1000}
+    rsp = {'q': 'aa', 'limit': 20, 'pt_dataset[]': ['bib'], 'timeout': 1000}
     len(list(rsp.keys())) == len(list(params.keys()))
     for key, value in rsp.items():
         assert key in params

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -42,7 +42,7 @@ class DatasetChecker(object):
         self.datasets = datasets
 
     def __call__(self, *args, **kwargs):
-        d = kwargs.get('params', {}).get('pt_dataset')
+        d = kwargs.get('params', {}).get('pt_dataset[]')
         if d is not None:
             assert set(d) == self.datasets
         else:

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -534,7 +534,7 @@ def mock_bragi_autocomplete_call(bragi_response, limite=10, http_response_code=2
         'q': u'bob',
         'type[]': [u'public_transport:stop_area', u'street', u'house', u'poi', u'city'],
         'limit': limite,
-        'pt_dataset': 'main_routing_test',
+        'pt_dataset[]': 'main_routing_test',
         'timeout': 2000,
     }
 
@@ -550,7 +550,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_RESPONSE)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region"
             )
 
@@ -570,7 +570,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(deepcopy(BRAGI_MOCK_RESPONSE))
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&timeout=2000&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&timeout=2000&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=0"
             )
 
@@ -688,13 +688,13 @@ class TestBragiAutocomplete(AbstractTestFixture):
 
     def test_features_call(self):
         url = 'https://host_of_bragi'
-        params = {'timeout': 200, 'pt_dataset': 'main_routing_test'}
+        params = {'timeout': 200, 'pt_dataset[]': 'main_routing_test'}
 
         url += "/features/1234?{}".format(urlencode(params, doseq=True))
 
         mock_requests = MockRequests({url: (BRAGI_MOCK_RESPONSE, 200)})
         with mock.patch('requests.get', mock_requests.get):
-            response = self.query_region("places/1234?&pt_dataset=main_routing_test")
+            response = self.query_region("places/1234?&pt_dataset[]=main_routing_test")
 
             is_valid_global_autocomplete(response, depth=1)
             r = response.get('places')
@@ -706,7 +706,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
 
     def test_features_unknown_uri(self):
         url = 'https://host_of_bragi'
-        params = {'timeout': 200, 'pt_dataset': 'main_routing_test'}
+        params = {'timeout': 200, 'pt_dataset[]': 'main_routing_test'}
 
         url += "/features/AAA?{}".format(urlencode(params, doseq=True))
         mock_requests = MockRequests(
@@ -714,20 +714,20 @@ class TestBragiAutocomplete(AbstractTestFixture):
         )
 
         with mock.patch('requests.get', mock_requests.get):
-            response = self.query_region("places/AAA?&pt_dataset=main_routing_test", check=False)
+            response = self.query_region("places/AAA?&pt_dataset[]=main_routing_test", check=False)
             assert response[1] == 404
             assert response[0]["error"]["id"] == 'unknown_object'
             assert response[0]["error"]["message"] == "The object AAA doesn't exist"
 
     def test_poi_without_address(self):
         url = 'https://host_of_bragi'
-        params = {'pt_dataset': 'main_routing_test', 'timeout': 200}
+        params = {'pt_dataset[]': 'main_routing_test', 'timeout': 200}
 
         url += "/features/1234?{}".format(urlencode(params, doseq=True))
 
         mock_requests = MockRequests({url: (BRAGI_MOCK_POI_WITHOUT_ADDRESS, 200)})
         with mock.patch('requests.get', mock_requests.get):
-            response = self.query_region("places/1234?&pt_dataset=main_routing_test")
+            response = self.query_region("places/1234?&pt_dataset[]=main_routing_test")
 
             r = response.get('places')
             assert len(r) == 1
@@ -739,13 +739,13 @@ class TestBragiAutocomplete(AbstractTestFixture):
 
     def test_stop_area_with_modes(self):
         url = 'https://host_of_bragi'
-        params = {'pt_dataset': 'main_routing_test', 'timeout': 200}
+        params = {'pt_dataset[]': 'main_routing_test', 'timeout': 200}
 
         url += "/features/1234?{}".format(urlencode(params, doseq=True))
 
         mock_requests = MockRequests({url: (BRAGI_MOCK_STOP_AREA_WITH_MORE_ATTRIBUTS, 200)})
         with mock.patch('requests.get', mock_requests.get):
-            response = self.query_region("places/1234?&pt_dataset=main_routing_test")
+            response = self.query_region("places/1234?&pt_dataset[]=main_routing_test")
 
             assert response.get('feed_publishers')
             if app.config['USE_SERPY']:
@@ -787,7 +787,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(deepcopy(BRAGI_MOCK_STOP_AREA_WITH_MORE_ATTRIBUTS))
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=0"
             )
 
@@ -828,13 +828,13 @@ class TestBragiAutocomplete(AbstractTestFixture):
 
     def test_stop_area_without_modes(self):
         url = 'https://host_of_bragi'
-        params = {'pt_dataset': 'main_routing_test', 'timeout': 200}
+        params = {'pt_dataset[]': 'main_routing_test', 'timeout': 200}
 
         url += "/features/1234?{}".format(urlencode(params, doseq=True))
 
         mock_requests = MockRequests({url: (BRAGI_MOCK_STOP_AREA_WITH_BASIC_ATTRIBUTS, 200)})
         with mock.patch('requests.get', mock_requests.get):
-            response = self.query_region("places/1234?&pt_dataset=main_routing_test")
+            response = self.query_region("places/1234?&pt_dataset[]=main_routing_test")
 
             assert response.get('feed_publishers')
             assert len(response.get('feed_publishers')) == 2
@@ -873,7 +873,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_ZERO)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=0"
             )
 
@@ -898,7 +898,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_ONE)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=1"
             )
 
@@ -933,7 +933,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_TWO)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=2"
             )
 
@@ -976,7 +976,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_THREE)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=3"
             )
 
@@ -1022,7 +1022,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_ADMIN)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=0"
             )
 
@@ -1071,7 +1071,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(deepcopy(BRAGI_MOCK_ADMIN))
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region&depth=2"
             )
 
@@ -1092,7 +1092,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_RESPONSE_STOP_AREA_WITH_COMMENTS)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region"
             )
             is_valid_global_autocomplete(response, depth=1)
@@ -1113,7 +1113,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_RESPONSE_STOP_AREA_WITHOUT_COMMENTS)
         with mock.patch('requests.get', mock_requests.get):
             response = self.query_region(
-                "places?q=bob&pt_dataset=main_routing_test&type[]=stop_area"
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
                 "&type[]=address&type[]=poi&type[]=administrative_region"
             )
             is_valid_global_autocomplete(response, depth=1)
@@ -1243,13 +1243,13 @@ class TestBragiShape(AbstractTestFixture):
         assert "if 'from' is provided it cannot be null" in r.get('message')
 
     def test_global_place_uri(self):
+        params = {'timeout': 200, 'pt_dataset[]': 'main_routing_test'}
+        url = 'https://host_of_bragi/features/bob?{}'.format(urlencode(params, doseq=True))
+
         mock_requests = MockRequests(
             {
-                # there is no authentication so all the known pt_dataset are added as parameters
-                'https://host_of_bragi/features/bob?timeout=200&pt_dataset=main_routing_test': (
-                    BRAGI_MOCK_RESPONSE,
-                    200,
-                )
+                # there is no authentication so all the known pt_dataset[] are added as parameters
+                url: (BRAGI_MOCK_RESPONSE, 200)
             }
         )
         with mock.patch('requests.get', mock_requests.get):
@@ -1265,7 +1265,7 @@ class TestBragiShape(AbstractTestFixture):
 
     def test_global_coords_uri(self):
         url = 'https://host_of_bragi'
-        params = {'pt_dataset': 'main_routing_test', 'lon': 3.282103, 'lat': 49.84758, 'timeout': 200}
+        params = {'pt_dataset[]': 'main_routing_test', 'lon': 3.282103, 'lat': 49.84758, 'timeout': 200}
         url += "/reverse?{}".format(urlencode(params, doseq=True))
 
         mock_requests = MockRequests({url: (BRAGI_MOCK_RESPONSE, 200)})
@@ -1273,7 +1273,7 @@ class TestBragiShape(AbstractTestFixture):
         with mock.patch('requests.get', mock_requests.get):
             response = self.query(
                 "/v1/coverage/{pt_dataset}/coords/{lon};{lat}?_autocomplete=bragi".format(
-                    lon=params.get('lon'), lat=params.get('lat'), pt_dataset=params.get('pt_dataset')
+                    lon=params.get('lon'), lat=params.get('lat'), pt_dataset=params.get('pt_dataset[]')
                 )
             )
 
@@ -1299,26 +1299,33 @@ class AbstractAutocompleteAndRouting:
          - an adresse in bob's street that is not in the dataset
         """
         args = {
-            u'pt_dataset': 'main_routing_test',
+            u'pt_dataset[]': 'main_routing_test',
             u'type[]': [u'public_transport:stop_area', u'street', u'house', u'poi', u'city'],
             u'limit': 10,
             'timeout': 2000,
         }
         params = urlencode(args, doseq=True)
+
+        features_url = 'https://host_of_bragi/features/bobette?{}'.format(
+            urlencode({'timeout': 200, 'pt_dataset[]': 'main_routing_test'}, doseq=True)
+        )
+        reverse_url = 'https://host_of_bragi/reverse?{}'.format(
+            urlencode(
+                {
+                    'lon': check_utils.r_coord.split(';')[0],
+                    'lat': check_utils.r_coord.split(';')[1],
+                    'timeout': 200,
+                    'pt_dataset[]': 'main_routing_test',
+                },
+                doseq=True,
+            )
+        )
         mock_requests = MockRequests(
             {
                 'https://host_of_bragi/autocomplete?q=bobette&{p}'.format(p=params): (BRAGI_MOCK_BOBETTE, 200),
-                'https://host_of_bragi/features/bobette?timeout=200&pt_dataset=main_routing_test': (
-                    BRAGI_MOCK_BOBETTE,
-                    200,
-                ),
+                features_url: (BRAGI_MOCK_BOBETTE, 200),
                 'https://host_of_bragi/autocomplete?q=20+rue+bob&{p}'.format(p=params): (BOB_STREET, 200),
-                'https://host_of_bragi/reverse?lat={lat}&lon={lon}&timeout=200&pt_dataset=main_routing_test'.format(
-                    lon=check_utils.r_coord.split(';')[0], lat=check_utils.r_coord.split(';')[1]
-                ): (
-                    BOB_STREET,
-                    200,
-                ),
+                reverse_url: (BOB_STREET, 200),
             }
         )
 
@@ -1363,7 +1370,7 @@ class AbstractAutocompleteAndRouting:
 
     def test_global_coords_uri(self):
         url = 'https://host_of_bragi'
-        params = {'pt_dataset': 'main_routing_test', 'lon': 3.282103, 'lat': 49.84758, 'timeout': 200}
+        params = {'pt_dataset[]': 'main_routing_test', 'lon': 3.282103, 'lat': 49.84758, 'timeout': 200}
 
         url += "/reverse?{}".format(urlencode(params, doseq=True))
 
@@ -1372,7 +1379,7 @@ class AbstractAutocompleteAndRouting:
         with mock.patch('requests.get', mock_requests.get):
             response = self.query(
                 "/v1/coverage/{pt_dataset}/coords/{lon};{lat}".format(
-                    lon=params.get('lon'), lat=params.get('lat'), pt_dataset=params.get('pt_dataset')
+                    lon=params.get('lon'), lat=params.get('lat'), pt_dataset=params.get('pt_dataset[]')
                 )
             )
 


### PR DESCRIPTION
mimir multi parameters handling was very lenient, it was ok to do:

  * `pt_dataset[]=toto&pt_dataset[]=tata`
  * `pt_dataset=toto&pt_dataset=tata`
  * `pt_dataset=[toto,tata]`

with https://github.com/CanalTP/mimirsbrunn/pull/286 only `pt_dataset[]=toto&pt_dataset[]=tata` will be accepted.

In navitia `type[]` was passed as `type[]` but `pt_dataset` had no `[]`.

This PR renames all `pt_dataset` to `pt_dataset[]` for coherence and mimir compatibility