### PR TITLE
Jormungandr: no db request at equipment_providers init

### DIFF
--- a/source/jormungandr/jormungandr/__init__.py
+++ b/source/jormungandr/jormungandr/__init__.py
@@ -80,7 +80,8 @@ rest_api = Api(app, catch_all_404s=True, serve_challenge_on_401=True)
 
 from navitiacommon.models import db
 
-db.app = app
+# NOTE: no db request should be made outside of a request context
+# Therefore, the db app shouldn't be set here in order not to cause idle_in_transaction deadlock
 db.init_app(app)
 cache = Cache(app, config=app.config[str('CACHE_CONFIGURATION')])  # type: Cache
 memory_cache = Cache(app, config=app.config[str('MEMORY_CACHE_CONFIGURATION')])  # type: Cache

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -64,9 +64,6 @@ class EquipmentProviderManager(object):
             ):
                 self._equipment_providers_legacy[key] = self._init_class(provider['class'], provider['args'])
 
-        # Init providers from db
-        self.update_config()
-
     def _init_class(self, cls, arguments):
         """
         Create an instance of a provider according to config

--- a/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
@@ -100,6 +100,7 @@ def equipments_provider_manager_db_test():
     # 2 providers defined in db but only 1 matches the key defined in coverage
     # -> Only 1 provider created
     manager.init_providers(['sytral'])
+    manager.update_config()
     assert not manager._equipment_providers_legacy
     assert len(manager._equipment_providers) == 1
     assert 'sytral' in manager._equipment_providers
@@ -122,6 +123,7 @@ def equipments_provider_manager_db_test():
     # Long update interval so provider shouldn't be updated
     manager = EquipmentProviderManager([], providers_getter_ok, 600)
     manager.init_providers(['sytral'])
+    manager.update_config()
     assert not manager._equipment_providers_legacy
     assert len(manager._equipment_providers) == 1
     assert 'sytral' in manager._equipment_providers


### PR DESCRIPTION
Action necessary after merge of this PR:
- perform a `pg_terminate_backend()` in db on the query idle_in_transaction (`pg_cancel_backend()` didn't work).

Before this PR, problem was:
- Each jormun's process does a db request through SQLAlchemy.
- SQLAlchemy always opens a transaction (`begin_transaction`) that must later be closed via `commit` or `rollback`. Even for a "simple" SELECT. This closing must be done "by hand" in a pure SQLAlchemy context.
- At init, we were in a pure SQLAlchemy context and no closing of the transaction was done. Letting the transaction open, and using an ACCESS_SHARE lock.
- We performed a migration on the base which showed the problem (but it was a problem already without migration, as multiple processes opened persistent transactions...). Migration needs an ACCESS_EXCLUSIVE lock, which is not compatible with the ACCESS_SHARE lock from the transaction: https://www.postgresql.org/docs/9.4/explicit-locking.html#TABLE-LOCK-COMPATIBILITY. This led to the migration query being 'idle_in_transaction' in base.

After this PR, it's OK because:
- without access to db at init we forbid query at that moment ("pure" SQLAlchemy context)
- the query is lazily done later, in a flask-SQLAlchemy context, which manages the closing of transaction