### PR TITLE
kraken: route_schedule API, fix empty lines at beginning of thermometer

### DIFF
--- a/source/time_tables/thermometer.cpp
+++ b/source/time_tables/thermometer.cpp
@@ -200,6 +200,8 @@ void Thermometer::generate_thermometer(const std::vector<vector_idx>& sps) {
     boost::range::sort(stop_point_lists, [](const vector_idx& a, const vector_idx& b) { return a.size() > b.size(); });
 
     if (stop_point_lists.size() > 1) {
+        // Clean old results
+        thermometer.clear();
         // Try a topological_sort first
         // If succeed, return, else use custom algorithm
         if (generate_topological_thermometer(stop_point_lists)) {


### PR DESCRIPTION
**JIRA** : https://jira.kisio.org/browse/NAVITIAII-2830
A little fix for a peculiar case into the _thermometer_ (**route_schedule API**).

When we generate the _thermometer_ ([generate_thermometer function](https://github.com/CanalTP/navitia/blob/dev/source/time_tables/thermometer.cpp#L196)) with a `stop_point list > 1`, we don't clean the thermometer old results... 
This introduces wrong empty stop point into the result list. 
Like this :
![before_patch](https://user-images.githubusercontent.com/32099204/63938908-3bc8c880-ca66-11e9-8812-9225d7e1245a.png)

if the `stop point list is <= 1` (the _most common case_), the clean of the old list result is managed by the [operator assigment](https://github.com/CanalTP/navitia/blob/dev/source/time_tables/thermometer.cpp#L228). So no problem



With the fix, we obtain :
![after_patch](https://user-images.githubusercontent.com/32099204/63938913-3ec3b900-ca66-11e9-99ad-615ef958262f.png)

**PS**: I think it's quite obvious, we don't need to create a big UTest for that.