### PR TITLE
Kraken: rebuild previous raptor cache in maintenance worker after applying realtime

### DIFF
--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -204,6 +204,7 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         data->pt_data->clean_weak_impacts();
         LOG4CPLUS_INFO(logger, "rebuilding data raptor");
         data->build_raptor(conf.raptor_cache_size());
+        data->warmup(*data_manager.get_data());
         data->set_last_rt_data_loaded(pt::microsec_clock::universal_time());
         data_manager.set_data(std::move(data));
         auto duration = pt::microsec_clock::universal_time() - begin;

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -118,6 +118,10 @@ void dataRAPTOR::load(const type::PT_Data& data, size_t cache_size)
     }
 
     cached_next_st_manager = std::make_unique<CachedNextStopTimeManager>(*this, cache_size);
+}
+
+void dataRAPTOR::warmup(const dataRAPTOR& other){
+    this->cached_next_st_manager->warmup(*other.cached_next_st_manager);
 }
 
 }}

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -114,6 +114,8 @@ struct dataRAPTOR {
 
     dataRAPTOR() {}
     void load(const navitia::type::PT_Data&, size_t cache_size = 10);
+
+    void warmup(const dataRAPTOR& other);
 };
 
 }}

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -1,28 +1,28 @@
 /* Copyright © 2001-2015, Canal TP and/or its affiliates. All rights reserved.
-  
+
 This file is part of Navitia,
     the software to build cool stuff with public transport.
- 
+
 Hope you'll enjoy and contribute to this project,
     powered by Canal TP (www.canaltp.fr).
 Help us simplify mobility and open public transport:
     a non ending quest to the responsive locomotion way of traveling!
-  
+
 LICENCE: This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
-   
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU Affero General Public License for more details.
-   
+
 You should have received a copy of the GNU Affero General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
-  
+
 Stay tuned using
-twitter @navitia 
+twitter @navitia
 IRC #navitia on freenode
 https://groups.google.com/d/forum/navitia
 www.navitia.io
@@ -276,6 +276,10 @@ struct CachedNextStopTimeManager {
     load(const DateTime from,
          const type::RTLevel rt_level,
          const type::AccessibiliteParams& accessibilite_params);
+
+    void warmup(const CachedNextStopTimeManager& other){
+        this->lru.warmup(other.lru);
+    }
 
 private:
     struct CacheCreator {

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -183,6 +183,10 @@ void Data::build_raptor(size_t cache_size) {
     LOG4CPLUS_DEBUG(logger, "Finished to build data Raptor");
 }
 
+void Data::warmup(const Data& other){
+    this->dataRaptor->warmup(*other.dataRaptor);
+}
+
 void Data::save(const std::string& filename) const {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     boost::filesystem::path p(filename);

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -231,6 +231,8 @@ public:
                           const std::vector<std::string>& contributors = {});
     void build_raptor(size_t cache_size = 10);
 
+    void warmup(const Data& other);
+
     /** Sauvegarde les données */
     void save(const std::string & filename) const;
 


### PR DESCRIPTION
With this PR after having apply some disruption on data we rebuild the
raptor cache that are currently in use in the current_data.
This should greatly improve performance of kraken with realtime data.

I'm not a fan of the implementation: it's totally untestable, like almost
every that is done in maintenance worker.
Also, as usual it's not clear who should have the responsibility of
building this cache:
  - maintenance_worker alone
  - the cache itself
  - data_manager
  - data & dataRaptor (currently implemented)

If someone as a strong opinion on that I listening...

I don't really see any drawback of always restoring the previous cache,
it may increase the memory usage a bit, but it has already been
allocated one time, there is no reason it won't be a second time.

Require https://github.com/CanalTP/utils/pull/75

update on the performance impact, first response time of journeys while loading realtime data as soon as possible on transilien's coverage with the v2.71.0:
![image](https://user-images.githubusercontent.com/448185/52274343-ae4c4c80-294c-11e9-927f-60647a057354.png)

Same things with this PR:
![image](https://user-images.githubusercontent.com/448185/52274381-c7ed9400-294c-11e9-979a-2a3a5e910168.png)
the 99th centile is improved by almost 10 time on pic.
