### PR TITLE
Jormun: Expose frequency informations inside vehicle journeys

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -547,7 +547,13 @@ class VehicleJourneySerializer(PbGenericSerializer):
     disruptions = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
     start_time = TimeField(display_none=False)
     end_time = TimeField(display_none=False)
-    headway_secs = jsonschema.Field(schema_type=int, display_none=False)
+    headway_secs = jsonschema.MethodField(schema_type=int, display_none=False)
+
+    def get_headway_secs(self, obj):
+        if obj.HasField(str('headway_secs')):
+            return obj.headway_secs
+        else:
+            return None
 
 
 class ConnectionSerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -545,6 +545,9 @@ class VehicleJourneySerializer(PbGenericSerializer):
     calendars = CalendarSerializer(many=True)
     trip = TripSerializer()
     disruptions = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
+    start_time = TimeField(display_none=False)
+    end_time = TimeField(display_none=False)
+    headway_secs = jsonschema.Field(schema_type=int, display_none=False)
 
 
 class ConnectionSerializer(PbNestedSerializer):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -165,6 +165,15 @@ class TestPtRef(AbstractTestFixture):
         assert vjs[0]['end_time'] == '110000'
         assert vjs[0]['headway_secs'] == 600  # a 10 min step
 
+        # with a not frequency VJ
+        response = self.query_region('lines/line:A/vehicle_journeys?depth=3')
+        vjs = get_not_null(response, 'vehicle_journeys')
+
+        assert len(vjs) == 1
+        assert not 'start_time' in vjs[0]
+        assert not 'end_time' in vjs[0]
+        assert not 'headway_secs' in vjs[0]
+
     def test_vj_show_codes_propagation(self):
         """stop_area:stop1 has a code, we should be able to find it when accessing it by the vj"""
         response = self.query_region("stop_areas/stop_area:stop1/vehicle_journeys")

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -81,7 +81,7 @@ class TestPtRef(AbstractTestFixture):
         for vj in vjs:
             is_valid_vehicle_journey(vj, depth_check=1)
 
-        assert len(vjs) == 3
+        assert len(vjs) == 4
         vj = vjs[0]
         assert vj['id'] == 'vehicle_journey:vj1'
 
@@ -149,6 +149,21 @@ class TestPtRef(AbstractTestFixture):
 
         for vj in vjs:
             is_valid_vehicle_journey(vj, depth_check=3)
+
+    def test_frequency_vj(self):
+        """
+        The response should have 3 optional fields
+            start_time
+            end_time
+            headway_secs
+        """
+        response = self.query_region('lines/line:freq/vehicle_journeys?depth=3')
+        vjs = get_not_null(response, 'vehicle_journeys')
+
+        assert len(vjs) == 1
+        assert vjs[0]['start_time'] == '100000'
+        assert vjs[0]['end_time'] == '110000'
+        assert vjs[0]['headway_secs'] == 600  # a 10 min step
 
     def test_vj_show_codes_propagation(self):
         """stop_area:stop1 has a code, we should be able to find it when accessing it by the vj"""
@@ -266,7 +281,7 @@ class TestPtRef(AbstractTestFixture):
 
         lines = get_not_null(response, 'lines')
 
-        assert len(lines) == 3
+        assert len(lines) == 4
 
         l = lines[0]
 
@@ -303,7 +318,7 @@ class TestPtRef(AbstractTestFixture):
         response = self.query_region("lines?disable_geojson=true")
         lines = get_not_null(response, 'lines')
 
-        assert len(lines) == 3
+        assert len(lines) == 4
         l = lines[0]
         is_valid_line(l, depth_check=1)
         # we don't want a geojson since we have desactivate them
@@ -312,7 +327,7 @@ class TestPtRef(AbstractTestFixture):
         response = self.query_region("lines")
         lines = get_not_null(response, 'lines')
 
-        assert len(lines) == 3
+        assert len(lines) == 4
         l = lines[0]
         is_valid_line(l, depth_check=1)
 
@@ -327,7 +342,7 @@ class TestPtRef(AbstractTestFixture):
 
         lines = get_not_null(response, 'lines')
 
-        assert len(lines) == 3
+        assert len(lines) == 4
 
         l = lines[0]
 
@@ -401,7 +416,7 @@ class TestPtRef(AbstractTestFixture):
         response = self.query_region("routes")
 
         routes = get_not_null(response, 'routes')
-        assert len(routes) == 3
+        assert len(routes) == 4
 
         r = [r for r in routes if r['id'] == 'line:A:0']
         assert len(r) == 1
@@ -490,7 +505,7 @@ class TestPtRef(AbstractTestFixture):
         response = self.query_region("lines")
 
         lines = get_not_null(response, 'lines')
-        assert len(lines) == 3
+        assert len(lines) == 4
 
         assert len(lines[0]['physical_modes']) == 1
         assert lines[0]['physical_modes'][0]['id'] == 'physical_mode:Car'
@@ -699,7 +714,7 @@ class TestPtRef(AbstractTestFixture):
 
         i = i_manager.instances['main_ptref_test']
 
-        assert len([r for r in i.ptref.get_objs(type_pb2.ROUTE)]) == 3
+        assert len([r for r in i.ptref.get_objs(type_pb2.ROUTE)]) == 4
 
     def test_ptref_on_stop_areas_with_disable_disruption(self):
         """

--- a/source/tests/main_ptref_test.cpp
+++ b/source/tests/main_ptref_test.cpp
@@ -109,6 +109,10 @@ struct data_set {
             r->destination = b.sas.find("stop_area:stop1")->second;
         }
 
+        b.frequency_vj("line:freq", "10:00:00"_t, "11:00:00"_t, "00:10:00"_t, "network:freq", "1")
+            .name("vj:freq")("stop_area:stop2", "10:00:00"_t, "10:00:00"_t)("stop_area:stop1", "10:05:00"_t,
+                                                                            "10:05:00"_t);
+
         // Company added
         navitia::type::Company* cmp1 = new navitia::type::Company();
         cmp1->line_list.push_back(b.lines["line:A"]);


### PR DESCRIPTION
Related to https://github.com/CanalTP/navitia/pull/2873
and https://github.com/CanalTP/navitia/pull/2868

This is the last PR of the quest. 
- We expose now _frequency VJ_ informations into Jormun response
- Integration test are available :crossed_swords: 
- Updated the other test with new freq VJ (Now 4 Vjs)

**QA** part :

screenshot of a local test with **fr-auv** coverage

![frequency_vj](https://user-images.githubusercontent.com/32099204/61778025-486e5700-adfe-11e9-9cd9-828bbfc6a9b0.png)


