### PR TITLE
Doc: Update for equipment_reports

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1554,10 +1554,9 @@ This endpoint gives you access to time tables going through a stop
 point as:
 ![stop_schedules](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg/640px-Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg)
 
-The response is made of an array of [stop_schedule](#stop-schedule), and another
-one of [note](#note).
-[Context](#context) object provides the `current_datetime`, useful to compute waiting time when requesting Navitia without a `from_datetime`.
-You can access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource}/stop_schedules>
+The response is made of an array of [stop_schedule](#stop-schedule), and another one of [note](#note).  
+[Context](#context) object provides the `current_datetime`, useful to compute waiting time when requesting Navitia without a `from_datetime`.  
+Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/stop_schedules>
 
 See how disruptions affect stop schedules in the [real time](#realtime) section.
 
@@ -1783,14 +1782,13 @@ HTTP/1.1 200 OK
 
 ```
 
-This service provides the state of public transport traffic, grouped by lines and all their stops.
-It can be called for an overall coverage or for a specific object.
+This service provides the state of public transport traffic, grouped by lines and all their stops.  
+It can be called for an overall coverage or for a specific object.  
+Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/line_reports>
 
 <img src="./images/traffic_reports.png" alt="Traffic reports" width="300"/>
 
 ### Parameters
-
-You can access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource}/line_reports>
 
 For example:
 
@@ -1954,12 +1952,12 @@ HTTP/1.1 200 OK
 
 Also known as `/traffic_reports` service. We recommand to use line_reports in place of traffic_reports.
 
-This service provides the state of public transport traffic, grouped by network.
-It can be called for an overall coverage or for a specific object.
+This service provides the state of public transport traffic, grouped by network.  
+It can be called for an overall coverage or for a specific object.  
+Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/traffic_reports>
 
 ### Parameters
 
-You can access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource}/traffic_reports>
 
 For example:
 
@@ -2207,11 +2205,11 @@ HTTP/1.1 200 OK
 
 Also known as the `"/equipment_reports"` service.
 
-This service provides the state of equipments such as lifts or elevators that are giving you better accessibility to public transport facilities.
-The endpoint will report accessible equipment per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered per line.
-Some of the fields (cause, effect, periods etc...) are only displayed if a realtime equipment provider is setup with available data. Otherwise, only information provided by the NTFS will be reported.
-For more information, refer to [Equipment reports](#equipment-reports) API description.
-You can access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource}/equipment_reports>
+This service provides the state of equipments such as lifts or elevators that are giving you better accessibility to public transport facilities.  
+The endpoint will report accessible equipment per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered per line.  
+Some of the fields (cause, effect, periods etc...) are only displayed if a realtime equipment provider is setup with available data. Otherwise, only information provided by the NTFS will be reported.  
+For more information, refer to [Equipment reports](#equipment-reports) API description.  
+Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/equipment_reports>
 
 <aside class="warning">
     This feature requires a specific configuration from a equipment service provider.

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -2161,7 +2161,7 @@ Equipment_Reports
 ---------------------------------------------
 ``` shell
 #request
-$ curl 'http://api.navitia.io/v1/coverage/sandbox/equipment_reports' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
+$ curl 'http://api.navitia.io/v1/coverage/<my_coverage>/equipment_reports'
 ```
 
 ``` shell
@@ -2208,9 +2208,10 @@ HTTP/1.1 200 OK
 Also known as the `"/equipment_reports"` service.
 
 This service provides the state of equipments such as lifts or elevators that are giving you better accessibility to public transport facilities.
-The endpoint will report accessible equipement per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered on a per line basis.
+The endpoint will report accessible equipment per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered per line.
 Some of the fields (cause, effect, periods etc...) are only displayed if a realtime equipment provider is setup with available data. Otherwise, only information provided by the NTFS will be reported.
-For more information, refer to [equipment-reports](#equipment-reports) API description.
+For more information, refer to [Equipment reports](#equipment-reports) API description.
+You can access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource}/equipment_reports>
 
 <aside class="warning">
     This feature requires a specific configuration from a equipment service provider.
@@ -2220,10 +2221,10 @@ For more information, refer to [equipment-reports](#equipment-reports) API descr
 ### Parameters
 
 
-Required | Name             | Type   | Description                                        | Default Value
----------|------------------|--------|----------------------------------------------------|--------------
-no       | count            | int    | Elements per page                                  | 10
-no       | depth            | int    | Json response [depth](#depth)                      | 1
-no       | filter           | string | A [filter](#filter) to refine your request         |
-no       | forbidden_uris[] | id     | If you want to avoid lines, modes, networks, etc.  |
-no       | start_page       | int    | The page number (cf the [paging section](#paging)) | 0
+Required | Name             | Type   | Description                                         | Default Value
+---------|------------------|--------|-----------------------------------------------------|--------------
+no       | count            | int    | Elements per page                                   | 10
+no       | depth            | int    | Json response [depth](#depth)                       | 1
+no       | filter           | string | A [filter](#filter) to refine your request          |
+no       | forbidden_uris[] | id     | If you want to avoid lines, modes, networks, etc.   |
+no       | start_page       | int    | The page number (cf. the [paging section](#paging)) | 0

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -627,7 +627,7 @@ Cities are mainly on the 8 level, dependant on the country
 (<http://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative>)
 
 
-### Equipment-reports
+### Equipment reports
 
 ```json
 "equipment_reports": [
@@ -639,15 +639,15 @@ Cities are mainly on the 8 level, dependant on the country
 ]
 ```
 
-A list of object that maps each lines with its associated stop area equipments report.
+A list of objects that maps each line with its associated stop area equipments.
 
 |Field|Type|Description|
 |-----|----|-----------|
 |line|[line](#line)|The line to which equipments are associated |
-|stop_area_equipments|[stop-area-equipments](#stop-area-equipments)|A list of objects that describes equipments for each stop area |
+|stop_area_equipments|[stop area equipments](#stop-area-equipments)|A list of objects that describes equipments for each stop area |
 
 
-### Stop-area-equipments
+### Stop area equipments
 
 ```json
 "stop_area_equipments": [
@@ -658,15 +658,15 @@ A list of object that maps each lines with its associated stop area equipments r
     ...
 ]
 ```
-A list of objects that maps equipments details for each stop area.
+A list of objects that maps equipment details for each stop area.
 
 |Field|Type|Description|
 |-----|----|-----------|
-|equipment_details|[equipment-details](#equipment-details)|The equipment details associated with the stop area|
-|stop_area|[stop-area](#stop-area)|The stop area to which the `equipments_details` is associated |
+|equipment_details|[Equipment details](#equipment-details)|The equipment details associated with the stop area|
+|stop_area|[Stop Area](#stop-area)|The stop area to which the `equipment_details` are associated |
 
 
-### Equipment-details
+### Equipment details
 ```json
 "equipment_details": [
     {
@@ -680,13 +680,13 @@ A list of objects that maps equipments details for each stop area.
 ```
 |Field|Type|Occurrence|Description|
 |-----|----|--------|-----------|
-current_availability|[current-availability](#current-availability)|always| Describes equipments information like: status, name, id etc...
-embedded_type|string|always|Define the equipment type: `"escalator"`, `"elevator"`
+current_availability|[Equipment availability](#equipment-availability)|always| Describes equipments information like: status, name, id etc...
+embedded_type|string|always|Define the equipment type: `escalator`, `elevator`
 id|string|always|The equipment's unique identifier
 name|string|optional|the equipment's name/description
 
 
-### Current-availability
+### Equipment availability
 
 ```json
 "current_availability": {
@@ -708,10 +708,10 @@ name|string|optional|the equipment's name/description
 
 |Field|Type|Required|Description|
 |-----|----|--------|-----------|
-status|string|always|Equipment status: <ul><li>`"unknown"`: no realtime information available</li><li>`"unavailable"`: equipment is known to be unavailable with details provided below </li></ul>
+status|string|always|Equipment status: <ul><li>`unknown`: no realtime information available</li><li>`unavailable`: equipment is known to be unavailable with details provided below </li></ul>
 cause|label|optional|If status is `unavailable`, gives you the cause in a label
 effect|label|optional|If status is `unavailable`, gives you the effect in a label
-periods|period|optional|If status is `unavailable`, gives the effected period with a begin & end date
+periods|period|optional|If status is `unavailable`, gives the affected period (with a `begin` & `end` datetime attributes)
 
 Other objects
 -------------
@@ -841,7 +841,7 @@ Special Parameters
 
 ### datetime
 
-A date time with the format YYYYMMDDThhmmss
+A date time with the format YYYYMMDDThhmmss, considered local to the coverage used.
 
 #### depth
 

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -703,7 +703,6 @@ name|string|optional|the equipment's name/description
         }
     ],
     "status": "unavailable",
-    "updated_at": "2019-05-17T15:54:53+02:00"
 }
 ```
 
@@ -713,7 +712,6 @@ status|string|always|Equipment status: <ul><li>`"unknown"`: no realtime informat
 cause|label|optional|If status is `unavailable`, gives you the cause in a label
 effect|label|optional|If status is `unavailable`, gives you the effect in a label
 periods|period|optional|If status is `unavailable`, gives the effected period with a begin & end date
-updated_at|[iso-date-time](#iso-date-time)|optional|Last update time of the provided information
 
 Other objects
 -------------

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -627,7 +627,7 @@ Cities are mainly on the 8 level, dependant on the country
 (<http://wiki.openstreetmap.org/wiki/Tag:boundary%3Dadministrative>)
 
 
-### Equipment reports
+### <a name="equipment-reports"></a>Equipment reports
 
 ```json
 "equipment_reports": [
@@ -647,7 +647,7 @@ A list of objects that maps each line with its associated stop area equipments.
 |stop_area_equipments|[stop area equipments](#stop-area-equipments)|A list of objects that describes equipments for each stop area |
 
 
-### Stop area equipments
+### <a name="stop-area-equipments"></a>Stop area equipments
 
 ```json
 "stop_area_equipments": [
@@ -658,15 +658,15 @@ A list of objects that maps each line with its associated stop area equipments.
     ...
 ]
 ```
-A list of objects that maps equipment details for each stop area.
+A list of objects that maps equipments details for each stop area.
 
 |Field|Type|Description|
 |-----|----|-----------|
 |equipment_details|[Equipment details](#equipment-details)|The equipment details associated with the stop area|
-|stop_area|[Stop Area](#stop-area)|The stop area to which the `equipment_details` are associated |
+|stop_area|[Stop Area](#stop-area)|The stop area to which the `equipment_details` is associated |
 
 
-### Equipment details
+### <a name="equipment-details"></a>Equipment details
 ```json
 "equipment_details": [
     {
@@ -686,7 +686,7 @@ id|string|always|The equipment's unique identifier
 name|string|optional|the equipment's name/description
 
 
-### Equipment availability
+### <a name="equipment-availability"></a>Equipment availability
 
 ```json
 "current_availability": {
@@ -841,7 +841,7 @@ Special Parameters
 
 ### datetime
 
-A date time with the format YYYYMMDDThhmmss, considered local to the coverage used.
+A date time with the format YYYYMMDDThhmmss, considered local to the coverage being used.
 
 #### depth
 


### PR DESCRIPTION
Related to PR https://github.com/CanalTP/navitia/pull/2795

Removes the doc of `updated_at` as it is usable, but deprecated (wrong format)