### PR TITLE
Kraken: Add and use PT_Data::get_or_create_meta_vehicle_journey() 

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -278,7 +278,7 @@ void Worker::metadatas() {
         metadatas->set_end_production_date(bg::to_iso_string(d->meta->production_date.last()));
         metadatas->set_shape(d->meta->shape);
         // we get the first timezone of the dataset
-        const auto* tz = d->pt_data->tz_manager.get_first_timezone();
+        const auto* tz = d->pt_data->get_main_timezone();
         if (tz) {
             metadatas->set_timezone(tz->tz_name);
         }

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -127,6 +127,22 @@ type::Route* PT_Data::get_or_create_route(const std::string& uri,
     return route;
 }
 
+const type::TimeZoneHandler* PT_Data::get_main_timezone() {
+    // using TZ already used by MetaVJ as they all use the same when reading base_schedule data
+    if (meta_vjs.size() > 0) {
+        return meta_vjs.begin()->get()->tz_handler;
+    }
+    return tz_manager.get_first_timezone();
+}
+
+type::MetaVehicleJourney* PT_Data::get_or_create_meta_vehicle_journey(const std::string& uri,
+                                                                      const type::TimeZoneHandler* tz) {
+    auto* mvj = meta_vjs.get_or_create(uri);
+    mvj->tz_handler = tz;
+
+    return mvj;
+}
+
 ValidityPattern* PT_Data::get_or_create_validity_pattern(const ValidityPattern& vp_ref) {
     for (auto vp : validity_patterns) {
         if (vp->days == vp_ref.days && vp->beginning_date == vp_ref.beginning_date) {

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -170,6 +170,9 @@ struct PT_Data : boost::noncopyable{
                                      type::Line* line,
                                      type::StopArea* destination = nullptr,
                                      const std::string& direction_type = {});
+    const type::TimeZoneHandler* get_main_timezone();
+    type::MetaVehicleJourney* get_or_create_meta_vehicle_journey(const std::string& uri,
+                                                                 const type::TimeZoneHandler* tz);
 
     void clean_weak_impacts();
 


### PR DESCRIPTION
Also add a PT_Data::get_main_timezone() on the way
Could not think of a better (and "light") way to handle default TZ as we lose the information in ed (initially linked to network) : https://github.com/CanalTP/navitia/blob/dev/source/ed/ed_persistor.cpp#L1102

:mag_right: Hide whitespace changes for review

TODO:
- [x] merge https://github.com/CanalTP/utils/pull/80 and update submodule once build is OK