### PR TITLE
Build: use ccache and gold if available

### DIFF
--- a/source/cmake_modules/CompilationFlags.cmake
+++ b/source/cmake_modules/CompilationFlags.cmake
@@ -20,6 +20,25 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_EXE_LINKER_FLAGS_PROFILE "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 
+
+option(USE_LD_GOLD "Use GNU gold linker" ON)
+
+if(USE_LD_GOLD AND "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  execute_process(COMMAND ${CMAKE_C_COMPILER} -fuse-ld=gold -Wl,--version OUTPUT_VARIABLE stdout ERROR_QUIET)
+  if("${stdout}" MATCHES "GNU gold")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fuse-ld=gold")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fuse-ld=gold")
+  else()
+    message(WARNING "GNU gold linker isn't available, using the default system linker.")
+  endif()
+endif()
+
+option(CCACHE "Use ccache if available" ON)
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE AND CCACHE_PROGRAM)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 # Clang Release flags
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
     # it could be great to remove these warnings, but there is so much :


### PR DESCRIPTION
[Gold](https://en.wikipedia.org/wiki/Gold_(linker)) is an alternative linker part of the gnu project. It's faster than
ld, [around three time faster](https://lld.llvm.org/#performance).

ccache is a compiler cache that speedup rebuild.