### PR TITLE
[Kraken] - UTests around clean_useless_vjs func

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -56,7 +56,8 @@ VJ::VJ(builder& b,
        const std::string& physical_mode,
        const uint32_t start_time,
        const uint32_t end_time,
-       const uint32_t headway_secs):
+       const uint32_t headway_secs,
+       const nt::RTLevel vj_type):
     b(b),
     network_name(network_name),
     line_name(line_name),
@@ -69,6 +70,7 @@ VJ::VJ(builder& b,
     start_time(start_time),
     end_time(end_time),
     headway_secs(headway_secs),
+    _vj_type(vj_type),
     _vp(b.begin, validity_pattern)
 {}
 
@@ -180,14 +182,14 @@ nt::VehicleJourney* VJ::make() {
         "vj:" + line_name + ":" + std::to_string(pt_data.vehicle_journeys.size()) :
         _uri;
     if (is_frequency) {
-        auto* fvj = mvj->create_frequency_vj(uri_str, nt::RTLevel::Base, _vp, route, sts, pt_data);
+        auto* fvj = mvj->create_frequency_vj(uri_str, _vj_type, _vp, route, sts, pt_data);
         fvj->start_time = start_time;
         const size_t nb_trips = std::ceil((end_time - start_time) / headway_secs);
         fvj->end_time = start_time + (nb_trips * headway_secs);
         fvj->headway_secs = headway_secs;
         vj = fvj;
     } else {
-        vj = mvj->create_discrete_vj(uri_str, nt::RTLevel::Base, _vp, route, sts, pt_data);
+        vj = mvj->create_discrete_vj(uri_str, _vj_type, _vp, route, sts, pt_data);
     }
     // default dataset
     if (!vj->dataset){
@@ -543,9 +545,22 @@ VJ builder::vj(const std::string& line_name,
                const bool wheelchair_boarding,
                const std::string& uri,
                const std::string& meta_vj,
-               const std::string& physical_mode){
-    return vj_with_network("base_network", line_name, validity_pattern, block_id,
-                           wheelchair_boarding, uri, meta_vj, physical_mode);
+               const std::string& physical_mode,
+               const nt::RTLevel vj_type)
+{
+    return vj_with_network("base_network",
+                           line_name,
+                           validity_pattern,
+                           block_id,
+                           wheelchair_boarding,
+                           uri,
+                           meta_vj,
+                           physical_mode,
+                           false,
+                           0,
+                           0,
+                           0,
+                           vj_type);
 }
 
 VJ builder::vj_with_network(const std::string& network_name,
@@ -559,10 +574,12 @@ VJ builder::vj_with_network(const std::string& network_name,
                             const bool is_frequency,
                             const uint32_t start_time,
                             const uint32_t end_time,
-                            const uint32_t headway_secs) {
+                            const uint32_t headway_secs,
+                            const nt::RTLevel vj_type)
+{
     return VJ(*this, network_name, line_name, validity_pattern, block_id, is_frequency,
               wheelchair_boarding, uri, meta_vj, physical_mode,
-              start_time, end_time, headway_secs);
+              start_time, end_time, headway_secs, vj_type);
 }
 
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -70,7 +70,7 @@ VJ::VJ(builder& b,
     start_time(start_time),
     end_time(end_time),
     headway_secs(headway_secs),
-    _vj_type(vj_type),
+    vj_type(vj_type),
     _vp(b.begin, validity_pattern)
 {}
 
@@ -182,14 +182,14 @@ nt::VehicleJourney* VJ::make() {
         "vj:" + line_name + ":" + std::to_string(pt_data.vehicle_journeys.size()) :
         _uri;
     if (is_frequency) {
-        auto* fvj = mvj->create_frequency_vj(uri_str, _vj_type, _vp, route, sts, pt_data);
+        auto* fvj = mvj->create_frequency_vj(uri_str, vj_type, _vp, route, sts, pt_data);
         fvj->start_time = start_time;
         const size_t nb_trips = std::ceil((end_time - start_time) / headway_secs);
         fvj->end_time = start_time + (nb_trips * headway_secs);
         fvj->headway_secs = headway_secs;
         vj = fvj;
     } else {
-        vj = mvj->create_discrete_vj(uri_str, _vj_type, _vp, route, sts, pt_data);
+        vj = mvj->create_discrete_vj(uri_str, vj_type, _vp, route, sts, pt_data);
     }
     // default dataset
     if (!vj->dataset){

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -78,7 +78,7 @@ struct VJ {
     const uint32_t start_time;
     const uint32_t end_time;
     const uint32_t headway_secs;
-    const nt::RTLevel _vj_type;
+    const nt::RTLevel vj_type;
     std::vector<ST> stop_times;
     nt::VehicleJourney* vj = nullptr;
     nt::ValidityPattern _vp;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -78,6 +78,7 @@ struct VJ {
     const uint32_t start_time;
     const uint32_t end_time;
     const uint32_t headway_secs;
+    const nt::RTLevel _vj_type;
     std::vector<ST> stop_times;
     nt::VehicleJourney* vj = nullptr;
     nt::ValidityPattern _vp;
@@ -96,7 +97,8 @@ struct VJ {
        const std::string& physical_mode = "",
        const uint32_t start_time = 0,
        const uint32_t end_time = 0,
-       const uint32_t headway_secs = 0);
+       const uint32_t headway_secs = 0,
+       const nt::RTLevel vj_type =  nt::RTLevel::Base);
 
     VJ(VJ&&) = default;
     VJ& operator=(VJ&&) = delete;
@@ -244,7 +246,8 @@ struct builder {
           const bool wheelchair_boarding = true,
           const std::string& uri="",
           const std::string& meta_vj="",
-          const std::string& physical_mode = "");
+          const std::string& physical_mode = "",
+          const nt::RTLevel vj_type = nt::RTLevel::Base);
 
     VJ vj_with_network(const std::string& network_name,
                        const std::string& line_name,
@@ -257,7 +260,8 @@ struct builder {
                        const bool is_frequency=false,
                        const uint32_t start_time = 0,
                        const uint32_t end_time = 0,
-                       const uint32_t headway_secs = 0);
+                       const uint32_t headway_secs = 0,
+                       const nt::RTLevel vj_type = nt::RTLevel::Base);
 
     VJ frequency_vj(const std::string& line_name,
                     const uint32_t start_time,

--- a/source/type/tests/create_vj_test.cpp
+++ b/source/type/tests/create_vj_test.cpp
@@ -95,3 +95,120 @@ BOOST_AUTO_TEST_CASE(create_vj_test) {
     BOOST_CHECK_EQUAL(rt_vj->adapted_validity_pattern()->days, year("0000000" "0000000"));
     BOOST_CHECK_EQUAL(rt_vj->rt_validity_pattern()->days, year("0000000" "0000110"));
 }
+
+BOOST_AUTO_TEST_CASE(clean_up_useless_vjs_test) {
+    using year = navitia::type::ValidityPattern::year_bitset;
+    namespace nt = navitia::type;
+
+    {
+        // clean_up_useless_vjs() is called to clean VJs, with all validity patterns = 0
+
+        ed::builder b("20120614");
+        auto& pt_data = *b.data->pt_data;
+
+        // Add new base VJ uri_A (all validity patterns = 0)
+        const auto* empty_base_vj = b.vj("A", "000000", "block_id_A", false, "uri_A")("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+        auto* mvj = pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(0));
+        BOOST_CHECK_EQUAL(empty_base_vj->base_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(empty_base_vj->adapted_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(empty_base_vj->rt_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 1);
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
+
+        // Add new base VJ uri_B
+        const auto* base_vj = b.vj("A", "000001", "block_id_A", false, "uri_B")("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+        BOOST_CHECK_EQUAL(base_vj->base_validity_pattern()->days, year("000001"));
+        BOOST_CHECK_EQUAL(base_vj->adapted_validity_pattern()->days, year("000001"));
+        BOOST_CHECK_EQUAL(base_vj->rt_validity_pattern()->days, year("000001"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 2);
+
+        // Cleaning VJs with all validity patterns = 0
+        // Vj uri_A have to disappear
+        mvj->clean_up_useless_vjs(pt_data);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 1);
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 2);
+
+        // Add new base VJ uri_C
+        base_vj = b.vj("A", "000010", "block_id_A", false, "uri_C")("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+        BOOST_CHECK_EQUAL(base_vj->base_validity_pattern()->days, year("000010"));
+        BOOST_CHECK_EQUAL(base_vj->adapted_validity_pattern()->days, year("000010"));
+        BOOST_CHECK_EQUAL(base_vj->rt_validity_pattern()->days, year("000010"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 2);
+
+        // All MetaVehiceJourneys are kept, even after suppression of useless VJs...
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 3);
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(0))->get_label(), "uri_A");
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(1))->get_label(), "uri_B");
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(2))->get_label(), "uri_C");
+    }
+
+    {
+        // clean_up_useless_vjs() is not called to clean VJs, with all validity patterns = 0, because it
+        // is already called at the end of the "create_discrete_vj" function.
+        // This function is use to add a new adapted vj.
+
+        ed::builder b("20120614");
+        auto& pt_data = *b.data->pt_data;
+
+        // Add new base VJ uri_A (all validity patterns = 0)
+        const auto* empty_base_vj = b.vj("A", "000000", "block_id_A", false, "uri_A")("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+        BOOST_CHECK_EQUAL(empty_base_vj->base_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(empty_base_vj->adapted_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(empty_base_vj->rt_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 1);
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
+        // Add new base VJ uri_B
+        const auto* base_vj = b.vj("A", "000001", "block_id_A", false, "uri_B")("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+        BOOST_CHECK_EQUAL(base_vj->base_validity_pattern()->days, year("000001"));
+        BOOST_CHECK_EQUAL(base_vj->adapted_validity_pattern()->days, year("000001"));
+        BOOST_CHECK_EQUAL(base_vj->rt_validity_pattern()->days, year("000001"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 2);
+
+        // Add new adapted VJ
+        auto sts = base_vj->stop_time_list;
+        sts.at(1).arrival_time = 8200;
+        sts.at(1).departure_time = 8200;
+        nt::ValidityPattern vp(boost::gregorian::date(2012,06,14));
+        vp.days = year("000000");
+        // we add an adapted vj in the first MetaVehicleJourney, corresponding to the base VJ with all
+        // validity pattern = 0. So the cleaning function will suppress it.
+        auto* mvj = pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(0));
+        const auto* adapted_vj = mvj->create_discrete_vj("adapted", nt::RTLevel::Adapted, vp, base_vj->route, sts, pt_data);
+        BOOST_CHECK_EQUAL(adapted_vj->base_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(adapted_vj->adapted_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(adapted_vj->rt_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 2);
+        // when we added an adapted vj, we don't create new MetaVehiceJourney, but we hang up this one inside
+        // an existing mvj.
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 2);
+
+        // Add new realtime VJ
+        sts = base_vj->stop_time_list;
+        sts.at(1).arrival_time = 8300;
+        sts.at(1).departure_time = 8300;
+        nt::ValidityPattern vp2(boost::gregorian::date(2012,06,14));
+        vp2.days = year("000000");
+        // we add a realtime vj in the first MetaVehicleJourney, corresponding to the adapted VJ with all
+        // validity pattern = 0. So the cleaning function will suppress it.
+        mvj = pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(0));
+        adapted_vj = mvj->create_discrete_vj("realime", nt::RTLevel::RealTime, vp2, base_vj->route, sts, pt_data);
+        BOOST_CHECK_EQUAL(adapted_vj->base_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(adapted_vj->adapted_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(adapted_vj->rt_validity_pattern()->days, year("000000"));
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys_map.size(), 2);
+        BOOST_CHECK_EQUAL(pt_data.vehicle_journeys.size(), 2);
+        // when we added a realtime vj, we don't create new MetaVehiceJourney, but we hang up this one inside
+        // an existing mvj.
+        BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 2);
+    }
+}
+

--- a/source/type/tests/create_vj_test.cpp
+++ b/source/type/tests/create_vj_test.cpp
@@ -198,14 +198,14 @@ BOOST_AUTO_TEST_CASE(create_only_rt_vjs_test) {
     ed::builder b("20120614");
     auto& pt_data = *b.data->pt_data;
 
-    const auto* rt_vj = b.vj("line_A", "000011", "block_id_A", false, "uri_C", "meta_vj_name_A", "", nt::RTLevel::RealTime)("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+    const auto* rt_vj = b.vj("line_A", "000011", "block_id_A", false, "uri_A", "meta_vj_name_A", "", nt::RTLevel::RealTime)("stop1", 8000, 8000)("stop2", 8100, 8100).make();
     BOOST_CHECK_EQUAL(rt_vj->base_validity_pattern()->days, year("000000"));
     BOOST_CHECK_EQUAL(rt_vj->adapted_validity_pattern()->days, year("000000"));
     BOOST_CHECK_EQUAL(rt_vj->rt_validity_pattern()->days, year("000011"));
-    rt_vj = b.vj("line_A", "001100", "block_id_A", false, "uri_C", "meta_vj_name_A", "", nt::RTLevel::RealTime)("stop1", 8000, 8000)("stop2", 8100, 8100).make();
-    BOOST_CHECK_EQUAL(rt_vj->base_validity_pattern()->days, year("000000"));
-    BOOST_CHECK_EQUAL(rt_vj->adapted_validity_pattern()->days, year("000000"));
-    BOOST_CHECK_EQUAL(rt_vj->rt_validity_pattern()->days, year("001100"));
+    const auto* rt_vj2 = b.vj("line_A", "001100", "block_id_A", false, "uri_B", "meta_vj_name_A", "", nt::RTLevel::RealTime)("stop1", 8000, 8000)("stop2", 8100, 8100).make();
+    BOOST_CHECK_EQUAL(rt_vj2->base_validity_pattern()->days, year("000000"));
+    BOOST_CHECK_EQUAL(rt_vj2->adapted_validity_pattern()->days, year("000000"));
+    BOOST_CHECK_EQUAL(rt_vj2->rt_validity_pattern()->days, year("001100"));
     // Meta VJ
     BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
     auto* mvj = pt_data.meta_vjs.get_mut(navitia::Idx<nt::MetaVehicleJourney>(0));


### PR DESCRIPTION
There was no Utests around `clean_useless_vjs` function (https://github.com/CanalTP/navitia/blob/dev/source/type/type.cpp#L527)...
This function aims to clean All VJs with _validity patterns = 0_ before adding a new one.

That's increase tests strongness and prepare for the new development (Add new trip in realtime mode).
