### PR TITLE
Kraken: Fix the way best journey is picked (filter)

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -749,6 +749,8 @@ Admin::Admin(u_int64_t id,
     this->center = center;
 }
 
+Admin::~Admin(){};
+
 OSMAdminRelation::OSMAdminRelation(u_int64_t id,
                                    const std::string& uri,
                                    const std::vector<CanalTP::Reference>& refs,

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -128,7 +128,7 @@ struct Admin {
           const uint32_t level,
           mpolygon_type&& polygon,
           point&& center);
-    virtual ~Admin() {}
+    virtual ~Admin();
     virtual void build_geometry(OSMCache&) {}
     bool is_city() const { return level == 8; }
 

--- a/source/routing/journey.h
+++ b/source/routing/journey.h
@@ -96,12 +96,12 @@ const Journey& get_best_journey(const Journeys& journeys, bool clockwise) {
     if (journeys.size() == 0)
         throw recoverable_exception("get_best_journey takes a list of at least 1 journey");
 
-    auto earliest_journey = [](const Journey& j1, const Journey& j2) { return j1.departure_dt < j2.departure_dt; };
+    auto departure_comp = [](const Journey& j1, const Journey& j2) { return j1.departure_dt < j2.departure_dt; };
 
-    auto latest_journey = [](const Journey& j1, const Journey& j2) { return j1.arrival_dt < j2.arrival_dt; };
+    auto arrival_comp = [](const Journey& j1, const Journey& j2) { return j1.arrival_dt < j2.arrival_dt; };
 
-    const auto best = clockwise ? std::min_element(journeys.cbegin(), journeys.cend(), earliest_journey)
-                                : std::max_element(journeys.cbegin(), journeys.cend(), latest_journey);
+    const auto best = clockwise ? std::min_element(journeys.cbegin(), journeys.cend(), arrival_comp)
+                                : std::max_element(journeys.cbegin(), journeys.cend(), departure_comp);
 
     return *best;
 }

--- a/source/routing/journey.h
+++ b/source/routing/journey.h
@@ -83,18 +83,19 @@ struct SectionHash {
 typedef std::unordered_set<Journey, JourneyHash> JourneySet;
 
 /**
- * @brief Get the best journey
+ * @brief Get the pseudo-best journey
  *
- * Find the earliest departure (clockwise case) or the lastest arrival (anti clockwise case)
+ * Find journey with the earliest arrival (clockwise case) or the lastest departure (anti clockwise case)
+ * When equal, real "best" uses more criteria, but this is enough for the current use
  *
  * @param journeys A container of journeys
  * @param clokwise Active clockwise or not
  * @return best jouney
  */
 template <class Journeys>
-const Journey& get_best_journey(const Journeys& journeys, bool clockwise) {
+const Journey& get_pseudo_best_journey(const Journeys& journeys, bool clockwise) {
     if (journeys.size() == 0)
-        throw recoverable_exception("get_best_journey takes a list of at least 1 journey");
+        throw recoverable_exception("get_pseudo_best_journey takes a list of at least 1 journey");
 
     auto departure_comp = [](const Journey& j1, const Journey& j2) { return j1.departure_dt < j2.departure_dt; };
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1294,7 +1294,7 @@ void filter_late_journeys(RAPTOR::Journeys& journeys, const NightBusFilter::Para
     if (journeys.size() == 0)
         return;
 
-    const auto& best = get_best_journey(journeys, params.clockwise);
+    const auto& best = get_pseudo_best_journey(journeys, params.clockwise);
 
     auto it = journeys.begin();
     while (it != journeys.end()) {

--- a/source/routing/tests/journey_test.cpp
+++ b/source/routing/tests/journey_test.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(journeys_should_get_best_journey) {
 
     std::vector<Journey> journeys = {j1, j2, j3};
 
-    auto best = get_best_journey(journeys, true);
+    auto best = get_pseudo_best_journey(journeys, true);
     BOOST_CHECK_EQUAL(best.departure_dt, j2.departure_dt);
 }
 
@@ -147,13 +147,13 @@ BOOST_AUTO_TEST_CASE(journeys_should_get_best_journey_clockwise) {
 
     std::vector<Journey> journeys = {j1, j2, j3};
 
-    auto best = get_best_journey(journeys, false);
+    auto best = get_pseudo_best_journey(journeys, false);
     BOOST_CHECK_EQUAL(best.arrival_dt, j3.arrival_dt);
 }
 
 BOOST_AUTO_TEST_CASE(get_best_journey_should_throw) {
     std::vector<Journey> journeys = {};
-    BOOST_CHECK_THROW(get_best_journey(journeys, true), recoverable_exception);
+    BOOST_CHECK_THROW(get_pseudo_best_journey(journeys, true), recoverable_exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Previously it was based on sooner _departure_ (for clockwise best), now it's sooner **arrival**.
Nota : `filter_late_journeys` is the only caller of `get_pseudo_best_journeys` for now, that's why tests are using that.

:mag: easier to review by commit (+read commit message)

This PR fixes a side-bug discovered when debugging JIRA https://jira.kisio.org/browse/NAVITIAII-2690 