### PR TITLE
[Tyr ] Add job 'cities' and returns it in /cities/status

### DIFF
--- a/source/tyr/tests/conftest.py
+++ b/source/tyr/tests/conftest.py
@@ -104,3 +104,16 @@ def init_instances_dir():
     yield
 
     shutil.rmtree(instance_dir)
+
+
+@pytest.fixture(scope="function", autouse=False)
+def init_cities_dir():
+    """
+    Create a temp dir of an instance with its config file
+    """
+    cities_dir = tempfile.mkdtemp(prefix='cities_')
+    app.config['CITIES_OSM_FILE_PATH'] = cities_dir
+
+    yield
+
+    shutil.rmtree(cities_dir)

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1765,7 +1765,11 @@ class Cities(flask_restful.Resource):
             dataset.type = exe = 'cities'
 
         models.db.session.commit()
-        cities.delay(file_path, job.id, exe)
+        try:
+            cities.delay(file_path, job.id, exe)
+        except:
+            job.state = 'failed'
+            models.db.session.commit()
 
         return {'message': 'OK'}, 200
 

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -475,50 +475,27 @@ def load_data(instance_id, data_dirs):
 
 
 @celery.task()
-def cities(osm_path, job_id):
-    """ launch cities """
+def cities(file_path, job_id, exe):
+    """ Launch 'cities' or 'cosmogony2cities' """
     job = models.Job.query.get(job_id)
     res = -1
     try:
         res = launch_exec(
-            "cities", ['-i', osm_path, '--connection-string', current_app.config['CITIES_DATABASE_URI']], logging
-        )
-        if res != 0:
-            job.state = 'failed'
-            logging.error('cities failed')
-        else:
-            job.state = 'done'
-
-    except Exception as e:
-        logging.exception('cities exception : {}'.format(e.message))
-
-    models.db.session.commit()
-    logging.info('Import of cities finished')
-    return res
-
-
-@celery.task()
-def cosmogony2cities(cosmogony_path, job_id):
-    """ launch cosmogony2cities """
-    job = models.Job.query.get(job_id)
-    res = -1
-    try:
-        res = launch_exec(
-            "cosmogony2cities",
-            ['--input', cosmogony_path, '--connection-string', current_app.config['CITIES_DATABASE_URI']],
+            "{}".format(exe),
+            ['-i', file_path, '--connection-string', current_app.config['CITIES_DATABASE_URI']],
             logging,
         )
         if res != 0:
             job.state = 'failed'
-            logging.error('cosmogony2cities failed')
+            logging.error('{} failed'.format(exe))
         else:
             job.state = 'done'
 
     except Exception as e:
-        logging.exception('cosmogony2cities exception : {}'.format(e.message))
+        logging.exception('{} exception : {}'.format(exe, e.message))
 
     models.db.session.commit()
-    logging.info('Import of cosmogony2cities finished')
+    logging.info('Import of {} finished'.format(exe))
     return res
 
 

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -492,6 +492,7 @@ def cities(file_path, job_id, exe):
             job.state = 'done'
 
     except Exception as e:
+        job.state = 'failed'
         logging.exception('{} exception : {}'.format(exe, e.message))
 
     models.db.session.commit()

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -522,8 +522,10 @@ def cities(file_path, job_id, exe):
             job.state = 'done'
 
     except Exception as e:
-        job.state = 'failed'
         logging.exception('{} exception : {}'.format(exe, e.message))
+        job.state = 'failed'
+        models.db.session.commit()
+        raise
 
     models.db.session.commit()
     logging.info('Import of {} finished'.format(exe))


### PR DESCRIPTION
First part of https://jira.kisio.org/browse/NAVP-1093
A job and a dataset 'cities' are now created in Tyr db.

The endpoint /cities/status now returns:
```
{
    "cities db version": "1d99ba678e3f",
    "latest_job": {
        "created_at": "2019-05-03T09:43:55.452338",
        "data_sets": [
            {
                "family_type": "cities",
                "name": "/home/mehdi/second_fork/navitia/source/tyr/france_boundaries.osm.pbf",
                "type": "cities"
            }
        ],
        "id": 8,
        "state": "done",
        "updated_at": "2019-05-03T09:44:32.344140"
    }
}
```

The 'cities' purge task will be done during the already existing 'purge' task called by the cron 'purge-old-job-every-week'.
The number of jobs and datasets to keep is determined by the already existing conf parameter 'DATASET_MAX_BACKUPS_TO_KEEP'
