### PR TITLE
Handle comment types

### DIFF
--- a/fixtures/ed/ntfs/comments.txt
+++ b/fixtures/ed/ntfs/comments.txt
@@ -1,3 +1,3 @@
-comment_id,comment_name,comment_typ
+comment_id,comment_name,comment_type
 bobette,"test comment",ODT
 bob,"bob is in the kitchen",

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1117,6 +1117,7 @@ void CommercialModeFusioHandler::handle_line(Data& data, const csv_row& row, boo
 void CommentFusioHandler::init(Data&) {
     id_c = csv.get_pos_col("comment_id");
     comment_c = csv.get_pos_col("comment_name");
+    type_c = csv.get_pos_col("comment_type");
 }
 
 void CommentFusioHandler::handle_line(Data& data, const csv_row& row, bool is_first_line) {
@@ -1130,7 +1131,12 @@ void CommentFusioHandler::handle_line(Data& data, const csv_row& row, bool is_fi
                        "Error while reading " + csv.filename + "  row has column comment for the id : " + row[id_c]);
         return;
     }
-    data.comment_by_id[row[id_c]] = row[comment_c];
+    nt::Comment comment;
+    comment.value = row[comment_c];
+    if (has_col(type_c, row)) {
+        comment.type = row[type_c];
+    }
+    data.comment_by_id[row[id_c]] = comment;
 }
 
 void OdtConditionsFusioHandler::init(Data&) {
@@ -1637,7 +1643,7 @@ void CommentLinksFusioHandler::handle_line(Data& data, const csv_row& row, bool)
     const auto comment_id = row[comment_id_c];
 
     // for coherence purpose we check that the comment exists
-    std::string comment;
+    nt::Comment comment;
     const auto comment_it = data.comment_by_id.find(comment_id);
     if (comment_it != data.comment_by_id.end()) {
         comment = comment_it->second;

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1131,10 +1131,13 @@ void CommentFusioHandler::handle_line(Data& data, const csv_row& row, bool is_fi
                        "Error while reading " + csv.filename + "  row has column comment for the id : " + row[id_c]);
         return;
     }
-    nt::Comment comment;
-    comment.value = row[comment_c];
+    nt::Comment comment(row[comment_c]);
     if (has_col(type_c, row)) {
-        comment.type = row[type_c];
+        auto type = row[type_c];
+        // if type is empty we keep the default value
+        if (!type.empty()) {
+            comment.type = type;
+        }
     }
     data.comment_by_id[row[id_c]] = comment;
 }

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -208,7 +208,7 @@ struct CommercialModeFusioHandler : public GenericHandler {
 
 struct CommentFusioHandler : public GenericHandler {
     CommentFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int id_c, comment_c;
+    int id_c, comment_c, type_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"comment_id", "comment_name"}; }

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -93,8 +93,10 @@ void add_gtfs_comment(GtfsData& gtfs_data, Data& data, const T& obj, const std::
         comment_id = "comment__" + boost::lexical_cast<std::string>(gtfs_data.comments_id_map.size());
     }
     data.add_pt_object_comment(obj, comment_id);
-
-    data.comment_by_id[comment_id] = comment;
+    nt::Comment comment_obj;
+    comment_obj.value = comment;
+    comment_obj.type = "information";
+    data.comment_by_id[comment_id] = comment_obj;
 }
 
 static int default_waiting_duration = 120;

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -93,10 +93,7 @@ void add_gtfs_comment(GtfsData& gtfs_data, Data& data, const T& obj, const std::
         comment_id = "comment__" + boost::lexical_cast<std::string>(gtfs_data.comments_id_map.size());
     }
     data.add_pt_object_comment(obj, comment_id);
-    nt::Comment comment_obj;
-    comment_obj.value = comment;
-    comment_obj.type = "information";
-    data.comment_by_id[comment_id] = comment_obj;
+    data.comment_by_id[comment_id] = nt::Comment(comment);
 }
 
 static int default_waiting_duration = 120;

--- a/source/ed/data.h
+++ b/source/ed/data.h
@@ -32,6 +32,7 @@ www.navitia.io
 #include "types.h"
 
 #include "type/type.h"
+#include "type/comment.h"
 #include "type/data.h"
 #include "type/meta_data.h"
 #include "fare/fare.h"
@@ -153,7 +154,7 @@ public:
 
     // list of comment ids for pt_objects
     std::map<ed::types::pt_object_header, std::vector<std::string>> comments;
-    std::map<std::string, std::string> comment_by_id;
+    std::map<std::string, nt::Comment> comment_by_id;
 
     // we don't want stoptime to derive from Header so we use a custom container
     std::map<const ed::types::StopTime*, std::vector<std::string>> stoptime_comments;

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -1198,12 +1198,12 @@ void EdPersistor::insert_admin_stop_areas(const std::vector<types::AdminStopArea
 }
 
 void EdPersistor::insert_comments(const Data& data) {
-    this->lotus.prepare_bulk_insert("navitia.comments", {"id", "comment"});
+    this->lotus.prepare_bulk_insert("navitia.comments", {"id", "comment", "type"});
     // we store the db id's
     std::map<std::string, unsigned int> comment_bd_ids;
     unsigned int cpt = 0;
     for (const auto& comment : data.comment_by_id) {
-        lotus.insert({std::to_string(cpt), comment.second});
+        lotus.insert({std::to_string(cpt), comment.second.value, comment.second.type});
 
         comment_bd_ids[comment.first] = cpt++;
     }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1192,7 +1192,7 @@ void EdReader::fill_comments(nt::Data& data, pqxx::work& work) {
             continue;
         }
 
-       const auto& comment = it->second;
+        const auto& comment = it->second;
 
         if (type_str == "route") {
             cpt_not_found += add_comment(data, obj_id, route_map, comment);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1192,7 +1192,7 @@ void EdReader::fill_comments(nt::Data& data, pqxx::work& work) {
             continue;
         }
 
-        auto comment = it->second;
+       const auto& comment = it->second;
 
         if (type_str == "route") {
             cpt_not_found += add_comment(data, obj_id, route_map, comment);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1150,31 +1150,33 @@ void EdReader::finish_stop_times(nt::Data& data) {
 }
 
 template <typename Map>
-size_t add_comment(nt::Data& data, const idx_t obj_id, const Map& map, const boost::shared_ptr<std::string>& comment) {
+size_t add_comment(nt::Data& data, const idx_t obj_id, const Map& map, const nt::Comment& comment) {
     const auto obj = find_or_default(obj_id, map);
 
     if (!obj) {
         return 1;
     }
 
-    std::string str_com = *comment;  // TODO shared_ptr
-    data.pt_data->comments.add(obj, str_com);
+    data.pt_data->comments.add(obj, comment);
 
     return 0;
 }
 
 void EdReader::fill_comments(nt::Data& data, pqxx::work& work) {
     // since the comments can be big we use shared_ptr to share them
-    std::map<unsigned int, boost::shared_ptr<std::string>> comments_by_id;
+    std::map<unsigned int, nt::Comment> comments_by_id;
 
-    std::string comment_request = "SELECT id, comment FROM navitia.comments;";
+    const std::string comment_request = "SELECT id, comment, type FROM navitia.comments;";
     pqxx::result comment_result = work.exec(comment_request);
     for (auto const_it = comment_result.begin(); const_it != comment_result.end(); ++const_it) {
-        comments_by_id[const_it["id"].as<unsigned int>()] =
-            boost::make_shared<std::string>(const_it["comment"].as<std::string>());
+        nt::Comment comment;
+        const_it["comment"].to(comment.value);
+        const_it["type"].to(comment.type);
+        comments_by_id[const_it["id"].as<unsigned int>()] = comment;
     }
 
-    std::string pt_object_comment_request = "SELECT object_type, object_id, comment_id FROM navitia.ptobject_comments;";
+    const std::string pt_object_comment_request =
+        "SELECT object_type, object_id, comment_id FROM navitia.ptobject_comments;";
     pqxx::result result = work.exec(pt_object_comment_request);
 
     size_t cpt_not_found(0);
@@ -1190,7 +1192,7 @@ void EdReader::fill_comments(nt::Data& data, pqxx::work& work) {
             continue;
         }
 
-        const boost::shared_ptr<std::string>& comment = it->second;
+        auto comment = it->second;
 
         if (type_str == "route") {
             cpt_not_found += add_comment(data, obj_id, route_map, comment);
@@ -1206,10 +1208,10 @@ void EdReader::fill_comments(nt::Data& data, pqxx::work& work) {
             // for stop time we store the comment on a temporary map
             // and we will store them when the stop time is read.
             // this way we don't have to store all stoptimes in a map
-            stop_time_comments[obj_id].push_back(*comment);
+            stop_time_comments[obj_id].push_back(comment);
         } else if (type_str == "trip") {
             // as we need to create vjs after stop times, we need to store the comments
-            vehicle_journey_comments[obj_id].push_back(*comment);
+            vehicle_journey_comments[obj_id].push_back(comment);
         } else {
             LOG4CPLUS_WARN(log, "invalid type, skipping object comment: " << obj_id << "(" << type_str << ")");
         }

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -83,8 +83,8 @@ private:
     std::unordered_map<idx_t, std::vector<navitia::type::StopTime>> sts_from_vj;
 
     // we need a temporary structure to store the comments on the stop times
-    std::unordered_map<idx_t, std::vector<std::string>> stop_time_comments;
-    std::unordered_map<idx_t, std::vector<std::string>> vehicle_journey_comments;
+    std::unordered_map<idx_t, std::vector<nt::Comment>> stop_time_comments;
+    std::unordered_map<idx_t, std::vector<nt::Comment>> vehicle_journey_comments;
     std::unordered_map<idx_t, std::string> stop_time_headsigns;
     using StKey = std::pair<idx_t, uint16_t>;  // idx ed vj, order stop time
     std::unordered_map<idx_t, StKey> id_to_stop_time_key;

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -141,8 +141,11 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
 
     // check comments
     BOOST_REQUIRE_EQUAL(data.comment_by_id.size(), 2);
-    BOOST_CHECK_EQUAL(data.comment_by_id["bob"], "bob is in the kitchen");
-    BOOST_CHECK_EQUAL(data.comment_by_id["bobette"], "test comment");
+    nt::Comment bob, bobette;
+    bob.value = "bob is in the kitchen";
+    bobette.value = "test comment";
+    BOOST_CHECK_EQUAL(data.comment_by_id["bob"], bob);
+    BOOST_CHECK_EQUAL(data.comment_by_id["bobette"], bobette);
 
     // 7 objects have comments
     // the file contains wrongly formated comments, but they are skiped

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -144,6 +144,7 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     nt::Comment bob, bobette;
     bob.value = "bob is in the kitchen";
     bobette.value = "test comment";
+    bobette.type = "ODT";
     BOOST_CHECK_EQUAL(data.comment_by_id["bob"], bob);
     BOOST_CHECK_EQUAL(data.comment_by_id["bobette"], bobette);
 

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -199,13 +199,10 @@ class complete_links(object):
 
     def make_and_get_link(self, elem, collect):
         if collect == "notes":
-            return {
-                "id": elem['id'],
-                "category": elem['category'],
-                "value": elem['value'],
-                "type": collect,
-                "comment_type": elem.get('comment_type'),
-            }
+            note = {"id": elem['id'], "category": elem['category'], "value": elem['value'], "type": collect}
+            if 'comment_type' in elem:
+                note['comment_type'] = elem['comment_type']
+            return note
         type_ = "Add" if elem['except_type'] == 0 else "Remove"
         return {"id": elem['id'], "date": elem['date'], "type": type_}
 

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -192,14 +192,20 @@ class add_computed_resources(object):
 
 class complete_links(object):
     # This list should not change
-    EXPECTED_ITEMS = set(['category', 'id', 'internal', 'rel', 'type'])
+    EXPECTED_ITEMS = set(['category', 'id', 'internal', 'rel', 'type', 'comment_type'])
 
     def __init__(self, resource):
         self.resource = resource
 
     def make_and_get_link(self, elem, collect):
         if collect == "notes":
-            return {"id": elem['id'], "category": elem['category'], "value": elem['value'], "type": collect}
+            return {
+                "id": elem['id'],
+                "category": elem['category'],
+                "value": elem['value'],
+                "type": collect,
+                "comment_type": elem.get('comment_type'),
+            }
         type_ = "Add" if elem['except_type'] == 0 else "Remove"
         return {"id": elem['id'], "date": elem['date'], "type": type_}
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -345,8 +345,8 @@ def make_notes(notes):
             "value": value.note,
             "internal": True,
         }
-        if value.type:
-            note["comment_type"] = value.type
+        if value.comment_type:
+            note["comment_type"] = value.comment_type
         result.append(note)
     return result
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -342,6 +342,7 @@ def make_notes(notes):
             "category": "comment",
             "id": value.uri,
             "value": value.note,
+            "comment_type": value.type,
             "internal": True,
         }
         for value in notes

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -335,18 +335,20 @@ class BetaEndpointsSerializer(serpy.Serializer):
 
 
 def make_notes(notes):
-    return [
-        {
+    result = []
+    for value in notes:
+        note = {
             "type": "notes",
             "rel": "notes",
             "category": "comment",
             "id": value.uri,
             "value": value.note,
-            "comment_type": value.type,
             "internal": True,
         }
-        for value in notes
-    ]
+        if value.type:
+            note["comment_type"] = value.type
+        result.append(note)
+    return result
 
 
 class NestedDictGenericField(DictGenericSerializer, NestedPropertyField):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
@@ -146,6 +146,7 @@ class LinkSchema(serpy.Serializer):
     href = StrField()
     value = StrField()
     category = StrField()
+    comment_type = StrField()
 
 
 class DisruptionLinkSerializer(jsonschema.Field):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
@@ -218,7 +218,7 @@ class NoteSerializer(serpy.Serializer):
     id = jsonschema.Field(schema_type=str, display_none=True)
     value = jsonschema.Field(schema_type=str)
     category = jsonschema.Field(schema_type=str, schema_metadata={'enum': ['comment', 'terminus']})
-    comment_type = jsonschema.Field(schema_type=str)
+    comment_type = jsonschema.Field(schema_type=str, display_none=False)
 
 
 class ExceptionSerializer(serpy.Serializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
@@ -218,6 +218,7 @@ class NoteSerializer(serpy.Serializer):
     id = jsonschema.Field(schema_type=str, display_none=True)
     value = jsonschema.Field(schema_type=str)
     category = jsonschema.Field(schema_type=str, schema_metadata={'enum': ['comment', 'terminus']})
+    comment_type = jsonschema.Field(schema_type=str)
 
 
 class ExceptionSerializer(serpy.Serializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/test/resource_uri_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/resource_uri_tests.py
@@ -98,7 +98,7 @@ def test_complete_links():
     assert len(response["exceptions"]) == 2
     assert len(response["notes"]) == 1
     for item in response["notes"][0].keys():
-        assert item in ["category", "type", "id", "value"]
+        assert item in ["category", "type", "id", "value", "comment_type"]
 
     for exception in response["exceptions"]:
         for item in exception.keys():

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -847,6 +847,10 @@ def is_valid_note(note):
     get_not_null(note, "value")
     assert get_not_null(note, "type") == "notes"
     assert get_not_null(note, "category") in ["comment", "terminus"]
+    if note["category"] == "comment":
+        # TODO: migrate realtime proxy to use "terminus" note
+        # assert get_not_null(note, "comment_type")
+        pass
 
 
 def is_valid_places(places, depth_check=1):

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -291,6 +291,7 @@ class TestDepartureBoard(AbstractTestFixture):
         assert len(response["notes"]) == 1
         assert response["notes"][0]["type"] == "notes"
         assert response["notes"][0]["value"] == "Tstop2"
+        assert response["notes"][0]["category"] == "terminus"
         assert response["stop_schedules"][0]["date_times"][0]["links"][1]["type"] == "vehicle_journey"
         assert response["stop_schedules"][0]["date_times"][0]["links"][1]["value"] == "vehicle_journey:vj1"
         assert response["stop_schedules"][0]["date_times"][1]["links"][0]["type"] == "vehicle_journey"
@@ -419,6 +420,7 @@ class TestDepartureBoard(AbstractTestFixture):
         schedule_notes = get_real_notes(schedule, response)
         assert len(schedule_notes) == 1
         assert schedule_notes[0]['value'] == 'walk the line'
+        assert schedule_notes[0]['comment_type'] == 'information'
 
         headers = get_not_null(get_not_null(schedule, 'table'), 'headers')
         # there is 4 vjs
@@ -439,6 +441,7 @@ class TestDepartureBoard(AbstractTestFixture):
         all_vj_notes = get_real_notes(all_vj, response)
         assert len(all_vj_notes) == 1
         assert all_vj_notes[0]['value'] == 'vj comment'
+        assert all_vj_notes[0]['comment_type'] == 'on_demand_transport'
 
     def test_routes_schedule_with_calendar(self):
         """

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -103,7 +103,7 @@ class TestPtRef(AbstractTestFixture):
         # we added some comments on the vj, we should have them
         com = get_not_null(vj, 'comments')
         assert len(com) == 1
-        assert com[0]['type'] == 'standard'
+        assert com[0]['type'] == 'information'
         assert com[0]['value'] == 'hello'
         assert "feed_publishers" in response
 
@@ -303,7 +303,7 @@ class TestPtRef(AbstractTestFixture):
 
         com = get_not_null(l, 'comments')
         assert len(com) == 1
-        assert com[0]['type'] == 'standard'
+        assert com[0]['type'] == 'information'
         assert com[0]['value'] == "I'm a happy comment"
 
         physical_modes = get_not_null(l, 'physical_modes')
@@ -378,7 +378,7 @@ class TestPtRef(AbstractTestFixture):
             if depth > 0:
                 com = get_not_null(lg, 'comments')
                 assert len(com) == 1
-                assert com[0]['type'] == 'standard'
+                assert com[0]['type'] == 'information'
                 assert com[0]['value'] == "I'm a happy comment"
 
         # test if line_groups are accessible through the ptref graph
@@ -438,7 +438,7 @@ class TestPtRef(AbstractTestFixture):
 
         com = get_not_null(r, 'comments')
         assert len(com) == 1
-        assert com[0]['type'] == 'standard'
+        assert com[0]['type'] == 'information'
         assert com[0]['value'] == "I'm a happy comment"
 
         self._test_links(response, 'routes')
@@ -456,9 +456,9 @@ class TestPtRef(AbstractTestFixture):
 
         com = get_not_null(s, 'comments')
         assert len(com) == 2
-        assert com[0]['type'] == 'standard'
+        assert com[0]['type'] == 'information'
         assert com[0]['value'] == "comment on stop A"
-        assert com[1]['type'] == 'standard'
+        assert com[1]['type'] == 'information'
         assert com[1]['value'] == "the stop is sad"
 
         self._test_links(response, 'stop_areas')
@@ -490,7 +490,7 @@ class TestPtRef(AbstractTestFixture):
 
         com = get_not_null(s, 'comments')
         assert len(com) == 1
-        assert com[0]['type'] == 'standard'
+        assert com[0]['type'] == 'information'
         assert com[0]['value'] == "hello bob"
 
         modes = get_not_null(s, 'physical_modes')

--- a/source/sql/alembic/versions/25b7f3ace052_type_comments.py
+++ b/source/sql/alembic/versions/25b7f3ace052_type_comments.py
@@ -12,7 +12,6 @@ down_revision = '56c1c7a19078'
 
 from alembic import op
 import sqlalchemy as sa
-import geoalchemy2 as ga
 
 
 def upgrade():

--- a/source/sql/alembic/versions/25b7f3ace052_type_comments.py
+++ b/source/sql/alembic/versions/25b7f3ace052_type_comments.py
@@ -1,0 +1,23 @@
+"""type comments
+
+Revision ID: 25b7f3ace052
+Revises: 56c1c7a19078
+Create Date: 2019-08-06 12:01:56.485924
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '25b7f3ace052'
+down_revision = '56c1c7a19078'
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2 as ga
+
+
+def upgrade():
+    op.add_column('comments', sa.Column('type', sa.Text(), nullable=True), schema='navitia')
+
+
+def downgrade():
+    op.drop_column('comments', 'type', schema='navitia')

--- a/source/tests/mock-kraken/main_ptref_test.cpp
+++ b/source/tests/mock-kraken/main_ptref_test.cpp
@@ -150,13 +150,14 @@ struct data_set {
 
         // we add some comments
         auto& comments = b.data->pt_data->comments;
-        comments.add(b.data->pt_data->routes_map["line:A:0"], "I'm a happy comment");
-        comments.add(b.lines["line:A"], "I'm a happy comment");
-        comments.add(b.sas["stop_area:stop1"], "comment on stop A");
-        comments.add(b.sas["stop_area:stop1"], "the stop is sad");
-        comments.add(b.data->pt_data->stop_points_map["stop_area:stop2"], "hello bob");
-        comments.add(b.data->pt_data->vehicle_journeys[0], "hello");
-        comments.add(b.data->pt_data->vehicle_journeys[0]->stop_time_list.front(), "stop time is blocked");
+        comments.add(b.data->pt_data->routes_map["line:A:0"], nt::Comment("I'm a happy comment", "information"));
+        comments.add(b.lines["line:A"], nt::Comment("I'm a happy comment", "information"));
+        comments.add(b.sas["stop_area:stop1"], nt::Comment("comment on stop A", "information"));
+        comments.add(b.sas["stop_area:stop1"], nt::Comment("the stop is sad", "information"));
+        comments.add(b.data->pt_data->stop_points_map["stop_area:stop2"], nt::Comment("hello bob", "information"));
+        comments.add(b.data->pt_data->vehicle_journeys[0], nt::Comment("hello", "information"));
+        comments.add(b.data->pt_data->vehicle_journeys[0]->stop_time_list.front(),
+                     nt::Comment("stop time is blocked", "on_demand_transport"));
         // Disruption on stoparea
         using btp = boost::posix_time::time_period;
         b.impact(nt::RTLevel::RealTime, "Disruption 1")
@@ -172,7 +173,7 @@ struct data_set {
         lg->main_line = b.lines["line:A"];
         lg->line_list.push_back(b.lines["line:A"]);
         b.lines["line:A"]->line_group_list.push_back(lg);
-        comments.add(lg, "I'm a happy comment");
+        comments.add(lg, nt::Comment("I'm a happy comment", "information"));
         b.data->pt_data->line_groups.push_back(lg);
 
         b.impact(nt::RTLevel::RealTime, "Disruption On line:A")

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -217,7 +217,7 @@ struct calendar_fixture {
             b.vj("line:A", "1100101", "", true, "all")("stop1", "15:00"_t, "15:10"_t)("stop2", "16:00"_t, "16:10"_t);
         // Add a comment on the vj
         auto& pt_data = *(b.data->pt_data);
-        pt_data.comments.add(builder_vj.vj, "vj comment");
+        pt_data.comments.add(builder_vj.vj, nt::Comment("vj comment", "on_demand_transport"));
 
         // and wednesday that will not be matched to any cal
         b.vj("line:A", "110010011", "", true, "wednesday")("stop1", "17:00"_t, "17:10"_t)("stop2", "18:00"_t,
@@ -347,7 +347,7 @@ struct calendar_fixture {
         }
 
         // and add a comment on a line
-        pt_data.comments.add(b.lines["line:A"], "walk the line");
+        pt_data.comments.add(b.lines["line:A"], nt::Comment("walk the line", "information"));
 
         auto it_sa = b.sas.find("Tstop3");
         auto it_rt = pt_data.routes_map.find("A:1");

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -97,7 +97,7 @@ target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY
 add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp
     validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp calendar.cpp stop_area.cpp network.cpp
     contributor.cpp dataset.cpp company.cpp commercial_mode.cpp physical_mode.cpp line.cpp route.cpp
-    vehicle_journey.cpp stop_time.cpp type_interfaces.cpp comment_container.cpp odt_properties.cpp)
+    vehicle_journey.cpp stop_time.cpp type_interfaces.cpp comment_container.cpp odt_properties.cpp comment.cpp)
 target_link_libraries(types ptreferential utils pb_lib protobuf)
 add_dependencies(types protobuf_files)
 

--- a/source/type/comment.cpp
+++ b/source/type/comment.cpp
@@ -40,5 +40,9 @@ void Comment::serialize(Archive& ar, const unsigned int) {
 }
 SERIALIZABLE(Comment)
 
+std::ostream& operator<<(std::ostream& os, const Comment& comment) {
+    return os << comment.value;
+}
+
 }  // namespace type
 }  // namespace navitia

--- a/source/type/comment.cpp
+++ b/source/type/comment.cpp
@@ -40,6 +40,10 @@ void Comment::serialize(Archive& ar, const unsigned int) {
 }
 SERIALIZABLE(Comment)
 
+bool Comment::operator==(const Comment& other) const {
+    return this->value == other.value && this->type == other.type;
+}
+
 std::ostream& operator<<(std::ostream& os, const Comment& comment) {
     return os << comment.value;
 }

--- a/source/type/comment.cpp
+++ b/source/type/comment.cpp
@@ -1,0 +1,44 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "type/comment.h"
+#include "type/serialization.h"
+
+namespace navitia {
+namespace type {
+
+template <class Archive>
+void Comment::serialize(Archive& ar, const unsigned int) {
+    ar& value& type;
+}
+SERIALIZABLE(Comment)
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/comment.h
+++ b/source/type/comment.h
@@ -41,5 +41,7 @@ struct Comment {
     void serialize(Archive& ar, const unsigned int);
 };
 
+std::ostream& operator<<(std::ostream& os, const Comment& comment);
+
 }  // namespace type
 }  // namespace navitia

--- a/source/type/comment.h
+++ b/source/type/comment.h
@@ -35,7 +35,7 @@ namespace navitia {
 namespace type {
 struct Comment {
     std::string value;
-    std::string type;
+    std::string type = "information";
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);
@@ -43,6 +43,7 @@ struct Comment {
 
     Comment() {}
     Comment(const std::string& value, const std::string& type) : value(value), type(type) {}
+    explicit Comment(const std::string& value) : value(value) {}
 };
 
 std::ostream& operator<<(std::ostream& os, const Comment& comment);

--- a/source/type/comment.h
+++ b/source/type/comment.h
@@ -40,6 +40,9 @@ struct Comment {
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);
     bool operator==(const Comment& other) const;
+
+    Comment() {}
+    Comment(const std::string& value, const std::string& type) : value(value), type(type) {}
 };
 
 std::ostream& operator<<(std::ostream& os, const Comment& comment);

--- a/source/type/comment.h
+++ b/source/type/comment.h
@@ -1,0 +1,45 @@
+/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+IRC #navitia on freenode
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include "type/type_interfaces.h"
+
+namespace navitia {
+namespace type {
+struct Comment {
+    std::string value;
+    std::string type;
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int);
+};
+
+}  // namespace type
+}  // namespace navitia

--- a/source/type/comment.h
+++ b/source/type/comment.h
@@ -39,6 +39,7 @@ struct Comment {
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);
+    bool operator==(const Comment& other) const;
 };
 
 std::ostream& operator<<(std::ostream& os, const Comment& comment);

--- a/source/type/comment_container.h
+++ b/source/type/comment_container.h
@@ -34,6 +34,7 @@ www.navitia.io
 #include <map>
 #include <type_traits>
 #include <boost/fusion/include/at_key.hpp>
+#include "type/comment.h"
 
 #pragma once
 
@@ -47,18 +48,26 @@ namespace type {
  */
 struct Comments {
     template <typename T>
-    const std::vector<std::string>& get(const T& obj) const {
+    const std::vector<std::string> get(const T& obj) const {
         const auto& c =
             boost::fusion::at_key<typename std::remove_const<typename std::remove_pointer<T>::type>::type>(map);
 
-        return find_or_default(get_as_key(obj), c);
+        // TODO return Comment
+        auto& comments = find_or_default(get_as_key(obj), c);
+        std::vector<std::string> result;
+        for (auto& comment : comments) {
+            result.push_back(comment.value);
+        }
+        return result;
     }
 
     template <typename T>
     void add(const T& obj, const std::string& comment) {
         auto& c = boost::fusion::at_key<typename std::remove_const<typename std::remove_pointer<T>::type>::type>(map);
-
-        c[get_as_key(obj)].push_back(comment);
+        // TODO take Comment as input
+        auto obj_comment = Comment();
+        obj_comment.value = comment;
+        c[get_as_key(obj)].push_back(obj_comment);
     }
 
     template <class Archive>
@@ -68,7 +77,7 @@ struct Comments {
 
 private:
     // using comment_list = std::vector<boost::shared_ptr<std::string>>; //TODO
-    using comment_list = std::vector<std::string>;
+    using comment_list = std::vector<Comment>;
 
     template <typename T>
     using pt_object_comment_map = std::map<const T*, comment_list>;

--- a/source/type/comment_container.h
+++ b/source/type/comment_container.h
@@ -56,15 +56,6 @@ struct Comments {
     }
 
     template <typename T>
-    void add(const T& obj, const std::string& comment) {
-        auto& c = boost::fusion::at_key<typename std::remove_const<typename std::remove_pointer<T>::type>::type>(map);
-        // TODO take Comment as input
-        auto obj_comment = Comment();
-        obj_comment.value = comment;
-        c[get_as_key(obj)].push_back(obj_comment);
-    }
-
-    template <typename T>
     void add(const T& obj, const Comment& comment) {
         auto& c = boost::fusion::at_key<typename std::remove_const<typename std::remove_pointer<T>::type>::type>(map);
         c[get_as_key(obj)].push_back(comment);

--- a/source/type/comment_container.h
+++ b/source/type/comment_container.h
@@ -48,17 +48,11 @@ namespace type {
  */
 struct Comments {
     template <typename T>
-    const std::vector<std::string> get(const T& obj) const {
+    const std::vector<Comment> get(const T& obj) const {
         const auto& c =
             boost::fusion::at_key<typename std::remove_const<typename std::remove_pointer<T>::type>::type>(map);
 
-        // TODO return Comment
-        auto& comments = find_or_default(get_as_key(obj), c);
-        std::vector<std::string> result;
-        for (auto& comment : comments) {
-            result.push_back(comment.value);
-        }
-        return result;
+        return find_or_default(get_as_key(obj), c);
     }
 
     template <typename T>
@@ -70,13 +64,18 @@ struct Comments {
         c[get_as_key(obj)].push_back(obj_comment);
     }
 
+    template <typename T>
+    void add(const T& obj, const Comment& comment) {
+        auto& c = boost::fusion::at_key<typename std::remove_const<typename std::remove_pointer<T>::type>::type>(map);
+        c[get_as_key(obj)].push_back(comment);
+    }
+
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar& map;
     }
 
 private:
-    // using comment_list = std::vector<boost::shared_ptr<std::string>>; //TODO
     using comment_list = std::vector<Comment>;
 
     template <typename T>

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -63,7 +63,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 71;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 72;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -977,6 +977,15 @@ void PbCreator::Filler::fill_pb_object(const nt::StopTime* st, pbnavitia::StopDa
     fill(pb_creator.data->pt_data->comments.get(*st), properties->mutable_notes());
 }
 
+void PbCreator::Filler::fill_pb_object(const nt::Comment* comment, pbnavitia::Note* note) {
+    std::hash<std::string> hash_fn;
+    note->set_uri("note:" + std::to_string(hash_fn(comment->value)));
+    note->set_note(comment->value);
+    if (!comment->type.empty()) {
+        note->set_type(comment->type);
+    }
+}
+
 void PbCreator::Filler::fill_pb_object(const std::string* comment, pbnavitia::Note* note) {
     std::hash<std::string> hash_fn;
     note->set_uri("note:" + std::to_string(hash_fn(*comment)));

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -979,7 +979,7 @@ void PbCreator::Filler::fill_pb_object(const nt::StopTime* st, pbnavitia::StopDa
 
 void PbCreator::Filler::fill_pb_object(const nt::Comment* comment, pbnavitia::Note* note) {
     std::hash<std::string> hash_fn;
-    note->set_uri("note:" + std::to_string(hash_fn(comment->value)));
+    note->set_uri("note:" + std::to_string(hash_fn(comment->value + comment->type)));
     note->set_note(comment->value);
     if (!comment->type.empty()) {
         note->set_type(comment->type);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -982,7 +982,7 @@ void PbCreator::Filler::fill_pb_object(const nt::Comment* comment, pbnavitia::No
     note->set_uri("note:" + std::to_string(hash_fn(comment->value + comment->type)));
     note->set_note(comment->value);
     if (!comment->type.empty()) {
-        note->set_type(comment->type);
+        note->set_comment_type(comment->type);
     }
 }
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -440,13 +440,14 @@ private:
         }
 
         template <typename NT, typename PB>
-        void fill_comments(const NT* nt, PB* pb, const std::string& type = "standard") {
+        void fill_comments(const NT* nt, PB* pb) {
             if (nt == nullptr) {
                 return;
             }
             for (const auto& comment : pb_creator.data->pt_data->comments.get(nt)) {
                 auto com = pb->add_comments();
-                com->set_value(comment);
+                auto type = comment.type.empty() ? "standard" : comment.type;
+                com->set_value(comment.value);
                 com->set_type(type);
             }
         }
@@ -502,6 +503,7 @@ private:
         void fill_pb_object(const nt::EntryPoint*, pbnavitia::PtObject*);
         void fill_pb_object(const WayCoord*, pbnavitia::PtObject*);
         void fill_pb_object(const WayCoord*, pbnavitia::Address*);
+        void fill_pb_object(const nt::Comment*, pbnavitia::Note*);
 
         // Used for place
         template <typename T>

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -448,7 +448,7 @@ private:
                 auto com = pb->add_comments();
                 auto type = comment.type.empty() ? "information" : comment.type;
                 com->set_value(comment.value);
-                com->set_type(type);
+                com->set_type(comment.type);
             }
         }
 

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -446,7 +446,7 @@ private:
             }
             for (const auto& comment : pb_creator.data->pt_data->comments.get(nt)) {
                 auto com = pb->add_comments();
-                auto type = comment.type.empty() ? "standard" : comment.type;
+                auto type = comment.type.empty() ? "information" : comment.type;
                 com->set_value(comment.value);
                 com->set_type(type);
             }

--- a/source/type/tests/comments_test.cpp
+++ b/source/type/tests/comments_test.cpp
@@ -73,15 +73,16 @@ BOOST_AUTO_TEST_CASE(comment_map_test) {
     nt::Comments& comments_container = b.data->pt_data->comments;
 
     const nt::Line* l = b.data->pt_data->lines[0];
-    comments_container.add(l, "bob");
+    comments_container.add(l, nt::Comment("bob", "information"));
     nt::Line* l2 = b.data->pt_data->lines[0];  // to test with const or no const type
-    comments_container.add(l2, "bobette");
+    comments_container.add(l2, nt::Comment("bobette", "information"));
 
-    comments_container.add(b.data->pt_data->stop_areas[0], "sabob");
-    comments_container.add(b.data->pt_data->stop_points[0], "spbob");
-    comments_container.add(b.data->pt_data->vehicle_journeys[0], "vj com");
+    comments_container.add(b.data->pt_data->stop_areas[0], nt::Comment("sabob", "information"));
+    comments_container.add(b.data->pt_data->stop_points[0], nt::Comment("spbob", "information"));
+    comments_container.add(b.data->pt_data->vehicle_journeys[0], nt::Comment("vj com", "information"));
 
-    comments_container.add(b.data->pt_data->vehicle_journeys[0]->stop_time_list.front(), "st com");
+    comments_container.add(b.data->pt_data->vehicle_journeys[0]->stop_time_list.front(),
+                           nt::Comment("st com", "information"));
 
     std::vector<std::string> expected = {"bob", "bobette"};
     BOOST_CHECK_EQUAL(comments_container.get(b.data->pt_data->lines[0]), expected);

--- a/source/type/tests/comments_test.cpp
+++ b/source/type/tests/comments_test.cpp
@@ -48,6 +48,22 @@ struct logger_initialized {
 };
 BOOST_GLOBAL_FIXTURE(logger_initialized);
 
+namespace navitia {
+namespace type {
+bool operator==(const std::vector<Comment>& lhs, const std::vector<std::string>& rhs) {
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    for (size_t i = 0; i < lhs.size(); ++i) {
+        if (lhs[i].value != rhs[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace type
+}  // namespace navitia
+
 BOOST_AUTO_TEST_CASE(comment_map_test) {
     ed::builder b("20120614");
     b.vj("A")("stop1", 8000, 8050)("stop2", 8100, 8150);


### PR DESCRIPTION
This PR add support for [`comment_type`](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#commentstxt-optionnel) from NTFS.
Previously comments where only `string` so it required more changes than I liked.

## Comment class
A new serializable object had to be created to represent comments, this requires `data_version` to be incremented.
This is done [here](https://github.com/CanalTP/navitia/commit/fa391b7bdc0438dcbe75a997a45cfe8d2d98ede9)

It should be possible to not require a rebinarisation, but we do not have the infrastructure in place to differentiate between retrocompatible changes and not.
If we had it would be easy to create a `Comment` from the previously stored string.

## Data integration
This part is mostly covered by this commit: https://github.com/CanalTP/navitia/commit/4527a772edaed63dc1d3923c6da08bda3c2df055
ED database has been updated to store the comment type
The NTFS specify only two possible value to `comment_type`, I choose to not check this value and to treat it as a string. We could use an enumeration and restrict it to those value, but it would require updating navitia if we choose to add new value later. This point is open to discussion and must be addressed before merging this PR.

## Output
Comments are quite a mess in the interface, they can be outputted two ways.
### notes
Notes are used in journeys and schedules, there is a central list of notes at the root of the response and links to them on objects that need it, mostly (?) stop_times. These notes have their `category`  set to `comment`.
Notes can also be used to indicate alternative terminus on schedules, this kind of notes are generated by kraken and jormungandr automatically and their `category` should be set to `terminus`

When a comment has is type set it will generate the following link:
```json
{
    "category": "comment",
    "comment_type": "information",
    "id": "note:4991244079665878499",
    "internal": true,
    "rel": "notes",
     "type": "notes",
},
```
and the following note:
```json
{
    "category": "comment",
    "comment_type": "on_demand_transport",
    "id": "note:14443104559327237812",
    "type": "notes",
    "value": "Service à réservation ILEVIA (03.20.40.40.40)"
}
```
if  `comment_type` isn't set the field will not be in the response.

Currently, realtime proxy adds a note about the destination that has its `category` set to `comment`. I think it should be changed to `terminus`, once it is done (in another PR), [this test](https://github.com/CanalTP/navitia/commit/78a439494f67f5c5b84070f119e7bd8e5f8b1d71#diff-75dec1e2d23a2e9bc7163d480c7808edR850-R853) should be enabled.

### comment and comments
Comments can also be directly in an object like a stop_point and other pt_object.
The field  `comment` is deprecated since quite some time and hasn't nor can't be updated.
The field  `comments` had already a type that was hard coded to `standard`, it now contains the `comment_type` if set, else I kept `standard` as the default value to prevent breakage.
```json
"comments": [
       {
            "type": "information",
            "value": "CHAUSSEE ALBERT EINSTEIN 59200 TOURCOING -"
        }
    ],
```

All the interface part is done in https://github.com/CanalTP/navitia/commit/319552615c3bea411eb5b7b1b382fefd2588f59b and https://github.com/CanalTP/navitia/commit/bf59698d2c4976ce0d14c863fe1da87417e3700e
this need to be refactored later on as notes are handled with those hideous and magic decorators in jormungandr.

It is probably easier to read it commit by commit.
Refer to: https://jira.kisio.org/browse/NAVITIAII-2831

Require:
  - [ ] https://github.com/CanalTP/navitia-proto/pull/133