### PR TITLE
Kraken: Add ability to configure max core dump file size

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -80,6 +80,7 @@ po::options_description get_options_description(const boost::optional<std::strin
 
         ("GENERAL.enable_request_deadline", po::value<bool>()->default_value(true), "enable deadline of request")
         ("GENERAL.metrics_binding", po::value<std::string>(), "IP:PORT to serving metrics in http")
+        ("GENERAL.core_file_size_limit", po::value<int>()->default_value(0), "ulimit that define the maximum size of a core file")
 
         ("BROKER.host", po::value<std::string>()->default_value("localhost"), "host of rabbitmq")
         ("BROKER.port", po::value<int>()->default_value(5672), "port of rabbitmq")
@@ -179,6 +180,10 @@ bool Configuration::is_realtime_add_trip_enabled() const {
 
 int Configuration::kirin_timeout() const {
     return this->vm["GENERAL.kirin_timeout"].as<int>();
+}
+
+int Configuration::core_file_size_limit() const {
+    return this->vm["GENERAL.core_file_size_limit"].as<int>();
 }
 
 std::string Configuration::broker_host() const {

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -67,6 +67,7 @@ public:
     int kirin_retry_timeout() const;
     bool display_contributors() const;
     size_t raptor_cache_size() const;
+    int core_file_size_limit() const;
     int slow_request_duration() const;
     boost::optional<std::string> log_level() const;
     boost::optional<std::string> log_format() const;


### PR DESCRIPTION
Expose a way to configure the core dump max size limit with `GENERAL.core_file_size_limit`

This is equivalent to running cmd 
```sh
$ ulimit -c <my_limit>
```