### PR TITLE
PTRef: Building missing relations on ptref added by realtime

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1920,6 +1920,44 @@ class TestPtRefOnAddedTrip(MockKirinDisruptionsFixture):
         assert status == 404
         assert resp['error']['message'] == 'ptref : Filters: Unable to find object'
 
+        # The following ptref search should work with theorical data.
+        # network <-> datasets
+        resp = self.query_region("networks/base_network/datasets")
+        assert resp["datasets"][0]["id"] == "default:dataset"
+        resp = self.query_region("datasets/default:dataset/networks")
+        assert resp["networks"][0]["id"] == "base_network"
+
+        # line <-> company
+        resp = self.query_region("lines/A/companies")
+        assert resp["companies"][0]["id"] == "base_company"
+        resp = self.query_region("companies/base_company/lines")
+        assert resp["lines"][0]["id"] == "A"
+
+        # company <-> commercial_modes
+        resp = self.query_region("companies/base_company/commercial_modes")
+        assert resp['commercial_modes'][0]['id'] == '0x0'
+        resp = self.query_region("commercial_modes/0x0/companies")
+        assert resp["companies"][0]["id"] == "base_company"
+
+        # route <-> dataset
+        resp = self.query_region("routes/B:3/datasets")
+        assert resp["datasets"][0]["id"] == "default:dataset"
+        resp = self.query_region("datasets/default:dataset/routes")
+        routes = [rt["id"] for rt in resp["routes"]]
+        assert "B:3" in routes
+
+        # vehicle_journey <-> company
+        resp = self.query_region("vehicle_journeys/vehicle_journey:vjA/companies")
+        assert resp["companies"][0]["id"] == "base_company"
+        resp = self.query_region("companies/base_company/vehicle_journeys")
+        assert len(resp["vehicle_journeys"]) == 8
+
+        # network <-> contributor
+        resp = self.query_region("networks/base_network/contributors")
+        assert resp["contributors"][0]["id"] == "default:contributor"
+        resp = self.query_region("contributors/default:contributor/networks")
+        assert resp["networks"][0]["id"] == "base_network"
+
         # New disruption, a new trip with 2 stop_times in realtime
         self.send_mock(
             "additional-trip",
@@ -1996,92 +2034,41 @@ class TestPtRefOnAddedTrip(MockKirinDisruptionsFixture):
         )
         assert resp["physical_modes"][0]["id"] == "physical_mode:Bus"
 
-        # The following ptref search should work with theorical data.
+        # The following ptref search should work with a trip added.
         # network <-> datasets
-        resp = self.query_region("networks/base_network/datasets")
+        resp = self.query_region("networks/network:additional_service/datasets")
         assert resp["datasets"][0]["id"] == "default:dataset"
         resp = self.query_region("datasets/default:dataset/networks")
-        assert resp["networks"][0]["id"] == "base_network"
-
-        # line <-> company
-        resp, status = self.query_region("lines/A/companies", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
-        resp, status = self.query_region("companies/base_company/lines", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
-
-        # company <-> commercial_modes
-        resp, status = self.query_region("companies/base_company/commercial_modes", check=False)
-        assert status == 404
-        assert resp['error']['message'] == 'ptref : Filters: Unable to find object'
-        resp, status = self.query_region("commercial_modes/Bike/companies", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
+        networks = [nw["id"] for nw in resp["networks"]]
+        assert "network:additional_service" in networks
 
         # route <-> dataset
-        resp = self.query_region("routes/B:3/datasets")
+        resp = self.query_region("routes/route:stopC_stopB/datasets")
         assert resp["datasets"][0]["id"] == "default:dataset"
         resp = self.query_region("datasets/default:dataset/routes")
         routes = [rt["id"] for rt in resp["routes"]]
-        assert "B:3" in routes
-
-        # vehicle_journey <-> company
-        resp = self.query_region("vehicle_journeys/vehicle_journey:vjA/companies")
-        assert resp["companies"][0]["id"] == "base_company"
-        resp, status = self.query_region("companies/base_company/vehicle_journeys", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
+        assert "route:stopC_stopB" in routes
 
         # network <-> contributor
-        resp = self.query_region("networks/base_network/contributors")
+        resp = self.query_region("networks/network:additional_service/contributors")
         assert resp["contributors"][0]["id"] == "default:contributor"
         resp = self.query_region("contributors/default:contributor/networks")
-        assert resp["networks"][0]["id"] == "base_network"
-
-        # The following ptref search should work with a trip added.
-        # network <-> datasets: use of data->build_relations() in maintenance_worker works
-        resp, status = self.query_region("networks/network:additional_service/datasets", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
-        resp = self.query_region("datasets/default:dataset/networks")
         networks = [nw["id"] for nw in resp["networks"]]
-        assert "network:additional_service" not in networks
+        assert "network:additional_service" in networks
 
-        # route <-> dataset: use of data->build_relations() in maintenance_worker works
-        resp, status = self.query_region("routes/route:stopC_stopB/datasets", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
-        resp = self.query_region("datasets/default:dataset/routes")
-        routes = [rt["id"] for rt in resp["routes"]]
-        assert "route:stopC_stopB" not in routes
-
-        # network <-> contributor: use of data->build_relations() in maintenance_worker works
-        resp, status = self.query_region("networks/network:additional_service/contributors", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
-        resp = self.query_region("contributors/default:contributor/networks")
-        networks = [nw["id"] for nw in resp["networks"]]
-        assert "network:additional_service" not in networks
-
-        # line <-> company: Line.company_list/Company.line_list is filled in the function
-        # EdReader::fill_vehicle_journeys only and is used only during generation theoretical data.
-        resp, status = self.query_region("lines/line:stopC_stopB/companies", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
-        resp, status = self.query_region("companies/base_company/lines", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
+        # line <-> company
+        resp = self.query_region("lines/line:stopC_stopB/companies")
+        assert resp["companies"][0]["id"] == "base_company"
+        resp = self.query_region("companies/base_company/lines")
+        assert resp["lines"][6]["id"] == "line:stopC_stopB"
 
         # vehicle_journey <-> company
         resp = self.query_region(
             "vehicle_journeys/vehicle_journey:additional-trip:modified:0:new_trip/companies"
         )
         assert resp["companies"][0]["id"] == "base_company"
-        # company -> vehicle_journey doesn't work as it's done in EdReader::fill_vehicle_journeys only
-        resp, status = self.query_region("companies/base_company/vehicle_journeys", check=False)
-        assert status == 404
-        assert resp["error"]["message"] == "ptref : Filters: Unable to find object"
+        resp = self.query_region("companies/base_company/vehicle_journeys")
+        assert len(resp["vehicle_journeys"]) == 9
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING)

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -121,7 +121,7 @@ public:
             // to reload the data
             try {
                 data->load_disruptions(*chaos_database, contributors);
-                data->build_autocomplete();
+                data->build_autocomplete_partial();
             } catch (const navitia::data::disruptions_broken_connection&) {
                 LOG4CPLUS_WARN(logger, "Load data without disruptions");
             } catch (const navitia::data::disruptions_loading_error&) {

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -196,6 +196,8 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         }
     }
     if (data) {
+        LOG4CPLUS_INFO(logger, "rebuilding relations");
+        data->build_relations();
         LOG4CPLUS_INFO(logger, "rebuilding autocomplete");
         data->build_autocomplete();
         LOG4CPLUS_INFO(logger, "cleaning weak impacts");

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -199,7 +199,7 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         LOG4CPLUS_INFO(logger, "rebuilding relations");
         data->build_relations();
         LOG4CPLUS_INFO(logger, "rebuilding autocomplete");
-        data->build_autocomplete();
+        data->build_autocomplete_partial();
         LOG4CPLUS_INFO(logger, "cleaning weak impacts");
         data->pt_data->clean_weak_impacts();
         LOG4CPLUS_INFO(logger, "rebuilding data raptor");

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -45,7 +45,7 @@ public:
     void load_disruptions(const std::string&, const std::vector<std::string>& = {}) {}
     void build_raptor(size_t) {}
     void build_proximity_list() {}
-    void build_autocomplete() {}
+    void build_autocomplete_partial() {}
     mutable std::atomic<bool> loading;
     mutable std::atomic<bool> is_connected_to_rabbitmq;
     static bool load_status;

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -318,9 +318,8 @@ void Data::build_administrative_regions() {
 }
 
 void Data::build_autocomplete() {
-    pt_data->build_autocomplete(*geo_ref);
     geo_ref->build_autocomplete_list();
-    pt_data->compute_score_autocomplete(*geo_ref);
+    build_autocomplete_partial();
 }
 
 void Data::build_autocomplete_partial() {

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -323,6 +323,11 @@ void Data::build_autocomplete() {
     pt_data->compute_score_autocomplete(*geo_ref);
 }
 
+void Data::build_autocomplete_partial() {
+    pt_data->build_autocomplete(*geo_ref);
+    pt_data->compute_score_autocomplete(*geo_ref);
+}
+
 ValidityPattern* Data::get_similar_validity_pattern(ValidityPattern* vp) const {
     auto find_vp_predicate = [&](ValidityPattern* vp1) { return ((*vp) == (*vp1)); };
     auto it = std::find_if(this->pt_data->validity_patterns.begin(), this->pt_data->validity_patterns.end(),

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -430,6 +430,17 @@ static void build_datasets(navitia::type::VehicleJourney* vj) {
     }
 }
 
+static void build_companies(navitia::type::VehicleJourney* vj) {
+    if (vj->company) {
+        if (boost::range::find(vj->route->line->company_list, vj->company) == vj->route->line->company_list.end()) {
+            vj->route->line->company_list.push_back(vj->company);
+        }
+        if (boost::range::find(vj->company->line_list, vj->route->line) == vj->company->line_list.end()) {
+            vj->company->line_list.push_back(vj->route->line);
+        }
+    }
+}
+
 void Data::build_relations() {
     // physical_mode_list of line
     for (auto* vj : pt_data->vehicle_journeys) {
@@ -437,6 +448,7 @@ void Data::build_relations() {
         if (!vj->physical_mode || !vj->route || !vj->route->line) {
             continue;
         }
+        build_companies(vj);
         if (!navitia::contains(vj->route->line->physical_mode_list, vj->physical_mode)) {
             vj->route->line->physical_mode_list.push_back(vj->physical_mode);
         }

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -211,6 +211,7 @@ public:
 
     /** Build Autocomplete index */
     void build_autocomplete();
+    void build_autocomplete_partial();
 
     /** Build ProximityList index */
     void build_proximity_list();


### PR DESCRIPTION
Concerned ticket: https://jira.kisio.org/browse/NAVP-1270

**Durations in MS for Guichet Unique data:** 

| build_relations  | build_autocomplete | build_raptor | Total |
| ------------- | ------------- | ------------- | ------------- |
| 114 | 28165  |1218 | 29976 |
| 118  | 26361  | 1231  | 28641  |
| 105  | 26663  | 1288  | 29138  |
| 93  | 26104  | 1230  | 28339  |

**Durations in MS for Transilien data:**
 
| build_relations  | build_autocomplete | build_raptor | Total |
| ------------- | ------------- | ------------- | ------------- |
| 126 | **40773** | 4439 | 46439 |
| 127 | **40046** | 4404 | 46589 |

**Durations in MS for Transilien data with optimization:**
 
| build_relations  | build_autocomplete | build_raptor | Total |
| ------------- | ------------- | ------------- | ------------- |
| 124 | **12947** | 4445 | 18663 |
| 122 | **12977** | 4312 | 18863 |

Follow-up on #2824 
