### PR TITLE
kraken: manage line_section and routes

### DIFF
--- a/source/kraken/tests/disruption_reader_test.cpp
+++ b/source/kraken/tests/disruption_reader_test.cpp
@@ -89,6 +89,19 @@ struct Const_it {
                   {"ptobject_updated_at", Value()},
                   {"ptobject_uri", Value()},
                   {"ptobject_type", Value()},
+                  {"ls_line_uri", Value()},
+                  {"ls_line_created_at", Value()},
+                  {"ls_line_updated_at", Value()},
+                  {"ls_start_uri", Value()},
+                  {"ls_start_created_at", Value()},
+                  {"ls_start_updated_at", Value()},
+                  {"ls_end_uri", Value()},
+                  {"ls_end_created_at", Value()},
+                  {"ls_end_updated_at", Value()},
+                  {"ls_route_id", Value()},
+                  {"ls_route_uri", Value()},
+                  {"ls_route_created_at", Value()},
+                  {"ls_route_updated_at", Value()},
                   {"property_key", Value()},
                   {"property_type", Value()},
                   {"property_value", Value()},
@@ -180,6 +193,34 @@ struct Const_it {
         values["ptobject_updated_at"] = updated_at;
         values["ptobject_uri"] = uri;
         values["ptobject_type"] = type;
+    }
+
+    void set_line_section(const std::string& ls_line_uri,
+                          const std::string& ls_line_created_at,
+                          const std::string& ls_line_updated_at,
+                          const std::string& ls_start_uri,
+                          const std::string& ls_start_created_at,
+                          const std::string& ls_start_updated_at,
+                          const std::string& ls_end_uri,
+                          const std::string& ls_end_created_at,
+                          const std::string& ls_end_updated_at,
+                          const std::string& ls_route_id,
+                          const std::string& ls_route_uri,
+                          const std::string& ls_route_created_at,
+                          const std::string& ls_route_updated_at) {
+        values["ls_line_uri"] = Value(ls_line_uri);
+        values["ls_line_created_at"] = Value(ls_line_created_at);
+        values["ls_line_updated_at"] = Value(ls_line_updated_at);
+        values["ls_start_uri"] = Value(ls_start_uri);
+        values["ls_start_created_at"] = Value(ls_start_created_at);
+        values["ls_start_updated_at"] = Value(ls_start_updated_at);
+        values["ls_end_uri"] = Value(ls_end_uri);
+        values["ls_end_created_at"] = Value(ls_end_created_at);
+        values["ls_end_updated_at"] = Value(ls_end_updated_at);
+        values["ls_route_id"] = Value(ls_route_id);
+        values["ls_route_uri"] = Value(ls_route_uri);
+        values["ls_route_created_at"] = Value(ls_route_created_at);
+        values["ls_route_updated_at"] = Value(ls_route_updated_at);
     }
 
     void set_property(const std::string& key, const std::string& type, const std::string& value) {
@@ -850,6 +891,135 @@ BOOST_AUTO_TEST_CASE(disruption_well_sorted_informations) {
     BOOST_REQUIRE_EQUAL(channel.types_size(), 1);
     auto channel_type = channel.types(0);
     BOOST_CHECK_EQUAL(channel_type, chaos::Channel_Type_web);
+    // Message mobile
+    message = impact.messages(1);
+    BOOST_CHECK_EQUAL(message.text(), "message_text_mobile");
+    channel = message.channel();
+    BOOST_CHECK_EQUAL(channel.name(), "channel_name_mobile");
+    BOOST_REQUIRE_EQUAL(channel.types_size(), 1);
+    channel_type = channel.types(0);
+    BOOST_CHECK_EQUAL(channel_type, chaos::Channel_Type_mobile);
+
+    // Message notification
+    message = impact.messages(2);
+    BOOST_CHECK_EQUAL(message.text(), "message_text_notification");
+    channel = message.channel();
+    BOOST_CHECK_EQUAL(channel.name(), "channel_name_notification");
+    BOOST_REQUIRE_EQUAL(channel.types_size(), 1);
+    channel_type = channel.types(0);
+    BOOST_CHECK_EQUAL(channel_type, chaos::Channel_Type_notification);
+}
+
+BOOST_AUTO_TEST_CASE(disruption_with_line_sections) {
+    navitia::type::PT_Data pt_data;
+    navitia::type::MetaData meta;
+    navitia::DisruptionDatabaseReader reader(pt_data, meta);
+
+    Const_it const_it;
+    const_it.set_disruption("1", "22", "33", "44", "55", "note", "reference");
+    const_it.set_cause("1", "wording", "11", "22");
+    const_it.set_tag("1", "name", "11", "22");
+    const_it.set_impact("1", "11", "22");
+    const_it.set_severity("2", "wording", "22", "33", "blocking", "color", "2");
+    const_it.set_application_period("0", "1", "2");
+
+    // Add a line section with a line, start stop_area, end stop_area and two routes
+    const_it.set_ptobject("id_1", "uri_1", "line_section", "1", "2");
+    const_it.set_line_section("ls_uri_1", "1", "2", "ls_start_uri_1", "1", "2", "ls_end_uri_1", "1", "2", "ls_r_id_1",
+                              "ls_r_uri_1", "1", "2");
+    reader(const_it);
+    const_it.set_line_section("ls_uri_1", "1", "2", "ls_start_uri_1", "1", "2", "ls_end_uri_1", "1", "2", "ls_r_id_2",
+                              "ls_r_uri_2", "1", "2");
+    reader(const_it);
+    // We try to add a duplicate route in line_section but wont be added.
+    const_it.set_line_section("ls_uri_1", "1", "2", "ls_start_uri_1", "1", "2", "ls_end_uri_1", "1", "2", "ls_r_id_2",
+                              "ls_r_uri_2", "1", "2");
+    reader(const_it);
+
+    // First combination of message, channel and channel_type with duplicate values
+    const_it.set_message("m_id_1", "message_text_web", "1", "2");
+    const_it.set_channel("channel_id", "channel_name_web", "type", "400", "1", "2");
+    const_it.set_channel_type("id_1", "web");
+    reader(const_it);
+
+    // Second combination of message, channel and channel_type with duplicate values
+    const_it.set_message("m_id_2", "message_text_mobile", "1", "2");
+    const_it.set_channel("channel_id_2", "channel_name_mobile", "type", "400", "1", "2");
+    const_it.set_channel_type("id_2", "mobile");
+    reader(const_it);
+
+    // Third combination of message, channel and channel_type with duplicate values
+    const_it.set_message("m_id_3", "message_text_notification", "1", "2");
+    const_it.set_channel("channel_id_3", "channel_name_notification", "type", "400", "1", "2");
+    const_it.set_channel_type("id_3", "notification");
+    reader(const_it);
+
+    const_it.set_message("m_id_3", "message_text_notification", "1", "2");
+    const_it.set_channel("channel_id_3", "channel_name_notification", "type", "400", "1", "2");
+    const_it.set_channel_type("id_3", "notification");
+    reader(const_it);
+
+    // Add another line section with a line, start stop_area, end stop_area and two routes
+    const_it.set_ptobject("id_2", "uri_2", "line_section", "1", "2");
+    const_it.set_line_section("ls_uri_2", "1", "2", "ls_start_uri_2", "1", "2", "ls_end_uri_2", "1", "2", "ls_r_id_3",
+                              "ls_r_uri_3", "1", "2");
+    reader(const_it);
+    const_it.set_line_section("ls_uri_2", "1", "2", "ls_start_uri_2", "1", "2", "ls_end_uri_2", "1", "2", "ls_r_id_4",
+                              "ls_r_uri_4", "1", "2");
+    reader(const_it);
+
+    const auto& disruption = reader.disruption;
+    BOOST_CHECK_EQUAL(disruption->id(), "1");
+    auto cause = disruption->cause();
+    BOOST_CHECK_EQUAL(cause.id(), "1");
+    BOOST_CHECK_EQUAL(disruption->tags_size(), 1);
+    BOOST_REQUIRE_EQUAL(disruption->impacts_size(), 1);
+    auto impact = disruption->impacts(0);
+    BOOST_CHECK_EQUAL(impact.id(), "1");
+    auto severity = impact.severity();
+    BOOST_CHECK_EQUAL(severity.id(), "2");
+    BOOST_CHECK_EQUAL(impact.application_periods_size(), 1);
+    BOOST_REQUIRE_EQUAL(impact.informed_entities_size(), 2);
+
+    // First impacted_object
+    auto pt_object = impact.informed_entities(0);
+    BOOST_CHECK_EQUAL(pt_object.pt_object_type(), chaos::PtObject_Type_line_section);
+    auto line = pt_object.pt_line_section().line();
+    BOOST_CHECK_EQUAL(line.uri(), "ls_uri_1");
+    auto start_sa = pt_object.pt_line_section().start_point();
+    BOOST_CHECK_EQUAL(start_sa.uri(), "ls_start_uri_1");
+    auto end_sa = pt_object.pt_line_section().end_point();
+    BOOST_REQUIRE_EQUAL(pt_object.pt_line_section().routes_size(), 2);
+    auto route_1 = pt_object.pt_line_section().routes(0);
+    BOOST_CHECK_EQUAL(route_1.uri(), "ls_r_uri_1");
+    auto route_2 = pt_object.pt_line_section().routes(1);
+    BOOST_CHECK_EQUAL(route_2.uri(), "ls_r_uri_2");
+
+    // second impacted_object
+    pt_object = impact.informed_entities(1);
+    BOOST_CHECK_EQUAL(pt_object.pt_object_type(), chaos::PtObject_Type_line_section);
+    line = pt_object.pt_line_section().line();
+    BOOST_CHECK_EQUAL(line.uri(), "ls_uri_2");
+    start_sa = pt_object.pt_line_section().start_point();
+    BOOST_CHECK_EQUAL(start_sa.uri(), "ls_start_uri_2");
+    end_sa = pt_object.pt_line_section().end_point();
+    BOOST_REQUIRE_EQUAL(pt_object.pt_line_section().routes_size(), 2);
+    route_1 = pt_object.pt_line_section().routes(0);
+    BOOST_CHECK_EQUAL(route_1.uri(), "ls_r_uri_3");
+    route_2 = pt_object.pt_line_section().routes(1);
+    BOOST_CHECK_EQUAL(route_2.uri(), "ls_r_uri_4");
+
+    // Check messages, channels and channel_types
+    BOOST_REQUIRE_EQUAL(impact.messages_size(), 3);
+    // Message web
+    auto message = impact.messages(0);
+    BOOST_CHECK_EQUAL(message.text(), "message_text_web");
+    auto channel = message.channel();
+    BOOST_CHECK_EQUAL(channel.name(), "channel_name_web");
+    BOOST_REQUIRE_EQUAL(channel.types_size(), 1);
+    auto channel_type = channel.types(0);
+    BOOST_CHECK_EQUAL(channel_type, chaos::Channel_Type_web);
+
     // Message mobile
     message = impact.messages(1);
     BOOST_CHECK_EQUAL(message.text(), "message_text_mobile");


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVITIAII-2781

Needs https://github.com/CanalTP/navitia/pull/2863 to test disruption charging from a Postgres database with a backup restored and containing somes disruptions on stop_area, line_section, deviation... 
