### PR TITLE
Kraken: Omit deleted stop in intermediate stops of a journey section

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -531,6 +531,8 @@ class StopTimeSerializer(PbNestedSerializer):
     headsign = jsonschema.Field(schema_type=str)
     journey_pattern_point = JourneyPatternPointSerializer()
     stop_point = StopPointSerializer()
+    pickup_allowed = BoolField()
+    drop_off_allowed = BoolField()
 
 
 class VehicleJourneySerializer(PbGenericSerializer):

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2235,7 +2235,7 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 4);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 3);
     BOOST_CHECK_EQUAL(res.impacts_size(), 2);
     for (const auto& impact : res.impacts()) {
         if (impact.uri() == "feed-2") {
@@ -2341,14 +2341,14 @@ BOOST_AUTO_TEST_CASE(add_new_and_delete_existingstop_time_in_the_trip_for_detour
 
     b.finalize_disruption_batch();
 
-    // The new stop_time added should be in stop_date_times
+    // The delete stop_time should not be in stop_date_times where as the added stop_time should be in stop_date_times
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 4);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 3);
     BOOST_CHECK_EQUAL(res.impacts(0).severity().effect(), pbnavitia::Severity_Effect_DETOUR);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).stop_point().uri(), "stop_point:B_bis");
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(3).arrival_date_time(), "20171101T0900"_pts);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).stop_point().uri(), "stop_point:B_bis");
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).arrival_date_time(), "20171101T0900"_pts);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects_size(), 1);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops_size(), 4);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(0).is_detour(), false);
@@ -2432,10 +2432,10 @@ BOOST_AUTO_TEST_CASE(add_new_with_earlier_arrival_and_delete_existingstop_time_i
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 4);
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times_size(), 3);
     BOOST_CHECK_EQUAL(res.impacts_size(), 1);
     BOOST_CHECK_EQUAL(res.impacts(0).severity().effect(), pbnavitia::Severity_Effect_DETOUR);
-    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(2).stop_point().uri(), "stop_point:B_bis");
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).stop_date_times(1).stop_point().uri(), "stop_point:B_bis");
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects_size(), 1);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops_size(), 4);
     BOOST_CHECK_EQUAL(res.impacts(0).impacted_objects(0).impacted_stops(0).is_detour(), false);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -556,6 +556,12 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
                 if (i != 0 && i != nb_sps - 1 && item.stop_times[i]->date_time_estimated()) {
                     continue;
                 }
+
+                // skipping stop_time having a 'deleted' or 'deleted for detour' stop_point
+                if (!item.stop_times[i]->pick_up_allowed() && !item.stop_times[i]->drop_off_allowed()) {
+                    continue;
+                }
+
                 pbnavitia::StopDateTime* stop_time = pb_section->add_stop_date_times();
                 auto arr_time = navitia::to_posix_timestamp(item.arrivals[i]);
                 stop_time->set_arrival_date_time(arr_time);


### PR DESCRIPTION
- Do not display object related to deleted stop_point in jouney.section.stop_date_times
- Display attributes "drop_off_allowed" and "pickup_allowed" vehicle_journey.stop_times for debug purpose.
- Unit test realtime_test modified
- Some integration tests added in kirin_realtime_test

concerned ticket: https://jira.kisio.org/browse/NAVP-1363