### PR TITLE
Add equipment details provider configuration mechanism

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -91,6 +91,12 @@ else:
 
     global_autocomplete = {'kraken': Kraken()}
 
+
+from jormungandr.equipments.equipment_provider_manager import EquipmentProviderManager
+
+equipment_provider_manager = EquipmentProviderManager(app.config[str('EQUIPMENT_DETAILS_PROVIDERS')])
+
+
 from jormungandr.instance_manager import InstanceManager
 
 i_manager = InstanceManager(
@@ -111,11 +117,6 @@ bss_provider_manager = init.bss_providers(app)
 from jormungandr.parking_space_availability.car.car_park_provider_manager import CarParkingProviderManager
 
 car_park_provider_manager = CarParkingProviderManager(app.config[str('CAR_PARK_PROVIDER')])
-
-
-from jormungandr.equipments.equipment_provider_manager import EquipmentProviderManager
-
-equipment_provider_manager = EquipmentProviderManager(app.config[str('EQUIPMENT_DETAILS_PROVIDERS')])
 
 
 from jormungandr import api

--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -100,14 +100,22 @@ i_manager = InstanceManager(
 )
 i_manager.initialisation()
 
+
 from jormungandr.stat_manager import StatManager
 
 stat_manager = StatManager()
 
 bss_provider_manager = init.bss_providers(app)
+
+
 from jormungandr.parking_space_availability.car.car_park_provider_manager import CarParkingProviderManager
 
 car_park_provider_manager = CarParkingProviderManager(app.config[str('CAR_PARK_PROVIDER')])
+
+
+from jormungandr.equipments.equipment_provider_manager import EquipmentProviderManager
+
+equipment_provider_manager = EquipmentProviderManager(app.config[str('EQUIPMENT_DETAILS_PROVIDERS')])
 
 
 from jormungandr import api

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -71,11 +71,17 @@ LOGGER = {
 BSS_PROVIDER = []
 # Car parking places availability service
 CAR_PARK_PROVIDER = []
+# Equipment details service configuration
+EQUIPMENT_DETAILS_PROVIDERS = []
+
 for key, value in os.environ.items():
     if key.startswith('JORMUNGANDR_BSS_PROVIDER_'):
         BSS_PROVIDER.append(json.loads(value))
     elif key.startswith('JORMUNGANDR_CAR_PARK_PROVIDER_'):
         CAR_PARK_PROVIDER.append(json.loads(value))
+    elif key.startswith('JORMUNGANDR_EQUIPMENT_DETAILS_PROVIDER_'):
+        EQUIPMENT_DETAILS_PROVIDERS.append(json.loads(value))
+
 
 # Parameters for statistics
 SAVE_STAT = boolean(os.getenv('JORMUNGANDR_SAVE_STAT', False))

--- a/source/jormungandr/jormungandr/equipments/__init__.py
+++ b/source/jormungandr/jormungandr/equipments/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, division

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -44,7 +44,9 @@ class EquipmentProviderManager(object):
         # TODO: create providers instance only if key is present in the Jormungandr instance config ?
         for configuration in equipment_providers_configuration:
             arguments = configuration.get('args', {})
-            self._equipment_providers_legacy[configuration['key']] = self._init_class(configuration['class'], arguments)
+            self._equipment_providers_legacy[configuration['key']] = self._init_class(
+                configuration['class'], arguments
+            )
 
     def _init_class(self, cls, arguments):
         """

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+import logging
+
+
+class EquipmentProviderManager(object):
+    def __init__(self, equipment_providers_configuration):
+        self.logger = logging.getLogger(__name__)
+        self.providers_config = equipment_providers_configuration
+        self.providers = {}
+
+    def get_providers(self, provider_key):
+        """
+        :param provider_key: provider set in instance configuration
+        :return: True if provider key is defined in Jormun configuration
+        """
+        if not any([provider['key'] == provider_key for provider in self.providers_config]):
+            return None
+
+        provider = self.providers.get(provider_key)
+        if not provider:
+            provider = self.providers[provider_key] = self._create_provider(self.providers_config[provider_key])
+
+        return provider
+
+    def _create_provider(self, config):
+        """
+        Create the Equipment Provider class
+        :param config: Configuration of the equipment provider found in the config file
+        :return: provider
+        """
+
+        # TODO: creation of the provider instance will be created in another PR
+        return None
+

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -124,7 +124,6 @@ class Instance(object):
         self.timezone = None  # timezone will be fetched from the kraken
         self.publication_date = -1
         self.is_initialized = False  # kraken hasn't been called yet we don't have geom nor timezone
-        self.equipment_details_providers = []
         self.breaker = pybreaker.CircuitBreaker(
             fail_max=app.config.get(str('CIRCUIT_BREAKER_MAX_INSTANCE_FAIL'), 5),
             reset_timeout=app.config.get(str('CIRCUIT_BREAKER_INSTANCE_TIMEOUT_S'), 60),

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -158,17 +158,8 @@ class Instance(object):
 
         self.zmq_socket_type = zmq_socket_type
 
-        self.equipment_providers = {}
-
-        self.configure_equipment_details_providers(instance_equipment_providers)
-
-    def configure_equipment_details_providers(self, instance_equipment_providers):
-        for provider_key in instance_equipment_providers:
-            provider = equipment_provider_manager.get_providers(provider_key)
-            if provider:
-                self.equipment_providers[provider_key] = provider
-            else:
-                logging.getLogger(__name__).warning("Couldn't find Provider: {}".format(provider))
+        self.equipment_providers_ids = instance_equipment_providers
+        self.equipment_provider_manager = equipment_provider_manager
 
     @property
     def autocomplete(self):

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -108,6 +108,7 @@ class InstanceManager(object):
             config.get('realtime_proxies', []),
             config.get('zmq_socket_type', app.config.get('ZMQ_DEFAULT_SOCKET_TYPE', 'persistent')),
             config.get('default_autocomplete', None),
+            config.get('equipment_details_providers', []),
         )
         self.instances[instance.name] = instance
 

--- a/source/jormungandr/jormungandr/parking_space_availability/abstract_parking_places_provider.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/abstract_parking_places_provider.py
@@ -33,7 +33,7 @@ import six
 
 class AbstractParkingPlacesProvider(six.with_metaclass(ABCMeta, object)):
     """
-    abstract class managing calls to external service providing real-time next passages
+    abstract class managing calls to external service providing real-time parking places info
     """
 
     @abstractmethod


### PR DESCRIPTION
Add preliminary mechanism to Jormun for configuring the Equipment Details Providers !

The idea is to define each provider individually, and refer to them by their keys in the instance config like:
```json
JORMUNGANDR_EQUIPMENT_DETAIL_PROVIDER_SYTRAL = {
	"class": "jormungandr.my.class", 
	"key":"sytral", 
	"args": { "url": "http://blabla.bla", "operators": ["my_operator"], "dataset": "_", "fail_max": 5, "timeout": 1 } 
}
JORMUNGANDR_EQUIPMENT_DETAIL_PROVIDER_OTHER = {
	"class": "jormungandr.my.other.class", 
	"key":"other", 
	"args": {"url": "http://other.blabla.bla", "operators": ["other_op"], "dataset": "_", "fail_max": 5, "timeout": 1 } 
}

JORMUNGANDR_INSTANCE_IDF={
	"key": "IDF", 
	"zmq_socket": "ipc:///tmp/idf_kraken", 
	"equipment_details_providers": [ "sytral", "other" ]
}

```

[#NAVP-1212](https://jira.kisio.org/browse/NAVP-1212)

TODO: Configuration from tyr and then tyr-configurator