### PR TITLE
Unify and fix all python libraries version among all python projets

### DIFF
--- a/source/cities/requirements.txt
+++ b/source/cities/requirements.txt
@@ -1,7 +1,7 @@
 GeoAlchemy2==0.2.4
 Jinja2==2.10.1
 Mako==0.9.1
-MarkupSafe==0.18
+MarkupSafe==0.23
 SQLAlchemy==1.3.3
 Shapely==1.3.0
 alembic==1.0.11

--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,6 +1,6 @@
-future==0.13.1
+future==0.15.2
 docker==3.4.1
-retrying==1.2.3
+retrying==1.3.3
 psycopg2
 clingon==0.1.4
 GeoAlchemy2==0.2.4

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -36,7 +36,7 @@ Flask-Caching==1.4.0
 git+https://github.com/canaltp/serpy.git@ctp
 python-json-logger==0.1.7
 jmespath==0.9.3
-shortuuid
+shortuuid==0.5.0
 click==6.7
 typing==3.7.4
 coloredlogs==10.0

--- a/source/jormungandr/requirements_dev.txt
+++ b/source/jormungandr/requirements_dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 -r ../../requirements_pre-commit.txt
+
 swagger-spec-validator==2.1.0
 mock==1.0.1
 validators==0.10

--- a/source/monitor/requirements.txt
+++ b/source/monitor/requirements.txt
@@ -5,5 +5,5 @@ Werkzeug==0.14.1
 argparse==1.2.1
 itsdangerous==1.1.0
 protobuf
-pyzmq==14.0.1
+pyzmq==15.4.0
 wsgiref==0.1.2

--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -1,7 +1,7 @@
 GeoAlchemy2==0.2.4
 Jinja2==2.10.1
 Mako==0.9.1
-MarkupSafe==0.18
+MarkupSafe==0.23
 SQLAlchemy==1.3.3
 Shapely==1.3.0
 alembic==1.0.11

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -26,7 +26,7 @@ pydns==2.3.6
 pytz==2013.9
 redis==2.9.1
 six==1.10.0
-validate-email==1.1
+validate-email==1.2
 wsgiref==0.1.2
 retrying==1.3.3
 ujson==1.35

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 -r ../../requirements_pre-commit.txt
+
 docker==3.4.1
 pytest==3.7.2
 python-dateutil==2.5.3


### PR DESCRIPTION
Don't hesite to say if you like the idea or not.

The main idea is to create one unified python env for navitia build with :
`mkvirtualenv -r ./eitri/requirements.txt -r ./cities/requirements.txt -r ./tyr/requirements_dev.txt -r ./monitor/requirements.txt -r ./jormungandr/requirements_dev.txt -r ./sql/requirements.txt -p /usr/bin/python2 navitia_dev`

Then just :
`workon navitia_dev`