### PR TITLE
Attach physical mode to vj: tests of verifications 

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1763,7 +1763,7 @@ class TestKirinAddNewTripWithWrongPhysicalMode(MockKirinDisruptionsFixture):
         disruptions_after = self.query_region(disruption_query)
         assert nb_disruptions_before == len(disruptions_after['disruptions'])
 
-        # /journeys before (only direct walk)
+        # / Journeys: as no trip on pt added, only direct walk.
         C_B_query = (
             "journeys?from={f}&to={to}&data_freshness=realtime&"
             "datetime={dt}&_current_datetime={dt}".format(
@@ -1775,11 +1775,6 @@ class TestKirinAddNewTripWithWrongPhysicalMode(MockKirinDisruptionsFixture):
         self.is_valid_journey_response(response, C_B_query)
         assert len(response['journeys']) == 1
         assert 'non_pt_walking' in response['journeys'][0]['tags']
-
-        # /pt_objects before
-        ptobj_query = 'pt_objects?q={q}&_current_datetime={dt}'.format(q='adi', dt='20120614T080000')  # ++typo
-        response = self.query_region(ptobj_query)
-        assert 'pt_objects' not in response
 
         # Check that no vehicle_journey exists on the future realtime-trip
         vj_query = 'vehicle_journeys/{vj}?_current_datetime={dt}'.format(

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1724,8 +1724,7 @@ class TestKirinAddNewTripWithWrongPhysicalMode(MockKirinDisruptionsFixture):
     def test_add_new_trip_with_wrong_physical_mode(self):
         """
         1. send a disruption to create a new trip with physical_mode absent in kaken
-        2. test that no journey is possible using this new trip
-        3. test that no PT-Ref objects were created
+        2. check of journey, disruption and PT-Ref objects to verify that no trip is added
         """
         disruption_query = 'disruptions?_current_datetime={dt}'.format(dt='20120614T080000')
         disruptions_before = self.query_region(disruption_query)
@@ -1789,41 +1788,6 @@ class TestKirinAddNewTripWithWrongPhysicalMode(MockKirinDisruptionsFixture):
         response, status = self.query_region(vj_query, check=False)
         assert status == 404
         assert 'vehicle_journeys' not in response
-
-        # Check that no additional line exists
-        line_query = 'lines/{l}?_current_datetime={dt}'.format(l='line:additional_service', dt='20120614T080000')
-        response, status = self.query_region(line_query, check=False)
-        assert status == 404
-        assert 'lines' not in response
-
-        # Check that PT-Ref filter fails as no object exists
-        vj_filter_query = 'commercial_modes/{cm}/vehicle_journeys?_current_datetime={dt}'.format(
-            cm='commercial_mode:additional_service', dt='20120614T080000'
-        )
-        response, status = self.query_region(vj_filter_query, check=False)
-        assert status == 404
-        assert response['error']['message'] == 'ptref : Filters: Unable to find object'
-
-        network_filter_query = 'vehicle_journeys/{vj}/networks?_current_datetime={dt}'.format(
-            vj='additional-trip:modified:0:new_trip', dt='20120614T080000'
-        )
-        response, status = self.query_region(network_filter_query, check=False)
-        assert status == 404
-        assert response['error']['message'] == 'ptref : Filters: Unable to find object'
-
-        # Check that no departure exist on stop_point stop_point:stopC
-        departure_query = "stop_points/stop_point:stopC/departures?_current_datetime=20120614T080000"
-        departures = self.query_region(departure_query)
-        assert len(departures['departures']) == 0
-
-        # Check that no stop_schedule exist on line:additional_service and stop_point stop_point:stopC
-        ss_query = (
-            "stop_points/stop_point:stopC/lines/line:additional_service/"
-            "stop_schedules?_current_datetime=20120614T080000&data_freshness=realtime"
-        )
-        stop_schedules, status = self.query_region(ss_query, check=False)
-        assert status == 404
-        assert len(stop_schedules['stop_schedules']) == 0
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING_NO_ADD)

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1610,7 +1610,7 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
             ],
             disruption_id='new_trip',
             effect='additional_service',
-            physical_mode_id='physical_mode:Bus',   # this physical mode exists in kraken
+            physical_mode_id='physical_mode:Bus',  # this physical mode exists in kraken
         )
 
         # Check new disruption 'additional-trip' to add a new trip
@@ -1756,7 +1756,7 @@ class TestKirinAddNewTripWithWrongPhysicalMode(MockKirinDisruptionsFixture):
             ],
             disruption_id='new_trip',
             effect='additional_service',
-            physical_mode_id='physical_mode:Toto',   # this physical mode doesn't exist in kraken
+            physical_mode_id='physical_mode:Toto',  # this physical mode doesn't exist in kraken
         )
 
         # Check there is no new disruption
@@ -1900,8 +1900,9 @@ class TestKirinAddNewTripBlocked(MockKirinDisruptionsFixture):
         assert len(stop_schedules['stop_schedules']) == 0
 
 
-def make_mock_kirin_item(vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None, effect=None,
-                         physical_mode_id=None):
+def make_mock_kirin_item(
+    vj_id, date, status='canceled', new_stop_time_list=[], disruption_id=None, effect=None, physical_mode_id=None
+):
     feed_message = gtfs_realtime_pb2.FeedMessage()
     feed_message.header.gtfs_realtime_version = '1.0'
     feed_message.header.incrementality = gtfs_realtime_pb2.FeedHeader.DIFFERENTIAL

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -290,8 +290,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 if (!mvj->get_base_vj().empty()) {
                     vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
                 } else {
-                    // for protection, use the physical_modes[0]
-                    // TODO : Create default physical mode
+                    // for protection, use the physical_modes[0] instead of creating a new one
                     vj->physical_mode = pt_data.physical_modes[0];
                     LOG4CPLUS_WARN(
                         log, "[disruption] Associate random physical mode to new VJ because base VJ doesn't exist");


### PR DESCRIPTION
**For a new trip to be added the physical_mode is managed as following:**

- **Kirn:** 
  For "indicateurFer": "FERRE" in Flux cots 'physical_mode:LongDistanceTrain' is used in GTFS-RT
  For "indicateurFer": "ROUTIER" in Flux cots 'physical_mode:Coach' is used in GTFS-RT

- **Kraken: Already done in kraken**
  If physical_mode exists in GTFS-RT then fetch in kraken. The disruption is rejected if the physical_mode doesn't exist.

Concerns:  https://jira.kisio.org/browse/NAVP-1257
