### PR TITLE
Jormungandr: fallback to kraken for /places/<uri>

### DIFF
--- a/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
+++ b/source/jormungandr/jormungandr/autocomplete/abstract_autocomplete.py
@@ -111,6 +111,10 @@ class AbstractAutocomplete(six.with_metaclass(ABCMeta, object)):
             return places[0]
         return None
 
+    @abstractmethod
+    def is_handling_stop_points(self):
+        pass
+
 
 class GeoStatusResponse(object):
     def __init__(self):

--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -356,6 +356,9 @@ class GeocodeJson(AbstractAutocomplete):
     def status(self):
         return {'class': self.__class__.__name__, 'timeout': self.timeout, 'fast_timeout': self.fast_timeout}
 
+    def is_handling_stop_points(self):
+        return False
+
 
 class GeocodeJsonError(AutocompleteError):
     pass

--- a/source/jormungandr/jormungandr/autocomplete/kraken.py
+++ b/source/jormungandr/jormungandr/autocomplete/kraken.py
@@ -105,3 +105,6 @@ class Kraken(AbstractAutocomplete):
 
     def status(self):
         return {'class': self.__class__.__name__}
+
+    def is_handling_stop_points(self):
+        return True

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -219,12 +219,8 @@ class Instance(object):
             )
         return backend
 
-    @property
-    def kraken_autocomplete(self):
-        backend = global_autocomplete.get('kraken')
-        if backend is None:
-            raise RuntimeError('impossible to find autocomplete kraken for instance {}'.format(self.name))
-        return backend
+    def stop_point_fallbacks(self):
+        return [a for a in global_autocomplete.values() if a.is_handling_stop_points()]
 
     def get_models(self):
         if self.name not in g.instances_model:

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -219,6 +219,13 @@ class Instance(object):
             )
         return backend
 
+    @property
+    def kraken_autocomplete(self):
+        backend = global_autocomplete.get('kraken')
+        if backend is None:
+            raise RuntimeError('impossible to find autocomplete kraken for instance {}'.format(self.name))
+        return backend
+
     def get_models(self):
         if self.name not in g.instances_model:
             g.instances_model[self.name] = self._get_models()

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -191,19 +191,19 @@ class Scenario(object):
                 uri=request["uri"], instances=[instance], current_datetime=request['_current_datetime']
             )
         except UnknownObject as e:
-            if not autocomplete.is_handling_stop_points():
-                # the autocomplete have not found anything and it does not handle stop_points,
-                # we'll search for the object in kraken too
-
-                kraken_res = instance.kraken_autocomplete.get_by_uri(
+            # the autocomplete have not found anything
+            # We'll check if we can find another autocomplete system that explictly handle stop_points
+            # because for the moment mimir does not have stoppoints, but kraken do
+            for autocomplete_system in instance.stop_point_fallbacks():
+                if autocomplete_system == autocomplete:
+                    continue
+                res = autocomplete_system.get_by_uri(
                     uri=request["uri"], instances=[instance], current_datetime=request['_current_datetime']
                 )
-                if kraken_res.get("places"):
-                    return kraken_res
-                # we raise the initial exception
-                raise e
-            else:
-                raise e
+                if res.get("places"):
+                    return res
+            # we raise the initial exception
+            raise e
 
     def pt_objects(self, request, instance):
         req = request_pb2.Request()


### PR DESCRIPTION
stop_points are not loaded into the new autocomplete system (mimir), and
are not meant to.

To not break integrations where users are using some ids from other api
results (mainly from /journeys) to get more information on the object
with `/places/<uri>`, if mimir does not find the object, we now look
into the kraken.

Note:
* this works only for `/v1/coverage/<bobette>/places/<uri>`, not for the
autocomplete (`/v1/coverage/<bobette>/places?q=bob`)
* this works only when querying one coverage
(`/v1/coverage/<bobette>/places`), not for the global autocomplete
(`/v1/places`)