### PR TITLE
kraken: include portable boost serialization is missing

### DIFF
--- a/source/type/tests/comments_test.cpp
+++ b/source/type/tests/comments_test.cpp
@@ -35,10 +35,10 @@ www.navitia.io
 #include "ed/build_helper.h"
 #include "type/pt_data.h"
 #include "type/type.h"
+#include "type/serialization.h"
 #include "tests/utils_test.h"
 #include "type/comment_container.h"
 #include <memory>
-#include <boost/archive/binary_oarchive.hpp>
 #include <string>
 #include <type_traits>
 #include "utils/logger.h"


### PR DESCRIPTION
Since the header change (https://github.com/CanalTP/navitia/pull/2784), we have lost a include inside `comment_test.cpp` that is required for boost new version, the famous `"type/serialization.h"`
The bug was not seen by the CI because it is a Debian 8 :turtle: 