### PR TITLE
PTRef: Update grammar doc and behavior of param data_freshness for since/until

### DIFF
--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -72,9 +72,9 @@ In the following table, if the invocation starts with `collection`, any collecti
 |`disruption.between(since, until)`|all the disruptions that are active during the `[since, until]` period|`since` and `until` must be UTC datetime in the ISO 8601 format (ending with `Z`)|
 |`disruption.since(since)`|all the disruptions that are active after the given datetime|as above|
 |`disruption.until(until)`|all the disruptions that are active before the given datetime|as above|
-|`vehicle_journey.between(since, until)`|all the vehicle journeys that start during the `[since, until]` period|as above|
-|`vehicle_journey.since(since)`|all the vehicle journeys that start after the given datetime|as above|
-|`vehicle_journey.until(until)`|all the vehicle journeys that start before the given datetime|as above|
+|`vehicle_journey.between(since, until, data_freshness)`|all the vehicle journeys that start during the `[since, until]` period|`since` and `until` must be UTC datetime in the ISO 8601 format (ending with `Z`)</br>Additional `data_freshness` parameter allows to get only the vehicle journeys valid for the data freshness level requested (`base_schedule`, `adapted_schedule`, `realtime`)|
+|`vehicle_journey.since(since, data_freshness)`|all the vehicle journeys that start after the given datetime|as above|
+|`vehicle_journey.until(until, data_freshness)`|all the vehicle journeys that start before the given datetime|as above|
 |`vehicle_journey.has_disruption()`|all the vehicle journeys containing at least a disruption ||
 |`vehicle_journey.has_headsign(headsign)`|all the vehicle journeys containing the given headsign ||
 |`line.code(code)`|all the lines containing the given code|this predicate use the field `line.code`, not `line.codes[]`|

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -115,11 +115,12 @@ class Uri(ResourceUri, ResourceUtc):
         )
         parser.add_argument(
             "data_freshness",
-            help="Define the freshness of data to use to compute vehicle_journeys "
+            help="Define the freshness of data to use to filter vehicle_journeys "
             "along with parameters &since and/or &until .\n"
-            "When using `&data_freshness=base_schedule` you get original vehicle_journeys "
-            "where as when using `&data_freshness=realtime` you get vehicle_journeys "
-            "added or modified by realtime.",
+            "Provides only the vehicle_journeys valid for the data freshness level requested.\n"
+            "Using `&data_freshness=base_schedule` will return all original vehicle_journeys only"
+            "whereas using `&data_freshness=realtime` will return vehicle_journeys after applying"
+            "modifications by realtime (amended vehicle_journeys, and non-impacted original vehicle_journeys).",
             type=OptionValue(['base_schedule', 'adapted_schedule', 'realtime']),
             default='base_schedule',
         )

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1641,7 +1641,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
         base_journey_query = B_C_query + "&data_freshness=realtime&_current_datetime=20120614T080000"
 
         # There is a public transport from B to C with realtime having only two stop_date_times
-        # as the stop deleted for detour should not be displayed
+        # as the deleted-for-detour stop should not be displayed
         response = self.query_region(base_journey_query)
         assert len(response['journeys']) == 2
         assert response['journeys'][0]['status'] == 'DETOUR'
@@ -1970,7 +1970,7 @@ class TestPtRefOnAddedTrip(MockKirinDisruptionsFixture):
         1. Test all possibles ptref calls with/without filters before adding a new trip
         2. Test all possibles ptref calls with/without filters after adding a new trip
         3. Test all possibles ptref calls with/without filters after modifying the recently added trip
-        Note: physical_mode is present in gtfs-rt where as for network and commercial_mode default value is used
+        Note: physical_mode is present in gtfs-rt whereas for network and commercial_mode default value is used
         """
         disruption_query = 'disruptions?_current_datetime={dt}'.format(dt='20120614T080000')
         disruptions_before = self.query_region(disruption_query)

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -211,20 +211,20 @@ OdtLevel_e odt_level_from_string(const std::string& s) {
 const char* rt_level_to_string(RTLevel rt_level) {
     switch (rt_level) {
         case type::RTLevel::Base:
-            return "base";
+            return "base_schedule";
         case type::RTLevel::Adapted:
-            return "adapted";
+            return "adapted_schedule";
         case type::RTLevel::RealTime:
             return "realtime";
         default:
-            return "base";
+            return "base_schedule";
     }
 }
 
 RTLevel rt_level_from_string(const std::string& s) {
     if (s == "realtime") {
         return RTLevel::RealTime;
-    } else if (s == "adapted") {
+    } else if (s == "adapted_schedule") {
         return RTLevel::Adapted;
     } else {
         return RTLevel::Base;

--- a/source/ptreferential/tests/ptref_ng_test.cpp
+++ b/source/ptreferential/tests/ptref_ng_test.cpp
@@ -189,11 +189,11 @@ BOOST_AUTO_TEST_CASE(make_request_since_until) {
     assert_since_until(Type_e::Line, "", "", "", RTLevel::Base, "all");
     assert_since_until(Type_e::Line, "", "20180714T1337", "20180714T1338", RTLevel::Base, "all");
     assert_since_until(Type_e::VehicleJourney, "", "20180714T1337", "20180714T1338", RTLevel::Base,
-                       R"((all AND vehicle_journey.between("20180714T133700Z", "20180714T133800Z", "base")))");
+                       R"((all AND vehicle_journey.between("20180714T133700Z", "20180714T133800Z", "base_schedule")))");
     assert_since_until(Type_e::VehicleJourney, "", "20180714T1337", "", RTLevel::RealTime,
                        R"((all AND vehicle_journey.since("20180714T133700Z", "realtime")))");
     assert_since_until(Type_e::VehicleJourney, "", "", "20180714T1338", RTLevel::Base,
-                       R"((all AND vehicle_journey.until("20180714T133800Z", "base")))");
+                       R"((all AND vehicle_journey.until("20180714T133800Z", "base_schedule")))");
     assert_since_until(Type_e::Impact, "", "20180714T1337", "20180714T1338", RTLevel::RealTime,
                        R"((all AND disruption.between("20180714T133700Z", "20180714T133800Z", "realtime")))");
     assert_since_until(Type_e::Impact, "", "20180714T1337", "", RTLevel::Base,

--- a/source/ptreferential/tests/ptref_ng_test.cpp
+++ b/source/ptreferential/tests/ptref_ng_test.cpp
@@ -195,13 +195,13 @@ BOOST_AUTO_TEST_CASE(make_request_since_until) {
     assert_since_until(Type_e::VehicleJourney, "", "", "20180714T1338", RTLevel::Base,
                        R"((all AND vehicle_journey.until("20180714T133800Z", "base_schedule")))");
     assert_since_until(Type_e::Impact, "", "20180714T1337", "20180714T1338", RTLevel::RealTime,
-                       R"((all AND disruption.between("20180714T133700Z", "20180714T133800Z", "realtime")))");
+                       R"((all AND disruption.between("20180714T133700Z", "20180714T133800Z")))");
     assert_since_until(Type_e::Impact, "", "20180714T1337", "", RTLevel::Base,
-                       R"((all AND disruption.since("20180714T133700Z", "base")))");
+                       R"((all AND disruption.since("20180714T133700Z")))");
     assert_since_until(Type_e::Impact, "", "", "20180714T1338", RTLevel::Base,
-                       R"((all AND disruption.until("20180714T133800Z", "base")))");
+                       R"((all AND disruption.until("20180714T133800Z")))");
     assert_since_until(Type_e::Impact, "all or all", "", "20180714T1338", RTLevel::Adapted,
-                       R"(((all OR all) AND disruption.until("20180714T133800Z", "adapted")))");
+                       R"(((all OR all) AND disruption.until("20180714T133800Z")))");
 }
 
 static void assert_forbidden(const Type_e requested_type,
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(make_request_since_forbidden_uris) {
                                   boost::posix_time::from_iso_string("20180714T1337"), {}, {}, *b.data);
     assert_expr(
         req,
-        R"((((all OR all) AND disruption.since("20180714T133700Z", "base")) - (commercial_mode.id("Bus") OR commercial_mode.id("0x1"))))");
+        R"((((all OR all) AND disruption.since("20180714T133700Z")) - (commercial_mode.id("Bus") OR commercial_mode.id("0x1"))))");
 }
 
 BOOST_AUTO_TEST_CASE(ng_specific_features) {


### PR DESCRIPTION
After PR https://github.com/CanalTP/navitia/pull/2878
JIRA https://jira.kisio.org/browse/NAVP-1273

Documenting the add of `data_freshness` param to the `since`/`until` methods of PTRef **grammar**.
Also:
* Renaming RTLevels in **grammar** to the ones used in jormun, as they are exposed
* Removing from **grammar** the mandatory `data_freshness` param on disruptions (as it does not make sense to have it on anything else than VJ).

:mag: can be reviewed by commit