### PR TITLE
Jormungandr: equipment_reports api with uri filter

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/common.py
+++ b/source/jormungandr/jormungandr/interfaces/common.py
@@ -62,9 +62,6 @@ def split_uri(uri):
     :param uri: concatenated uri params
     :return: the splitted uri list
     """
-    uris = []
-    if uri:
-        if uri[-1] == "/":
-            uri = uri[:-1]
-        uris = uri.split("/")
-    return uris
+    if not uri:
+        return []
+    return uri.strip('/').split('/')

--- a/source/jormungandr/jormungandr/interfaces/common.py
+++ b/source/jormungandr/jormungandr/interfaces/common.py
@@ -54,3 +54,17 @@ def handle_poi_infos(add_poi_info_param, bss_stands_param):
         add_poi_info_param.append("bss_stands")
 
     return any(value in add_poi_info_param for value in ['bss_stands', 'car_park'])
+
+
+def split_uri(uri):
+    """
+    Split uri into an output list
+    :param uri: concatened uri params
+    :return: the splitted uri list
+    """
+    uris = []
+    if uri:
+        if uri[-1] == "/":
+            uri = uri[:-1]
+        uris = uri.split("/")
+    return uris

--- a/source/jormungandr/jormungandr/interfaces/common.py
+++ b/source/jormungandr/jormungandr/interfaces/common.py
@@ -59,7 +59,7 @@ def handle_poi_infos(add_poi_info_param, bss_stands_param):
 def split_uri(uri):
     """
     Split uri into an output list
-    :param uri: concatened uri params
+    :param uri: concatenated uri params
     :return: the splitted uri list
     """
     uris = []

--- a/source/jormungandr/jormungandr/interfaces/v1/Calendars.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Calendars.py
@@ -36,6 +36,7 @@ from jormungandr.interfaces.parsers import default_count_arg_type
 from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.serializer import api
+from jormungandr.interfaces.common import split_uri
 from navitiacommon.parser_args_type import DateTimeFormat, DepthArgument
 from datetime import datetime
 import six
@@ -106,10 +107,7 @@ class Calendars(ResourceUri):
             args["filter"] = "calendar.uri=" + id
         elif uri:
             # Calendars of line
-            if uri[-1] == "/":
-                uri = uri[:-1]
-            uris = uri.split("/")
-            args["filter"] = self.get_filter(uris, args)
+            args["filter"] = self.get_filter(split_uri(uri), args)
         else:
             args["filter"] = ""
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -38,6 +38,7 @@ from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from jormungandr.interfaces.v1.serializer import api
+from jormungandr.interfaces.common import split_uri
 from navitiacommon.parser_args_type import BooleanType, DateTimeFormat, DepthArgument
 from flask.globals import g
 from datetime import datetime
@@ -116,12 +117,7 @@ class TrafficReport(ResourceUri):
         for forbid_id in args['__temporary_forbidden_id[]']:
             args['forbidden_uris[]'].append(forbid_id)
 
-        uris = []
-        if uri:
-            if uri[-1] == "/":
-                uri = uri[:-1]
-            uris = uri.split("/")
-        args["filter"] = self.get_filter(uris, args)
+        args["filter"] = self.get_filter(split_uri(uri), args)
 
         response = i_manager.dispatch(args, "traffic_reports", instance_name=self.region)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -84,11 +84,18 @@ class EquipmentReports(ResourceUri, ResourceUtc):
             abort(404, message='No code type exists into equipment provider')
         return "stop_point.has_code_type(" + code_types + ")"
 
-    def get(self, region=None, lon=None, lat=None):
+    def get(self, region=None, lon=None, lat=None, uri=None):
         self.region = i_manager.get_region(region, lon, lat)
         timezone.set_request_timezone(self.region)
         args = self.parsers["get"].parse_args()
         instance = i_manager.instances.get(self.region)
+
+        uris = []
+        if uri:
+            if uri[-1] == "/":
+                uri = uri[:-1]
+            uris = uri.split("/")
+        args["filter"] = self.get_filter(uris, args)
 
         # create filter
         if args["filter"] != "":

--- a/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/EquipmentReports.py
@@ -39,6 +39,7 @@ from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from jormungandr.interfaces.v1.serializer import api
 from jormungandr.resources_utils import ResourceUtc
+from jormungandr.interfaces.common import split_uri
 
 import six
 import logging
@@ -90,12 +91,7 @@ class EquipmentReports(ResourceUri, ResourceUtc):
         args = self.parsers["get"].parse_args()
         instance = i_manager.instances.get(self.region)
 
-        uris = []
-        if uri:
-            if uri[-1] == "/":
-                uri = uri[:-1]
-            uris = uri.split("/")
-        args["filter"] = self.get_filter(uris, args)
+        args["filter"] = self.get_filter(split_uri(uri), args)
 
         # create filter
         if args["filter"] != "":

--- a/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
@@ -39,6 +39,7 @@ from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from jormungandr.interfaces.v1.serializer import api
+from jormungandr.interfaces.common import split_uri
 from jormungandr.resources_utils import ResourceUtc
 from jormungandr.utils import date_to_timestamp
 from flask_restful import reqparse
@@ -103,12 +104,7 @@ class LineReports(ResourceUri, ResourceUtc):
         if args['disable_geojson']:
             g.disable_geojson = True
 
-        uris = []
-        if uri:
-            if uri[-1] == "/":
-                uri = uri[:-1]
-            uris = uri.split("/")
-        args["filter"] = self.get_filter(uris, args)
+        args["filter"] = self.get_filter(split_uri(uri), args)
 
         if args['since']:
             args['since'] = date_to_timestamp(self.convert_to_utc(args['since']))

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -41,6 +41,7 @@ from datetime import datetime, timedelta
 from jormungandr.interfaces.argument import ArgumentDoc
 from jormungandr.interfaces.parsers import default_count_arg_type
 from jormungandr.interfaces.v1.errors import ManageError
+from jormungandr.interfaces.common import split_uri
 from flask_restful.inputs import natural
 from jormungandr.resources_utils import ResourceUtc
 from jormungandr.interfaces.v1.make_links import create_external_link, create_internal_link
@@ -189,7 +190,7 @@ class Schedules(ResourceUri, ResourceUtc):
                 self.region = i_manager.get_region(object_id=parts[1].strip())
         else:
             self.collection = 'schedules'
-            args["filter"] = self.get_filter(uri.split("/"), args)
+            args["filter"] = self.get_filter(split_uri(uri), args)
             self.region = i_manager.get_region(region, lon, lat)
         timezone.set_request_timezone(self.region)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -41,7 +41,7 @@ from jormungandr.interfaces.parsers import default_count_arg_type
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.Coord import Coord
 from jormungandr.timezone import set_request_timezone
-from jormungandr.interfaces.common import odt_levels, add_poi_infos_types, handle_poi_infos
+from jormungandr.interfaces.common import odt_levels, add_poi_infos_types, handle_poi_infos, split_uri
 from jormungandr.utils import date_to_timestamp
 from jormungandr.resources_utils import ResourceUtc
 from datetime import datetime
@@ -183,9 +183,7 @@ class Uri(ResourceUri, ResourceUtc):
             return {"error": "No region"}, 404
         uris = []
         if uri:
-            if uri[-1] == "/":
-                uri = uri[:-1]
-            uris = uri.split("/")
+            uris = split_uri(uri)
             if self.collection is None:
                 self.collection = uris[-1] if len(uris) % 2 != 0 else uris[-2]
         args["filter"] = self.get_filter(uris, args)

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -344,7 +344,7 @@ class TestEquipment(AbstractTestFixture):
             ("8", "elevator", "unknown"),
             ("9", "elevator", "unknown"),
         ]
-        # filtered with the A line
+        # filtered with the A line that serve stopA and stopB
         expected_result = {"A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details}}
 
         equipment_reports = get_not_null(response, 'equipment_reports')
@@ -355,7 +355,8 @@ class TestEquipment(AbstractTestFixture):
 
         response = self.query_region(default_stop_areas_uri_filter + 'equipment_reports?' + default_date_filter)
 
-        # filtered with the stopA stop_area
+        # Filtered with the stopA stop_area.
+        # The A, B, C, D, M Line serve stopA
         expected_result = {
             "A": {"stopA": stopA_equipment_details},
             "B": {"stopA": stopA_equipment_details},

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -330,10 +330,6 @@ class TestEquipment(AbstractTestFixture):
         )
         response = self.query_region(default_line_uri_filter + 'equipment_reports?' + default_date_filter)
 
-        warnings = get_not_null(response, 'warnings')
-        assert len(warnings) == 1
-        assert warnings[0]['id'] == 'beta_endpoint'
-
         # Expected response
         stopA_equipment_details = [
             ("5", "elevator", "unknown"),
@@ -358,10 +354,6 @@ class TestEquipment(AbstractTestFixture):
         self._check_equipment_report(equipment_reports, expected_result)
 
         response = self.query_region(default_stop_areas_uri_filter + 'equipment_reports?' + default_date_filter)
-
-        warnings = get_not_null(response, 'warnings')
-        assert len(warnings) == 1
-        assert warnings[0]['id'] == 'beta_endpoint'
 
         # Expected response
         stopA_equipment_details = [

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -355,20 +355,6 @@ class TestEquipment(AbstractTestFixture):
 
         response = self.query_region(default_stop_areas_uri_filter + 'equipment_reports?' + default_date_filter)
 
-        # Expected response
-        stopA_equipment_details = [
-            ("5", "elevator", "unknown"),
-            ("1", "escalator", "unknown"),
-            ("2", "escalator", "unknown"),
-            ("3", "escalator", "unknown"),
-            ("4", "escalator", "unknown"),
-        ]
-        stopb_equipment_details = [
-            ("6", "elevator", "available"),
-            ("7", "elevator", "unavailable"),
-            ("8", "elevator", "unknown"),
-            ("9", "elevator", "unknown"),
-        ]
         # filtered with the stopA stop_area
         expected_result = {
             "A": {"stopA": stopA_equipment_details},

--- a/source/jormungandr/tests/equipment_tests.py
+++ b/source/jormungandr/tests/equipment_tests.py
@@ -35,6 +35,8 @@ from tests.check_utils import get_not_null, is_valid_equipment_report
 
 default_date_filter = '_current_datetime=20120801T000000&'
 default_line_filter = 'filter=line.uri(A)'
+default_line_uri_filter = 'lines/A/'
+default_stop_areas_uri_filter = 'stop_areas/stopA/'
 default_forbidden_uris_filter = 'forbidden_uris[]=stop_point:stopB'
 
 
@@ -312,6 +314,80 @@ class TestEquipment(AbstractTestFixture):
 
         equipment_reports = get_not_null(response, 'equipment_reports')
         assert len(equipment_reports) == 1
+        for equipment_report in equipment_reports:
+            is_valid_equipment_report(equipment_report)
+        self._check_equipment_report(equipment_reports, expected_result)
+
+    def test_equipment_reports_with_uri(self):
+        """
+        with uri filter
+        """
+
+        mock_equipment_providers(
+            equipment_provider_manager=self.equipment_provider_manager("main_routing_test"),
+            data=standard_mock_elevator_data,
+            code_types_list=["TCL_ASCENSEUR", "TCL_ESCALIER"],
+        )
+        response = self.query_region(default_line_uri_filter + 'equipment_reports?' + default_date_filter)
+
+        warnings = get_not_null(response, 'warnings')
+        assert len(warnings) == 1
+        assert warnings[0]['id'] == 'beta_endpoint'
+
+        # Expected response
+        stopA_equipment_details = [
+            ("5", "elevator", "unknown"),
+            ("1", "escalator", "unknown"),
+            ("2", "escalator", "unknown"),
+            ("3", "escalator", "unknown"),
+            ("4", "escalator", "unknown"),
+        ]
+        stopb_equipment_details = [
+            ("6", "elevator", "available"),
+            ("7", "elevator", "unavailable"),
+            ("8", "elevator", "unknown"),
+            ("9", "elevator", "unknown"),
+        ]
+        # filtered with the A line
+        expected_result = {"A": {"stopA": stopA_equipment_details, "stopB": stopb_equipment_details}}
+
+        equipment_reports = get_not_null(response, 'equipment_reports')
+        assert len(equipment_reports) == 1
+        for equipment_report in equipment_reports:
+            is_valid_equipment_report(equipment_report)
+        self._check_equipment_report(equipment_reports, expected_result)
+
+        response = self.query_region(default_stop_areas_uri_filter + 'equipment_reports?' + default_date_filter)
+
+        warnings = get_not_null(response, 'warnings')
+        assert len(warnings) == 1
+        assert warnings[0]['id'] == 'beta_endpoint'
+
+        # Expected response
+        stopA_equipment_details = [
+            ("5", "elevator", "unknown"),
+            ("1", "escalator", "unknown"),
+            ("2", "escalator", "unknown"),
+            ("3", "escalator", "unknown"),
+            ("4", "escalator", "unknown"),
+        ]
+        stopb_equipment_details = [
+            ("6", "elevator", "available"),
+            ("7", "elevator", "unavailable"),
+            ("8", "elevator", "unknown"),
+            ("9", "elevator", "unknown"),
+        ]
+        # filtered with the stopA stop_area
+        expected_result = {
+            "A": {"stopA": stopA_equipment_details},
+            "B": {"stopA": stopA_equipment_details},
+            "C": {"stopA": stopA_equipment_details},
+            "D": {"stopA": stopA_equipment_details},
+            "M": {"stopA": stopA_equipment_details},
+        }
+
+        equipment_reports = get_not_null(response, 'equipment_reports')
+        assert len(equipment_reports) == 5
         for equipment_report in equipment_reports:
             is_valid_equipment_report(equipment_report)
         self._check_equipment_report(equipment_reports, expected_result)


### PR DESCRIPTION
Added **URI filter** option with `/equipment_reports` API
JIRA : https://jira.kisio.org/browse/NAVP-1317

**QA part** :

Local tests

| Filter      | ID Type         | Resp        |
| ------------- | ------------- | ------------- |
| lines  | with good id  | Status: OK (200) |
| lines  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| networks  | with good id  | Status: OK (200) |
| networks  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| routes  | with good id  | Status: OK (200) |
| routes  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| stop_areas  | with good id  | Status: OK (200) |
| stop_areas  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| stop_points  | with good id  | Status: OK (200) |
| stop_points  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| commercial_modes  | with good id  | Status: OK (200) |
| commercial_modes  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| physical_modes  | with good id  | Status: OK (200) |
| physical_modes  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| vehicle_journeys  | with good id  | Status: OK (200) |
| vehicle_journeys  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| companies  | with good id  | Status: OK (200) |
| companies  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| contributors  | with good id  | Status: OK (200) |
| contributors  | with bad id  | Bad id 404 filters: Unable to find object (404) |
|   |     |  |
| disruptions  | with bad id  | Bad id 404 filters: Unable to find object (404) |

No 500 detected
If I have forgotten some tests, let me know