### PR TITLE
Ed: Fix warning in osm2ed

### DIFF
--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -797,7 +797,7 @@ Admin::Admin(u_int64_t id,
     this->center = center;
 }
 
-Admin::~Admin(){};
+Admin::~Admin() {}
 
 OSMAdminRelation::OSMAdminRelation(u_int64_t id,
                                    const std::string& uri,


### PR DESCRIPTION
Fix annoying warning :
`osm2ed.cpp:800:18: warning: extra ‘;’ [-Wpedantic]
 Admin::~Admin(){};`