### PR TITLE
Ed: protect more osm2ed from bad shapes

### DIFF
--- a/source/cities/cities.cpp
+++ b/source/cities/cities.cpp
@@ -314,13 +314,13 @@ void OSMRelation::build_polygon(OSMCache& cache, OSMId osm_id) {
             }
             next_node = next_way.nodes.back();
         }
+        auto log = log4cplus::Logger::getInstance("log");
         if (tmp_polygon.outer().size() < 2 || ref == references.end()) {
             // add some logs
             // some admins are at the boundary of the osm data, so their own boundary may be incomplete
             // some other admins have a split boundary and it is impossible to compute it.
             // to check if the boundary is likely to be split we look for a very near point
             // The admin can also be checked with: http://ra.osmsurround.org/index
-            auto log = log4cplus::Logger::getInstance("log");
             for (const auto& r : references) {
                 if (!is_outer_way(r)) {
                     continue;
@@ -341,6 +341,18 @@ void OSMRelation::build_polygon(OSMCache& cache, OSMId osm_id) {
             }
             break;
         }
+
+        if (boost::geometry::area(tmp_polygon) < std::numeric_limits<double>::epsilon()) {
+            // if area is negative, the polygon needs to be reversed to be valid in OGC norm
+            boost::geometry::reverse(tmp_polygon);
+            if (boost::geometry::area(tmp_polygon) < std::numeric_limits<double>::epsilon()) {
+                // if area is null, it's not a valid shape (refused by PostGIS)
+                LOG4CPLUS_WARN(log, "Part or all of the shape of admin " << name << " (insee = " << insee
+                                                                         << ") is rejected. Cause: null area.");
+                continue;
+            }
+        }
+
         const auto front = tmp_polygon.outer().front();
         const auto back = tmp_polygon.outer().back();
 


### PR DESCRIPTION
JIRA: https://jira.kisio.org/browse/NAVITIAII-2843

Issue is on https://www.openstreetmap.org/relation/8522033,
in particular this `outer` thats just a line (pointA - pointB - pointA): https://www.openstreetmap.org/way/615974857

- [x] Hand-tested with complete files for ca-bc, ca-qc and fr from geofabrik

Nota:
* Using area(), as boost::geometry::is_valid() is only available from boost 1.56.00
* Did not mutualize code for cities as it is deprecated (in favour of cosmogony)
* No test added as nothing is tested on osm2ed and it's too expensive to add some for the gain