### PR TITLE
New API entry point : equipment_reports

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+
+#  Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from jormungandr import i_manager, timezone
+from jormungandr.interfaces.parsers import default_count_arg_type
+from jormungandr.interfaces.v1.decorators import get_obj_serializer
+from jormungandr.interfaces.v1.errors import ManageError
+from jormungandr.interfaces.v1.ResourceUri import ResourceUri
+from jormungandr.interfaces.v1.serializer import api
+from jormungandr.resources_utils import ResourceUtc
+import six
+
+
+class EquipmentReports(ResourceUri, ResourceUtc):
+    def __init__(self):
+        ResourceUri.__init__(self, output_type_serializer=api.EquipmentReportsSerializer)
+        ResourceUtc.__init__(self)
+        parser_get = self.parsers["get"]
+        parser_get.add_argument("depth", type=int, default=1, help="The depth of your object")
+        parser_get.add_argument(
+            "count", type=default_count_arg_type, default=25, help="Number of objects per page"
+        )
+        parser_get.add_argument("start_page", type=int, default=0, help="The current page")
+        parser_get.add_argument(
+            "forbidden_uris[]",
+            type=six.text_type,
+            help="forbidden uris",
+            dest="forbidden_uris[]",
+            default=[],
+            action="append",
+            schema_metadata={'format': 'pt-object'},
+        )
+
+        self.collection = 'equipment_reports'
+        self.get_decorators.insert(0, ManageError())
+        self.get_decorators.insert(1, get_obj_serializer(self))
+
+    def options(self, **kwargs):
+        return self.api_description(**kwargs)
+
+    def get(self, region=None, lon=None, lat=None, uri=None):
+        self.region = i_manager.get_region(region, lon, lat)
+        timezone.set_request_timezone(self.region)
+        args = self.parsers["get"].parse_args()
+
+        uris = []
+        if uri:
+            if uri[-1] == "/":
+                uri = uri[:-1]
+            uris = uri.split("/")
+        args["filter"] = self.get_filter(uris, args)
+
+        response = i_manager.dispatch(args, "equipment_reports", instance_name=self.region)
+
+        return response

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-#  Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
+#  Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,
 #     the software to build cool stuff with public transport.

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -167,7 +167,15 @@ class add_pagination_links(object):
 
 class add_coverage_link(generate_links):
     def __init__(self):
-        self.links = ["coverage", "places", "pt_objects", "journeys", "traffic_reports", "line_reports"]
+        self.links = [
+            "coverage",
+            "places",
+            "pt_objects",
+            "journeys",
+            "traffic_reports",
+            "line_reports",
+            "equipment_reports",
+        ]
 
         if app.config['GRAPHICAL_ISOCHRONE']:
             self.links.append("isochrones")

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -351,6 +351,11 @@ class LineReportsSerializer(PTReferentialSerializer):
     warnings = base.BetaEndpointsSerializer()
 
 
+class EquipmentReportsSerializer(PTReferentialSerializer):
+    equipment_reports = report.EquipmentReportSerializer(many=True, display_none=True)
+    warnings = base.BetaEndpointsSerializer()
+
+
 class TrafficReportsSerializer(PTReferentialSerializer):
     traffic_reports = report.TrafficReportSerializer(many=True, display_none=True)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -508,6 +508,17 @@ class LineSerializer(PbGenericSerializer):
     line_groups = LineGroupSerializer(many=True, display_none=False)
 
 
+class StopAreaEquipmentsSerializer(PbGenericSerializer):
+    stop_area = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
+    equipment_details = EquipmentDetailsSerializer(many=True, display_none=False)
+
+    def get_stop_area(self, obj):
+        if obj.HasField(str('stop_area')):
+            return StopAreaSerializer(obj.stop_area, display_none=False).data
+        else:
+            return None
+
+
 class JourneyPatternPointSerializer(PbNestedSerializer):
     id = jsonschema.Field(attr='uri', display_none=True, schema_type=str)
     stop_point = StopPointSerializer(display_none=False)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -509,14 +509,8 @@ class LineSerializer(PbGenericSerializer):
 
 
 class StopAreaEquipmentsSerializer(PbGenericSerializer):
-    stop_area = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
+    stop_area = StopAreaSerializer(display_none=False)
     equipment_details = EquipmentDetailsSerializer(many=True, display_none=False)
-
-    def get_stop_area(self, obj):
-        if obj.HasField(str('stop_area')):
-            return StopAreaSerializer(obj.stop_area, display_none=False).data
-        else:
-            return None
 
 
 class JourneyPatternPointSerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/report.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/report.py
@@ -38,6 +38,11 @@ class LineReportSerializer(PbNestedSerializer):
     pt_objects = pt.PtObjectSerializer(many=True, display_none=True)
 
 
+class EquipmentReportSerializer(PbNestedSerializer):
+    line = pt.LineSerializer()
+    stop_area_equipments = pt.StopAreaEquipmentsSerializer()
+
+
 class TrafficReportSerializer(PbNestedSerializer):
     network = pt.NetworkSerializer()
     lines = pt.LineSerializer(many=True)

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -46,6 +46,7 @@ from jormungandr.interfaces.v1 import (
     GeoStatus,
     JSONSchema,
     LineReports,
+    EquipmentReports,
 )
 from werkzeug.routing import BaseConverter, FloatConverter, PathConverter
 from jormungandr.modules_loader import AModule
@@ -259,6 +260,15 @@ class V1Routing(AModule):
             region + '<uri:uri>/line_reports',
             coord + '<uri:uri>/line_reports',
             endpoint='line_reports',
+        )
+
+        self.add_resource(
+            EquipmentReports.EquipmentReports,
+            region + 'equipment_reports',
+            coord + 'equipment_reports',
+            region + '<uri:uri>/equipment_reports',
+            coord + '<uri:uri>/equipment_reports',
+            endpoint='equipment_reports',
         )
 
         self.add_resource(Status.Status, region + 'status', coord + 'status', endpoint='status')

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -165,6 +165,21 @@ class Scenario(object):
         resp = instance.send_and_receive(req)
         return resp
 
+    def equipment_reports(self, request, instance):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.equipment_reports
+        req.equipment_reports.depth = request['depth']
+        req.equipment_reports.filter = request['filter']
+        req.equipment_reports.count = request['count']
+        req.equipment_reports.start_page = request['start_page']
+
+        if request["forbidden_uris[]"]:
+            for forbidden_uri in request["forbidden_uris[]"]:
+                req.traffic_reports.forbidden_uris.append(forbidden_uri)
+
+        resp = instance.send_and_receive(req)
+        return resp
+
     def places(self, request, instance):
         return instance.get_autocomplete(request.get('_autocomplete')).get(request, instances=[instance])
 

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -206,3 +206,20 @@ class TestEndPoint(AbstractTestFixture):
         response = self.query('/v1/coverage/main_routing_test/lines', display=True)
         self.check_context(response)
         assert response['context']['timezone'] == 'UTC'
+
+    def test_equipment_reports_context(self):
+        # TODO : When Kraken API is ready, replace
+        # raw_response = self.tester.get('/v1/coverage/main_routing_test/equipment_reports')
+        # assert response.status_code == 404
+        # response = json.loads(raw_response.data)
+        # by
+        # response = self.query('/v1/coverage/main_routing_test/equipment_reports', display=True)
+        raw_response = self.tester.get('/v1/coverage/main_routing_test/equipment_reports')
+        assert raw_response.status_code == 404
+        response = json.loads(raw_response.data)
+        self.check_context(response)
+        assert response['context']['timezone'] == 'UTC'
+        # TODO : Remove "error" check after kraken API implementation
+        assert response['error']
+        assert response['error']['id'] == "unknown_object"
+        assert response['error']['message'] == "Unknown API"


### PR DESCRIPTION
For the moment the _Kraken API_ is absent, so the response is `Unknown API`, when you call `equipment_reports` (In Kraken :  https://github.com/CanalTP/navitia/blob/dev/source/kraken/worker.cpp#L1100)

Playground response :
![unknown_api](https://user-images.githubusercontent.com/32099204/55479883-56198a00-561f-11e9-847f-a7b804ff2d22.png)

This PR udpate the submodule navitia-proto (https://github.com/CanalTP/navitia-proto/pull/124)

JIRA ticket : https://jira.kisio.org/browse/NAVP-1217