### PR TITLE
[Kraken]: Split sn proximity list

### DIFF
--- a/source/georef/dijkstra_path_finder.cpp
+++ b/source/georef/dijkstra_path_finder.cpp
@@ -176,9 +176,9 @@ routing::map_stop_point_duration DijkstraPathFinder::find_nearest_stop_points(
 
 struct ProjectionGetterOnFly {
     const GeoRef& geo_ref;
-    const nt::idx_t offset;
+    const type::Mode_e mode;
     const georef::ProjectionData operator()(const type::GeographicalCoord& coord) const {
-        return georef::ProjectionData{coord, geo_ref, offset, geo_ref.pl};
+        return georef::ProjectionData{coord, geo_ref, mode};
     }
 };
 
@@ -196,7 +196,7 @@ DijkstraPathFinder::get_duration_with_dijkstra(const navitia::time_duration& rad
         offset = geo_ref.offsets[mode];
     }
 
-    ProjectionGetterOnFly projection_getter{geo_ref, offset};
+    ProjectionGetterOnFly projection_getter{geo_ref, mode == type::Mode_e::Car ? nt::Mode_e::Walking : mode};
     return start_dijkstra_and_fill_duration_map<DijkstraPathFinder::coord_uri, type::GeographicalCoord,
                                                 ProjectionGetterOnFly>(radius, dest_coords, projection_getter);
 }

--- a/source/georef/dijkstra_path_finder.cpp
+++ b/source/georef/dijkstra_path_finder.cpp
@@ -188,13 +188,6 @@ DijkstraPathFinder::get_duration_with_dijkstra(const navitia::time_duration& rad
     if (dest_coords.empty()) {
         return {};
     }
-    nt::idx_t offset;
-    if (mode == type::Mode_e::Car) {
-        // on direct path with car we want to arrive on the walking graph
-        offset = geo_ref.offsets[nt::Mode_e::Walking];
-    } else {
-        offset = geo_ref.offsets[mode];
-    }
 
     ProjectionGetterOnFly projection_getter{geo_ref, mode == type::Mode_e::Car ? nt::Mode_e::Walking : mode};
     return start_dijkstra_and_fill_duration_map<DijkstraPathFinder::coord_uri, type::GeographicalCoord,

--- a/source/georef/dijkstra_path_finder.cpp
+++ b/source/georef/dijkstra_path_finder.cpp
@@ -176,7 +176,7 @@ routing::map_stop_point_duration DijkstraPathFinder::find_nearest_stop_points(
 
 struct ProjectionGetterOnFly {
     const GeoRef& geo_ref;
-    const type::Mode_e mode;
+    const type::Mode_e mode = type::Mode_e::Walking;
     const georef::ProjectionData operator()(const type::GeographicalCoord& coord) const {
         return georef::ProjectionData{coord, geo_ref, mode};
     }

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -390,6 +390,9 @@ void GeoRef::build_proximity_list() {
 
     auto build_sn_pl = [this](proximitylist::ProximityList<vertex_t>& sn_pl, nt::idx_t offset) {
         for (vertex_t v = offset; v < nb_vertex_by_mode + offset; ++v) {
+            if (boost::algorithm::none_of(boost::out_edges(v, graph),
+                                          [=](const auto& e) { return is_sn_edge(*this, e); }))
+                continue;
             sn_pl.add(graph[v].coord, v);
         }
         sn_pl.build();

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -383,7 +383,7 @@ void GeoRef::build_proximity_list() {
     pl_car.clear();
     poi_proximity_list.clear();
 
-    auto log = log4cplus::Logger::getInstance("");
+    auto log = log4cplus::Logger::getInstance("GeoRef::build_proximity_list");
 
     auto build_sn_pl = [this](proximitylist::ProximityList<vertex_t>& sn_pl, nt::idx_t offset) {
         for (vertex_t v = offset; v < nb_vertex_by_mode + offset; ++v) {
@@ -690,7 +690,7 @@ edge_t GeoRef::nearest_edge(const type::GeographicalCoord& coordinates, type::Mo
         case type::Mode_e::CarNoPark:
             return nearest_edge(coordinates, pl_car);
         default:
-            throw navitia::exception("Unknown mode when looking for nearest edges");
+            throw navitia::recoverable_exception("Unknown mode when looking for nearest edges");
     }
 }
 

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -390,9 +390,6 @@ void GeoRef::build_proximity_list() {
 
     auto build_sn_pl = [this](proximitylist::ProximityList<vertex_t>& sn_pl, nt::idx_t offset) {
         for (vertex_t v = offset; v < nb_vertex_by_mode + offset; ++v) {
-            if (boost::algorithm::none_of(boost::out_edges(v, graph),
-                                          [=](const auto& edge) { return is_sn_edge(*this, edge); }))
-                continue;
             sn_pl.add(graph[v].coord, v);
         }
         sn_pl.build();

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -295,10 +295,7 @@ float PathItem::get_length(float speed_factor) const {
     return duration.total_milliseconds() * def_speed * speed_factor / 1000;
 }
 
-ProjectionData::ProjectionData(const type::GeographicalCoord& coord,
-                               const GeoRef& sn,
-                               type::Mode_e mode,
-                               double horizon) {
+ProjectionData::ProjectionData(const type::GeographicalCoord& coord, const GeoRef& sn, type::Mode_e mode) {
     edge_t edge;
     found = true;
     try {
@@ -664,8 +661,6 @@ std::pair<GeoRef::ProjectionByMode, bool> GeoRef::project_stop_point(const type:
 
     for (auto const mode_layer : mode_to_layer) {
         nt::Mode_e mode = mode_layer.first;
-        nt::idx_t offset = offsets[mode_layer.second];
-
         ProjectionData proj(stop_point->coord, *this, mode_layer.second);
         projections[mode] = proj;
         if (proj.found)

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -377,7 +377,6 @@ void GeoRef::init() {
 }
 
 void GeoRef::build_proximity_list() {
-    pl.clear();
     pl_walking.clear();
     pl_bike.clear();
     pl_car.clear();

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -226,6 +226,8 @@ struct GeoRef {
         autocomplete::Autocomplete<unsigned int>(navitia::type::Type_e::POI);
 
     /// Indexe tous les nœuds
+
+    // TODO: Remove this before the next re-binarisation
     proximitylist::ProximityList<vertex_t> pl;
 
     proximitylist::ProximityList<vertex_t> pl_walking;

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -391,10 +391,7 @@ struct ProjectionData {
 
     ProjectionData() {}
     /// Project the coordinate on the graph corresponding to the transportation mode of the offset
-    ProjectionData(const type::GeographicalCoord& coord,
-                   const GeoRef& sn,
-                   type::Mode_e mode = type::Mode_e::Walking,
-                   double horizon = 500);
+    ProjectionData(const type::GeographicalCoord& coord, const GeoRef& sn, type::Mode_e mode = type::Mode_e::Walking);
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -228,6 +228,10 @@ struct GeoRef {
     /// Indexe tous les nœuds
     proximitylist::ProximityList<vertex_t> pl;
 
+    proximitylist::ProximityList<vertex_t> pl_walking;
+    proximitylist::ProximityList<vertex_t> pl_bike;
+    proximitylist::ProximityList<vertex_t> pl_car;
+
     /// for all stop_point, we store it's projection on each graph
     typedef flat_enum_map<nt::Mode_e, ProjectionData> ProjectionByMode;
     std::vector<ProjectionByMode> projected_stop_points = {};
@@ -320,14 +324,9 @@ struct GeoRef {
     vertex_t nearest_vertex(const type::GeographicalCoord& coordinates,
                             const proximitylist::ProximityList<vertex_t>& prox) const;
     edge_t nearest_edge(const type::GeographicalCoord& coordinates) const;
-    edge_t nearest_edge(const type::GeographicalCoord& coordinates,
-                        const proximitylist::ProximityList<vertex_t>& prox,
-                        type::idx_t offset = 0,
-                        double horizon = 500) const;
 
-    edge_t nearest_edge(const type::GeographicalCoord& coordinates, type::Mode_e mode) const {
-        return nearest_edge(coordinates, pl, offsets[mode]);
-    }
+    edge_t nearest_edge(const type::GeographicalCoord& coordinates, type::Mode_e mode) const;
+
     std::pair<int, const Way*> nearest_addr(const type::GeographicalCoord&) const;
     std::pair<int, const Way*> nearest_addr(const type::GeographicalCoord& coord,
                                             const std::function<bool(const Way&)>& filter) const;
@@ -348,6 +347,11 @@ struct GeoRef {
     ~GeoRef();
     GeoRef() = default;
     GeoRef(const GeoRef& other) = default;
+
+private:
+    edge_t nearest_edge(const type::GeographicalCoord& coordinates,
+                        const proximitylist::ProximityList<vertex_t>& prox,
+                        double horizon = 500) const;
 };
 
 /** When given a coordinate, we have to associate it with the street network.
@@ -384,15 +388,10 @@ struct ProjectionData {
     flat_enum_map<Direction, double> distances{{{-1, -1}}};
 
     ProjectionData() {}
-    /// Project the coordinate on the graph
-    ProjectionData(const type::GeographicalCoord& coord,
-                   const GeoRef& sn,
-                   const proximitylist::ProximityList<vertex_t>& prox);
     /// Project the coordinate on the graph corresponding to the transportation mode of the offset
     ProjectionData(const type::GeographicalCoord& coord,
                    const GeoRef& sn,
-                   type::idx_t offset,
-                   const proximitylist::ProximityList<vertex_t>& prox,
+                   type::Mode_e mode = type::Mode_e::Walking,
                    double horizon = 500);
 
     template <class Archive>

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -225,11 +225,7 @@ struct GeoRef {
     autocomplete::Autocomplete<unsigned int> fl_poi =
         autocomplete::Autocomplete<unsigned int>(navitia::type::Type_e::POI);
 
-    /// Indexe tous les nœuds
-
-    // TODO: Remove this before the next re-binarisation
-    proximitylist::ProximityList<vertex_t> pl;
-
+    // We creat one proximity list for each mode
     proximitylist::ProximityList<vertex_t> pl_walking;
     proximitylist::ProximityList<vertex_t> pl_bike;
     proximitylist::ProximityList<vertex_t> pl_car;
@@ -265,7 +261,7 @@ struct GeoRef {
 
     template <class Archive>
     void save(Archive& ar, const unsigned int) const {
-        ar& ways& way_map& graph& offsets& fl_admin& fl_way& pl& projected_stop_points& admins& admin_map& pois& fl_poi&
+        ar& ways& way_map& graph& offsets& fl_admin& fl_way& projected_stop_points& admins& admin_map& pois& fl_poi&
             poitypes& poitype_map& poi_map& synonyms& ghostwords& poi_proximity_list& nb_vertex_by_mode;
     }
 
@@ -274,7 +270,7 @@ struct GeoRef {
         // La désérialisation d'une boost adjacency list ne vide pas le graphe
         // On avait donc une fuite de mémoire
         graph.clear();
-        ar& ways& way_map& graph& offsets& fl_admin& fl_way& pl& projected_stop_points& admins& admin_map& pois& fl_poi&
+        ar& ways& way_map& graph& offsets& fl_admin& fl_way& projected_stop_points& admins& admin_map& pois& fl_poi&
             poitypes& poitype_map& poi_map& synonyms& ghostwords& poi_proximity_list& nb_vertex_by_mode;
 
         compute_inversed_nb_vertex_by_mode();

--- a/source/georef/path_finder.cpp
+++ b/source/georef/path_finder.cpp
@@ -98,7 +98,7 @@ void PathFinder::init_start(const type::GeographicalCoord& start_coord, nt::Mode
     this->speed_factor = speed_factor;  // the speed factor is the factor we have to multiply the edge cost with
     nt::idx_t offset = this->geo_ref.offsets[mode];
     this->start_coord = start_coord;
-    starting_edge = ProjectionData(start_coord, this->geo_ref, offset, this->geo_ref.pl);
+    starting_edge = ProjectionData(start_coord, this->geo_ref, mode);
 
     distance_to_entry_point.clear();
     // we initialize the distances to the maximum value

--- a/source/georef/path_finder.cpp
+++ b/source/georef/path_finder.cpp
@@ -96,7 +96,6 @@ void PathFinder::init_start(const type::GeographicalCoord& start_coord, nt::Mode
     // in the right transport mode (walk, bike, car, ...) (ie offset)
     this->mode = mode;
     this->speed_factor = speed_factor;  // the speed factor is the factor we have to multiply the edge cost with
-    nt::idx_t offset = this->geo_ref.offsets[mode];
     this->start_coord = start_coord;
     starting_edge = ProjectionData(start_coord, this->geo_ref, mode);
 

--- a/source/georef/street_network.cpp
+++ b/source/georef/street_network.cpp
@@ -127,7 +127,7 @@ Path StreetNetwork::get_direct_path(const type::EntryPoint& origin, const type::
         // on direct path with car we want to arrive on the walking graph
         dest_mode = type::Mode_e::Walking;
     }
-    const auto dest_edge = ProjectionData(destination.coordinates, geo_ref, geo_ref.offsets[dest_mode], geo_ref.pl);
+    const auto dest_edge = ProjectionData(destination.coordinates, geo_ref, dest_mode);
     if (!dest_edge.found) {
         return Path();
     }

--- a/source/georef/tests/builder.cpp
+++ b/source/georef/tests/builder.cpp
@@ -46,8 +46,6 @@ GraphBuilder& GraphBuilder::add_vertex(std::string node_name, double x, double y
     }
 
     this->geo_ref.graph[v].coord = coord;
-    this->geo_ref.pl.add(coord, v);
-    this->geo_ref.pl.build();
     return *this;
 }
 

--- a/source/georef/tests/builder.h
+++ b/source/georef/tests/builder.h
@@ -44,6 +44,11 @@ struct GraphBuilder {
     /// node by names
     std::map<std::string, vertex_t> vertex_map;
 
+    void init() {
+        geo_ref.init();
+        geo_ref.build_proximity_list();
+    };
+
     /// upsert a node
     GraphBuilder& add_vertex(std::string node_name, double x, double y);
 

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -73,7 +73,7 @@ void print_coord(const std::vector<navitia::type::GeographicalCoord>& coord) {
 
 // Compute the path from the starting point to the the target geographical coord
 Path compute_path(DijkstraPathFinder& finder, const navitia::type::GeographicalCoord& target_coord) {
-    ProjectionData dest(target_coord, finder.geo_ref, finder.geo_ref.pl);
+    ProjectionData dest(target_coord, finder.geo_ref);
 
     auto best_pair = finder.update_path(dest);
 
@@ -82,7 +82,7 @@ Path compute_path(DijkstraPathFinder& finder, const navitia::type::GeographicalC
 
 // Compute the path from the starting point to the the target geographical coord
 Path compute_path(AstarPathFinder& finder, const navitia::type::GeographicalCoord& target_coord) {
-    ProjectionData dest(target_coord, finder.geo_ref, finder.geo_ref.pl);
+    ProjectionData dest(target_coord, finder.geo_ref);
     auto const max_dur = navitia::seconds(1000.);
 
     finder.start_distance_or_target_astar(max_dur, dest.projected, {dest[source_e], dest[target_e]});

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(init_test) {
 
     BOOST_CHECK_EQUAL(boost::num_vertices(b.geo_ref.graph), 5);
 
-    b.geo_ref.init();
+    b.init();
 
     BOOST_CHECK_EQUAL(boost::num_vertices(b.geo_ref.graph), 15);  // one graph for each transportation mode save VLS
 
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(nearest_segment) {
 
     b("a", 0, 10)("b", -10, 0)("c", 10, 0)("d", 0, -10)("o", 0, 0)("e", 50, 10);
     b("o", "a")("o", "b")("o", "c")("o", "d")("b", "o");
-    b.geo_ref.init();
+    b.init();
 
     navitia::type::GeographicalCoord c(1, 2, false);
     BOOST_CHECK(b.geo_ref.nearest_edge(c) == b.get("o", "a"));
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(real_nearest_edge) {
     */
     b("a", 0, -100)("b", 0, 100)("c", 10, 0)("d", 10, 10);
     b("a", "b")("c", "d");
-    b.geo_ref.init();
+    b.init();
 
     navitia::type::GeographicalCoord s(-10, 0, false);
     BOOST_CHECK(b.geo_ref.nearest_edge(s) == b.get("a", "b"));
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(nearest_edge_with_geometries) {
     nt::GeographicalCoord x3(23, 2, false);
     nt::GeographicalCoord x4(15, 5, false);
     nt::GeographicalCoord x5(40, 32, false);
-    b.geo_ref.init();
+    b.init();
 
     BOOST_CHECK(b.geo_ref.nearest_edge(x1) == b.get("b", "e"));
     BOOST_CHECK(b.geo_ref.nearest_edge(x2) == b.get("c", "d"));
@@ -384,7 +384,7 @@ BOOST_AUTO_TEST_CASE(accurate_path_geometries) {
     std::reverse(geom.begin(), geom.end());
     b.add_geom(b.get("e", "d"), geom);
 
-    b.geo_ref.init();
+    b.init();
     DijkstraPathFinder djikstra_path_finder(b.geo_ref);
     AstarPathFinder astar_path_finder(b.geo_ref);
 
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(parallel_and_same_vertex_edges) {
         }
     }
 
-    b.geo_ref.init();
+    b.init();
 
     auto edge_x1 = b.geo_ref.nearest_edge(x1);
     BOOST_REQUIRE_EQUAL(boost::source(edge_x1, b.geo_ref.graph), b.get("a"));
@@ -690,7 +690,7 @@ BOOST_AUTO_TEST_CASE(compute_directions_test) {
     b.geo_ref.graph[b.get("d", "e")].way_idx = 1;
     b.geo_ref.graph[b.get("e", "d")].way_idx = 1;
 
-    b.geo_ref.init();
+    b.init();
 
     DijkstraPathFinder djikstra_path_finder(b.geo_ref);
     AstarPathFinder astar_path_finder(b.geo_ref);
@@ -777,7 +777,7 @@ BOOST_AUTO_TEST_CASE(compute_coord) {
     start.set_xy(3, -1);
     GeographicalCoord destination;
     destination.set_xy(4, 11);
-    b.geo_ref.init();
+    b.init();
     djikstra_path_finder.init(start, Mode_e::Walking, 1);
     Path p = compute_path(djikstra_path_finder, destination);
     auto coords = get_coords_from_path(p);
@@ -832,7 +832,7 @@ BOOST_AUTO_TEST_CASE(compute_nearest) {
     pl.add(c1, 0);
     pl.add(c2, 1);
     pl.build();
-    b.geo_ref.init();
+    b.init();
 
     StopPoint* sp1 = new StopPoint();
     sp1->idx = 0;
@@ -1218,7 +1218,7 @@ BOOST_AUTO_TEST_CASE(two_scc) {
     pl.add(c1, 0);
     pl.add(c2, 1);
     pl.build();
-    b.geo_ref.init();
+    b.init();
 
     StopPoint* sp1 = new StopPoint();
     sp1->coord = c1;
@@ -1477,7 +1477,7 @@ BOOST_AUTO_TEST_CASE(find_nearest_on_same_edge) {
     pl.add(c2, 2);
     pl.add(c3, 3);
     pl.build();
-    b.geo_ref.init();
+    b.init();
 
     StopPoint* sp0 = new StopPoint();
     sp0->coord = c0;

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -101,7 +101,7 @@ const ProjectionData build_data(GraphBuilder& b, type::Data& data) {
     sp->coord.set_xy(8., 8.);
     sp->idx = 0;
     data.pt_data->stop_points.push_back(sp);
-    b.geo_ref.init();
+    b.init();
     b.geo_ref.project_stop_points(data.pt_data->stop_points);
 
     const GeoRef::ProjectionByMode& projections = b.geo_ref.projected_stop_points[sp->idx];

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -257,7 +257,7 @@ std::vector<navitia::time_duration> init_distance(const georef::GeoRef& worker,
     size_t n = boost::num_vertices(worker.graph);
     distances.assign(n, bt::pos_infin);
     nt::idx_t offset = worker.offsets[mode];
-    auto proj = georef::ProjectionData(coord_origin, worker, offset, worker.pl);
+    auto proj = georef::ProjectionData(coord_origin, worker, mode);
     if (proj.found) {
         distances[proj[source_e]] =
             std::min(distances[proj[source_e]], time_duration(seconds(proj.distances[source_e] / speed)));
@@ -290,8 +290,7 @@ static std::vector<georef::vertex_t> init_vertex(const georef::GeoRef& worker,
                                                  const bool clockwise,
                                                  const DateTime& bound) {
     std::vector<georef::vertex_t> initialized_points;
-    nt::idx_t offset = worker.offsets[mode];
-    auto proj = georef::ProjectionData(coord_origin, worker, offset, worker.pl);
+    auto proj = georef::ProjectionData(coord_origin, worker, mode);
     if (proj.found) {
         initialized_points.push_back(proj[source_e]);
         initialized_points.push_back(proj[target_e]);
@@ -323,8 +322,7 @@ static BoundBox find_boundary_box(const georef::GeoRef& worker,
                                   const double speed) {
     auto box = BoundBox();
     const auto distance_500m = (500 / type::GeographicalCoord::EARTH_RADIUS_IN_METERS) * N_RAD_TO_DEG;
-    nt::idx_t offset = worker.offsets[mode];
-    auto proj = georef::ProjectionData(coord_origin, worker, offset, worker.pl);
+    auto proj = georef::ProjectionData(coord_origin, worker, mode);
     if (proj.found) {
         box.set_box(coord_origin, walking_distance(max_duration, 0, speed) + distance_500m);
     }

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -256,7 +256,6 @@ std::vector<navitia::time_duration> init_distance(const georef::GeoRef& worker,
     std::vector<navitia::time_duration> distances;
     size_t n = boost::num_vertices(worker.graph);
     distances.assign(n, bt::pos_infin);
-    nt::idx_t offset = worker.offsets[mode];
     auto proj = georef::ProjectionData(coord_origin, worker, mode);
     if (proj.found) {
         distances[proj[source_e]] =

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -141,26 +141,27 @@ static std::vector<std::vector<Projection>> find_projection(BoundBox box,
     std::vector<std::vector<Projection>> dist_pixel = {step, {step, Projection()}};
     const size_t offset_lon = floor(min_dist / (width_step * N_DEG_TO_DISTANCE)) + 1;
     const size_t offset_lat = floor(min_dist / (height_step * N_DEG_TO_DISTANCE)) + 1;
-    auto begin = std::lower_bound(
-        worker.pl.items.begin(), worker.pl.items.end(), box.min.lon(),
-        [](const proximitylist::ProximityList<georef::vertex_t>::Item& i, double min) { return i.coord.lon() < min; });
 
-    if (begin == worker.pl.items.end()) {
-        return dist_pixel;
+    auto box_center = type::GeographicalCoord{(box.min.lon() + box.max.lon()) / 2, (box.min.lat() + box.max.lat()) / 2};
+
+    auto radius = box.min.distance_to(box.max);
+
+    auto objects_inside = worker.pl_walking.find_within(box_center, 1.4 * radius);
+
+    if (objects_inside.empty()) {
+        return {};
     }
 
-    auto end = std::upper_bound(
-        begin, worker.pl.items.end(), box.max.lon(),
-        [](double max, const proximitylist::ProximityList<georef::vertex_t>::Item& i) { return max <= i.coord.lon(); });
+    const auto coslat = cos(objects_inside.front().second.lat() * type::GeographicalCoord::N_DEG_TO_RAD);
+    for (const auto& o : objects_inside) {
+        const auto element = o.first;
+        const auto& source = o.second;
 
-    const auto coslat = cos(begin->coord.lat() * type::GeographicalCoord::N_DEG_TO_RAD);
-    for (auto it = begin; it != end; ++it) {
-        const auto& source = it->coord;
         if (!box.contains(source)) {
             continue;
         }
         const auto rank_source = find_rank(box, source, height_step, width_step);
-        BOOST_FOREACH (georef::edge_t e, boost::out_edges(it->element, worker.graph)) {
+        BOOST_FOREACH (georef::edge_t e, boost::out_edges(element, worker.graph)) {
             const auto v = target(e, worker.graph);
             const auto& target = worker.graph[v].coord;
             const auto rank_target = find_rank(box, target, height_step, width_step);
@@ -175,7 +176,7 @@ static std::vector<std::vector<Projection>> find_projection(BoundBox box,
                         && (!dist_pixel[lon_rank][lat_rank].distance
                             || length < *dist_pixel[lon_rank][lat_rank].distance)) {
                         dist_pixel[lon_rank][lat_rank].distance = length;
-                        dist_pixel[lon_rank][lat_rank].source = it->element;
+                        dist_pixel[lon_rank][lat_rank].source = element;
                         dist_pixel[lon_rank][lat_rank].target = v;
                     }
                 }

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -146,7 +146,7 @@ static std::vector<std::vector<Projection>> find_projection(BoundBox box,
 
     auto radius = box.min.distance_to(box.max);
 
-    auto objects_inside = worker.pl_walking.find_within(box_center, 1.4 * radius);
+    auto objects_inside = worker.pl_walking.find_within(box_center, radius);
 
     if (objects_inside.empty()) {
         return {};
@@ -161,7 +161,7 @@ static std::vector<std::vector<Projection>> find_projection(BoundBox box,
             continue;
         }
         const auto rank_source = find_rank(box, source, height_step, width_step);
-        BOOST_FOREACH (georef::edge_t e, boost::out_edges(element, worker.graph)) {
+        BOOST_FOREACH (const georef::edge_t& e, boost::out_edges(element, worker.graph)) {
             const auto v = target(e, worker.graph);
             const auto& target = worker.graph[v].coord;
             const auto rank_target = find_rank(box, target, height_step, width_step);

--- a/source/routing/tests/heat_map_test.cpp
+++ b/source/routing/tests/heat_map_test.cpp
@@ -126,7 +126,6 @@ BOOST_AUTO_TEST_CASE(heat_map_test) {
     boost::add_vertex(ng::Vertex(B), b.data->geo_ref->graph);
     boost::add_vertex(ng::Vertex(C), b.data->geo_ref->graph);
     boost::add_vertex(ng::Vertex(D), b.data->geo_ref->graph);
-    b.data->geo_ref->init();
 
     size_t way_idx = 0;
     for (const auto& name : {"ab", "bc", "ac", "cd"}) {
@@ -149,6 +148,10 @@ BOOST_AUTO_TEST_CASE(heat_map_test) {
     b.data->geo_ref->ways[1]->edges.push_back(std::make_pair(BB, CC));
     b.data->geo_ref->ways[2]->edges.push_back(std::make_pair(AA, CC));
     b.data->geo_ref->ways[3]->edges.push_back(std::make_pair(CC, DD));
+
+    b.data->geo_ref->init();
+    b.data->geo_ref->build_proximity_list();
+
     b.data->build_proximity_list();
     b.data->meta->production_date = boost::gregorian::date_period(boost::gregorian::date(2012, 06, 14), 7_days);
     b.vj("A")("stop1", "08:00"_t)("stop2", "08:10"_t)("stop3", "08:20"_t);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1770,7 +1770,7 @@ BOOST_AUTO_TEST_CASE(projection_on_one_way) {
     b.data->meta->production_date = boost::gregorian::date_period(boost::gregorian::date(2012, 06, 14), 7_days);
 
     // first we want to check that the projection is done on A->B (the whole point of this test)
-    auto starting_edge = ng::ProjectionData(start, *b.data->geo_ref, 0, b.data->geo_ref->pl);
+    auto starting_edge = ng::ProjectionData(start, *b.data->geo_ref);
     BOOST_REQUIRE(starting_edge.found);
 
     BOOST_CHECK_EQUAL(starting_edge.vertices[ng::ProjectionData::Direction::Target], AA);

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -63,7 +63,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 69;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 70;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),


### PR DESCRIPTION
split georef proximity list into 3: one proximity list for each graph(walking, bike car)

A projection problem has been reported after merging  this PR:https://github.com/CanalTP/navitia/pull/2774

The problem is when flann try to find nearest vertices, it doesn't see if a node is on walking/bike/car graph. In case where we try to project a coord on the car graph and flann has found only some nodes on walking graph, the projection will fail. This case is particularly true when projecting a stop_area on bike/car graph, since the nodes of walking graph are highly dense.  

The advantage of doing so is be able to eliminate nodes that don't have any edges. 
The disadvantage is that it becomes more memory consuming. 

Proximity lists are built after data loading. The loading time is about 5 seconds on stif and 2 seconds on fr-idf