### PR TITLE
cities: handle case where insee or post_code is NULL

### DIFF
--- a/source/cities/alembic/versions/1d99ba678e3f_add_constraints.py
+++ b/source/cities/alembic/versions/1d99ba678e3f_add_constraints.py
@@ -1,0 +1,26 @@
+"""Add constraints
+
+Revision ID: 1d99ba678e3f
+Revises: c2373c7750f
+Create Date: 2019-03-05 07:44:17.703306
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1d99ba678e3f'
+down_revision = 'c2373c7750f'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column("administrative_regions", "level", nullable=False)
+    op.alter_column("administrative_regions", "boundary", nullable=False)
+    op.alter_column("administrative_regions", "coord", nullable=False)
+
+
+def downgrade():
+    op.alter_column("administrative_regions", "level", nullable=True)
+    op.alter_column("administrative_regions", "boundary", nullable=True)
+    op.alter_column("administrative_regions", "coord", nullable=True)

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -118,7 +118,7 @@ struct FindAdminWithCities {
         if (!georef_res.empty()) {++nb_georef; return georef_res;}
 
         std::stringstream request;
-        request << "SELECT uri, name, insee, level, post_code, "
+        request << "SELECT uri, name, coalesce(insee, '') as insee, level, coalesce(post_code, '') as post_code, "
                 << "ST_X(coord::geometry) as lon, ST_Y(coord::geometry) as lat "
                 << "FROM administrative_regions "
                 << "WHERE ST_DWithin(ST_GeographyFromText('POINT("


### PR DESCRIPTION
Also update cities schema to require a level, coord and boundary.
Cities and cosmogony2cities already fill them, it's just to be safe