### PR TITLE
Doc: Equipment reports

### DIFF
--- a/documentation/slate/CONTRIBUTING.md
+++ b/documentation/slate/CONTRIBUTING.md
@@ -15,7 +15,12 @@ plus some Slate widgets (such as notices).
 
 Once some changes have been done, Slate needs to build HTML sources from Markdown files.
 
-First, install bundler using `apt-get install bundler` or `gem install bundler`.
+First, install bundler using `apt-get install bundler` or `gem install bundler`. Make sure you've also installed ruby's header to build the json package.
+On ubuntu 18:
+```
+sudo apt install ruby-bundler ruby2.5-dev
+```
+
 Then check that Slate dependencies are installed:
 
 ``` bash

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1049,7 +1049,7 @@ In this example, the stop points within the circle (SP1, SP2 et SP3) can be reac
 The journeys can only use allowed vehicle journeys (as present in the `public_transport` or `on_demand_transport` sections).
 They also can only use the allowed stop points for getting in or out of a vehicle (as present in the `street_network`, `transfer` and `crow_fly` sections).
 
-For filtering vehicle journeys, the identifier of a line, route, commercial mode, physical mode or network can be used.
+To filter vehicle journeys, the identifier of a line, route, commercial mode, physical mode or network can be used.
 
 For filtering stop points, the identifier of a stop point or stop area can be used.
 

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1049,7 +1049,7 @@ In this example, the stop points within the circle (SP1, SP2 et SP3) can be reac
 The journeys can only use allowed vehicle journeys (as present in the `public_transport` or `on_demand_transport` sections).
 They also can only use the allowed stop points for getting in or out of a vehicle (as present in the `street_network`, `transfer` and `crow_fly` sections).
 
-For filtering vehicle journeys, the identifier of a line, route, commercial mode, physical mode or network can be used. 
+For filtering vehicle journeys, the identifier of a line, route, commercial mode, physical mode or network can be used.
 
 For filtering stop points, the identifier of a stop point or stop area can be used.
 
@@ -1665,7 +1665,7 @@ Required | Name             | Type                            | Description     
 nop      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                          | the current datetime
 nop      | duration         | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                           | 86400
 nop      | count            | int                             | Maximum number of results.                                                                               | 10
-nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                        | 
+nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                        |
 nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul> | realtime
 nop      | disable_geojson  | boolean                         | remove geojson fields from the response                                                                  | false
 
@@ -1770,7 +1770,7 @@ HTTP/1.1 200 OK
 
 ```
 
-This service provides the state of public transport traffic, grouped by lines and all their stops. 
+This service provides the state of public transport traffic, grouped by lines and all their stops.
 It can be called for an overall coverage or for a specific object.
 
 <img src="./images/traffic_reports.png" alt="Traffic reports" width="300"/>
@@ -1795,7 +1795,7 @@ no       | until            | [iso-date-time](#iso-date-time) | Only display dis
 no       | count            | int                             | Maximum number of results.                        | 10
 no       | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc. |
 no       | disable_geojson  | boolean                         | remove geojson fields from the response           | false
-no       | tags[]           | array of string                 | Restrain the search within the given disruption tags| 
+no       | tags[]           | array of string                 | Restrain the search within the given disruption tags|
 
 The response is made of an array of [line_reports](#line-reports),
 and another one of [disruptions](#disruption).
@@ -1879,7 +1879,7 @@ see the [inner-reference](#inner-references) section to use them.
 Line_reports is an array of some line_report object.
 
 One Line_report object is a complex object, made of a line, and an array
-of [pt_objects](#pt-objects) linked (for example stop_areas, stop_point or network). 
+of [pt_objects](#pt-objects) linked (for example stop_areas, stop_point or network).
 
 #### What a **complete** response **means**
 
@@ -1905,7 +1905,7 @@ Details for disruption objects : [disruptions](#disruptions)
 
 -   1 line which is the grouping object
     -   it can contain links to its disruptions.  
-    These disruptions are globals and might not be applied on stop_areas and stop_points. 
+    These disruptions are globals and might not be applied on stop_areas and stop_points.
 -   1..n pt_objects
     -   each one contains at least a link to its disruptions.
 
@@ -2132,3 +2132,75 @@ Details for disruption objects : [disruptions](#disruptions)
 -   0..n stop_areas
     -   each stop_area contains at least a link to its disruptions  
     If a stop_area is used by multiple networks, it will appear each time.
+
+
+Equipment_Reports
+---------------------------------------------
+``` shell
+#request
+$ curl 'http://api.navitia.io/v1/coverage/sandbox/equipment_reports' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
+```
+
+``` shell
+# response, composed by 1 main list: "equipment_reports"
+HTTP/1.1 200 OK
+
+{
+    "equipment_reports": [
+        {
+            "line": {15 items},
+            "stop_area_equipments": [
+                {  
+                    "equipment_details": [
+                        {
+                            "current_availability": {
+                                "cause": {
+                                    "label": "engineering work in progress"
+                                },
+                                "effect": {
+                                    "label": "platform 3 available via stairs only"
+                                },
+                                "periods": [
+                                    {
+                                        "begin": "20190216T000000",
+                                        "end": "20190601T220000"
+                                    }
+                                ],
+                                "status": "unavailable",
+                                "updated_at": "2019-05-17T15:54:53+02:00"
+                            }
+                        "embedded_type": "escalator",
+                        "id": "2702",
+                        "name": "du quai direction Vaulx-en-Velin La Soie  jusqu'à la sortie B",
+                        },
+                    ]
+                    "stop_area": {9 items},
+                },
+            ]
+        },
+    ],
+}
+```
+
+Also known as the `"/equipment_reports"` service.
+
+This service provides the state of equipments such as lifts or elevators that are giving you better accessibility to public transport facilities.
+The endpoint will report accessible equipement per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered on a per line basis.
+Some of the fields (cause, effect, periods etc...) are only displayed if a realtime equipment provider is setup with available data. Otherwise, only information provided by the NTFS will be reported.
+For more information, refer to [equipment-reports](#equipment-reports) API description.
+
+<aside class="warning">
+    This feature requires a specific configuration from a equipment service provider.
+    Therefore this service is not available by default.
+</aside>
+
+### Parameters
+
+
+Required | Name             | Type   | Description                                        | Default Value
+---------|------------------|--------|----------------------------------------------------|--------------
+no       | count            | int    | Elements per page                                  | 10
+no       | depth            | int    | Depth                                              | 1
+no       | filter           | string | A [filter](#filter) to refine your request         |
+no       | forbidden_uris[] | id     | If you want to avoid lines, modes, networks, etc.  |
+no       | start_page       | int    | The page number (cf the [paging section](#paging)) | 0

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -387,7 +387,7 @@ Real time and disruption objects
 |severity      | [severity](#severity)          |gives some categorization element
 |application_periods |array of [period](#period)      |dates where the current disruption is active
 |messages            |array of [message](#message)    |texts to provide to the traveler
-|updated_at          |[iso-date-time](#iso-date-time) |date_time of last modifications 
+|updated_at          |[iso-date-time](#iso-date-time) |date_time of last modifications
 |impacted_objects    |array of [impacted_object](#impacted_object) |The list of public transport objects which are affected by the disruption
 |cause               |string                   |why is there such a disruption?
 |category            |string                   |The category of the disruption, such as "construction works" or "incident"
@@ -557,7 +557,7 @@ $ curl 'https://api.navitia.io/v1/coverage/sandbox/poi_types' -H 'Authorization:
 
 `/poi_types` lists groups of point of interest. You will find classifications as theater, offices or bicycle rental station for example.
 
- 
+
 |Field|Type|Description|
 |-----|----|-----------|
 |id|string|Identifier of the poi type|
@@ -583,7 +583,7 @@ $ curl 'https://api.navitia.io/v1/coverage/sandbox/pois' -H 'Authorization: 3b03
 $ curl 'https://api.navitia.io/v1/coverage/sandbox/coords/2.377310;48.847002/pois' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
 
 #very smart request
-#combining filters to get some specific POIs, as bicycle rental stations, 
+#combining filters to get some specific POIs, as bicycle rental stations,
 #nearby a coordinate
 $ curl 'https://api.navitia.io/v1/coverage/sandbox/poi_types/poi_type:amenity:bicycle_rental/coords/2.377310;48.847002/pois' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
 ```
@@ -623,6 +623,101 @@ Poi = Point Of Interest
 Cities are mainly on the 8 level, dependant on the country
 (<http://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative>)
 
+
+### <a name="equipment-reports"></a>Equipment Reports
+
+```json
+"equipment_reports": [
+    {
+        "line": {...},
+        "stop_area_equipments": [...]
+    },
+    ...
+]
+```
+
+A list of object that maps foreach line, the equipments associated with its stop areas.
+
+|Field|Type|Description|
+|-----|----|-----------|
+|line|[line](#line)|The line to which equipments are associated |
+|stop_area_equipments|[stop-area-equipments](#stop-area-equipments)|a list of objects that describes the equipments for each stop area |
+
+
+### <a name="stop-area-equipments"></a>Stop Area Equipments
+
+```json
+"stop_area_equipments": [
+    {
+        "equipment_details": [...],
+        "stop_area": {...},
+    },
+    ...
+]
+```
+A list of object that maps foreach stop area, the equipments details.
+
+|Field|Type|Description|
+|-----|----|-----------|
+|equipment_details|[equipment-details](#equipment-details)|The line to which equipments are associated |
+|stop_area|[stop-area](#stop-area)|The stop area to which equipments are associated |
+
+
+### <a name="equipment-details"></a>Equipment Details
+```json
+"equipment_details": [
+    {
+        "current_availability": {
+            "status": "unknown"
+        }
+        "embedded_type": "elevator",
+        "id": "272",
+    },
+    {
+        "current_availability": {
+            "cause": {
+                "label": "Travaux à proximité"
+            },
+            "effect": {
+                "label": "."
+            },
+            "periods": [
+                {
+                    "begin": "20190216T000000",
+                    "end": "20190601T220000"
+                }
+            ],
+            "status": "unavailable",
+            "updated_at": "2019-05-17T15:54:53+02:00"
+        }
+        "embedded_type": "escalator",
+        "id": "2702",
+        "name": "du quai direction Vaulx-en-Velin La Soie  jusqu'à la sortie",
+    },
+    ...
+]
+```
+
+### <a name="current-availability"></a>Current Availability
+
+```json
+"current_availability": {
+    "cause": {
+        "label": "Travaux à proximité"
+    },
+    "effect": {
+        "label": "."
+    },
+    "periods": [
+        {
+            "begin": "20190216T000000",
+            "end": "20190601T220000"
+        }
+    ],
+    "status": "unavailable",
+    "updated_at": "2019-05-17T15:54:53+02:00"
+}
+```
 
 Other objects
 -------------

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -624,7 +624,7 @@ Cities are mainly on the 8 level, dependant on the country
 (<http://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative>)
 
 
-### <a name="equipment-reports"></a>Equipment Reports
+### Equipment-reports
 
 ```json
 "equipment_reports": [
@@ -636,15 +636,15 @@ Cities are mainly on the 8 level, dependant on the country
 ]
 ```
 
-A list of object that maps foreach line, the equipments associated with its stop areas.
+A list of object that maps each lines with its associated stop area equipments report.
 
 |Field|Type|Description|
 |-----|----|-----------|
 |line|[line](#line)|The line to which equipments are associated |
-|stop_area_equipments|[stop-area-equipments](#stop-area-equipments)|a list of objects that describes the equipments for each stop area |
+|stop_area_equipments|[stop-area-equipments](#stop-area-equipments)|A list of objects that describes equipments for each stop area |
 
 
-### <a name="stop-area-equipments"></a>Stop Area Equipments
+### Stop-area-equipments
 
 ```json
 "stop_area_equipments": [
@@ -655,58 +655,43 @@ A list of object that maps foreach line, the equipments associated with its stop
     ...
 ]
 ```
-A list of object that maps foreach stop area, the equipments details.
+A list of objects that maps equipments details for each stop area.
 
 |Field|Type|Description|
 |-----|----|-----------|
-|equipment_details|[equipment-details](#equipment-details)|The line to which equipments are associated |
-|stop_area|[stop-area](#stop-area)|The stop area to which equipments are associated |
+|equipment_details|[equipment-details](#equipment-details)|The equipment details associated with the stop area|
+|stop_area|[stop-area](#stop-area)|The stop area to which the `equipments_details` is associated |
 
 
-### <a name="equipment-details"></a>Equipment Details
+### Equipment-details
 ```json
 "equipment_details": [
     {
-        "current_availability": {
-            "status": "unknown"
-        }
-        "embedded_type": "elevator",
-        "id": "272",
-    },
-    {
-        "current_availability": {
-            "cause": {
-                "label": "Travaux à proximité"
-            },
-            "effect": {
-                "label": "."
-            },
-            "periods": [
-                {
-                    "begin": "20190216T000000",
-                    "end": "20190601T220000"
-                }
-            ],
-            "status": "unavailable",
-            "updated_at": "2019-05-17T15:54:53+02:00"
-        }
+        "current_availability": {...},
         "embedded_type": "escalator",
         "id": "2702",
-        "name": "du quai direction Vaulx-en-Velin La Soie  jusqu'à la sortie",
+        "name": "Escalator 2702, for platform 3",
     },
     ...
 ]
 ```
+|Field|Type|Occurrence|Description|
+|-----|----|--------|-----------|
+current_availability|[current-availability](#current-availability)|always| Describes equipments information like: status, name, id etc...
+embedded_type|string|always|Define the equipment type: `"escalator"`, `"elevator"`
+id|string|always|The equipment's unique identifier
+name|string|optional|the equipment's name/description
 
-### <a name="current-availability"></a>Current Availability
+
+### Current-availability
 
 ```json
 "current_availability": {
     "cause": {
-        "label": "Travaux à proximité"
+        "label": "engineering work in progress"
     },
     "effect": {
-        "label": "."
+        "label": "platform 3 available via stairs only"
     },
     "periods": [
         {
@@ -718,6 +703,14 @@ A list of object that maps foreach stop area, the equipments details.
     "updated_at": "2019-05-17T15:54:53+02:00"
 }
 ```
+
+|Field|Type|Required|Description|
+|-----|----|--------|-----------|
+status|string|always|Equipment status: <ul><li>`"unknown"`: no realtime information available</li><li>`"unavailable"`: equipment is known to be unavailable with details provided below </li></ul>
+cause|label|optional|If `unavailable`, gives you the cause in a label
+effect|label|optional|If `unavailable`, gives you the effect in a label
+periods|period|optional|If `unavailable`, gives the effected period with a begin & end date
+updated_at|[iso-date-time](#iso-date-time)|optional|Last update time of the provided information
 
 Other objects
 -------------

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -707,9 +707,9 @@ name|string|optional|the equipment's name/description
 |Field|Type|Required|Description|
 |-----|----|--------|-----------|
 status|string|always|Equipment status: <ul><li>`"unknown"`: no realtime information available</li><li>`"unavailable"`: equipment is known to be unavailable with details provided below </li></ul>
-cause|label|optional|If `unavailable`, gives you the cause in a label
-effect|label|optional|If `unavailable`, gives you the effect in a label
-periods|period|optional|If `unavailable`, gives the effected period with a begin & end date
+cause|label|optional|If status is `unavailable`, gives you the cause in a label
+effect|label|optional|If status is `unavailable`, gives you the effect in a label
+periods|period|optional|If status is `unavailable`, gives the effected period with a begin & end date
 updated_at|[iso-date-time](#iso-date-time)|optional|Last update time of the provided information
 
 Other objects


### PR DESCRIPTION
Add API documentation for `/equipment_reports` and the associated object response definitions.