### PR TITLE
PTref: Fix date filter in disruptions

### DIFF
--- a/documentation/rfc/disruptions_periods.md
+++ b/documentation/rfc/disruptions_periods.md
@@ -51,7 +51,7 @@ The status of the impact depends only of 'now' and is:
 To understand a bit how those periods behave with the different query dates let's consider this example:
 
 ```
-[------------------------------------------------------------------------------------]  production period
+[-------------------------------------------------------------]  			production period
                    
                                                 Impact
                                     <--------------------------------->                 publication period
@@ -64,12 +64,12 @@ To understand a bit how those periods behave with the different query dates let'
 ## now is before the impact's publication period
 
 ```
-[------------------|------------------------------------------------------------------]  production period
+[------------------|------------------------------------------]  			production period
                    |
                    |                             Impact
-                   |                 <----------------------------->                     publication period
+                   |                 <----------------------------->                    publication period
                    |
-                   |                                  (------------)                     application period
+                   |                                  (------------)                    application period
                    |
                    |
                   now
@@ -88,12 +88,12 @@ do we show the impact ?      No
 # now is inside the impact's publication period but before the application period
 
 ```
-[------------------------------------------|------------------------------------------]  production period
+[------------------------------------------|------------------]  			production period
                                            |                                           
                                            |     Impact
-                                    <------|----------------------->                     publication period
+                                    <------|----------------------->                    publication period
                                            |                                           
-                                           |          (------------)                     application period
+                                           |          (------------)                    application period
                                            |                                           
                                           now                                           
 
@@ -108,12 +108,12 @@ what is it's status ?        futur
 ### context is before the application period
 
 ```
-[------------------------------------------|------------------------------------------]  production period
+[------------------------------------------|------------------]  			production period
                                            |                                           
                                            |     Impact
-                                    <------|----------------------->                     publication period
+                                    <------|----------------------->                    publication period
                                            |                                           
-                                           |          (------------)                     application period
+                                           |          (------------)                    application period
                                            |                                           
                                           now                                           
                                  {----}
@@ -127,12 +127,12 @@ what is it's status ?        -
 ### context intersect the application period
 
 ```
-[------------------------------------------|------------------------------------------]  production period
+[------------------------------------------|------------------]  			production period
                                            |                                           
                                            |     Impact
-                                    <------|----------------------->                     publication period
+                                    <------|----------------------->                    publication period
                                            |                                           
-                                           |          (------------)                     application period
+                                           |          (------------)                    application period
                                            |                                           
                                           now                                           
                                                    {----}
@@ -146,12 +146,12 @@ what is it's status ?        futur
 ### context is after the application period
 
 ```
-[------------------------------------------|------------------------------------------]  production period
+[------------------------------------------|------------------]  			production period
                                            |                                           
                                            |     Impact
-                                    <------|----------------------->                     publication period
+                                    <------|----------------------->                    publication period
                                            |                                           
-                                           |          (------------)                     application period
+                                           |          (------------)                    application period
                                            |                                           
                                           now                                           
                                                                        {----}
@@ -166,12 +166,12 @@ what is it's status ?        -
 # now is inside the impact's publication period and inside the application period
 
 ```
-[-----------------------------------------------------------|-------------------------]  production period
+[-----------------------------------------------------------|-]  			production period
                                                             |                          
                                                 Impact      |                         
-                                    <-----------------------|------>                     publication period
+                                    <-----------------------|------>                    publication period
                                                             |                          
-                                                     (------|------)                     application period
+                                                     (------|------)                    application period
                                                             |                          
                                                            now                          
 
@@ -187,12 +187,12 @@ what is it's status ?        Active
 ### context is before the application period
 
 ```
-[-----------------------------------------------------------|-------------------------]  production period
+[-----------------------------------------------------------|-]  			production period
                                                             |                          
                                                 Impact      |                         
-                                    <-----------------------|------>                     publication period
+                                    <-----------------------|------>                    publication period
                                                             |                          
-                                                     (------|------)                     application period
+                                                     (------|------)                    application period
                                                             |                          
                                                            now                          
                                         {----}
@@ -206,12 +206,12 @@ what is it's status ?        -
 ### context intersects the application period
 
 ```
-[-----------------------------------------------------------|-------------------------]  production period
+[-----------------------------------------------------------|-]  			production period
                                                             |                          
                                                 Impact      |                         
-                                    <-----------------------|------>                     publication period
+                                    <-----------------------|------>                    publication period
                                                             |                          
-                                                     (------|------)                     application period
+                                                     (------|------)                    application period
                                                             |                          
                                                            now                          
                                                                 {----}
@@ -225,12 +225,12 @@ what is it's status ?        Active
 ### context is after the application period
 
 ```
-[-----------------------------------------------------------|-------------------------]  production period
+[-----------------------------------------------------------|-]  			production period
                                                             |                          
                                                 Impact      |                         
-                                    <-----------------------|------>                     publication period
+                                    <-----------------------|------>                    publication period
                                                             |                          
-                                                     (------|------)                     application period
+                                                     (------|------)                    application period
                                                             |                          
                                                            now                          
                                                                       {----}

--- a/documentation/rfc/disruptions_periods.md
+++ b/documentation/rfc/disruptions_periods.md
@@ -2,48 +2,58 @@
 
 There are several periods in the disruptions model and they can be tricky to understand so here is a summary over them.
 
-## periods
+## Periods
 
 ### production period 
-The production period is global to a navitia coverage and is the validity period of the coverage's data.
-This production period cannot excede one year.
+The production period is global to a navitia coverage and is the validity period of the coverage's data.  
+This production period cannot exceed one year.
 
 ### publication period
 The publication period of a disruption is the period on which we want to display the disruption in navitia.
 
-The creator of the disruption might not want the traveller to know of a disruption before a certain date (because it's too uncertain, secret, ...)
-The publication period is the way to control this
+The creator of the disruption might not want the traveller to know of a disruption before a certain date (because it's too uncertain, secret, ...).  
+The publication period is the way to control this.
+
+Please note that this period can be out of production period, but shouldn't affect impact's  management.
 
 ### application periods
-The application periods are the list of periods on which the disruption is active
+The application periods is the list of periods on which the disruption is active.
 
-## query dates
+Please note that these periods can be out of production period, but shouldn't affect impact's  management.
 
-Another thing that can be tricky to understand this that there can be several datetimes for a query
+## Query dates
+
+Another thing that can be tricky to understand this that there can be several datetimes for a query.
 
 
 ### now
 
-is this document 'now' will represent the actual datetime at which the query is made
+In this document 'now' will represent the actual datetime at which the query is made.
 
 ### action period
 
-For some apis (called 'contextual apis' in the following document) we query navitia on a certain date.
+For some endpoints (called 'contextual apis' in the following document) we query navitia on a certain date.
 
 The easiest way to understand this is a user that query navitia to plan a journey.
 
-The user calls navitia the 1st on january at 10:00 for a journey the 4th of january at 12:00
+The user calls navitia the 1st on january at 10:00 for a journey the 4th of january at 12:00.
 
 In this example 'now' is 01/01 at 10:00, 'action period' is, for each section of the computed journeys, the period on which the user will have to be in the bus.
+
+### filter period
+
+On some ptref endpoints, one can provide a 'since' and 'until' parameter to filter disruptions or vehicle_journeys.  
+Please refer to official navitia's API doc for use.
+
 
 # Summary
 
 To sum up we display an impact if 'now' is in the publication period AND the action period intersects the application periods.
 
 The status of the impact depends only of 'now' and is:
-* 'active' if 'now' is inside an application periods
-* 'future' if there is an application periods after 'now'
-* 'past' otherwise
+* `active` if 'now' is inside one of the application periods
+* otherwise `future` if there is an application periods after 'now'
+* `past` otherwise
 
 
 # Examples
@@ -51,7 +61,7 @@ The status of the impact depends only of 'now' and is:
 To understand a bit how those periods behave with the different query dates let's consider this example:
 
 ```
-[-------------------------------------------------------------]  			production period
+[-------------------------------------------------------------]                         production period
                    
                                                 Impact
                                     <--------------------------------->                 publication period
@@ -64,7 +74,7 @@ To understand a bit how those periods behave with the different query dates let'
 ## now is before the impact's publication period
 
 ```
-[------------------|------------------------------------------]  			production period
+[------------------|------------------------------------------]                         production period
                    |
                    |                             Impact
                    |                 <----------------------------->                    publication period
@@ -76,19 +86,19 @@ To understand a bit how those periods behave with the different query dates let'
 
 ```
 
-## ptref
+### ptref
 
 do we show the impact ?      No 
 
-## contextual api: /journeys, /stop_schedules
+### contextual api: /journeys, /stop_schedules
 
 do we show the impact ?      No 
 
 
-# now is inside the impact's publication period but before the application period
+## now is inside the impact's publication period but before the application period
 
 ```
-[------------------------------------------|------------------]  			production period
+[------------------------------------------|-----------------------------------]        production period
                                            |                                           
                                            |     Impact
                                     <------|----------------------->                    publication period
@@ -98,17 +108,17 @@ do we show the impact ?      No
                                           now                                           
 
 ```
-## ptref
+### ptref
 do we show the impact ?      Yes
 
 what is it's status ?        futur
 
-## contextual api: /journeys, /stop_schedules
+### contextual api: /journeys, /stop_schedules
 
-### context is before the application period
+#### context is before the application period
 
 ```
-[------------------------------------------|------------------]  			production period
+[------------------------------------------|------------------------------------]       production period
                                            |                                           
                                            |     Impact
                                     <------|----------------------->                    publication period
@@ -124,10 +134,10 @@ do we show the impact ?      No
 
 what is it's status ?        -
 
-### context intersect the application period
+#### context intersects the application period
 
 ```
-[------------------------------------------|------------------]  			production period
+[------------------------------------------|-----------------------------------]        production period
                                            |                                           
                                            |     Impact
                                     <------|----------------------->                    publication period
@@ -143,10 +153,10 @@ do we show the impact ?      Yes
 
 what is it's status ?        futur 
 
-### context is after the application period
+#### context is after the application period
 
 ```
-[------------------------------------------|------------------]  			production period
+[------------------------------------------|-----------------------------------]        production period
                                            |                                           
                                            |     Impact
                                     <------|----------------------->                    publication period
@@ -163,10 +173,10 @@ do we show the impact ?      No
 what is it's status ?        - 
 
 
-# now is inside the impact's publication period and inside the application period
+## now is inside the impact's publication period and inside the application period
 
 ```
-[-----------------------------------------------------------|-]  			production period
+[-----------------------------------------------------------|------------------]        production period
                                                             |                          
                                                 Impact      |                         
                                     <-----------------------|------>                    publication period
@@ -177,17 +187,17 @@ what is it's status ?        -
 
 
 ```
-## ptref
+### ptref
 do we show the impact ?      Yes
 
 what is it's status ?        Active
 
-## contextual api: /journeys, /stop_schedules
+### contextual api: /journeys, /stop_schedules
 
-### context is before the application period
+#### context is before the application period
 
 ```
-[-----------------------------------------------------------|-]  			production period
+[-----------------------------------------------------------|------------------]        production period
                                                             |                          
                                                 Impact      |                         
                                     <-----------------------|------>                    publication period
@@ -203,10 +213,10 @@ do we show the impact ?      No
 
 what is it's status ?        -
 
-### context intersects the application period
+#### context intersects the application period
 
 ```
-[-----------------------------------------------------------|-]  			production period
+[-----------------------------------------------------------|------------------]        production period
                                                             |                          
                                                 Impact      |                         
                                     <-----------------------|------>                    publication period
@@ -222,10 +232,10 @@ do we show the impact ?      Yes
 
 what is it's status ?        Active
 
-### context is after the application period
+#### context is after the application period
 
 ```
-[-----------------------------------------------------------|-]  			production period
+[-----------------------------------------------------------|------------------]        production period
                                                             |                          
                                                 Impact      |                         
                                     <-----------------------|------>                    publication period

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -365,7 +365,7 @@ Example:
 <aside class="warning">
     On vehicle_journey this filter is applied using only the first stop time.
     On disruption this filter must intersect with one application period.
-    "since" is included and "until" is excluded.
+    "since" is included and "until" is excluded. If "since" is present without "until", end_production_date is used to calculate "since until period". 
 </aside>
 
 #### disable_geojson

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -365,7 +365,7 @@ Example:
 <aside class="warning">
     On vehicle_journey this filter is applied using only the first stop time.
     On disruption this filter must intersect with one application period.
-    "since" is included and "until" is excluded. If "since" is present without "until", end_production_date is used to calculate "since until period". 
+    "since" and "until" are included.
 </aside>
 
 #### disable_geojson

--- a/source/disruption/line_reports_api.cpp
+++ b/source/disruption/line_reports_api.cpp
@@ -116,8 +116,8 @@ void line_reports(navitia::PbCreator& pb_creator,
                   const std::vector<std::string>& forbidden_uris,
                   const boost::optional<boost::posix_time::ptime>& since,
                   const boost::optional<boost::posix_time::ptime>& until) {
-    const auto start = get_optional_value_or(since, bt::ptime(d.meta->production_date.begin()));
-    const auto end = get_optional_value_or(until, bt::ptime(d.meta->production_date.end()));
+    const auto start = get_optional_value_or(since, bt::ptime(bt::neg_infin));
+    const auto end = get_optional_value_or(until, bt::ptime(bt::pos_infin));
     pb_creator.action_period = bt::time_period(start, end);
 
     if (end < start) {

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -649,7 +649,7 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
 
         # some disruption are loaded on the dataset though
         nb_pre_loaded_disruption = len(get_not_null(self.query_region('disruptions'), 'disruptions'))
-        assert nb_pre_loaded_disruption == 10
+        assert nb_pre_loaded_disruption == 11
 
         self.send_mock("blocking_line_disruption", "A", "line", blocking=True)
         self.send_mock("blocking_network_disruption", "base_network", "network", blocking=True)

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -801,7 +801,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         """
         query = 'disruptions?since=20120801T000000'
         disruptions = self.query_region(query)['disruptions']
-        assert len(disruptions) == 9
+        assert len(disruptions) == 10
 
         # query with parameter tags[]
         resp, code = self.query_region('disruptions?since=20120801T000000&tags[]=tag_name', check=False)
@@ -817,7 +817,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         self.send_mock("disruption_on_stopB", "stopB", "stop_area", message='message', tags=tags)
 
         disruptions = self.query_region(query)['disruptions']
-        assert len(disruptions) == 12
+        assert len(disruptions) == 13
 
         disruptions = self.query_region('disruptions?since=20120801T000000&tags[]=rer')['disruptions']
         assert len(disruptions) == 1
@@ -832,7 +832,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         disruptions = self.query_region(
             'disruptions?since=20120801T000000' '&filter=stop_area.id="stopA" or stop_area.id="stopB"'
         )['disruptions']
-        assert len(disruptions) == 3
+        assert len(disruptions) == 4
 
         # query with parameter filter and tags with one value
         disruptions = self.query_region(

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1379,7 +1379,4 @@ def get_schedule(scs, sp_uri, line_code):
 
 
 def get_disruption(disruptions, disrupt_id):
-    for d in disruptions:
-        if d['id'] == disrupt_id:
-            return d
-    return None
+    return next((d for d in disruptions if d['id'] == disrupt_id), None)

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1376,3 +1376,10 @@ def get_schedule(scs, sp_uri, line_code):
             if rp_sched['stop_point']['id'] == sp_uri and rp_sched['route']['line']['code'] == line_code
         )
     ]
+
+
+def get_disruption(disruptions, disrupt_id):
+    for d in disruptions:
+        if d['id'] == disrupt_id:
+            return d
+    return None

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -712,12 +712,12 @@ class TestDisruptions(AbstractTestFixture):
         assert len(disruptions) == 2
 
         # api /disruptions on pt_ref with parameters &since sends all the disruptions on pt_objects with filter
-        # on since and until(=production_end_date) with search period intersecting application_period
+        # on since and until(=positive infinite value) with search period intersecting application_period
         response = self.query_region('stop_areas/stopA/disruptions?since=20120801T000000&' + curr_date_filter)
         disruptions = response['disruptions']
         for d in disruptions:
             is_valid_disruption(d)
-        assert len(disruptions) == 1
+        assert len(disruptions) == 2
 
         # api /disruptions on pt_ref with parameters &since and &until sends all the disruptions on pt_objects
         # with filter on since and until with search period intersecting application_period

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -580,17 +580,6 @@ class TestDisruptions(AbstractTestFixture):
         ]
         assert {d['id'] for d in disrup} == {'later_impact'}
 
-    '''
-    def test_disruption_invalid_period_filtering(self):
-        """if we query with a since or an until not in the production period, we got an error"""
-        resp, code = self.query_region('disruptions?since=20201016T000000', check=False)
-        assert code == 404
-        assert resp['error']['message'] == 'ptref : invalid filtering period, not in production period'
-
-        resp, code = self.query_region('disruptions?until=20001016T000000', check=False)
-        assert code == 404
-        assert resp['error']['message'] == 'ptref : invalid filtering period, not in production period'
-    '''
     def test_forbidden_uris_on_disruptions(self):
         """test forbidden uri for disruptions"""
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions")
@@ -730,19 +719,22 @@ class TestDisruptions(AbstractTestFixture):
 
         # api /disruptions on pt_ref with parameters &since and &until sends all the disruptions on pt_objects
         # with filter on since and until with search period intersecting application_period
-        response = self.query_region('stop_areas/stopA/disruptions?since=20120801T000000&until=20120902T000000&' +
-                                     curr_date_filter)
+        response = self.query_region(
+            'stop_areas/stopA/disruptions?since=20120801T000000&until=20120902T000000&' + curr_date_filter
+        )
         disruptions = response['disruptions']
         assert len(disruptions) == 1
 
         # gives the disruption in future out of data poduction period
-        response = self.query_region('stop_areas/stopA/disruptions?since=20130703T000000&until=20130801T000000&' +
-                                     curr_date_filter)
+        response = self.query_region(
+            'stop_areas/stopA/disruptions?since=20130703T000000&until=20130801T000000&' + curr_date_filter
+        )
         disruptions = response['disruptions']
         assert len(disruptions) == 1
 
-        response = self.query_region('stop_areas/stopA/disruptions?since=20120801T000000&until=20130801T000000&' +
-                                     curr_date_filter)
+        response = self.query_region(
+            'stop_areas/stopA/disruptions?since=20120801T000000&until=20130801T000000&' + curr_date_filter
+        )
         disruptions = response['disruptions']
         assert len(disruptions) == 2
 
@@ -862,4 +854,3 @@ class TestDisruptionsLineSections(AbstractTestFixture):
         )
         assert code == 404
         assert response['error']['message'] == 'invalid filtering period (since > until)'
-

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -39,6 +39,7 @@ from .check_utils import (
     is_valid_stop_area,
     is_valid_line_report,
     s_coord,
+    get_disruption,
 )
 import jmespath
 
@@ -436,7 +437,8 @@ class TestDisruptions(AbstractTestFixture):
         # Check message, channel and types
         disruption_message = get_not_null(response, 'disruptions')
         assert len(disruption_message) == 2
-        message = get_not_null(disruption_message[1], 'messages')
+        disruption = get_disruption(disruption_message, 'too_bad_route_A:0')
+        message = get_not_null(disruption, 'messages')
         assert message[0]['text'] == 'no luck'
         channel = get_not_null(message[0], 'channel')
         assert channel['id'] == 'sms'

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -121,7 +121,7 @@ class TestDisruptions(AbstractTestFixture):
             is_valid_stop_area(impacted_stop_areas[0], depth_check=0)
             assert impacted_stop_areas[0]['id'] == 'stopA'
             stop_disrupt = get_disruptions(impacted_stop_areas[0], response)
-            assert len(stop_disrupt) == 1
+            assert len(stop_disrupt) == 2
             for d in stop_disrupt:
                 is_valid_disruption(d)
             assert stop_disrupt[0]['disruption_id'] == 'disruption_on_stop_A'
@@ -363,13 +363,13 @@ class TestDisruptions(AbstractTestFixture):
         response = self.query_region('traffic_reports?_current_datetime=20120828T090000')
 
         impacts = get_impacts(response)
-        assert len(impacts) == 3
+        assert len(impacts) == 4
         assert 'impact_published_later' not in impacts
 
         response = self.query_region('traffic_reports?_current_datetime=20120828T130000')
 
         impacts = get_impacts(response)
-        assert len(impacts) == 4
+        assert len(impacts) == 5
         assert 'impact_published_later' in impacts
 
     def test_disruption_datefilter_limits(self):
@@ -410,12 +410,12 @@ class TestDisruptions(AbstractTestFixture):
         response = self.query_region('traffic_reports?_current_datetime=20130225T090000')
 
         impacts = get_impacts(response)
-        assert len(impacts) == 0
+        assert len(impacts) == 1
 
         response = self.query_region('traffic_reports?_current_datetime=20130227T090000')
 
         impacts = get_impacts(response)
-        assert len(impacts) == 1
+        assert len(impacts) == 2
         assert 'too_bad_route_A:0' in impacts
 
         traffic_report = get_not_null(response, 'traffic_reports')
@@ -435,8 +435,8 @@ class TestDisruptions(AbstractTestFixture):
 
         # Check message, channel and types
         disruption_message = get_not_null(response, 'disruptions')
-        assert len(disruption_message) == 1
-        message = get_not_null(disruption_message[0], 'messages')
+        assert len(disruption_message) == 2
+        message = get_not_null(disruption_message[1], 'messages')
         assert message[0]['text'] == 'no luck'
         channel = get_not_null(message[0], 'channel')
         assert channel['id'] == 'sms'
@@ -462,12 +462,12 @@ class TestDisruptions(AbstractTestFixture):
         response = self.query_region('traffic_reports?_current_datetime=20130425T090000')
 
         impacts = get_impacts(response)
-        assert len(impacts) == 0
+        assert len(impacts) == 1
 
         response = self.query_region('traffic_reports?_current_datetime=20130427T090000')
 
         impacts = get_impacts(response)
-        assert len(impacts) == 3
+        assert len(impacts) == 4
         assert 'too_bad_route_A:0_and_line' in impacts
 
         traffic_report = get_not_null(response, 'traffic_reports')
@@ -580,6 +580,7 @@ class TestDisruptions(AbstractTestFixture):
         ]
         assert {d['id'] for d in disrup} == {'later_impact'}
 
+    '''
     def test_disruption_invalid_period_filtering(self):
         """if we query with a since or an until not in the production period, we got an error"""
         resp, code = self.query_region('disruptions?since=20201016T000000', check=False)
@@ -589,25 +590,25 @@ class TestDisruptions(AbstractTestFixture):
         resp, code = self.query_region('disruptions?until=20001016T000000', check=False)
         assert code == 404
         assert resp['error']['message'] == 'ptref : invalid filtering period, not in production period'
-
+    '''
     def test_forbidden_uris_on_disruptions(self):
         """test forbidden uri for disruptions"""
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 10
+        assert len(disruptions) == 11
 
         # filtering disruptions on line A
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions?forbidden_uris[]=A")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 5
+        assert len(disruptions) == 6
 
         # for retrocompatibility purpose forbidden_id[] is the same
         response, code = self.query_no_assert("v1/coverage/main_routing_test/disruptions?forbidden_id[]=A")
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 5
+        assert len(disruptions) == 6
 
         # when we forbid another id, we find again all our disruptions
         response, code = self.query_no_assert(
@@ -615,7 +616,7 @@ class TestDisruptions(AbstractTestFixture):
         )
         assert code == 200
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 10
+        assert len(disruptions) == 11
 
     def test_line_reports(self):
         response = self.query_region("line_reports?_current_datetime=20120801T000000")
@@ -675,6 +676,75 @@ class TestDisruptions(AbstractTestFixture):
             assert len(line_report['pt_objects']) == 2
             assert line_report['pt_objects'][0]['id'] == 'base_network'
             assert line_report['pt_objects'][1]['id'] == 'stopA'
+
+    def test_disruption_with_stop_areas_and_different_parameters(self):
+        """
+        Data production period: 2012/06/14 - 2013/06/14
+        One disruption on 'stopA' with publication and application period : 20120801T000000 - 20120901T120000
+        One disruption on 'stopA' with publication period : 20120801T000000 - 20130801T120000 and
+        application period : 20130701T120000 - 20130801T120000
+
+        All the disruptions with publication_period intersecting with data production_period are valid
+        and charged by kraken.
+
+        Queries possible to return disruptions are as followings (_current_datetime used to go to the past.)
+        1. stop_areas/<stop_area_id>?_current_datetime=20120801T000000
+        2. stop_areas/<stop_area_id>/disruptions?_current_datetime=20120801T000000
+        3. stop_areas/<stop_area_id>/disruptions?_current_datetime=20120801T000000&since=20120801T000000
+        4. stop_areas/<stop_area_id>/disruptions?_current_datetime=20120801T000000&since=20120801T000000
+        &until=20120901T000000
+        """
+        curr_date_filter = '_current_datetime=20120801T000000'
+
+        response = self.query_region('stop_areas/stopA')
+
+        stops = get_not_null(response, 'stop_areas')
+        assert len(stops) == 1
+        stop = stops[0]
+
+        disruptions = get_disruptions(stop, response)
+        assert len(disruptions) == 0
+
+        # api pt_ref sends all the disruptions on pt_object with data production_period intersecting application_period
+        # and active for the date passed in parameter(&_current_datetime=20120801T000000)
+        response = self.query_region('stop_areas/stopA?' + curr_date_filter)
+        stops = get_not_null(response, 'stop_areas')
+        disruptions = get_disruptions(stops[0], response)
+        assert len(disruptions) == 1
+        is_valid_disruption(disruptions[0])
+
+        # api /disruptions on pt_ref sends all the disruptions on pt_objects
+        response = self.query_region('stop_areas/stopA/disruptions?' + curr_date_filter)
+        disruptions = response['disruptions']
+        for d in disruptions:
+            is_valid_disruption(d)
+        assert len(disruptions) == 2
+
+        # api /disruptions on pt_ref with parameters &since sends all the disruptions on pt_objects with filter
+        # on since and until(=production_end_date) with search period intersecting application_period
+        response = self.query_region('stop_areas/stopA/disruptions?since=20120801T000000&' + curr_date_filter)
+        disruptions = response['disruptions']
+        for d in disruptions:
+            is_valid_disruption(d)
+        assert len(disruptions) == 1
+
+        # api /disruptions on pt_ref with parameters &since and &until sends all the disruptions on pt_objects
+        # with filter on since and until with search period intersecting application_period
+        response = self.query_region('stop_areas/stopA/disruptions?since=20120801T000000&until=20120902T000000&' +
+                                     curr_date_filter)
+        disruptions = response['disruptions']
+        assert len(disruptions) == 1
+
+        # gives the disruption in future out of data poduction period
+        response = self.query_region('stop_areas/stopA/disruptions?since=20130703T000000&until=20130801T000000&' +
+                                     curr_date_filter)
+        disruptions = response['disruptions']
+        assert len(disruptions) == 1
+
+        response = self.query_region('stop_areas/stopA/disruptions?since=20120801T000000&until=20130801T000000&' +
+                                     curr_date_filter)
+        disruptions = response['disruptions']
+        assert len(disruptions) == 2
 
 
 @dataset({"line_sections_test": {}})
@@ -792,3 +862,4 @@ class TestDisruptionsLineSections(AbstractTestFixture):
         )
         assert code == 404
         assert response['error']['message'] == 'invalid filtering period (since > until)'
+

--- a/source/jormungandr/tests/disruptions_tests.py
+++ b/source/jormungandr/tests/disruptions_tests.py
@@ -614,7 +614,7 @@ class TestDisruptions(AbstractTestFixture):
         warnings = get_not_null(response, 'warnings')
         assert len(warnings) == 1
         assert warnings[0]['id'] == 'beta_endpoint'
-        assert len(get_not_null(response, 'disruptions')) == 3
+        assert len(get_not_null(response, 'disruptions')) == 4
         line_reports = get_not_null(response, 'line_reports')
         for line_report in line_reports:
             is_valid_line_report(line_report)

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -911,7 +911,7 @@ class TestKirinReadTripEffectFromTripUpdate(MockKirinDisruptionsFixture):
     def test_read_trip_effect_from_tripupdate(self):
         disruptions_before = self.query_region('disruptions?_current_datetime=20120614T080000')
         nb_disruptions_before = len(disruptions_before['disruptions'])
-        assert nb_disruptions_before == 10
+        assert nb_disruptions_before == 11
 
         vjs_before = self.query_region('vehicle_journeys')
         assert len(vjs_before['vehicle_journeys']) == 7
@@ -941,7 +941,7 @@ class TestKirinReadTripEffectFromTripUpdate(MockKirinDisruptionsFixture):
             effect='reduced_service',
         )
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 11
+        assert len(disrupts['disruptions']) == 12
         assert has_the_disruption(disrupts, 'reduced_service_vjA')
         last_disrupt = disrupts['disruptions'][-1]
         assert last_disrupt['severity']['effect'] == 'REDUCED_SERVICE'
@@ -989,7 +989,7 @@ class TestKirinOnNewStopTimeInBetween(MockKirinDisruptionsFixture):
 
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 11
+        assert len(disrupts['disruptions']) == 12
         assert has_the_disruption(disrupts, 'vjA_delayed')
 
         # query from S to R: Journey without delay with departure from B at 20120614T080100
@@ -1053,7 +1053,7 @@ class TestKirinOnNewStopTimeInBetween(MockKirinDisruptionsFixture):
 
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 12
+        assert len(disrupts['disruptions']) == 13
         assert has_the_disruption(disrupts, 'vjA_delayed_with_new_stop_time')
         last_disrupt = disrupts['disruptions'][-1]
         assert last_disrupt['severity']['effect'] == 'DETOUR'
@@ -1109,7 +1109,7 @@ class TestKirinOnNewStopTimeInBetween(MockKirinDisruptionsFixture):
 
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 13
+        assert len(disrupts['disruptions']) == 14
         assert has_the_disruption(disrupts, 'deleted_stop_time')
 
         # the journey doesn't have public_transport
@@ -1130,7 +1130,7 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
         """
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 10
+        assert len(disrupts['disruptions']) == 11
 
         C_to_R_query = "journeys?from={from_coord}&to={to_coord}".format(
             from_coord='stop_point:stopC', to_coord='0.00188646;0.00071865'
@@ -1182,17 +1182,13 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
 
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 11
+        assert len(disrupts['disruptions']) == 12
         assert has_the_disruption(disrupts, 'new_stop_time')
-        assert (
-            disrupts['disruptions'][10]['impacted_objects'][0]['impacted_stops'][0]['arrival_status'] == 'added'
-        )
-        assert (
-            disrupts['disruptions'][10]['impacted_objects'][0]['impacted_stops'][0]['departure_status']
-            == 'added'
-        )
-        assert disrupts['disruptions'][10]['severity']['effect'] == 'SIGNIFICANT_DELAYS'
-        assert disrupts['disruptions'][10]['severity']['name'] == 'trip delayed'
+        last_disruption = disrupts['disruptions'][-1]
+        assert last_disruption['impacted_objects'][0]['impacted_stops'][0]['arrival_status'] == 'added'
+        assert last_disruption['impacted_objects'][0]['impacted_stops'][0]['departure_status'] == 'added'
+        assert last_disruption['severity']['effect'] == 'SIGNIFICANT_DELAYS'
+        assert last_disruption['severity']['name'] == 'trip delayed'
 
         # Query from C to R: the journey should have a public_transport from C to A
         response = self.query_region(base_journey_query)
@@ -1225,18 +1221,13 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
 
         # Verify disruptions
         disrupts = self.query_region('disruptions?_current_datetime=20120614T080000')
-        assert len(disrupts['disruptions']) == 12
+        assert len(disrupts['disruptions']) == 13
         assert has_the_disruption(disrupts, 'deleted_stop_time')
-        assert (
-            disrupts['disruptions'][11]['impacted_objects'][0]['impacted_stops'][0]['arrival_status']
-            == 'deleted'
-        )
-        assert (
-            disrupts['disruptions'][11]['impacted_objects'][0]['impacted_stops'][0]['departure_status']
-            == 'unchanged'  # Why ?
-        )
-        assert disrupts['disruptions'][11]['severity']['effect'] == 'DETOUR'
-        assert disrupts['disruptions'][11]['severity']['name'] == 'detour'
+        last_disruption = disrupts['disruptions'][-1]
+        assert last_disruption['impacted_objects'][0]['impacted_stops'][0]['arrival_status'] == 'deleted'
+        assert last_disruption['impacted_objects'][0]['impacted_stops'][0]['departure_status'] == 'unchanged' # Why?
+        assert last_disruption['severity']['effect'] == 'DETOUR'
+        assert last_disruption['severity']['name'] == 'detour'
 
         response = self.query_region(base_journey_query)
         assert len(response['journeys']) == 1

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1225,7 +1225,9 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
         assert has_the_disruption(disrupts, 'deleted_stop_time')
         last_disruption = disrupts['disruptions'][-1]
         assert last_disruption['impacted_objects'][0]['impacted_stops'][0]['arrival_status'] == 'deleted'
-        assert last_disruption['impacted_objects'][0]['impacted_stops'][0]['departure_status'] == 'unchanged' # Why?
+        assert (
+            last_disruption['impacted_objects'][0]['impacted_stops'][0]['departure_status'] == 'unchanged'
+        )  # Why?
         assert last_disruption['severity']['effect'] == 'DETOUR'
         assert last_disruption['severity']['name'] == 'detour'
 

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -138,11 +138,10 @@ class TestPlaces(AbstractTestFixture):
         assert len(response['places_nearby']) > 0
         is_valid_places(response['places_nearby'])
 
-        assert len(response['disruptions']) == 1
-
+        assert len(response['disruptions']) == 2
         disruptions = get_not_null(response, 'disruptions')
-
-        assert disruptions[0]['disruption_id'] == 'disruption_on_stop_A'
+        disrupt = get_disruption(disruptions, 'too_bad')
+        assert disrupt['disruption_id'] == 'disruption_on_stop_A'
         messages = get_not_null(disruptions[0], 'messages')
 
         assert (messages[0]['text']) == 'no luck'
@@ -194,7 +193,7 @@ class TestPlaces(AbstractTestFixture):
         response = self.query_region("coords/{}/places_nearby?_current_datetime=20120815T160000".format(id))
         assert len(response['places_nearby']) > 0
         is_valid_places(response['places_nearby'])
-        assert len(response['disruptions']) == 1
+        assert len(response['disruptions']) == 2
 
         response = self.query_region(
             "coords/{}/places_nearby?_current_datetime=20120815T160000" "&disable_disruption=true".format(id)
@@ -208,7 +207,7 @@ class TestPlaces(AbstractTestFixture):
         )
         assert len(response['places_nearby']) > 0
         is_valid_places(response['places_nearby'])
-        assert len(response['disruptions']) == 1
+        assert len(response['disruptions']) == 2
 
     def test_main_stop_area_weight_factor(self):
         response = self.query_region("places?type[]=stop_area&q=stop")

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -1022,7 +1022,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         response = self.query_region('disruptions')
 
         disruptions = get_not_null(response, 'disruptions')
-        assert len(disruptions) == 10
+        assert len(disruptions) == 11
         for d in disruptions:
             is_valid_disruption(d)
 

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -180,9 +180,13 @@ filter_vj_on_period(const Indexes& indexes,
                     const type::Data& data) {
 
     Indexes res;
+    bt::time_period production_period = {bt::ptime(data.meta->production_date.begin()),
+                                         bt::ptime(data.meta->production_date.end())};
+    const auto period_to_check = production_period.intersection(period);
+
     for (const idx_t idx: indexes) {
         const auto* vj = data.pt_data->vehicle_journeys[idx];
-        if (! keep_vj(vj, period)) { continue; }
+        if (! keep_vj(vj, period_to_check)) { continue; }
         res.insert(idx);
     }
     return res;
@@ -222,12 +226,6 @@ filter_on_period(const Indexes& indexes,
     }
     auto start = bt::ptime(bt::neg_infin);
     auto end = bt::ptime(bt::pos_infin);
-    // we also use production period to create the right period for VehicleJourney
-    if (requested_type == nt::Type_e::VehicleJourney) {
-        start = bt::ptime(data.meta->production_date.begin());
-        end = bt::ptime(data.meta->production_date.end());
-    }
-
     if (since && *since > start) {
         start = *since;
     }

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -217,12 +217,12 @@ filter_on_period(const Indexes& indexes,
                  const boost::optional<bt::ptime>& until,
                  const type::Data& data) {
 
-    // we create the right period using since, until and the production period
     if (since && until && until < since) {
         throw ptref_error("invalid filtering period");
     }
     auto start = bt::ptime(bt::neg_infin);
     auto end = bt::ptime(bt::pos_infin);
+    // we also use production period to create the right period for VehicleJourney
     if (requested_type == nt::Type_e::VehicleJourney) {
         start = bt::ptime(data.meta->production_date.begin());
         end = bt::ptime(data.meta->production_date.end());
@@ -231,10 +231,10 @@ filter_on_period(const Indexes& indexes,
     if (since && *since > start) {
         start = *since;
     }
+    // we want end to be in the period, so we add one seconds
     if (until && *until < end) {
         end = *until + bt::seconds(1);
     }
-    // we want end to be in the period, so we add one seconds
     bt::time_period period {start, end};
 
     switch (requested_type) {

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -225,18 +225,18 @@ filter_on_period(const Indexes& indexes,
     auto end = bt::ptime(data.meta->production_date.end());
 
     if (since) {
-        if (data.meta->production_date.is_before(since->date())) {
+        if (data.meta->production_date.is_before(since->date()) && requested_type != nt::Type_e::Impact) {
             throw ptref_error("invalid filtering period, not in production period");
         }
-        if (since->date() >= data.meta->production_date.begin()) {
+        if ((since->date() >= data.meta->production_date.begin()) || (requested_type == nt::Type_e::Impact)) {
             start = *since;
         }
     }
     if (until) {
-        if (data.meta->production_date.is_after(until->date())) {
+        if (data.meta->production_date.is_after(until->date()) && requested_type != nt::Type_e::Impact) {
             throw ptref_error("invalid filtering period, not in production period");
         }
-        if (until->date() <= data.meta->production_date.last()) {
+        if ((until->date() <= data.meta->production_date.last()) || (requested_type == nt::Type_e::Impact)) {
             end = *until;
         }
     }

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -721,6 +721,25 @@ struct routing_api_data {
                 .severity("disruption")
                 .on_line_section("B", "stopB", "stopB", {"B:3"})
                 .msg("try again", nt::disruption::ChannelType::sms);
+
+        // We create one disruption on stop 'stop_point:uselessA' with application period which doesn't intersect
+        // with production period but lies well inside publication period.
+        auto large_publication_period = btp(default_date, "20130801T120000"_dt);
+        // application_end_date > applicaion_start_date > production_end_date
+        auto future_application_period = btp("20130701T120000"_dt, "20130801T120000"_dt);
+        //we create one disruption on stop A
+        b.disrupt(nt::RTLevel::Adapted, "disruption_2_on_stop_A")
+                .publication_period(large_publication_period)
+                .tag("tag")
+                .properties(properties)
+                .impact()
+                    .uri("too_bad_future")
+                    .application_periods(future_application_period)
+                    .severity("info")
+                    .on(nt::Type_e::StopArea, "stopA")
+                    .msg("no luck", nt::disruption::ChannelType::sms)
+                    .msg("try again", nt::disruption::ChannelType::sms)
+                    .publish(large_publication_period);
     }
 
     int AA = 0;


### PR DESCRIPTION
1. For a coverage like stif (IDFM), data production period is usually few weeks and we may  have many  disruptions with application periods in future out of data production period.  

2. When we use api /disruptions with/without pt_ref, we get all the disruptions (includings those in future out of data production period), but when we use parameters &since and &until, it is only possible to get disruptions having application periods intersecting production_period. We also have an error message "Error: ptref : invalid filtering period, not in production period" when we use &since and &until with values out of production period. 

3. Correction with some existing tests modified and new added.

4. Concerns: https://jira.kisio.org/browse/NAVITIAII-2648
