### PR TITLE
Jormun: call realtime proxy in parallel

### DIFF
--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -333,10 +333,28 @@ class MixedSchedule(object):
         if request['data_freshness'] != RT_PROXY_DATA_FRESHNESS:
             return resp
 
+        futures = []
+        pool = gevent.pool.Pool(self.instance.realtime_pool_size)
+
+        # Copy the current request context to be used in greenlet
+        reqctx = utils.copy_flask_request_context()
+
+        def worker(rt_proxy, route_point, request, stop_schedule):
+            # Use the copied request context in greenlet
+            with utils.copy_context_in_greenlet_stack(reqctx):
+                return (
+                    rt_proxy,
+                    stop_schedule,
+                    self._get_next_realtime_passages(rt_proxy, route_point, request),
+                )
+
         for stop_schedule in resp.stop_schedules:
             route_point = _get_route_point_from_stop_schedule(stop_schedule)
             rt_proxy = self._get_realtime_proxy(route_point)
             if rt_proxy:
-                next_rt_passages = self._get_next_realtime_passages(rt_proxy, route_point, request)
-                rt_proxy._update_stop_schedule(stop_schedule, next_rt_passages)
+                futures.append(pool.spawn(worker, rt_proxy, route_point, request, stop_schedule))
+
+        for future in gevent.iwait(futures):
+            rt_proxy, stop_schedule, next_rt_passages = future.get()
+            rt_proxy._update_stop_schedule(stop_schedule, next_rt_passages)
         return resp


### PR DESCRIPTION
In stop_schedules call to realtime proxies was done in serial, this PR
make theses call in parallel with gevent.
This will reduce the response time of `/stop_schedules`