### PR TITLE
Fix empty distances returned on /places by Kraken

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -408,8 +408,8 @@ class PlaceSerializer(PbGenericSerializer):
     embedded_type = EnumField(attr='embedded_type', pb_type=NavitiaType, display_none=True)
     address = AddressSerializer(display_none=False)
     poi = PoiSerializer(display_none=False)
-    distance = jsonschema.StrField(
-        required=False, display_none=True, description='Distance to the object in meters'
+    distance = base.PbStrField(
+        required=False, display_none=False, description='Distance to the object in meters'
     )
 
 

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -240,3 +240,13 @@ class TestPlaces(AbstractTestFixture):
         assert len(places) == 1
         is_valid_places(places)
         assert len(response['disruptions']) == 0
+
+    def test_places_has_no_distance(self):
+        """So far, Kraken has no distance returned from its API (as opposed to Bragi)
+        We want to make sure that the distance field isn't returned in the response (as it will be zeroed)"
+        """
+
+        response = self.query_region("places?q=rue ab")
+        places = response['places']
+        assert len(places) == 1
+        assert places[0].has_key('distance') == False


### PR DESCRIPTION
Fix nil distances returned by Kraken on `/places`.

The problem was coming from the protobuf that always allocates a distance as attribute which is never none.... 

[#NAVITIAII-2673](https://jira.kisio.org/browse/NAVITIAII-2673)