### PR TITLE
kraken: Add new realtime trip into new mvj and vj

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -244,8 +244,11 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
                 vj->name = mvj->get_base_vj().at(0)->name;
             } else {
-                // If we set nothing for physical_mode, it'll crash when building raptor
-                vj->physical_mode = pt_data.physical_modes[0];
+                if (!impact->physical_mode_id.empty()) {
+                    nu::make_map_find(pt_data.physical_modes_map, impact->physical_mode_id)
+                        .if_found([&vj](navitia::type::PhysicalMode* p){ vj->physical_mode = p; })
+                        .if_not_found([&](){ LOG4CPLUS_WARN(log, "[disruption] Associate physical mode into new VJ. Physical mode doesn't exist with id : " << impact->physical_mode_id); });
+                }
                 vj->name = new_vj_uri;
             }
             vj->physical_mode->vehicle_journey_list.push_back(vj);

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -546,6 +546,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
 static bool is_modifying_effect(nt::disruption::Effect e) {
     // check if the effect needs to modify the model
     return in(e, {nt::disruption::Effect::NO_SERVICE,
+                  nt::disruption::Effect::UNKNOWN_EFFECT,
                   nt::disruption::Effect::SIGNIFICANT_DELAYS,
                   nt::disruption::Effect::MODIFIED_SERVICE,
                   nt::disruption::Effect::DETOUR,

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -232,7 +232,6 @@ struct add_impacts_visitor : public apply_impacts_visitor {
 
             // Add company
             if (!impact->company_id.empty()) {
-                LOG4CPLUS_TRACE(log, "kikou " << impact->company_id);
                 nu::make_map_find(pt_data.companies_map, impact->company_id)
                     .if_found([&](navitia::type::Company* c){
                         vj->company = c;
@@ -241,7 +240,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                         // for protection, use the companies[0]
                         // TODO : Create default company
                         vj->company = pt_data.companies[0];
-                        LOG4CPLUS_WARN(log, "[disruption] Associate company into new VJ. Company doesn't exist with id : " << impact->company_id); });
+                        LOG4CPLUS_WARN(log, "[disruption] Associate random company to new VJ. Company doesn't exist with id : " << impact->company_id); });
             } else {
                 if (! mvj->get_base_vj().empty()) {
                     vj->company = mvj->get_base_vj().at(0)->company;
@@ -249,6 +248,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                     // for protection, use the companies[0]
                     // TODO : Create default company
                     vj->company = pt_data.companies[0];
+                    LOG4CPLUS_WARN(log, "[disruption] Associate random company to new VJ because base VJ doesn't exist");
                 }
             }
 
@@ -262,7 +262,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                         // for protection, use the physical_modes[0]
                         // TODO : Create default physical mode
                         vj->physical_mode = pt_data.physical_modes[0];
-                        LOG4CPLUS_WARN(log, "[disruption] Associate physical mode into new VJ. Physical mode doesn't exist with id : " << impact->physical_mode_id); });
+                        LOG4CPLUS_WARN(log, "[disruption] Associate random physical mode to new VJ. Physical mode doesn't exist with id : " << impact->physical_mode_id); });
             } else {
                 if (! mvj->get_base_vj().empty()) {
                     vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
@@ -270,6 +270,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                     // for protection, use the physical_modes[0]
                     // TODO : Create default physical mode
                     vj->physical_mode = pt_data.physical_modes[0];
+                    LOG4CPLUS_WARN(log, "[disruption] Associate random physical mode to new VJ because base VJ doesn't exist");
                 }
             }
 
@@ -291,7 +292,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 // for protection, use the datasets[0]
                 // TODO : Create default data set
                 vj->dataset = pt_data.datasets[0];
-                LOG4CPLUS_WARN(log, "[disruption] Associate dataset into new VJ doesn't work, take first data set by default");
+                LOG4CPLUS_WARN(log, "[disruption] Associate random dataset to new VJ doesn't work because base VJ doesn't exist");
             }
             vj->physical_mode->vehicle_journey_list.push_back(vj);
             // we need to associate the stoptimes to the created vj

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -208,6 +208,10 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                                                          meta.production_date);
             if (! r && ! mvj->get_base_vj().empty()) {
                 r = mvj->get_base_vj().at(0)->route;
+            } else {
+                // Take the first route into the data (it is temporary).
+                // It'll replace by new method to create new default route.
+                r = pt_data.routes[0];
             }
             auto nb_rt_vj = mvj->get_rt_vj().size();
             std::string new_vj_uri = mvj->uri + ":modified:" + std::to_string(nb_rt_vj) + ":"
@@ -499,7 +503,8 @@ static bool is_modifying_effect(nt::disruption::Effect e) {
                   nt::disruption::Effect::SIGNIFICANT_DELAYS,
                   nt::disruption::Effect::MODIFIED_SERVICE,
                   nt::disruption::Effect::DETOUR,
-                  nt::disruption::Effect::REDUCED_SERVICE});
+                  nt::disruption::Effect::REDUCED_SERVICE,
+                  nt::disruption::Effect::ADDITIONAL_SERVICE});
 }
 
 void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact,

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -284,9 +284,18 @@ static bool is_handleable(const transit_realtime::TripUpdate& trip_update,
         // check if company id exists
         if (trip_update.trip().HasExtension(kirin::company_id) &&
             pt_data.companies_map.find(trip_update.trip().GetExtension(kirin::company_id)) == pt_data.companies_map.end()) {
-            LOG4CPLUS_DEBUG(log, "Trip company "
+            LOG4CPLUS_DEBUG(log, "Trip company id "
                     << trip_update.trip().GetExtension(kirin::company_id)
-                    <<  " don't exists: ignoring trip id "
+                    <<  " doesn't exists: ignoring trip id "
+                    << trip_update.trip().trip_id());
+            return false;
+        }
+        // check if physical mode id exists
+        if (trip_update.vehicle().HasExtension(kirin::physical_mode_id) &&
+            pt_data.physical_modes_map.find(trip_update.vehicle().GetExtension(kirin::physical_mode_id)) == pt_data.physical_modes_map.end()) {
+            LOG4CPLUS_DEBUG(log, "Trip physical mode id "
+                    << trip_update.vehicle().GetExtension(kirin::physical_mode_id)
+                    <<  " doesn't exists: ignoring trip id "
                     << trip_update.trip().trip_id());
             return false;
         }
@@ -431,6 +440,9 @@ create_disruption(const std::string& id,
         impact->updated_at = timestamp;
         if (trip_update.trip().HasExtension(kirin::company_id)) {
             impact->company_id = trip_update.trip().GetExtension(kirin::company_id);
+        }
+        if (trip_update.vehicle().HasExtension(kirin::physical_mode_id)) {
+            impact->physical_mode_id = trip_update.vehicle().GetExtension(kirin::physical_mode_id);
         }
         if (trip_update.HasExtension(kirin::trip_message)) {
             impact->messages.push_back(create_message(trip_update.GetExtension(kirin::trip_message)));

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -289,7 +289,8 @@ static bool is_handleable(const transit_realtime::TripUpdate& trip_update,
     if (is_circulating(trip_update)) {
 
         // check if company id exists
-        if (trip_update.trip().HasExtension(kirin::company_id) &&
+        if (trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED &&
+            trip_update.trip().HasExtension(kirin::company_id) &&
             pt_data.companies_map.find(trip_update.trip().GetExtension(kirin::company_id)) == pt_data.companies_map.end()) {
             LOG4CPLUS_DEBUG(log, "Trip company id "
                     << trip_update.trip().GetExtension(kirin::company_id)
@@ -298,7 +299,8 @@ static bool is_handleable(const transit_realtime::TripUpdate& trip_update,
             return false;
         }
         // check if physical mode id exists
-        if (trip_update.vehicle().HasExtension(kirin::physical_mode_id) &&
+        if (trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED &&
+            trip_update.vehicle().HasExtension(kirin::physical_mode_id) &&
             pt_data.physical_modes_map.find(trip_update.vehicle().GetExtension(kirin::physical_mode_id)) == pt_data.physical_modes_map.end()) {
             LOG4CPLUS_DEBUG(log, "Trip physical mode id "
                     << trip_update.vehicle().GetExtension(kirin::physical_mode_id)
@@ -599,7 +601,7 @@ void handle_realtime(const std::string& id,
                 << trip_update.trip().trip_id());
         return;
     } else {
-        LOG4CPLUS_DEBUG(log, "Vehicle journey founded : " << trip_update.trip().trip_id());
+        LOG4CPLUS_DEBUG(log, "Vehicle journey found : " << trip_update.trip().trip_id());
         meta_vj = data.pt_data->meta_vjs.get_mut(trip_update.trip().trip_id());
     }
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -67,6 +67,7 @@ static bool is_circulating_trip(const transit_realtime::TripUpdate& trip_update)
 {
     if (trip_update.HasExtension(kirin::effect)) {
         if ((trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_REDUCED_SERVICE ||
+             trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_UNKNOWN_EFFECT ||
              trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS ||
              trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_DETOUR ||
              trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE ||
@@ -373,13 +374,15 @@ static nt::disruption::Effect get_calculated_trip_effect(nt::disruption::StopTim
     using nt::disruption::Effect;
 
     switch (status) {
-    case StopTimeUpdate::Status::DELAYED:
     case StopTimeUpdate::Status::UNCHANGED: // it can be a back to normal case
+        return Effect::UNKNOWN_EFFECT;
+    case StopTimeUpdate::Status::DELAYED:
         return Effect::SIGNIFICANT_DELAYS;
     case StopTimeUpdate::Status::ADDED:
-    case StopTimeUpdate::Status::ADDED_FOR_DETOUR:
         return Effect::MODIFIED_SERVICE;
     case StopTimeUpdate::Status::DELETED:
+        return Effect::REDUCED_SERVICE;
+    case StopTimeUpdate::Status::ADDED_FOR_DETOUR:
     case StopTimeUpdate::Status::DELETED_FOR_DETOUR:
         return Effect::DETOUR;
     default:

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -50,7 +50,7 @@ static bool is_circulating(const transit_realtime::TripUpdate& trip_update)
 {
     if ((trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED ||
          trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED)
-         && trip_update.stop_time_update_size()) {
+         && trip_update.stop_time_update_size() > 1) {
         return true;
     } else {
         return false;

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -50,7 +50,7 @@ static bool is_circulating(const transit_realtime::TripUpdate& trip_update)
 {
     if ((trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED ||
          trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED)
-         && trip_update.stop_time_update_size() > 1) {
+         && trip_update.stop_time_update_size()) {
         return true;
     } else {
         return false;

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2877,7 +2877,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip, AddTripDataset) {
         transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
 
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
-    b.make();
+    b.data->build_raptor();
 
     // Check meta vj table
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.size(), 2);
@@ -2966,7 +2966,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip, AddTripDataset) {
         phy_mode_uri,
         transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
-    b.make();
+    b.data->build_raptor();
 
     //Check meta vj (there is no creation)
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.size(), 2);
@@ -3026,7 +3026,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip, AddTripDataset) {
         phy_mode_uri,
         transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
     navitia::handle_realtime("feed-2", timestamp, new_trip_2, *b.data, true, true);
-    b.make();
+    b.data->build_raptor();
 
     // Check if meta vj exist
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.size(), 3);
@@ -3120,7 +3120,7 @@ BOOST_FIXTURE_TEST_CASE(flags_block_new_trip, AddTripDataset) {
     // call function with is_realtime_add_enabled=false and is_realtime_add_trip_enabled=false
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, false, false);
-    b.make();
+    b.data->build_raptor();
     auto res = compute("20190101T073000", "stop_point:A", "stop_point:G");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
@@ -3130,7 +3130,7 @@ BOOST_FIXTURE_TEST_CASE(flags_block_new_trip, AddTripDataset) {
     // call function with is_realtime_add_enabled=false
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, false, true);
-    b.make();
+    b.data->build_raptor();
     res = compute("20190101T073000", "stop_point:A", "stop_point:G");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
@@ -3140,7 +3140,7 @@ BOOST_FIXTURE_TEST_CASE(flags_block_new_trip, AddTripDataset) {
     // call function with is_realtime_add_trip_enabled=false
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, false);
-    b.make();
+    b.data->build_raptor();
     res = compute("20190101T073000", "stop_point:A", "stop_point:G");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
@@ -3185,7 +3185,7 @@ BOOST_FIXTURE_TEST_CASE(company_id_doesnt_exist_in_new_trip, AddTripDataset) {
 
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
-    b.make();
+    b.data->build_raptor();
     auto res = compute("20190101T073000", "stop_point:A", "stop_point:J");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
@@ -3228,7 +3228,7 @@ BOOST_FIXTURE_TEST_CASE(physical_mode_id_doesnt_exist_in_new_trip, AddTripDatase
 
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
-    b.make();
+    b.data->build_raptor();
     auto res = compute("20190101T073000", "stop_point:A", "stop_point:J");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1030,14 +1030,8 @@ BOOST_AUTO_TEST_CASE(add_delays_and_back_to_normal) {
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).departure_date_time(), "20190101T090000"_pts);
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).stop_point().uri(), "stop2");
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).type(), pbnavitia::PUBLIC_TRANSPORT);
-    // impact
-    BOOST_CHECK_EQUAL(res.impacts_size(), 1);
-    BOOST_CHECK_EQUAL(res.impacts(0).uri(), "feed-1");
-    BOOST_CHECK_EQUAL(res.impacts(0).severity().effect(), pbnavitia::Severity_Effect_UNKNOWN_EFFECT);
-    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects_size(), 1);
-    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops_size(), 2);
-    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(0).departure_status(), pbnavitia::StopTimeUpdateStatus::UNCHANGED);
-    BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(1).departure_status(), pbnavitia::StopTimeUpdateStatus::UNCHANGED);
+    // Unknown effect impact is only with disruption API
+    BOOST_CHECK_EQUAL(res.impacts_size(), 0);
 }
 
 /* testing a vj delayed to the day after (1 day late)

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2997,7 +2997,7 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
             RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
             RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
         },
-        comp_uri,
+        "comp_uri_2",
         "physical_mode_id_new_trip_2",
         transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
     navitia::handle_realtime("feed-2", timestamp, new_trip_2, *b.data, true, true);
@@ -3017,8 +3017,9 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
 
     // new VJ
     vj = pt_data.vehicle_journeys_map["vj_new_trip_2:modified:0:feed-2"];
-    BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
-    BOOST_CHECK_EQUAL(vj->company->name, comp_name);
+    // Can't access to company because the field is null...
+    // BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
+    // BOOST_CHECK_EQUAL(vj->company->name, comp_name);
     BOOST_CHECK_EQUAL(vj->uri, "vj_new_trip_2:modified:0:feed-2");
     BOOST_CHECK_EQUAL(vj->idx, 2);
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip_2");

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2823,7 +2823,7 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).type(), pbnavitia::PUBLIC_TRANSPORT);
     BOOST_CHECK_EQUAL(res.impacts_size(), 0);
 
-    // For the moment, trip from A to G no exists
+    // For the moment, trip from A to G doesn't exist
     res = compute("20190101T073000", "stop_point:A", "stop_point:G");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
@@ -3006,7 +3006,7 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
 
 
-    // If the company id doesn't exist inside the data, we reject teh new trip
+    // If the company id doesn't exist inside the data, we reject the new trip
     transit_realtime::TripUpdate new_trip_2 = ntest::make_delay_message("vj_new_trip_2",
         "20190101",
         {
@@ -3041,7 +3041,7 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
         "physical_mode_id_that_doesnt_exist",
         transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
 
-    // the new trip update is blocked directly
+    // The new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
     b.make();
     res = compute("20190101T073000", "stop_point:A", "stop_point:J");
@@ -3065,7 +3065,7 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     navitia::handle_realtime("feed-2", timestamp, new_trip_2, *b.data, true, true);
     b.make();
 
-    //Check if meta vj exist
+    // Check if meta vj exist
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.size(), 3);
     mvj = pt_data.meta_vjs.get_mut("vj_new_trip_2");
     BOOST_CHECK_EQUAL(mvj->get_label(), "vj_new_trip_2");
@@ -3077,11 +3077,12 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys_map.size(), 3);
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 3);
 
-    // new VJ
+    // New VJ
     vj = pt_data.vehicle_journeys_map["vj_new_trip_2:modified:0:feed-2"];
-    // Can't access to company because the field is null...
-    // BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
-    // BOOST_CHECK_EQUAL(vj->company->name, comp_name);
+    BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
+    BOOST_CHECK_EQUAL(vj->company->name, comp_name);
+    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
     BOOST_CHECK_EQUAL(vj->uri, "vj_new_trip_2:modified:0:feed-2");
     BOOST_CHECK_EQUAL(vj->idx, 2);
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip_2");

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2938,6 +2938,18 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     // Recall the same new trip.
     // The old "new trip" is replace by the new, but the meta VJ is the same (don't create).
     // The old impact is suppress too
+    // To show that it is the new GTFS-RT, schedules has changed
+    new_trip = ntest::make_delay_message("vj_new_trip",
+        "20190101",
+        {
+            RTStopTime("stop_point:A", "20190101T0900"_pts).added(),
+            RTStopTime("stop_point:E", "20190101T0930"_pts).added(),
+            RTStopTime("stop_point:F", "20190101T1000"_pts).added(),
+            RTStopTime("stop_point:G", "20190101T1030"_pts).added(),
+        },
+        comp_uri,
+        "physical_mode_id_new_trip",
+        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
     b.make();
 
@@ -2965,13 +2977,13 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 4);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(0).departure_date_time(), "20190101T080000"_pts);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(0).departure_date_time(), "20190101T090000"_pts);
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(0).stop_point().uri(), "stop_point:A");
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).departure_date_time(), "20190101T083000"_pts);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).departure_date_time(), "20190101T093000"_pts);
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).stop_point().uri(), "stop_point:E");
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).departure_date_time(), "20190101T090000"_pts);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).departure_date_time(), "20190101T100000"_pts);
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).stop_point().uri(), "stop_point:F");
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(3).departure_date_time(), "20190101T093000"_pts);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(3).departure_date_time(), "20190101T103000"_pts);
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(3).stop_point().uri(), "stop_point:G");
     BOOST_CHECK_EQUAL(res.journeys(0).sections(0).type(), pbnavitia::PUBLIC_TRANSPORT);
     // impact

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2907,6 +2907,8 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     vj = pt_data.vehicle_journeys_map["vj_new_trip:modified:0:feed-1"];
     BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
     BOOST_CHECK_EQUAL(vj->company->name, comp_name);
+    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
     BOOST_CHECK_EQUAL(vj->uri, "vj_new_trip:modified:0:feed-1");
     BOOST_CHECK_EQUAL(vj->idx, 1);
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip");

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -258,6 +258,7 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
                     RTStopTime("stop1", "20150928T0810"_pts).delay(9_min),
                     RTStopTime("stop2", "20150928T0910"_pts).delay(9_min)
             },
+            transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS,
             comp_id_1);
     b.data->build_uri();
 
@@ -1954,7 +1955,8 @@ BOOST_AUTO_TEST_CASE(train_delayed_and_on_time) {
                     RTStopTime("C", "20150928T1000"_pts).delay(0_min),
                     RTStopTime("D", "20150928T1105"_pts).delay(5_min),
                     RTStopTime("E", "20150928T1200"_pts).delay(0_min)
-            });
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS);
     b.data->build_uri();
 
     navitia::handle_realtime("bob", timestamp, trip_update, *b.data, true, true);
@@ -2191,7 +2193,8 @@ BOOST_AUTO_TEST_CASE(add_new_stop_time_in_the_trip) {
                     RTStopTime("stop_point:B", "20171101T0830"_pts),
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).added(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
-            });
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE);
 
     navitia::handle_realtime("add_new_stop_time_in_the_trip", timestamp, just_new_stop, *b.data, true, true);
 
@@ -2350,7 +2353,8 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
                     RTStopTime("stop_point:B", "20171101T0830"_pts),
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).skipped(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
-            });
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_DETOUR);
 
     navitia::handle_realtime("feed-2", timestamp, delete_new_stop, *b.data, true, true);
 
@@ -2390,7 +2394,8 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
                     RTStopTime("stop_point:B", "20171101T0830"_pts),
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).skipped(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
-            });
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_DETOUR);
 
     navitia::handle_realtime("feed-3", timestamp, redelete_stop, *b.data, true, true);
     b.make();
@@ -2468,8 +2473,8 @@ BOOST_AUTO_TEST_CASE(add_new_and_delete_existingstop_time_in_the_trip_for_detour
                     RTStopTime("stop_point:B", "20171101T0830"_pts).deleted_for_detour(),
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).added_for_detour(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
-            });
-
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_DETOUR);
     navitia::handle_realtime("add_new_and_delete_existingstop_time_in_the_trip_for_detour", timestamp, just_new_stop, *b.data, true, true);
 
     b.make();
@@ -2555,7 +2560,8 @@ BOOST_AUTO_TEST_CASE(add_new_with_earlier_arrival_and_delete_existingstop_time_i
                     RTStopTime("stop_point:B", "20171101T0830"_pts).deleted_for_detour(),
                     RTStopTime("stop_point:B_bis", "20171101T0825"_pts).added_for_detour(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
-            });
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_DETOUR);
 
     navitia::handle_realtime("add_new_and_delete_existingstop_time_in_the_trip_for_detour", timestamp, just_new_stop, *b.data, true, true);
 
@@ -2872,9 +2878,9 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip, AddTripDataset) {
             RTStopTime("stop_point:F", "20190101T0900"_pts).added(),
             RTStopTime("stop_point:G", "20190101T0930"_pts).added(),
         },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE,
         comp_uri,
-        phy_mode_uri,
-        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
+        phy_mode_uri);
 
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
     b.data->build_raptor();
@@ -2962,9 +2968,9 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip, AddTripDataset) {
             RTStopTime("stop_point:F", "20190101T1000"_pts).added(),
             RTStopTime("stop_point:G", "20190101T1030"_pts).added(),
         },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE,
         comp_uri,
-        phy_mode_uri,
-        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
+        phy_mode_uri);
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
     b.data->build_raptor();
 
@@ -3022,9 +3028,9 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip, AddTripDataset) {
             RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
             RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
         },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE,
         comp_uri,
-        phy_mode_uri,
-        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
+        phy_mode_uri);
     navitia::handle_realtime("feed-2", timestamp, new_trip_2, *b.data, true, true);
     b.data->build_raptor();
 
@@ -3113,9 +3119,9 @@ BOOST_FIXTURE_TEST_CASE(flags_block_new_trip, AddTripDataset) {
             RTStopTime("stop_point:F", "20190101T0900"_pts).added(),
             RTStopTime("stop_point:G", "20190101T0930"_pts).added(),
         },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE,
         comp_uri,
-        phy_mode_uri,
-        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
+        phy_mode_uri);
 
     // call function with is_realtime_add_enabled=false and is_realtime_add_trip_enabled=false
     // the new trip update is blocked directly
@@ -3179,9 +3185,9 @@ BOOST_FIXTURE_TEST_CASE(company_id_doesnt_exist_in_new_trip, AddTripDataset) {
             RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
             RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
         },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE,
         "company_id_that_doesnt_exist",
-        phy_mode_uri,
-        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
+        phy_mode_uri);
 
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
@@ -3222,9 +3228,9 @@ BOOST_FIXTURE_TEST_CASE(physical_mode_id_doesnt_exist_in_new_trip, AddTripDatase
             RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
             RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
         },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE,
         comp_uri,
-        "physical_mode_id_that_doesnt_exist",
-        transit_realtime::TripDescriptor_ScheduleRelationship_ADDED);
+        "physical_mode_id_that_doesnt_exist");
 
     // the new trip update is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2817,8 +2817,6 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
 
 
-
-
     transit_realtime::TripUpdate new_trip = ntest::make_delay_message("vj_new_trip",
         "20190101",
         {
@@ -2860,8 +2858,6 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.size(), 1);
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_new_trip"), false);
-
-
 
 
     // New call with all activation parameter = true
@@ -2931,8 +2927,6 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(1).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(2).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
-
-
 
 
     // Recall the same new trip.
@@ -3085,6 +3079,5 @@ BOOST_AUTO_TEST_CASE(add_new_trip) {
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(1).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(2).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(3).departure_status(), pbnavitia::StopTimeUpdateStatus::ADDED);
-
 }
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2796,7 +2796,7 @@ struct AddTripDataset {
         b.data->pt_data->contributors.push_back(contributor);
         b.data->pt_data->contributors_map[contributor->uri] = contributor;
 
-        // Add data set
+        // Add dataset
         dataset_name = "dataset_name";
         dataset_uri = "dataset_uri";
         navitia::type::Dataset * dataset = new navitia::type::Dataset();

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2355,7 +2355,7 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).skipped(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
             },
-            transit_realtime::Alert_Effect::Alert_Effect_DETOUR);
+            transit_realtime::Alert_Effect::Alert_Effect_REDUCED_SERVICE);
 
     navitia::handle_realtime("feed-2", timestamp, delete_new_stop, *b.data, true, true);
 
@@ -2375,7 +2375,7 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
     BOOST_CHECK_EQUAL(res.impacts_size(), 2);
     for (const auto& impact: res.impacts()) {
         if (impact.uri() == "feed-2") {
-            BOOST_CHECK_EQUAL(impact.severity().effect(), pbnavitia::Severity_Effect_DETOUR);
+            BOOST_CHECK_EQUAL(impact.severity().effect(), pbnavitia::Severity_Effect_REDUCED_SERVICE);
             BOOST_CHECK_EQUAL(impact.impacted_objects(0).impacted_stops(2).is_detour(), false);
             BOOST_CHECK_EQUAL(impact.impacted_objects(0).impacted_stops(2).departure_status(), pbnavitia::StopTimeUpdateStatus::DELETED);
         }
@@ -2396,7 +2396,7 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).skipped(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
             },
-            transit_realtime::Alert_Effect::Alert_Effect_DETOUR);
+            transit_realtime::Alert_Effect::Alert_Effect_REDUCED_SERVICE);
 
     navitia::handle_realtime("feed-3", timestamp, redelete_stop, *b.data, true, true);
     b.make();
@@ -2411,7 +2411,7 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
     BOOST_CHECK_EQUAL(res.impacts_size(), 3);
     for (const auto& impact: res.impacts()) {
         if (impact.uri() == "feed-3") {
-            BOOST_CHECK_EQUAL(impact.severity().effect(), pbnavitia::Severity_Effect_DETOUR);
+            BOOST_CHECK_EQUAL(impact.severity().effect(), pbnavitia::Severity_Effect_REDUCED_SERVICE);
             BOOST_CHECK_EQUAL(impact.impacted_objects(0).impacted_stops(2).is_detour(), false);
             BOOST_CHECK_EQUAL(impact.impacted_objects(0).impacted_stops(2).departure_status(), pbnavitia::StopTimeUpdateStatus::DELETED);
         }

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2311,7 +2311,8 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
                     RTStopTime("stop_point:B", "20171101T0830"_pts),
                     RTStopTime("stop_point:B_bis", "20171101T0845"_pts).added(),
                     RTStopTime("stop_point:C", "20171101T0900"_pts),
-            });
+            },
+            transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE);
 
     navitia::handle_realtime("feed-1", timestamp, just_new_stop, *b.data, true, true);
 

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -69,9 +69,13 @@ make_delay_message(const std::string& vj_uri,
     transit_realtime::TripUpdate trip_update;
     auto trip = trip_update.mutable_trip();
     trip->set_trip_id(vj_uri);
-    trip->SetExtension(kirin::company_id, company_id);
+    if (company_id != "") {
+        trip->SetExtension(kirin::company_id, company_id);
+    }
     auto vehicle_descriptor = trip_update.mutable_vehicle();
-    vehicle_descriptor->SetExtension(kirin::physical_mode_id, physical_mode_id);
+    if (physical_mode_id != "") {
+        vehicle_descriptor->SetExtension(kirin::physical_mode_id, physical_mode_id);
+    }
     // start_date is used to disambiguate trips that are very late, cf:
     // https://github.com/CanalTP/chaos-proto/blob/master/gtfs-realtime.proto#L459
     trip->set_start_date(start_date);

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -21,7 +21,7 @@ inline void handle_realtime_test(const std::string& id,
                                  const transit_realtime::TripUpdate& trip_update,
                                  const type::Data& data,
                                  std::unique_ptr<navitia::routing::RAPTOR>& raptor) {
-    navitia::handle_realtime(id, timestamp, trip_update, data, true, true);
+    navitia::handle_realtime(id, timestamp, trip_update, data,true);
     data.dataRaptor->load(*data.pt_data);
     raptor = std::make_unique<navitia::routing::RAPTOR>(data);
 }
@@ -62,15 +62,20 @@ inline transit_realtime::TripUpdate
 make_delay_message(const std::string& vj_uri,
         const std::string& start_date,
         const std::vector<RTStopTime>& delayed_time_stops,
-        const std::string& company_id = "") {
+        const std::string& company_id = "",
+        const std::string& physical_mode_id = "",
+        const transit_realtime::TripDescriptor_ScheduleRelationship effect = transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED)
+{
     transit_realtime::TripUpdate trip_update;
     auto trip = trip_update.mutable_trip();
     trip->set_trip_id(vj_uri);
     trip->SetExtension(kirin::company_id, company_id);
+    auto vehicle_descriptor = trip_update.mutable_vehicle();
+    vehicle_descriptor->SetExtension(kirin::physical_mode_id, physical_mode_id);
     // start_date is used to disambiguate trips that are very late, cf:
     // https://github.com/CanalTP/chaos-proto/blob/master/gtfs-realtime.proto#L459
     trip->set_start_date(start_date);
-    trip->set_schedule_relationship(transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED);
+    trip->set_schedule_relationship(effect);
     auto st_update = trip_update.mutable_stop_time_update();
 
     for (const auto& delayed_st: delayed_time_stops) {

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -62,7 +62,7 @@ inline transit_realtime::TripUpdate
 make_delay_message(const std::string& vj_uri,
         const std::string& start_date,
         const std::vector<RTStopTime>& delayed_time_stops,
-        const transit_realtime::Alert_Effect effect = transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE,
+        const transit_realtime::Alert_Effect effect = transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS,
         const std::string& company_id = "",
         const std::string& physical_mode_id = "")
 {
@@ -80,7 +80,6 @@ make_delay_message(const std::string& vj_uri,
     // start_date is used to disambiguate trips that are very late, cf:
     // https://github.com/CanalTP/chaos-proto/blob/master/gtfs-realtime.proto#L459
     trip->set_start_date(start_date);
-    trip->set_schedule_relationship(transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED);
     auto st_update = trip_update.mutable_stop_time_update();
 
     for (const auto& delayed_st: delayed_time_stops) {

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -62,11 +62,12 @@ inline transit_realtime::TripUpdate
 make_delay_message(const std::string& vj_uri,
         const std::string& start_date,
         const std::vector<RTStopTime>& delayed_time_stops,
+        const transit_realtime::Alert_Effect effect = transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE,
         const std::string& company_id = "",
-        const std::string& physical_mode_id = "",
-        const transit_realtime::TripDescriptor_ScheduleRelationship effect = transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED)
+        const std::string& physical_mode_id = "")
 {
     transit_realtime::TripUpdate trip_update;
+    trip_update.SetExtension(kirin::effect, effect);
     auto trip = trip_update.mutable_trip();
     trip->set_trip_id(vj_uri);
     if (company_id != "") {
@@ -79,7 +80,7 @@ make_delay_message(const std::string& vj_uri,
     // start_date is used to disambiguate trips that are very late, cf:
     // https://github.com/CanalTP/chaos-proto/blob/master/gtfs-realtime.proto#L459
     trip->set_start_date(start_date);
-    trip->set_schedule_relationship(effect);
+    trip->set_schedule_relationship(transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED);
     auto st_update = trip_update.mutable_stop_time_update();
 
     for (const auto& delayed_st: delayed_time_stops) {

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -21,7 +21,7 @@ inline void handle_realtime_test(const std::string& id,
                                  const transit_realtime::TripUpdate& trip_update,
                                  const type::Data& data,
                                  std::unique_ptr<navitia::routing::RAPTOR>& raptor) {
-    navitia::handle_realtime(id, timestamp, trip_update, data,true);
+    navitia::handle_realtime(id, timestamp, trip_update, data, true, true);
     data.dataRaptor->load(*data.pt_data);
     raptor = std::make_unique<navitia::routing::RAPTOR>(data);
 }

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -61,7 +61,7 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace type {
 
-const unsigned int Data::data_version = 69; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 70; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -61,7 +61,7 @@ namespace pt = boost::posix_time;
 
 namespace navitia { namespace type {
 
-const unsigned int Data::data_version = 70; //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 69; //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier) :
     _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -170,7 +170,9 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
 
 bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
     // No delay on the section
-    if (severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS && ! aux_info.stop_times.empty()) {
+    if ((severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS
+            || severity->effect == nt::disruption::Effect::UNKNOWN_EFFECT)
+        && ! aux_info.stop_times.empty()) {
         // We don't handle removed or added stop, but we already match
         // on SIGNIFICANT_DELAYS, thus we should not have that here
         // (removed and added stop should be a DETOUR)

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -170,7 +170,8 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
 
 bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
     // No delay on the section
-    if (severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS
+    if ((severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS ||
+         severity->effect == nt::disruption::Effect::UNKNOWN_EFFECT)
          && ! aux_info.stop_times.empty()) {
         // We don't handle removed or added stop, but we already match
         // on SIGNIFICANT_DELAYS, thus we should not have that here

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -39,8 +39,8 @@ www.navitia.io
 namespace pt = boost::posix_time;
 namespace bg = boost::gregorian;
 
-namespace navitia { 
-namespace type { 
+namespace navitia {
+namespace type {
 namespace disruption {
 
 std::vector<ImpactedVJ>
@@ -170,9 +170,8 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date, const bo
 
 bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
     // No delay on the section
-    if ((severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS
-            || severity->effect == nt::disruption::Effect::UNKNOWN_EFFECT)
-        && ! aux_info.stop_times.empty()) {
+    if (severity->effect == nt::disruption::Effect::SIGNIFICANT_DELAYS
+         && ! aux_info.stop_times.empty()) {
         // We don't handle removed or added stop, but we already match
         // on SIGNIFICANT_DELAYS, thus we should not have that here
         // (removed and added stop should be a DETOUR)

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -283,6 +283,7 @@ struct Impact {
     using SharedImpact = boost::shared_ptr<Impact>;
     std::string uri;
     std::string company_id;
+    std::string physical_mode_id;
     boost::posix_time::ptime created_at;
     boost::posix_time::ptime updated_at;
 
@@ -303,7 +304,7 @@ struct Impact {
 
     template<class Archive>
     void serialize(Archive& ar, const unsigned int) {
-        ar & uri & company_id & created_at & updated_at & application_periods
+        ar & uri & company_id & physical_mode_id & created_at & updated_at & application_periods
            & severity & _informed_entities & messages & disruption
            & aux_info;
     }


### PR DESCRIPTION
**Remains to be done** :

- [x] Add physical mode into new vj + test, **JIRA** : https://jira.kisio.org/browse/NAVP-1065
- [x] Add company into new vj + test, **DONE**

**Tests cover**
- Add new meta VJ mechanism
- Add new VJ mechanism
- Activation flags mechanism (is_realtime_add_enabled, is_realtime_add_trip_enable)
- Check impacts
- Check new journey
- Tests when you send the same GTFS-RT twice
- Test adding 2 different GTFS-RT
- Reject GTFS-RT if company id doesn't match
- Reject GTFS-RT if physical mode id doesn't match

**JIRA** 
- https://jira.kisio.org/browse/NAVP-1066
- https://jira.kisio.org/browse/NAVP-1067 (added part)

**Warning**
- now, if you can't match the _company id_ in GTFS-RT with the company inside Kraken data, there is just a log to inform you (Add inside prometheus probe is better I think). In fact, in this case, this is very dangerous to acces to the company field of the VJ _new trip_ (Example: vj->company->uri) because it is a NULL ptr... It is memory access violation behavior
**Solution** In this case, our choice is to _reject the GTFS-RT new trip_. **DONE** see test
Same technic is used for physical mode id. **DONE** see test