### PR TITLE
kraken: fix boost::posix_time::seconds on ubuntu disco with boost 1.67

### DIFF
--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1907,7 +1907,7 @@ void PbCreator::finalize_section(pbnavitia::Section* section,
     section->set_length(total_length);
 
     section->set_begin_date_time(navitia::to_posix_timestamp(departure));
-    section->set_end_date_time(navitia::to_posix_timestamp(departure + bt::seconds(total_duration)));
+    section->set_end_date_time(navitia::to_posix_timestamp(departure + bt::seconds(long(total_duration))));
 
     // add the destination as a placemark
     pbnavitia::PtObject* dest_place = section->mutable_destination();


### PR DESCRIPTION
With this fix, **Kraken** can compile on a clean **ubuntu 19.04** env (**gcc 9**, **boost 1.67**)
Boost was too lenient about the input type of **boost:posix_time:seconds()**. Now, it is fix for "long" type like in the doc.
It's job is linked with https://github.com/CanalTP/navitia/pull/2786