### PR TITLE
kraken: trying to reduce build time and memory

### DIFF
--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 #include "georef.h"
 #include <boost/math/constants/constants.hpp>
 #include <chrono>
+#include "utils/logger.h"
 #ifdef _DEBUG_DIJKSTRA_QUANTUM_
 #include <boost/foreach.hpp>
 #endif

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 #include <boost/test/unit_test.hpp>
 #include <execinfo.h>
 #include <iostream>
+#include "utils/logger.h"
 
 #include "georef/georef.h"
 #include "tests/utils_test.h"

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -46,6 +46,7 @@ www.navitia.io
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/classification.hpp>
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -32,6 +32,7 @@ www.navitia.io
 #include "ptreferential_utils.h"
 #include "ptreferential.h"
 #include "type/pt_data.h"
+#include "utils/logger.h"
 
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix.hpp>

--- a/source/ptreferential/tests/ptref_companies_test.cpp
+++ b/source/ptreferential/tests/ptref_companies_test.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "ptreferential/ptref_graph.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "utils/logger.h"
 
 #include <boost/graph/strong_components.hpp>
 #include <boost/graph/connected_components.hpp>

--- a/source/ptreferential/tests/ptref_odt_level_test.cpp
+++ b/source/ptreferential/tests/ptref_odt_level_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "ptreferential/ptref_graph.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "utils/logger.h"
 
 #include <boost/graph/strong_components.hpp>
 #include <boost/graph/connected_components.hpp>

--- a/source/routing/isochrone.cpp
+++ b/source/routing/isochrone.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 #include "isochrone.h"
 #include "raptor.h"
 #include "raptor_api.h"
+#include "utils/logger.h"
 
 #include <set>
 #include <assert.h>

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "type/pt_data.h"
 #include "type/meta_data.h"
 #include "type/type_utils.h"
+#include "utils/logger.h"
 
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include <boost/range/algorithm/fill.hpp>
 #include <boost/functional/hash.hpp>
 #include <chrono>
+#include "utils/logger.h"
 
 namespace bt = boost::posix_time;
 

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -32,6 +32,7 @@ www.navitia.io
 #include "raptor.h"
 #include "raptor_visitors.h"
 #include "journey.h"
+#include "utils/logger.h"
 
 #include <boost/range/algorithm/reverse.hpp>
 #include <boost/range/algorithm/find_if.hpp>

--- a/source/routing/tests/frequency_raptor_test.cpp
+++ b/source/routing/tests/frequency_raptor_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "routing/routing.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }

--- a/source/routing/tests/heat_map_test.cpp
+++ b/source/routing/tests/heat_map_test.cpp
@@ -40,6 +40,7 @@ www.navitia.io
 #include "routing/heat_map.h"
 #include "utils/init.h"
 #include "routing/tests/routing_api_test_data.h"
+#include "utils/logger.h"
 
 #include <boost/test/unit_test.hpp>
 #include <iomanip>

--- a/source/routing/tests/isochrone_test.cpp
+++ b/source/routing/tests/isochrone_test.cpp
@@ -37,6 +37,7 @@ www.navitia.io
 #include "routing/raptor.h"
 #include "routing/routing.h"
 #include "tests/utils_test.h"
+#include "utils/logger.h"
 
 #include <boost/test/unit_test.hpp>
 #include <iomanip>

--- a/source/routing/tests/journey_test.cpp
+++ b/source/routing/tests/journey_test.cpp
@@ -34,6 +34,7 @@ www.navitia.io
 #include "routing/journey.h"
 #include "tests/utils_test.h"
 #include "ed/build_helper.h"
+#include "utils/logger.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "routing/routing.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "routing/raptor.h"
 #include "ed/build_helper.h"
 #include "tests/utils_test.h"
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }

--- a/source/time_tables/thermometer.cpp
+++ b/source/time_tables/thermometer.cpp
@@ -34,6 +34,7 @@ www.navitia.io
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/topological_sort.hpp>
 #include <boost/range/algorithm/sort.hpp>
+#include "type/type.h"
 
 namespace navitia {
 namespace timetables {

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -94,7 +94,7 @@ SET_SOURCE_FILES_PROPERTIES(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS ${PROTO_CMAKE
 add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
 target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY})
 
-add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp validity_pattern.cpp type_utils.cpp)
+add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp)
 target_link_libraries(types ptreferential utils pb_lib protobuf)
 add_dependencies(types protobuf_files)
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -94,7 +94,8 @@ SET_SOURCE_FILES_PROPERTIES(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS ${PROTO_CMAKE
 add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
 target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY})
 
-add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp)
+add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp
+    validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp calendar.cpp)
 target_link_libraries(types ptreferential utils pb_lib protobuf)
 add_dependencies(types protobuf_files)
 

--- a/source/type/calendar.cpp
+++ b/source/type/calendar.cpp
@@ -1,0 +1,105 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include <type/calendar.h>
+#include <type/pt_data.h>
+#include <type/serialization.h>
+
+namespace navitia {
+namespace type {
+
+Calendar::Calendar(boost::gregorian::date beginning_date) : validity_pattern(beginning_date) {}
+
+template <class Archive>
+void Calendar::serialize(Archive& ar, const unsigned int) {
+    ar& name& idx& uri& week_pattern& active_periods& exceptions& validity_pattern;
+}
+SERIALIZABLE(Calendar)
+
+template <class Archive>
+void AssociatedCalendar::serialize(Archive& ar, const unsigned int) {
+    ar& calendar& exceptions;
+}
+SERIALIZABLE(AssociatedCalendar)
+
+void Calendar::build_validity_pattern(boost::gregorian::date_period production_period) {
+    // initialisation of the validity pattern from the active periods and the exceptions
+    for (boost::gregorian::date_period period : this->active_periods) {
+        auto intersection_period = production_period.intersection(period);
+        if (intersection_period.is_null()) {
+            continue;
+        }
+        validity_pattern.add(intersection_period.begin(), intersection_period.end(), week_pattern);
+    }
+    for (navitia::type::ExceptionDate exd : this->exceptions) {
+        if (!production_period.contains(exd.date)) {
+            continue;
+        }
+        if (exd.type == ExceptionDate::ExceptionType::sub) {
+            validity_pattern.remove(exd.date);
+        } else if (exd.type == ExceptionDate::ExceptionType::add) {
+            validity_pattern.add(exd.date);
+        }
+    }
+}
+
+Indexes Calendar::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
+    switch (type) {
+        case Type_e::Line: {
+            // if the method is slow, adding a list of lines in calendar
+            for (Line* line : data.lines) {
+                for (Calendar* cal : line->calendar_list) {
+                    if (cal == this) {
+                        result.insert(line->idx);
+                        break;
+                    }
+                }
+            }
+        } break;
+        default:
+            break;
+    }
+    return result;
+}
+
+std::string to_string(ExceptionDate::ExceptionType t) {
+    switch (t) {
+        case ExceptionDate::ExceptionType::add:
+            return "Add";
+        case ExceptionDate::ExceptionType::sub:
+            return "Sub";
+        default:
+            throw navitia::exception("unhandled exception type");
+    }
+}
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/calendar.h
+++ b/source/type/calendar.h
@@ -1,0 +1,122 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#pragma once
+#include <vector>
+#include <string>
+#include <bitset>
+#include <boost/date_time/gregorian/gregorian.hpp>
+#include <type/type_interfaces.h>
+#include <type/validity_pattern.h>
+#include <utils/exception.h>
+
+namespace navitia {
+namespace type {
+struct ExceptionDate {
+    enum class ExceptionType {
+        sub = 0,  // remove
+        add = 1   // add
+    };
+    ExceptionType type;
+    boost::gregorian::date date;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar& type& date;
+    }
+    inline bool operator<(const ExceptionDate& that) const {
+        if (this->type < that.type)
+            return true;
+        if (that.type < this->type)
+            return false;
+        return this->date < that.date;
+    }
+    inline bool operator==(const ExceptionDate& that) const {
+        return this->type == that.type && this->date == that.date;
+    }
+};
+inline std::ostream& operator<<(std::ostream& os, const ExceptionDate& ed) {
+    switch (ed.type) {
+        case ExceptionDate::ExceptionType::add:
+            os << "excl ";
+            break;
+        case ExceptionDate::ExceptionType::sub:
+            os << "incl ";
+            break;
+    }
+    return os << ed.date;
+}
+
+std::string to_string(ExceptionDate::ExceptionType t);
+
+inline ExceptionDate::ExceptionType to_exception_type(const std::string& str) {
+    if (str == "Add") {
+        return ExceptionDate::ExceptionType::add;
+    }
+    if (str == "Sub") {
+        return ExceptionDate::ExceptionType::sub;
+    }
+    throw navitia::exception("unhandled exception type: " + str);
+}
+
+struct Calendar : public Nameable, public Header {
+    const static Type_e type = Type_e::Calendar;
+    typedef std::bitset<7> Week;
+    Week week_pattern;
+    std::vector<boost::gregorian::date_period> active_periods;
+    std::vector<ExceptionDate> exceptions;
+
+    ValidityPattern validity_pattern;  // computed validity pattern
+
+    Calendar() {}
+    Calendar(boost::gregorian::date beginning_date);
+
+    // we limit the validity pattern to the production period
+    void build_validity_pattern(boost::gregorian::date_period production_period);
+
+    bool operator<(const Calendar& other) const { return this->uri < other.uri; }
+
+    Indexes get(Type_e type, const PT_Data& data) const;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int);
+};
+struct AssociatedCalendar {
+    /// calendar matched
+    const Calendar* calendar;
+
+    /// exceptions to this association (not to be mixed up with the exceptions in the calendar)
+    /// the calendar exceptions change it's validity pattern
+    /// the AssociatedCalendar exceptions are the differences between the vj validity pattern and the calendar's
+    std::vector<ExceptionDate> exceptions;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int);
+};
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/connection.cpp
+++ b/source/type/connection.cpp
@@ -1,0 +1,73 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "type/connection.h"
+#include "type/type.h"
+#include "type/indexes.h"
+#include "type/serialization.h"
+
+namespace navitia {
+namespace type {
+
+template <class Archive>
+void StopPointConnection::save(Archive& ar, const unsigned int) const {
+    ar& idx& uri& departure& destination& display_duration& duration& max_duration& connection_type& _properties;
+}
+template <class Archive>
+void StopPointConnection::load(Archive& ar, const unsigned int) {
+    ar& idx& uri& departure& destination& display_duration& duration& max_duration& connection_type& _properties;
+
+    // loading manage StopPoint::stop_point_connection_list
+    departure->stop_point_connection_list.push_back(this);
+    destination->stop_point_connection_list.push_back(this);
+}
+SPLIT_SERIALIZABLE(StopPointConnection)
+
+Indexes StopPointConnection::get(Type_e type, const PT_Data&) const {
+    Indexes result;
+    switch (type) {
+        case Type_e::StopPoint:
+            result.insert(this->departure->idx);
+            result.insert(this->destination->idx);
+            break;
+        default:
+            break;
+    }
+    return result;
+}
+bool StopPointConnection::operator<(const StopPointConnection& other) const {
+    if (this->departure != other.departure) {
+        return *this->departure < *other.departure;
+    }
+    return *this->destination < *other.destination;
+}
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/connection.h
+++ b/source/type/connection.h
@@ -1,0 +1,67 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+
+#include "type/type_interfaces.h"
+#include <boost/serialization/split_member.hpp>
+
+namespace navitia {
+namespace type {
+
+struct StopPoint;
+struct PT_Data;
+
+enum class ConnectionType { StopPoint = 0, StopArea, Walking, VJ, Default, stay_in, undefined };
+
+struct StopPointConnection : public Header, hasProperties {
+    const static Type_e type = Type_e::Connection;
+    StopPoint* departure;
+    StopPoint* destination;
+    int display_duration;
+    int duration;
+    int max_duration;
+    ConnectionType connection_type;
+
+    StopPointConnection()
+        : departure(nullptr), destination(nullptr), display_duration(0), duration(0), max_duration(0) {}
+
+    template <class Archive>
+    void save(Archive& ar, const unsigned int) const;
+    template <class Archive>
+    void load(Archive& ar, const unsigned int);
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
+    Indexes get(Type_e type, const PT_Data& data) const;
+
+    bool operator<(const StopPointConnection& other) const;
+};
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -29,19 +29,20 @@ www.navitia.io
 */
 
 #pragma once
-#include "utils/logger.h"
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/shared_ptr.hpp>
 #include <boost/utility.hpp>
 #include <boost/serialization/version.hpp>
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <atomic>
-#include "type/type.h"
+#include "type/validity_pattern.h"
 #include "utils/serialization_unique_ptr.h"
 #include "utils/serialization_atomic.h"
 #include "data_exceptions.h"
 #include "utils/obj_factory.h"
 #include "utils/ptime.h"
-#include "georef/adminref.h"
+#include "type/fwd_type.h"
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 #if __GNUG__ && __GNUC__ < 5
@@ -49,26 +50,6 @@ www.navitia.io
 #else
 #define IS_TRIVIALLY_COPYABLE(T) std::is_trivially_copyable<T>::value
 #endif
-
-// forward declare
-namespace navitia {
-namespace georef {
-struct GeoRef;
-struct POI;
-struct POIType;
-}  // namespace georef
-namespace fare {
-struct Fare;
-}
-namespace routing {
-struct dataRAPTOR;
-struct JourneyPattern;
-struct JourneyPatternPoint;
-}  // namespace routing
-namespace type {
-struct MetaData;
-}
-}  // namespace navitia
 
 namespace navitia {
 namespace type {
@@ -252,8 +233,6 @@ public:
     void build_proximity_list();
     /** Set admins*/
     void build_administrative_regions();
-
-    void build_associated_calendar();
 
     void aggregate_odt();
     void build_relations();

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -1,0 +1,81 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#pragma once
+
+// forward declare
+//
+template <class DATATYPE, class ELEMTYPE, int NUMDIMS, class ELEMTYPEREAL, int TMAXNODES, int TMINNODES>
+class RTree;
+namespace navitia {
+namespace georef {
+struct GeoRef;
+struct POI;
+struct POIType;
+struct Admin;
+using AdminRtree = class RTree<Admin*, double, 2, double, 8, 4>;
+}  // namespace georef
+namespace fare {
+struct Fare;
+}
+namespace routing {
+struct dataRAPTOR;
+struct JourneyPattern;
+struct JourneyPatternPoint;
+}  // namespace routing
+namespace type {
+class MetaData;
+
+struct GeographicalCoord;
+struct Line;
+struct StopArea;
+struct Network;
+struct StopPointConnection;
+struct ValidityPattern;
+struct Route;
+struct VehicleJourney;
+struct StopTime;
+struct Dataset;
+struct StopPoint;
+struct ExceptionDate;
+struct Contributor;
+struct Company;
+struct CommercialMode;
+struct PhysicalMode;
+struct LineGroup;
+struct MetaVehicleJourney;
+struct DiscreteVehicleJourney;
+struct FrequencyVehicleJourney;
+struct Calendar;
+namespace disruption {
+struct Impact;
+struct Message;
+}  // namespace disruption
+}  // namespace type
+}  // namespace navitia

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -50,7 +50,7 @@ struct JourneyPattern;
 struct JourneyPatternPoint;
 }  // namespace routing
 namespace type {
-class MetaData;
+struct MetaData;
 
 struct GeographicalCoord;
 struct Line;

--- a/source/type/geographical_coord.cpp
+++ b/source/type/geographical_coord.cpp
@@ -30,9 +30,16 @@ www.navitia.io
 
 #include "geographical_coord.h"
 #include <iomanip>
+#include "type/serialization.h"
 
 namespace navitia {
 namespace type {
+
+template <class Archive>
+void GeographicalCoord::serialize(Archive& ar, const unsigned int) {
+    ar& _lon& _lat;
+}
+SERIALIZABLE(GeographicalCoord)
 
 double GeographicalCoord::distance_to(const GeographicalCoord& other) const {
     double longitudeArc = (this->lon() - other.lon()) * N_DEG_TO_RAD;

--- a/source/type/geographical_coord.h
+++ b/source/type/geographical_coord.h
@@ -134,9 +134,7 @@ struct GeographicalCoord {
     }
 
     template <class Archive>
-    void serialize(Archive& ar, const unsigned int) {
-        ar& _lon& _lat;
-    }
+    void serialize(Archive& ar, const unsigned int);
 
 private:
     double _lon;

--- a/source/type/indexes.h
+++ b/source/type/indexes.h
@@ -1,0 +1,58 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#pragma once
+
+#include <set>
+#include <vector>
+#include "type/type_interfaces.h"
+
+namespace navitia {
+namespace type {
+
+template <typename T>
+Indexes indexes(const std::vector<T*>& elements) {
+    Indexes result;
+    for (T* element : elements) {
+        result.insert(element->idx);
+    }
+    return result;
+}
+
+template <typename T>
+Indexes indexes(const std::set<T*>& elements) {
+    Indexes result;
+    for (T* element : elements) {
+        result.insert(element->idx);
+    }
+    return result;
+}
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -35,6 +35,7 @@ www.navitia.io
 #include "type/pt_data.h"
 #include "vptranslator/vptranslator.h"
 #include "ptreferential/ptreferential.h"
+#include "utils/logger.h"
 
 namespace pt = boost::posix_time;
 namespace nt = navitia::type;

--- a/source/type/serialization.h
+++ b/source/type/serialization.h
@@ -1,0 +1,50 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#pragma once
+#include <eos_portable_archive/portable_iarchive.hpp>
+#include <eos_portable_archive/portable_oarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+
+// TODO: should be removed when migration is completed
+#include <boost/serialization/weak_ptr.hpp>
+
+#define SERIALIZABLE(T)                                                                                                \
+    template void T::serialize<boost::archive::binary_oarchive>(boost::archive::binary_oarchive&, const unsigned int); \
+    template void T::serialize<boost::archive::binary_iarchive>(boost::archive::binary_iarchive&, const unsigned int); \
+    template void T::serialize<eos::portable_oarchive>(eos::portable_oarchive&, const unsigned int);                   \
+    template void T::serialize<eos::portable_iarchive>(eos::portable_iarchive&, const unsigned int);
+
+#define SPLIT_SERIALIZABLE(T)                                                                                     \
+    template void T::save<boost::archive::binary_oarchive>(boost::archive::binary_oarchive&, const unsigned int)  \
+        const;                                                                                                    \
+    template void T::save<eos::portable_oarchive>(eos::portable_oarchive&, const unsigned int) const;             \
+    template void T::load<boost::archive::binary_iarchive>(boost::archive::binary_iarchive&, const unsigned int); \
+    template void T::load<eos::portable_iarchive>(eos::portable_iarchive&, const unsigned int);

--- a/source/type/stop_point.cpp
+++ b/source/type/stop_point.cpp
@@ -1,0 +1,84 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#include "type/stop_point.h"
+#include "type/type.h"
+#include "type/pt_data.h"
+
+#include "type/serialization.h"
+#include <boost/serialization/weak_ptr.hpp>
+#include "type/indexes.h"
+
+namespace navitia {
+namespace type {
+
+template <class Archive>
+void StopPoint::serialize(Archive& ar, const unsigned int) {
+    // The *_list are not serialized here to avoid stack abuse
+    // during serialization and deserialization.
+    //
+    // stop_point_connection_list is managed by StopPointConnection
+    ar& uri& label& name& stop_area& coord& fare_zone& is_zonal& idx& platform_code& admin_list& _properties& impacts&
+        dataset_list;
+}
+SERIALIZABLE(StopPoint)
+
+bool StopPoint::operator<(const StopPoint& other) const {
+    if (this->stop_area != other.stop_area) {
+        return *this->stop_area < *other.stop_area;
+    }
+    if (this->name != other.name) {
+        return this->name < other.name;
+    }
+    return this->uri < other.uri;
+}
+
+Indexes StopPoint::get(Type_e type, const PT_Data& data) const {
+    Indexes result;
+    switch (type) {
+        case Type_e::StopArea:
+            result.insert(stop_area->idx);
+            break;
+        case Type_e::Connection:
+        case Type_e::StopPointConnection:
+            for (const StopPointConnection* stop_cnx : stop_point_connection_list)
+                result.insert(stop_cnx->idx);  // TODO use bulk insert ?
+            break;
+        case Type_e::Impact:
+            return data.get_impacts_idx(get_impacts());
+        case Type_e::Dataset:
+            return indexes(dataset_list);
+        default:
+            break;
+    }
+    return result;
+}
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/stop_point.h
+++ b/source/type/stop_point.h
@@ -1,0 +1,66 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+
+#include "type/type_interfaces.h"
+#include "type/geographical_coord.h"
+#include <vector>
+#include <set>
+#include "type/fwd_type.h"
+
+namespace navitia {
+namespace type {
+
+struct StopPoint : public Header, Nameable, hasProperties, HasMessages {
+    const static Type_e type = Type_e::StopPoint;
+    GeographicalCoord coord;
+    std::string fare_zone;
+    bool is_zonal = false;
+    std::string platform_code;
+    std::string label;
+
+    StopArea* stop_area;
+    std::vector<navitia::georef::Admin*> admin_list;
+    Network* network;
+    std::vector<StopPointConnection*> stop_point_connection_list;
+    std::set<Dataset*> dataset_list;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int);
+
+    StopPoint() : fare_zone(), stop_area(nullptr), network(nullptr) {}
+
+    Indexes get(Type_e type, const PT_Data& data) const;
+    bool operator<(const StopPoint& other) const;
+};
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/tests/comments_test.cpp
+++ b/source/type/tests/comments_test.cpp
@@ -38,9 +38,10 @@ www.navitia.io
 #include "tests/utils_test.h"
 #include "type/comment_container.h"
 #include <memory>
-#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
 #include <string>
 #include <type_traits>
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }
@@ -81,6 +82,6 @@ BOOST_AUTO_TEST_CASE(comment_map_test) {
     expected = {"st com"};
     BOOST_CHECK_EQUAL(comments_container.get(b.data->pt_data->vehicle_journeys[0]->stop_time_list.front()), expected);
 
-    boost::archive::text_oarchive oa(std::cout);
+    boost::archive::binary_oarchive oa(std::cout);
     oa& comments_container;
 }

--- a/source/type/tests/create_vj_test.cpp
+++ b/source/type/tests/create_vj_test.cpp
@@ -41,6 +41,7 @@ www.navitia.io
 #include <boost/archive/text_oarchive.hpp>
 #include <string>
 #include <type_traits>
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -42,6 +42,7 @@ www.navitia.io
 #include <boost/archive/text_oarchive.hpp>
 #include <string>
 #include <type_traits>
+#include "utils/logger.h"
 
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -802,54 +802,11 @@ Mode_e static_data::modeByCaption(const std::string& mode_str) {
     return it_mode->second;
 }
 
-Calendar::Calendar(boost::gregorian::date beginning_date) : validity_pattern(beginning_date) {}
-
-void Calendar::build_validity_pattern(boost::gregorian::date_period production_period) {
-    // initialisation of the validity pattern from the active periods and the exceptions
-    for (boost::gregorian::date_period period : this->active_periods) {
-        auto intersection_period = production_period.intersection(period);
-        if (intersection_period.is_null()) {
-            continue;
-        }
-        validity_pattern.add(intersection_period.begin(), intersection_period.end(), week_pattern);
-    }
-    for (navitia::type::ExceptionDate exd : this->exceptions) {
-        if (!production_period.contains(exd.date)) {
-            continue;
-        }
-        if (exd.type == ExceptionDate::ExceptionType::sub) {
-            validity_pattern.remove(exd.date);
-        } else if (exd.type == ExceptionDate::ExceptionType::add) {
-            validity_pattern.add(exd.date);
-        }
-    }
-}
-
 bool VehicleJourney::operator<(const VehicleJourney& other) const {
     if (this->route != other.route) {
         return *this->route < *other.route;
     }
     return this->uri < other.uri;
-}
-
-Indexes Calendar::get(Type_e type, const PT_Data& data) const {
-    Indexes result;
-    switch (type) {
-        case Type_e::Line: {
-            // if the method is slow, adding a list of lines in calendar
-            for (Line* line : data.lines) {
-                for (Calendar* cal : line->calendar_list) {
-                    if (cal == this) {
-                        result.insert(line->idx);
-                        break;
-                    }
-                }
-            }
-        } break;
-        default:
-            break;
-    }
-    return result;
 }
 
 bool StopArea::operator<(const StopArea& other) const {
@@ -1152,17 +1109,6 @@ Indexes Contributor::get(Type_e type, const PT_Data&) const {
             break;
     }
     return result;
-}
-
-std::string to_string(ExceptionDate::ExceptionType t) {
-    switch (t) {
-        case ExceptionDate::ExceptionType::add:
-            return "Add";
-        case ExceptionDate::ExceptionType::sub:
-            return "Sub";
-        default:
-            throw navitia::exception("unhandled exception type");
-    }
 }
 
 EntryPoint::EntryPoint(const Type_e type, const std::string& uri, int access_duration)

--- a/source/type/validity_pattern.cpp
+++ b/source/type/validity_pattern.cpp
@@ -32,9 +32,18 @@ www.navitia.io
 #include <log4cplus/loggingmacros.h>
 #include "utils/exception.h"
 #include "datetime.h"
+#include <type/serialization.h>
+#include <boost/date_time/gregorian/greg_serialize.hpp>
+#include <boost/serialization/bitset.hpp>
 
 namespace navitia {
 namespace type {
+
+template <class Archive>
+void ValidityPattern::serialize(Archive& ar, const unsigned int) {
+    ar& beginning_date& days& idx& uri;
+}
+SERIALIZABLE(ValidityPattern)
 
 bool ValidityPattern::is_valid(int day) const {
     if (day < 0) {

--- a/source/type/validity_pattern.h
+++ b/source/type/validity_pattern.h
@@ -61,9 +61,7 @@ public:
     bool empty() const { return days.none(); }
     std::string str() const;
     template <class Archive>
-    void serialize(Archive& ar, const unsigned int) {
-        ar& beginning_date& days& idx& uri;
-    }
+    void serialize(Archive& ar, const unsigned int);
 
     bool check(boost::gregorian::date day) const;
     bool check(unsigned int day) const;


### PR DESCRIPTION
Building data.cpp takes a very long time (more than 2minute) and a lot
of memory (around 4.5go). This seems to be caused by boost serialize.

In this PR I have started to move serialization function in .cpp to
limit the need of rebuilding it every time. I also moved each type in
its own unit to reduce memory usage and prevent the rebuild of
everything. It should also speed up the build as each unit will be
smaller and build concurrently.

Also, I have added some forward-declare in `data.h`, so a lot of files had to be updated.