### PR TITLE
[Kraken] Equipment details optimisation

### DIFF
--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -63,7 +63,7 @@ In the following table, if the invocation starts with `collection`, any collecti
 | query | signification | note |
 |-------|---------------|------|
 |`collection.has_code(type, value)`|all the objects of type `collection` that have the code `{type: "type", value: "value"}` in `codes[]`|only the `codes[]` field is used|
-|`collection.has_code_type(type)`|all the objects of type `collection` that has a code with the specific type `{type: "type"}` in `codes[]`|only the `codes[]` field is used|
+|`collection.has_code_type(type1, type2, ...)`|all the objects of type `collection` that have any of the specific types `{type: "type1"}` in `codes[]`|only the `codes[]` field is used|
 |`collection.id(id)`|the object of type `collection` that have `id` as identifier (empty if this identifier is not present)|for types without identifier (as `connection`), it is equivalent to `empty`|
 |`collection.uri(id)`|same as `collection.id(id)`|deprecated|
 |`collection.name(name)`|all the objects of type `collection` that have `name` as name|for types without name (as `connection`), it is equivalent to `empty`|

--- a/source/equipment/equipment_api.cpp
+++ b/source/equipment/equipment_api.cpp
@@ -36,25 +36,19 @@ www.navitia.io
 #include <tuple>
 #include <vector>
 #include <string>
+#include <map>
+#include <algorithm>
 
 namespace navitia {
 namespace equipment {
 
 namespace {
-const std::string build_ptref_sa_filter(const std::string& line_uri, const std::string& filter) {
+const std::string build_ptref_line_filter(const std::string& line_uri, const std::string& filter) {
     std::string sa_filter = "line.uri=" + line_uri;
     if (filter.size()) {
         sa_filter += " and (" + filter + ")";
     }
     return sa_filter;
-}
-
-const std::string build_ptref_sp_filter(const std::string& stop_area_uri, const std::string& filter) {
-    std::string sp_filter = "stop_area.uri=" + stop_area_uri;
-    if (filter.size()) {
-        sp_filter += " and (" + filter + ")";
-    }
-    return sp_filter;
 }
 
 void fill_equipment_to_pb(const equipment::EquipmentReportList& reports, PbCreator& pb_creator, int depth) {
@@ -94,18 +88,21 @@ EquipmentReportList EquipmentReports::get_paginated_equipment_report_list() {
 
     EquipmentReportList res;
     for (const auto line : paginated_lines) {
-        const std::string sa_filter = build_ptref_sa_filter(line->uri, filter);
-        const type::Indexes sa_indexes = ptref::make_query(type::Type_e::StopArea, sa_filter, forbidden_uris, data);
-        const auto stop_areas = data.get_data<type::StopArea>(sa_indexes);
+        const std::string line_filter = build_ptref_line_filter(line->uri, filter);
+        const type::Indexes sp_indexes = ptref::make_query(type::Type_e::StopPoint, line_filter, forbidden_uris, data);
+        const auto stop_points = data.get_data<type::StopPoint>(sp_indexes);
 
-        std::vector<equipment::StopAreaEquipment> sa_equipments;
-        for (type::StopArea* sa : stop_areas) {
-            const std::string sp_filter = build_ptref_sp_filter(sa->uri, sa_filter);
-            const type::Indexes sp_indexes =
-                ptref::make_query(type::Type_e::StopPoint, sp_filter, forbidden_uris, data);
-            const auto stop_points = data.get_data<type::StopPoint>(sp_indexes);
-            sa_equipments.emplace_back(sa, stop_points);
+        std::map<type::StopArea*, std::set<type::StopPoint*>> sa_map;
+        for (type::StopPoint* sp : stop_points) {
+            sa_map[sp->stop_area].emplace(sp);
         }
+
+        std::vector<StopAreaEquipment> sa_equipments;
+        std::transform(std::cbegin(sa_map), std::cend(sa_map), std::back_inserter(sa_equipments),
+                       [](const auto& p) -> StopAreaEquipment {
+                           return {p.first, p.second};
+                       });
+
         res.emplace_back(line, sa_equipments);
     }
 

--- a/source/equipment/equipment_api.cpp
+++ b/source/equipment/equipment_api.cpp
@@ -99,9 +99,7 @@ EquipmentReportList EquipmentReports::get_paginated_equipment_report_list() {
 
         std::vector<StopAreaEquipment> sa_equipments;
         std::transform(sa_map.cbegin(), sa_map.cend(), std::back_inserter(sa_equipments),
-                       [](const auto& p) -> StopAreaEquipment {
-                           return {p.first, p.second};
-                       });
+                       [](const auto& p) { return StopAreaEquipment(p.first, p.second); });
 
         res.emplace_back(line, sa_equipments);
     }

--- a/source/equipment/equipment_api.cpp
+++ b/source/equipment/equipment_api.cpp
@@ -98,7 +98,7 @@ EquipmentReportList EquipmentReports::get_paginated_equipment_report_list() {
         }
 
         std::vector<StopAreaEquipment> sa_equipments;
-        std::transform(std::cbegin(sa_map), std::cend(sa_map), std::back_inserter(sa_equipments),
+        std::transform(sa_map.cbegin(), sa_map.cend(), std::back_inserter(sa_equipments),
                        [](const auto& p) -> StopAreaEquipment {
                            return {p.first, p.second};
                        });

--- a/source/equipment/equipment_api.h
+++ b/source/equipment/equipment_api.h
@@ -35,12 +35,13 @@ www.navitia.io
 
 #include <string>
 #include <vector>
+#include <set>
 #include <tuple>
 
 namespace navitia {
 namespace equipment {
 
-using StopAreaEquipment = std::tuple<type::StopArea*, std::vector<type::StopPoint*>>;
+using StopAreaEquipment = std::tuple<type::StopArea*, std::set<type::StopPoint*>>;
 using EquipmentReport = std::tuple<type::Line*, std::vector<StopAreaEquipment>>;
 using EquipmentReportList = std::vector<EquipmentReport>;
 using ForbiddenUris = std::vector<std::string>;

--- a/source/equipment/tests/equipment_api_tests.cpp
+++ b/source/equipment/tests/equipment_api_tests.cpp
@@ -184,10 +184,10 @@ BOOST_FIXTURE_TEST_CASE(equipment_reports_test_api, EquipmentTestFixture) {
     const auto resp = pb_creator.get_response();
 
     map<string, set<string>> sa_per_line_uris;
-    for (const auto equip_rep : resp.equipment_reports()) {
+    for (const auto& equip_rep : resp.equipment_reports()) {
         BOOST_REQUIRE(equip_rep.has_line());
         set<string> stop_area_uris;
-        for (const auto sae : equip_rep.stop_area_equipments()) {
+        for (const auto& sae : equip_rep.stop_area_equipments()) {
             BOOST_REQUIRE(sae.has_stop_area());
             stop_area_uris.emplace(sae.stop_area().uri());
         }

--- a/source/equipment/tests/equipment_api_tests.cpp
+++ b/source/equipment/tests/equipment_api_tests.cpp
@@ -231,19 +231,18 @@ BOOST_FIXTURE_TEST_CASE(equipment_reports_should_have_stop_points_codes, Equipme
     const auto filter = "stop_point.has_code_type(CodeType1)";
     equipment::equipment_reports(pb_creator, filter, 1);
 
-    // with "count = 1", only "sa1" with "stop1" will be returned
-    // hence the expected codes are the one from stop point "stop1"
     BOOST_REQUIRE_EQUAL(pb_creator.equipment_reports_size(), 1);
-    const auto pb_codes =
-        pb_creator.get_response().equipment_reports(0).stop_area_equipments(0).stop_area().stop_points(0).codes();
 
-    vector<pair<string, string>> codes;
-    for (const auto& pb_code : pb_codes) {
-        codes.emplace_back(pb_code.type(), pb_code.value());
+    multiset<string> codes;
+    for (const auto& sae : pb_creator.get_response().equipment_reports(0).stop_area_equipments()) {
+        for (const auto& sp : sae.stop_area().stop_points()) {
+            for (const auto& c : sp.codes()) {
+                codes.emplace(c.value());
+            }
+        }
     }
 
-    vector<pair<string, string>> expected_codes = {{"CodeType1", "code1"}, {"CodeType1", "code2"}};
-
+    multiset<string> expected_codes = {"code1", "code2", "code6"};
     BOOST_CHECK_EQUAL_RANGE(codes, expected_codes);
 }
 

--- a/source/equipment/tests/equipment_api_tests.cpp
+++ b/source/equipment/tests/equipment_api_tests.cpp
@@ -231,6 +231,11 @@ BOOST_FIXTURE_TEST_CASE(equipment_reports_should_have_stop_points_codes, Equipme
     const auto filter = "stop_point.has_code_type(CodeType1)";
     equipment::equipment_reports(pb_creator, filter, 1);
 
+    /*
+     * With count = 1, we'll only get stop_areas/stop_points from the 1sr line ("A")
+     * This means we'll only populate codes from stop1 and stop3,
+     * as they both have code type "CodeType1"
+     */
     BOOST_REQUIRE_EQUAL(pb_creator.equipment_reports_size(), 1);
 
     multiset<string> codes;

--- a/source/equipment/tests/equipment_api_tests.cpp
+++ b/source/equipment/tests/equipment_api_tests.cpp
@@ -232,7 +232,7 @@ BOOST_FIXTURE_TEST_CASE(equipment_reports_should_have_stop_points_codes, Equipme
     equipment::equipment_reports(pb_creator, filter, 1);
 
     /*
-     * With count = 1, we'll only get stop_areas/stop_points from the 1sr line ("A")
+     * With count = 1, we'll only get stop_areas/stop_points from the 1st line ("A")
      * This means we'll only populate codes from stop1 and stop3,
      * as they both have code type "CodeType1"
      */

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -306,8 +306,8 @@ struct Eval : boost::static_visitor<Indexes> {
             indexes = get_indexes_from_name(type_by_caption(f.type), f.args.at(0), data);
         } else if (f.method == "has_code" && f.args.size() == 2) {
             indexes = get_indexes_from_code(type_by_caption(f.type), f.args.at(0), f.args.at(1), data);
-        } else if (f.method == "has_code_type" && f.args.size() == 1) {
-            indexes = get_indexes_from_code_type(type_by_caption(f.type), f.args.at(0), data);
+        } else if (f.method == "has_code_type") {
+            indexes = get_indexes_from_code_type(type_by_caption(f.type), f.args, data);
         } else {
             std::stringstream ss;
             ss << "Unknown function: " << f;

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -294,13 +294,13 @@ static
     get_indexes_from_code_type(const std::vector<std::string>& keys, const Data& data) {
     Indexes indexes;
     auto collection = data.pt_data->collection<T>();
-    for (const auto& key : keys) {
-        for (const auto* obj : collection) {
-            auto codes = data.pt_data->codes.get_codes<T>(obj);
-            if (codes.find(key) == codes.end()) {
-                continue;
+    for (const auto* obj : collection) {
+        auto codes = data.pt_data->codes.get_codes<T>(obj);
+        for (const auto& key : keys) {
+            if (codes.find(key) != codes.end()) {
+                indexes.insert(obj->idx);
+                break;
             }
-            indexes.insert(obj->idx);
         }
     }
 

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -294,9 +294,9 @@ static
     get_indexes_from_code_type(const std::vector<std::string>& keys, const Data& data) {
     Indexes indexes;
     auto collection = data.pt_data->collection<T>();
-    for (const auto* obj : collection) {
-        auto codes = data.pt_data->codes.get_codes<T>(obj);
-        for (const auto& key : keys) {
+    for (const auto& key : keys) {
+        for (const auto* obj : collection) {
+            auto codes = data.pt_data->codes.get_codes<T>(obj);
             if (codes.find(key) == codes.end()) {
                 continue;
             }

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -291,30 +291,35 @@ type::Indexes get_indexes_from_code(const type::Type_e type,
 template <typename T>
 static
     typename boost::enable_if<typename boost::mpl::contains<nt::CodeContainer::SupportedTypes, T>::type, Indexes>::type
-    get_indexes_from_code_type(const std::string& key, const Data& data) {
+    get_indexes_from_code_type(const std::vector<std::string>& keys, const Data& data) {
     Indexes indexes;
     auto collection = data.pt_data->collection<T>();
     for (const auto* obj : collection) {
         auto codes = data.pt_data->codes.get_codes<T>(obj);
-        if (codes.find(key) == codes.end()) {
-            continue;
+        for (const auto& key : keys) {
+            if (codes.find(key) == codes.end()) {
+                continue;
+            }
+            indexes.insert(obj->idx);
         }
-        indexes.insert(obj->idx);
     }
+
     return indexes;
 }
 template <typename T>
 static
     typename boost::disable_if<typename boost::mpl::contains<nt::CodeContainer::SupportedTypes, T>::type, Indexes>::type
-    get_indexes_from_code_type(const std::string&, const Data&) {
+    get_indexes_from_code_type(const std::vector<std::string>&, const Data&) {
     // there is no code for unsupported types, thus the result is empty
     return Indexes{};
 }
-type::Indexes get_indexes_from_code_type(const type::Type_e type, const std::string& key, const type::Data& data) {
+type::Indexes get_indexes_from_code_type(const type::Type_e type,
+                                         const std::vector<std::string>& keys,
+                                         const type::Data& data) {
     switch (type) {
 #define GET_INDEXES(type_name, collection_name) \
     case Type_e::type_name:                     \
-        return get_indexes_from_code_type<type::type_name>(key, data);
+        return get_indexes_from_code_type<type::type_name>(keys, data);
         ITERATE_NAVITIA_PT_TYPES(GET_INDEXES)
 #undef GET_INDEXES
         default:

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -59,7 +59,9 @@ type::Indexes get_indexes_from_code(const type::Type_e type,
                                     const type::Data& data);
 type::Indexes get_indexes_from_id(const type::Type_e type, const std::string& id, const type::Data& data);
 type::Indexes get_indexes_from_name(const type::Type_e type, const std::string& name, const type::Data& data);
-type::Indexes get_indexes_from_code_type(const type::Type_e type, const std::string& key, const type::Data& data);
+type::Indexes get_indexes_from_code_type(const type::Type_e type,
+                                         const std::vector<std::string>& keys,
+                                         const type::Data& data);
 
 }  // namespace ptref
 }  // namespace navitia


### PR DESCRIPTION
2 optimisations performed:
- Add `collection.has_code_type(type1, type2, ...)` with multiple types as an parameter. It acts the same way as `disruption.tags(...)`.
- Retrieve stop area through stop points to avoid one level of lookup.

[#NAVP-1281](https://jira.kisio.org/browse/NAVP-1281)