### PR TITLE
fusio2ed: Stop times are over computed with frequencies.txt

### DIFF
--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -275,7 +275,6 @@ void Data::complete() {
     build_associated_calendar();
 
     shift_stop_times();
-    finalize_frequency();
 
     ::ed::normalize_uri(routes);
 

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -482,3 +482,38 @@ BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
         BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
     }
 }
+
+BOOST_AUTO_TEST_CASE(frequencies_tests) {
+    ed::Data data;
+    ed::connectors::FusioParser parser(ntfs_path);
+    parser.fill(data);
+    data.complete();  // complete() is called by fusio2ed
+
+    // trip_5 is composed of 4 stop_times.
+    // Check that inside fixtures/ed/ntfs/stop_times.txt
+    const auto& mvj = data.meta_vj_map["trip_5"];
+    // We split the vj in 2 parts because of the time change
+    BOOST_REQUIRE_EQUAL(mvj.theoric_vj.size(), 2);
+    const auto& vj = mvj.theoric_vj[0];
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
+    BOOST_CHECK_EQUAL(vj->name, "trip_5_dst_1");
+    BOOST_CHECK_EQUAL(vj->stop_time_list[0]->departure_time, "05:00:00"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list[0]->stop_point->uri, "SP:A");
+    BOOST_CHECK_EQUAL(vj->stop_time_list[1]->departure_time, "05:10:00"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list[1]->stop_point->uri, "SP:B");
+    BOOST_CHECK_EQUAL(vj->stop_time_list[2]->departure_time, "05:20:00"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list[2]->stop_point->uri, "SP:C");
+    BOOST_CHECK_EQUAL(vj->stop_time_list[3]->departure_time, "05:30:00"_t);
+    BOOST_CHECK_EQUAL(vj->stop_time_list[3]->stop_point->uri, "SP:D");
+    const auto& vj2 = mvj.theoric_vj[1];
+    BOOST_REQUIRE_EQUAL(vj2->stop_time_list.size(), 4);
+    BOOST_CHECK_EQUAL(vj2->name, "trip_5_dst_2");
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[0]->departure_time, "04:00:00"_t);
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[0]->stop_point->uri, "SP:A");
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[1]->departure_time, "04:10:00"_t);
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[1]->stop_point->uri, "SP:B");
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[2]->departure_time, "04:20:00"_t);
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[2]->stop_point->uri, "SP:C");
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[3]->departure_time, "04:30:00"_t);
+    BOOST_CHECK_EQUAL(vj2->stop_time_list[3]->stop_point->uri, "SP:D");
+}


### PR DESCRIPTION
Currently, we have the following behavior

- **fusio2ed** fills `ed::data` struct with stop_times (_stop_times.txt_ file)

stop_times.txt example
![stop_times](https://user-images.githubusercontent.com/32099204/60899702-2fe13700-a26b-11e9-9552-94855be6b223.png)


- If **frequencies.txt** exists with the same `trip_id`, **fusio2ed** shifts all the stop times to the frequencies starting value (_start_time_ col)

frequencies.txt example
![frequencies](https://user-images.githubusercontent.com/32099204/60899870-7fbffe00-a26b-11e9-806a-515caca5efc0.png)


- But a bug is introduced because of an untimely function (_finalize_frequency_ function). 
In fact, after the _fusioParser_ calling, **fusio2ed** calls `data.complete()` which calls `finalize_frequency()`. 
This is an over computing that create wrong stop times values around zero.

- Solution, don't call `finalize_frequency()` and tests it with a Utest :unicorn: 

This PR shows that we need some extra _RFC doc_ about this mechanism. Maybe in a future PR.
