### PR TITLE
tyr: do not try to import data in mimir if there is no mimir

### DIFF
--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -133,7 +133,7 @@ CELERYBEAT_SCHEDULE_FILENAME = '/tmp/celerybeat-schedule'
 
 CELERYD_HIJACK_ROOT_LOGGER = False
 
-MIMIR_URL = os.getenv('TYR_MIMIR_URL', 'http://localhost:9200')
+MIMIR_URL = os.getenv('TYR_MIMIR_URL', None)
 
 # we don't enable serpy for now
 USE_SERPY = False

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -178,6 +178,10 @@ def send_to_mimir(instance, filename):
 
     returns action list
     """
+    if not current_app.config.get('MIMIR_URL'):
+        # if mimir isn't setup do not try to import data for the autocompletion
+        return []
+
     # This test is to avoid creating a new job if there is no action on mimir.
     if not (instance.import_ntfs_in_mimir or instance.import_stops_in_mimir):
         return []


### PR DESCRIPTION
job like ntfs2mimir will fail miserably if mimir isn't configured.
Deployment fail because of this.

This PR will conflict with #2894, tests must be added once this PR is
merged