### PR TITLE
[TYR] Add job 'cities' and returns it in /cities/status

### DIFF
--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -476,16 +476,33 @@ def load_data(instance_id, data_dirs):
 @celery.task()
 def cities(osm_path):
     """ launch cities """
+    # Create Job and Dataset in db to track progress
+    job = models.Job()
+    job.state = 'running'
+    models.db.session.add(job)
+    dataset = models.DataSet()
+    dataset.type = 'cities'
+    dataset.name = osm_path
+    dataset.family_type = 'cities'
+    models.db.session.add(dataset)
+    job.data_sets.append(dataset)
+    models.db.session.commit()
+
     res = -1
     try:
         res = launch_exec(
             "cities", ['-i', osm_path, '--connection-string', current_app.config['CITIES_DATABASE_URI']], logging
         )
         if res != 0:
+            job.state = 'failed'
             logging.error('cities failed')
+        else:
+            job.state = 'done'
+
     except Exception as e:
         logging.exception('cities exception : {}'.format(e.message))
 
+    models.db.session.commit()
     logging.info('Import of cities finished')
     return res
 


### PR DESCRIPTION
First part of https://jira.kisio.org/browse/NAVP-1093

A job and a dataset 'cities' are now created in Tyr db.

The endpoint /cities/status now returns:
```
{
    "cities db version": "1d99ba678e3f",
    "latest_job": {
        "created_at": "2019-04-17T06:20:48.214670",
        "data_sets": [
            {
                "family_type": "cities",
                "name": "/navitia/source/tyr/france_boundaries.osm.pbf",
                "type": "cities"
            }
        ],
        "id": 7,
        "state": "done",
        "updated_at": "2019-04-17T06:21:25.789480"
    }
}
```