### PR TITLE
[Kraken] Replace Clang-format hooks with navitia-pre-commit's one

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,10 +11,10 @@ repos:
     -   id: check-ast
     -   id: check-merge-conflict
     #-   id: flake8
--   repo: git://github.com/doublify/pre-commit-clang-format
+-   repo: https://github.com/CanalTP/navitia-pre-commit
     rev: master
     hooks:
-    -   id: clang-format
+    -   id: clang-format-6.0
         verbose: true
         exclude: ^source/third_party/
         files: \.(c|cc|cxx|cpp|h|hpp|hxx)$

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,8 @@ before_script:
   - bash source/scripts/build_protobuf.sh
 
 script:
-  # Make sure submodules references are merged in !
   - bash source/scripts/check_submodules.sh
-  - pushd source && pre-commit run clang-format --all --show-diff-on-failure; popd
+  - pre-commit run clang-format-6.0 --all --show-diff-on-failure
   - pushd source/tyr && PYTHONPATH=.:../navitiacommon/ py.test --doctest-modules --ignore=migrations/ ; popd
 
 matrix:


### PR DESCRIPTION
Introducing a new repo that hold our pre-commits hooks - https://github.com/CanalTP/navitia-pre-commit 