### PR TITLE
Osm2ed improve association of Way to Admin

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -492,13 +492,13 @@ void OSMCache::build_way_map() {
             min_lat = std::min(min_lat, node->lat());
         }
         for (const auto& admin_score : admin_candidate) {
-            // we keep the admin that are associated to at least two nodes
+            // keeping the admins that are associated to at least two nodes
             if (admin_score.second > 1) {
                 admins.insert(admin_score.first);
             }
         }
         // if there is no admin found, we take all of them
-        // this case will happen when a way with 2 node is between two admins
+        // this case will happen when a way with 2 nodes is between two admins
         if (admins.empty()) {
             for (const auto& admin_score : admin_candidate) {
                 admins.insert(admin_score.first);

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -477,11 +477,12 @@ void OSMCache::build_way_map() {
         }
         double max_lon = max_double, max_lat = max_double, min_lon = max_double, min_lat = max_double;
         std::set<const OSMRelation*> admins;
-        for (auto node : way_it->nodes) {
+        std::unordered_map<const OSMRelation*, int> admin_candidate;
+        for (const auto& node : way_it->nodes) {
             if (!node->admin) {
                 continue;
             }
-            admins.insert(node->admin);
+            admin_candidate[node->admin]++;
             if (!node->is_defined()) {
                 continue;
             }
@@ -489,6 +490,19 @@ void OSMCache::build_way_map() {
             max_lat = max_lat >= max_double ? node->lat() : std::max(max_lat, node->lat());
             min_lon = std::min(min_lon, node->lon());
             min_lat = std::min(min_lat, node->lat());
+        }
+        for (const auto& admin_score : admin_candidate) {
+            // we keep the admin that are associated to at least two nodes
+            if (admin_score.second > 1) {
+                admins.insert(admin_score.first);
+            }
+        }
+        // if there is no admin found, we take all of them
+        // this case will happen when a way with 2 node is between two admins
+        if (admins.empty()) {
+            for (const auto& admin_score : admin_candidate) {
+                admins.insert(admin_score.first);
+            }
         }
         way_admin_map[way_it->name][admins].insert(way_it);
         bg::simplify(way_it->ls, way_it->ls, 0.5);
@@ -656,7 +670,7 @@ OSMRelation::OSMRelation(const u_int64_t osm_id,
 }
 
 void OSMRelation::build_geometry(OSMCache& cache) const {
-    for (CanalTP::Reference ref : references) {
+    for (const CanalTP::Reference& ref : references) {
         if (ref.member_type == OSMPBF::Relation_MemberType::Relation_MemberType_NODE) {
             auto node_it = cache.nodes.find(ref.member_id);
             if (node_it == cache.nodes.end()) {


### PR DESCRIPTION
## Glossary
  - Way: an object georef.Way in kraken, it should represent a real street
  - street: a street in the real world
  - OSMWay: a Way in the OSM model: https://wiki.openstreetmap.org/wiki/Way in our case it will mostly be a [Highway](https://wiki.openstreetmap.org/wiki/Highways)
  - Admin: an administrative region with  an [admin level](https://wiki.openstreetmap.org/wiki/Key:admin_level) equal to 8, corresponding to a city in France.

## Problems

This PR refers to: https://jira.kisio.org/browse/NAVITIAII-2718
![the problem](https://i.imgur.com/9jgcVIY.png)

The street id divided into two Way in kraken:
  - the green one, associated to the correct admin
  - the red one, associated to two admins

On this picture we also see the house_number associated to these streets, red house_number are associated to the red street and the green one to the green street.

Almost all house_numbers of this street are associated to the wrong Way in kraken.
In the autocompletion kraken tries to interpolate the position of the queried house_number by using the existing house_number of this Way.
By example when searching the 115 of this street at Lyon we will be placed on the 255, not great...


 1. The street have been divided in two Ways because one of the OSMWay is a bit inside another admin.
This is caused by osm2ed: a Way is the fusion of all the OSMWay having the same [name](https://wiki.openstreetmap.org/wiki/Key:name) inside the same Admin.
The Admins of an OSMWay is the list of all the admins of all its Nodes.
In our [example](https://www.openstreetmap.org/way/380708671) the end of the way is on the admin's boundary, so the end-Node (and the OSMWay) is associated to Lyon and Villeurbanne.

 2. The house_numbers aren't associated to the correct Way, this is caused by the fact that we are handling only partially [AssociatedStreet Relation](https://wiki.openstreetmap.org/wiki/Relation:associatedStreet) 
This relation is used to group together OSMWays and house_numbers that are part of the same street.
It isn't required to use it in OSM, so most streets don't use it. We are using it to associate the house_number to the OSMWay. But since we have created two Ways for this relation we have already lost (all house_numbers linked to a Way that misses one of its parts).

## Fix

This PR tries to improve the association of a Way to an Admin, it's far from perfect but will fix a lot of edge cases like the one in our example.

I improved a bit `build_way_map()` by ignoring the Admin of an OSMWay associated to only one of its Nodes. This fixes the case when only one Node is at the boundary.
To be safe, if an OSMWay is associated to zero admins with this method there is a fallback to the previous implementation by taking the Admins of all its Nodes.

This PR supersedes #2754 

case like https://www.openstreetmap.org/relation/3743313#map=18/45.76674/4.86614 isn't fixed :(
http://canaltp.github.io/navitia-playground/play.html?request=http%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Ffr-se-lyon%2Fplaces%3Fq%3D90%2520Rue%2520d%27Inkermann%26
The three result are in fact the same street, but the position of the house_number changes quite a bit between each result :(