### PR TITLE
Kraken: handle A* clang warning

### DIFF
--- a/source/georef/astar_path_finder.cpp
+++ b/source/georef/astar_path_finder.cpp
@@ -37,6 +37,8 @@ www.navitia.io
 namespace navitia {
 namespace georef {
 
+AstarPathFinder::~AstarPathFinder() = default;
+
 void AstarPathFinder::start_distance_or_target_astar(const navitia::time_duration& radius,
                                                      const std::vector<vertex_t>& destinations) {
     if (!starting_edge.found)

--- a/source/georef/astar_path_finder.cpp
+++ b/source/georef/astar_path_finder.cpp
@@ -45,7 +45,8 @@ void AstarPathFinder::start_distance_or_target_astar(const navitia::time_duratio
     // We start astar from source and target nodes
     try {
         astar({starting_edge[source_e], starting_edge[target_e]},
-              astar_distance_heuristic(geo_ref.graph, destinations.back(), 1. / (default_speed[mode] * speed_factor)),
+              astar_distance_heuristic(geo_ref.graph, destinations.back(),
+                                       1. / double(default_speed[mode] * speed_factor)),
               astar_distance_or_target_visitor(radius, distances, destinations));
     } catch (DestinationFound&) {
     }

--- a/source/georef/astar_path_finder.h
+++ b/source/georef/astar_path_finder.h
@@ -59,6 +59,8 @@ public:
     std::vector<navitia::time_duration> costs;
 
     AstarPathFinder(const GeoRef& geo_ref) : PathFinder(geo_ref) {}
+    AstarPathFinder(const AstarPathFinder& o) = default;
+    virtual ~AstarPathFinder();
 
     void init(const type::GeographicalCoord& start_coord,
               const type::GeographicalCoord& dest_coord,

--- a/source/georef/astar_path_finder.h
+++ b/source/georef/astar_path_finder.h
@@ -71,7 +71,7 @@ public:
         costs.assign(n, bt::pos_infin);
 
         auto const distance_to_dest = start_coord.distance_to(dest_coord);
-        auto const duration_to_dest = navitia::seconds(distance_to_dest / (default_speed[mode] * speed_factor));
+        auto const duration_to_dest = navitia::seconds(distance_to_dest / double(default_speed[mode] * speed_factor));
         costs[starting_edge[source_e]] = duration_to_dest;
         costs[starting_edge[target_e]] = duration_to_dest;
     }

--- a/source/georef/astar_path_finder.h
+++ b/source/georef/astar_path_finder.h
@@ -66,7 +66,7 @@ public:
               const type::GeographicalCoord& dest_coord,
               nt::Mode_e mode,
               const float speed_factor) {
-        PathFinder::init(start_coord, mode, speed_factor);
+        PathFinder::init_start(start_coord, mode, speed_factor);
 
         // we initialize the costs to the maximum value
         size_t n = boost::num_vertices(geo_ref.graph);

--- a/source/georef/dijkstra_path_finder.cpp
+++ b/source/georef/dijkstra_path_finder.cpp
@@ -35,6 +35,8 @@ www.navitia.io
 namespace navitia {
 namespace georef {
 
+DijkstraPathFinder::~DijkstraPathFinder() = default;
+
 void DijkstraPathFinder::start_distance_dijkstra(const navitia::time_duration& radius) {
     if (!starting_edge.found)
         return;

--- a/source/georef/dijkstra_path_finder.h
+++ b/source/georef/dijkstra_path_finder.h
@@ -42,6 +42,8 @@ namespace georef {
 class DijkstraPathFinder : public PathFinder {
 public:
     DijkstraPathFinder(const GeoRef& geo_ref) : PathFinder(geo_ref) {}
+    DijkstraPathFinder(const DijkstraPathFinder& o) = default;
+    virtual ~DijkstraPathFinder();
 
     void start_distance_dijkstra(const navitia::time_duration& radius);
     void start_distance_or_target_dijkstra(const navitia::time_duration& radius,

--- a/source/georef/dijkstra_path_finder.h
+++ b/source/georef/dijkstra_path_finder.h
@@ -45,6 +45,10 @@ public:
     DijkstraPathFinder(const DijkstraPathFinder& o) = default;
     virtual ~DijkstraPathFinder();
 
+    void init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor) {
+        PathFinder::init_start(start_coord, mode, speed_factor);
+    }
+
     void start_distance_dijkstra(const navitia::time_duration& radius);
     void start_distance_or_target_dijkstra(const navitia::time_duration& radius,
                                            const std::vector<vertex_t>& destinations);

--- a/source/georef/path_finder.cpp
+++ b/source/georef/path_finder.cpp
@@ -90,7 +90,7 @@ nt::LineString PathFinder::path_coordinates_on_same_edge(const Edge& e,
 
 PathFinder::PathFinder(const GeoRef& gref) : geo_ref(gref), color(boost::num_vertices(geo_ref.graph)) {}
 
-void PathFinder::init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor) {
+void PathFinder::init_start(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor) {
     computation_launch = false;
     // we look for the nearest edge from the start coordinate
     // in the right transport mode (walk, bike, car, ...) (ie offset)

--- a/source/georef/path_finder.cpp
+++ b/source/georef/path_finder.cpp
@@ -37,7 +37,7 @@ www.navitia.io
 namespace navitia {
 namespace georef {
 
-PathFinder::~PathFinder() {}
+PathFinder::~PathFinder() = default;
 
 navitia::time_duration PathFinder::crow_fly_duration(const double distance) const {
     // For BSS we want the default speed of walking, because on extremities we walk !

--- a/source/georef/path_finder.cpp
+++ b/source/georef/path_finder.cpp
@@ -179,25 +179,20 @@ PathItem::TransportCaracteristic PathFinder::get_transportation_mode_item_to_upd
         case georef::PathItem::TransportCaracteristic::Car:
         case georef::PathItem::TransportCaracteristic::Bike:
             return previous_transportation;
-            break;
             // if we were switching between walking and biking, we need to take either
             // the previous or the next transportation mode depending on 'append_to_begin'
         case georef::PathItem::TransportCaracteristic::BssTake:
             return (append_to_begin ? georef::PathItem::TransportCaracteristic::Walk
                                     : georef::PathItem::TransportCaracteristic::Bike);
-            break;
         case georef::PathItem::TransportCaracteristic::BssPutBack:
             return (append_to_begin ? georef::PathItem::TransportCaracteristic::Bike
                                     : georef::PathItem::TransportCaracteristic::Walk);
-            break;
         case georef::PathItem::TransportCaracteristic::CarLeaveParking:
             return (append_to_begin ? georef::PathItem::TransportCaracteristic::Walk
                                     : georef::PathItem::TransportCaracteristic::Car);
-            break;
         case georef::PathItem::TransportCaracteristic::CarPark:
             return (append_to_begin ? georef::PathItem::TransportCaracteristic::Car
                                     : georef::PathItem::TransportCaracteristic::Walk);
-            break;
         default:
             throw navitia::recoverable_exception("unhandled transportation carac case");
     }

--- a/source/georef/path_finder.h
+++ b/source/georef/path_finder.h
@@ -142,6 +142,7 @@ public:
     boost::two_bit_color_map<> color;
 
     PathFinder(const GeoRef& geo_ref);
+    PathFinder(const PathFinder& o) = default;
 
     // Virtual destructor, to allow use as a public base class,
     // but pure to ensure object itself isn't instantiated
@@ -164,8 +165,9 @@ public:
                   const std::pair<navitia::time_duration, ProjectionData::Direction>& nearest_edge);
 
     // find the nearest vertex from the projection. return the distance to this vertex and the vertex
-    std::pair<navitia::time_duration, ProjectionData::Direction> find_nearest_vertex(const ProjectionData& target,
-                                                                                     bool handle_on_node = false) const;
+    virtual std::pair<navitia::time_duration, ProjectionData::Direction> find_nearest_vertex(
+        const ProjectionData& target,
+        bool handle_on_node = false) const;
 
     // return the duration between two projection on the same edge
     navitia::time_duration path_duration_on_same_edge(const ProjectionData& p1, const ProjectionData& p2);

--- a/source/georef/path_finder.h
+++ b/source/georef/path_finder.h
@@ -148,12 +148,6 @@ public:
     // but pure to ensure object itself isn't instantiated
     virtual ~PathFinder() = 0;
 
-    /**
-     *  Update the structure for a given starting point and transportation mode
-     *  The init HAS to be called before any other methods
-     */
-    void init(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor);
-
     // return the path from the starting point to the target. the target has to have been previously visited.
     Path get_path(type::idx_t idx);
 
@@ -176,6 +170,12 @@ public:
     type::LineString path_coordinates_on_same_edge(const Edge& e, const ProjectionData& p1, const ProjectionData& p2);
 
 protected:
+    /**
+     *  Update the structure for a given starting point and transportation mode
+     *  The init HAS to be called before any other methods
+     */
+    void init_start(const type::GeographicalCoord& start_coord, nt::Mode_e mode, const float speed_factor);
+
     // return the time the travel the distance at the current speed (used for projections)
     navitia::time_duration crow_fly_duration(const double val) const;
 


### PR DESCRIPTION
:mag: please review by commit

There is probably more to be done, as get_path(idx) is only used by Astar, and almost no method of PathFinder needs to be public... But not now :smiling_imp: 