### PR TITLE
Concurent integration tests

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -90,6 +90,8 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
         ("BROKER.timeout", po::value<int>()->default_value(100), "timeout for maintenance worker in millisecond")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
+        ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")
+        ("BROKER.queue_auto_delete", po::value<bool>()->default_value(false), "auto delete rabbitmq's queue when unbind")
 
         ("CHAOS.database", po::value<std::string>(), "Chaos database connection string");
 
@@ -204,6 +206,17 @@ int Configuration::broker_timeout() const {
 
 int Configuration::broker_sleeptime() const {
     return vm["BROKER.sleeptime"].as<int>();
+}
+
+std::string Configuration::broker_queue(const std::string& default_queue) const {
+    if (vm.count("BROKER.queue")) {
+        return this->vm["BROKER.queue"].as<std::string>();
+    }
+    return default_queue;
+}
+
+bool Configuration::broker_queue_auto_delete() const {
+    return vm["BROKER.queue_auto_delete"].as<bool>();
 }
 
 std::vector<std::string> Configuration::rt_topics() const {

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -56,6 +56,8 @@ public:
     std::string broker_password() const;
     std::string broker_vhost() const;
     std::string broker_exchange() const;
+    std::string broker_queue(const std::string& default_queue) const;
+    bool broker_queue_auto_delete() const;
     int broker_timeout() const;
     int broker_sleeptime() const;
     bool is_realtime_enabled() const;

--- a/source/tests/basic_routing_test.cpp
+++ b/source/tests/basic_routing_test.cpp
@@ -174,6 +174,6 @@ int main(int argc, const char* const argv[]) {
     b.manage_admin();
     b.make();
 
-    mock_kraken kraken(b, "basic_routing_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
     return 0;
 }

--- a/source/tests/basic_schedule_test.cpp
+++ b/source/tests/basic_schedule_test.cpp
@@ -60,7 +60,7 @@ int main(int argc, const char* const argv[]) {
 
     departure_board_fixture data_set;
 
-    mock_kraken kraken(data_set.b, "basic_schedule_test", argc, argv);
+    mock_kraken kraken(data_set.b, argc, argv);
 
     return 0;
 }

--- a/source/tests/departure_board_test.cpp
+++ b/source/tests/departure_board_test.cpp
@@ -42,7 +42,7 @@ int main(int argc, const char* const argv[]) {
 
     calendar_fixture data_set;
 
-    mock_kraken kraken(data_set.b, "departure_board_test", argc, argv);
+    mock_kraken kraken(data_set.b, argc, argv);
 
     return 0;
 }

--- a/source/tests/empty_routing_test.cpp
+++ b/source/tests/empty_routing_test.cpp
@@ -48,7 +48,7 @@ int main(int argc, const char* const argv[]) {
        << routing_data.S.lon() - 1 << " " << routing_data.S.lat() - 1 << "))";
     b.data->meta->shape = ss.str();
 
-    mock_kraken kraken(b, "empty_routing_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
 
     return 0;
 }

--- a/source/tests/line_sections_test.cpp
+++ b/source/tests/line_sections_test.cpp
@@ -111,7 +111,7 @@ int main(int argc, const char* const argv[]) {
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
-    mock_kraken kraken(b, "line_sections_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
 
     return 0;
 }

--- a/source/tests/main_autocomplete_test.cpp
+++ b/source/tests/main_autocomplete_test.cpp
@@ -129,6 +129,6 @@ int main(int argc, const char* const argv[]) {
        << 8. << ", " << 1. << " " << 1. << "))";
     b.data->meta->shape = ss.str();
 
-    mock_kraken kraken(b, "main_autocomplete_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
     return 0;
 }

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -224,7 +224,7 @@ int main(int argc, const char* const argv[]) {
 
     data_set data(date, publisher_name, timezone_name, timezones);
 
-    mock_kraken kraken(data.b, "main_ptref_test", argc, argv);
+    mock_kraken kraken(data.b, argc, argv);
 
     return 0;
 }

--- a/source/tests/main_routing_test.cpp
+++ b/source/tests/main_routing_test.cpp
@@ -37,7 +37,7 @@ int main(int argc, const char* const argv[]) {
 
     routing_api_data<normal_speed_provider> routing_data;
 
-    mock_kraken kraken(routing_data.b, "main_routing_test", argc, argv);
+    mock_kraken kraken(routing_data.b, argc, argv);
 
     return 0;
 }

--- a/source/tests/main_routing_without_pt_test.cpp
+++ b/source/tests/main_routing_without_pt_test.cpp
@@ -37,7 +37,7 @@ int main(int argc, const char* const argv[]) {
 
     routing_api_data<normal_speed_provider> routing_data(200, false);
 
-    mock_kraken kraken(routing_data.b, "main_routing_without_pt_test", argc, argv);
+    mock_kraken kraken(routing_data.b, argc, argv);
 
     return 0;
 }

--- a/source/tests/main_stif_test.cpp
+++ b/source/tests/main_stif_test.cpp
@@ -69,6 +69,6 @@ int main(int argc, const char* const argv[]) {
 
     b.make();
 
-    mock_kraken kraken(b, "main_stif_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
     return 0;
 }

--- a/source/tests/min_nb_journeys_test.cpp
+++ b/source/tests/min_nb_journeys_test.cpp
@@ -146,6 +146,6 @@ int main(int argc, const char* const argv[]) {
     b.data->build_uri();
 
     // mock kraken
-    mock_kraken kraken(b, "min_nb_journeys_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
     return 0;
 }

--- a/source/tests/mock_kraken.h
+++ b/source/tests/mock_kraken.h
@@ -47,21 +47,21 @@ namespace po = boost::program_options;
  * Pratically the same behavior as a real kraken, but with already loaded data
  */
 struct mock_kraken {
-    inline mock_kraken(ed::builder& d, const std::string& name, int argc, const char* const argv[]) {
+    inline mock_kraken(ed::builder& d, int argc, const char* const argv[]) {
         DataManager<navitia::type::Data> data_manager;
         data_manager.set_data(d.data.release());
 
         boost::thread_group threads;
         // Prepare our context and sockets
         zmq::context_t context(1);
-        const std::string zmq_socket = "ipc:///tmp/" + name;
 
         // we load the conf to have the default values
         navitia::kraken::Configuration conf;
         // we mock a command line load
-        po::options_description desc = navitia::kraken::get_options_description(
-            boost::optional<std::string>("default"), boost::optional<std::string>(zmq_socket),
-            boost::optional<bool>(true));  // not used
+        po::options_description desc =
+            navitia::kraken::get_options_description(boost::optional<std::string>("default"),
+                                                     boost::none,  // zmq_socket is set throught cmd line option
+                                                     boost::optional<bool>(true));  // not used
         auto other_options = conf.load_from_command_line(desc, argc, argv);
 
         LoadBalancer lb(context);

--- a/source/tests/multiple_schedules.cpp
+++ b/source/tests/multiple_schedules.cpp
@@ -86,7 +86,7 @@ int main(int argc, const char* const argv[]) {
     b.data->pt_data->codes.add(b.get<nt::Line>("B"), "Kisio数字", "syn_lineB");
     b.data->pt_data->codes.add(b.get<nt::Line>("C"), "Kisio数字", "syn_lineC");
 
-    mock_kraken kraken(b, "multiple_schedules", argc, argv);
+    mock_kraken kraken(b, argc, argv);
 
     return 0;
 }

--- a/source/tests/null_status_test.cpp
+++ b/source/tests/null_status_test.cpp
@@ -37,7 +37,7 @@ int main(int argc, const char* const argv[]) {
     navitia::init_app();
     b.data->loaded = false;
     b.data->loading = false;
-    mock_kraken kraken(b, "null_status_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
 
     return 0;
 }

--- a/source/tests/timezone_cape_verde_test.cpp
+++ b/source/tests/timezone_cape_verde_test.cpp
@@ -113,7 +113,7 @@ int main(int argc, const char* const argv[]) {
     b.build_autocomplete();
     b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(30));
 
-    mock_kraken kraken(b, "timezone_cape_verde_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
 
     return 0;
 }

--- a/source/tests/timezone_hong_kong_test.cpp
+++ b/source/tests/timezone_hong_kong_test.cpp
@@ -106,7 +106,7 @@ int main(int argc, const char* const argv[]) {
     b.build_autocomplete();
     b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(30));
 
-    mock_kraken kraken(b, "timezone_hong_kong_test", argc, argv);
+    mock_kraken kraken(b, argc, argv);
 
     return 0;
 }


### PR DESCRIPTION
Jobs might fail on our CI when we try to run 2 concurrent jobs... This is a bummer :-1: 

This is due to 2 things:
 - Jenkins mounts `/tmp` within all dockers it pops. This is a problem as 2 kraken instances will trample each other zmq socket (`ipc://temp/kraken_{instance_name}`).
 - Similar problem exists with Rabbimq's queues. A Kraken make sure the queue is deleted before binding to it. If another Kraken is already up and using a queue, a second Kraken will delete the one already in use with what is potentially in there.

Solution:
- Making sure each test instances have its own unique id.
- Use that unique id to set a zmq_socket and a queue's name. 

We add 2 Kraken command line options:
- `--BROKER.queue=my_name` to set RabbitMQ queue's name
- `--BROKER.queue_auto_delete=true` to tell RabbitMQ to delete the queues when done with it.
