### PR TITLE
kraken: Avoid duplicate fields into last street network section

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -882,7 +882,6 @@ void make_pathes(PbCreator& pb_creator,
                     pb_creator.action_period =
                         bt::time_period(navitia::from_posix_timestamp(section->begin_date_time()),
                                         navitia::from_posix_timestamp(section->end_date_time() + 1));
-                    pb_creator.fill(arrival_stop_point, section->mutable_origin(), 2);
                 }
 
                 // We add coherence with the destination object of the request

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1294,13 +1294,14 @@ BOOST_FIXTURE_TEST_CASE(car_parking_bus, streetnetworkmode_fixture<test_speed_pr
     // section 3: PT B->A
     BOOST_CHECK_EQUAL(sections.Get(3).type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
     BOOST_CHECK_EQUAL(sections.Get(3).origin().name(), "stop_point:stopB (Condom)");
+    BOOST_REQUIRE_EQUAL(sections.Get(3).destination().stop_point().codes().size(), 5);
     BOOST_CHECK_EQUAL(sections.Get(3).destination().name(), "stop_point:stopA (Condom)");
 
     // section 4: goto R
     BOOST_CHECK_EQUAL(sections.Get(4).type(), pbnavitia::SectionType::STREET_NETWORK);
     BOOST_CHECK_EQUAL(sections.Get(4).origin().name(), "stop_point:stopA (Condom)");
-    // BOOST_CHECK_EQUAL(sections.Get(4).origin().address().name(), "rue bd");
     BOOST_CHECK_EQUAL(sections.Get(4).destination().address().name(), "rue ag");
+    BOOST_REQUIRE_EQUAL(sections.Get(4).origin().stop_point().codes().size(), 5);
     BOOST_CHECK_EQUAL(sections.Get(4).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
     BOOST_CHECK_EQUAL(sections.Get(4).street_network().duration(), 90);
     const auto pathitems4 = sections.Get(4).street_network().path_items();


### PR DESCRIPTION
**JIRA** : https://jira.kisio.org/browse/NAVITIAII-2791
Fix a bug which is introducing by writing twice, inside the *last street network section* (into *from/stop_point*), in a journey.

![x2](https://user-images.githubusercontent.com/32099204/62079999-1458c300-b250-11e9-89c2-a5fbc3e804f5.png)

This bug is introduce because, when we fill the *last_protobuf_street_network_section->from->stop_point* twice, we add twice inside **repeated protobuf** fields (like *equipments, codes, etc...*). 
You can see the *StopPoint protobuf* [here](https://github.com/CanalTP/navitia-proto/blob/master/type.proto#L253).
So, the problem is to *call twice* the [fill stop_point function](https://github.com/CanalTP/navitia/blob/dev/source/type/pb_converter.cpp#L562), that fulfill this part, when we create the last street network section.

All protobuf creation is inside **make_pathes** function (*raptor_api.cpp*)
I identified the call too much into this logic :dart:, precisely [here](https://github.com/CanalTP/navitia/compare/dev...benoit-bst:erase_duplicate_field_into_last_street_network_section?expand=1#diff-ff96ef579b6f85489dec9c8a3ad480f6L885). 
If we read the piece of code, above, it tells us the following story :

* If we have a *street network path*, for the arrival (`else if (!sn_arrival_path.path_items.empty())` is our case), 
we call [pb_creator.fill_street_sections(destination, sn_arrival_path, pb_journey, begin_section_time);](https://github.com/CanalTP/navitia/blob/dev/source/routing/raptor_api.cpp#L876) 
this function calls in turn [auto section = create_section(pb_journey, path.path_items.front(), depth);](https://github.com/CanalTP/navitia/blob/dev/source/routing/raptor_api.cpp#L876)
now this new sub function creates the desired street network section, and especially fills its **origin** (the **from** field) with a [copy](https://github.com/CanalTP/navitia/blob/dev/source/type/pb_converter.cpp#L1881) of the **destination prev section** inside the **origin** of the new section.
So, **origin** is currently filled. 
No need to fill again with [pb_creator.fill(arrival_stop_point, section->mutable_origin(), 2);](https://github.com/CanalTP/navitia/compare/dev...benoit-bst:erase_duplicate_field_into_last_street_network_section?expand=1#diff-ff96ef579b6f85489dec9c8a3ad480f6L885)

I hope this will help you to figure out :dove: 

**QA part** :
Tested a lot of combination with success

| coverage  | from type | to type | result |
| ------------- | ------------- | ------------- | ------------- |
| fr-idf  | Stop_area | coord | fixed |
| fr-idf  | coord | coord | fixed |
| fr-se-lyon  | Stop_area  | coord | fixed |
| fr-se-lyon  | coord  | coord | fixed |

