### PR TITLE
fusio2ed: suppress station_id retrocompatibility inside admin_stations.txt file

### DIFF
--- a/fixtures/ed/ntfs/admin_stations.txt
+++ b/fixtures/ed/ntfs/admin_stations.txt
@@ -1,2 +1,2 @@
-admin_id,admin_name,station_id,station_name,stop_id,stop_name
-admin:A,"admin_name_A_that_is_not_read",station_id_A_that_is_not_read,"station_name_A_that_is_not_read",SA:A,"stop_name_A_that_is_not_read"
+admin_id,admin_name,stop_id,stop_name
+admin:A,"admin_name_A_that_is_not_read",SA:A,"stop_name_A_that_is_not_read"

--- a/fixtures/ed/ntfs_dst/admin_stations.txt
+++ b/fixtures/ed/ntfs_dst/admin_stations.txt
@@ -1,2 +1,1 @@
 admin_id,admin_name,stop_id,stop_name
-admin:A,"admin_name_A_that_is_not_read",SCF:SP:SPOCENoctilien87976902,"stop_name_A_that_is_not_read"

--- a/fixtures/ed/ntfs_v5/admin_stations.txt
+++ b/fixtures/ed/ntfs_v5/admin_stations.txt
@@ -1,2 +1,1 @@
-admin_id,admin_name,station_id,station_name
-admin:A,"admin_name_A_that_is_not_read",A,"station_name_A_that_is_not_read"
+admin_id,admin_name,stop_id,stop_name

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -44,8 +44,6 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
-static const int UNKNOWN_COLUMN = -1;
-
 struct FeedInfoFusioHandler : public GenericHandler {
     FeedInfoFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
     int feed_info_param_c, feed_info_value_c;
@@ -304,19 +302,13 @@ struct GridCalendarTripExceptionDatesFusioHandler : public GenericHandler {
 }  // namespace grid_calendar
 
 struct AdminStopAreaFusioHandler : public GenericHandler {
-    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader)
-        : GenericHandler(gdata, reader), stop_id_is_present(true) {}
+    AdminStopAreaFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
     int admin_c, stop_area_c;
-    bool stop_id_is_present;
-
-    // temporaty map to have a StopArea by it's external code
-    std::unordered_map<std::string, ed::types::StopArea*> tmp_stop_area_map;
 
     std::unordered_map<std::string, ed::types::AdminStopArea*> admin_stop_area_map;
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
-    // TODO : "stop_id" will becomme required, after the data team update (NAVP-1285)
-    const std::vector<std::string> required_headers() const { return {"admin_id"}; }
+    const std::vector<std::string> required_headers() const { return {"admin_id", "stop_id"}; }
 };
 
 struct CommentLinksFusioHandler : public GenericHandler {

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -442,43 +442,13 @@ BOOST_AUTO_TEST_CASE(sync_ntfs) {
     BOOST_CHECK_EQUAL(vj->accessible(has_vehicle_properties.vehicles()), false);
 }
 
-BOOST_AUTO_TEST_CASE(admin_stations_retrocompatibilty_tests) {
-    // admin_stations.txt file contains "stop_id" and "station_id"
-    // Following the norm, we only read "stop_id"
-    {
-        ed::Data data;
-        ed::connectors::FusioParser parser(ntfs_path);
-        parser.fill(data);
-        BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
-        BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Arrêt A");
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
-    }
-
-    // admin_stations.txt file contains only "stop_id"
-    {
-        ed::Data data;
-        ed::connectors::FusioParser parser(ntfs_path + "_dst");
-        parser.fill(data);
-        BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
-        BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Brunoy-Wittlich");
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SCF:SP:SPOCENoctilien87976902");
-    }
-
-    // For retrocompatibity
-    // admin_stations.txt file contains only "station_id"
-    // TODO : to remove after the data team update, it will become useless (NAVP-1285)
-    {
-        ed::Data data;
-        ed::connectors::FusioParser parser(ntfs_path + "_v5");
-        parser.fill(data);
-        BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
-        BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Arrêt A");
-        BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
-    }
+BOOST_AUTO_TEST_CASE(admin_stations_tests) {
+    ed::Data data;
+    ed::connectors::FusioParser parser(ntfs_path);
+    parser.fill(data);
+    BOOST_REQUIRE_EQUAL(data.admin_stop_areas.size(), 1);
+    BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->admin, "admin:A");
+    BOOST_REQUIRE_EQUAL(data.admin_stop_areas[0]->stop_area.size(), 1);
+    BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->name, "Arrêt A");
+    BOOST_CHECK_EQUAL(data.admin_stop_areas[0]->stop_area[0]->uri, "SA:A");
 }


### PR DESCRIPTION
Previously on PR https://github.com/CanalTP/navitia/pull/2836, we wanted to read **station_id** column or **stop_id** column inside `admin_stations.txt`. 
For retrocompatibility, **station_id** was readed if **stop_id** didn't exist.

When the _data team_ will finish its migration, we'll allowed to only read **stop_id** column.
This PR aims to suppress the retrocompatibilty for **station_id** column. 
It's now strict about field, only **stop_id** is read and it is required.

:warning:  Wait the GO of the data team to merge