### PR TITLE
Kraken: correct application period processing for RT added trip

### DIFF
--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1350,8 +1350,12 @@ def new_default_pagination_journey_comparator(clockwise):
     ]
 
 
+def get_disruptions_by_id(response, disrupt_id):
+    return [d for d in response['disruptions'] if d['id'] == disrupt_id]
+
+
 def has_the_disruption(response, disrupt_id):
-    return any([d['id'] for d in response['disruptions'] if d['id'] == disrupt_id])
+    return any(get_disruptions_by_id(response, disrupt_id))
 
 
 def get_departure(dep, sp_uri, line_code):


### PR DESCRIPTION
Using `min()` to compute date must start with `+infinity` by default

Before this PR, application period on a new trip circulating on [20120614T080100; 20120614T080102[ was [20120614T`000000`; 20120614T080101]
Now [20120614T`080100`; 20120614T080101]