### PR TITLE
Jormun: Fix distributed kraken

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -684,15 +684,6 @@ class Instance(object):
     def get_all_street_networks(self):
         return self._streetnetwork_backend_manager.get_all_street_networks_legacy(self)
 
-    def get_street_network_routing_matrix(
-        self, origins, destinations, mode, max_duration_to_pt, request, service, **kwargs
-    ):
-        if not service:
-            return None
-        return service.get_street_network_routing_matrix(
-            origins, destinations, mode, max_duration_to_pt, request, **kwargs
-        )
-
     def get_autocomplete(self, requested_autocomplete):
         if not requested_autocomplete:
             return self.autocomplete

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
@@ -106,8 +106,6 @@ class FallbackDurations:
     @new_relic.distributedEvent("routing_matrix", "street_network")
     def _get_street_network_routing_matrix(self, origins, destinations):
         try:
-            if not self._streetnetwork_service:
-                return None
             return self._streetnetwork_service.get_street_network_routing_matrix(
                 self._instance,
                 origins,

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
@@ -106,13 +106,15 @@ class FallbackDurations:
     @new_relic.distributedEvent("routing_matrix", "street_network")
     def _get_street_network_routing_matrix(self, origins, destinations):
         try:
-            return self._instance.get_street_network_routing_matrix(
+            if not self._streetnetwork_service:
+                return None
+            return self._streetnetwork_service.get_street_network_routing_matrix(
+                self._instance,
                 origins,
                 destinations,
                 self._mode,
                 self._max_duration_to_pt,
                 self._request,
-                self._streetnetwork_service,
                 **self._speed_switcher
             )
         except Exception as e:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -44,6 +44,7 @@ class StreetNetworkPath:
         self,
         future_manager,
         instance,
+        streetnetwork_service,
         orig_obj,
         dest_obj,
         mode,
@@ -55,6 +56,7 @@ class StreetNetworkPath:
         :param future_manager: a module that manages the future pool properly
         :param instance: instance of the coverage, all outside services callings pass through it(street network,
                          auto completion)
+        :param streetnetwork_service: backend
         :param orig_obj: proto obj
         :param dest_obj: proto obj
         :param mode: street network mode, should be one of ['walking', 'bike', 'bss', 'car']
@@ -64,6 +66,7 @@ class StreetNetworkPath:
         """
         self._future_manager = future_manager
         self._instance = instance
+        self._streetnetwork_service = streetnetwork_service
         self._orig_obj = orig_obj
         self._dest_obj = dest_obj
         self._mode = mode
@@ -77,7 +80,8 @@ class StreetNetworkPath:
     @new_relic.distributedEvent("direct_path", "street_network")
     def _direct_path_with_fp(self):
         try:
-            return self._instance.direct_path_with_fp(
+            return self._streetnetwork_service.direct_path_with_fp(
+                self._instance,
                 self._mode,
                 self._orig_obj,
                 self._dest_obj,
@@ -99,7 +103,7 @@ class StreetNetworkPath:
             self._mode,
         )
 
-        dp = self._direct_path_with_fp(self._instance)
+        dp = self._direct_path_with_fp(self._streetnetwork_service)
 
         if getattr(dp, "journeys", None):
             dp.journeys[0].internal_id = str(utils.generate_id())
@@ -150,6 +154,7 @@ class StreetNetworkPathPool:
         if not path:
             path = self._value[key] = StreetNetworkPath(
                 self._future_manager,
+                self._instance,
                 streetnetwork_service,
                 requested_orig_obj,
                 requested_dest_obj,

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -56,7 +56,7 @@ class StreetNetworkPath:
         :param future_manager: a module that manages the future pool properly
         :param instance: instance of the coverage, all outside services callings pass through it(street network,
                          auto completion)
-        :param streetnetwork_service: backend
+        :param streetnetwork_service: service that will be used to compute the path
         :param orig_obj: proto obj
         :param dest_obj: proto obj
         :param mode: street network mode, should be one of ['walking', 'bike', 'bss', 'car']

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -69,7 +69,9 @@ class Asgard(Kraken):
             'asgard_socket': self.asgard_socket,
         }
 
-    def get_street_network_routing_matrix(self, origins, destinations, mode, max_duration, request, **kwargs):
+    def get_street_network_routing_matrix(
+        self, instance, origins, destinations, mode, max_duration, request, **kwargs
+    ):
         speed_switcher = make_speed_switcher(request)
 
         req = self._create_sn_routing_matrix_request(
@@ -101,7 +103,14 @@ class Asgard(Kraken):
         return response
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         req = self._create_direct_path_request(
             mode, pt_object_origin, pt_object_destination, fallback_extremity, request

--- a/source/jormungandr/jormungandr/street_network/geovelo.py
+++ b/source/jormungandr/jormungandr/street_network/geovelo.py
@@ -184,7 +184,7 @@ class Geovelo(AbstractStreetNetworkService):
             raise TechnicalError('Geovelo service unavailable, impossible to query : {}'.format(response.url))
 
     def get_street_network_routing_matrix(
-        self, origins, destinations, street_network_mode, max_duration, request, **kwargs
+        self, instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
     ):
         if street_network_mode != "bike":
             logging.getLogger(__name__).error('Geovelo, mode {} not implemented'.format(street_network_mode))
@@ -304,7 +304,14 @@ class Geovelo(AbstractStreetNetworkService):
         return resp
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         if mode != "bike":
             logging.getLogger(__name__).error('Geovelo, mode {} not implemented'.format(mode))

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -233,7 +233,14 @@ class Here(AbstractStreetNetworkService):
         return params
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         params = self.get_direct_path_params(pt_object_origin, pt_object_destination, mode, fallback_extremity)
         r = self._call_here(self.routing_service_url, params=params)
@@ -310,7 +317,9 @@ class Here(AbstractStreetNetworkService):
 
         return params
 
-    def get_street_network_routing_matrix(self, origins, destinations, mode, max_duration, request, **kwargs):
+    def get_street_network_routing_matrix(
+        self, instance, origins, destinations, mode, max_duration, request, **kwargs
+    ):
         params = self.get_matrix_params(origins, destinations, mode, max_duration, request)
         r = self._call_here(self.matrix_service_url, params=params)
 

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -69,7 +69,7 @@ class Kraken(AbstractStreetNetworkService):
         return response
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self, instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
     ):
         """
         :param direct_path_type: we need to "invert" a direct path when it's a ending fallback by car if and only if
@@ -83,7 +83,7 @@ class Kraken(AbstractStreetNetworkService):
             mode, pt_object_origin, pt_object_destination, fallback_extremity, request
         )
 
-        response = self.instance.send_and_receive(req)
+        response = instance.send_and_receive(req)
         if should_invert_journey:
             return self._reverse_journeys(response)
 
@@ -121,7 +121,7 @@ class Kraken(AbstractStreetNetworkService):
         return utils.get_uri_pt_object(pt_object)
 
     def get_street_network_routing_matrix(
-        self, origins, destinations, street_network_mode, max_duration, request, **kwargs
+        self, instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
     ):
         # TODO: reverse is not handled as so far
         speed_switcher = jormungandr.street_network.utils.make_speed_switcher(request)
@@ -138,7 +138,7 @@ class Kraken(AbstractStreetNetworkService):
             origins, destinations, street_network_mode, max_duration, speed_switcher, **kwargs
         )
 
-        res = self.instance.send_and_receive(req)
+        res = instance.send_and_receive(req)
         self._check_for_error_and_raise(res)
 
         return res.sn_routing_matrix

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -69,7 +69,14 @@ class Kraken(AbstractStreetNetworkService):
         return response
 
     def _direct_path(
-        self, instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         """
         :param direct_path_type: we need to "invert" a direct path when it's a ending fallback by car if and only if

--- a/source/jormungandr/jormungandr/street_network/ridesharing.py
+++ b/source/jormungandr/jormungandr/street_network/ridesharing.py
@@ -51,14 +51,27 @@ class Ridesharing(AbstractStreetNetworkService):
         return {'id': unicode(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         # TODO: the ridesharing_speed is stored in car_no_park_speed
         # a proper way to handle this is to override car_no_park_speed use the ridesharing_speed here
         # copy_request = copy.deepcopy(request)
         # copy_request["car_no_park_speed"] = copy_request["ridesharing_speed"]
         response = self.street_network._direct_path(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+            instance,
+            mode,
+            pt_object_origin,
+            pt_object_destination,
+            fallback_extremity,
+            request,
+            direct_path_type,
         )
         for journey in response.journeys:
             journey.durations.ridesharing = journey.durations.car
@@ -71,14 +84,14 @@ class Ridesharing(AbstractStreetNetworkService):
         return response
 
     def get_street_network_routing_matrix(
-        self, origins, destinations, street_network_mode, max_duration, request, **kwargs
+        self, instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
     ):
         # TODO: the ridesharing_speed is stored in car_no_park_speed
         # a proper way to handle this is to override car_no_park_speed use the ridesharing_speed here
         # copy_request = copy.deepcopy(request)
         # copy_request["car_no_park_speed"] = copy_request["ridesharing_speed"]
         return self.street_network.get_street_network_routing_matrix(
-            origins, destinations, street_network_mode, max_duration, request, **kwargs
+            instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
         )
 
     def make_path_key(self, mode, orig_uri, dest_uri, streetnetwork_path_type, period_extremity):

--- a/source/jormungandr/jormungandr/street_network/street_network.py
+++ b/source/jormungandr/jormungandr/street_network/street_network.py
@@ -66,10 +66,23 @@ class AbstractStreetNetworkService(ABC):  # type: ignore
         pass
 
     def direct_path_with_fp(
-        self, instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type,
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         resp = self._direct_path(
-            instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+            instance,
+            mode,
+            pt_object_origin,
+            pt_object_destination,
+            fallback_extremity,
+            request,
+            direct_path_type,
         )
 
         self._add_feed_publisher(resp)
@@ -77,7 +90,14 @@ class AbstractStreetNetworkService(ABC):  # type: ignore
 
     @abc.abstractmethod
     def _direct_path(
-        self, instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type,
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         '''
         :param fallback_extremity: is a PeriodExtremity (a datetime and it's meaning on the fallback period)

--- a/source/jormungandr/jormungandr/street_network/street_network.py
+++ b/source/jormungandr/jormungandr/street_network/street_network.py
@@ -57,7 +57,7 @@ StreetNetworkPathKey = namedtuple(
 class AbstractStreetNetworkService(ABC):  # type: ignore
     @abc.abstractmethod
     def get_street_network_routing_matrix(
-        self, origins, destinations, street_network_mode, max_duration, request, **kwargs
+        self, instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
     ):
         pass
 
@@ -66,10 +66,10 @@ class AbstractStreetNetworkService(ABC):  # type: ignore
         pass
 
     def direct_path_with_fp(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self, instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type,
     ):
         resp = self._direct_path(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+            instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
         )
 
         self._add_feed_publisher(resp)
@@ -77,7 +77,7 @@ class AbstractStreetNetworkService(ABC):  # type: ignore
 
     @abc.abstractmethod
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self, instance, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type,
     ):
         '''
         :param fallback_extremity: is a PeriodExtremity (a datetime and it's meaning on the fallback period)

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -156,7 +156,14 @@ class StreetNetworkBackendManager(object):
         # Make sure we update the streetnetwork_backends list from the database before returning them
         self._update_config(instance)
 
-        return self._streetnetwork_backends.get(streetnetwork_backend_conf, None)
+        sn = self._streetnetwork_backends.get(streetnetwork_backend_conf, None)
+        if sn is None:
+            raise TechnicalError(
+                'impossible to find a streetnetwork module for instance {} with configuration {}'.format(
+                    instance, streetnetwork_backend_conf
+                )
+            )
+        return sn
 
     def get_street_network_legacy(self, instance, mode, request):
         overriden_sn_id = request.get('_street_network')

--- a/source/jormungandr/jormungandr/street_network/taxi.py
+++ b/source/jormungandr/jormungandr/street_network/taxi.py
@@ -58,13 +58,26 @@ class Taxi(AbstractStreetNetworkService):
         return {'id': unicode(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
 
         copy_request = copy.deepcopy(request)
         copy_request["car_no_park_speed"] = copy_request["taxi_speed"]
         response = self.street_network._direct_path(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, copy_request, direct_path_type
+            instance,
+            mode,
+            pt_object_origin,
+            pt_object_destination,
+            fallback_extremity,
+            copy_request,
+            direct_path_type,
         )
         if not response:
             return response
@@ -157,13 +170,13 @@ class Taxi(AbstractStreetNetworkService):
         journey.nb_sections += 1
 
     def get_street_network_routing_matrix(
-        self, origins, destinations, street_network_mode, max_duration, request, **kwargs
+        self, instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
     ):
 
         copy_request = copy.deepcopy(request)
         copy_request["car_no_park_speed"] = copy_request["taxi_speed"]
         response = self.street_network.get_street_network_routing_matrix(
-            origins, destinations, street_network_mode, max_duration, copy_request, **kwargs
+            instance, origins, destinations, street_network_mode, max_duration, copy_request, **kwargs
         )
 
         if response and len(response.rows):

--- a/source/jormungandr/jormungandr/street_network/tests/geovelo_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/geovelo_test.py
@@ -266,7 +266,7 @@ def direct_path_geovelo_test():
             json=resp_json,
         )
         geovelo_resp = geovelo.direct_path_with_fp(
-            'bike', origin, destination, fallback_extremity, MOCKED_REQUEST, None
+            instance, 'bike', origin, destination, fallback_extremity, MOCKED_REQUEST, None
         )
         assert geovelo_resp.status_code == 200
         assert geovelo_resp.response_type == response_pb2.ITINERARY_FOUND
@@ -304,7 +304,7 @@ def direct_path_geovelo_zero_test():
             json=resp_json,
         )
         geovelo_resp = geovelo.direct_path_with_fp(
-            'bike', origin, destination, fallback_extremity, MOCKED_REQUEST, None
+            instance, 'bike', origin, destination, fallback_extremity, MOCKED_REQUEST, None
         )
         assert geovelo_resp.status_code == 200
         assert geovelo_resp.response_type == response_pb2.ITINERARY_FOUND
@@ -345,7 +345,7 @@ def isochrone_geovelo_test():
     with requests_mock.Mocker() as req:
         req.post('http://bob.com/api/v2/routes_m2m', json=resp_json, status_code=200)
         geovelo_response = geovelo.get_street_network_routing_matrix(
-            origins, destinations, 'bike', 13371337, MOCKED_REQUEST
+            instance, origins, destinations, 'bike', 13371337, MOCKED_REQUEST
         )
         assert geovelo_response.rows[0].routing_response[0].duration == 1051
         assert geovelo_response.rows[0].routing_response[0].routing_status == response_pb2.reached

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -121,6 +121,7 @@ def test_matrix(valid_here_matrix):
     with requests_mock.Mocker() as req:
         req.get(requests_mock.ANY, json=valid_here_matrix, status_code=200)
         response = here.get_street_network_routing_matrix(
+            instance,
             [origin],
             [destination, destination, destination],
             mode='walking',
@@ -146,6 +147,7 @@ def test_matrix_timeout():
         req.get(requests_mock.ANY, exc=requests.exceptions.Timeout)
         with pytest.raises(TechnicalError):
             here.get_street_network_routing_matrix(
+                instance,
                 [origin],
                 [destination, destination, destination],
                 mode='walking',

--- a/source/jormungandr/jormungandr/street_network/tests/streetnetwork_backend_manager_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/streetnetwork_backend_manager_test.py
@@ -374,7 +374,7 @@ def append_default_street_network_to_config_test():
     ]
     assert response == wrong_plus_default_config
 
-    
+
 def get_street_network_db_test():
     manager = StreetNetworkBackendManager(sn_backends_getter_ok, -1)
 

--- a/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/valhalla_test.py
@@ -431,7 +431,7 @@ def direct_path_func_without_response_valhalla_test():
     valhalla._call_valhalla = MagicMock(return_value=None)
     valhalla._make_request_arguments = MagicMock(return_value=None)
     with pytest.raises(TechnicalError) as excinfo:
-        valhalla.direct_path_with_fp(None, None, None, None, None, None)
+        valhalla.direct_path_with_fp(None, None, None, None, None, None, None)
     assert '500 Internal Server Error' in str(excinfo.value)
     assert 'TechnicalError' == str(excinfo.typename)
 
@@ -447,7 +447,7 @@ def direct_path_func_with_status_code_400_response_valhalla_test():
         with pytest.raises(TechnicalError) as excinfo:
             req.post('http://bob.com/route', json={'error_code': 42}, status_code=400)
             valhalla.direct_path_with_fp(
-                'walking', origin, destination, fallback_extremity, MOCKED_REQUEST, None
+                instance, 'walking', origin, destination, fallback_extremity, MOCKED_REQUEST, None
             )
         assert '500 Internal Server Error' in str(excinfo.value)
         assert (
@@ -467,7 +467,7 @@ def direct_path_func_with_no_response_valhalla_test():
     with requests_mock.Mocker() as req:
         req.post('http://bob.com/route', json={'error_code': 442}, status_code=400)
         valhalla_response = valhalla.direct_path_with_fp(
-            'walking', origin, destination, fallback_extremity, MOCKED_REQUEST, None
+            instance, 'walking', origin, destination, fallback_extremity, MOCKED_REQUEST, None
         )
         assert valhalla_response.status_code == 200
         assert valhalla_response.response_type == response_pb2.NO_SOLUTION
@@ -486,7 +486,7 @@ def direct_path_func_with_valid_response_valhalla_test():
     with requests_mock.Mocker() as req:
         req.post('http://bob.com/route', json=resp_json)
         valhalla_response = valhalla.direct_path_with_fp(
-            'walking', origin, destination, fallback_extremity, MOCKED_REQUEST, None
+            instance, 'walking', origin, destination, fallback_extremity, MOCKED_REQUEST, None
         )
         assert valhalla_response.status_code == 200
         assert valhalla_response.response_type == response_pb2.ITINERARY_FOUND
@@ -522,7 +522,7 @@ def sources_to_targets_valhalla_test():
     with requests_mock.Mocker() as req:
         req.post('http://bob.com/sources_to_targets', json=response, status_code=200)
         valhalla_response = valhalla.get_street_network_routing_matrix(
-            [origin], [destination, destination, destination], 'walking', 42, MOCKED_REQUEST
+            instance, [origin], [destination, destination, destination], 'walking', 42, MOCKED_REQUEST
         )
         assert valhalla_response.rows[0].routing_response[0].duration == 42
         assert valhalla_response.rows[0].routing_response[0].routing_status == response_pb2.reached
@@ -556,6 +556,7 @@ def sources_to_targets_valhalla_with_park_cost_test():
         req.post('http://bob.com/sources_to_targets', json=response, status_code=200)
         # it changes nothing for walking
         valhalla_response = valhalla.get_street_network_routing_matrix(
+            instance,
             [origin],
             [destination, destination, destination],
             mode='walking',
@@ -571,6 +572,7 @@ def sources_to_targets_valhalla_with_park_cost_test():
 
         # for bike every reached point have an additional 30s
         valhalla_response = valhalla.get_street_network_routing_matrix(
+            instance,
             [origin],
             [destination, destination, destination],
             mode='bike',
@@ -586,6 +588,7 @@ def sources_to_targets_valhalla_with_park_cost_test():
 
         # for car every reached point have an additional 5mn
         valhalla_response = valhalla.get_street_network_routing_matrix(
+            instance,
             [origin],
             [destination, destination, destination],
             mode='car',

--- a/source/jormungandr/jormungandr/street_network/valhalla.py
+++ b/source/jormungandr/jormungandr/street_network/valhalla.py
@@ -278,7 +278,14 @@ class Valhalla(AbstractStreetNetworkService):
             raise TechnicalError('Valhalla service unavailable, impossible to query : {}'.format(response.url))
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         data = self._make_request_arguments(
             mode, [pt_object_origin], [pt_object_destination], request, api='route'
@@ -321,7 +328,9 @@ class Valhalla(AbstractStreetNetworkService):
                     routing.routing_status = response_pb2.unknown
         return sn_routing_matrix
 
-    def get_street_network_routing_matrix(self, origins, destinations, mode, max_duration, request, **kwargs):
+    def get_street_network_routing_matrix(
+        self, instance, origins, destinations, mode, max_duration, request, **kwargs
+    ):
         # for now valhalla only manages 1-n request, so we reverse request if needed
         if len(origins) > 1:
             if len(destinations) > 1:

--- a/source/jormungandr/jormungandr/street_network/with_parking.py
+++ b/source/jormungandr/jormungandr/street_network/with_parking.py
@@ -55,10 +55,23 @@ class WithParking(AbstractStreetNetworkService):
         return {'id': unicode(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
 
     def _direct_path(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+        self,
+        instance,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
     ):
         response = self.street_network._direct_path(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type
+            instance,
+            mode,
+            pt_object_origin,
+            pt_object_destination,
+            fallback_extremity,
+            request,
+            direct_path_type,
         )
         if response and len(response.journeys):
             # Depending of the fallback type(beginning/ending fallback), the parking section's
@@ -114,10 +127,10 @@ class WithParking(AbstractStreetNetworkService):
             journey.nb_sections += 1
 
     def get_street_network_routing_matrix(
-        self, origins, destinations, street_network_mode, max_duration, request, **kwargs
+        self, instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
     ):
         response = self.street_network.get_street_network_routing_matrix(
-            origins, destinations, street_network_mode, max_duration, request, **kwargs
+            instance, origins, destinations, street_network_mode, max_duration, request, **kwargs
         )
 
         if response and len(response.rows) and len(response.rows[0].routing_response):

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -233,16 +233,16 @@ class TestJourneysDistributed(
             "taxi_speed": instance.taxi_speed,
         }
         service = instance.get_street_network(mode, request)
-        resp = instance.get_street_network_routing_matrix(
-            [origin], [destination], mode, max_duration, request, service, **kwargs
+        resp = service.get_street_network_routing_matrix(
+            instance, [origin], [destination], mode, max_duration, request, **kwargs
         )
         assert len(resp.rows[0].routing_response) == 1
         assert resp.rows[0].routing_response[0].duration == 107
         assert resp.rows[0].routing_response[0].routing_status == response_pb2.reached
 
         max_duration = 106
-        resp = instance.get_street_network_routing_matrix(
-            [origin], [destination], mode, max_duration, request, service, **kwargs
+        resp = service.get_street_network_routing_matrix(
+            instance, [origin], [destination], mode, max_duration, request, **kwargs
         )
         assert len(resp.rows[0].routing_response) == 1
         assert resp.rows[0].routing_response[0].duration == 0


### PR DESCRIPTION
After streetnetwork_backends were added in database, distributed with kraken was broken because we didn't call the right kraken for the requested coverage.

To fix that, we now send the instance to the service to use the right socket hence the right kraken.
(direct_path_with_fp and get_street_network_routing_matrix)

QA test : 
1) Request a journey with distributed on any coverage using kraken with distributed mode.
2) Request a journey with distributed on an OTHER coverage using kraken with distributed mode.
3) You have an error there. You shouldn't.