### PR TITLE
Kraken: Add RT route dynamically

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -349,9 +349,6 @@ struct DisruptedNetwork {
                 .get_disruption(),
             *b.data->pt_data, *b.data->meta);
 
-//        b.data->pt_data->build_autocomplete(*(b.data->geo_ref));
-        b.data->build_raptor(1);
-
         pb_creator.init(b.data.get(), since, period);
     }
 };

--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -349,6 +349,9 @@ struct DisruptedNetwork {
                 .get_disruption(),
             *b.data->pt_data, *b.data->meta);
 
+//        b.data->pt_data->build_autocomplete(*(b.data->geo_ref));
+        b.data->build_raptor(1);
+
         pb_creator.init(b.data.get(), since, period);
     }
 };

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1495,6 +1495,248 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
         assert has_the_disruption(response, 'stop_time_with_detour')
 
 
+@dataset(MAIN_ROUTING_TEST_SETTING)
+class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
+    def test_add_new_trip(self):
+        """
+        0. test that no PT-Ref object related to the new trip exists and that no PT-journey exists
+        1. create a new trip
+        2. test that journey is possible using this new trip
+        3. test some PT-Ref objects were created
+        4. test that /pt_objects returns those objects
+        5. test that PT-Ref filters are working
+        """
+        disruption_query = 'disruptions?_current_datetime={dt}'.format(dt='20120614T080000')
+        disruptions_before = self.query_region(disruption_query)
+        nb_disruptions_before = len(disruptions_before['disruptions'])
+
+        # /journeys before (only direct walk)
+        C_B_query = (
+            "journeys?from={f}&to={to}&data_freshness=realtime&"
+            "datetime={dt}&_current_datetime={dt}".format(
+                f='stop_point:stopC', to='stop_point:stopB', dt='20120614T080000'
+            )
+        )
+        response = self.query_region(C_B_query)
+        assert not has_the_disruption(response, 'new_trip')
+        self.is_valid_journey_response(response, C_B_query)
+        assert len(response['journeys']) == 1
+        assert 'non_pt_walking' in response['journeys'][0]['tags']
+
+        # /pt_objects before
+        ptobj_query = 'pt_objects?q={q}&_current_datetime={dt}'.format(q='adi', dt='20120614T080000')  # ++typo
+        response = self.query_region(ptobj_query)
+        assert 'pt_objects' not in response
+
+        # Check that no vehicle_journey exists on the future realtime-trip
+        vj_query = 'vehicle_journeys/{vj}?_current_datetime={dt}'.format(
+            vj='additional-trip:modified:0:new_trip', dt='20120614T080000'
+        )
+        response, status = self.query_region(vj_query, check=False)
+        assert status == 404
+        assert 'vehicle_journeys' not in response
+
+        # Check that no additional line exists
+        line_query = 'lines/{l}?_current_datetime={dt}'.format(l='line:additional_service', dt='20120614T080000')
+        response, status = self.query_region(line_query, check=False)
+        assert status == 404
+        assert 'lines' not in response
+
+        # Check that PT-Ref filter fails as no object exists
+        vj_filter_query = 'commercial_modes/{cm}/vehicle_journeys?_current_datetime={dt}'.format(
+            cm='commercial_mode:additional_service', dt='20120614T080000'
+        )
+        response, status = self.query_region(vj_filter_query, check=False)
+        assert status == 404
+        assert response['error']['message'] == 'ptref : Filters: Unable to find object'
+
+        network_filter_query = 'vehicle_journeys/{vj}/networks?_current_datetime={dt}'.format(
+            vj='additional-trip:modified:0:new_trip', dt='20120614T080000'
+        )
+        response, status = self.query_region(network_filter_query, check=False)
+        assert status == 404
+        assert response['error']['message'] == 'ptref : Filters: Unable to find object'
+
+        # New disruption, a new trip with 2 stop_times in realtime
+        self.send_mock(
+            "additional-trip",
+            "20120614",
+            'added',
+            [
+                UpdatedStopTime(
+                    "stop_point:stopC",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080100"),
+                    departure=tstamp("20120614T080100"),
+                    message='on time',
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopB",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080102"),
+                    departure=tstamp("20120614T080102"),
+                ),
+            ],
+            disruption_id='new_trip',
+            effect='additional_service',
+        )
+
+        # Check new disruption 'additional-trip' to add a new trip
+        disruptions_after = self.query_region(disruption_query)
+        assert nb_disruptions_before + 1 == len(disruptions_after['disruptions'])
+        assert has_the_disruption(disruptions_after, 'new_trip')
+        last_disrupt = disruptions_after['disruptions'][-1]
+        assert last_disrupt['severity']['effect'] == 'ADDITIONAL_SERVICE'
+        assert len(last_disrupt['impacted_objects'][0]['impacted_stops']) == 2
+        assert all(
+            [
+                (s['departure_status'] == 'added' and s['arrival_status'] == 'added')
+                for s in last_disrupt['impacted_objects'][0]['impacted_stops']
+            ]
+        )
+
+        # Check that a PT journey now exists
+        response = self.query_region(C_B_query)
+        assert has_the_disruption(response, 'new_trip')
+        self.is_valid_journey_response(response, C_B_query)
+        assert len(response['journeys']) == 2
+        pt_journey = response['journeys'][0]
+        assert 'non_pt_walking' not in pt_journey['tags']
+        assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
+        assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
+        assert pt_journey['sections'][0]['display_informations']['commercial_mode'] == 'additional service'
+
+        # Check /pt_objects after: new objects created
+        response = self.query_region(ptobj_query)
+        assert len(response['pt_objects']) == 4
+        assert len([o for o in response['pt_objects'] if o['id'] == 'network:additional_service']) == 1
+        assert len([o for o in response['pt_objects'] if o['id'] == 'commercial_mode:additional_service']) == 1
+        assert len([o for o in response['pt_objects'] if o['id'] == 'line:additional_service']) == 1
+        assert len([o for o in response['pt_objects'] if o['id'] == 'route:additional_service']) == 1
+
+        # Check that the vehicle_journey has been created
+        response = self.query_region(vj_query)
+        assert has_the_disruption(response, 'new_trip')
+        assert len(response['vehicle_journeys']) == 1
+        assert response['vehicle_journeys'][0]['disruptions'][0]['id'] == 'new_trip'
+        assert len(response['vehicle_journeys'][0]['stop_times']) == 2
+
+        # Check that the new line has been created
+        response = self.query_region(line_query)
+        assert len(response['lines']) == 1
+        assert response['lines'][0]['name'] == 'additional service'
+        assert response['lines'][0]['network']['id'] == 'network:additional_service'
+        assert response['lines'][0]['commercial_mode']['id'] == 'commercial_mode:additional_service'
+
+        # Check that objects created are linked in PT-Ref filter
+        response = self.query_region(vj_filter_query)
+        assert has_the_disruption(response, 'new_trip')
+        assert len(response['vehicle_journeys']) == 1
+
+        response = self.query_region(network_filter_query)
+        assert len(response['networks']) == 1
+        assert response['networks'][0]['name'] == 'additional service'
+
+
+@dataset(MAIN_ROUTING_TEST_SETTING_NO_ADD)
+class TestKirinAddNewTripBlocked(MockKirinDisruptionsFixture):
+    def test_add_new_trip_blocked(self):
+        """
+        Disable realtime trip-add in Kraken
+        1. send a disruption to create a new trip
+        2. test that no journey is possible using this new trip
+        3. test that no PT-Ref objects were created
+        4. test that /pt_objects doesn't return objects
+        5. test that PT-Ref filters find nothing
+        """
+        disruption_query = 'disruptions?_current_datetime={dt}'.format(dt='20120614T080000')
+        disruptions_before = self.query_region(disruption_query)
+        nb_disruptions_before = len(disruptions_before['disruptions'])
+
+        # New disruption, a new trip with 2 stop_times in realtime
+        self.send_mock(
+            "additional-trip",
+            "20120614",
+            'added',
+            [
+                UpdatedStopTime(
+                    "stop_point:stopC",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080100"),
+                    departure=tstamp("20120614T080100"),
+                    message='on time',
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopB",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080102"),
+                    departure=tstamp("20120614T080102"),
+                ),
+            ],
+            disruption_id='new_trip',
+            effect='additional_service',
+        )
+
+        # Check there is no new disruption
+        disruptions_after = self.query_region(disruption_query)
+        assert nb_disruptions_before == len(disruptions_after['disruptions'])
+
+        # /journeys before (only direct walk)
+        C_B_query = (
+            "journeys?from={f}&to={to}&data_freshness=realtime&"
+            "datetime={dt}&_current_datetime={dt}".format(
+                f='stop_point:stopC', to='stop_point:stopB', dt='20120614T080000'
+            )
+        )
+        response = self.query_region(C_B_query)
+        assert not has_the_disruption(response, 'new_trip')
+        self.is_valid_journey_response(response, C_B_query)
+        assert len(response['journeys']) == 1
+        assert 'non_pt_walking' in response['journeys'][0]['tags']
+
+        # /pt_objects before
+        ptobj_query = 'pt_objects?q={q}&_current_datetime={dt}'.format(q='adi', dt='20120614T080000')  # ++typo
+        response = self.query_region(ptobj_query)
+        assert 'pt_objects' not in response
+
+        # Check that no vehicle_journey exists on the future realtime-trip
+        vj_query = 'vehicle_journeys/{vj}?_current_datetime={dt}'.format(
+            vj='additional-trip:modified:0:new_trip', dt='20120614T080000'
+        )
+        response, status = self.query_region(vj_query, check=False)
+        assert status == 404
+        assert 'vehicle_journeys' not in response
+
+        # Check that no additional line exists
+        line_query = 'lines/{l}?_current_datetime={dt}'.format(l='line:additional_service', dt='20120614T080000')
+        response, status = self.query_region(line_query, check=False)
+        assert status == 404
+        assert 'lines' not in response
+
+        # Check that PT-Ref filter fails as no object exists
+        vj_filter_query = 'commercial_modes/{cm}/vehicle_journeys?_current_datetime={dt}'.format(
+            cm='commercial_mode:additional_service', dt='20120614T080000'
+        )
+        response, status = self.query_region(vj_filter_query, check=False)
+        assert status == 404
+        assert response['error']['message'] == 'ptref : Filters: Unable to find object'
+
+        network_filter_query = 'vehicle_journeys/{vj}/networks?_current_datetime={dt}'.format(
+            vj='additional-trip:modified:0:new_trip', dt='20120614T080000'
+        )
+        response, status = self.query_region(network_filter_query, check=False)
+        assert status == 404
+        assert response['error']['message'] == 'ptref : Filters: Unable to find object'
+
+
 def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None, effect=None):
     feed_message = gtfs_realtime_pb2.FeedMessage()
     feed_message.header.gtfs_realtime_version = '1.0'
@@ -1520,11 +1762,19 @@ def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], 
         trip_update.Extensions[kirin_pb2.effect] = gtfs_realtime_pb2.Alert.DETOUR
     elif effect == 'reduced_service':
         trip_update.Extensions[kirin_pb2.effect] = gtfs_realtime_pb2.Alert.REDUCED_SERVICE
+    elif effect == 'additional_service':
+        trip_update.Extensions[kirin_pb2.effect] = gtfs_realtime_pb2.Alert.ADDITIONAL_SERVICE
 
     if status == 'canceled':
+        # TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
         trip.schedule_relationship = gtfs_realtime_pb2.TripDescriptor.CANCELED
-    elif status == 'modified':
-        trip.schedule_relationship = gtfs_realtime_pb2.TripDescriptor.SCHEDULED
+    elif status in ['modified', 'added']:
+        # TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
+        if status == 'modified':
+            trip.schedule_relationship = gtfs_realtime_pb2.TripDescriptor.SCHEDULED
+        elif status == 'added':
+            trip.schedule_relationship = gtfs_realtime_pb2.TripDescriptor.ADDED
+
         for st in new_stop_time_list:
             stop_time_update = trip_update.stop_time_update.add()
             stop_time_update.stop_id = st.stop_id

--- a/source/kraken/apply_disruption.h
+++ b/source/kraken/apply_disruption.h
@@ -42,6 +42,12 @@ namespace navitia {
 boost::posix_time::time_period
 execution_period(const boost::gregorian::date& date, const nt::VehicleJourney& vj);
 
+/**
+ * WARNING: this method can add, remove or transform PT-Ref objects in PT_Data
+ * After using it, make sure to rebuild:
+ * - RAPTOR (probably through Data.build_raptor)
+ * - AUTOCOMPLETE on PT-Ref (probably through PT_Data.build_autocomplete)
+ */
 void apply_disruption(const type::disruption::Disruption&,
                       navitia::type::PT_Data&,
                       const navitia::type::MetaData&);

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -125,6 +125,7 @@ public:
             // to reload the data
             try {
                 data->load_disruptions(*chaos_database, contributors);
+                data->build_autocomplete();
             } catch (const navitia::data::disruptions_broken_connection&) {
                 LOG4CPLUS_WARN(logger, "Load data without disruptions");
             } catch(const navitia::data::disruptions_loading_error&) {

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -204,6 +204,7 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         }
     }
     if (data) {
+        data->pt_data->build_autocomplete(*(data->geo_ref));
         data->pt_data->clean_weak_impacts();
         LOG4CPLUS_INFO(logger, "rebuilding data raptor");
         data->build_raptor(conf.raptor_cache_size());

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -204,7 +204,9 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         }
     }
     if (data) {
+        LOG4CPLUS_INFO(logger, "rebuilding autocomplete");
         data->pt_data->build_autocomplete(*(data->geo_ref));
+        LOG4CPLUS_INFO(logger, "cleaning weak impacts");
         data->pt_data->clean_weak_impacts();
         LOG4CPLUS_INFO(logger, "rebuilding data raptor");
         data->build_raptor(conf.raptor_cache_size());

--- a/source/kraken/realtime.h
+++ b/source/kraken/realtime.h
@@ -35,6 +35,12 @@ www.navitia.io
 
 namespace navitia {
 
+/**
+ * WARNING: this method can add, remove or transform PT-Ref objects in PT_Data
+ * After using it, make sure to rebuild:
+ * - RAPTOR (probably through Data.build_raptor)
+ * - AUTOCOMPLETE on PT-Ref (probably through PT_Data.build_autocomplete)
+ */
 void handle_realtime(const std::string& id,
                      const boost::posix_time::ptime& timestamp,
                      const transit_realtime::TripUpdate&,

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -46,6 +46,7 @@ class Data {
         void load_disruptions(const std::string&,
                               const std::vector<std::string>& = {}){}
         void build_raptor(size_t){}
+        void build_autocomplete(){}
         mutable std::atomic<bool> loading;
         mutable std::atomic<bool> is_connected_to_rabbitmq;
         static bool load_status;

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1549,6 +1549,8 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys) {
     transit_realtime::TripUpdate trip_update_vj3 = make_cancellation_message("vj:3", "20150928");
     navitia::handle_realtime("trip_update_vj2", timestamp, trip_update_vj2, *b.data, true, true);
     navitia::handle_realtime("trip_update_vj3", timestamp, trip_update_vj3, *b.data, true, true);
+//    b.data->pt_data->build_autocomplete(*(b.data->geo_ref));
+    b.data->build_raptor(1);
 
     auto * data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::posix_time::from_iso_string("20150928T0830"), null_time_period);
@@ -1573,6 +1575,8 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys_no_base) {
             RTStopTime("stop2", "20150929T1010"_pts).delay(69_min)
         });
     navitia::handle_realtime("trip_update", timestamp, trip_update, *b.data, true, true);
+//    b.data->pt_data->build_autocomplete(*(b.data->geo_ref));
+    b.data->build_raptor(1);
     auto * data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::posix_time::from_iso_string("20150928T0830"), null_time_period);
     navitia::disruption::traffic_reports(pb_creator, *b.data,

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1549,8 +1549,6 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys) {
     transit_realtime::TripUpdate trip_update_vj3 = make_cancellation_message("vj:3", "20150928");
     navitia::handle_realtime("trip_update_vj2", timestamp, trip_update_vj2, *b.data, true, true);
     navitia::handle_realtime("trip_update_vj3", timestamp, trip_update_vj3, *b.data, true, true);
-//    b.data->pt_data->build_autocomplete(*(b.data->geo_ref));
-    b.data->build_raptor(1);
 
     auto * data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::posix_time::from_iso_string("20150928T0830"), null_time_period);
@@ -1575,8 +1573,6 @@ BOOST_AUTO_TEST_CASE(traffic_reports_vehicle_journeys_no_base) {
             RTStopTime("stop2", "20150929T1010"_pts).delay(69_min)
         });
     navitia::handle_realtime("trip_update", timestamp, trip_update, *b.data, true, true);
-//    b.data->pt_data->build_autocomplete(*(b.data->geo_ref));
-    b.data->build_raptor(1);
     auto * data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::posix_time::from_iso_string("20150928T0830"), null_time_period);
     navitia::disruption::traffic_reports(pb_creator, *b.data,

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -35,6 +35,98 @@ www.navitia.io
 
 namespace navitia { namespace type {
 
+type::Network* PT_Data::get_or_create_network(const std::string& uri, const std::string& name, int sort) {
+    const auto it = networks_map.find(uri);
+    if (it != networks_map.end()) {
+        return it->second;
+    }
+
+    nt::Network* network = new nt::Network();
+    network->uri = uri;
+    network->name = name;
+    network->sort = sort;
+
+    network->idx = networks.size();
+    networks.push_back(network);
+    networks_map[uri] = network;
+
+    return network;
+}
+
+type::CommercialMode* PT_Data::get_or_create_commercial_mode(const std::string& uri, const std::string& name) {
+    const auto it = commercial_modes_map.find(uri);
+    if (it != commercial_modes_map.end()) {
+        return it->second;
+    }
+
+    nt::CommercialMode* mode = new nt::CommercialMode();
+    mode->uri = uri;
+    mode->name = name;
+
+    mode->idx = commercial_modes.size();
+    commercial_modes.push_back(mode);
+    commercial_modes_map[uri] = mode;
+
+    return mode;
+}
+
+type::Line* PT_Data::get_or_create_line(const std::string& uri,
+                                        const std::string& name,
+                                        type::Network* network,
+                                        type::CommercialMode* commercial_mode,
+                                        int sort,
+                                        const std::string& color,
+                                        const std::string& text_color) {
+    const auto it = lines_map.find(uri);
+    if (it != lines_map.end()) {
+        return it->second;
+    }
+
+    nt::Line* line = new nt::Line();
+    line->uri = uri;
+    line->name = name;
+    line->sort = sort;
+    line->color = color;
+    line->text_color = text_color;
+
+    line->network = network;
+    network->line_list.push_back(line);
+    line->commercial_mode = commercial_mode;
+    commercial_mode->line_list.push_back(line);
+
+    line->idx = lines.size();
+    lines.push_back(line);
+    lines_map[uri] = line;
+
+    return line;
+}
+
+type::Route* PT_Data::get_or_create_route(const std::string& uri,
+                                          const std::string& name,
+                                          type::Line* line,
+                                          type::StopArea* destination,
+                                          const std::string& direction_type) {
+    const auto it = routes_map.find(uri);
+    if (it != routes_map.end()) {
+        return it->second;
+    }
+
+    nt::Route* route = new nt::Route();
+    route->uri = uri;
+    route->name = name;
+    route->destination = destination;
+    route->direction_type = direction_type;
+
+    route->line = line;
+    line->route_list.push_back(route);
+
+    route->idx = routes.size();
+    routes.push_back(route);
+    routes_map[uri] = route;
+
+    return route;
+}
+
 ValidityPattern* PT_Data::get_or_create_validity_pattern(const ValidityPattern& vp_ref) {
     for (auto vp : validity_patterns) {
         if (vp->days == vp_ref.days && vp->beginning_date == vp_ref.beginning_date) {

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -153,6 +153,23 @@ struct PT_Data : boost::noncopyable{
 
     type::ValidityPattern* get_or_create_validity_pattern(const ValidityPattern& vp_ref);
 
+    type::Network* get_or_create_network(const std::string& uri,
+                                         const std::string& name,
+                                         int sort = std::numeric_limits<int>::max());
+    type::CommercialMode* get_or_create_commercial_mode(const std::string& uri,
+                                                        const std::string& name);
+    type::Line* get_or_create_line(const std::string& uri,
+                                   const std::string& name,
+                                   type::Network* network,
+                                   type::CommercialMode* commercial_mode,
+                                   int sort = std::numeric_limits<int>::max(),
+                                   const std::string& color = {"000000"},
+                                   const std::string& text_color = {"FFFFFF"});
+    type::Route* get_or_create_route(const std::string& uri,
+                                     const std::string& name,
+                                     type::Line* line,
+                                     type::StopArea* destination = nullptr,
+                                     const std::string& direction_type = {});
 
     void clean_weak_impacts();
 


### PR DESCRIPTION
For history on comments, this PR is exactly this draft: https://github.com/pbougue/navitia/pull/2
A lot of discussions were addressed there.
JIRA: https://jira.kisio.org/browse/NAVP-1064

:mag_right: please review by commit (and read commit message).
Only 2 commits are "canceling one-another", but it's highlighting the way things work (commits 2 & 3, `fix tests` and `remove fix`).

TODO (only what's left from draft):
- [x] Add kraken realtime_tests on objects created to check that there are no `nullptr` left.

> Another PR follows, using news methods in build_helper (to challenge methods more): #2729 
