### PR TITLE
Tyr: Add required default value before downgrade migration

### DIFF
--- a/source/tyr/migrations/versions/266658781c00_instances_nullable_in_equipments_provider.py
+++ b/source/tyr/migrations/versions/266658781c00_instances_nullable_in_equipments_provider.py
@@ -21,6 +21,7 @@ def upgrade():
 
 
 def downgrade():
+    op.execute("UPDATE equipments_provider SET instances = '{null_instance}';")
     op.alter_column(
         'equipments_provider', 'instances', existing_type=postgresql.ARRAY(sa.TEXT()), nullable=False
     )


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVP-1302

To avoid a crash when downgrading db with value `nullable=True` to `nullable=False`, add a default value.
Crash not seen in tests because every rows are deleted before downgrade. 
Fix tested manually