### PR TITLE
kraken: physical mode id in realtime, only impact additional service

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1908,13 +1908,10 @@ class TestKirinUpdateTripWithPhysicalMode(MockKirinDisruptionsFixture):
         pt_response = self.query_region('vehicle_journeys')
         assert len(pt_response['vehicle_journeys']) == (initial_nb_vehicle_journeys + 1)
 
-        # physical_mode of the newly created vehicle_journey should be that of base vehicle_journey (Tramway)
-        # TODO : Modify kraken to use physical_mode of base vehicle_journey for a trip update even if
-        # a physical_mode is present in GTFS-RT
-        # ticket jira pour la correction : https://jira.kisio.org/browse/NAVP-1284
+        # physical_mode of the newly created vehicle_journey is the base vehicle_journey physical mode (Tramway)
         pt_response = self.query_region('vehicle_journeys/vjA:modified:0:vjA_delayed/physical_modes')
         assert len(pt_response['physical_modes']) == 1
-        assert pt_response['physical_modes'][0]['name'] == 'Bus'
+        assert pt_response['physical_modes'][0]['name'] == 'Tramway'
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING_NO_ADD)

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -269,9 +269,13 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 }
             }
 
-            // Add physical mode
-            if (!impact->physical_mode_id.empty()
-                && impact->severity->effect == nt::disruption::Effect::ADDITIONAL_SERVICE) {
+            // Add physical mode:
+            // Use base-VJ's mode if exists,
+            // fallback on impact's mode
+            // last resort is picking physical_modes[0]
+            if (!mvj->get_base_vj().empty()) {
+                vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
+            } else if (!impact->physical_mode_id.empty()) {  // fallback on impact's mode
                 nu::make_map_find(pt_data.physical_modes_map, impact->physical_mode_id)
                     .if_found([&](navitia::type::PhysicalMode* p) {
                         vj->physical_mode = p;
@@ -288,14 +292,10 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                                            << impact->physical_mode_id);
                     });
             } else {
-                if (!mvj->get_base_vj().empty()) {
-                    vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
-                } else {
-                    // for protection, use the physical_modes[0] instead of creating a new one
-                    vj->physical_mode = pt_data.physical_modes[0];
-                    LOG4CPLUS_WARN(
-                        log, "[disruption] Associate random physical mode to new VJ because base VJ doesn't exist");
-                }
+                // for protection, use the physical_modes[0] instead of creating a new one
+                vj->physical_mode = pt_data.physical_modes[0];
+                LOG4CPLUS_WARN(log,
+                               "[disruption] Associate random physical mode to new VJ because base VJ doesn't exist");
             }
 
             // Use the corresponding base stop_time for boarding and alighting duration

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -270,7 +270,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             }
 
             // Add physical mode
-            if (!impact->physical_mode_id.empty()) {
+            if (!impact->physical_mode_id.empty() && impact->severity->effect == nt::disruption::Effect::ADDITIONAL_SERVICE) {
                 nu::make_map_find(pt_data.physical_modes_map, impact->physical_mode_id)
                     .if_found([&](navitia::type::PhysicalMode* p) {
                         vj->physical_mode = p;

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -270,7 +270,8 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             }
 
             // Add physical mode
-            if (!impact->physical_mode_id.empty() && impact->severity->effect == nt::disruption::Effect::ADDITIONAL_SERVICE) {
+            if (!impact->physical_mode_id.empty()
+                && impact->severity->effect == nt::disruption::Effect::ADDITIONAL_SERVICE) {
                 nu::make_map_find(pt_data.physical_modes_map, impact->physical_mode_id)
                     .if_found([&](navitia::type::PhysicalMode* p) {
                         vj->physical_mode = p;

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2619,7 +2619,7 @@ struct AddTripDataset {
         b.sa("I", 0, 0, true, true);
         b.sa("J", 0, 0, true, true);
 
-        b.vj("1").uri("vj:1")("stop_point:A", "08:00"_t)("stop_point:B", "08:30"_t)("stop_point:C", "09:00"_t)(
+        b.vj("1").uri("vj:1").physical_mode("physical_mode_uri")("stop_point:A", "08:00"_t)("stop_point:B", "08:30"_t)("stop_point:C", "09:00"_t)(
             "stop_point:D", "09:30"_t);
 
         // Add company
@@ -2635,7 +2635,7 @@ struct AddTripDataset {
         b.lines["1"]->company_list.push_back(cmp1);
 
         // Add physical mode
-        phy_mode_name = "physical_mode_name";
+        phy_mode_name = "name physical_mode_uri";
         phy_mode_uri = "physical_mode_uri";
         navitia::type::PhysicalMode* phy_mode = new navitia::type::PhysicalMode();
         phy_mode->idx = b.data->pt_data->physical_modes.size();
@@ -2645,6 +2645,17 @@ struct AddTripDataset {
         b.data->pt_data->physical_modes.push_back(phy_mode);
         b.data->pt_data->physical_modes_map[phy_mode_uri] = phy_mode;
         b.lines["1"]->physical_mode_list.push_back(phy_mode);
+
+        // Add second physical mode
+        phy_mode_name_2 = "name physical_mode_uri_2";
+        phy_mode_uri_2 = "physical_mode_uri_2";
+        phy_mode = new navitia::type::PhysicalMode();
+        phy_mode->idx = b.data->pt_data->physical_modes.size();
+        phy_mode->name = phy_mode_name_2;
+        phy_mode->uri = phy_mode_uri_2;
+        phy_mode->vehicle_journey_list.push_back(b.data->pt_data->vehicle_journeys[0]);
+        b.data->pt_data->physical_modes.push_back(phy_mode);
+        b.data->pt_data->physical_modes_map[phy_mode_uri_2] = phy_mode;
 
         // Add contributor
         contributor_name = "contributor_name";
@@ -2676,6 +2687,8 @@ struct AddTripDataset {
     std::string comp_uri;
     std::string phy_mode_name;
     std::string phy_mode_uri;
+    std::string phy_mode_name_2;
+    std::string phy_mode_uri_2;
     std::string contributor_name;
     std::string contributor_uri;
     std::string dataset_name;
@@ -3319,3 +3332,49 @@ BOOST_FIXTURE_TEST_CASE(cant_cancel_trip_that_doesnt_exist, AddTripDataset) {
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys_map.size(), 1);
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 1);
 }
+
+BOOST_FIXTURE_TEST_CASE(physical_mode_id_only_impact_additional_service, AddTripDataset) {
+    auto& pt_data = *b.data->pt_data;
+
+    // Base VJ
+    auto* vj = pt_data.vehicle_journeys_map["vj:1"];
+    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
+
+    transit_realtime::TripUpdate update_trip = ntest::make_trip_update_message(
+        "vj:1", "20190101",
+        {
+            RTStopTime("stop_point:A", "20190101T0800"_pts).delay(0_min),
+            RTStopTime("stop_point:B", "20190101T0830"_pts).delay(0_min),
+            RTStopTime("stop_point:C", "20190101T0900"_pts).delay(5_min),
+            RTStopTime("stop_point:D", "20190101T0930"_pts).delay(5_min),
+        },
+        transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS, "", phy_mode_uri_2);
+
+    navitia::handle_realtime("feed-1", timestamp, update_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+
+    // physical mode =  base VJ physical mode
+    vj = pt_data.vehicle_journeys_map["vj:1:modified:0:feed-1"];
+    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
+
+    update_trip = ntest::make_trip_update_message(
+        "vj:1", "20190101",
+        {
+            RTStopTime("stop_point:A", "20190101T0800"_pts).delay(0_min),
+            RTStopTime("stop_point:B", "20190101T0830"_pts).delay(0_min),
+            RTStopTime("stop_point:C", "20190101T0900"_pts).delay(5_min),
+            RTStopTime("stop_point:D", "20190101T0930"_pts).delay(5_min),
+        },
+        transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS, "", "physical_mode_id_that_doesnt_exist");
+
+    navitia::handle_realtime("feed-1", timestamp, update_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+
+    // physical mode =  base VJ physical mode
+    vj = pt_data.vehicle_journeys_map["vj:1:modified:0:feed-1"];
+    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
+}
+

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2619,8 +2619,8 @@ struct AddTripDataset {
         b.sa("I", 0, 0, true, true);
         b.sa("J", 0, 0, true, true);
 
-        b.vj("1").uri("vj:1").physical_mode("physical_mode_uri")("stop_point:A", "08:00"_t)("stop_point:B", "08:30"_t)("stop_point:C", "09:00"_t)(
-            "stop_point:D", "09:30"_t);
+        b.vj("1").uri("vj:1").physical_mode("physical_mode_uri")("stop_point:A", "08:00"_t)("stop_point:B", "08:30"_t)(
+            "stop_point:C", "09:00"_t)("stop_point:D", "09:30"_t);
 
         // Add company
         comp_name = "comp_name";
@@ -3359,15 +3359,15 @@ BOOST_FIXTURE_TEST_CASE(physical_mode_id_only_impact_additional_service, AddTrip
     BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
     BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
 
-    update_trip = ntest::make_trip_update_message(
-        "vj:1", "20190101",
-        {
-            RTStopTime("stop_point:A", "20190101T0800"_pts).delay(0_min),
-            RTStopTime("stop_point:B", "20190101T0830"_pts).delay(0_min),
-            RTStopTime("stop_point:C", "20190101T0900"_pts).delay(5_min),
-            RTStopTime("stop_point:D", "20190101T0930"_pts).delay(5_min),
-        },
-        transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS, "", "physical_mode_id_that_doesnt_exist");
+    update_trip = ntest::make_trip_update_message("vj:1", "20190101",
+                                                  {
+                                                      RTStopTime("stop_point:A", "20190101T0800"_pts).delay(0_min),
+                                                      RTStopTime("stop_point:B", "20190101T0830"_pts).delay(0_min),
+                                                      RTStopTime("stop_point:C", "20190101T0900"_pts).delay(5_min),
+                                                      RTStopTime("stop_point:D", "20190101T0930"_pts).delay(5_min),
+                                                  },
+                                                  transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS, "",
+                                                  "physical_mode_id_that_doesnt_exist");
 
     navitia::handle_realtime("feed-1", timestamp, update_trip, *b.data, true, true);
     b.finalize_disruption_batch();
@@ -3377,4 +3377,3 @@ BOOST_FIXTURE_TEST_CASE(physical_mode_id_only_impact_additional_service, AddTrip
     BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
     BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
 }
-


### PR DESCRIPTION
After test into this PR https://github.com/CanalTP/navitia/pull/2737 that highlight a bug, this PR aims to fix that. Describe in JIRA : https://jira.kisio.org/browse/NAVP-1284

Actions :
- Fix the Bug
- Add Utest in Kraken
- Update the integration test  that highlight it
