### PR TITLE
Kraken: Fix realtime test (on ubuntu 16.04)

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -105,7 +105,7 @@ namespace {
         navitia::apply_disruption( disruption, *b.data->pt_data, *b.data->meta);
     }
 
-    std::set<std::string> get_impacts_uris(const std::set<Impact::SharedImpact> & impacts)
+    std::set<std::string> get_impacts_uris(const std::set<Impact::SharedImpact, Less> & impacts)
     {
         std::set<std::string> uris;
         boost::range::transform(impacts,

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -173,7 +173,7 @@ inline pbnavitia::NavitiaType get_embedded_type(const nt::MetaVehicleJourney*) {
 
 struct PbCreator {
     std::set<const nt::Contributor*, Less> contributors;
-    std::set<boost::shared_ptr<type::disruption::Impact>> impacts;
+    std::set<boost::shared_ptr<type::disruption::Impact>, Less> impacts;
     //std::reference_wrapper<const nt::Data> data;
     const nt::Data* data = nullptr;
     pt::ptime now;


### PR DESCRIPTION
Currently, _realtime tests_ failed on **Ubuntu 16.04** but not on **Debian 8** and **Ubuntu 18**.
In fact, it is the `impact list order`, because it depends on protobuf version.

Impact list is coded with  :
`google::protobuf::RepeatedPtrField< ::pbnavitia::Impact >`

The test was develop on _ubuntu 18_. This is the reason why we didn't see it on ubuntu 16.04...

:heavy_check_mark:  I fixed and tested on **Ubuntu 16.04** (native machine) and **debian 8** (docker).
