### PR TITLE
PTReferential: manage rt_vehicle_journeys with since and until params

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -114,6 +114,16 @@ class Uri(ResourceUri, ResourceUtc):
             'of the disruptions.',
         )
         parser.add_argument(
+            "data_freshness",
+            help="Define the freshness of data to use to compute vehicle_journeys "
+            "along with parameters &since and/or &until .\n"
+            "When using `&data_freshness=base_schedule` you get original vehicle_journeys "
+            "where as when using `&data_freshness=realtime` you get vehicle_journeys "
+            "added or modified by realtime.",
+            type=OptionValue(['base_schedule', 'adapted_schedule', 'realtime']),
+            default='base_schedule',
+        )
+        parser.add_argument(
             "distance",
             type=int,
             default=200,

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -286,6 +286,7 @@ class Scenario(object):
             req.ptref.since_datetime = request['since']
         if request['until']:
             req.ptref.until_datetime = request['until']
+        req.ptref.realtime_level = get_pb_data_freshness(request)
         req.disable_disruption = request["disable_disruption"]
         resp = instance.send_and_receive(req)
         build_pagination(request, resp)

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2937,6 +2937,17 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->adapted_validity_pattern()->days, year("00000000"));
     BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, year("00000001"));
 
+    // verify that filters &since and &until work well with vehicle_jouneys added by realtime (added trip)
+    // Note: For backward compatibility parameter &data_freshness with base_schedule is added and works
+    // only with &since and &until
+    auto indexes =
+        navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all, {"20190101T0400"_dt},
+                                   {"20190101T1000"_dt}, navitia::type::RTLevel::Base, *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 1);
+    indexes = navitia::ptref::make_query(nt::Type_e::VehicleJourney, "", {}, nt::OdtLevel_e::all, {"20190101T0400"_dt},
+                                         {"20190101T1000"_dt}, navitia::type::RTLevel::RealTime, *(b.data));
+    BOOST_CHECK_EQUAL(indexes.size(), 2);
+
     // New trip added
     res = compute("20190101T073000", "stop_point:A", "stop_point:G");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -772,11 +772,12 @@ void Worker::pt_ref(const pbnavitia::PTRefRequest& request) {
     for (int i = 0; i < request.forbidden_uri_size(); ++i) {
         forbidden_uri.push_back(request.forbidden_uri(i));
     }
+    auto rt_level = get_realtime_level(request.realtime_level());
     navitia::ptref::query_pb(
         this->pb_creator, get_type(request.requested_type()), request.filter(), forbidden_uri,
         get_odt_level(request.odt_level()), request.depth(), request.start_page(), request.count(),
         boost::make_optional(request.has_since_datetime(), bt::from_time_t(request.since_datetime())),
-        boost::make_optional(request.has_until_datetime(), bt::from_time_t(request.until_datetime())), *data);
+        boost::make_optional(request.has_until_datetime(), bt::from_time_t(request.until_datetime())), rt_level, *data);
 }
 
 // returns true if there is an error

--- a/source/ptreferential/ptreferential.cpp
+++ b/source/ptreferential/ptreferential.cpp
@@ -45,12 +45,24 @@ type::Indexes make_query(const type::Type_e requested_type,
                          const type::OdtLevel_e odt_level,
                          const boost::optional<boost::posix_time::ptime>& since,
                          const boost::optional<boost::posix_time::ptime>& until,
+                         const type::RTLevel rt_level,
                          const type::Data& data) {
-    const auto indexes = make_query_ng(requested_type, request, forbidden_uris, odt_level, since, until, data);
+    const auto indexes =
+        make_query_ng(requested_type, request, forbidden_uris, odt_level, since, until, rt_level, data);
     if (indexes.empty()) {
         throw ptref_error("Filters: Unable to find object");
     }
     return indexes;
+}
+
+type::Indexes make_query(const type::Type_e requested_type,
+                         const std::string& request,
+                         const std::vector<std::string>& forbidden_uris,
+                         const type::OdtLevel_e odt_level,
+                         const boost::optional<boost::posix_time::ptime>& since,
+                         const boost::optional<boost::posix_time::ptime>& until,
+                         const type::Data& data) {
+    return make_query(requested_type, request, forbidden_uris, odt_level, since, until, type::RTLevel::Base, data);
 }
 
 type::Indexes make_query(const type::Type_e requested_type,

--- a/source/ptreferential/ptreferential.h
+++ b/source/ptreferential/ptreferential.h
@@ -36,6 +36,7 @@ www.navitia.io
 
 #include <boost/optional.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include "type/rt_level.h"
 
 namespace navitia {
 namespace ptref {
@@ -60,6 +61,15 @@ struct parsing_error : public ptref_error {
 
 /// Runs the query on the data, and returns the corresponding indexes.
 /// Throws in case of error (parsing, unknown function, no resultst...).
+type::Indexes make_query(const type::Type_e requested_type,
+                         const std::string& request,
+                         const std::vector<std::string>& forbidden_uris,
+                         const type::OdtLevel_e odt_level,
+                         const boost::optional<boost::posix_time::ptime>& since,
+                         const boost::optional<boost::posix_time::ptime>& until,
+                         const type::RTLevel rt_level,
+                         const type::Data& data);
+
 type::Indexes make_query(const type::Type_e requested_type,
                          const std::string& request,
                          const std::vector<std::string>& forbidden_uris,

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -150,11 +150,12 @@ void query_pb(navitia::PbCreator& pb_creator,
               const int count,
               const boost::optional<boost::posix_time::ptime>& since,
               const boost::optional<boost::posix_time::ptime>& until,
+              const type::RTLevel rt_level,
               const type::Data& data) {
     type::Indexes final_indexes;
     int total_result;
     try {
-        final_indexes = make_query(requested_type, request, forbidden_uris, odt_level, since, until, data);
+        final_indexes = make_query(requested_type, request, forbidden_uris, odt_level, since, until, rt_level, data);
     } catch (const parsing_error& parse_error) {
         pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse, "Unable to parse :" + parse_error.more);
         return;

--- a/source/ptreferential/ptreferential_api.h
+++ b/source/ptreferential/ptreferential_api.h
@@ -49,6 +49,7 @@ void query_pb(navitia::PbCreator& pb_creator,
               const int count,
               const boost::optional<boost::posix_time::ptime>& since,
               const boost::optional<boost::posix_time::ptime>& until,
+              const type::RTLevel rt_level,
               const type::Data& data);
 
 std::vector<const type::Route*> get_matching_routes(const type::Data*,

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -223,8 +223,9 @@ boost::posix_time::ptime from_datetime(const std::string& s) {
 
 struct Eval : boost::static_visitor<Indexes> {
     const Type_e target;
+    const type::RTLevel rt_level;
     const type::Data& data;
-    Eval(Type_e t, const type::Data& d) : target(t), data(d) {}
+    Eval(Type_e t, const type::RTLevel rtl, const type::Data& d) : target(t), rt_level(rtl), data(d) {}
 
     Indexes operator()(const ast::All&) const { return data.get_all_index(target); }
     Indexes operator()(const ast::Empty&) const { return Indexes(); }
@@ -282,7 +283,8 @@ struct Eval : boost::static_visitor<Indexes> {
                 until = from_datetime(f.args.at(1));
             }
             const auto type = type_by_caption(f.type);
-            indexes = filter_on_period(data.get_all_index(type), type, since, until, data);
+            indexes = filter_on_period(data.get_all_index(type), type, since, until, rt_level, data);
+
         } else if (f.method == "within" && f.args.size() == 2) {
             double distance = 0.;
             try {
@@ -320,7 +322,7 @@ struct Eval : boost::static_visitor<Indexes> {
     }
     Indexes operator()(const ast::GetCorresponding& expr) const {
         const auto from = type_by_caption(expr.type);
-        auto indexes = Eval(from, data)(expr.expr);
+        auto indexes = Eval(from, type::RTLevel::Base, data)(expr.expr);
         return get_corresponding(indexes, from, target, data);
     }
     Indexes operator()(const ast::BinaryOp<ast::And>& expr) const {
@@ -434,13 +436,14 @@ Indexes make_query_ng(const Type_e requested_type,
                       const OdtLevel_e odt_level,
                       const boost::optional<boost::posix_time::ptime>& since,
                       const boost::optional<boost::posix_time::ptime>& until,
+                      const type::RTLevel rt_level,
                       const type::Data& data) {
     auto logger = log4cplus::Logger::getInstance("ptref");
     const auto request_ng = make_request(requested_type, request, forbidden_uris, odt_level, since, until, data);
     const auto expr = parse(request_ng);
     LOG4CPLUS_TRACE(logger, "ptref_ng parsed: " << expr << " [requesting: "
                                                 << navitia::type::static_data::captionByType(requested_type) << "]");
-    return Eval(requested_type, data)(expr);
+    return Eval(requested_type, rt_level, data)(expr);
 }
 
 }  // namespace ptref

--- a/source/ptreferential/ptreferential_ng.h
+++ b/source/ptreferential/ptreferential_ng.h
@@ -122,6 +122,7 @@ std::string make_request(const type::Type_e requested_type,
                          const type::OdtLevel_e odt_level,
                          const boost::optional<boost::posix_time::ptime>& since,
                          const boost::optional<boost::posix_time::ptime>& until,
+                         const type::RTLevel rt_level,
                          const type::Data& data);
 
 }  // namespace ptref

--- a/source/ptreferential/ptreferential_ng.h
+++ b/source/ptreferential/ptreferential_ng.h
@@ -38,6 +38,7 @@ www.navitia.io
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/fusion/adapted/struct.hpp>
 #include <boost/variant/recursive_variant.hpp>
+#include "type/rt_level.h"
 
 namespace navitia {
 namespace ptref {
@@ -48,6 +49,7 @@ type::Indexes make_query_ng(const type::Type_e requested_type,
                             const type::OdtLevel_e odt_level,
                             const boost::optional<boost::posix_time::ptime>& since,
                             const boost::optional<boost::posix_time::ptime>& until,
+                            const type::RTLevel rt_level,
                             const type::Data& data);
 
 namespace ast {

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -149,8 +149,7 @@ static bool keep_vj(const type::VehicleJourney* vj, const bt::time_period& perio
 
     const auto& first_departure_dt = vj->earliest_time();
     for (boost::gregorian::day_iterator it(period.begin().date()); it <= period.last().date(); ++it) {
-        if (!(vj->base_validity_pattern()->check(*it)
-              || (rt_level == type::RTLevel::RealTime && vj->rt_validity_pattern()->check(*it)))) {
+        if (!vj->validity_patterns[rt_level]->check(*it)) {
             continue;
         }
         bt::ptime vj_dt = bt::ptime(*it, bt::seconds(first_departure_dt));

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -142,14 +142,15 @@ Indexes get_impacts_by_tags(const std::vector<std::string>& tag_name, const Data
     return result;
 }
 
-static bool keep_vj(const type::VehicleJourney* vj, const bt::time_period& period) {
+static bool keep_vj(const type::VehicleJourney* vj, const bt::time_period& period, const type::RTLevel rt_level) {
     if (vj->stop_time_list.empty()) {
         return false;  // no stop time, so it cannot be valid
     }
 
     const auto& first_departure_dt = vj->earliest_time();
     for (boost::gregorian::day_iterator it(period.begin().date()); it <= period.last().date(); ++it) {
-        if (!vj->base_validity_pattern()->check(*it)) {
+        if (!(vj->base_validity_pattern()->check(*it)
+              || (rt_level == type::RTLevel::RealTime && vj->rt_validity_pattern()->check(*it)))) {
             continue;
         }
         bt::ptime vj_dt = bt::ptime(*it, bt::seconds(first_departure_dt));
@@ -161,7 +162,10 @@ static bool keep_vj(const type::VehicleJourney* vj, const bt::time_period& perio
     return false;
 }
 
-static Indexes filter_vj_on_period(const Indexes& indexes, const bt::time_period& period, const type::Data& data) {
+static Indexes filter_vj_on_period(const Indexes& indexes,
+                                   const bt::time_period& period,
+                                   const type::RTLevel rt_level,
+                                   const type::Data& data) {
     Indexes res;
     bt::time_period production_period = {bt::ptime(data.meta->production_date.begin()),
                                          bt::ptime(data.meta->production_date.end())};
@@ -169,7 +173,7 @@ static Indexes filter_vj_on_period(const Indexes& indexes, const bt::time_period
 
     for (const idx_t idx : indexes) {
         const auto* vj = data.pt_data->vehicle_journeys[idx];
-        if (!keep_vj(vj, period_to_check)) {
+        if (!keep_vj(vj, period_to_check, rt_level)) {
             continue;
         }
         res.insert(idx);
@@ -203,6 +207,7 @@ Indexes filter_on_period(const Indexes& indexes,
                          const navitia::type::Type_e requested_type,
                          const boost::optional<bt::ptime>& since,
                          const boost::optional<bt::ptime>& until,
+                         const type::RTLevel rt_level,
                          const type::Data& data) {
     if (since && until && until < since) {
         throw ptref_error("invalid filtering period");
@@ -220,7 +225,7 @@ Indexes filter_on_period(const Indexes& indexes,
 
     switch (requested_type) {
         case nt::Type_e::VehicleJourney:
-            return filter_vj_on_period(indexes, period, data);
+            return filter_vj_on_period(indexes, period, rt_level, data);
         case nt::Type_e::Impact:
             return filter_impact_on_period(indexes, period, data);
         default:

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -149,7 +149,7 @@ static bool keep_vj(const type::VehicleJourney* vj, const bt::time_period& perio
 
     const auto& first_departure_dt = vj->earliest_time();
     for (boost::gregorian::day_iterator it(period.begin().date()); it <= period.last().date(); ++it) {
-        if (!vj->validity_patterns[rt_level]->check(*it)) {
+        if ((vj->validity_patterns[rt_level] != nullptr) && !vj->validity_patterns[rt_level]->check(*it)) {
             continue;
         }
         bt::ptime vj_dt = bt::ptime(*it, bt::seconds(first_departure_dt));

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -31,6 +31,7 @@ www.navitia.io
 #pragma once
 
 #include "type/data.h"
+#include "type/rt_level.h"
 
 namespace navitia {
 namespace ptref {
@@ -48,6 +49,7 @@ type::Indexes filter_on_period(const type::Indexes& indexes,
                                const type::Type_e requested_type,
                                const boost::optional<boost::posix_time::ptime>& since,
                                const boost::optional<boost::posix_time::ptime>& until,
+                               const type::RTLevel rt_level,
                                const type::Data& data);
 type::Indexes get_within(const type::Type_e type,
                          const type::GeographicalCoord& coord,

--- a/source/ptreferential/tests/ptref_ng_test.cpp
+++ b/source/ptreferential/tests/ptref_ng_test.cpp
@@ -249,26 +249,26 @@ BOOST_AUTO_TEST_CASE(ng_specific_features) {
     b.vj("B")("stop2", 700)("stop3", 800)("stop4", 900);
     b.vj("C")("stop1", 700)("stop3", 800)("stop5", 900);
     b.make();
-
+    auto rt_level = navitia::type::RTLevel::Base;
     auto indexes = make_query_ng(Type_e::StopArea, "get vehicle_journey <- stop_area.id=stop2", {}, OdtLevel_e::all, {},
-                                 {}, *b.data);
+                                 {}, rt_level, *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, make_indexes({0, 1, 2, 3, 4}));
 
     indexes = make_query_ng(Type_e::StopArea, "(get vehicle_journey <- stop_area.id=stop2) - stop_area.id=stop2", {},
-                            OdtLevel_e::all, {}, {}, *b.data);
+                            OdtLevel_e::all, {}, {}, rt_level, *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, make_indexes({0, 1, 3, 4}));
 
-    indexes = make_query_ng(Type_e::StopArea, "all", {}, OdtLevel_e::all, {}, {}, *b.data);
+    indexes = make_query_ng(Type_e::StopArea, "all", {}, OdtLevel_e::all, {}, {}, rt_level, *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, make_indexes({0, 1, 2, 3, 4, 5}));
 
-    indexes = make_query_ng(Type_e::StopArea, "empty", {}, OdtLevel_e::all, {}, {}, *b.data);
+    indexes = make_query_ng(Type_e::StopArea, "empty", {}, OdtLevel_e::all, {}, {}, rt_level, *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, make_indexes({}));
 
-    indexes = make_query_ng(Type_e::StopArea, "all and empty", {}, OdtLevel_e::all, {}, {}, *b.data);
+    indexes = make_query_ng(Type_e::StopArea, "all and empty", {}, OdtLevel_e::all, {}, {}, rt_level, *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, make_indexes({}));
 
     indexes = make_query_ng(Type_e::StopArea, "stop_area.id=stop2 or stop_area.id=stop5", {}, OdtLevel_e::all, {}, {},
-                            *b.data);
+                            rt_level, *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, make_indexes({2, 5}));
 }
 
@@ -280,8 +280,8 @@ BOOST_AUTO_TEST_CASE(get_connection) {
     b.connection("stop2", "stop1", 50);
     b.make();
 
-    auto indexes =
-        make_query_ng(Type_e::Line, "(get connection <- line.id=A) - line.id=A", {}, OdtLevel_e::all, {}, {}, *b.data);
+    auto indexes = make_query_ng(Type_e::Line, "(get connection <- line.id=A) - line.id=A", {}, OdtLevel_e::all, {}, {},
+                                 navitia::type::RTLevel::Base, *b.data);
     BOOST_REQUIRE_EQUAL(indexes.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.at(*indexes.begin())->uri, "B");
 }
@@ -297,8 +297,8 @@ BOOST_AUTO_TEST_CASE(get_disruption_by_tag) {
                               *b.data->pt_data, *b.data->meta);
     b.make();
 
-    auto indexes =
-        make_query_ng(Type_e::Impact, "disruption.tag=\"my_tag name\"", {}, OdtLevel_e::all, {}, {}, *b.data);
+    auto indexes = make_query_ng(Type_e::Impact, "disruption.tag=\"my_tag name\"", {}, OdtLevel_e::all, {}, {},
+                                 navitia::type::RTLevel::Base, *b.data);
 
     BOOST_REQUIRE_EQUAL(indexes.size(), 1);
 
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_CASE(get_disruptions_with_multiple_tags) {
     b.make();
 
     auto indexes = make_query_ng(Type_e::Impact, "disruption.tags(\"tag_0 name\", \"tag_2 name\")", {}, OdtLevel_e::all,
-                                 {}, {}, *b.data);
+                                 {}, {}, navitia::type::RTLevel::Base, *b.data);
     BOOST_CHECK_EQUAL(indexes.size(), 2);
 
     std::vector<std::string> disruption_names;

--- a/source/ptreferential/tests/vehicle_journey_test.cpp
+++ b/source/ptreferential/tests/vehicle_journey_test.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(frequency_vehicle_journeys_test) {
     navitia::PbCreator pb_creator(data, bt::second_clock::universal_time(), null_time_period);
     navitia::ptref::query_pb(pb_creator, nt::Type_e::VehicleJourney, {}, {}, nt::OdtLevel_e::all, depth, start_page,
                              count, boost::make_optional(true, "20190101T000000"_dt),
-                             boost::make_optional(true, "20190102T000000"_dt), *data);
+                             boost::make_optional(true, "20190102T000000"_dt), navitia::type::RTLevel::Base, *data);
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.vehicle_journeys().size(), 2);
     auto vehicle_journey = resp.vehicle_journeys(0);


### PR DESCRIPTION
After many fails on Artemis tests (guichet_unique_test), parameter 'data_feshness' with 'base_schedule' as default value has to be added for backward compatibility (as for kirin). Api /journeys with parameters &since and &until should return only valid vjs of type base_schedule where as use of &data_fresness=realtime with other two parameter will return also valid vjs modified or added by realtime.

Merged PR with errors on Artemis tests: https://github.com/CanalTP/navitia/pull/2869

Reverted PR: https://github.com/CanalTP/navitia/pull/2872

A test artemis with this build will be realized in futur.

JIRA: https://jira.kisio.org/browse/NAVP-1273