### PR TITLE
Tyr: load open addresses in mimir

### DIFF
--- a/source/navitiacommon/navitiacommon/utils.py
+++ b/source/navitiacommon/navitiacommon/utils.py
@@ -33,7 +33,7 @@ import glob
 import logging
 
 street_source_types = ['OSM']
-address_source_types = ['BANO', 'OSM']
+address_source_types = ['BANO', 'OA']
 poi_source_types = ['FUSIO', 'OSM']
 admin_source_types = ['OSM', 'COSMOGONY']
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1523,7 +1523,7 @@ class AutocompleteParameter(flask_restful.Resource):
             type=str,
             required=False,
             default='BANO',
-            help='source for address: [BANO, OpenAddresses]',
+            help='source for address: {}'.format(utils.address_source_types),
             location=('json', 'values'),
             choices=utils.address_source_types,
         )


### PR DESCRIPTION
add the capability for tyr to load [open addresses](https://openaddresses.io/) data into mimir.