### PR TITLE
ed: fix for out of range in osm2ed

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -86,9 +86,10 @@ void ReadRelationsVisitor::relation_callback(uint64_t osm_id,
                                                      << " is out of date: " << end_date << " (dropped)");
                     return;
                 }
-            } catch (...) {
-                LOG4CPLUS_INFO(logger, "admin '" << tags.find("name")->second << "' with osm_id=" << osm_id
-                                                 << " has an invalid end date: '" << it_end_date->second << "' (kept)");
+            } catch (std::exception& e) {
+                LOG4CPLUS_WARN(logger, "admin '" << tags.find("name")->second << "' with osm_id=" << osm_id
+                                                 << " has an invalid end date (" << e.what() << "): '"
+                                                 << it_end_date->second << "' (kept)");
             }
         }
         for (const CanalTP::Reference& ref : refs) {

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -86,7 +86,7 @@ void ReadRelationsVisitor::relation_callback(uint64_t osm_id,
                                                      << " is out of date: " << end_date << " (dropped)");
                     return;
                 }
-            } catch (boost::bad_lexical_cast& exception) {
+            } catch (...) {
                 LOG4CPLUS_INFO(logger, "admin '" << tags.find("name")->second << "' with osm_id=" << osm_id
                                                  << " has an invalid end date: '" << it_end_date->second << "' (kept)");
             }

--- a/source/ed/tests/osm2ed_test.cpp
+++ b/source/ed/tests/osm2ed_test.cpp
@@ -126,7 +126,8 @@ BOOST_AUTO_TEST_CASE(osm_admin_out_of_range_in_end_date) {
     OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
     ReadRelationsVisitor relations_visitor(cache, false);
 
-    Tags tags = {{"name", "NavitiaCity4"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-31-12"}};
+    Tags tags = {
+        {"name", "NavitiaCity4"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-31-12"}};
     References ref(1, Reference());
 
     relations_visitor.relation_callback(5, tags, ref);
@@ -138,7 +139,8 @@ BOOST_AUTO_TEST_CASE(osm_admin_wrong_day_value_in_end_date) {
     OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
     ReadRelationsVisitor relations_visitor(cache, false);
 
-    Tags tags = {{"name", "NavitiaCity5"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-02-31"}};
+    Tags tags = {
+        {"name", "NavitiaCity5"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-02-31"}};
     References ref(1, Reference());
 
     relations_visitor.relation_callback(5, tags, ref);
@@ -150,7 +152,8 @@ BOOST_AUTO_TEST_CASE(osm_admin_without_zero_in_month_in_end_date) {
     OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
     ReadRelationsVisitor relations_visitor(cache, false);
 
-    Tags tags = {{"name", "NavitiaCity6"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-2-12"}};
+    Tags tags = {
+        {"name", "NavitiaCity6"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-2-12"}};
     References ref(1, Reference());
 
     relations_visitor.relation_callback(5, tags, ref);

--- a/source/ed/tests/osm2ed_test.cpp
+++ b/source/ed/tests/osm2ed_test.cpp
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE(osm_admin_wrong_day_value_in_end_date) {
     BOOST_CHECK(relations_visitor.cache.admins.find(5) != relations_visitor.cache.admins.end());
 }
 
-// Check if the administration is accepted if the "end_date" tag is well-formatted but differently
+// Check if the administration is rejected if the "end_date" tag is well-formatted but differently
 BOOST_AUTO_TEST_CASE(osm_admin_without_zero_in_month_in_end_date) {
     OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
     ReadRelationsVisitor relations_visitor(cache, false);

--- a/source/ed/tests/osm2ed_test.cpp
+++ b/source/ed/tests/osm2ed_test.cpp
@@ -120,3 +120,39 @@ BOOST_AUTO_TEST_CASE(osm_admin_ill_formated_date) {
     relations_visitor.relation_callback(5, tags, ref);
     BOOST_CHECK(relations_visitor.cache.admins.find(5) != relations_visitor.cache.admins.end());
 }
+
+// Check if the administration is accepted if the "end_date" tag is well-formatted with out of range value
+BOOST_AUTO_TEST_CASE(osm_admin_out_of_range_in_end_date) {
+    OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
+    ReadRelationsVisitor relations_visitor(cache, false);
+
+    Tags tags = {{"name", "NavitiaCity4"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-31-12"}};
+    References ref(1, Reference());
+
+    relations_visitor.relation_callback(5, tags, ref);
+    BOOST_CHECK(relations_visitor.cache.admins.find(5) != relations_visitor.cache.admins.end());
+}
+
+// Check if the administration is accepted if the "end_date" tag is well-formatted with wrong day value
+BOOST_AUTO_TEST_CASE(osm_admin_wrong_day_value_in_end_date) {
+    OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
+    ReadRelationsVisitor relations_visitor(cache, false);
+
+    Tags tags = {{"name", "NavitiaCity5"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-02-31"}};
+    References ref(1, Reference());
+
+    relations_visitor.relation_callback(5, tags, ref);
+    BOOST_CHECK(relations_visitor.cache.admins.find(5) != relations_visitor.cache.admins.end());
+}
+
+// Check if the administration is accepted if the "end_date" tag is well-formatted but differently
+BOOST_AUTO_TEST_CASE(osm_admin_without_zero_in_month_in_end_date) {
+    OSMCache cache(std::unique_ptr<Lotus>(), boost::none);
+    ReadRelationsVisitor relations_visitor(cache, false);
+
+    Tags tags = {{"name", "NavitiaCity6"}, {"admin_level", "9"}, {"boundary", "administrative"}, {"end_date", "2000-2-12"}};
+    References ref(1, Reference());
+
+    relations_visitor.relation_callback(5, tags, ref);
+    BOOST_CHECK(relations_visitor.cache.admins.find(5) == relations_visitor.cache.admins.end());
+}


### PR DESCRIPTION
Following error during deployment on dev_bina, catch all exception from gregorian::date