### PR TITLE
jormun: handle HEAD request correctly

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/StatedResource.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/StatedResource.py
@@ -40,6 +40,8 @@ class StatedResource(DocumentedResource):
         DocumentedResource.__init__(self, *args, **kwargs)
         self.method_decorators = {'get': []}
         self.get_decorators = self.method_decorators['get']
+        # HEAD is an alias for GET, we need to have the same decorators
+        self.method_decorators['head'] = self.method_decorators['get']
 
         self.get_decorators.append(self._stat_regions)
         if stat_manager.save_stat:

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -207,6 +207,14 @@ class TestEndPoint(AbstractTestFixture):
         self.check_context(response)
         assert response['context']['timezone'] == 'UTC'
 
+    def test_lines_head(self):
+        """
+        check that HEAD request works
+        """
+        response = self.tester.head('/v1/coverage/main_routing_test/lines')
+        assert response.status_code == 200
+        assert len(response.data) == 0
+
     def test_equipment_reports_context(self):
         mock_equipment_providers(
             equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),


### PR DESCRIPTION
flask handle automaticaly HEAD request by doing a GET and doesn't return
the response. we need to use the same decorators between the two method
to deserialize the proto response :)