### PR TITLE
Doc: 'distance' field from 'Place' object in the swagger

### DIFF
--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -308,7 +308,7 @@ geocode_admin = {
     "id": fields.String(attribute='properties.geocoding.id'),
     "name": fields.String(attribute='properties.geocoding.name'),
     "administrative_region": AdministrativeRegionField(),
-    "distance": Integer(attribute='distance', default=None),
+    "distance": fields.String(attribute='distance', default=None),
 }
 
 
@@ -318,7 +318,7 @@ geocode_addr = {
     "id": CoordId,
     "name": fields.String(attribute='properties.geocoding.label'),
     "address": AddressField(),
-    "distance": Integer(attribute='distance', default=None),
+    "distance": fields.String(attribute='distance', default=None),
 }
 
 geocode_poi = {
@@ -327,7 +327,7 @@ geocode_poi = {
     "id": fields.String(attribute='properties.geocoding.id'),
     "name": fields.String(attribute='properties.geocoding.label'),
     "poi": PoiField(),
-    "distance": Integer(attribute='distance', default=None),
+    "distance": fields.String(attribute='distance', default=None),
 }
 
 geocode_stop_area = {
@@ -336,7 +336,7 @@ geocode_stop_area = {
     "id": fields.String(attribute='properties.geocoding.id'),
     "name": fields.String(attribute='properties.geocoding.label'),
     "stop_area": StopAreaField(),
-    "distance": Integer(attribute='distance', default=None),
+    "distance": fields.String(attribute='distance', default=None),
 }
 
 geocode_feature_func_mapping = {

--- a/source/jormungandr/jormungandr/interfaces/v1/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/fields.py
@@ -776,6 +776,7 @@ place = {
     "name": fields.String(),
     "quality": fields.Integer(),
     "id": fields.String(attribute='uri'),
+    "distance": fields.String(),
 }
 
 pt_object = {

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -80,9 +80,9 @@ class PbIntField(PbField):
 class NestedPbField(PbField):
     """
     handle nested pb field.
-    
+
     define attr='base_stop_time.departure_time'
-    
+
     it will get the departure_time field of the base_stop_time field
     """
 
@@ -283,8 +283,10 @@ class NestedPropertyField(jsonschema.Field):
 class IntNestedPropertyField(NestedPropertyField):
     to_value = staticmethod(int)
 
+
 class StringNestedPropertyField(NestedPropertyField):
     to_value = staticmethod(str)
+
 
 class LambdaField(Field):
     getter_takes_serializer = True

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -283,6 +283,8 @@ class NestedPropertyField(jsonschema.Field):
 class IntNestedPropertyField(NestedPropertyField):
     to_value = staticmethod(int)
 
+class StringNestedPropertyField(NestedPropertyField):
+    to_value = staticmethod(str)
 
 class LambdaField(Field):
     getter_takes_serializer = True

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
@@ -142,6 +142,7 @@ class PlacesCommonSerializer(serpy.DictSerializer):
     If you add/modify fields here, please reflect your changes in
     'jormungandr.jormungandr.interfaces.v1.serializer.pt.PlaceSerializer'.
     '''
+
     id = NestedPropertyField(attr='properties.geocoding.id', display_none=True)
     name = NestedPropertyField(attr='properties.geocoding.name', display_none=True)
     quality = LiteralField(0, deprecated=True)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
@@ -27,13 +27,6 @@
 
 from __future__ import absolute_import
 import serpy
-from .base import (
-    LiteralField,
-    NestedPropertyField,
-    IntNestedPropertyField,
-    value_by_path,
-    BetaEndpointsSerializer,
-)
 import logging
 from jormungandr.interfaces.v1.serializer import jsonschema
 from jormungandr.interfaces.v1.fields import raw_feed_publisher_bano, raw_feed_publisher_osm
@@ -42,6 +35,12 @@ from jormungandr.interfaces.v1.serializer.base import (
     NestedDictCodeField,
     NestedPropertiesField,
     NestedDictCommentField,
+    NestedPropertyField,
+    StringNestedPropertyField,
+    LiteralField,
+    IntNestedPropertyField,
+    value_by_path,
+    BetaEndpointsSerializer,
 )
 from jormungandr.utils import get_house_number
 from jormungandr.autocomplete.geocodejson import create_address_field, get_lon_lat
@@ -137,13 +136,21 @@ class AdministrativeRegionSerializer(serpy.DictSerializer):
     administrative_regions = AdministrativeRegionsSerializer(display_none=False)
 
 
-class GeocodeAdminSerializer(serpy.DictSerializer):
+class PlacesCommonSerializer(serpy.DictSerializer):
+    '''
+    Warning: This class share it's interface with PlaceSerializer (for Kraken)
+    If you add/modify fields here, please reflect your changes in
+    'jormungandr.jormungandr.interfaces.v1.serializer.pt.PlaceSerializer'.
+    '''
     id = NestedPropertyField(attr='properties.geocoding.id', display_none=True)
     name = NestedPropertyField(attr='properties.geocoding.name', display_none=True)
     quality = LiteralField(0, deprecated=True)
+    distance = StringNestedPropertyField(attr='distance', display_none=False, required=False)
     embedded_type = LiteralField("administrative_region", display_none=True)
+
+
+class GeocodeAdminSerializer(PlacesCommonSerializer):
     administrative_region = jsonschema.MethodField()
-    distance = IntNestedPropertyField(attr='distance', display_none=False)
 
     def get_administrative_region(self, obj):
         return AdministrativeRegionSerializer(obj).data
@@ -182,13 +189,10 @@ class PoiSerializer(serpy.DictSerializer):
         return create_address_field(address, poi_lat=poi_lat, poi_lon=poi_lon)
 
 
-class GeocodePoiSerializer(serpy.DictSerializer):
+class GeocodePoiSerializer(PlacesCommonSerializer):
     embedded_type = LiteralField("poi", display_none=True)
-    quality = LiteralField(0, deprecated=True)
-    id = NestedPropertyField(attr='properties.geocoding.id', display_none=True)
     name = NestedPropertyField(attr='properties.geocoding.label', display_none=True)
     poi = jsonschema.MethodField()
-    distance = IntNestedPropertyField(attr='distance', display_none=False)
 
     def get_poi(self, obj):
         return PoiSerializer(obj).data
@@ -207,13 +211,11 @@ class AddressSerializer(serpy.DictSerializer):
         return get_house_number(geocoding.get('housenumber'))
 
 
-class GeocodeAddressSerializer(serpy.DictSerializer):
+class GeocodeAddressSerializer(PlacesCommonSerializer):
     embedded_type = LiteralField("address", display_none=True)
-    quality = LiteralField(0, deprecated=True)
     id = CoordId(display_none=True)
     name = NestedPropertyField(attr='properties.geocoding.label', display_none=True)
     address = jsonschema.MethodField()
-    distance = IntNestedPropertyField(attr='distance', display_none=False)
 
     def get_address(self, obj):
         return AddressSerializer(obj).data
@@ -242,13 +244,10 @@ class StopAreaSerializer(serpy.DictSerializer):
             return next(iter(comments or []), None).get('name')
 
 
-class GeocodeStopAreaSerializer(serpy.DictSerializer):
+class GeocodeStopAreaSerializer(PlacesCommonSerializer):
     embedded_type = LiteralField("stop_area", display_none=True)
-    quality = LiteralField(0, deprecated=True)
-    id = NestedPropertyField(attr='properties.geocoding.id', display_none=True)
     name = NestedPropertyField(attr='properties.geocoding.label', display_none=True)
     stop_area = jsonschema.MethodField()
-    distance = IntNestedPropertyField(attr='distance', display_none=False)
 
     def get_stop_area(self, obj):
         return StopAreaSerializer(obj).data

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -399,10 +399,10 @@ class PlaceSerializer(PbGenericSerializer):
     stop_area = StopAreaSerializer(display_none=False)
     stop_point = StopPointSerializer(display_none=False)
     administrative_region = AdminSerializer(display_none=False)
-    embedded_type = EnumField(attr='embedded_type', required=False, pb_type=NavitiaType, display_none=True)
+    embedded_type = EnumField(attr='embedded_type', pb_type=NavitiaType, display_none=True)
     address = AddressSerializer(display_none=False)
     poi = PoiSerializer(display_none=False)
-    distance = jsonschema.IntField(required=False, display_none=True, description='Distance to the object in meters')
+    distance = jsonschema.StrField(required=False, display_none=True, description='Distance to the object in meters')
 
 class PlaceNearbySerializer(PlaceSerializer):
     pass

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -399,14 +399,13 @@ class PlaceSerializer(PbGenericSerializer):
     stop_area = StopAreaSerializer(display_none=False)
     stop_point = StopPointSerializer(display_none=False)
     administrative_region = AdminSerializer(display_none=False)
-    embedded_type = EnumField(attr='embedded_type', pb_type=NavitiaType, display_none=True)
+    embedded_type = EnumField(attr='embedded_type', required=False, pb_type=NavitiaType, display_none=True)
     address = AddressSerializer(display_none=False)
     poi = PoiSerializer(display_none=False)
-
+    distance = jsonschema.IntField(required=False, display_none=True, description='Distance to the object in meters')
 
 class PlaceNearbySerializer(PlaceSerializer):
-    distance = jsonschema.StrField(display_none=True)
-
+    pass
 
 class NetworkSerializer(PbGenericSerializer):
     links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -400,6 +400,7 @@ class PlaceSerializer(PbGenericSerializer):
     If you add/modify fields here, please reflect your changes in
     'jormungandr.jormungandr.interfaces.v1.serializer.geocode_json.PlacesCommonSerializer'.
     '''
+
     quality = jsonschema.Field(schema_type=int, display_none=True, required=False, deprecated=True)
     stop_area = StopAreaSerializer(display_none=False)
     stop_point = StopPointSerializer(display_none=False)
@@ -407,10 +408,14 @@ class PlaceSerializer(PbGenericSerializer):
     embedded_type = EnumField(attr='embedded_type', pb_type=NavitiaType, display_none=True)
     address = AddressSerializer(display_none=False)
     poi = PoiSerializer(display_none=False)
-    distance = jsonschema.StrField(required=False, display_none=True, description='Distance to the object in meters')
+    distance = jsonschema.StrField(
+        required=False, display_none=True, description='Distance to the object in meters'
+    )
+
 
 class PlaceNearbySerializer(PlaceSerializer):
     pass
+
 
 class NetworkSerializer(PbGenericSerializer):
     links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -395,6 +395,11 @@ class StopAreaSerializer(PbGenericSerializer):
 
 
 class PlaceSerializer(PbGenericSerializer):
+    '''
+    Warning: This class share it's interface with PlacesCommonSerializer (for Bragi)
+    If you add/modify fields here, please reflect your changes in
+    'jormungandr.jormungandr.interfaces.v1.serializer.geocode_json.PlacesCommonSerializer'.
+    '''
     quality = jsonschema.Field(schema_type=int, display_none=True, required=False, deprecated=True)
     stop_area = StopAreaSerializer(display_none=False)
     stop_point = StopPointSerializer(display_none=False)

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -566,7 +566,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert r[0]['embedded_type'] == 'address'
             assert r[0]['address']['name'] == 'Rue Bob'
             assert r[0]['address']['label'] == '20 Rue Bob (Bobtown)'
-            assert r[0]['distance'] == 400
+            assert r[0]['distance'] == '400'
             fbs = response['feed_publishers']
             assert {fb['id'] for fb in fbs} >= {u'osm', u'bano'}
             assert len(r[0]['address'].get('administrative_regions')) == 1
@@ -743,7 +743,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert r[0]['embedded_type'] == 'poi'
             assert r[0]['poi']['name'] == 'bobette'
             assert r[0]['poi']['label'] == "bobette's label"
-            assert r[0]['distance'] == 400
+            assert r[0]['distance'] == '400'
             assert not r[0]['poi'].get('address')
 
     def test_stop_area_with_modes(self):
@@ -789,7 +789,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
 
             assert r[0]['stop_area'].get('timezone') == 'Europe/Paris'
             admins = r[0]['stop_area'].get('administrative_regions')
-            assert r[0]['distance'] == 400
+            assert r[0]['distance'] == '400'
             assert len(admins) == 1
 
     def test_stop_area_with_modes_depth_zero(self):
@@ -1041,7 +1041,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert r[0]['name'] == 'Dijon'
             assert r[0]['embedded_type'] == 'administrative_region'
             assert r[0]['id'] == 'admin:fr:21231'
-            assert r[0]['distance'] == 400
+            assert r[0]['distance'] == '400'
             assert r[0]['administrative_region']['id'] == 'admin:fr:21231'
             assert r[0]['administrative_region']['insee'] == '21231'
             assert r[0]['administrative_region']['label'] == 'Dijon (21000)'


### PR DESCRIPTION
The SDK's team has reported a missing field in the swagger... Let's make them happy :)
```
"Place" : {
         "properties" : {
+          "distance" : {
+             "type" : "integer",
+             "description" : "Distance to the object in meters"
            },
            [...]
         },
         "type" : "object",
         "required" : [
            "name",
            "id"
         ]
      },
```

poke: @Guitouille  :)