### PR TITLE
Jormun: Sytral-Rt with multi stop id request

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -155,7 +155,7 @@ class Sytral(RealtimeProxy):
             direction = next_expected_st.get('direction_name')
             stop_id = next_expected_st.get('stop')
             is_real_time = next_expected_st.get('type') == 'E'
-            next_passage = RealTimePassage(dt, direction, is_real_time, stop_id)
+            next_passage = RealTimePassage(dt, direction, is_real_time)
             next_passages.append(next_passage)
 
         return next_passages

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -125,9 +125,9 @@ class Sytral(RealtimeProxy):
             self.record_internal_failure('missing id')
             return None
 
-        url = self.service_url
-        for stop_id in stop_id_list:
-            url += "?stop_id={stop_id}".format(stop_id=stop_id)
+        url = self.service_url + "?stop_id={stop_id}".format(stop_id=stop_id_list[0])
+        for stop_id in stop_id_list[1:]:
+            url += "&stop_id={stop_id}".format(stop_id=stop_id)
 
         return url
 

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -115,17 +115,19 @@ class Sytral(RealtimeProxy):
         The url returns something like a departure on a stop point
         """
 
-        stop_id = route_point.fetch_stop_id(self.object_id_tag)
+        stop_id_list = route_point.fetch_all_stop_id(self.object_id_tag)
 
-        if not stop_id:
+        if not stop_id_list:
             logging.getLogger(__name__).debug(
-                'missing realtime id for {obj}: stop code={s}'.format(obj=route_point, s=stop_id),
+                'missing realtime id for {obj}: stop code={s}'.format(obj=route_point, s=stop_id_list),
                 extra={'rt_system_id': unicode(self.rt_system_id)},
             )
             self.record_internal_failure('missing id')
             return None
 
-        url = "{base_url}?stop_id={stop_id}".format(base_url=self.service_url, stop_id=stop_id)
+        url = self.service_url
+        for stop_id in stop_id_list:
+            url += "?stop_id={stop_id}".format(stop_id=stop_id)
 
         return url
 
@@ -151,8 +153,9 @@ class Sytral(RealtimeProxy):
                 continue
             dt = self._get_dt(next_expected_st['datetime'])
             direction = next_expected_st.get('direction_name')
+            stop_id = next_expected_st.get('stop')
             is_real_time = next_expected_st.get('type') == 'E'
-            next_passage = RealTimePassage(dt, direction, is_real_time)
+            next_passage = RealTimePassage(dt, direction, is_real_time, stop_id)
             next_passages.append(next_passage)
 
         return next_passages

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -153,7 +153,6 @@ class Sytral(RealtimeProxy):
                 continue
             dt = self._get_dt(next_expected_st['datetime'])
             direction = next_expected_st.get('direction_name')
-            stop_id = next_expected_st.get('stop')
             is_real_time = next_expected_st.get('type') == 'E'
             next_passage = RealTimePassage(dt, direction, is_real_time)
             next_passages.append(next_passage)

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
@@ -459,7 +459,7 @@ def next_passage_for_route_point_multi_stop_point_id_test(mock_multi_stop_point_
     sytral = Sytral(id='tata', service_url='http://bob.com/')
 
     mock_requests = MockRequests(
-        {'http://bob.com/?stop_id=42?stop_id=43': (mock_multi_stop_point_id_response, 200)}
+        {'http://bob.com/?stop_id=42&stop_id=43': (mock_multi_stop_point_id_response, 200)}
     )
 
     route_point = MockRoutePoint(line_code='05', stop_id=['42', '43'])

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
@@ -469,15 +469,13 @@ def next_passage_for_route_point_multi_stop_point_id_test(mock_multi_stop_point_
 
         assert len(passages) == 4
 
+        # Stop id 42
         assert passages[0].datetime == datetime.datetime(2016, 4, 11, 13, 37, 15, tzinfo=pytz.UTC)
         assert not passages[0].is_real_time
-        assert passages[0].stop_id == '42'
         assert passages[1].datetime == datetime.datetime(2016, 4, 11, 13, 45, 35, tzinfo=pytz.UTC)
         assert passages[1].is_real_time
-        assert passages[1].stop_id == '42'
+        # Stop id 43
         assert passages[2].datetime == datetime.datetime(2016, 4, 11, 13, 38, 15, tzinfo=pytz.UTC)
         assert not passages[2].is_real_time
-        assert passages[2].stop_id == '43'
         assert passages[3].datetime == datetime.datetime(2016, 4, 11, 13, 47, 35, tzinfo=pytz.UTC)
         assert passages[3].is_real_time
-        assert passages[3].stop_id == '43'

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -63,11 +63,10 @@ def get_realtime_system_code(route_point):
 
 
 class RealTimePassage(object):
-    def __init__(self, datetime, direction=None, is_real_time=True, stop_id=None):
+    def __init__(self, datetime, direction=None, is_real_time=True):
         self.datetime = datetime
         self.direction = direction
         self.is_real_time = is_real_time
-        self.stop_id = stop_id
 
 
 def _create_template_from_passage(passage):

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -63,10 +63,11 @@ def get_realtime_system_code(route_point):
 
 
 class RealTimePassage(object):
-    def __init__(self, datetime, direction=None, is_real_time=True):
+    def __init__(self, datetime, direction=None, is_real_time=True, stop_id=None):
         self.datetime = datetime
         self.direction = direction
         self.is_real_time = is_real_time
+        self.stop_id = stop_id
 
 
 def _create_template_from_passage(passage):
@@ -146,6 +147,10 @@ class RoutePoint(object):
     def fetch_route_id(self, object_id_tag):
         # type: (Text) -> Optional[Text]
         return self._get_code(self.pb_route, object_id_tag)
+
+    def fetch_all_stop_id(self, object_id_tag):
+        # type: (Text) -> List[Text]
+        return self._get_all_codes(self.pb_stop_point, object_id_tag)
 
     def fetch_all_route_id(self, object_id_tag):
         # type: (Text) -> List[Text]


### PR DESCRIPTION
**Change** : Jormun allows to send multi **stop_id** parameters to the _Go service_ (**Sytral-RT**) like, `http://bob.com/?stop_id=42&stop_id=43`

**JIRA** : https://jira.kisio.org/browse/NAVP-1391

TODO : Update the _Go service_ -> PR https://github.com/CanalTP/sytralrt/pull/17