### PR TITLE
Jormun: journey filter sort more consistent with kraken journey sort

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -457,11 +457,13 @@ def shared_section_generator(journey):
             yield "origin:{}/dest:{}".format(s.origin.uri, s.destination.uri)
 
 
-def fallback_duration(journey):
+def fallback_duration(journey, transfer_penalty):
     duration = 0
     for section in journey.sections:
-        if section.type in (response_pb2.STREET_NETWORK, response_pb2.CROW_FLY):
+        if section.type in (response_pb2.STREET_NETWORK, response_pb2.CROW_FLY, response_pb2.TRANSFER):
             duration += section.duration
+        if section.type == response_pb2.TRANSFER:
+            duration += transfer_penalty
 
     return duration
 
@@ -511,7 +513,7 @@ def _debug_journey(journey):
             dep=_datetime_to_str(journey.departure_date_time),
             arr=_datetime_to_str(journey.arrival_date_time),
             duration=datetime.timedelta(seconds=journey.duration),
-            fallback=datetime.timedelta(seconds=fallback_duration(journey)),
+            fallback=datetime.timedelta(seconds=fallback_duration(journey, 0)),
             sec=" - ".join(sections),
         )
     )
@@ -612,8 +614,9 @@ def _get_worst_similar(j1, j2, request):
     if j1.duration != j2.duration:
         return j1 if j1.duration > j2.duration else j2
 
-    if fallback_duration(j1) != fallback_duration(j2):
-        return j1 if fallback_duration(j1) > fallback_duration(j2) else j2
+    transfer_penalty = request.get('_walking_transfer_penalty', 120)
+    if fallback_duration(j1, transfer_penalty) != fallback_duration(j2, transfer_penalty):
+        return j1 if fallback_duration(j1, transfer_penalty) > fallback_duration(j2, transfer_penalty) else j2
 
     if get_nb_connections(j1) != get_nb_connections(j2):
         return j1 if get_nb_connections(j1) > get_nb_connections(j2) else j2


### PR DESCRIPTION
Adding `transfer time` and `transfer penalty` ("2 min du peuple" :fr:) to fallback duration.

The jormun sorting is only used when we have to get rid of the worst journey (too much journey in response for example).
So this is more cleanup, and should affect minor side-side cases (just spotted that while crawling code).

Tell me if you think it needs more testing than just check that current tests are OK.