### PR TITLE
jormun: always install typing

### DIFF
--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -40,4 +40,4 @@ python-json-logger==0.1.7
 jmespath==0.9.3
 shortuuid
 click==6.7
-typing; python_version < '3.0'
+typing


### PR DESCRIPTION
debian 8 has a `pip` version so old that we can't use condition...
Since installing `typing` on version of python that come bundled with it have to effect I removed the condition.
This should make the docker image build happy