### PR TITLE
All: Update Mypy and Pre-commit to check all projects in Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 18.9b0
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.4.0  # Use the ref you want to point at
     hooks:
@@ -25,5 +25,5 @@ repos:
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports, --py2]
-        files: source/jormungandr/jormungandr
-        language_version: python3.6
+        files: source
+        language_version: python3

--- a/source/eitri/ed_handler.py
+++ b/source/eitri/ed_handler.py
@@ -30,7 +30,6 @@ from contextlib import contextmanager
 import glob
 import os
 from navitiacommon import utils, launch_exec
-from navitiacommon.launch_exec import launch_exec
 import psycopg2
 import zipfile
 import logging

--- a/source/tyr/migrations/env.py
+++ b/source/tyr/migrations/env.py
@@ -72,13 +72,6 @@ def include_object(object, name, type_, reflected, compare_to):
         return True
 
 
-def include_object(object, name, type_, reflected, compare_to):
-    if type_ == "table" and name in exclude_tables:
-        return False
-    else:
-        return True
-
-
 def run_migrations_offline():
     """Run migrations in 'offline' mode.
 

--- a/source/tyr/tests/conftest.py
+++ b/source/tyr/tests/conftest.py
@@ -35,10 +35,11 @@ import pytest
 import tempfile
 import shutil
 
+# TODO : need to clean that after full migration to python3
 try:
     import ConfigParser
 except:
-    import configparser as ConfigParser
+    import configparser as ConfigParser  # type: ignore
 
 from tests.docker_wrapper import PostgresDocker
 

--- a/source/tyr/tests/integration/purge_test.py
+++ b/source/tyr/tests/integration/purge_test.py
@@ -38,10 +38,11 @@ from tyr import app, tasks
 from navitiacommon import models
 from tests.check_utils import api_get, api_delete
 
+# TODO : need to clean that after full migration to python3
 try:
     import ConfigParser
 except:
-    import configparser as ConfigParser
+    import configparser as ConfigParser  # type: ignore
 
 
 def create_dataset(dataset_type, dir):


### PR DESCRIPTION
Typecheck across Python modules is not well supported. Preliminary tests show that Mypy doesn't check types if they're shared among modules. But for "simple" checks, it works well and allow us to provide some improvements.

Mypy seems to have many limitations and an harder work in the futur may be done to improve its effectiveness.

Also, this patch allow each contributor to run pre-commit with any version of python3. It improves portability for internal and external builds.