### PR TITLE
Kraken: fix disruption deletion when multiple impacts impacting the same vj

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -579,10 +579,18 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
 
         for(const auto& wptr: modified_by_moved) {
             if (auto share_ptr = wptr.lock()){
-                // Do not reapply the same disruption. If we have more than one impact we will
-                // reapply the one we just deleted.
-                // We need to keep the link though, because other impacts from the disruption may
-                // need to be deleted after this one and they need to stay in modified_by.
+                /*
+                 * Do not reapply the same disruption. If we have more than one impact in it
+                 * we would reapply all of its impacts (even the one we are deleting).
+                 * We need to keep the link to remaining impacts of the disruption though, because
+                 * they will be deleted after this one. They must stay in modified_by for that.
+                 *
+                 * /!\ WARNING /!\
+                 * This is working because we never delete a single impact of a disruption.
+                 * delete_impact is only called by delete_disruption which delete every impacts.
+                 * If this was not the case we would need to find a way to reapply part of a
+                 * disruption's impacts, and not all of them, after each deletion of an impact.
+                 */
                 if (share_ptr->disruption->uri != impact->disruption->uri) {
                     disruptions_collection.insert(share_ptr);
                 } else {

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -579,7 +579,15 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
 
         for(const auto& wptr: modified_by_moved) {
             if (auto share_ptr = wptr.lock()){
-                disruptions_collection.insert(share_ptr);
+                // Do not reapply the same disruption. If we have more than one impact we will
+                // reapply the one we just deleted.
+                // We need to keep the link though, because other impacts from the disruption may
+                // need to be deleted after this one and they need to stay in modified_by.
+                if (share_ptr->disruption->uri != impact->disruption->uri) {
+                    disruptions_collection.insert(share_ptr);
+                } else {
+                    mvj->push_unique_impact(share_ptr);
+                }
             }
         }
         // we check if we now have useless vehicle_journeys to cleanup

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2396,7 +2396,7 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
 }
 
 // We check that with a disruption with two impacts impacting the same vj the update is working.
-// It was failing before since after deleting each impact, we were reapplying the all disruption.
+// It was failing before since after deleting each impact, we were reapplying the disruption.
 BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_same_vj) {
     ed::builder b("20190301");
 
@@ -2413,11 +2413,7 @@ BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_same_vj) {
             ("stop_point:40", "13:00"_t)
             ("stop_point:50", "14:00"_t);
 
-    b.generate_dummy_basis();
-    b.finish();
-    b.data->pt_data->sort_and_index();
-    b.data->build_raptor();
-    b.data->build_uri();
+    b.make();
     b.data->meta->production_date = bg::date_period("20190301"_d, 7_days);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
@@ -2506,11 +2502,7 @@ BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_different_vj) {
             ("stop_point:20", "13:00"_t)
             ("stop_point:10", "14:00"_t);
 
-    b.generate_dummy_basis();
-    b.finish();
-    b.data->pt_data->sort_and_index();
-    b.data->build_raptor();
-    b.data->build_uri();
+    b.make();
     b.data->meta->production_date = bg::date_period("20190301"_d, 7_days);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2394,3 +2394,181 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
             ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00000000"),
             rt_vj1->rt_validity_pattern()->days);
 }
+
+// We check that with a disruption with two impacts impacting the same vj the update is working.
+// It was failing before since after deleting each impact, we were reapplying the all disruption.
+BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_same_vj) {
+    ed::builder b("20190301");
+
+    b.sa("stop_area:1", 0, 0, false, true)("stop_point:10");
+    b.sa("stop_area:2", 0, 0, false, true)("stop_point:20");
+    b.sa("stop_area:3", 0, 0, false, true)("stop_point:30");
+    b.sa("stop_area:4", 0, 0, false, true)("stop_point:40");
+    b.sa("stop_area:5", 0, 0, false, true)("stop_point:50");
+
+    b.vj("line:A", "1111111", "", true, "vj:1")
+            ("stop_point:10", "10:00"_t)
+            ("stop_point:20", "11:00"_t)
+            ("stop_point:30", "12:00"_t)
+            ("stop_point:40", "13:00"_t)
+            ("stop_point:50", "14:00"_t);
+
+    b.generate_dummy_basis();
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    b.data->meta->production_date = bg::date_period("20190301"_d, 7_days);
+
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 0);
+
+    auto dis_builder = b.disrupt(nt::RTLevel::Adapted, "line_section_on_line:A_two_stops_in_two_impacts");
+    dis_builder.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:2", {"line:A:0"});
+
+    dis_builder.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:4", "stop_area:4", {"line:A:0"});
+
+    navitia::apply_disruption(dis_builder.disruption, *b.data->pt_data, *b.data->meta);
+
+    // There should be only one more vj
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
+    // And the base vj:1 should have 2 impacts
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 2);
+
+    const auto* disruption = b.data->pt_data->disruption_holder.get_disruption("line_section_on_line:A_two_stops_in_two_impacts");
+    BOOST_REQUIRE(disruption != nullptr);
+    BOOST_REQUIRE_EQUAL(disruption->get_impacts().size(), 2);
+
+    navitia::delete_disruption("line_section_on_line:A_two_stops_in_two_impacts", *b.data->pt_data, *b.data->meta);
+
+    // Once again one vj after deletion. This was failing, we were reapplying the disruption and an adapted vj was kept
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
+    // No more impacts
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 0);
+
+    // Can't reuse the same disruption since the memory has been freed.
+    auto dis_builder_update = b.disrupt(nt::RTLevel::Adapted, "line_section_on_line:A_two_stops_in_two_impacts");
+    dis_builder_update.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:2", {"line:A:0"});
+
+    dis_builder_update.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:4", "stop_area:4", {"line:A:0"});
+
+    navitia::apply_disruption(dis_builder_update.disruption, *b.data->pt_data, *b.data->meta);
+
+    // There should be only one more vj again
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
+    // This was failing too since the impact was not able to be applied again. We were getting 0.
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 2);
+
+    disruption = b.data->pt_data->disruption_holder.get_disruption("line_section_on_line:A_two_stops_in_two_impacts");
+    BOOST_REQUIRE(disruption != nullptr);
+    BOOST_REQUIRE_EQUAL(disruption->get_impacts().size(), 2);
+
+    navitia::delete_disruption("line_section_on_line:A_two_stops_in_two_impacts", *b.data->pt_data, *b.data->meta);
+
+    // Once again one vj after deletion. This was failing, we were reapplying the disruption
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 0);
+}
+
+// Same kind of test but applying to two differents VJ
+BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_different_vj) {
+    ed::builder b("20190301");
+
+    b.sa("stop_area:1", 0, 0, false, true)("stop_point:10");
+    b.sa("stop_area:2", 0, 0, false, true)("stop_point:20");
+    b.sa("stop_area:3", 0, 0, false, true)("stop_point:30");
+    b.sa("stop_area:4", 0, 0, false, true)("stop_point:40");
+    b.sa("stop_area:5", 0, 0, false, true)("stop_point:50");
+
+    b.vj("line:A", "1111111", "", true, "vj:1")
+            ("stop_point:10", "10:00"_t)
+            ("stop_point:20", "11:00"_t)
+            ("stop_point:30", "12:00"_t)
+            ("stop_point:40", "13:00"_t)
+            ("stop_point:50", "14:00"_t);
+
+    b.vj("line:A", "1111111", "", true, "vj:2").route("line:A:1")
+            ("stop_point:50", "10:00"_t)
+            ("stop_point:40", "11:00"_t)
+            ("stop_point:30", "12:00"_t)
+            ("stop_point:20", "13:00"_t)
+            ("stop_point:10", "14:00"_t);
+
+    b.generate_dummy_basis();
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->build_uri();
+    b.data->meta->production_date = bg::date_period("20190301"_d, 7_days);
+
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:2")->get_impacts().size(), 0);
+
+    auto dis_builder = b.disrupt(nt::RTLevel::Adapted, "line_section_on_line:A_section_in_each_way");
+    dis_builder.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:4", {"line:A:0"});
+
+    dis_builder.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:4", "stop_area:2", {"line:A:1"});
+
+    navitia::apply_disruption(dis_builder.disruption, *b.data->pt_data, *b.data->meta);
+
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 4);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:2")->get_impacts().size(), 1);
+
+    const auto* disruption = b.data->pt_data->disruption_holder.get_disruption("line_section_on_line:A_section_in_each_way");
+    BOOST_REQUIRE(disruption != nullptr);
+    BOOST_REQUIRE_EQUAL(disruption->get_impacts().size(), 2);
+
+    navitia::delete_disruption("line_section_on_line:A_section_in_each_way", *b.data->pt_data, *b.data->meta);
+
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:2")->get_impacts().size(), 0);
+
+    // Can't reuse the same disruption since the memory has been freed.
+    auto dis_builder_update = b.disrupt(nt::RTLevel::Adapted, "line_section_on_line:A_section_in_each_way");
+    dis_builder_update.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:4", {"line:A:0"});
+
+    dis_builder_update.impact()
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
+            .on_line_section("line:A", "stop_area:4", "stop_area:2", {"line:A:1"});
+
+    navitia::apply_disruption(dis_builder_update.disruption, *b.data->pt_data, *b.data->meta);
+
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 4);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:2")->get_impacts().size(), 1);
+
+    disruption = b.data->pt_data->disruption_holder.get_disruption("line_section_on_line:A_section_in_each_way");
+    BOOST_REQUIRE(disruption != nullptr);
+    BOOST_REQUIRE_EQUAL(disruption->get_impacts().size(), 2);
+
+    navitia::delete_disruption("line_section_on_line:A_section_in_each_way", *b.data->pt_data, *b.data->meta);
+
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:1")->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys_map.at("vj:2")->get_impacts().size(), 0);
+}


### PR DESCRIPTION
Hello.

We found a bug disruptions when multiple impacts are in the same disruption and are impacting the same meta_vj.
If we have a disruption D with two impacts I1 and I2, both impacting VJ what was happening was :
1. First application of D
  - I1 is applied, we are creating a new VJ VJ:Adapted:0.
  - I2 is applied, we are creating a new VJ VJ:Adapted:0:Adapted:1. VJ:Adapted:0 is useless and cleaned.
2. Deletion of D
  - I1 is deleted. We are deleting VJ:Adapted:0:Adapted:1. We detect that another impact was on this VJ, I2 so we keep the disruption D in a list to reapply it at the end.
  - We are applying D again. Both I1 and I2 are reapplied. We have VJ:Adapted:0:Adapted:1 again.
  - I2 is deleted. Same thing happen because I1 is still linked since we just applied it.
  - We are applying D again. We have VJ:Adapted:0:Adapted:1.

Things are pretty strange then. We have two VJ, VJ and VJ:Adapted:0:Adapted:1. The disruption was deleted so VJ has no impact left. VJ:Adapted:0:Adapted:1 still exists with the adapted validity pattern.

If we try to apply the disruption another time it fails, since we don't find any vj to impact (if it's an unserved stop between two dates, VJ:Adapted:0:Adapted:1 is still active between those two dates and don't serve this stop).

I made a test with some comments, it might be easier to understand :).

My fix is pretty simple. When we are deleting an impact, don't reapply the disruption if another impact is still in the modified_by of the meta_vj, if it's the same disruption uri.
We still need to keep the other impact in modified_by though, because we will be deleting it just after and the delete_impacts_visitor look inside modified_by to see which vj must be processed. So I just insert the impact back in modified_by.
It works, because we don't delete an impact without deleting the complete disruption. If this was to change we would need to do something smarter.

Let me know what you think and if you have better ideas on how to fix this !