### PR TITLE
[Ed] add a cli param to fetch admins from cities to osm2ed

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -1066,7 +1066,7 @@ int osm2ed(int argc, const char** argv) {
                        "a json string describing poi_types and rules to build them from OSM tags")
         ("local_syslog", "activate log redirection within local syslog")
         ("log_comment", po::value<std::string>(), "optional field to add extra information like coverage name")
-        ("cities-connection-string", po::value<std::string>(), 
+        ("cities-connection-string", po::value<std::string>(),
             "cities database connection string, to use admins from cities instead of osm's relations");
     // clang-format on
 

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -128,7 +128,7 @@ struct Admin {
           const uint32_t level,
           mpolygon_type&& polygon,
           point&& center);
-
+    virtual ~Admin() {}
     virtual void build_geometry(OSMCache&) {}
     bool is_city() const { return level == 8; }
 
@@ -152,6 +152,7 @@ struct OSMAdminRelation : public Admin {
                      const std::string& postal_code,
                      const std::string& name,
                      const uint32_t level);
+    virtual ~OSMAdminRelation() {}
 
     virtual void build_geometry(OSMCache& cache);
     void build_polygon(OSMCache& cache);

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -216,12 +216,8 @@ struct OSMWay {
     }
 
     bool contains_admin(const Admin* admin) const {
-        for (auto node : nodes) {
-            if (node->admin == admin) {
-                return true;
-            }
-        }
-        return false;
+        auto has_admin = [&](const auto& n) { return n->admin == admin; };
+        return boost::find_if(nodes, has_admin) != nodes.end();
     }
 
     bool is_used() const { return way_ref == nullptr || this == way_ref; }

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -53,7 +53,7 @@ typedef bg::model::linestring<point> ls_type;
 namespace ed {
 namespace connectors {
 
-struct OSMRelation;
+struct Admin;
 struct OSMCache;
 
 struct OSMNode {
@@ -64,7 +64,7 @@ struct OSMNode {
 
     // We use int32_t to save memory, these are coordinates *  factor
     mutable int32_t ilon = std::numeric_limits<int32_t>::max(), ilat = std::numeric_limits<int32_t>::max();
-    mutable const OSMRelation* admin = nullptr;
+    mutable const Admin* admin = nullptr;
     static constexpr double factor = 1e6;
 
     OSMNode(uint64_t osm_id) : osm_id(osm_id) {}
@@ -113,33 +113,48 @@ private:
     mutable std::bitset<2> properties = 0;
 };
 
-struct OSMRelation {
-    const u_int64_t osm_id;
-    CanalTP::References references;
-    const std::string insee = "", name = "";
+struct Admin {
+    Admin(u_int64_t id,
+          const std::string& uri,
+          const std::string& insee,
+          const std::string& postal_code,
+          const std::string& name,
+          const uint32_t level);
+    Admin(u_int64_t id,
+          const std::string& uri,
+          const std::string& insee,
+          const std::string& postal_code,
+          const std::string& name,
+          const uint32_t level,
+          mpolygon_type&& polygon,
+          point&& center);
+
+    virtual void build_geometry(OSMCache&) {}
+    bool is_city() const { return level == 8; }
+
+    const u_int64_t id;
+    const std::string uri;
+    const std::string insee;
+    const std::string name;
     std::vector<std::string> postal_codes;
     const uint32_t level = std::numeric_limits<uint32_t>::max();
+    mpolygon_type polygon;
+    point center = point(0.0, 0.0);
+};
 
-    // these attributes are mutable because this object would be use in a set, and
-    // all object in a set are const, since these attributes are not used in the key we can modify them
-    mutable mpolygon_type polygon;
-    mutable point centre = point(0.0, 0.0);
+struct OSMAdminRelation : public Admin {
+    CanalTP::References references;
 
-    OSMRelation(const u_int64_t osm_id,
-                const std::vector<CanalTP::Reference>& refs,
-                const std::string& insee,
-                const std::string& postal_code,
-                const std::string& name,
-                const uint32_t level);
+    OSMAdminRelation(u_int64_t id,
+                     const std::string& uri,
+                     const std::vector<CanalTP::Reference>& refs,
+                     const std::string& insee,
+                     const std::string& postal_code,
+                     const std::string& name,
+                     const uint32_t level);
 
-    bool operator<(const OSMRelation& other) const { return this->osm_id < other.osm_id; }
-
-    bool operator<(const u_int64_t other) const { return osm_id < other; }
-
-    void set_centre(double lon, double lat) const { centre = point(lon, lat); }
-
-    void build_geometry(OSMCache& cache) const;
-    void build_polygon(OSMCache& cache) const;
+    virtual void build_geometry(OSMCache& cache);
+    void build_polygon(OSMCache& cache);
 };
 
 struct OSMWay {
@@ -200,14 +215,13 @@ struct OSMWay {
         return bg::distance(p, ls);
     }
 
-    std::set<const OSMRelation*> admins() const {
-        std::set<const OSMRelation*> result;
+    bool contains_admin(const Admin* admin) const {
         for (auto node : nodes) {
-            if (node->admin != nullptr) {
-                result.insert(node->admin);
+            if (node->admin == admin) {
+                return true;
             }
         }
-        return result;
+        return false;
     }
 
     bool is_used() const { return way_ref == nullptr || this == way_ref; }
@@ -237,27 +251,42 @@ struct AssociateStreetRelation {
 };
 
 typedef std::set<OSMWay>::const_iterator it_way;
-typedef std::map<std::set<const OSMRelation*>, std::set<it_way>> rel_ways;
-typedef std::set<OSMRelation>::const_iterator admin_type;
+typedef std::map<std::set<const Admin*>, std::set<it_way>> rel_ways;
+typedef std::set<OSMAdminRelation>::const_iterator admin_type;
 typedef std::pair<admin_type, double> admin_distance;
 
+constexpr double M_TO_DEG = 1.0 / 111320.0;  // approximate the convertion between meter to degree
+
 struct OSMCache {
-    std::set<OSMRelation> relations;
+    std::map<uint64_t, std::unique_ptr<Admin>> admins;
     std::set<OSMNode> nodes;
     std::set<OSMWay> ways;
     std::set<AssociateStreetRelation> associated_streets;
     std::unordered_map<std::string, rel_ways> way_admin_map;
-    RTree<const OSMRelation*, double, 2> admin_tree;
+    RTree<const Admin*, double, 2> admin_tree;
     RTree<it_way, double, 2> way_tree;
     double max_search_distance = 0;
     size_t NB_PROJ = 0;
+    double cities_bbox_to_fetch =
+        10000.0 * M_TO_DEG;  // by default if we search for cities in the db, we get all the cities +/- 10km around
+
+    size_t admin_from_cities = 0;
+    size_t cities_db_calls = 0;
 
     Lotus lotus;
 
-    OSMCache(const std::string& connection_string) : lotus(connection_string) {}
+    std::unique_ptr<pqxx::connection> cities_db = {};
+
+    OSMCache(const std::string& connection_string, const boost::optional<std::string>& cities_cnx)
+        : lotus(connection_string) {
+        if (cities_cnx) {
+            cities_db = std::make_unique<pqxx::connection>(*cities_cnx);
+        }
+    }
 
     void build_relations_geometries();
-    const OSMRelation* match_coord_admin(const double lon, const double lat);
+    const Admin* match_coord_admin(const double lon, const double lat);
+    const Admin* find_admin_in_cities(const double lon, const double lat);
     void match_nodes_admin();
     void insert_nodes();
     void insert_ways();
@@ -272,7 +301,8 @@ struct OSMCache {
 
 struct ReadRelationsVisitor {
     OSMCache& cache;
-    ReadRelationsVisitor(OSMCache& cache) : cache(cache) {}
+    bool use_cities;
+    ReadRelationsVisitor(OSMCache& cache, bool use_cities) : cache(cache), use_cities(use_cities) {}
 
     void node_callback(uint64_t, double, double, const CanalTP::Tags&) {}
     void relation_callback(uint64_t osm_id, const CanalTP::Tags& tags, const CanalTP::References& refs);

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -291,6 +291,8 @@ class Instance(db.Model):  # type: ignore
 
     import_ntfs_in_mimir = db.Column(db.Boolean, default=False, nullable=False)
 
+    admins_from_cities_db = db.Column(db.Boolean, default=False, nullable=False)
+
     # ============================================================
     # params for jormungandr
     # ============================================================

--- a/source/tyr/migrations/versions/38cf24479595_admins_from_cities_db.py
+++ b/source/tyr/migrations/versions/38cf24479595_admins_from_cities_db.py
@@ -1,0 +1,23 @@
+"""Add a field to use cities in osm2ed
+
+Revision ID: 38cf24479595
+Revises: 35d86bbbe642
+Create Date: 2019-05-09 17:09:41.400340
+
+"""
+
+revision = '38cf24479595'
+down_revision = '35d86bbbe642'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        'instance', sa.Column('admins_from_cities_db', sa.Boolean(), nullable=False, server_default='False')
+    )
+
+
+def downgrade():
+    op.drop_column('instance', 'admins_from_cities_db')

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -278,6 +278,13 @@ def osm2ed(self, instance_config, osm_filename, job_id, dataset_uid):
         args.append("--log_comment")
         args.append(instance_config.name)
 
+        if instance.admins_from_cities_db:
+            cities_db = current_app.config.get('CITIES_DATABASE_URI')
+            if not cities_db:
+                raise ValueError(
+                    'impossible to use osm2ed with cities db since no cities database configuration has been set'
+                )
+            args.extend(["--cities-connection-string", cities_db])
         with collect_metric('osm2ed', job, dataset_uid):
             res = launch_exec('osm2ed', args, logger)
         if res != 0:

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -96,6 +96,7 @@ instance_fields = {
     'is_free': fields.Raw,
     'import_stops_in_mimir': fields.Raw,
     'import_ntfs_in_mimir': fields.Raw,
+    'admins_from_cities_db': fields.Raw,
     'scenario': fields.Raw,
     'journey_order': fields.Raw,
     'max_walking_duration_to_pt': fields.Raw,

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -511,6 +511,13 @@ class Instance(flask_restful.Resource):
             default=instance.import_ntfs_in_mimir,
         )
         parser.add_argument(
+            'admins_from_cities_db',
+            type=inputs.boolean,
+            help='use cities db while importing data from osm',
+            location=('json', 'values'),
+            default=instance.admins_from_cities_db,
+        )
+        parser.add_argument(
             'min_nb_journeys',
             type=int,
             help='minimum number of different suggested journeys',
@@ -652,6 +659,7 @@ class Instance(flask_restful.Resource):
                     'is_open_data',
                     'import_stops_in_mimir',
                     'import_ntfs_in_mimir',
+                    'admins_from_cities_db',
                     'min_nb_journeys',
                     'max_nb_journeys',
                     'min_journeys_calls',


### PR DESCRIPTION
add a new param to `osm2ed`: `--cities-connection-string=<cnx string to the database>`. With this params, the administrative regions are no longer fetched from osm's relation, but from the `cities` database (this db being filled up either by [cosmogony2cities](https://github.com/CanalTP/cosmogony2cities) or by the [legacy tool](https://github.com/CanalTP/navitia/blob/dev/source/cities/cities.h).

This makes it possible to have nicely read admins even in kraken.

To enable this in tyr, change the `admins_from_cities_db` instance variable to True.

### Note:
#### results

Since we fetch the admins by bulk (to reduce the number of calls to the database, we end up with more admins than before.
Here are the admins imported in qgis:
![Capture d’écran de 2019-05-09 12-04-32](https://user-images.githubusercontent.com/3987698/57459895-66530380-7274-11e9-8d91-dd90534052c3.png)
(pink is new, green is old)

We could filter the other admins, but I don't think it's a problem to keep them.

#### bench 

This costs a bit at import time since we need to make some calls the the database
On my computer, importing a pbf on ile de france 

old | new
-----|------
2m45|3m07

Since we do the query to the db in bulk (asking for all the admins within a 20km square bbox), we only make 80 calls to the db for the idf


#### :warning: I corrected what seems to be a mistake :warning: but it might breaks stuff :roll_eyes: 
A node that was just on an admin boundary was not associated to any admin with `boost::geometry::within` is a strict inclusion. I changed `within` to `covered_by` to fix this.

I'm not sure about the implication of this change though since it's not trivial. The thing is that now, we have less ways not associated to an admins (since the use the node's admin to compute the way's admin), but more way associated to more than one admin....

on ile de france:

name| old | new
-----|-----|------
way with no admin|1276 |0
way with a name, but no admin |559|0
way with more than one admin |11131|12859


#### No more admin 9-10
cities db contains only real city (admin=8 in france), so now osm2ed will no longer import paris district. I don't think it's a problem since I don't think they are used afterward