### PR TITLE
Kraken: Reject realtime update with bad id in classical mode

### DIFF
--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -629,15 +629,17 @@ void handle_realtime(const std::string& id,
     // Get or create meta VJ
     navitia::type::MetaVehicleJourney* meta_vj = nullptr;
     bool meta_vj_exists = data.pt_data->meta_vjs.exists(trip_update.trip().trip_id());
-    if (! meta_vj_exists && is_added_trip(trip_update)) {
-        LOG4CPLUS_DEBUG(log, "unknown vehicle journey, create Meta VJ " << trip_update.trip().trip_id());
-        meta_vj = data.pt_data->meta_vjs.emplace(trip_update.trip().trip_id());
-        // TODO : pick a meaningful TZ
-        meta_vj->tz_handler = data.pt_data->tz_manager.get_first_timezone();
-    } else if (! meta_vj_exists && is_added_trip(trip_update)) {
-        LOG4CPLUS_DEBUG(log, "Meta VJ doesn't exist without Added trip type: ignoring trip update id "
-                << trip_update.trip().trip_id());
-        return;
+    if (! meta_vj_exists) {
+        if (is_added_trip(trip_update)) {
+            LOG4CPLUS_DEBUG(log, "unknown vehicle journey, create Meta VJ " << trip_update.trip().trip_id());
+            meta_vj = data.pt_data->meta_vjs.emplace(trip_update.trip().trip_id());
+            // TODO : pick a meaningful TZ
+            meta_vj->tz_handler = data.pt_data->tz_manager.get_first_timezone();
+        } else {
+            LOG4CPLUS_DEBUG(log, "Meta VJ doesn't exist without Added trip type: ignoring trip update id "
+                    << trip_update.trip().trip_id());
+            return;
+        }
     } else {
         LOG4CPLUS_DEBUG(log, "Vehicle journey found : " << trip_update.trip().trip_id());
         meta_vj = data.pt_data->meta_vjs.get_mut(trip_update.trip().trip_id());

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3336,7 +3336,7 @@ BOOST_FIXTURE_TEST_CASE(trip_id_that_doesnt_exist_must_be_rejected_in_classical_
     // the new trip update with bad id is blocked directly
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
     b.data->build_raptor();
-    BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.size(), 1);
+    BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_id_doesnt_exist"), false);
 }
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3337,6 +3337,6 @@ BOOST_FIXTURE_TEST_CASE(trip_id_that_doesnt_exist_must_be_rejected_in_classical_
     navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
     b.data->build_raptor();
     BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
-    BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_id_doesnt_exist"), false);
+    BOOST_CHECK(!pt_data.meta_vjs.exists("vj_id_doesnt_exist"));
 }
 


### PR DESCRIPTION
A Bug has been detected during the disruption loading at the kraken start (After a deploy on dev)
With a bad VJ id, a seg fault occured...

It was a typing error into condition...
Now it is fixed with a UTest to highlight the good behaviour
