### PR TITLE
fusio2ed: stop_id is supported into admin_stations.txt

### DIFF
--- a/fixtures/ed/ntfs/admin_stations.txt
+++ b/fixtures/ed/ntfs/admin_stations.txt
@@ -1,2 +1,2 @@
-admin_id,admin_name,station_id,station_name,stop_id,stop_name
-admin:A,"admin A",A,"Arrêt A",SA:A,"Arrêt A"
+admin_id,admin_name,station_id,station_name
+admin:A,"admin:A_name_that_is_no_read",A,"station_name_A_that_is_no_read"

--- a/fixtures/ed/ntfs/admin_stations.txt
+++ b/fixtures/ed/ntfs/admin_stations.txt
@@ -1,2 +1,2 @@
 admin_id,admin_name,station_id,station_name
-admin:A,"admin:A_name_that_is_no_read",A,"station_name_A_that_is_no_read"
+admin:A,"admin_name_A_that_is_no_read",A,"station_name_A_that_is_no_read"

--- a/fixtures/ed/ntfs/admin_stations.txt
+++ b/fixtures/ed/ntfs/admin_stations.txt
@@ -1,2 +1,2 @@
-admin_id,admin_name,station_id,station_name
-admin:A,"admin_name_A_that_is_no_read",A,"station_name_A_that_is_no_read"
+admin_id,admin_name,station_id,station_name,stop_id,stop_name
+admin:A,"admin_name_A_that_is_not_read",station_id_A_that_is_not_read,"station_name_A_that_is_not_read",SA:A,"stop_name_A_that_is_not_read"

--- a/fixtures/ed/ntfs/admin_stations.txt
+++ b/fixtures/ed/ntfs/admin_stations.txt
@@ -1,0 +1,2 @@
+admin_id,admin_name,station_id,station_name,stop_id,stop_name
+admin:A,"admin A",A,"Arrêt A",SA:A,"Arrêt A"

--- a/fixtures/ed/ntfs_dst/admin_stations.txt
+++ b/fixtures/ed/ntfs_dst/admin_stations.txt
@@ -1,0 +1,1 @@
+admin_id,admin_name,station_id,station_name,stop_id,stop_name

--- a/fixtures/ed/ntfs_dst/admin_stations.txt
+++ b/fixtures/ed/ntfs_dst/admin_stations.txt
@@ -1,1 +1,2 @@
-admin_id,admin_name,station_id,station_name,stop_id,stop_name
+admin_id,admin_name,stop_id,stop_name
+admin:A,"admin_name_A_that_is_not_read",SCF:SP:SPOCENoctilien87976902,"stop_name_A_that_is_not_read"

--- a/fixtures/ed/ntfs_dst/admin_stations.txt
+++ b/fixtures/ed/ntfs_dst/admin_stations.txt
@@ -1,1 +1,2 @@
-admin_id,admin_name,station_id,station_name,stop_id,stop_name
+admin_id,admin_name,stop_id,stop_name
+admin_id_1,"admin name 1",SCF:SP:SPOCENoctilien87976902,"Brunoy-Wittlich"

--- a/fixtures/ed/ntfs_dst/admin_stations.txt
+++ b/fixtures/ed/ntfs_dst/admin_stations.txt
@@ -1,2 +1,0 @@
-admin_id,admin_name,stop_id,stop_name
-admin_id_1,"admin name 1",SCF:SP:SPOCENoctilien87976902,"Brunoy-Wittlich"

--- a/fixtures/ed/ntfs_v5/admin_stations.txt
+++ b/fixtures/ed/ntfs_v5/admin_stations.txt
@@ -1,2 +1,2 @@
 admin_id,admin_name,station_id,station_name,stop_id,stop_name
-admin:A,"admin:A_name_that_is_no_read",station_id_that_is_no_read,"station_name_A_that_is_no_read",SA:A,"stop_name_that_is_no_read"
+admin:A,"admin_name_A_that_is_no_read",station_id_A_that_is_no_read,"station_name_A_that_is_no_read",SA:A,"stop_name_A_that_is_no_read"

--- a/fixtures/ed/ntfs_v5/admin_stations.txt
+++ b/fixtures/ed/ntfs_v5/admin_stations.txt
@@ -1,0 +1,2 @@
+admin_id,admin_name,station_id,station_name,stop_id,stop_name
+admin:A,"admin:A_name_that_is_no_read",station_id_that_is_no_read,"station_name_A_that_is_no_read",SA:A,"stop_name_that_is_no_read"

--- a/fixtures/ed/ntfs_v5/admin_stations.txt
+++ b/fixtures/ed/ntfs_v5/admin_stations.txt
@@ -1,2 +1,2 @@
-admin_id,admin_name,station_id,station_name,stop_id,stop_name
-admin:A,"admin_name_A_that_is_no_read",station_id_A_that_is_no_read,"station_name_A_that_is_no_read",SA:A,"stop_name_A_that_is_no_read"
+admin_id,admin_name,station_id,station_name
+admin:A,"admin_name_A_that_is_not_read",A,"station_name_A_that_is_not_read"

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1550,7 +1550,7 @@ void AdminStopAreaFusioHandler::init(Data& data) {
 
     // For retro compatibity
     // TODO : to remove after the data team update, it will become useless (NAVP-1285)
-    if (stop_area_c == unknown_column) {
+    if (stop_area_c == UNKNOWN_COLUMN) {
         stop_id_is_present = false;
         stop_area_c = csv.get_pos_col("station_id");
         for (const auto& object_code_map : data.object_codes) {

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1580,16 +1580,17 @@ void AdminStopAreaFusioHandler::handle_line(Data& data, const csv_row& row, bool
     if (!stop_id_is_present) {
         sa_it = tmp_stop_area_map.find(row[stop_area_c]);
         if (sa_it == tmp_stop_area_map.end()) {
-            LOG4CPLUS_ERROR(logger, "AdminStopAreaFusioHandler : Impossible to find the stop_area " << row[stop_area_c]);
+            LOG4CPLUS_ERROR(logger,
+                            "AdminStopAreaFusioHandler : Impossible to find the stop_area " << row[stop_area_c]);
             return;
         }
     } else {
         sa_it = gtfs_data.stop_area_map.find(row[stop_area_c]);
         if (sa_it == tmp_stop_area_map.end()) {
-            LOG4CPLUS_ERROR(logger, "AdminStopAreaFusioHandler : Impossible to find the stop_area " << row[stop_area_c]);
+            LOG4CPLUS_ERROR(logger,
+                            "AdminStopAreaFusioHandler : Impossible to find the stop_area " << row[stop_area_c]);
             return;
         }
-
     }
 
     ed::types::AdminStopArea* admin_stop_area{nullptr};

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1586,7 +1586,7 @@ void AdminStopAreaFusioHandler::handle_line(Data& data, const csv_row& row, bool
         }
     } else {
         sa_it = gtfs_data.stop_area_map.find(row[stop_area_c]);
-        if (sa_it == tmp_stop_area_map.end()) {
+        if (sa_it == gtfs_data.stop_area_map.end()) {
             LOG4CPLUS_ERROR(logger,
                             "AdminStopAreaFusioHandler : Impossible to find the stop_area " << row[stop_area_c]);
             return;

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -304,7 +304,8 @@ struct GridCalendarTripExceptionDatesFusioHandler : public GenericHandler {
 }  // namespace grid_calendar
 
 struct AdminStopAreaFusioHandler : public GenericHandler {
-    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader), stop_id_is_present(true){}
+    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader)
+        : GenericHandler(gdata, reader), stop_id_is_present(true) {}
     int admin_c, stop_area_c;
     bool stop_id_is_present;
 

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -44,7 +44,7 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
-static const int unknown_column = -1;
+static const int UNKNOWN_COLUMN = -1;
 
 struct FeedInfoFusioHandler : public GenericHandler {
     FeedInfoFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -44,6 +44,8 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
+static const int unknown_column = -1;
+
 struct FeedInfoFusioHandler : public GenericHandler {
     FeedInfoFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
     int feed_info_param_c, feed_info_value_c;
@@ -302,8 +304,9 @@ struct GridCalendarTripExceptionDatesFusioHandler : public GenericHandler {
 }  // namespace grid_calendar
 
 struct AdminStopAreaFusioHandler : public GenericHandler {
-    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
+    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader), stop_id_is_present(true){}
     int admin_c, stop_area_c;
+    bool stop_id_is_present;
 
     // temporaty map to have a StopArea by it's external code
     std::unordered_map<std::string, ed::types::StopArea*> tmp_stop_area_map;
@@ -311,7 +314,8 @@ struct AdminStopAreaFusioHandler : public GenericHandler {
     std::unordered_map<std::string, ed::types::AdminStopArea*> admin_stop_area_map;
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
-    const std::vector<std::string> required_headers() const { return {"admin_id", "station_id"}; }
+    // TODO : "stop_id" will becomme required, after the data team update (NAVP-1285)
+    const std::vector<std::string> required_headers() const { return {"admin_id"}; }
 };
 
 struct CommentLinksFusioHandler : public GenericHandler {

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -461,12 +461,12 @@ BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
     // Following the norm, we only read "stop_id"
     {
         ed::Data data;
-        ed::connectors::FusioParser parser(ntfs_path + "_dst");
+        ed::connectors::FusioParser parser(ntfs_path + "_v5");
         parser.fill(data);
         BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin_id_1");
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
         BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Brunoy-Wittlich");
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SCF:SP:SPOCENoctilien87976902");
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Arrêt A");
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
     }
 }

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -443,7 +443,6 @@ BOOST_AUTO_TEST_CASE(sync_ntfs) {
 }
 
 BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
-
     // for retrocompatibity
     // admin_stations.txt file contains only "station_id"
     // TODO : to remove after the data team update, it will become useless (NAVP-1285)
@@ -456,7 +455,6 @@ BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
         BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Arrêt A");
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
-
     }
 
     // admin_stations.txt file contains "stop_id" and "station_id"
@@ -470,6 +468,5 @@ BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
         BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Brunoy-Wittlich");
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SCF:SP:SPOCENoctilien87976902");
-
     }
 }

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -456,6 +456,18 @@ BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
     }
 
+    // admin_stations.txt file contains only "stop_id"
+    {
+        ed::Data data;
+        ed::connectors::FusioParser parser(ntfs_path + "_dst");
+        parser.fill(data);
+        BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
+        BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Brunoy-Wittlich");
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SCF:SP:SPOCENoctilien87976902");
+    }
+
     // For retrocompatibity
     // admin_stations.txt file contains only "station_id"
     // TODO : to remove after the data team update, it will become useless (NAVP-1285)

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -443,9 +443,8 @@ BOOST_AUTO_TEST_CASE(sync_ntfs) {
 }
 
 BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
-    // for retrocompatibity
-    // admin_stations.txt file contains only "station_id"
-    // TODO : to remove after the data team update, it will become useless (NAVP-1285)
+    // admin_stations.txt file contains "stop_id" and "station_id"
+    // Following the norm, we only read "stop_id"
     {
         ed::Data data;
         ed::connectors::FusioParser parser(ntfs_path);
@@ -457,8 +456,9 @@ BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
     }
 
-    // admin_stations.txt file contains "stop_id" and "station_id"
-    // Following the norm, we only read "stop_id"
+    // For retrocompatibity
+    // admin_stations.txt file contains only "station_id"
+    // TODO : to remove after the data team update, it will become useless (NAVP-1285)
     {
         ed::Data data;
         ed::connectors::FusioParser parser(ntfs_path + "_v5");

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -441,3 +441,35 @@ BOOST_AUTO_TEST_CASE(sync_ntfs) {
     vj = data.vehicle_journeys.back();
     BOOST_CHECK_EQUAL(vj->accessible(has_vehicle_properties.vehicles()), false);
 }
+
+BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
+
+    // for retrocompatibity
+    // admin_stations.txt file contains only "station_id"
+    // TODO : to remove after the data team update, it will become useless (NAVP-1285)
+    {
+        ed::Data data;
+        ed::connectors::FusioParser parser(ntfs_path);
+        parser.fill(data);
+        BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
+        BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Arrêt A");
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
+
+    }
+
+    // admin_stations.txt file contains "stop_id" and "station_id"
+    // Following the norm, we only read "stop_id"
+    {
+        ed::Data data;
+        ed::connectors::FusioParser parser(ntfs_path + "_dst");
+        parser.fill(data);
+        BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin_id_1");
+        BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Brunoy-Wittlich");
+        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SCF:SP:SPOCENoctilien87976902");
+
+    }
+}


### PR DESCRIPTION
As @prhod said, rules are simple :
- if `stop_id` column is not present, we continue to read `station_id` (For retrocompatibility)
- if `stop_id` column is present, we read it

*station_id* refers to external code, a `NAV-I id`
*stop_id* is a pur `NAV-II id`

Later, when data team will be ready, an other PR will suppress the retrocompatibility patch
PR -> https://github.com/CanalTP/navitia/pull/2857


JIRA : https://jira.kisio.org/browse/NAVP-1285