### PR TITLE
kraken: Add new method "has_code_type" in PtRef Grammar

### DIFF
--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -63,6 +63,7 @@ In the following table, if the invocation starts with `collection`, any collecti
 | query | signification | note |
 |-------|---------------|------|
 |`collection.has_code(type, value)`|all the objects of type `collection` that have the code `{type: "type", value: "value"}` in `codes[]`|only the `codes[]` field is used|
+|`collection.has_code_type(type)`|all the objects of type `collection` that have this kind of code `{type: "type"}` in `codes[]`|only the `codes[]` field is used|
 |`collection.id(id)`|the object of type `collection` that have `id` as identifier (empty if this identifier is not present)|for types without identifier (as `connection`), it is equivalent to `empty`|
 |`collection.uri(id)`|same as `collection.id(id)`|deprecated|
 |`collection.name(name)`|all the objects of type `collection` that have `name` as name|for types without name (as `connection`), it is equivalent to `empty`|

--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -63,7 +63,7 @@ In the following table, if the invocation starts with `collection`, any collecti
 | query | signification | note |
 |-------|---------------|------|
 |`collection.has_code(type, value)`|all the objects of type `collection` that have the code `{type: "type", value: "value"}` in `codes[]`|only the `codes[]` field is used|
-|`collection.has_code_type(type)`|all the objects of type `collection` that have this kind of code `{type: "type"}` in `codes[]`|only the `codes[]` field is used|
+|`collection.has_code_type(type)`|all the objects of type `collection` that has a code with the specific type `{type: "type"}` in `codes[]`|only the `codes[]` field is used|
 |`collection.id(id)`|the object of type `collection` that have `id` as identifier (empty if this identifier is not present)|for types without identifier (as `connection`), it is equivalent to `empty`|
 |`collection.uri(id)`|same as `collection.id(id)`|deprecated|
 |`collection.name(name)`|all the objects of type `collection` that have `name` as name|for types without name (as `connection`), it is equivalent to `empty`|

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -289,6 +289,8 @@ struct Eval: boost::static_visitor<Indexes> {
             indexes = get_indexes_from_name(type_by_caption(f.type), f.args.at(0), data);
         } else if (f.method == "has_code" && f.args.size() == 2) {
             indexes = get_indexes_from_code(type_by_caption(f.type), f.args.at(0), f.args.at(1), data);
+        } else if (f.method == "has_code_type" && f.args.size() == 1) {
+            indexes = get_indexes_from_codes(type_by_caption(f.type), f.args.at(0), data);
         } else {
             std::stringstream ss;
             ss << "Unknown function: " << f;

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -290,7 +290,7 @@ struct Eval: boost::static_visitor<Indexes> {
         } else if (f.method == "has_code" && f.args.size() == 2) {
             indexes = get_indexes_from_code(type_by_caption(f.type), f.args.at(0), f.args.at(1), data);
         } else if (f.method == "has_code_type" && f.args.size() == 1) {
-            indexes = get_indexes_from_codes(type_by_caption(f.type), f.args.at(0), data);
+            indexes = get_indexes_from_code_type(type_by_caption(f.type), f.args.at(0), data);
         } else {
             std::stringstream ss;
             ss << "Unknown function: " << f;

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -322,7 +322,7 @@ get_indexes_from_code_type(const std::string& key, const Data& data) {
     for (const auto* obj: collection) {
         auto codes = data.pt_data->codes.get_codes<T>(obj);
         if (codes.find(key) == codes.end()) { continue; }
-            indexes.insert(obj->idx);
+        indexes.insert(obj->idx);
     }
     return indexes;
 }

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -316,12 +316,12 @@ typename boost::enable_if<
         nt::CodeContainer::SupportedTypes,
         T>::type,
     Indexes>::type
-get_indexes_from_codes(const std::string& key, const Data& data) {
+get_indexes_from_code_type(const std::string& key, const Data& data) {
     Indexes indexes;
     auto collection = data.pt_data->collection<T>();
     for (const auto* obj: collection) {
         auto codes = data.pt_data->codes.get_codes<T>(obj);
-        if (codes.empty() || codes.find(key) == codes.end()) { continue; }
+        if (codes.find(key) == codes.end()) { continue; }
             indexes.insert(obj->idx);
     }
     return indexes;
@@ -333,19 +333,19 @@ typename boost::disable_if<
         nt::CodeContainer::SupportedTypes,
         T>::type,
     Indexes>::type
-get_indexes_from_codes(const std::string&, const Data&) {
+get_indexes_from_code_type(const std::string&, const Data&) {
     // there is no codes for unsupporded types, thus the result is empty
     return Indexes{};
 }
-type::Indexes get_indexes_from_codes(const type::Type_e type,
+type::Indexes get_indexes_from_code_type(const type::Type_e type,
                                      const std::string& key,
                                      const type::Data& data) {
     switch (type) {
 #define GET_INDEXES(type_name, collection_name) \
-        case Type_e::type_name: return get_indexes_from_codes<type::type_name>(key, data);
+        case Type_e::type_name: return get_indexes_from_code_type<type::type_name>(key, data);
         ITERATE_NAVITIA_PT_TYPES(GET_INDEXES)
 #undef GET_INDEXES
-    default: return Indexes();// no code supported, empty result
+    default: return Indexes{};// no code supported, empty result
     }
 }
 

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -334,7 +334,7 @@ typename boost::disable_if<
         T>::type,
     Indexes>::type
 get_indexes_from_code_type(const std::string&, const Data&) {
-    // there is no codes for unsupporded types, thus the result is empty
+    // there is no code for unsupported types, thus the result is empty
     return Indexes{};
 }
 type::Indexes get_indexes_from_code_type(const type::Type_e type,

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -309,6 +309,46 @@ type::Indexes get_indexes_from_code(const type::Type_e type,
     }
 }
 
+template<typename T>
+static
+typename boost::enable_if<
+    typename boost::mpl::contains<
+        nt::CodeContainer::SupportedTypes,
+        T>::type,
+    Indexes>::type
+get_indexes_from_codes(const std::string& key, const Data& data) {
+    Indexes indexes;
+    auto collection = data.pt_data->collection<T>();
+    for (const auto* obj: collection) {
+        auto codes = data.pt_data->codes.get_codes<T>(obj);
+        if (codes.empty() || codes.find(key) == codes.end()) { continue; }
+            indexes.insert(obj->idx);
+    }
+    return indexes;
+}
+template<typename T>
+static
+typename boost::disable_if<
+    typename boost::mpl::contains<
+        nt::CodeContainer::SupportedTypes,
+        T>::type,
+    Indexes>::type
+get_indexes_from_codes(const std::string&, const Data&) {
+    // there is no codes for unsupporded types, thus the result is empty
+    return Indexes{};
+}
+type::Indexes get_indexes_from_codes(const type::Type_e type,
+                                     const std::string& key,
+                                     const type::Data& data) {
+    switch (type) {
+#define GET_INDEXES(type_name, collection_name) \
+        case Type_e::type_name: return get_indexes_from_codes<type::type_name>(key, data);
+        ITERATE_NAVITIA_PT_TYPES(GET_INDEXES)
+#undef GET_INDEXES
+    default: return Indexes();// no code supported, empty result
+    }
+}
+
 type::Indexes get_indexes_from_id(const type::Type_e type,
                                   const std::string& id,
                                   const type::Data& data) {

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -65,5 +65,8 @@ type::Indexes get_indexes_from_id(const type::Type_e type,
 type::Indexes get_indexes_from_name(const type::Type_e type,
                                     const std::string& name,
                                     const type::Data& data);
+type::Indexes get_indexes_from_codes(const type::Type_e type,
+                                     const std::string& key,
+                                     const type::Data& data);
 
 }} // navitia::ptref

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -65,8 +65,8 @@ type::Indexes get_indexes_from_id(const type::Type_e type,
 type::Indexes get_indexes_from_name(const type::Type_e type,
                                     const std::string& name,
                                     const type::Data& data);
-type::Indexes get_indexes_from_codes(const type::Type_e type,
-                                     const std::string& key,
-                                     const type::Data& data);
+type::Indexes get_indexes_from_code_type(const type::Type_e type,
+                                         const std::string& key,
+                                         const type::Data& data);
 
 }} // navitia::ptref

--- a/source/ptreferential/tests/ptref_ng_test.cpp
+++ b/source/ptreferential/tests/ptref_ng_test.cpp
@@ -72,6 +72,10 @@ BOOST_AUTO_TEST_CASE(parse_pred) {
         R"#(vehicle_journey . has_code ( external_code , "OIF:42" ) )#",
         R"#(vehicle_journey.has_code("external_code", "OIF:42"))#"
     );
+    assert_expr(
+        R"#(vehicle_journey . has_code_type ( external_code ) )#",
+        R"#(vehicle_journey.has_code_type("external_code"))#"
+    );
     assert_expr(R"#(stop_area . uri ( "OIF:42" ) )#", R"#(stop_area.uri("OIF:42"))#");
     assert_expr(R"#(stop_area . uri = "OIF:42" )#", R"#(stop_area.uri("OIF:42"))#");
     assert_expr(R"#(stop_area . uri = OIF:42 )#", R"#(stop_area.uri("OIF:42"))#");

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -558,6 +558,46 @@ BOOST_AUTO_TEST_CASE(code_request) {
     BOOST_CHECK_EQUAL_RANGE(get_uris<nt::StopArea>(res, *b.data), std::set<std::string>({"A"}));
 }
 
+BOOST_AUTO_TEST_CASE(code_type_request){
+    ed::builder b("20190101");
+    b.sa("sa_1");
+    b.vj("A")("stop1", 8000,8050)("stop2", 8200,8250);
+    b.vj("B")("stop3", 9000,9050)("stop4", 9200,9250);
+    b.make();
+
+    // Add codes on stop point
+    const auto* sp = b.get<nt::StopPoint>("stop1");
+    b.data->pt_data->codes.add(sp, "code_type_1", "0");
+    b.data->pt_data->codes.add(sp, "code_type_1", "1");
+    sp = b.get<nt::StopPoint>("stop3");
+    b.data->pt_data->codes.add(sp, "code_type_1", "0");
+    b.data->pt_data->codes.add(sp, "code_type_1", "1");
+    sp = b.get<nt::StopPoint>("stop2");
+    b.data->pt_data->codes.add(sp, "code_type_2", "0");
+    sp = b.get<nt::StopPoint>("stop4");
+    b.data->pt_data->codes.add(sp, "code_type_2", "1");
+
+    // Add codes on stop area
+    const auto* sa = b.get<nt::StopArea>("sa_1");
+    b.data->pt_data->codes.add(sa, "code_type_1", "0");
+
+    auto res = make_query(nt::Type_e::StopPoint,
+                          R"(stop_point.has_code_type(code_type_1))",
+                          *(b.data));
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::StopPoint>(res, *b.data), std::set<std::string>({"stop1", "stop3"}));
+
+    res = make_query(nt::Type_e::StopPoint,
+                     R"(stop_point.has_code_type(code_type_2))",
+                     *(b.data));
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::StopPoint>(res, *b.data), std::set<std::string>({"stop2", "stop4"}));
+
+    res = make_query(nt::Type_e::StopArea,
+                     R"(stop_area.has_code_type(code_type_1))",
+                     *(b.data));
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::StopArea>(res, *b.data), std::set<std::string>({"sa_1"}));
+}
+
+
 BOOST_AUTO_TEST_CASE(contributor_and_dataset) {
 
     ed::builder b("201601011T1739");

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -595,6 +595,11 @@ BOOST_AUTO_TEST_CASE(code_type_request){
                      R"(stop_area.has_code_type(code_type_1))",
                      *(b.data));
     BOOST_CHECK_EQUAL_RANGE(get_uris<nt::StopArea>(res, *b.data), std::set<std::string>({"sa_1"}));
+
+    BOOST_CHECK_THROW(make_query(nt::Type_e::StopArea,
+                      R"(stop_area.has_code_type(code_type_doesnt_exist))",
+                      *(b.data)),
+                      ptref_error);
 }
 
 


### PR DESCRIPTION
Add new method in PtRef Grammar, `has_code_type` like

```
filter=collection.has_code_type(Type)
```
First part for **JIRA** : https://jira.kisio.org/browse/NAVP-1219