### PR TITLE
Jormun: fix bragi multiple parameters

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
@@ -504,7 +504,7 @@ def bragi_call_test():
         ]
     }
     mock_requests = MockRequests(
-        {'http://bob.com/autocomplete?q=rue+bobette&limit=10&timeout=2000': (bragi_response, 200)}
+        {'http://bob.com/autocomplete?limit=10&q=rue+bobette&timeout=2000': (bragi_response, 200)}
     )
     from jormungandr import app
 
@@ -540,11 +540,32 @@ def bragi_make_params_with_instance_test():
     request = {"q": "aa", "count": 20}
 
     params = bragi.make_params(request=request, instances=[instance], timeout=1)
-    rsp = {'q': 'aa', 'limit': 20, 'pt_dataset[]': ['bib'], 'timeout': 1000}
-    len(list(rsp.keys())) == len(list(params.keys()))
-    for key, value in rsp.items():
-        assert key in params
-        assert value == params[key]
+    rsp = {'q': 'aa', 'limit': 20, 'pt_dataset[]': 'bib', 'timeout': 1000}
+
+    len(rsp) == len(params)
+    for key, value in params:
+        assert key in rsp
+        assert value == rsp[key]
+
+
+def bragi_make_params_with_multiple_instances_test():
+    """
+    test of generate params with instance
+    """
+    instance1 = mock.MagicMock()
+    instance1.name = 'bib'
+    instance2 = mock.MagicMock()
+    instance2.name = 'bob'
+    bragi = GeocodeJson(host='http://bob.com/autocomplete')
+
+    request = {"q": "aa", "count": 20}
+
+    params = bragi.make_params(request=request, instances=[instance1, instance2], timeout=1)
+    rsp = [('q', 'aa'), ('limit', 20), ('pt_dataset[]', 'bib'), ('pt_dataset[]', 'bob'), ('timeout', 1000)]
+
+    params.sort()
+    rsp.sort()
+    assert params == rsp
 
 
 def bragi_make_params_without_instance_test():
@@ -557,10 +578,10 @@ def bragi_make_params_without_instance_test():
 
     params = bragi.make_params(request=request, instances=[], timeout=0.1)
     rsp = {'q': 'aa', 'limit': 20, 'timeout': 100}
-    assert len(list(rsp.keys())) == len(list(params.keys()))
-    for key, value in rsp.items():
-        assert key in params
-        assert value == params[key]
+    len(rsp) == len(params)
+    for key, value in params:
+        assert key in rsp
+        assert value == rsp[key]
 
 
 # TODO at least a test on a invalid call to bragi + an invalid bragi response + a py breaker test ?

--- a/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/elastic_search_tests.py
@@ -540,12 +540,10 @@ def bragi_make_params_with_instance_test():
     request = {"q": "aa", "count": 20}
 
     params = bragi.make_params(request=request, instances=[instance], timeout=1)
-    rsp = {'q': 'aa', 'limit': 20, 'pt_dataset[]': 'bib', 'timeout': 1000}
-
-    len(rsp) == len(params)
-    for key, value in params:
-        assert key in rsp
-        assert value == rsp[key]
+    rsp = [('q', 'aa'), ('limit', 20), ('pt_dataset[]', 'bib'), ('timeout', 1000)]
+    params.sort()
+    rsp.sort()
+    assert rsp == params
 
 
 def bragi_make_params_with_multiple_instances_test():
@@ -577,11 +575,10 @@ def bragi_make_params_without_instance_test():
     request = {"q": "aa", "count": 20}
 
     params = bragi.make_params(request=request, instances=[], timeout=0.1)
-    rsp = {'q': 'aa', 'limit': 20, 'timeout': 100}
-    len(rsp) == len(params)
-    for key, value in params:
-        assert key in rsp
-        assert value == rsp[key]
+    rsp = [('q', 'aa'), ('limit', 20), ('timeout', 100)]
+    params.sort()
+    rsp.sort()
+    assert rsp == params
 
 
 # TODO at least a test on a invalid call to bragi + an invalid bragi response + a py breaker test ?

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -70,12 +70,18 @@ class MockRequests(object):
         self.responses = responses
 
     def get(self, url, *args, **kwargs):
-        if kwargs.get('params'):
+        params = kwargs.get('params')
+        if params:
             from six.moves.urllib.parse import urlencode
 
-            url += "?{}".format(urlencode(kwargs.get('params'), doseq=True))
+            params.sort()
+            url += "?{}".format(urlencode(params, doseq=True))
 
-        return MockResponse(self.responses[url][0], self.responses[url][1], url)
+        r = self.responses.get(url)
+        if r:
+            return MockResponse(r[0], r[1], url)
+        else:
+            raise Exception("impossible to find mock response for url {}".format(url))
 
     def post(self, *args, **kwargs):
         return self.get(*args, **kwargs)

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -42,11 +42,9 @@ class DatasetChecker(object):
         self.datasets = datasets
 
     def __call__(self, *args, **kwargs):
-        d = kwargs.get('params', {}).get('pt_dataset[]')
-        if d is not None:
-            assert set(d) == self.datasets
-        else:
-            assert d == self.datasets
+        params = kwargs.get('params', [])
+        d = set(p[1] for p in params if p[0] == 'pt_dataset[]')
+        assert d == self.datasets
         return MockResponse({"features": []}, 200, url='')
 
 


### PR DESCRIPTION
fix #2662
in #2662 `pt_dataset` has been renamed `pt_dataset[]` but all the bragi multiple parameters were still given as `param[]=[value1,value2]`

This will no longer be supported, so this PR changes all those parameters `pt_dataset[]` and `type[]` to
`param[]=value1&param[]=value2`