### PR TITLE
rt_validity_pattern used to verify vehicle_journey validity

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1847,6 +1847,15 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
         assert has_the_disruption(response, 'new_trip')
         assert len(response['vehicle_journeys']) == 1
 
+        # Check that the newly created vehicle journey are well filtered by &since and &until
+        response = self.query_region(vj_filter_query + '&since=20120614T080100&until=20120614T080102')
+        assert len(response['vehicle_journeys']) == 1
+        response, status = self.query_region(
+            vj_filter_query + '&since=20120614T080101&until=20120614T080102', check=False
+        )
+        assert status == 404
+        assert 'vehicle_journeys' not in response
+
         response = self.query_region(network_filter_query)
         assert len(response['networks']) == 1
         assert response['networks'][0]['name'] == 'additional service'

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -32,6 +32,7 @@ www.navitia.io
 #define BOOST_TEST_MODULE test_realtime
 #include <boost/test/unit_test.hpp>
 #include "type/gtfs-realtime.pb.h"
+#include "ptreferential/ptreferential.h"
 #include "type/pt_data.h"
 #include "type/kirin.pb.h"
 #include "kraken/realtime.h"
@@ -2936,6 +2937,15 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));
     BOOST_CHECK_EQUAL(vj->adapted_validity_pattern()->days, year("00000000"));
     BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, year("00000001"));
+
+    //verify that filters &since and &until work well with vehicle_jouneys added by realtime (added trip)
+    auto indexes = navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all,
+    {"20190101T0400"_dt}, {"20190101T1000"_dt}, *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 2);
+
+    indexes = navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all,
+    {"20190103T0400"_dt}, {"20190103T1000"_dt}, *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 1);
 
     // New trip added
     res = compute("20190101T073000", "stop_point:A", "stop_point:G");

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2938,13 +2938,13 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->adapted_validity_pattern()->days, year("00000000"));
     BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, year("00000001"));
 
-    //verify that filters &since and &until work well with vehicle_jouneys added by realtime (added trip)
+    // verify that filters &since and &until work well with vehicle_jouneys added by realtime (added trip)
     auto indexes = navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all,
-    {"20190101T0400"_dt}, {"20190101T1000"_dt}, *(b.data));
+                                              {"20190101T0400"_dt}, {"20190101T1000"_dt}, *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 2);
 
-    indexes = navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all,
-    {"20190103T0400"_dt}, {"20190103T1000"_dt}, *(b.data));
+    indexes = navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all, {"20190103T0400"_dt},
+                                         {"20190103T1000"_dt}, *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 1);
 
     // New trip added

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -149,7 +149,7 @@ static bool keep_vj(const type::VehicleJourney* vj, const bt::time_period& perio
 
     const auto& first_departure_dt = vj->earliest_time();
     for (boost::gregorian::day_iterator it(period.begin().date()); it <= period.last().date(); ++it) {
-        if (!vj->base_validity_pattern()->check(*it)) {
+        if (!vj->base_validity_pattern()->check(*it) && !vj->rt_validity_pattern()->check(*it)) {
             continue;
         }
         bt::ptime vj_dt = bt::ptime(*it, bt::seconds(first_departure_dt));


### PR DESCRIPTION
- In api /vehicle_journeys only base_validity_pattern is used to verify if the vehicle_journey is valid.
- Since for a vehicle_journey added by a realtime (added trip) base_validity_pattern is created with all zeros where as a rt_validity_pattern is created with at least one day valid (1) , the use of filters &since and/or &until returns 0 element.

Concerns : https://jira.kisio.org/browse/NAVP-1273