### PR TITLE
Jormun: Merge systral equipment response with Sytral web service

### DIFF
--- a/source/jormungandr/jormungandr/equipments/__init__.py
+++ b/source/jormungandr/jormungandr/equipments/__init__.py
@@ -28,3 +28,4 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, division
+from jormungandr.equipments.equipment_provider_manager import EquipmentProviderManager

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -122,32 +122,49 @@ class EquipmentProviderManager(object):
                 # If the provider added in db is also defined in legacy, delete it.
                 self._equipment_providers_legacy.pop(provider.id, None)
 
-    def manage_equipments(self, response):
+    def manage_equipments(self, response, api):
         """
         Call equipment details provider to update response
         :param response: the pb response received
+        :param api: the API type
         :return: response: the pb response updated with equipment details
         """
+        if api == type_pb2.API.Value('equipment_reports'):
+            stop_area_equipments = [sae for er in response.equipment_reports for sae in er.stop_area_equipments]
 
-        def get_from_to_stop_points_of_journeys(journeys):
-            """
-            :param journeys: the pb journey response
-            :return: generator of stop points that can be 'origin' or 'destination'
-            """
-            places = chain(*[(s.origin, s.destination) for j in journeys for s in j.sections])
-            return (
-                place.stop_point
-                for place in places
-                if place.embedded_type == type_pb2.NavitiaType.Value('STOP_POINT')
-                and place.HasField('stop_point')
-            )
+            # Update config before calling web-service
+            self.update_config()
 
-        stop_points = get_from_to_stop_points_of_journeys(response.journeys)
+            for provider in self._get_providers().values():
+                provider.get_informations_for_equipment_reports(stop_area_equipments)
 
-        # Update config before calling web-service
-        self.update_config()
+        elif api == type_pb2.API.Value('PLANNER'):
 
-        for provider in dict(self._equipment_providers, **self._equipment_providers_legacy).values():
-            provider.get_informations(stop_points)
+            def get_from_to_stop_points_of_journeys(journeys):
+                """
+                :param journeys: the pb journey response
+                :return: generator of stop points that can be 'origin' or 'destination'
+                """
+                places = chain(*[(s.origin, s.destination) for j in journeys for s in j.sections])
+                return (
+                    place.stop_point
+                    for place in places
+                    if place.embedded_type == type_pb2.NavitiaType.Value('STOP_POINT')
+                    and place.HasField('stop_point')
+                )
+
+            stop_points = get_from_to_stop_points_of_journeys(response.journeys)
+
+            # Update config before calling web-service
+            self.update_config()
+
+            for provider in self._get_providers().values():
+                provider.get_informations_for_journeys(stop_points)
+
+        else:
+            self.logger.exception('impossible to use api {} with equipments provider'.format(api))
 
         return response
+
+    def _get_providers(self):
+        return dict(self._equipment_providers, **self._equipment_providers_legacy)

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -63,6 +63,9 @@ class EquipmentProviderManager(object):
                 self._equipment_providers, **self._equipment_providers_legacy
             ):
                 self._equipment_providers_legacy[key] = self._init_class(provider['class'], provider['args'])
+            else:
+                self.logger.error('impossible to create provider with key: {}'.format(key))
+
 
     def _init_class(self, cls, arguments):
         """

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -66,7 +66,6 @@ class EquipmentProviderManager(object):
             else:
                 self.logger.error('impossible to create provider with key: {}'.format(key))
 
-
     def _init_class(self, cls, arguments):
         """
         Create an instance of a provider according to config

--- a/source/jormungandr/jormungandr/equipments/sytral.py
+++ b/source/jormungandr/jormungandr/equipments/sytral.py
@@ -162,12 +162,10 @@ class SytralProvider(object):
 
     def _process_for_equipment_reports(self, data, stop_area_equipments_list):
         """
-        For each stop point within journeys response, the structure 'equipment_details' is updated if the corresponding code is present
+        For each stop_area_equipments within equipment_reports response, the structure 'equipment_details' is updated if the corresponding code is present
         :param data: equipments data received from the webservice
-        :param stop_points_list: list of stop_points from the protobuf response
+        :param stop_area_equipments_list: list of stop_area_equipments from the protobuf response
         """
-
-        # stop_points = [sp for er in response.equipment_reports for sae in er.stop_area_equipments for sp in sae.stop_area.stop_points]
         for sae in stop_area_equipments_list:
             for st in sae.stop_area.stop_points:
                 for code in st.codes:

--- a/source/jormungandr/jormungandr/equipments/sytral.py
+++ b/source/jormungandr/jormungandr/equipments/sytral.py
@@ -48,6 +48,7 @@ class SytralProvider(object):
     """
 
     def __init__(self, url, timeout=2, **kwargs):
+        self.logger = logging.getLogger(__name__)
         self.url = url
         self.timeout = timeout
         self.breaker = pybreaker.CircuitBreaker(
@@ -57,14 +58,23 @@ class SytralProvider(object):
             ),
         )
 
-    def get_informations(self, stop_points_list):
+    def get_informations_for_journeys(self, stop_points_list):
         """
         Get equipment information from Sytral webservice and update response accordingly
         """
         data = self._call_webservice()
 
         if data:
-            return self._process_data(data, stop_points_list)
+            return self._process_for_journeys(data, stop_points_list)
+
+    def get_informations_for_equipment_reports(self, stop_area_equipments_list):
+        """
+        Get equipment information from Sytral webservice and update response accordingly
+        """
+        data = self._call_webservice()
+
+        if data:
+            return self._process_for_equipment_reports(data, stop_area_equipments_list)
 
     @cache.memoize(app.config.get(str('CACHE_CONFIGURATION'), {}).get(str('TIMEOUT_SYTRAL'), 30))
     def _call_webservice(self):
@@ -97,7 +107,41 @@ class SytralProvider(object):
         params.update(kwargs)
         new_relic.record_custom_event('parking_status', params)
 
-    def _process_data(self, data, stop_points_list):
+    def _fill_equipment_details(self, equipment_form_web_service, equipment_details):
+        equipment_details.id = equipment_form_web_service['id']
+        equipment_details.name = equipment_form_web_service['name']
+        equipment_details.embedded_type = type_pb2.EquipmentDetails.EquipmentType.Value(
+            '{}'.format(equipment_form_web_service['embedded_type'])
+        )
+        equipment_details.current_availability.status = type_pb2.CurrentAvailability.EquipmentStatus.Value(
+            '{}'.format(equipment_form_web_service['current_availaibity']['status'])
+        )
+        current_availaibity = equipment_form_web_service['current_availaibity']
+        for period in current_availaibity['periods']:
+            p = equipment_details.current_availability.periods.add()
+            p.begin = date_to_timestamp(parser.parse(period['begin']))
+            p.end = date_to_timestamp(parser.parse(period['end']))
+        equipment_details.current_availability.updated_at = current_availaibity['updated_at']
+        equipment_details.current_availability.cause.label = current_availaibity['cause']['label']
+        equipment_details.current_availability.effect.label = current_availaibity['effect']['label']
+
+    def _fill_default_equipment_details(self, id, embedded_type, equipment_details):
+        equipment_details.id = id
+        equipment_details.embedded_type = type_pb2.EquipmentDetails.EquipmentType.Value(embedded_type)
+        equipment_details.current_availability.status = type_pb2.CurrentAvailability.EquipmentStatus.Value(
+            "unknown"
+        )
+
+    def _embedded_type(self, embedded_type_sytral):
+        if embedded_type_sytral == "TCL_ASCENCEUR":
+            return "elevator"
+        elif embedded_type_sytral == "TCL_ESCALIER":
+            return "escalator"
+        else:
+            self.logger.exception('impossible to use {} sytral type'.format(embedded_type_sytral))
+            return ""
+
+    def _process_for_journeys(self, data, stop_points_list):
         """
         For each stop point within journeys response, the structure 'equipment_details' is updated if the corresponding code is present
         :param data: equipments data received from the webservice
@@ -111,20 +155,38 @@ class SytralProvider(object):
                     if equipments_list:
                         equipment = equipments_list[0]
                         # Fill PB
-                        details = st.equipment_details.add()
-                        details.id = equipment['id']
-                        details.name = equipment['name']
-                        details.embedded_type = type_pb2.EquipmentDetails.EquipmentType.Value(
-                            '{}'.format(equipment['embedded_type'])
+                        equipment_details = st.equipment_details.add()
+                        self._fill_equipment_details(
+                            equipment_form_web_service=equipment, equipment_details=equipment_details
                         )
-                        details.current_availability.status = type_pb2.CurrentAvailability.EquipmentStatus.Value(
-                            '{}'.format(equipment['current_availaibity']['status'])
+
+    def _process_for_equipment_reports(self, data, stop_area_equipments_list):
+        """
+        For each stop point within journeys response, the structure 'equipment_details' is updated if the corresponding code is present
+        :param data: equipments data received from the webservice
+        :param stop_points_list: list of stop_points from the protobuf response
+        """
+
+        # stop_points = [sp for er in response.equipment_reports for sae in er.stop_area_equipments for sp in sae.stop_area.stop_points]
+        for sae in stop_area_equipments_list:
+            for st in sae.stop_area.stop_points:
+                for code in st.codes:
+                    if SYTRAL_TYPE_PREFIX in code.type:
+                        equipments_list = jmespath.search(
+                            "equipments_details[?id=='{}']".format(code.value), data
                         )
-                        current_availaibity = equipment['current_availaibity']
-                        for period in current_availaibity['periods']:
-                            p = details.current_availability.periods.add()
-                            p.begin = date_to_timestamp(parser.parse(period['begin']))
-                            p.end = date_to_timestamp(parser.parse(period['end']))
-                        details.current_availability.updated_at = current_availaibity['updated_at']
-                        details.current_availability.cause.label = current_availaibity['cause']['label']
-                        details.current_availability.effect.label = current_availaibity['effect']['label']
+
+                        if equipments_list:
+                            equipment = equipments_list[0]
+                            # Fill PB
+                            equipment_details = sae.equipment_details.add()
+                            self._fill_equipment_details(
+                                equipment_form_web_service=equipment, equipment_details=equipment_details
+                            )
+                        else:
+                            equipment_details = sae.equipment_details.add()
+                            self._fill_default_equipment_details(
+                                id=code.value,
+                                embedded_type=self._embedded_type(code.type),
+                                equipment_details=equipment_details,
+                            )

--- a/source/jormungandr/jormungandr/equipments/sytral.py
+++ b/source/jormungandr/jormungandr/equipments/sytral.py
@@ -47,10 +47,11 @@ class SytralProvider(object):
     Class managing calls to SytralRT webservice, providing real-time equipment details
     """
 
-    def __init__(self, url, timeout=2, **kwargs):
+    def __init__(self, url, timeout=2, code_types=[], **kwargs):
         self.logger = logging.getLogger(__name__)
         self.url = url
         self.timeout = timeout
+        self.code_types = code_types
         self.breaker = pybreaker.CircuitBreaker(
             fail_max=kwargs.get('circuit_breaker_max_fail', app.config['CIRCUIT_BREAKER_MAX_SYTRAL_FAIL']),
             reset_timeout=kwargs.get(
@@ -149,7 +150,7 @@ class SytralProvider(object):
         """
         for st in stop_points_list:
             for code in st.codes:
-                if SYTRAL_TYPE_PREFIX in code.type:
+                if code.type in self.code_types:
                     equipments_list = jmespath.search("equipments_details[?id=='{}']".format(code.value), data)
 
                     if equipments_list:
@@ -169,7 +170,7 @@ class SytralProvider(object):
         for sae in stop_area_equipments_list:
             for st in sae.stop_area.stop_points:
                 for code in st.codes:
-                    if SYTRAL_TYPE_PREFIX in code.type:
+                    if code.type in self.code_types:
                         equipments_list = jmespath.search(
                             "equipments_details[?id=='{}']".format(code.value), data
                         )

--- a/source/jormungandr/jormungandr/equipments/sytral.py
+++ b/source/jormungandr/jormungandr/equipments/sytral.py
@@ -39,15 +39,13 @@ import logging
 import jmespath
 import requests as requests
 
-SYTRAL_TYPE_PREFIX = "TCL_"
-
 
 class SytralProvider(object):
     """
     Class managing calls to SytralRT webservice, providing real-time equipment details
     """
 
-    def __init__(self, url, timeout=2, code_types=[], **kwargs):
+    def __init__(self, url, timeout=2, code_types=["TCL_ESCALIER", "TCL_ASCENCEUR"], **kwargs):
         self.logger = logging.getLogger(__name__)
         self.url = url
         self.timeout = timeout
@@ -112,10 +110,10 @@ class SytralProvider(object):
         equipment_details.id = equipment_form_web_service['id']
         equipment_details.name = equipment_form_web_service['name']
         equipment_details.embedded_type = type_pb2.EquipmentDetails.EquipmentType.Value(
-            '{}'.format(equipment_form_web_service['embedded_type'])
+            equipment_form_web_service['embedded_type']
         )
         equipment_details.current_availability.status = type_pb2.CurrentAvailability.EquipmentStatus.Value(
-            '{}'.format(equipment_form_web_service['current_availaibity']['status'])
+            equipment_form_web_service['current_availaibity']['status']
         )
         current_availaibity = equipment_form_web_service['current_availaibity']
         for period in current_availaibity['periods']:

--- a/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
@@ -56,6 +56,7 @@ def equipments_provider_manager_env_test():
     assert not manager._equipment_providers
     assert len(manager._equipment_providers_legacy) == 1
     assert manager._equipment_providers_legacy.keys()[0] == 'sytral'
+    assert manager._get_providers() == {'sytral': 'Provider'}
 
     # Provider already created
     # No new provider added in providers list

--- a/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
@@ -55,8 +55,8 @@ def equipments_provider_manager_env_test():
     manager.init_providers(['SytralRT'])
     assert not manager._equipment_providers
     assert len(manager._equipment_providers_legacy) == 1
-    assert manager._equipment_providers_legacy.keys()[0] == 'sytralRT'
-    assert manager._get_providers() == {'sytralRT': 'Provider'}
+    assert manager._equipment_providers_legacy.keys()[0] == 'SytralRT'
+    assert manager._get_providers() == {'SytralRT': 'Provider'}
 
     # Provider already created
     # No new provider added in providers list

--- a/source/jormungandr/jormungandr/equipments/tests/sytral_equipment_test.py
+++ b/source/jormungandr/jormungandr/equipments/tests/sytral_equipment_test.py
@@ -64,7 +64,7 @@ def equipments_get_information_test():
     """
     Test that 'equipment_details' structure is added to StopPoint proto when conditions are met
     """
-    provider = SytralProvider(url="sytral.url")
+    provider = SytralProvider(url="sytral.url", timeout=3, code_types=["TCL_ASCENCEUR", "TCL_ESCALIER"])
     provider._call_webservice = MagicMock(return_value=mock_data)
 
     # stop point has code with correct type and value present in webservice response

--- a/source/jormungandr/jormungandr/equipments/tests/sytral_equipment_test.py
+++ b/source/jormungandr/jormungandr/equipments/tests/sytral_equipment_test.py
@@ -70,17 +70,17 @@ def equipments_get_information_test():
     # stop point has code with correct type and value present in webservice response
     # equipment_details is added
     st = create_stop_point("TCL_ASCENCEUR", "261")
-    provider.get_informations([st])
+    provider.get_informations_for_journeys([st])
     assert st.equipment_details
 
     # stop point has code with correct type but value not present in webservice response
     # equipment_details is not added
     st = create_stop_point("TCL_ASCENCEUR", "262")
-    provider.get_informations([st])
+    provider.get_informations_for_journeys([st])
     assert not st.equipment_details
 
     # stop point has code with incorrect type but value present in webservice response
     # equipment_details is not added
     st = create_stop_point("ASCENCEUR", "261")
-    provider.get_informations([st])
+    provider.get_informations_for_journeys([st])
     assert not st.equipment_details

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -40,6 +40,7 @@ from jormungandr.interfaces.v1.serializer import api
 from jormungandr.resources_utils import ResourceUtc
 from navitiacommon import type_pb2
 import six
+import logging
 
 
 class EquipmentReports(ResourceUri, ResourceUtc):
@@ -75,6 +76,9 @@ class EquipmentReports(ResourceUri, ResourceUtc):
             for provider in instance.equipment_provider_manager._get_providers().values()
             for code in provider.code_types
         ]
+        if not code_types:
+            logging.getLogger(__name__).warn("No code type exist into equipment provider")
+            return "stop_point.has_code_type(no_code_types)"
         filter = "stop_point.has_code_type("
         for c in code_types:
             filter = filter + str(c) + ","
@@ -88,7 +92,7 @@ class EquipmentReports(ResourceUri, ResourceUtc):
 
         # create filter
         args["filter"] = self._create_filter_equipment(instance)
-
+        logging.getLogger(__name__).debug("equipment provider filter: {}".format(args["filter"]))
         response = i_manager.dispatch(args, "equipment_reports", instance_name=self.region)
         return instance.equipment_provider_manager.manage_equipments(
             response, type_pb2.API.Value('equipment_reports')

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -77,7 +77,7 @@ class EquipmentReports(ResourceUri, ResourceUtc):
             for code in provider.code_types
         ]
         if not code_types:
-            logging.getLogger(__name__).warn("No code type exist into equipment provider")
+            logging.getLogger(__name__).warn("No code type exists into equipment provider")
             return "stop_point.has_code_type(no_code_types)"
         filter = "stop_point.has_code_type("
         for c in code_types:

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -52,6 +52,7 @@ class EquipmentReports(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "count", type=default_count_arg_type, default=25, help="Number of objects per page"
         )
+        parser_get.add_argument("filter", type=six.text_type, default="", help="Filter your objects")
         parser_get.add_argument("start_page", type=int, default=0, help="The current page")
         parser_get.add_argument(
             "forbidden_uris[]",
@@ -89,7 +90,11 @@ class EquipmentReports(ResourceUri, ResourceUtc):
         instance = i_manager.instances.get(self.region)
 
         # create filter
-        args["filter"] = self._create_filter_equipment(instance)
+        if args["filter"] != "":
+            args["filter"] += " and " + self._create_filter_equipment(instance)
+        else:
+            args["filter"] = self._create_filter_equipment(instance)
         logging.getLogger(__name__).debug("equipment provider filter: {}".format(args["filter"]))
+
         response = i_manager.dispatch(args, "equipment_reports", instance_name=self.region)
         return instance.equipment_provider_manager.manage_equipments_for_equipment_reports(response)

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -71,18 +71,16 @@ class EquipmentReports(ResourceUri, ResourceUtc):
         return self.api_description(**kwargs)
 
     def _create_filter_equipment(self, instance):
-        code_types = [
-            code
-            for provider in instance.equipment_provider_manager._get_providers().values()
-            for code in provider.code_types
-        ]
+        code_types = ",".join(
+            [
+                code
+                for provider in instance.equipment_provider_manager._get_providers().values()
+                for code in provider.code_types
+            ]
+        )
         if not code_types:
-            logging.getLogger(__name__).warn("No code type exists into equipment provider")
-            return "stop_point.has_code_type(no_code_types)"
-        filter = "stop_point.has_code_type("
-        for c in code_types:
-            filter = filter + str(c) + ","
-        return filter[:-1] + ")"
+            abort(404, message='No code type exists into equipment provider')
+        return "stop_point.has_code_type(" + code_types + ")"
 
     def get(self, region=None, lon=None, lat=None):
         self.region = i_manager.get_region(region, lon, lat)
@@ -94,6 +92,4 @@ class EquipmentReports(ResourceUri, ResourceUtc):
         args["filter"] = self._create_filter_equipment(instance)
         logging.getLogger(__name__).debug("equipment provider filter: {}".format(args["filter"]))
         response = i_manager.dispatch(args, "equipment_reports", instance_name=self.region)
-        return instance.equipment_provider_manager.manage_equipments(
-            response, type_pb2.API.Value('equipment_reports')
-        )
+        return instance.equipment_provider_manager.manage_equipments_for_equipment_reports(response)

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -38,6 +38,7 @@ from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from jormungandr.interfaces.v1.serializer import api
 from jormungandr.resources_utils import ResourceUtc
+from navitiacommon import type_pb2
 import six
 
 
@@ -81,5 +82,7 @@ class EquipmentReports(ResourceUri, ResourceUtc):
         args["filter"] = self.get_filter(uris, args)
 
         response = i_manager.dispatch(args, "equipment_reports", instance_name=self.region)
-
-        return response
+        instance = i_manager.instances.get(self.region)
+        return instance.equipment_provider_manager.manage_equipments(
+            response, type_pb2.API.Value('equipment_reports')
+        )

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -549,9 +549,7 @@ class Journeys(JourneyCommon):
             if args['equipment_details']:
                 # Manage equipments in stop points from the journeys sections
                 instance = i_manager.instances.get(self.region)
-                return instance.equipment_provider_manager.manage_equipments(
-                    response, type_pb2.API.Value('PLANNER')
-                )
+                return instance.equipment_provider_manager.manage_equipments_for_journeys(response)
 
             return response
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -41,7 +41,7 @@ from jormungandr.timezone import set_request_timezone
 from jormungandr.interfaces.v1.make_links import create_external_link, create_internal_link
 from jormungandr.interfaces.v1.errors import ManageError
 from collections import defaultdict
-from navitiacommon import response_pb2
+from navitiacommon import response_pb2, type_pb2
 from jormungandr.utils import date_to_timestamp
 from jormungandr.interfaces.v1.serializer import api
 from jormungandr.interfaces.v1.decorators import get_serializer
@@ -549,7 +549,9 @@ class Journeys(JourneyCommon):
             if args['equipment_details']:
                 # Manage equipments in stop points from the journeys sections
                 instance = i_manager.instances.get(self.region)
-                return instance.equipment_provider_manager.manage_equipments(response)
+                return instance.equipment_provider_manager.manage_equipments(
+                    response, type_pb2.API.Value('PLANNER')
+                )
 
             return response
 

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -268,6 +268,8 @@ class V1Routing(AModule):
             coord + 'equipment_reports',
             region + '<uri:uri>/equipment_reports',
             coord + '<uri:uri>/equipment_reports',
+            '/coord/' + lon_lat + 'equipment_reports',
+            '/coords/' + lon_lat + 'equipment_reports',
             endpoint='equipment_reports',
         )
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -175,7 +175,7 @@ class Scenario(object):
 
         if request["forbidden_uris[]"]:
             for forbidden_uri in request["forbidden_uris[]"]:
-                req.traffic_reports.forbidden_uris.append(forbidden_uri)
+                req.equipment_reports.forbidden_uris.append(forbidden_uri)
 
         resp = instance.send_and_receive(req)
         return resp

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -928,6 +928,47 @@ def is_valid_pt_object(pt_object, depth_check=1):
         check_embedded_route_label(n, pt_object['route'], depth_check)
 
 
+def is_valid_period(period, depth_check=1):
+    get_not_null(period, "begin")
+    get_not_null(period, "end")
+
+
+def is_valid_current_availability(current_availability, depth_check=1):
+    get_not_null(current_availability, "status")
+    periods = get_not_null(current_availability, 'periods')
+    for period in periods:
+        is_valid_period(period, 0)
+    get_not_null(current_availability, "updated_at")
+    cause = get_not_null(current_availability, "cause")
+    get_not_null(cause, "label")
+    effect = get_not_null(current_availability, "effect")
+    get_not_null(effect, "label")
+
+
+def is_valid_equipment_detail(equipment_detail, depth_check=1):
+    get_not_null(equipment_detail, "id")
+    get_not_null(equipment_detail, "embedded_type")
+    if equipment_detail['current_availability']['status'] != "unknown":
+        get_not_null(equipment_detail, "name")
+        is_valid_current_availability(get_not_null(equipment_detail, 'current_availability'), depth_check - 1)
+
+
+def is_valid_stop_area_equipment(stop_area_equipment, depth_check=1):
+    is_valid_stop_area(get_not_null(stop_area_equipment, 'stop_area'), depth_check - 1)
+    # equipment_details can be empty, if there is not filter into the request
+    if 'equipment_details' in stop_area_equipment:
+        equipment_details = stop_area_equipment['equipment_details']
+        for equipment_detail in equipment_details:
+            is_valid_equipment_detail(equipment_detail, 0)
+
+
+def is_valid_equipment_report(equipment_report, depth_check=1):
+    is_valid_line(get_not_null(equipment_report, 'line'), 1)
+    stop_area_equipments = get_not_null(equipment_report, 'stop_area_equipments')
+    for stop_area_equipment in stop_area_equipments:
+        is_valid_stop_area_equipment(stop_area_equipment, 0)
+
+
 def check_embedded_line_label(label, line, depth_check):
     is_valid_label(label)
     # the label must contains

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -28,7 +28,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from .tests_mechanism import AbstractTestFixture, dataset
+from .tests_mechanism import AbstractTestFixture, dataset, dataset, mock_equipment_providers
 from .check_utils import *
 
 
@@ -208,6 +208,11 @@ class TestEndPoint(AbstractTestFixture):
         assert response['context']['timezone'] == 'UTC'
 
     def test_equipment_reports_context(self):
+        mock_equipment_providers(
+            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
+            data={},
+            code_types_list=["TCL_ASCENCEUR", "TCL_ESCALIER"],
+        )
         response = self.query('/v1/coverage/main_routing_test/equipment_reports', display=True)
         self.check_context(response)
         assert response.get("equipment_reports", None) is not None

--- a/source/jormungandr/tests/equipment_mock.py
+++ b/source/jormungandr/tests/equipment_mock.py
@@ -1,0 +1,192 @@
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+standard_mock_escalator_data = {
+    "equipments_details": [
+        {
+            "id": "1",
+            "name": "equipment_detail_name_1",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "available",
+                "cause": {"label": "cause_message_1"},
+                "effect": {"label": "effect_message_1"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "2",
+            "name": "equipment_detail_name_2",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "unavailable",
+                "cause": {"label": "cause_message_2"},
+                "effect": {"label": "effect_message_2"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "3",
+            "name": "equipment_detail_name_3",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "unknown",
+                "cause": {"label": "cause_message_3"},
+                "effect": {"label": "effect_message_3"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+    ]
+}
+
+wrong_mock_with_bad_id_data = {
+    "equipments_details": [
+        {
+            "id": "qwdwqq",
+            "name": "equipment_detail_name_1",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "available",
+                "cause": {"label": "cause_message_1"},
+                "effect": {"label": "effect_message_1"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "-1234",
+            "name": "equipment_detail_name_2",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "unavailable",
+                "cause": {"label": "cause_message_2"},
+                "effect": {"label": "effect_message_2"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "3123.124",
+            "name": "equipment_detail_name_3",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "unknown",
+                "cause": {"label": "cause_message_3"},
+                "effect": {"label": "effect_message_3"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+    ]
+}
+
+standard_mock_elevator_data = {
+    "equipments_details": [
+        {
+            "id": "6",
+            "name": "equipment_detail_name_1",
+            "embedded_type": "elevator",
+            "current_availaibity": {
+                "status": "available",
+                "cause": {"label": "cause_message_1"},
+                "effect": {"label": "effect_message_1"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "7",
+            "name": "equipment_detail_name_2",
+            "embedded_type": "elevator",
+            "current_availaibity": {
+                "status": "unavailable",
+                "cause": {"label": "cause_message_2"},
+                "effect": {"label": "effect_message_2"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "8",
+            "name": "equipment_detail_name_3",
+            "embedded_type": "elevator",
+            "current_availaibity": {
+                "status": "unknown",
+                "cause": {"label": "cause_message_3"},
+                "effect": {"label": "effect_message_3"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+    ]
+}
+
+standard_mock_mixed_data = {
+    "equipments_details": [
+        {
+            "id": "1",
+            "name": "equipment_detail_name_1",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "available",
+                "cause": {"label": "cause_message_1"},
+                "effect": {"label": "effect_message_1"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "6",
+            "name": "equipment_detail_name_2",
+            "embedded_type": "elevator",
+            "current_availaibity": {
+                "status": "unavailable",
+                "cause": {"label": "cause_message_2"},
+                "effect": {"label": "effect_message_2"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+        {
+            "id": "3",
+            "name": "equipment_detail_name_3",
+            "embedded_type": "escalator",
+            "current_availaibity": {
+                "status": "unknown",
+                "cause": {"label": "cause_message_3"},
+                "effect": {"label": "effect_message_3"},
+                "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
+                "updated_at": "2012-07-25T15:01:31+02:00",
+            },
+        },
+    ]
+}

--- a/source/jormungandr/tests/equipment_mock.py
+++ b/source/jormungandr/tests/equipment_mock.py
@@ -169,7 +169,7 @@ standard_mock_mixed_data = {
             "name": "equipment_detail_name_2",
             "embedded_type": "elevator",
             "current_availaibity": {
-                "status": "unavailable",
+                "status": "available",
                 "cause": {"label": "cause_message_2"},
                 "effect": {"label": "effect_message_2"},
                 "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],
@@ -181,7 +181,7 @@ standard_mock_mixed_data = {
             "name": "equipment_detail_name_3",
             "embedded_type": "escalator",
             "current_availaibity": {
-                "status": "unknown",
+                "status": "available",
                 "cause": {"label": "cause_message_3"},
                 "effect": {"label": "effect_message_3"},
                 "periods": [{"begin": "2012-07-01T08:10:00+02:00", "end": "2012-09-01T23:30:00+02:00"}],

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -45,37 +45,46 @@ class TestEquipment(AbstractTestFixture):
     """
 
     def _check_equipment_report(self, equipment_reports, expected_result):
-        i = 0
+        """
+        Check most important fields into the equipment_reports
+        :equipment_reports: The equipment_reports fields of the response
+        :expected_result: The expected equipment_reports response
+        """
+        eq_r_idx = 0
         for line, stop_points in sorted(expected_result.items()):
-            print("INFO---> ", line)
-            assert equipment_reports[i]['line']['id'] == line
-            j = 0
+            assert equipment_reports[eq_r_idx]['line']['id'] == line
+            st_area_eq_idx = 0
             for stop_point, equipment_details in sorted(stop_points.items()):
-                assert equipment_reports[i]['stop_area_equipments'][j]['stop_area']['id'] == stop_point
-                if 'equipment_details' in equipment_reports[i]['stop_area_equipments'][j]:
+                assert (
+                    equipment_reports[eq_r_idx]['stop_area_equipments'][st_area_eq_idx]['stop_area']['id']
+                    == stop_point
+                )
+                if 'equipment_details' in equipment_reports[eq_r_idx]['stop_area_equipments'][st_area_eq_idx]:
                     eq_d_idx = 0
                     for eq_id, eq_type, eq_status in equipment_details:
                         assert (
-                            equipment_reports[i]['stop_area_equipments'][j]['equipment_details'][eq_d_idx]['id']
+                            equipment_reports[eq_r_idx]['stop_area_equipments'][st_area_eq_idx][
+                                'equipment_details'
+                            ][eq_d_idx]['id']
                             == eq_id
                         )
                         assert (
-                            equipment_reports[i]['stop_area_equipments'][j]['equipment_details'][eq_d_idx][
-                                'embedded_type'
-                            ]
+                            equipment_reports[eq_r_idx]['stop_area_equipments'][st_area_eq_idx][
+                                'equipment_details'
+                            ][eq_d_idx]['embedded_type']
                             == eq_type
                         )
                         assert (
-                            equipment_reports[i]['stop_area_equipments'][j]['equipment_details'][eq_d_idx][
-                                'current_availability'
-                            ]['status']
+                            equipment_reports[eq_r_idx]['stop_area_equipments'][st_area_eq_idx][
+                                'equipment_details'
+                            ][eq_d_idx]['current_availability']['status']
                             == eq_status
                         )
                         eq_d_idx = eq_d_idx + 1
-                j = j + 1
-            i = i + 1
+                st_area_eq_idx = st_area_eq_idx + 1
+            eq_r_idx = eq_r_idx + 1
 
-    def test_equipment_reports_end_point(self):
+    def test_equipment_reports_without_filter(self):
         """
         simple equipment_reports call
         """

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -318,9 +318,7 @@ class TestEquipment(AbstractTestFixture):
             ("4", "escalator", "unknown"),
         ]
         # stop B is forbidden and there is only the D line which doesn't have stop point B.
-        expected_result = {
-            "D": {"stopA": stopA_equipment_details},
-        }
+        expected_result = {"D": {"stopA": stopA_equipment_details}}
 
         equipment_reports = get_not_null(response, 'equipment_reports')
         assert len(equipment_reports) == 1

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -34,9 +34,6 @@ from .equipment_mock import *
 from tests.check_utils import get_not_null, is_valid_equipment_report
 
 default_date_filter = '_current_datetime=20120801T000000&'
-TCL_escalator_filter = 'filter=stop_point.has_code_type(TCL_ESCALIER)&'
-TCL_elevator_filter = 'filter=stop_point.has_code_type(TCL_ASCENCEUR)&'
-TCL_combined_filter = 'filter=stop_point.has_code_type(TCL_ASCENCEUR,TCL_ESCALIER)&'
 
 
 @dataset({"main_routing_test": {}})
@@ -85,7 +82,7 @@ class TestEquipment(AbstractTestFixture):
                 st_area_eq_idx = st_area_eq_idx + 1
             eq_r_idx = eq_r_idx + 1
 
-    def test_equipment_reports_without_filter(self):
+    def test_equipment_reports(self):
         """
         simple equipment_reports call
         """
@@ -120,7 +117,7 @@ class TestEquipment(AbstractTestFixture):
             "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
+            "D": {"stopA": stopA_equipment_details},
             "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
         }
 
@@ -160,7 +157,7 @@ class TestEquipment(AbstractTestFixture):
             "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
+            "D": {"stopA": stopA_equipment_details},
             "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
         }
 
@@ -200,120 +197,7 @@ class TestEquipment(AbstractTestFixture):
             "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
-            "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-        }
-
-        equipment_reports = get_not_null(response, 'equipment_reports')
-        assert len(equipment_reports) == 5
-        for equipment_report in equipment_reports:
-            is_valid_equipment_report(equipment_report)
-        self._check_equipment_report(equipment_reports, expected_result)
-
-    def test_equipment_reports_with_filter(self):
-        """
-        equipment_reports call with filter
-        """
-
-        # only elevator within received data
-        mock_equipment_providers(
-            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
-            data=standard_mock_elevator_data,
-            code_types_list=["TCL_ASCENCEUR"],
-        )
-        response = self.query_region('equipment_reports?' + default_date_filter + TCL_elevator_filter)
-
-        warnings = get_not_null(response, 'warnings')
-        assert len(warnings) == 1
-        assert warnings[0]['id'] == 'beta_endpoint'
-
-        # Expected response
-        stopA_equipment_details = [("5", "elevator", "unknown")]
-        stopb_equipment_details = [
-            ("6", "elevator", "available"),
-            ("7", "elevator", "unavailable"),
-            ("8", "elevator", "unknown"),
-            ("9", "elevator", "unknown"),
-        ]
-        expected_result = {
-            "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
-            "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-        }
-
-        equipment_reports = get_not_null(response, 'equipment_reports')
-        assert len(equipment_reports) == 5
-        for equipment_report in equipment_reports:
-            is_valid_equipment_report(equipment_report)
-        self._check_equipment_report(equipment_reports, expected_result)
-
-        # only escalator within received data
-        mock_equipment_providers(
-            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
-            data=standard_mock_escalator_data,
-            code_types_list=["TCL_ESCALIER"],
-        )
-        response = self.query_region('equipment_reports?' + default_date_filter + TCL_escalator_filter)
-
-        warnings = get_not_null(response, 'warnings')
-        assert len(warnings) == 1
-        assert warnings[0]['id'] == 'beta_endpoint'
-
-        # Expected response
-        stopA_equipment_details = [
-            ("1", "escalator", "available"),
-            ("2", "escalator", "unavailable"),
-            ("3", "escalator", "unknown"),
-            ("4", "escalator", "unknown"),
-        ]
-        stopb_equipment_details = []
-        expected_result = {
-            "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
-            "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-        }
-
-        equipment_reports = get_not_null(response, 'equipment_reports')
-        assert len(equipment_reports) == 5
-        for equipment_report in equipment_reports:
-            is_valid_equipment_report(equipment_report)
-        self._check_equipment_report(equipment_reports, expected_result)
-
-        # Mixed escalator/elevator within received data
-        mock_equipment_providers(
-            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
-            data=standard_mock_mixed_data,
-            code_types_list=["TCL_ASCENCEUR", "TCL_ESCALIER"],
-        )
-        response = self.query_region('equipment_reports?' + default_date_filter + TCL_combined_filter)
-
-        warnings = get_not_null(response, 'warnings')
-        assert len(warnings) == 1
-        assert warnings[0]['id'] == 'beta_endpoint'
-
-        # Expected response
-        stopA_equipment_details = [
-            ("5", "elevator", "unknown"),
-            ("1", "escalator", "available"),
-            ("2", "escalator", "unknown"),
-            ("3", "escalator", "available"),
-            ("4", "escalator", "unknown"),
-        ]
-        stopb_equipment_details = [
-            ("6", "elevator", "available"),
-            ("7", "elevator", "unknown"),
-            ("8", "elevator", "unknown"),
-            ("9", "elevator", "unknown"),
-        ]
-        expected_result = {
-            "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
+            "D": {"stopA": stopA_equipment_details},
             "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
         }
 
@@ -358,7 +242,7 @@ class TestEquipment(AbstractTestFixture):
             "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
             "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
-            "D": {"stopA": stopA_equipment_details, "stopC": []},
+            "D": {"stopA": stopA_equipment_details},
             "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
         }
 

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from .tests_mechanism import AbstractTestFixture, dataset, mock_equipment_providers
+from .equipment_mock import *
+from tests.check_utils import get_not_null, is_valid_equipment_report
+
+default_date_filter = '_current_datetime=20120801T000000&'
+TCL_escalator_filter = 'filter=stop_point.has_code_type(TCL_ESCALIER)&'
+TCL_elevator_filter = 'filter=stop_point.has_code_type(TCL_ASCENCEUR)&'
+TCL_escalator_elevator_filter = 'filter=stop_point.has_code_type(TCL_ASCENCEUR, TCL_ESCALIER)&'
+
+
+@dataset({"main_routing_test": {}})
+class TestEquipment(AbstractTestFixture):
+    """
+    Test the structure of the equipment_reports api
+    """
+
+    def _check_equipment_report(self, equipment_reports, expected_result):
+        i = 0
+        for line, stop_points in sorted(expected_result.items()):
+            print("INFO---> ", line)
+            assert equipment_reports[i]['line']['id'] == line
+            j = 0
+            for stop_point, equipment_details in sorted(stop_points.items()):
+                assert equipment_reports[i]['stop_area_equipments'][j]['stop_area']['id'] == stop_point
+                if 'equipment_details' in equipment_reports[i]['stop_area_equipments'][j]:
+                    eq_d_idx = 0
+                    for eq_id, eq_type, eq_status in equipment_details:
+                        assert (
+                            equipment_reports[i]['stop_area_equipments'][j]['equipment_details'][eq_d_idx]['id']
+                            == eq_id
+                        )
+                        assert (
+                            equipment_reports[i]['stop_area_equipments'][j]['equipment_details'][eq_d_idx][
+                                'embedded_type'
+                            ]
+                            == eq_type
+                        )
+                        assert (
+                            equipment_reports[i]['stop_area_equipments'][j]['equipment_details'][eq_d_idx][
+                                'current_availability'
+                            ]['status']
+                            == eq_status
+                        )
+                        eq_d_idx = eq_d_idx + 1
+                j = j + 1
+            i = i + 1
+
+    def test_equipment_reports_end_point(self):
+        """
+        simple equipment_reports call
+        """
+        mock_equipment_providers(
+            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
+            data=standard_mock_elevator_data,
+        )
+        response = self.query_region('equipment_reports?' + default_date_filter)
+
+        warnings = get_not_null(response, 'warnings')
+        assert len(warnings) == 1
+        assert warnings[0]['id'] == 'beta_endpoint'
+
+        equipment_reports = get_not_null(response, 'equipment_reports')
+        import json
+
+        print("resp ", json.dumps(equipment_reports, indent=4))
+
+        stopA_equipment_details = [
+            ("5", "elevator", "unknown"),
+            ("1", "escalator", "unknown"),
+            ("2", "escalator", "unknown"),
+            ("3", "escalator", "unknown"),
+            ("4", "escalator", "unknown"),
+        ]
+        stopb_equipment_details = [
+            ("6", "elevator", "available"),
+            ("7", "elevator", "unavailable"),
+            ("8", "elevator", "unknown"),
+            ("9", "elevator", "unknown"),
+        ]
+        expected_result = {
+            "A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
+            "B": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
+            "C": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
+            "D": {"stopA": stopA_equipment_details, "stopC": []},
+            "M": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details},
+        }
+
+        assert len(equipment_reports) == 5
+        for equipment_report in equipment_reports:
+            is_valid_equipment_report(equipment_report)
+        self._check_equipment_report(equipment_reports, expected_result)
+
+        # with mock_equipment_providers(data=standard_mock_elevator_data):
+        # response = self.query_region('equipment_reports?' + default_date_filter)
+
+        # equipment_reports = get_not_null(response, 'equipment_reports')
+        # for equipment_report in equipment_reports:
+        # is_valid_equipment_report(equipment_report)
+
+        # with mock_equipment_providers(data=standard_mock_mixed_data):
+        # response = self.query_region('equipment_reports?' + default_date_filter)
+
+        # equipment_reports = get_not_null(response, 'equipment_reports')
+        # for equipment_report in equipment_reports:
+        # is_valid_equipment_report(equipment_report)
+
+    # def test_equipment_reports_with_filter(self):
+    # """
+    # equipment_reports call with filter
+    # """
+    # with mock_equipment_providers(data=standard_mock_escalator_data):
+    # response = self.query_region('equipment_reports?' + default_date_filter + TCL_escalator_filter)
+
+    # equipment_reports = get_not_null(response, 'equipment_reports')
+    # for equipment_report in equipment_reports:
+    # is_valid_equipment_report(equipment_report)
+
+    # with mock_equipment_providers(data=standard_mock_elevator_data):
+    # response = self.query_region('equipment_reports?' + default_date_filter + TCL_elevator_filter)
+
+    # equipment_reports = get_not_null(response, 'equipment_reports')
+    # for equipment_report in equipment_reports:
+    # is_valid_equipment_report(equipment_report)
+
+    # with mock_equipment_providers(data=standard_mock_mixed_data):
+    # response = self.query_region('equipment_reports?' + default_date_filter + TCL_escalator_filter)
+
+    # equipment_reports = get_not_null(response, 'equipment_reports')
+    # for equipment_report in equipment_reports:
+    # is_valid_equipment_report(equipment_report)
+
+    # def test_equipment_reports_with_wrong_id(self):
+
+    # """
+    # wrong id test
+    # """
+    # with mock_equipment_providers(data=wrong_mock_with_bad_id_data):
+    # response = self.query_region('equipment_reports?' + default_date_filter)

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -34,6 +34,7 @@ from .equipment_mock import *
 from tests.check_utils import get_not_null, is_valid_equipment_report
 
 default_date_filter = '_current_datetime=20120801T000000&'
+default_line_filter = 'filter=line.uri(A)'
 
 
 @dataset({"main_routing_test": {}})
@@ -248,6 +249,46 @@ class TestEquipment(AbstractTestFixture):
 
         equipment_reports = get_not_null(response, 'equipment_reports')
         assert len(equipment_reports) == 5
+        for equipment_report in equipment_reports:
+            is_valid_equipment_report(equipment_report)
+        self._check_equipment_report(equipment_reports, expected_result)
+
+    def test_equipment_reports_with_filter(self):
+        """
+        wrong id test
+        """
+
+        # Bad id inside received data
+        mock_equipment_providers(
+            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
+            data=standard_mock_elevator_data,
+            code_types_list=["TCL_ASCENCEUR", "TCL_ESCALIER"],
+        )
+        response = self.query_region('equipment_reports?' + default_date_filter + default_line_filter)
+
+        warnings = get_not_null(response, 'warnings')
+        assert len(warnings) == 1
+        assert warnings[0]['id'] == 'beta_endpoint'
+
+        # Expected response
+        stopA_equipment_details = [
+            ("5", "elevator", "unknown"),
+            ("1", "escalator", "unknown"),
+            ("2", "escalator", "unknown"),
+            ("3", "escalator", "unknown"),
+            ("4", "escalator", "unknown"),
+        ]
+        stopb_equipment_details = [
+            ("6", "elevator", "available"),
+            ("7", "elevator", "unavailable"),
+            ("8", "elevator", "unknown"),
+            ("9", "elevator", "unknown"),
+        ]
+        # filtered with the line A
+        expected_result = {"A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details}}
+
+        equipment_reports = get_not_null(response, 'equipment_reports')
+        assert len(equipment_reports) == 1
         for equipment_report in equipment_reports:
             is_valid_equipment_report(equipment_report)
         self._check_equipment_report(equipment_reports, expected_result)

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -541,6 +541,8 @@ def mock_car_park_providers(pois_supported):
     )
 
 
-def mock_equipment_providers(equipment_provider_manager, data):
-    equipment_provider_manager._equipment_providers = {"sytral": SytralProvider(url="fake.url")}
+def mock_equipment_providers(equipment_provider_manager, data, code_types_list):
+    equipment_provider_manager._equipment_providers = {
+        "sytral": SytralProvider(url="fake.url", timeout=3, code_types=code_types_list)
+    }
     equipment_provider_manager._equipment_providers["sytral"]._call_webservice = MagicMock(return_value=data)

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -39,6 +39,7 @@ import mock
 import retrying
 from retrying import RetryError
 import six
+from mock import MagicMock
 
 if not 'JORMUNGANDR_CONFIG_FILE' in os.environ:
     os.environ['JORMUNGANDR_CONFIG_FILE'] = (
@@ -57,6 +58,7 @@ from jormungandr.parking_space_availability import (
     StandsStatus,
     ParkingPlaces,
 )
+from jormungandr.equipments.sytral import SytralProvider
 
 krakens_dir = os.environ['KRAKEN_BUILD_DIR'] + '/tests'
 
@@ -158,6 +160,13 @@ class AbstractTestFixture(unittest.TestCase):
             # we want to keep the same address for global_autocomplete as others might have references on it
             jormungandr.global_autocomplete.clear()
             jormungandr.global_autocomplete.update(cls.old_global_autocompletes)
+
+    @classmethod
+    def equipment_provider_manager(cls, key):
+        """
+        retrieve corresponding equipment provider manager
+        """
+        return i_manager.instances[key].equipment_provider_manager
 
     @classmethod
     def setup_class(cls):
@@ -530,3 +539,8 @@ def mock_car_park_providers(pois_supported):
         new_callable=mock.PropertyMock,
         return_value=lambda: providers,
     )
+
+
+def mock_equipment_providers(equipment_provider_manager, data):
+    equipment_provider_manager._equipment_providers = {"sytral": SytralProvider(url="fake.url")}
+    equipment_provider_manager._equipment_providers["sytral"]._call_webservice = MagicMock(return_value=data)

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -487,7 +487,20 @@ struct routing_api_data {
         b.data->pt_data->sort_and_index();
         b.data->build_raptor();
 
-        // add a main stop area to our admin
+        // Add SYTRAL codes on stop point
+        const auto* sp = b.get<nt::StopPoint>("stop_point:stopA");
+        b.data->pt_data->codes.add(sp, "TCL_ESCALIER", "1");
+        b.data->pt_data->codes.add(sp, "TCL_ESCALIER", "2");
+        b.data->pt_data->codes.add(sp, "TCL_ESCALIER", "3");
+        b.data->pt_data->codes.add(sp, "TCL_ESCALIER", "4");
+        b.data->pt_data->codes.add(sp, "TCL_ASCENCEUR", "5");
+        sp = b.get<nt::StopPoint>("stop_point:stopB");
+        b.data->pt_data->codes.add(sp, "TCL_ASCENCEUR", "6");
+        b.data->pt_data->codes.add(sp, "TCL_ASCENCEUR", "7");
+        b.data->pt_data->codes.add(sp, "TCL_ASCENCEUR", "8");
+        b.data->pt_data->codes.add(sp, "TCL_ASCENCEUR", "9");
+
+        // Add a main stop area to our admin
         admin->main_stop_areas.push_back(b.data->pt_data->stop_areas_map["stopC"]);
 
         // Add a fare_zone in stop point A


### PR DESCRIPTION
**WORK DONE**

- Merge kraken response with Sytral web service informations, for equipment_report entry point
- Create a hidden pt_ref filter with code types coming from providers config
- Create mock for the Sytral web service
- Add integrations tests with mock
- Update journeys entry point with equipment provider. Same logic for matching

It is a huge PR, sorry for that, but it was complicated to split it, because of feedbacks during the development.

JIRA tickets :
- https://jira.kisio.org/browse/NAVP-1220
- https://jira.kisio.org/browse/NAVP-1275


**BEHAVIOR**

We return, into the response, all equipment reports with code types `(TCL_ASCENCEUR,TCL_ESCALIER)` and expand the equipment list with realtime information, if we have it.
If the received equipment is not present in real-time information, we send it with only the `Id` and the `status = unknown` and `embedded_type` like this :
![default_value](https://user-images.githubusercontent.com/32099204/56414935-79ce0880-628c-11e9-8f70-b1c15d528e91.png)
If we match with realtime informations the equipment details correspond to :
![ed_sytral](https://user-images.githubusercontent.com/32099204/56415277-83a43b80-628d-11e9-96d0-1c3e62aab37c.png)

**CONFIGURATION**
Now for Sytral, the jormum configuration looks like :
```
EQUIPMENT_DETAILS_PROVIDERS=[{                                                                                                                                                                                                                                           
     "class": "jormungandr.equipments.sytral.SytralProvider",                                                        
     "key":"sytral",                                                                                                 
     "args": {                                                                                                       
         "url": "http://url",                                      
         "operators": ["SYTRAL"],                                                                                    
         "dataset": "_",                                                                                             
         "fail_max": 5,                                                                                              
         "timeout": 1,                                                                                               
         "code_types": ["TCL_ASCENCEUR", "TCL_ESCALIER"]                                                             
     }                                                                                                               
}] 
```
We have to fill `operators` and `code_types` for an equipment provider.
It is used too for `journeys` entry point.
Don't forget to fill the jormun.json file with equipment keys:
```
{
    "key": "fr-se-lyon",
    "zmq_socket": "ipc:///tmp/fr-se-lyon_kraken",
    "equipment_details_providers": [ "sytral", "sytral" ]
}
```

With this configuration your request become simply :
![request_sytral](https://user-images.githubusercontent.com/32099204/56415706-cc102900-628e-11e9-9188-fffdaf0efd2d.png)


**QA**

1. **Simple** :heavy_check_mark: 

     - Config : okay
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

The response fields are like this :
![ouput_sytral](https://user-images.githubusercontent.com/32099204/56415141-1bedf080-628d-11e9-8c68-5bf3fa313fbb.png)

2. **bad code types in config** :heavy_check_mark: 

     - Config settings.py : bad types -> `"code_types": ["lool", "kikou"]`
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

Logs show wrong code_types
```
[2019-04-19 10:58:27,845] [74476f42-6dff-435f-9ce6-dc737660b54f] [DEBUG] [ 2119] [jormungandr.interfaces.v1.EquipmentReports] equipment provider filter: stop_point.has_code_type(lool,kikou)
[2019-04-19 10:58:27,889] [74476f42-6dff-435f-9ce6-dc737660b54f] [ INFO] [ 2119] [jormungandr.access] "GET /v1/coverage/fr-idf/equipment_reports?" 404
```
The response fields are like this :
![404_sytral](https://user-images.githubusercontent.com/32099204/56417450-42635a00-6294-11e9-955a-b187100c8e4b.png)
Equipment Report is empty because kraken didn't match with `code types`

3. **bad key in config** :heavy_check_mark: 

     - Config jormun.json : bad types -> `"equipment_details_providers": [ "sdffsd", "sdfsd" ]`
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

Logs
```
[2019-04-19 11:33:11,016] [None] [ERROR] [19582] [jormungandr.equipments.equipment_provider_manager] impossible to create provider with key: sytral
[2019-04-19 11:25:03,996] [7c3dbce9-7fe9-46b0-a514-dac40cddbe52] [WARNING] [ 9073] [jormungandr.interfaces.v1.EquipmentReports] No code type exists into equipment provider
[2019-04-19 11:25:03,997] [7c3dbce9-7fe9-46b0-a514-dac40cddbe52] [DEBUG] [ 9073] [jormungandr.interfaces.v1.EquipmentReports] equipment provider filter: stop_point.has_code_type(no_code_types)
```
By default if there is no provider we create a filter with `no_code_types` codes. That force the response to be a 404 error as below

The response fields are like this :
![404_sytral](https://user-images.githubusercontent.com/32099204/56417450-42635a00-6294-11e9-955a-b187100c8e4b.png)
Equipment Report is empty because kraken didn't match with `code types`

4. **Simple case with coords that replace coverage** :heavy_check_mark: 

     - Config jormun.json : okay
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

Request: `http://localhost:5000/v1/coord/4.87123%3B45.74860/equipment_reports?`
The response is the same like first test. it's work

5. **Simple case with count option** :heavy_check_mark: 

     - Config jormun.json : okay
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

Request: `http://localhost:5000/v1/coverage/fr-idf/equipment_reports?count=2&`
The response we have 2 equipment_reports. it's work

5. **Simple case with depth option** :x: 

     - Config jormun.json : okay
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

The parameter has `no effect`

5. **Simple case with forbidden_uri option** :x: 

     - Config jormun.json : okay
     - Tested  with the **fr-se-lyon** coverage for **Sytral** case

It turns out, it doesn't work. It can't filter anything

**TODO**

- [x] :warning: Update deploy conf with `"code_types": ["TCL_ASCENCEUR", "TCL_ESCALIER"] `
```
EQUIPMENT_DETAILS_PROVIDERS=[{                                                                                                                                                                                                                                           
     "class": "jormungandr.equipments.sytral.SytralProvider",         
     ...                                                                                                               
         "code_types": ["TCL_ASCENCEUR", "TCL_ESCALIER"]  
     }                                                                                                               
}] 
```
PR deploy - > https://github.com/CanalTP/navitia_deployment_conf/pull/566#pullrequestreview-229543347