### PR TITLE
Ed/cities: change osm's admins id

### DIFF
--- a/source/cities/cities.cpp
+++ b/source/cities/cities.cpp
@@ -179,7 +179,7 @@ void OSMCache::insert_relations() {
             const auto coord = "POINT(" + std::to_string(relation.second.centre.get<0>())
                 + " " + std::to_string(relation.second.centre.get<1>()) + ")";
 
-            auto uri = "admin:osm:" + std::to_string(relation.first);
+            auto uri = "admin:osm:relation:" + std::to_string(relation.first);
             if ( ! relation.second.insee.empty()) {
                 uri = "admin:fr:" + relation.second.insee;
             }

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -397,7 +397,7 @@ void OSMCache::insert_relations() {
             std::string polygon_str = polygon_stream.str();
             const auto coord = "POINT(" + std::to_string(relation.centre.get<0>())
                 + " " + std::to_string(relation.centre.get<1>()) + ")";
-            auto uri = "admin:osm:" + std::to_string(relation.osm_id);
+            auto uri = "admin:osm:relation:" + std::to_string(relation.osm_id);
             if ( ! relation.insee.empty()) {
                 uri = "admin:fr:" + relation.insee;
             }

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -116,7 +116,7 @@ BRAGI_MOCK_TYPE_UNKNOWN = {
             "geometry": {"coordinates": [3.1092154, 50.6274528], "type": "Point"},
             "properties": {
                 "geocoding": {
-                    "id": "admin:osm:2643160",
+                    "id": "admin:osm:relation:2643160",
                     "type": "unknown",
                     "label": "Hellemmes-Lille",
                     "name": "Hellemmes-Lille",


### PR DESCRIPTION
Change the non french osm admin id from `osm:admin:{osm_id}` to `osm:admin:relation:{osm_id}`

(it does not impact french admin as they still follow the pattern: `osm:fr:{insee}`)

It is needed now that we want to use cosmogony, so we need to use cosmogony's pattern. It is especially important since cosmogony will soon (:tada:) also read admins from osm nodes.