### PR TITLE
Kraken: Skip realtime cancelled trip update on a VJ that doesn't exist + tests

### DIFF
--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -635,13 +635,14 @@ void handle_realtime(const std::string& id,
             meta_vj = data.pt_data->meta_vjs.emplace(trip_update.trip().trip_id());
             // TODO : pick a meaningful TZ
             meta_vj->tz_handler = data.pt_data->tz_manager.get_first_timezone();
-        } else if (is_cancelled_trip(trip_update)) {
-            LOG4CPLUS_DEBUG(log, "Can't cancel a trip that doesn't exist: ignoring trip update id "
-                    << trip_update.trip().trip_id());
-            return;
         } else {
-            LOG4CPLUS_DEBUG(log, "Meta VJ doesn't exist without Added trip type: ignoring trip update id "
-                    << trip_update.trip().trip_id());
+            LOG4CPLUS_WARN(log, "Cannot perform operation on an unknown Meta VJ (other than adding trip)"
+                    << ", trip id: " << trip_update.trip().trip_id()
+                    << ", effect: " << get_wordings(get_trip_effect(trip_update.GetExtension(kirin::effect))));
+            if (trip_update.stop_time_update_size()) {
+                LOG4CPLUS_WARN(log, "Meta VJ 1st stop time departure: "
+                    << trip_update.stop_time_update(0).departure().time());
+            }
             return;
         }
     } else {

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -635,6 +635,10 @@ void handle_realtime(const std::string& id,
             meta_vj = data.pt_data->meta_vjs.emplace(trip_update.trip().trip_id());
             // TODO : pick a meaningful TZ
             meta_vj->tz_handler = data.pt_data->tz_manager.get_first_timezone();
+        } else if (is_cancelled_trip(trip_update)) {
+            LOG4CPLUS_DEBUG(log, "Can't cancelled a trip that doesn't exist: ignoring trip update id "
+                    << trip_update.trip().trip_id());
+            return;
         } else {
             LOG4CPLUS_DEBUG(log, "Meta VJ doesn't exist without Added trip type: ignoring trip update id "
                     << trip_update.trip().trip_id());

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -636,7 +636,7 @@ void handle_realtime(const std::string& id,
             // TODO : pick a meaningful TZ
             meta_vj->tz_handler = data.pt_data->tz_manager.get_first_timezone();
         } else if (is_cancelled_trip(trip_update)) {
-            LOG4CPLUS_DEBUG(log, "Can't cancelled a trip that doesn't exist: ignoring trip update id "
+            LOG4CPLUS_DEBUG(log, "Can't cancel a trip that doesn't exist: ignoring trip update id "
                     << trip_update.trip().trip_id());
             return;
         } else {

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3478,6 +3478,11 @@ BOOST_FIXTURE_TEST_CASE(cant_cancelled_trip_that_doesnt_exist, AddTripDataset) {
 
     auto& pt_data = *b.data->pt_data;
 
+    BOOST_CHECK(!pt_data.meta_vjs.exists("vj_id_doesnt_exist"));
+    BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
+    BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
+    BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 1);
+
     // Can't cancelled trip that doesn't exist
     transit_realtime::TripUpdate remove_trip = ntest::make_delay_message("vj_id_doesnt_exist",
         "20190101",
@@ -3494,7 +3499,9 @@ BOOST_FIXTURE_TEST_CASE(cant_cancelled_trip_that_doesnt_exist, AddTripDataset) {
     navitia::handle_realtime("feed-1", timestamp, remove_trip, *b.data, true, true);
     b.data->build_raptor();
 
-    BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
     BOOST_CHECK(!pt_data.meta_vjs.exists("vj_id_doesnt_exist"));
+    BOOST_CHECK_EQUAL(pt_data.meta_vjs.size(), 1);
+    BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
+    BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 1);
 }
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3474,7 +3474,7 @@ BOOST_FIXTURE_TEST_CASE(cancelled_trip, AddTripDataset) {
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 2);
 }
 
-BOOST_FIXTURE_TEST_CASE(cant_cancelled_trip_that_doesnt_exist, AddTripDataset) {
+BOOST_FIXTURE_TEST_CASE(cant_cancel_trip_that_doesnt_exist, AddTripDataset) {
 
     auto& pt_data = *b.data->pt_data;
 
@@ -3483,7 +3483,7 @@ BOOST_FIXTURE_TEST_CASE(cant_cancelled_trip_that_doesnt_exist, AddTripDataset) {
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 1);
 
-    // Can't cancelled trip that doesn't exist
+    // Can't cancel trip that doesn't exist
     transit_realtime::TripUpdate remove_trip = ntest::make_delay_message("vj_id_doesnt_exist",
         "20190101",
         {

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3435,7 +3435,7 @@ BOOST_FIXTURE_TEST_CASE(cancelled_trip, AddTripDataset) {
     navitia::handle_realtime("feed-1", timestamp, remove_new_trip, *b.data, true, true);
     b.data->build_raptor();
 
-    // For the moment, trip from A to G doesn't exist
+    // trip from A to G is now removed
     res = compute("20190101T073000", "stop_point:A", "stop_point:G");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
     BOOST_CHECK_EQUAL(res.journeys_size(), 0);


### PR DESCRIPTION
Skip cancelled trip update at the `handle_realtime` function entry point, when the VJ id doesn't exist.
For the moment, it doesn't erase the Meta VJ concerned.
Tests show you the current behavior.