### PR TITLE
Plan B for equipment details. We only want it on journeys

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -296,12 +296,6 @@ class PlacesNearby(ResourceUri):
         parser_get.add_argument(
             "disable_disruption", type=BooleanType(), default=False, help="remove disruptions from the response"
         )
-        parser_get.add_argument(
-            "equipment_details",
-            default=False,
-            type=BooleanType(),
-            help="enhance response with accessibility equipement details",
-        )
 
         args = parser_get.parse_args()
         if handle_poi_infos(args["add_poi_infos"], args["bss_stands"]):

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -153,12 +153,6 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "disable_geojson", type=BooleanType(), default=False, help="remove geojson from the response"
         )
-        parser_get.add_argument(
-            "equipment_details",
-            default=False,
-            type=BooleanType(),
-            help="enhance response with accessibility equipement details",
-        )
 
         self.get_decorators.insert(0, ManageError())
         self.get_decorators.insert(1, get_obj_serializer(self))

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -308,12 +308,6 @@ def stop_points(is_collection):
             parser_get.add_argument(
                 "original_id", type=six.text_type, help="original uri of the object you want to query"
             )
-            parser_get.add_argument(
-                "equipment_details",
-                default=False,
-                type=BooleanType(),
-                help="enhance response with accessibility equipement details",
-            )
 
     return StopPoints
 
@@ -329,12 +323,6 @@ def stop_areas(is_collection):
             parser_get = self.parsers["get"]
             parser_get.add_argument(
                 "original_id", type=six.text_type, help="original uri of the object you want to query"
-            )
-            parser_get.add_argument(
-                "equipment_details",
-                default=False,
-                type=BooleanType(),
-                help="enhance response with accessibility equipement details",
             )
 
     return StopAreas


### PR DESCRIPTION
According to @kinnou02, they have a new plan ! Better, bigger, nicer :1st_place_medal: 

We will only display equipment details on `/journeys`. We'll see later for the other ones.

![planB](https://media3.giphy.com/media/3orieLYAq6cD7UuTzW/giphy.gif?cid=3640f6095c8146067a5236762e9a7084)