### PR TITLE
Jormun: handle zone and zone_type from bragi

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
@@ -263,6 +263,7 @@ class GeocodePlacesSerializer(serpy.DictSerializer):
         map_serializer = {
             'city': GeocodeAdminSerializer,
             'administrative_region': GeocodeAdminSerializer,
+            'zone': GeocodeAdminSerializer,
             'street': GeocodeAddressSerializer,
             'house': GeocodeAddressSerializer,
             'poi': GeocodePoiSerializer,
@@ -273,6 +274,11 @@ class GeocodePlacesSerializer(serpy.DictSerializer):
             type_ = feature.get('properties', {}).get('geocoding', {}).get('type')
             if not type_ or type_ not in map_serializer:
                 logging.getLogger(__name__).error('Place not serialized (unknown type): {}'.format(feature))
+                continue
+            zone_type = feature.get('properties', {}).get('geocoding', {}).get('zone_type')
+            # TODO: do something smart with other zone type
+            if type_ == 'zone' and zone_type != 'city':
+                logging.getLogger(__name__).error('Place not serialized (invalid zone type): {}'.format(feature))
                 continue
             res.append(map_serializer[type_](feature).data)
         return res

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
@@ -271,11 +271,12 @@ class GeocodePlacesSerializer(serpy.DictSerializer):
         }
         res = []
         for feature in obj.get('features', []):
-            type_ = feature.get('properties', {}).get('geocoding', {}).get('type')
+            geocoding = feature.get('properties', {}).get('geocoding', {})
+            type_ = geocoding.get('type')
             if not type_ or type_ not in map_serializer:
                 logging.getLogger(__name__).error('Place not serialized (unknown type): {}'.format(feature))
                 continue
-            zone_type = feature.get('properties', {}).get('geocoding', {}).get('zone_type')
+            zone_type = geocoding.get('zone_type')
             # TODO: do something smart with other zone type
             if type_ == 'zone' and zone_type != 'city':
                 logging.getLogger(__name__).error('Place not serialized (invalid zone type): {}'.format(feature))

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -106,6 +106,51 @@ BRAGI_MOCK_RESPONSE = {
     ]
 }
 
+BRAGI_MOCK_ZONE = {
+    "features": [
+        {
+            "type": "Feature",
+            "geometry": {"coordinates": [2.3514616, 48.8566969], "type": "Point"},
+            "properties": {
+                "geocoding": {
+                    "id": "admin:fr:75056",
+                    "type": "zone",
+                    "zone_type": "city",
+                    "label": "Paris (75000-75116), Île-de-France, France",
+                    "name": "Paris",
+                    "postcode": "75000;75001;75002;75003;75004;75005;75006;75007;75008;75009;75010;75011;75012;75013;75014;75015;75016;75017;75018;75019;75020;75116",
+                    "city": None,
+                    "citycode": "75056",
+                    "level": 8,
+                    "administrative_regions": [],
+                    "codes": [{"name": "ref:FR:MGP", "value": "T1"}, {"name": "ref:INSEE", "value": "75056"}],
+                    "bbox": [2.224122, 48.8155755, 2.4697602, 48.902156],
+                }
+            },
+        },
+        {
+            "type": "Feature",
+            "geometry": {"coordinates": [2.374402147020069, 48.84691600012601], "type": "Point"},
+            "properties": {
+                "geocoding": {
+                    "id": "admin:fr:7511248",
+                    "type": "zone",
+                    "zone_type": "suburb",
+                    "label": "Quartier des Quinze-Vingts (75012), Paris 12e Arrondissement, Paris, Île-de-France, France",
+                    "name": "Quartier des Quinze-Vingts",
+                    "postcode": "75012",
+                    "city": None,
+                    "citycode": "7511248",
+                    "level": 10,
+                    "administrative_regions": [],
+                    "codes": [{"name": "ref:INSEE", "value": "7511248"}],
+                    "bbox": [2.3644295, 48.8401716, 2.3843422, 48.853255399999995],
+                }
+            },
+        },
+    ]
+}
+
 
 BRAGI_MOCK_TYPE_UNKNOWN = {
     "type": "FeatureCollection",
@@ -870,6 +915,20 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert r[0]['embedded_type'] == 'administrative_region'
             assert r[0]['id'] == 'admin:fr:59350'
             assert r[0]['administrative_region']['label'] == 'Lille (59000-59800)'
+
+    def test_feature_zone(self):
+        mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_ZONE)
+        with mock.patch('requests.get', mock_requests.get):
+            response = self.query("v1/places?q=bob")
+
+            is_valid_global_autocomplete(response, depth=1)
+            r = response.get('places')
+            # The suburb is currently ignored, only cities are returned
+            assert len(r) == 1
+            assert r[0]['name'] == 'Paris'
+            assert r[0]['embedded_type'] == 'administrative_region'
+            assert r[0]['id'] == 'admin:fr:75056'
+            assert r[0]['administrative_region']['label'] == 'Paris (75000-75116), Île-de-France, France'
 
     def test_autocomplete_call_with_depth_zero(self):
         mock_requests = mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_ZERO)


### PR DESCRIPTION
since https://github.com/CanalTP/mimirsbrunn/pull/298 bragi return admin
as `type=zone` and added a property `zone_type` set to `city` cities.

This PR restore the compatibility for bragi by handling those.
zone_type other than `city` are still filtered, adding this notion in
navitia is tracked in NAVP-1225.