### PR TITLE
Clang-Format

### DIFF
--- a/source/.clang-format
+++ b/source/.clang-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle: chromium
+IndentWidth: 4
+---
+Language: Cpp
+ColumnLimit: 120
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: true
+BreakBeforeBinaryOperators: NonAssignment


### PR DESCRIPTION
This is a Draft PR to talk about auto formatting of our C++ code base. 
* linter `clang-format-7` 
* Line length: 120 char (based on the previous discussion we've had) (default: 80 char)
* Indentation width: 4 char. To be consistent with the actual code (default: 2) 
* cmd `clang-format-7 -sort-includes -i -style="{BasedOnStyle: chromium, ColumnLimit: 120, IndentWidth: 4}" *.cpp *.h`