### PR TITLE
osm2ed: improve handling of associatedStreetRelation and admin assocciation

### DIFF
--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -223,13 +223,21 @@ struct OSMHouseNumber {
         : number(number), lon(lon), lat(lat), way(way) {}
 };
 
+struct AssociateStreet {
+    uint64_t id;
+    std::string name;
+    const std::vector<uint64_t> way_ids;
+
+    AssociateStreet(uint64_t id, const std::string& name, const std::vector<uint64_t>& way_ids)
+        : id(id), name(name), way_ids(way_ids) {}
+};
+
 struct AssociateStreetRelation {
     const uint64_t osm_id;
     const uint64_t way_id = std::numeric_limits<uint64_t>::max();
-    const std::string streetname = "";
+    /// Ids of the ways part of this street
 
-    AssociateStreetRelation(const uint64_t osm_id, const uint64_t way_id, const std::string& streetname)
-        : osm_id(osm_id), way_id(way_id), streetname(streetname) {}
+    AssociateStreetRelation(const uint64_t osm_id, const uint64_t way_id) : osm_id(osm_id), way_id(way_id) {}
 
     AssociateStreetRelation(const uint64_t osm_id) : osm_id(osm_id) {}
 
@@ -245,7 +253,8 @@ struct OSMCache {
     std::set<OSMRelation> relations;
     std::set<OSMNode> nodes;
     std::set<OSMWay> ways;
-    std::set<AssociateStreetRelation> associated_streets;
+    std::set<AssociateStreetRelation> associated_street_relations;
+    std::vector<AssociateStreet> streets;
     std::unordered_map<std::string, rel_ways> way_admin_map;
     RTree<const OSMRelation*, double, 2> admin_tree;
     RTree<it_way, double, 2> way_tree;


### PR DESCRIPTION
A bit of vocabulary before I start:
  - Way: an object georef.Way in kraken, it should represent a real street
  - street: a street in the real world
  - OSMWay: a Way in the OSM model: https://wiki.openstreetmap.org/wiki/Way in our case it will mostly be a [Highway](https://wiki.openstreetmap.org/wiki/Highways)
  - Admin: an administrative region with  an [admin level](https://wiki.openstreetmap.org/wiki/Key:admin_level) equal to 8, corresponding to a city in France.

This PR refers to: https://jira.kisio.org/browse/NAVITIAII-2718
![the problem](https://i.imgur.com/9jgcVIY.png)

A street id cut into two Ways in kraken:
  - the green one, associated to the correct admin
  - the red one, associated to two admins

On this picture we also see the house_number associated to these street, red house_number are associated to the red street and the green one to the green street.

Almost all house_numbers of this street are associated to the wrong Way in kraken.
In the autocompletion, kraken tries to interpolate the position of the queried house_number by using the existing house_number of this Way.
By example when searching the 115 of this street at Lyon we will be placed on the 255, not great...

**Problems**

So we have two problems...

1. First, the street have been divided in two Ways because one of the OSMWay is a bit inside another admin. This is caused by osm2ed: a Way is the fusion of all the OSMWay having the same
[name](https://wiki.openstreetmap.org/wiki/Key:name) inside the same Admin. The Admins of an OSMWay is the list of all the admins of all its Nodes.  
In our [example](https://www.openstreetmap.org/way/380708671) the end of the way is on the admin's boundary, so the end-Node (and the OSMWay) is associated to Lyon and Villeurbanne.

2. Second problem: the house_numbers aren't associated to the correct Way, this is caused by the fact that we are only partially handling [AssociatedStreet Relation](https://wiki.openstreetmap.org/wiki/Relation:associatedStreet).
This relation is used to group together OSMWays and house_numbers that are part of the same street. It isn't required to use it in OSM, so most streets don't use it.
We are using it to associate the house_number to the OSMWay. But since we have created two Ways for this relation we have already lost (all house_numbers linked to a Way that misses one of its parts).


**Fixes**

* Let's start by fixing the second bug: by keeping track of the ways that compose an associatedStreet we have only one Way at the end. This is mostly done in `fusion_ways()` by aggregating all OSMWay of the
AssociatedStreet in one Way before doing the merge by Admin.
There is no object representing a Way in osm2ed, it's modeled as an OSMWay that references itself in `way_ref` (all the OSMWays grouped together are referencing the mother, including the mother itself).

* This change alone mostly solve our issue, but the resulting Way is still associated to two Admins. 
So I improved a bit this part in `build_way_map()` by ignoring the Admin of an OSMWay associated to only one of its Nodes.
This fixes the case when only one Node is at the boundary, it's far from perfect, but improve things a bit.
To be safe, if an OSMWay is associated to zero admins with this method, there is a fallback to the previous implementation by taking the Admins of all its Nodes.

I did some check on Lyon and didn't see any problems, there is a bit less Way after, but that's the point. And I didn't see any problem visually:
![Sélection_293](https://user-images.githubusercontent.com/448185/56223487-23837e80-606e-11e9-9755-97b2f2f7d6fd.png)

TODO: 
  - [ ] check "rue jean jaurés" at Lille
  - [ ] check test case from https://github.com/CanalTP/mimirsbrunn/issues/220
  - [ ] insert the correct admin in the database...
  - [ ] update the rtree

I will try to add a test for this in docker_test too :(