### PR TITLE
eitri: psycopg2 2.4.5 can't work with ubuntu 18.04

### DIFF
--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,7 +1,7 @@
 future==0.13.1
 docker==3.4.1
 retrying==1.2.3
-psycopg2==2.4.5
+psycopg2
 clingon==0.1.4
 GeoAlchemy2==0.2.4
 SQLAlchemy==1.0.4


### PR DESCRIPTION
**Psycopg2 2.4.5** lib can't work with **postgresql-10**, and it is the _default version_ with **Ubuntu 18.04**.
Just don't fixe the version number