### PR TITLE
[Raptor] Lex walking duration

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -652,10 +652,32 @@ def _get_worst_similar(j1, j2, request):
     """
     if request.get('clockwise', True):
         if j1.arrival_date_time != j2.arrival_date_time:
-            return j1 if j1.arrival_date_time > j2.arrival_date_time else j2
+            # we dont want to arrive a few seconds earlier if it means walking more
+            # so we consider that arriving 1s earlier is better if we walk at most 1s more
+            # hence we compare arrival_time + walking_time instead of just arrival time
+            j1_penalized_arrival = j1.arrival_date_time + fallback_duration(j1)
+            j2_penalized_arrival = j2.arrival_date_time + fallback_duration(j2)
+            return j1 if j1_penalized_arrival > j2_penalized_arrival else j2
+
+        # arrival times are the same, let's look at departure times
+        if j1.departure_date_time != j2.departure_date_time:
+            # we dont want to depart a few seconds later if it means walking more
+            # so we consider that departing 1s later is better if we walk at most 1s more
+            # hence we compare departure_time - walking_time instead of just departure time
+            j1_penalized_departure = j1.departure_date_time - fallback_duration(j1)
+            j2_penalized_departure = j2.departure_date_time - fallback_duration(j2)
+            return j1 if j1_penalized_departure < j2_penalized_departure else j2
     else:
         if j1.departure_date_time != j2.departure_date_time:
-            return j1 if j1.departure_date_time < j2.departure_date_time else j2
+            j1_penalized_departure = j1.departure_date_time - fallback_duration(j1)
+            j2_penalized_departure = j2.departure_date_time - fallback_duration(j2)
+            return j1 if j1_penalized_departure < j2_penalized_departure else j2
+
+        # departure times are the same, let's look at arrival times
+        if j1.arrival_date_time != j2.arrival_date_time:
+            j1_penalized_arrival = j1.arrival_date_time + fallback_duration(j1)
+            j2_penalized_arrival = j2.arrival_date_time + fallback_duration(j2)
+            return j1 if j1_penalized_arrival > j2_penalized_arrival else j2
 
     if j1.duration != j2.duration:
         return j1 if j1.duration > j2.duration else j2

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -666,7 +666,7 @@ class JourneyCommon(object):
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
-        assert len(response['journeys']) == 2
+        assert len(response['journeys']) == 1
 
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
@@ -690,7 +690,7 @@ class JourneyCommon(object):
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
-        assert len(response['journeys']) == 2
+        assert len(response['journeys']) == 1
 
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
@@ -773,8 +773,7 @@ class JourneyCommon(object):
         check_best(response)
         self.is_valid_journey_response(response, query)
         jrnys = response['journeys']
-
-        j = next((j for j in jrnys if j['type'] == 'non_pt_walk'), None)
+        j = jrnys[0]
         assert j
         assert j['sections'][0]['from']['id'] == 'stopA'
         assert j['sections'][0]['to']['id'] == 'stop_point:stopB'
@@ -796,14 +795,14 @@ class JourneyCommon(object):
         """
         When the departure is a stop_area...
         """
-        query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}".format(
+        query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}&max_walking_direct_path_duration=1".format(
             from_sa='stopA', to_sa='stopB', datetime="20120614T080000"
         )
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
         jrnys = response['journeys']
-        assert len(jrnys) == 2
+        assert len(jrnys) == 1
         section_0 = jrnys[0]['sections'][0]
         assert section_0['type'] == 'crow_fly'
         assert section_0['mode'] == 'walking'
@@ -934,23 +933,19 @@ class JourneyCommon(object):
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
-        assert len(response['journeys']) == 4
+        assert len(response['journeys']) == 3
         assert len(response['journeys'][0]['sections']) == 3
-        assert response['journeys'][0]['sections'][0]['mode'] == 'bike'
-        assert response['journeys'][0]['durations']['total'] == 95
-        assert response['journeys'][0]['durations']['bike'] == 13
-        assert len(response['journeys'][1]['sections']) == 3
-        assert response['journeys'][1]['sections'][0]['mode'] == 'walking'
-        assert response['journeys'][1]['durations']['walking'] == 97
-        assert response['journeys'][1]['durations']['total'] == 99
+        assert response['journeys'][0]['sections'][0]['mode'] == 'walking'
+        assert response['journeys'][0]['durations']['walking'] == 97
+        assert response['journeys'][0]['durations']['total'] == 99
+        assert len(response['journeys'][1]['sections']) == 1
+        assert response['journeys'][1]['sections'][0]['mode'] == 'bike'
+        assert response['journeys'][1]['durations']['total'] == 171
+        assert response['journeys'][1]['durations']['bike'] == 171
         assert len(response['journeys'][2]['sections']) == 1
-        assert response['journeys'][2]['sections'][0]['mode'] == 'bike'
-        assert response['journeys'][2]['durations']['total'] == 171
-        assert response['journeys'][2]['durations']['bike'] == 171
-        assert len(response['journeys'][3]['sections']) == 1
-        assert response['journeys'][3]['sections'][0]['mode'] == 'walking'
-        assert response['journeys'][3]['durations']['walking'] == 276
-        assert response['journeys'][3]['durations']['total'] == 276
+        assert response['journeys'][2]['sections'][0]['mode'] == 'walking'
+        assert response['journeys'][2]['durations']['total'] == 276
+        assert response['journeys'][2]['durations']['walking'] == 276
 
     def test_call_kraken_boarding_alighting(self):
         """
@@ -1111,7 +1106,7 @@ class JourneyCommon(object):
 
     def test_shared_section(self):
         # Query a journey from stopB to stopA
-        r = self.query('/v1/coverage/main_routing_test/journeys?to=stopA&from=stopB&datetime=20120614T080100&')
+        r = self.query('/v1/coverage/main_routing_test/journeys?to=stopA&from=stopB&datetime=20120614T080100')
         assert r['journeys'][0]['type'] == 'best'
         assert r['journeys'][0]['sections'][1]['type'] == 'public_transport'
         # Here the heassign is modified by the headsign at stop.

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -161,7 +161,7 @@ class JourneyCommon(object):
 
         journeys = response['journeys']
         assert journeys
-        non_pt_walk_j = next((j for j in journeys if j['type'] == 'non_pt_walk'), None)
+        non_pt_walk_j = next((j for j in journeys if "non_pt_walking" in j['tags']), None)
         assert non_pt_walk_j
         assert non_pt_walk_j['duration'] == non_pt_walk_j['sections'][0]['duration']
         # duration has floor round value: duration = 310 / 1.5 (speed-factor) = 206.66..
@@ -795,14 +795,14 @@ class JourneyCommon(object):
         """
         When the departure is a stop_area...
         """
-        query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}&max_walking_direct_path_duration=1".format(
+        query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}&walking_speed=0.1".format(
             from_sa='stopA', to_sa='stopB', datetime="20120614T080000"
         )
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
         jrnys = response['journeys']
-        assert len(jrnys) == 1
+        assert len(jrnys) >= 1
         section_0 = jrnys[0]['sections'][0]
         assert section_0['type'] == 'crow_fly'
         assert section_0['mode'] == 'walking'
@@ -929,19 +929,19 @@ class JourneyCommon(object):
         assert response['journeys'][2]['durations']['walking'] == 276
         assert response['journeys'][2]['distances']['walking'] == 309
 
-        query += '&bike_speed=1.5'
+        query += '&bike_speed=3'
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
         assert len(response['journeys']) == 3
-        assert len(response['journeys'][0]['sections']) == 3
-        assert response['journeys'][0]['sections'][0]['mode'] == 'walking'
-        assert response['journeys'][0]['durations']['walking'] == 97
-        assert response['journeys'][0]['durations']['total'] == 99
-        assert len(response['journeys'][1]['sections']) == 1
-        assert response['journeys'][1]['sections'][0]['mode'] == 'bike'
-        assert response['journeys'][1]['durations']['total'] == 171
-        assert response['journeys'][1]['durations']['bike'] == 171
+        assert len(response['journeys'][0]['sections']) == 1
+        assert response['journeys'][0]['sections'][0]['mode'] == 'bike'
+        assert response['journeys'][0]['durations']['total'] == 85
+        assert response['journeys'][0]['durations']['bike'] == 85
+        assert len(response['journeys'][1]['sections']) == 3
+        assert response['journeys'][1]['sections'][0]['mode'] == 'walking'
+        assert response['journeys'][1]['durations']['walking'] == 97
+        assert response['journeys'][1]['durations']['total'] == 99
         assert len(response['journeys'][2]['sections']) == 1
         assert response['journeys'][2]['sections'][0]['mode'] == 'walking'
         assert response['journeys'][2]['durations']['total'] == 276
@@ -1106,7 +1106,9 @@ class JourneyCommon(object):
 
     def test_shared_section(self):
         # Query a journey from stopB to stopA
-        r = self.query('/v1/coverage/main_routing_test/journeys?to=stopA&from=stopB&datetime=20120614T080100')
+        r = self.query(
+            '/v1/coverage/main_routing_test/journeys?to=stopA&from=stopB&datetime=20120614T080100&walking_speed=0.5'
+        )
         assert r['journeys'][0]['type'] == 'best'
         assert r['journeys'][0]['sections'][1]['type'] == 'public_transport'
         # Here the heassign is modified by the headsign at stop.
@@ -1124,7 +1126,7 @@ class JourneyCommon(object):
         # Query same journey schedules
         # A new journey vjM is available
         r = self.query(
-            'v1/coverage/main_routing_test/journeys?_no_shared_section=False&allowed_id%5B%5D=stop_point%3AstopA&allowed_id%5B%5D=stop_point%3AstopB&first_section_mode%5B%5D=walking&last_section_mode%5B%5D=walking&is_journey_schedules=True&datetime=20120614T080100&to=stopA&min_nb_journeys=5&min_nb_transfers=0&direct_path=none&from=stopB&'
+            'v1/coverage/main_routing_test/journeys?_no_shared_section=False&allowed_id%5B%5D=stop_point%3AstopA&allowed_id%5B%5D=stop_point%3AstopB&first_section_mode%5B%5D=walking&last_section_mode%5B%5D=walking&is_journey_schedules=True&datetime=20120614T080100&to=stopA&min_nb_journeys=5&min_nb_transfers=0&direct_path=none&from=stopB&walking_speed=0.5'
         )
         assert r['journeys'][0]['sections'][1]['display_informations']['name'] == first_journey_pt
         assert r['journeys'][0]['sections'][1]['type'] == 'public_transport'
@@ -1138,14 +1140,14 @@ class JourneyCommon(object):
         # Activate 'no_shared_section' parameter and query the same journey schedules
         # The parameter 'no_shared_section' shouldn't be taken into account
         r = self.query(
-            'v1/coverage/main_routing_test/journeys?allowed_id%5B%5D=stop_point%3AstopA&allowed_id%5B%5D=stop_point%3AstopB&first_section_mode%5B%5D=walking&last_section_mode%5B%5D=walking&is_journey_schedules=True&datetime=20120614T080100&to=stopA&min_nb_journeys=5&min_nb_transfers=0&direct_path=none&from=stopB&_no_shared_section=True&'
+            'v1/coverage/main_routing_test/journeys?allowed_id%5B%5D=stop_point%3AstopA&allowed_id%5B%5D=stop_point%3AstopB&first_section_mode%5B%5D=walking&last_section_mode%5B%5D=walking&is_journey_schedules=True&datetime=20120614T080100&to=stopA&min_nb_journeys=5&min_nb_transfers=0&direct_path=none&from=stopB&_no_shared_section=True&walking_speed=0.5'
         )
-        assert len(r['journeys']) == 2
+        assert len(r['journeys']) == 4
 
         # Query the same journey schedules without 'is_journey_schedules' that deletes the parameter 'no_shared_section'
         # The journey vjM isn't available as it is a shared section
         r = self.query(
-            'v1/coverage/main_routing_test/journeys?allowed_id%5B%5D=stop_point%3AstopA&allowed_id%5B%5D=stop_point%3AstopB&first_section_mode%5B%5D=walking&last_section_mode%5B%5D=walking&datetime=20120614T080100&to=stopA&min_nb_journeys=5&min_nb_transfers=0&direct_path=none&from=stopB&_no_shared_section=True&'
+            'v1/coverage/main_routing_test/journeys?allowed_id%5B%5D=stop_point%3AstopA&allowed_id%5B%5D=stop_point%3AstopB&first_section_mode%5B%5D=walking&last_section_mode%5B%5D=walking&datetime=20120614T080100&to=stopA&min_nb_journeys=5&min_nb_transfers=0&direct_path=none&from=stopB&_no_shared_section=True&walking_speed=0.5'
         )
         assert r['journeys'][0]['sections'][1]['display_informations']['name'] == first_journey_pt
         assert len(r['journeys']) == 1
@@ -1946,7 +1948,7 @@ class JourneysMinNbJourneys:
         query = "journeys?from=2.39592;48.84838&to=2.36381;48.86750&datetime=20180309T080000&min_nb_journeys=7"
         response = self.query_region(query)
         self.is_valid_journey_response(response, query)
-        assert len(response['journeys']) == 6
+        assert len(response['journeys']) <= 6
 
 
 @dataset({"min_nb_journeys_test": {}})

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1308,17 +1308,17 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
         assert len(disrupts['disruptions']) == 11
 
         C_to_R_query = "journeys?from={from_coord}&to={to_coord}".format(
-            from_coord='stop_point:stopC', to_coord='0.00188646;0.00071865'
+            from_coord='stop_point:stopC', to_coord='stop_point:stopA'
         )
 
         # Query from C to R: the journey doesn't have any public_transport
-        base_journey_query = C_to_R_query + "&data_freshness=realtime&datetime=20120614T080000"
+        base_journey_query = C_to_R_query + "&data_freshness=realtime&datetime=20120614T080000&walking_speed=0.7"
         response = self.query_region(base_journey_query)
         assert len(response['journeys']) == 1
         assert len(response['journeys'][0]['sections']) == 1
         assert response['journeys'][0]['sections'][0]['type'] == 'street_network'
         assert 'data_freshness' not in response['journeys'][0]['sections'][0]
-        assert response['journeys'][0]['durations']['walking'] == 159
+        assert response['journeys'][0]['durations']['walking'] == 127
 
         # New disruption with two stop_times same as base schedule and
         # a new stop_time on stop_point:stopC added at the beginning
@@ -1332,23 +1332,23 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
                     arrival_delay=0,
                     departure_delay=0,
                     is_added=True,
-                    arrival=tstamp("20120614T080055"),
-                    departure=tstamp("20120614T080055"),
+                    arrival=tstamp("20120614T080000"),
+                    departure=tstamp("20120614T080000"),
                 ),
                 UpdatedStopTime(
                     "stop_point:stopB",
                     arrival_delay=0,
                     departure_delay=0,
-                    arrival=tstamp("20120614T080100"),
-                    departure=tstamp("20120614T080100"),
+                    arrival=tstamp("20120614T080001"),
+                    departure=tstamp("20120614T080001"),
                     message='on time',
                 ),
                 UpdatedStopTime(
                     "stop_point:stopA",
                     arrival_delay=0,
                     departure_delay=0,
-                    arrival=tstamp("20120614T080102"),
-                    departure=tstamp("20120614T080102"),
+                    arrival=tstamp("20120614T080002"),
+                    departure=tstamp("20120614T080002"),
                 ),
             ],
             disruption_id='new_stop_time',
@@ -1368,11 +1368,11 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
         # Query from C to R: the journey should have a public_transport from C to A
         response = self.query_region(base_journey_query)
         assert len(response['journeys']) == 2
-        assert len(response['journeys'][0]['sections']) == 2
+        assert len(response['journeys'][1]['sections']) == 1
         assert response['journeys'][0]['sections'][0]['type'] == 'public_transport'
         assert response['journeys'][0]['sections'][0]['data_freshness'] == 'realtime'
-        assert response['journeys'][0]['sections'][0]['departure_date_time'] == '20120614T080055'
-        assert response['journeys'][0]['sections'][1]['arrival_date_time'] == '20120614T080222'
+        assert response['journeys'][0]['sections'][0]['departure_date_time'] == '20120614T080000'
+        assert response['journeys'][0]['sections'][0]['arrival_date_time'] == '20120614T080002'
         assert response['journeys'][1]['sections'][0]['type'] == 'street_network'
 
         # New disruption with a deleted stop_time recently added at stop_point:stopC
@@ -1385,8 +1385,8 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
                     "stop_point:stopC",
                     arrival_delay=0,
                     departure_delay=0,
-                    arrival=tstamp("20120614T080104"),
-                    departure=tstamp("20120614T080104"),
+                    arrival=tstamp("20120614T080000"),
+                    departure=tstamp("20120614T080000"),
                     message='stop_time deleted',
                     arrival_skipped=True,
                 )
@@ -1411,7 +1411,7 @@ class TestKirinOnNewStopTimeAtTheBeginning(MockKirinDisruptionsFixture):
         assert len(response['journeys'][0]['sections']) == 1
         assert response['journeys'][0]['sections'][0]['type'] == 'street_network'
         assert 'data_freshness' not in response['journeys'][0]['sections'][0]
-        assert response['journeys'][0]['durations']['walking'] == 159
+        assert response['journeys'][0]['durations']['walking'] == 127
 
         pt_response = self.query_region('vehicle_journeys/vehicle_journey:vjA?_current_datetime=20120614T080000')
         assert len(pt_response['disruptions']) == 2

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -80,8 +80,8 @@ class TestJourneysDistributedWithMock(JourneyMinBikeMinCar, NewDefaultScenarioAb
         # journey count = 18 / direct_path_call_count = 26 / routing_matrix_call_count = 20
         # get_directpath_count_by_mode(response, 'walking') == 5
         # get_directpath_count_by_mode(response, 'bike') == 5
-        assert len(response["journeys"]) == 13
-        assert sn_service.direct_path_call_count == 6
+        assert len(response["journeys"]) == 8
+        assert sn_service.direct_path_call_count == 4
         assert sn_service.routing_matrix_call_count == 4
         assert get_directpath_count_by_mode(response, 'walking') == 1
         assert get_directpath_count_by_mode(response, 'bike') == 1
@@ -113,7 +113,7 @@ class TestJourneysDistributedWithMock(JourneyMinBikeMinCar, NewDefaultScenarioAb
         # get_directpath_count_by_mode(response, 'walking') == 5
         # get_directpath_count_by_mode(response, 'bike') == 5
         assert len(response["journeys"]) == 5
-        assert sn_service.direct_path_call_count == 6
+        assert sn_service.direct_path_call_count == 4
         assert sn_service.routing_matrix_call_count == 4
         assert get_directpath_count_by_mode(response, 'walking') == 1
         assert get_directpath_count_by_mode(response, 'bike') == 0

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -347,7 +347,7 @@ class TestJourneysDistributed(
             'datetime=20120614T080000&'
             'first_section_mode[]=walking&first_section_mode[]=bss&'
             'last_section_mode[]=walking&last_section_mode[]=bss&'
-            'bss_speed=1&walking_speed=2&debug=true'
+            'bss_speed=1&walking_speed=1&debug=true'
         )
         # for the first request, the walking duration to the stop_point is equal to the bss duration
         r = self.query(query)

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
         std::uniform_int_distribution<> gen(0, data.pt_data->stop_areas.size() - 1);
         std::vector<unsigned int> hours{0, 28800, 36000, 72000, 86000};
         std::vector<unsigned int> days({7});
-        if (data.meta->production_date.begin().day_of_week().as_number() == 6)
+        if (data.meta->production_date.begin().day_of_week().as_number() == 6) {
             days.push_back(days.front() + 1);
         } else {
             days.push_back(days.front() + 6);

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -140,7 +140,7 @@ static type::EntryPoint make_entry_point(const std::string& entry_id, const type
 int main(int argc, char** argv) {
     navitia::init_app();
     po::options_description desc("Options de l'outil de benchmark");
-    std::string file, output, stop_input_file, start, target;
+    std::string file, output, stop_input_file, start, target, demands_output_file;
     int iterations, date, hour, nb_second_pass;
 
     auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
@@ -164,6 +164,7 @@ int main(int argc, char** argv) {
             ("verbose,v", "Verbose debugging output")
             ("nb_second_pass", po::value<int>(&nb_second_pass)->default_value(0), "nb second pass")
             ("stop_files", po::value<std::string>(&stop_input_file), "File with list of start and target")
+            ("dump_demands", po::value<std::string>(&demands_output_file), "Write a csv file with the list of demands (start, target, time) used")
             ("output,o", po::value<std::string>(&output)->default_value("benchmark.csv"),
                      "Output file");
     // clang-format on
@@ -242,6 +243,24 @@ int main(int argc, char** argv) {
                 }
             }
         }
+    }
+
+    //ecriture des requetes
+    if (vm.count("dump_demands")) {
+        std::fstream out_file(demands_output_file, std::ios::out);
+        out_file << "Start id, Target id, , , Day, Hour" << std::endl;
+
+        for (size_t i = 0; i < demands.size(); ++i) {
+            PathDemand demand = demands[i];
+            out_file << demand.start << ", "
+                    << demand.target << ", " 
+                    << " " << ","
+                    << " " << ","
+                    << demand.date << ", "
+                    << demand.hour
+                    << std::endl;
+        }
+        out_file.close();
     }
 
     // Calculs des itinéraires

--- a/source/routing/benchmark_full.cpp
+++ b/source/routing/benchmark_full.cpp
@@ -245,20 +245,18 @@ int main(int argc, char** argv) {
         }
     }
 
-    //ecriture des requetes
+    // ecriture des requetes
     if (vm.count("dump_demands")) {
         std::fstream out_file(demands_output_file, std::ios::out);
         out_file << "Start id, Target id, , , Day, Hour" << std::endl;
 
         for (size_t i = 0; i < demands.size(); ++i) {
             PathDemand demand = demands[i];
-            out_file << demand.start << ", "
-                    << demand.target << ", " 
-                    << " " << ","
-                    << " " << ","
-                    << demand.date << ", "
-                    << demand.hour
-                    << std::endl;
+            out_file << demand.start << ", " << demand.target << ", "
+                     << " "
+                     << ","
+                     << " "
+                     << "," << demand.date << ", " << demand.hour << std::endl;
         }
         out_file.close();
     }

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -42,8 +42,12 @@ void dataRAPTOR::Connections::load(const type::PT_Data& data) {
     forward_connections.assign(data.stop_points);
     backward_connections.assign(data.stop_points);
     for (const auto* conn : data.stop_point_connections) {
-        forward_connections[SpIdx(*conn->departure)].push_back({DateTime(conn->duration), SpIdx(*conn->destination)});
-        backward_connections[SpIdx(*conn->destination)].push_back({DateTime(conn->duration), SpIdx(*conn->departure)});
+        const SpIdx departure_stop_point = SpIdx(*conn->departure);
+        const SpIdx arrival_stop_point = SpIdx(*conn->destination);
+        const DateTime walking_duration = DateTime(conn->display_duration);
+        const DateTime total_duration = DateTime(conn->duration);
+        forward_connections[departure_stop_point].push_back({total_duration, walking_duration, arrival_stop_point});
+        backward_connections[arrival_stop_point].push_back({total_duration, walking_duration, departure_stop_point});
     }
     for (auto& conns : forward_connections.values()) {
         conns.shrink_to_fit();

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -80,6 +80,8 @@ struct dataRAPTOR {
     };
     JppsFromSp jpps_from_sp;
 
+    std::string print_jpps_from_sp();
+
     // cache friendly access to in order JourneyPatternPoints from a JourneyPattern
     struct JppsFromJp {
         // compressed JourneyPatternPoint

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -80,8 +80,6 @@ struct dataRAPTOR {
     };
     JppsFromSp jpps_from_sp;
 
-    std::string print_jpps_from_sp();
-
     // cache friendly access to in order JourneyPatternPoints from a JourneyPattern
     struct JppsFromJp {
         // compressed JourneyPatternPoint

--- a/source/routing/dataraptor.h
+++ b/source/routing/dataraptor.h
@@ -47,7 +47,8 @@ struct dataRAPTOR {
     // cache friendly access to the connections
     struct Connections {
         struct Connection {
-            DateTime duration;
+            DateTime duration;          // walking_duration + margin duration to be able to catch the next vehicle
+            DateTime walking_duration;  // walking_duration, filled with StopPointConnection.display_duration
             SpIdx sp_idx;
         };
         void load(const navitia::type::PT_Data&);

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -91,7 +91,7 @@ bool Journey::better_on_transfer(const Journey& that) const {
         return nb_vj_extentions <= that.nb_vj_extentions;
     }
 
-    return total_waiting_dur <= that.total_waiting_dur;
+    return true;
 }
 bool Journey::better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const {
     // we consider that the transfer duration as well as the street network duration are

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -66,13 +66,7 @@ bool Journey::better_on_dt(const Journey& that, bool request_clockwise) const {
             return arrival_dt <= that.arrival_dt;
         }
     }
-    // FIXME: I don't like this objective, for me, this is a
-    // transfer objective, but then you can return some solutions
-    // that we didn't return before.
-    // if (!(better_on_transfer(that, request_clockwise) && that.better_on_transfer(*this, request_clockwise))) {
-    //     // if they are not equal on transfer, we don't check min_waiting_dur
-    //     return true;
-    // }
+
     return min_waiting_dur >= that.min_waiting_dur;
 }
 
@@ -87,7 +81,10 @@ bool Journey::better_on_transfer(const Journey& that) const {
     return total_waiting_dur <= that.total_waiting_dur;
 }
 bool Journey::better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const {
-    // we consider the transfer sections also as walking sections
+    // we consider that the transfer duration as well as the street network duration are
+    // walking duration
+    // we consider that an extra transfer (hence a bigger sections.size() ) is worthwhile
+    // only if it reduces the walking duration by at least transfer_penalty
     return sn_dur + transfer_dur + transfer_penalty * sections.size()
            <= that.sn_dur + that.transfer_dur + transfer_penalty * that.sections.size();
     ;

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -69,10 +69,10 @@ bool Journey::better_on_dt(const Journey& that, bool request_clockwise) const {
     // FIXME: I don't like this objective, for me, this is a
     // transfer objective, but then you can return some solutions
     // that we didn't return before.
-    if (!(better_on_transfer(that) && that.better_on_transfer(*this))) {
-        // if they are not equal on transfer, we don't check min_waiting_dur
-        return true;
-    }
+    // if (!(better_on_transfer(that, request_clockwise) && that.better_on_transfer(*this, request_clockwise))) {
+    //     // if they are not equal on transfer, we don't check min_waiting_dur
+    //     return true;
+    // }
     return min_waiting_dur >= that.min_waiting_dur;
 }
 

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -86,9 +86,11 @@ bool Journey::better_on_transfer(const Journey& that) const {
 
     return total_waiting_dur <= that.total_waiting_dur;
 }
-bool Journey::better_on_sn(const Journey& that, bool) const {
+bool Journey::better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const {
     // we consider the transfer sections also as walking sections
-    return sn_dur + transfer_dur <= that.sn_dur + that.transfer_dur;
+    return sn_dur + transfer_dur + transfer_penalty * sections.size()
+           <= that.sn_dur + that.transfer_dur + transfer_penalty * that.sections.size();
+    ;
 }
 
 bool Journey::operator==(const Journey& rhs) const {

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -80,10 +80,13 @@ bool Journey::better_on_transfer(const Journey& that) const {
     if (sections.size() != that.sections.size()) {
         return sections.size() <= that.sections.size();
     }
-    return nb_vj_extentions <= that.nb_vj_extentions;
-}
+    if (nb_vj_extentions != that.nb_vj_extentions) {
+        return nb_vj_extentions <= that.nb_vj_extentions;
+    }
 
-bool Journey::better_on_sn(const Journey& that) const {
+    return total_waiting_dur <= that.total_waiting_dur;
+}
+bool Journey::better_on_sn(const Journey& that, bool) const {
     // we consider the transfer sections also as walking sections
     return sn_dur + transfer_dur <= that.sn_dur + that.transfer_dur;
 }

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -61,8 +61,10 @@ bool Journey::better_on_dt(const Journey& that,
     // only if it increases the departure time by at least transfer_penalty
     DateTime penalized_departure = departure_dt - transfer_penalty * sections.size();
     DateTime that_penalized_departure = that.departure_dt - transfer_penalty * that.sections.size();
+
     if (request_clockwise) {
-        if (penalized_arrival != that_penalized_arrival) {
+        // if the (non-penalized) arrival times are the same, we compare the penalized departure times
+        if (arrival_dt != that.arrival_dt) {
             return penalized_arrival <= that_penalized_arrival;
         }
 
@@ -70,7 +72,7 @@ bool Journey::better_on_dt(const Journey& that,
             return penalized_departure >= that_penalized_departure;
         }
     } else {
-        if (penalized_departure != that_penalized_departure) {
+        if (departure_dt != that.departure_dt) {
             return penalized_departure >= that_penalized_departure;
         }
         if (penalized_arrival != that_penalized_arrival) {

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -91,10 +91,13 @@ bool Journey::better_on_transfer(const Journey& that) const {
 
     return total_waiting_dur <= that.total_waiting_dur;
 }
-bool Journey::better_on_sn(const Journey& that) const {
+bool Journey::better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const {
     // we consider that the transfer duration as well as the street network duration are
     // walking duration
-    return sn_dur + transfer_dur <= that.sn_dur + that.transfer_dur;
+    // we consider that an extra transfer (hence a bigger sections.size() ) is worthwhile
+    // only if it reduces the walking duration by at least transfer_penalty
+    return sn_dur + transfer_dur + transfer_penalty * sections.size()
+           <= that.sn_dur + that.transfer_dur + transfer_penalty * that.sections.size();
     ;
 }
 

--- a/source/routing/journey.h
+++ b/source/routing/journey.h
@@ -58,9 +58,9 @@ struct Journey {
 
     bool is_pt() const;
 
-    bool better_on_dt(const Journey& that, bool request_clockwise) const;
+    bool better_on_dt(const Journey& that, bool request_clockwise, const navitia::time_duration transfer_penalty) const;
     bool better_on_transfer(const Journey& that) const;
-    bool better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const;
+    bool better_on_sn(const Journey& that) const;
     bool operator==(const Journey& rhs) const;
     bool operator!=(const Journey& rhs) const;
     friend std::ostream& operator<<(std::ostream& os, const Journey& j);

--- a/source/routing/journey.h
+++ b/source/routing/journey.h
@@ -60,7 +60,7 @@ struct Journey {
 
     bool better_on_dt(const Journey& that, bool request_clockwise) const;
     bool better_on_transfer(const Journey& that) const;
-    bool better_on_sn(const Journey& that) const;
+    bool better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const;
     bool operator==(const Journey& rhs) const;
     bool operator!=(const Journey& rhs) const;
     friend std::ostream& operator<<(std::ostream& os, const Journey& j);

--- a/source/routing/journey.h
+++ b/source/routing/journey.h
@@ -60,7 +60,7 @@ struct Journey {
 
     bool better_on_dt(const Journey& that, bool request_clockwise, const navitia::time_duration transfer_penalty) const;
     bool better_on_transfer(const Journey& that) const;
-    bool better_on_sn(const Journey& that) const;
+    bool better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const;
     bool operator==(const Journey& rhs) const;
     bool operator!=(const Journey& rhs) const;
     friend std::ostream& operator<<(std::ostream& os, const Journey& j);

--- a/source/routing/journey.h
+++ b/source/routing/journey.h
@@ -65,13 +65,14 @@ struct Journey {
     bool operator!=(const Journey& rhs) const;
     friend std::ostream& operator<<(std::ostream& os, const Journey& j);
 
-    std::vector<Section> sections;                 // the pt sections, with transfer between them
-    navitia::time_duration sn_dur = 0_s;           // street network duration
-    navitia::time_duration transfer_dur = 0_s;     // walking duration during transfer
-    navitia::time_duration min_waiting_dur = 0_s;  // minimal waiting duration on every transfers
-    DateTime departure_dt = 0;                     // the departure dt of the journey, including sn
-    DateTime arrival_dt = 0;                       // the arrival dt of the journey, including sn
-    uint8_t nb_vj_extentions = 0;                  // number of vehicle journey extentions (I love useless comments!)
+    std::vector<Section> sections;                   // the pt sections, with transfer between them
+    navitia::time_duration sn_dur = 0_s;             // street network duration
+    navitia::time_duration transfer_dur = 0_s;       // walking duration during transfer
+    navitia::time_duration min_waiting_dur = 0_s;    // minimal waiting duration on every transfers
+    navitia::time_duration total_waiting_dur = 0_s;  // sum of waiting duration over all transfers
+    DateTime departure_dt = 0;                       // the departure dt of the journey, including sn
+    DateTime arrival_dt = 0;                         // the arrival dt of the journey, including sn
+    uint8_t nb_vj_extentions = 0;                    // number of vehicle journey extentions (I love useless comments!)
 };
 
 struct JourneyHash {

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -492,7 +492,7 @@ std::pair<const type::StopTime*, DateTime> CachedNextStopTime::next_stop_time(co
 }
 
 CachedNextStopTimeManager::~CachedNextStopTimeManager() {
-    auto logger = log4cplus::Logger::getInstance("log");
+    auto logger = log4cplus::Logger::getInstance("logger");
     LOG4CPLUS_INFO(logger, "Cache miss : " << lru.get_nb_cache_miss() << " / " << lru.get_nb_calls());
 }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -491,11 +491,6 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
     LOG4CPLUS_TRACE(logger, "starting points 2nd phase " << std::endl
                                                          << print_starting_points_snd_phase(starting_points));
 
-    unsigned lower_bound_fb = std::numeric_limits<unsigned>::max();
-    for (const auto& pair_sp_dt : calc_dep) {
-        lower_bound_fb = std::min(lower_bound_fb, unsigned(pair_sp_dt.second.seconds()));
-    }
-
     LOG4CPLUS_TRACE(logger, "Before second pass, nb of solutions : " << solutions.size());
 
     size_t nb_snd_pass = 0, nb_useless = 0, last_usefull_2nd_pass = 0, supplementary_2nd_pass = 0;
@@ -539,8 +534,6 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
         init(init_map, working_labels.dt_pt(start.sp_idx), !clockwise, accessibilite_params.properties);
         boucleRAPTOR(!clockwise, rt_level, max_transfers);
 
-        // LOG4CPLUS_TRACE(logger, std::endl << "before solution_reader " << std::endl << print_all_labels() );
-
         read_solutions(*this, solutions, !clockwise, departure_datetime, departures, destinations, rt_level,
                        accessibilite_params, transfer_penalty, start);
 
@@ -549,9 +542,6 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
         ++nb_snd_pass;
     }
 
-    LOG4CPLUS_DEBUG(logger, "[2nd pass] lower bound fallback duration = "
-                                << lower_bound_fb << " s, lower bound connection duration = "
-                                << data.dataRaptor->min_connection_time << " s");
     LOG4CPLUS_DEBUG(logger, "[2nd pass] number of 2nd pass = "
                                 << nb_snd_pass << " / " << starting_points.size() << " (nb useless = " << nb_useless
                                 << ", last usefull try = " << last_usefull_2nd_pass << ")");

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -195,8 +195,8 @@ void RAPTOR::clear(const bool clockwise, const DateTime bound) {
 
     boost::fill(best_labels_pts.values(), bound);
     boost::fill(best_labels_transfers.values(), bound);
-    boost::fill(best_labels_pts.values(), DateTimeUtils::not_valid);
-    boost::fill(best_labels_transfers.values(), DateTimeUtils::not_valid);
+    boost::fill(best_labels_pts_fallback.values(), DateTimeUtils::not_valid);
+    boost::fill(best_labels_transfers_fallback.values(), DateTimeUtils::not_valid);
 }
 
 void RAPTOR::init(const map_stop_point_duration& dep,

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -64,6 +64,7 @@ bool RAPTOR::apply_vj_extension(const Visitor& v,
                                 const type::VehicleJourney* vj,
                                 const uint16_t l_zone,
                                 DateTime base_dt) {
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     auto& working_labels = labels[count];
     bool result = false;
     while (vj) {
@@ -93,7 +94,12 @@ bool RAPTOR::apply_vj_extension(const Visitor& v,
             if (!v.comp(workingDt, best_labels_pts[sp_idx])) {
                 continue;
             }
-
+            LOG4CPLUS_TRACE(logger, "Updating label dt count : " << count 
+                                    << " sp " << data.pt_data->stop_points[sp_idx.val]->uri
+                                    << " from " << working_labels.dt_pt(sp_idx)
+                                    << " to "  << workingDt
+                                    << " throught : " << st.vehicle_journey->route->line->uri
+                            );
             working_labels.mut_dt_pt(sp_idx) = workingDt;
             best_labels_pts[sp_idx] = workingDt;
             result = true;
@@ -105,6 +111,7 @@ bool RAPTOR::apply_vj_extension(const Visitor& v,
 
 template <typename Visitor>
 bool RAPTOR::foot_path(const Visitor& v) {
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     bool result = false;
     auto& working_labels = labels[count];
     const auto& cnx_list = v.clockwise() ? data.dataRaptor->connections.forward_connections
@@ -127,6 +134,13 @@ bool RAPTOR::foot_path(const Visitor& v) {
             if (!v.comp(next, best_labels_transfers[destination_sp_idx])) {
                 continue;
             }
+
+            LOG4CPLUS_TRACE(logger, "Updating label transfer count : " << count 
+                        << " sp " << data.pt_data->stop_points[destination_sp_idx.val]->uri
+                        << " from " << working_labels.dt_transfer(sp_idx)
+                        << " to "  << next
+                        << " throught connection : " << data.pt_data->stop_points[sp_idx.val]->uri
+                );
 
             // if we can improve the best label, we mark it
             working_labels.mut_dt_transfer(destination_sp_idx) = next;
@@ -748,6 +762,14 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                             && visitor.comp(workingDt, best_labels_pts[jpp.sp_idx])
                             && valid_stop_points[jpp.sp_idx.val])  // we need to check the accessibility
                         {
+
+                            LOG4CPLUS_TRACE(logger, "Updating label dt count : " << count 
+                                                    << " sp " << data.pt_data->stop_points[jpp.sp_idx.val]->uri
+                                                    << " from " << working_labels.dt_pt(jpp.sp_idx)
+                                                    << " to "  << workingDt
+                                                    << " throught : " << st.vehicle_journey->route->line->uri
+                                           );
+
                             working_labels.mut_dt_pt(jpp.sp_idx) = workingDt;
                             best_labels_pts[jpp.sp_idx] = working_labels.dt_pt(jpp.sp_idx);
                             continue_algorithm = true;

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -865,7 +865,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
 
                     bool update_boarding_stop_point = !is_onboard 
                                                         || visitor.comp(tmp_st_dt.second, workingDt)
-                                                        ||  (tmp_st_dt.second ==  workingDt && previous_walking_duration < working_walking_duration) ;
+                                                        ||  (tmp_st_dt.second ==  workingDt && previous_walking_duration <= working_walking_duration) ;
                     // if(working_walking_duration != DateTimeUtils::not_valid) {
                     //     update_boarding_stop_point = update_boarding_stop_point 
                     //                                   || ( visitor.equal(previous_dt, base_dt, *it_st)

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -96,14 +96,12 @@ bool RAPTOR::apply_vj_extension(const Visitor& v,
             if (!v.comp(workingDt, best_labels_pts[sp_idx])) {
                 continue;
             }
-            LOG4CPLUS_TRACE(logger, "Updating label dt count : " << count 
-                                    << " sp " << data.pt_data->stop_points[sp_idx.val]->uri
-                                    << " from " << working_labels.dt_pt(sp_idx)
-                                    << " to "  << workingDt
-                                    << " throught : " << st.vehicle_journey->route->line->uri
-                                    << " boarding_stop_point : " << data.pt_data->stop_points[boarding_stop_point.val]->uri
-                                    << " walk : " << working_walking_duration
-                            );
+            LOG4CPLUS_TRACE(logger, "Updating label dt count : "
+                                        << count << " sp " << data.pt_data->stop_points[sp_idx.val]->uri << " from "
+                                        << working_labels.dt_pt(sp_idx) << " to " << workingDt << " throught : "
+                                        << st.vehicle_journey->route->line->uri << " boarding_stop_point : "
+                                        << data.pt_data->stop_points[boarding_stop_point.val]->uri
+                                        << " walk : " << working_walking_duration);
             working_labels.mut_dt_pt(sp_idx) = workingDt;
             working_labels.mut_walking_duration_pt(sp_idx) = working_walking_duration;
             BOOST_ASSERT(working_walking_duration != DateTimeUtils::not_valid);
@@ -142,17 +140,16 @@ bool RAPTOR::foot_path(const Visitor& v) {
                 continue;
             }
 
-            LOG4CPLUS_TRACE(logger, "Updating label transfer count : " << count 
-                        << " sp " << data.pt_data->stop_points[destination_sp_idx.val]->uri
-                        << " from " << working_labels.dt_transfer(destination_sp_idx)
-                        << " to "  << next
-                        << " throught connection : " << data.pt_data->stop_points[sp_idx.val]->uri
-                        << " walk : " << previous_walking_duration_dt
-                );
+            LOG4CPLUS_TRACE(logger, "Updating label transfer count : "
+                                        << count << " sp " << data.pt_data->stop_points[destination_sp_idx.val]->uri
+                                        << " from " << working_labels.dt_transfer(destination_sp_idx) << " to " << next
+                                        << " throught connection : " << data.pt_data->stop_points[sp_idx.val]->uri
+                                        << " walk : " << previous_walking_duration_dt);
 
             // if we can improve the best label, we mark it
             working_labels.mut_dt_transfer(destination_sp_idx) = next;
-            working_labels.mut_walking_duration_transfer(destination_sp_idx) = previous_walking_duration_dt + conn.duration;
+            working_labels.mut_walking_duration_transfer(destination_sp_idx) =
+                previous_walking_duration_dt + conn.duration;
             best_labels_transfers[destination_sp_idx] = next;
             result = true;
         }
@@ -278,7 +275,7 @@ std::vector<StartingPointSndPhase> make_starting_points_snd_phase(const RAPTOR& 
     std::vector<StartingPointSndPhase> res;
     auto overfilter = ParetoFront<std::pair<size_t, StartingPointSndPhase>, Dom>(Dom(clockwise));
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
-    
+
     for (unsigned count = 1; count <= raptor.count; ++count) {
         const auto& working_labels = raptor.labels[count];
         for (const auto& a : arrs) {
@@ -292,19 +289,18 @@ std::vector<StartingPointSndPhase> make_starting_points_snd_phase(const RAPTOR& 
             const unsigned arrival_walking_t = a.second.total_seconds();
             const DateTime walking_duration_before_arrival_stop_point = working_labels.walking_duration_pt(a.first);
             const DateTime total_walking_duration = arrival_walking_t + walking_duration_before_arrival_stop_point;
-            StartingPointSndPhase starting_point = {
-                a.first, count,
-                (clockwise ? working_labels.dt_pt(a.first) + arrival_walking_t : working_labels.dt_pt(a.first) - arrival_walking_t),
-                total_walking_duration, false};
-            
-            // LOG4CPLUS_TRACE(logger, "Candidate starting point second phase : " 
+            StartingPointSndPhase starting_point = {a.first, count,
+                                                    (clockwise ? working_labels.dt_pt(a.first) + arrival_walking_t
+                                                               : working_labels.dt_pt(a.first) - arrival_walking_t),
+                                                    total_walking_duration, false};
+
+            // LOG4CPLUS_TRACE(logger, "Candidate starting point second phase : "
             //                     << raptor.data.pt_data->stop_points[a.first.val]->uri
             //                     << std::endl
             //                     << " count : " << count
             //                     << " arrival walking time : " << arrival_walking_t
             //                     << " walking_before_arrival : " << walking_duration_before_arrival_stop_point
             //                 );
-
 
             overfilter.add({res.size(), starting_point});
             res.push_back(starting_point);
@@ -333,9 +329,9 @@ Journey convert_to_bound(const StartingPointSndPhase& sp,
     uint32_t nb_conn = (sp.count >= 1 ? sp.count - 1 : 0);
     if (clockwise) {
         journey.arrival_dt = sp.end_dt;
-        journey.departure_dt = sp.end_dt - journey.sn_dur.seconds(); 
+        journey.departure_dt = sp.end_dt - journey.sn_dur.seconds();
     } else {
-        journey.arrival_dt = sp.end_dt + journey.sn_dur.seconds(); 
+        journey.arrival_dt = sp.end_dt + journey.sn_dur.seconds();
         journey.departure_dt = sp.end_dt;
     }
 
@@ -440,16 +436,14 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
                                               bool clockwise,
                                               const boost::optional<navitia::time_duration>& direct_path_dur,
                                               const size_t max_extra_second_pass) {
-
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
     LOG4CPLUS_TRACE(logger, "departure_datetime : " << iso_string(departure_datetime, data)
-                            << " bound : " << iso_string(bound, data)
-                    );
+                                                    << " bound : " << iso_string(bound, data));
 
     auto start_raptor = std::chrono::system_clock::now();
 
-    //auto solutions = ParetoFront<Journey, Dominates /*, JourneyParetoFrontVisitor*/>(Dominates(clockwise));
+    // auto solutions = ParetoFront<Journey, Dominates /*, JourneyParetoFrontVisitor*/>(Dominates(clockwise));
     auto dominator = Dominates(clockwise);
     auto solutions = Solutions(dominator);
 
@@ -498,7 +492,8 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
     init_best_pts_snd_pass(calc_dep, departure_datetime, clockwise, best_labels_pts_for_snd_pass);
     auto best_labels_transfers_for_snd_pass = snd_pass_best_labels(clockwise, best_labels_pts);
 
-    LOG4CPLUS_TRACE(logger, "starting points 2nd phase " << std::endl << print_starting_points_snd_phase(starting_points));
+    LOG4CPLUS_TRACE(logger, "starting points 2nd phase " << std::endl
+                                                         << print_starting_points_snd_phase(starting_points));
 
     unsigned lower_bound_fb = std::numeric_limits<unsigned>::max();
     for (const auto& pair_sp_dt : calc_dep) {
@@ -511,25 +506,19 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
     for (const auto& start : starting_points) {
         navitia::type::StopPoint* start_stop_point = data.pt_data->stop_points[start.sp_idx.val];
 
-        LOG4CPLUS_TRACE(logger, std::endl << "Second pass from " << start_stop_point->uri << "   count : " << start.count
-                                    << std::endl << std::endl
-                                    // << "   count : " << start.count
-                                    // << " end_dt : " << iso_string(start.end_dt, data)
-                                    // << " fallback_dur : " << start.fallback_dur
-                                    // << " has_priority : " << start.has_priority
-                        );
+        LOG4CPLUS_TRACE(logger, std::endl
+                                    << "Second pass from " << start_stop_point->uri << "   count : " << start.count);
 
         Journey fake_journey =
             convert_to_bound(start, lower_bound_fb, data.dataRaptor->min_connection_time, transfer_penalty, clockwise);
-        
-        LOG4CPLUS_TRACE(logger," fake journey : " << fake_journey);
-        
+
+        LOG4CPLUS_TRACE(logger, " fake journey : " << fake_journey);
 
         if (solutions.contains_better_than(fake_journey)) {
             LOG4CPLUS_TRACE(logger, "has better solution than fake journey from " << start_stop_point->uri);
-            for(auto solution : solutions) {
+            for (auto solution : solutions) {
                 if (dominator(solution, fake_journey)) {
-                    LOG4CPLUS_TRACE(logger,"  dominated by : " << solution);
+                    LOG4CPLUS_TRACE(logger, "  dominated by : " << solution);
                     break;
                 }
             }
@@ -741,7 +730,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
     bool continue_algorithm = true;
     count = 0;  //< Count iteration of raptor algorithm
- 
+
     // LOG4CPLUS_TRACE(logger, "start raptor loop");
 
     while (continue_algorithm && count <= max_transfers) {
@@ -762,14 +751,11 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
          * We want to do it, to favoritize normal vj against stay_in vjs
          */
         for (auto q_elt : Q) {
-
             /// We will scan the journey_pattern q_elt.first, starting from its stop numbered q_elt.second
 
             const JpIdx jp_idx = q_elt.first;
 
             const RouteIdx route_idx = data.dataRaptor->jp_container.get(jp_idx).route_idx;
-
-
 
             /// q_elt.second == visitor.init_queue_item() means that
             /// this journey_pattern is marked "not to be scanned"
@@ -778,8 +764,8 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                 bool is_onboard = false;
                 DateTime workingDt = visitor.worst_datetime();
                 DateTime base_dt = workingDt;
-                DateTime  working_walking_duration = DateTimeUtils::not_valid;
-                SpIdx    boarding_stop_point = SpIdx();
+                DateTime working_walking_duration = DateTimeUtils::not_valid;
+                SpIdx boarding_stop_point = SpIdx();
 
                 /// will be used to iterate through the StopTimeS of
                 /// the vehicle journey of the current journey_pattern (jp_idx)
@@ -787,10 +773,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                 typename Visitor::stop_time_iterator it_st;  /// item = type::StopTime
                 uint16_t l_zone = std::numeric_limits<uint16_t>::max();
 
-                LOG4CPLUS_TRACE(logger, " Scanning line  " 
-                        << data.pt_data->routes[route_idx.val]->line->uri
-                        );
-
+                LOG4CPLUS_TRACE(logger, " Scanning line  " << data.pt_data->routes[route_idx.val]->line->uri);
 
                 const auto& jpps_to_explore =
                     visitor.jpps_from_order(data.dataRaptor->jpps_from_jp, jp_idx, q_elt.second);
@@ -809,35 +792,29 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                             && visitor.comp(workingDt, best_labels_pts[jpp.sp_idx])
                             && valid_stop_points[jpp.sp_idx.val])  // we need to check the accessibility
                         {
-
-                            LOG4CPLUS_TRACE(logger, "Updating label dt count : " << count 
-                                                    << " sp " << data.pt_data->stop_points[jpp.sp_idx.val]->uri
-                                                    << " from " << working_labels.dt_pt(jpp.sp_idx)
-                                                    << " to "  << workingDt
-                                                    << " throught : " << st.vehicle_journey->route->line->uri
-                                                    << " boarding_stop_point : " << data.pt_data->stop_points[boarding_stop_point.val]->uri
-                                                    << " walk : " << working_walking_duration
-                                           );
+                            LOG4CPLUS_TRACE(logger, "Updating label dt "
+                                                        << "count : " << count << " sp "
+                                                        << data.pt_data->stop_points[jpp.sp_idx.val]->uri << " from "
+                                                        << working_labels.dt_pt(jpp.sp_idx) << " to " << workingDt
+                                                        << " throught : " << st.vehicle_journey->route->line->uri
+                                                        << " boarding_stop_point : "
+                                                        << data.pt_data->stop_points[boarding_stop_point.val]->uri
+                                                        << " walk : " << working_walking_duration);
 
                             working_labels.mut_dt_pt(jpp.sp_idx) = workingDt;
                             working_labels.mut_walking_duration_pt(jpp.sp_idx) = working_walking_duration;
                             BOOST_ASSERT(working_walking_duration != DateTimeUtils::not_valid);
-                            /// TODO : update working_labels.walking_duration_dt_pt
                             best_labels_pts[jpp.sp_idx] = working_labels.dt_pt(jpp.sp_idx);
                             continue_algorithm = true;
                         }
                     }
 
-
-
                     // We try to get on a vehicle, if we were already on a vehicle, but we arrived
                     // before on the previous via a connection, we try to catch a vehicle leaving this
                     // journey pattern point before
 
-
                     // if we cannot board at this stop point, nothing to do
-                    if (  !prec_labels.transfer_is_initialized(jpp.sp_idx)
-                        || ! valid_stop_points[jpp.sp_idx.val]  ) {
+                    if (!prec_labels.transfer_is_initialized(jpp.sp_idx) || !valid_stop_points[jpp.sp_idx.val]) {
                         continue;
                     }
 
@@ -845,7 +822,6 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                     //  hence we can board any vehicle arriving after previous_dt
                     const DateTime previous_dt = prec_labels.dt_transfer(jpp.sp_idx);
                     const DateTime previous_walking_duration = prec_labels.walking_duration_transfer(jpp.sp_idx);
-
 
                     /// we are at stop point jpp.idx at time previous_dt
                     /// waiting for the next vehicle journey of the journey_pattern jpp.jp_idx to embark on
@@ -861,22 +837,10 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                         continue;
                     }
 
+                    bool update_boarding_stop_point = !is_onboard
+                                                      || visitor.comp(tmp_st_dt.second, workingDt)
 
-
-                    bool update_boarding_stop_point = !is_onboard 
-                                                        || visitor.comp(tmp_st_dt.second, workingDt)
-                                                        ||  (tmp_st_dt.second ==  workingDt && previous_walking_duration <= working_walking_duration) ;
-                    // if(working_walking_duration != DateTimeUtils::not_valid) {
-                    //     update_boarding_stop_point = update_boarding_stop_point 
-                    //                                   || ( visitor.equal(previous_dt, base_dt, *it_st)
-                    //                                         && previous_walking_duration < working_walking_duration 
-                    //                                      );
-                    // }
-
-
-
-                    if (update_boarding_stop_point
-                        ) {
+                                                             if (update_boarding_stop_point) {
                         /// we are at stop point jpp.idx at time previous_dt
                         /// waiting for the next vehicle journey of the journey_pattern jpp.jp_idx to embark on
                         /// the next vehicle journey will arrive at
@@ -886,7 +850,6 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                         // const auto tmp_st_dt =
                         //     next_st->next_stop_time(visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise());
                         if (tmp_st_dt.first != nullptr) {
-
                             if (!is_onboard || &*it_st != tmp_st_dt.first) {
                                 // st_range is quite cache
                                 // unfriendly, so avoid using it if
@@ -907,26 +870,18 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                                 l_zone = std::numeric_limits<uint16_t>::max();
                             }
 
-                            if(boarding_stop_point == SpIdx()) {
-                                LOG4CPLUS_TRACE(logger, "Setting boarding stop point : " << count 
-                                                << " to "  << data.pt_data->stop_points[jpp.sp_idx.val]->uri
-                                                << " walk after : " << previous_walking_duration
-                                        );
-                            }
-                            else {
-
-                                LOG4CPLUS_TRACE(logger, "Switching boarding stop point : " << count 
-                                                    << " from " << data.pt_data->stop_points[boarding_stop_point.val]->uri
-                                                    << " to "  << data.pt_data->stop_points[jpp.sp_idx.val]->uri
-                                                    << " working dt before : " << workingDt
-                                                    << " working dt after : " << tmp_st_dt.second
-                                                    << " walk before : " << working_walking_duration
-                                                    << " walk after : " << previous_walking_duration
-                                            );
-                                LOG4CPLUS_TRACE(logger, "  previous_dt : : " << previous_dt 
-                                    << " section_end(base_dt)" << it_st->section_end(base_dt, !visitor.clockwise())
-                            );
-
+                            if (boarding_stop_point == SpIdx()) {
+                                LOG4CPLUS_TRACE(logger, "Setting boarding stop point  "
+                                                            << " to " << data.pt_data->stop_points[jpp.sp_idx.val]->uri
+                                                            << " walk after : " << previous_walking_duration);
+                            } else {
+                                LOG4CPLUS_TRACE(
+                                    logger, "Switching boarding stop point : "
+                                                << " from " << data.pt_data->stop_points[boarding_stop_point.val]->uri
+                                                << " to " << data.pt_data->stop_points[jpp.sp_idx.val]->uri
+                                                << " working dt before : " << workingDt << " working dt after : "
+                                                << tmp_st_dt.second << " walk before : " << working_walking_duration
+                                                << " walk after : " << previous_walking_duration);
                             }
                             workingDt = tmp_st_dt.second;
                             working_walking_duration = previous_walking_duration;
@@ -940,7 +895,8 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                 if (is_onboard) {
                     const type::VehicleJourney* vj_stay_in = visitor.get_extension_vj(it_st->vehicle_journey);
                     if (vj_stay_in) {
-                        bool applied = apply_vj_extension(visitor, rt_level, vj_stay_in, l_zone, base_dt, working_walking_duration, boarding_stop_point);
+                        bool applied = apply_vj_extension(visitor, rt_level, vj_stay_in, l_zone, base_dt,
+                                                          working_walking_duration, boarding_stop_point);
                         continue_algorithm = continue_algorithm || applied;
                     }
                 }
@@ -996,21 +952,13 @@ int RAPTOR::best_round(SpIdx sp_idx) {
     return -1;
 }
 
-
 std::string RAPTOR::print_jpps_from_sp() {
     std::ostringstream output;
     for (auto stop_point_jpps : jpps_from_sp) {
         SpIdx sp_idx = stop_point_jpps.first;
         navitia::type::StopPoint* stop_point = data.pt_data->stop_points[sp_idx.val];
         output << "stop point : " << stop_point->uri << std::endl;
-        for(auto jpp : stop_point_jpps.second) {
-            // JppIdx jpp_idx = jpp.idx;
-            // JpIdx jp_idx   = jpp.jp_idx;
-
-            // const JourneyPatternPoint journey_pattern_point = data.dataRaptor->jp_container.get(jpp_idx);
-            // const JourneyPattern      journey_pattern       = data.dataRaptor->jp_container.get(jp_idx);
-            
-
+        for (auto jpp : stop_point_jpps.second) {
             output << "  " << jpp.idx.val << " " << jpp.jp_idx.val << std::endl;
         }
     }
@@ -1023,98 +971,86 @@ std::string RAPTOR::print_current_labels() {
     output << "count : " << count << std::endl;
     for (auto stop_point_date_itr : current_labels.get_dt_pts()) {
         SpIdx sp_idx = stop_point_date_itr.first;
-        DateTime dt  = stop_point_date_itr.second;
+        DateTime dt = stop_point_date_itr.second;
         navitia::type::StopPoint* stop_point = data.pt_data->stop_points[sp_idx.val];
         output << "stop point : " << stop_point->uri;
-        if ( current_labels.pt_is_initialized(sp_idx) ) {
+        if (current_labels.pt_is_initialized(sp_idx)) {
             output << " dt_pt : " << str(dt) << std::endl;
+        } else {
+            output << " dt_pt : "
+                   << "not init" << std::endl;
         }
-        else {
-            output << " dt_pt : " << "not init" << std::endl;
-        }
-               
     }
     return output.str();
 }
 
 std::string RAPTOR::print_all_labels() {
     std::ostringstream output;
-    for(uint32_t stop_point_id = 0; stop_point_id < data.pt_data->stop_points.size(); ++stop_point_id) {
+    for (uint32_t stop_point_id = 0; stop_point_id < data.pt_data->stop_points.size(); ++stop_point_id) {
         SpIdx sp_idx = SpIdx(stop_point_id);
         navitia::type::StopPoint* stop_point = data.pt_data->stop_points[sp_idx.val];
 
         bool print_stop_point = false;
-        for(unsigned int count_id = 0; count_id < labels.size(); ++count_id) {
+        for (unsigned int count_id = 0; count_id < labels.size(); ++count_id) {
             Labels& current_labels = labels[count_id];
-            if( current_labels.pt_is_initialized(sp_idx) || current_labels.transfer_is_initialized(sp_idx) ) {
+            if (current_labels.pt_is_initialized(sp_idx) || current_labels.transfer_is_initialized(sp_idx)) {
                 print_stop_point = true;
                 break;
             }
         }
 
-        if(print_stop_point) {
+        if (print_stop_point) {
             output << "" << stop_point->uri << " : " << std::endl;
 
-            for(unsigned int count_id = 0; count_id < labels.size(); ++count_id) {
+            for (unsigned int count_id = 0; count_id < labels.size(); ++count_id) {
                 Labels& current_labels = labels[count_id];
-                if( ! current_labels.pt_is_initialized(sp_idx) && !current_labels.transfer_is_initialized(sp_idx) ) {
+                if (!current_labels.pt_is_initialized(sp_idx) && !current_labels.transfer_is_initialized(sp_idx)) {
                     continue;
                 }
                 output << "   count : " << count_id;
                 output << " dt_pt : ";
 
-                if ( current_labels.pt_is_initialized(sp_idx) ) {
-                output <<  iso_string(current_labels.dt_pt(sp_idx), data);
-                }
-                else {
-                    output <<  "not init";
+                if (current_labels.pt_is_initialized(sp_idx)) {
+                    output << iso_string(current_labels.dt_pt(sp_idx), data);
+                } else {
+                    output << "not init";
                 }
 
                 output << " transfer_dt : ";
 
-                if ( current_labels.transfer_is_initialized(sp_idx) ) {
-                    output <<  iso_string(current_labels.dt_transfer(sp_idx), data);
+                if (current_labels.transfer_is_initialized(sp_idx)) {
+                    output << iso_string(current_labels.dt_transfer(sp_idx), data);
+                } else {
+                    output << "not init";
                 }
-                else {
-                    output <<  "not init";
-                }    
 
-                output << std::endl;        
-
+                output << std::endl;
             }
         }
     }
     return output.str();
 }
 
-
-
 std::string RAPTOR::print_best_labels() {
     std::ostringstream output;
-    for(uint32_t stop_point_id = 0; stop_point_id < data.pt_data->stop_points.size(); ++stop_point_id) {
+    for (uint32_t stop_point_id = 0; stop_point_id < data.pt_data->stop_points.size(); ++stop_point_id) {
         SpIdx sp_idx = SpIdx(stop_point_id);
         navitia::type::StopPoint* stop_point = data.pt_data->stop_points[sp_idx.val];
 
-        output << "" << stop_point->uri << " : " 
-                << "best arrival : " << iso_string(best_labels_pts[sp_idx], data)
-                << " best departure : " << iso_string(best_labels_transfers[sp_idx], data)
-                << std::endl;
-
-        
+        output << "" << stop_point->uri << " : "
+               << "best arrival : " << iso_string(best_labels_pts[sp_idx], data)
+               << " best departure : " << iso_string(best_labels_transfers[sp_idx], data) << std::endl;
     }
     return output.str();
 }
 
-std::string RAPTOR::print_starting_points_snd_phase(std::vector<StartingPointSndPhase> & starting_points) {
+std::string RAPTOR::print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points) {
     std::ostringstream output;
-    for(auto start_point : starting_points) {
+    for (auto start_point : starting_points) {
         navitia::type::StopPoint* stop_point = data.pt_data->stop_points[start_point.sp_idx.val];
-        output << "" << stop_point->uri 
-                << " count : " << start_point.count
-                << " end_dt : " << iso_string(start_point.end_dt, data)
-                << " fallback_dur : " << start_point.fallback_dur
-                << " has_priority : " << start_point.has_priority
-                << std::endl;
+        output << "" << stop_point->uri << " count : " << start_point.count
+               << " end_dt : " << iso_string(start_point.end_dt, data) << " fallback_dur : " << start_point.fallback_dur
+               << " has_priority : " << start_point.has_priority << std::endl;
     }
     return output.str();
 }

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -512,28 +512,29 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
         LOG4CPLUS_DEBUG(logger, std::endl
                                     << "Second pass from " << start_stop_point->uri << "   count : " << start.count);
 
-        Journey fake_journey =
-            convert_to_bound(start, data.dataRaptor->min_connection_time, transfer_penalty, clockwise);
-
-        LOG4CPLUS_DEBUG(logger, " fake journey : " << fake_journey);
-
-        if (solutions.contains_better_than(fake_journey)) {
-            LOG4CPLUS_DEBUG(logger, "has better solution than fake journey from " << start_stop_point->uri);
-            for (const auto& solution : solutions) {
-                if (dominator(solution, fake_journey)) {
-                    LOG4CPLUS_DEBUG(logger, "  dominated by : " << solution);
-                    break;
-                }
-            }
-            continue;
-        }
-
         if (!start.has_priority) {
+            Journey fake_journey =
+                convert_to_bound(start, data.dataRaptor->min_connection_time, transfer_penalty, clockwise);
+
+            LOG4CPLUS_DEBUG(logger, " fake journey : " << fake_journey);
+
+            if (solutions.contains_better_than(fake_journey)) {
+                LOG4CPLUS_DEBUG(logger, "has better solution than fake journey from " << start_stop_point->uri);
+                for (const auto& solution : solutions) {
+                    if (dominator(solution, fake_journey)) {
+                        LOG4CPLUS_DEBUG(logger, "  dominated by : " << solution);
+                        break;
+                    }
+                }
+                continue;
+            }
+
             ++supplementary_2nd_pass;
-        }
-        if (supplementary_2nd_pass > max_extra_second_pass) {
-            LOG4CPLUS_TRACE(logger, "max second pass reached");
-            break;
+
+            if (supplementary_2nd_pass > max_extra_second_pass) {
+                LOG4CPLUS_TRACE(logger, "max second pass reached");
+                break;
+            }
         }
 
         const auto& working_labels = first_pass_labels[start.count];

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -329,13 +329,13 @@ Journey convert_to_bound(const StartingPointSndPhase& sp,
                          bool clockwise) {
     Journey journey;
     journey.sections.resize(sp.count);  // only the number of sections is part of the dominance function
-    journey.sn_dur = navitia::time_duration(0, 0, sp.fallback_dur + lower_bound_fb, 0);
+    journey.sn_dur = navitia::time_duration(0, 0, sp.fallback_dur, 0);
     uint32_t nb_conn = (sp.count >= 1 ? sp.count - 1 : 0);
     if (clockwise) {
         journey.arrival_dt = sp.end_dt;
-        journey.departure_dt = sp.end_dt - journey.sn_dur.seconds() - nb_conn * lower_bound_conn;
+        journey.departure_dt = sp.end_dt - journey.sn_dur.seconds(); 
     } else {
-        journey.arrival_dt = sp.end_dt + journey.sn_dur.seconds() + nb_conn * lower_bound_conn;
+        journey.arrival_dt = sp.end_dt + journey.sn_dur.seconds(); 
         journey.departure_dt = sp.end_dt;
     }
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -100,6 +100,7 @@ bool RAPTOR::apply_vj_extension(const Visitor& v,
                                     << " from " << working_labels.dt_pt(sp_idx)
                                     << " to "  << workingDt
                                     << " throught : " << st.vehicle_journey->route->line->uri
+                                    << " walk : " << working_walking_duration
                             );
             working_labels.mut_dt_pt(sp_idx) = workingDt;
             working_labels.mut_walking_duration_pt(sp_idx) = working_walking_duration;
@@ -141,15 +142,15 @@ bool RAPTOR::foot_path(const Visitor& v) {
 
             LOG4CPLUS_TRACE(logger, "Updating label transfer count : " << count 
                         << " sp " << data.pt_data->stop_points[destination_sp_idx.val]->uri
-                        << " from " << working_labels.dt_transfer(sp_idx)
+                        << " from " << working_labels.dt_transfer(destination_sp_idx)
                         << " to "  << next
                         << " throught connection : " << data.pt_data->stop_points[sp_idx.val]->uri
+                        << " walk : " << previous_walking_duration_dt
                 );
 
             // if we can improve the best label, we mark it
             working_labels.mut_dt_transfer(destination_sp_idx) = next;
             working_labels.mut_walking_duration_transfer(destination_sp_idx) = previous_walking_duration_dt + conn.duration;
-            BOOST_ASSERT(previous_walking_duration_dt != working_walking_duration);
             best_labels_transfers[destination_sp_idx] = next;
             result = true;
         }
@@ -803,6 +804,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
                                                     << " from " << working_labels.dt_pt(jpp.sp_idx)
                                                     << " to "  << workingDt
                                                     << " throught : " << st.vehicle_journey->route->line->uri
+                                                    << " walk : " << working_walking_duration
                                            );
 
                             working_labels.mut_dt_pt(jpp.sp_idx) = workingDt;

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -211,8 +211,8 @@ void RAPTOR::init(const map_stop_point_duration& dep,
         const DateTime begin_dt = bound + (clockwise ? sn_dur : -sn_dur);
         labels[0].mut_dt_transfer(sp_dt.first) = begin_dt;
         labels[0].mut_fallback_duration_transfer(sp_dt.first) = sn_dur;
-        // best_labels_transfers[sp_dt.first] = begin_dt;
-        // best_labels_transfers_fallback[sp_dt.first] = begin_dt;
+        best_labels_transfers[sp_dt.first] = begin_dt;
+        best_labels_transfers_fallback[sp_dt.first] = begin_dt;
         for (const auto& jpp : jpps_from_sp[sp_dt.first]) {
             if (clockwise && Q[jpp.jp_idx] > jpp.order) {
                 Q[jpp.jp_idx] = jpp.order;

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -344,6 +344,7 @@ Journey convert_to_bound(const StartingPointSndPhase& sp,
     journey.transfer_dur = transfer_penalty * sp.count + navitia::seconds(nb_conn * lower_bound_conn);
     // provide best values on unknown criteria
     journey.min_waiting_dur = navitia::time_duration(boost::date_time::pos_infin);
+    journey.total_waiting_dur = 0_s;
     journey.nb_vj_extentions = 0;
     return journey;
 }

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -157,7 +157,6 @@ bool RAPTOR::foot_path(const Visitor& v) {
 
                 // if we can improve the best label, we mark it
                 working_labels.mut_dt_transfer(destination_sp_idx) = end_connection_date;
-                // TODO ? : add conn.duration to fallback_duration_transfer ?
                 working_labels.mut_fallback_duration_transfer(destination_sp_idx) = candidate_fallback_duration;
                 best_labels_transfers[destination_sp_idx] = end_connection_date;
                 best_labels_transfers_fallback[destination_sp_idx] = candidate_fallback_duration;
@@ -451,7 +450,7 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
     auto start_raptor = std::chrono::system_clock::now();
 
     // auto solutions = ParetoFront<Journey, Dominates /*, JourneyParetoFrontVisitor*/>(Dominates(clockwise));
-    auto dominator = Dominates(clockwise);
+    auto dominator = Dominates(clockwise, transfer_penalty);
     auto solutions = Solutions(dominator);
 
     if (direct_path_dur) {

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -96,6 +96,8 @@ struct RAPTOR {
     // set to store if the stop_point is valid
     boost::dynamic_bitset<> valid_stop_points;
 
+    log4cplus::Logger raptor_logger;
+
     explicit RAPTOR(const navitia::type::Data& data)
         : data(data),
           best_labels_pts(data.pt_data->stop_points),
@@ -105,7 +107,8 @@ struct RAPTOR {
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
           Q(data.dataRaptor->jp_container.get_jps_values()),
-          valid_stop_points(data.pt_data->stop_points.size()) {
+          valid_stop_points(data.pt_data->stop_points.size()),
+          raptor_logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"))) {
         labels.assign(10, data.dataRaptor->labels_const);
         first_pass_labels.assign(10, data.dataRaptor->labels_const);
     }
@@ -239,10 +242,7 @@ struct RAPTOR {
 
     ~RAPTOR() = default;
 
-    std::string print_jpps_from_sp();
-    std::string print_current_labels();
     std::string print_all_labels();
-    std::string print_best_labels();
     std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points);
 };
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -208,7 +208,8 @@ struct RAPTOR {
                             const nt::RTLevel rt_level,
                             const type::VehicleJourney* vj,
                             const uint16_t l_zone,
-                            DateTime base_dt);
+                            DateTime workingDate,
+                            DateTime working_walking_duration);
 
     /// Main loop
     template <typename Visitor>

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -238,7 +238,7 @@ struct RAPTOR {
     std::string print_current_labels();
     std::string print_all_labels();
     std::string print_best_labels();
-    std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase> & starting_points);
+    std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points);
 };
 
 }  // namespace routing

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -209,7 +209,8 @@ struct RAPTOR {
                             const type::VehicleJourney* vj,
                             const uint16_t l_zone,
                             DateTime workingDate,
-                            DateTime working_walking_duration);
+                            DateTime working_walking_duration,
+                            SpIdx boarding_stop_point);
 
     /// Main loop
     template <typename Visitor>

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -62,7 +62,7 @@ struct StartingPointSndPhase {
     SpIdx sp_idx;
     unsigned count;
     DateTime end_dt;
-    unsigned fallback_dur;
+    unsigned walking_dur;
     bool has_priority;
 };
 
@@ -82,8 +82,8 @@ struct RAPTOR {
     IdxMap<type::StopPoint, DateTime> best_labels_pts;
     IdxMap<type::StopPoint, DateTime> best_labels_transfers;
 
-    IdxMap<type::StopPoint, DateTime> best_labels_pts_fallback;
-    IdxMap<type::StopPoint, DateTime> best_labels_transfers_fallback;
+    IdxMap<type::StopPoint, DateTime> best_labels_pts_walking;
+    IdxMap<type::StopPoint, DateTime> best_labels_transfers_walking;
 
     /// Number of transfers done for the moment
     unsigned int count;
@@ -102,8 +102,8 @@ struct RAPTOR {
         : data(data),
           best_labels_pts(data.pt_data->stop_points),
           best_labels_transfers(data.pt_data->stop_points),
-          best_labels_pts_fallback(data.pt_data->stop_points),
-          best_labels_transfers_fallback(data.pt_data->stop_points),
+          best_labels_pts_walking(data.pt_data->stop_points),
+          best_labels_transfers_walking(data.pt_data->stop_points),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
           Q(data.dataRaptor->jp_container.get_jps_values()),

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -82,6 +82,9 @@ struct RAPTOR {
     IdxMap<type::StopPoint, DateTime> best_labels_pts;
     IdxMap<type::StopPoint, DateTime> best_labels_transfers;
 
+    IdxMap<type::StopPoint, DateTime> best_labels_pts_fallback;
+    IdxMap<type::StopPoint, DateTime> best_labels_transfers_fallback;
+
     /// Number of transfers done for the moment
     unsigned int count;
     /// Are the journey pattern valid
@@ -97,6 +100,8 @@ struct RAPTOR {
         : data(data),
           best_labels_pts(data.pt_data->stop_points),
           best_labels_transfers(data.pt_data->stop_points),
+          best_labels_pts_fallback(data.pt_data->stop_points),
+          best_labels_transfers_fallback(data.pt_data->stop_points),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
           Q(data.dataRaptor->jp_container.get_jps_values()),

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -231,6 +231,12 @@ struct RAPTOR {
                            const bool clockwise);
 
     ~RAPTOR() = default;
+
+    std::string print_jpps_from_sp();
+    std::string print_current_labels();
+    std::string print_all_labels();
+    std::string print_best_labels();
+    std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase> & starting_points);
 };
 
 }  // namespace routing

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -136,10 +136,6 @@ static std::vector<Path> call_raptor(navitia::PbCreator& pb_creator,
                                      const boost::optional<uint32_t>& timeframe_duration) {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
-    LOG4CPLUS_TRACE(logger, "direct_path_duration : "
-                                << direct_path_duration.get_value_or(time_duration(boost::date_time::not_a_date_time))
-                                << " max_duration : " << max_duration);
-
     std::vector<Path> pathes;
 
     // We loop on datetimes, but in practice there's always only one
@@ -181,8 +177,6 @@ static std::vector<Path> call_raptor(navitia::PbCreator& pb_creator,
 
             // Remove direct path
             filter_direct_path(raptor_journeys);
-
-            LOG4CPLUS_DEBUG(logger, "after filter direct path :  " << raptor_journeys.size() << " solutions");
 
             // filter joureys that are too late.....with the magic formula...
             NightBusFilter::Params params{request_date_secs, clockwise, night_bus_filter_max_factor,
@@ -1366,8 +1360,6 @@ void make_response(navitia::PbCreator& pb_creator,
                    const int32_t night_bus_filter_base_factor,
                    const boost::optional<uint32_t>& timeframe_duration,
                    const uint32_t depth) {
-    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
-
     // Create datetime
     auto datetimes = parse_datetimes(raptor, timestamps, pb_creator, clockwise);
     if (pb_creator.has_error() || pb_creator.has_response_type(pbnavitia::DATE_OUT_OF_BOUNDS)) {
@@ -1392,20 +1384,6 @@ void make_response(navitia::PbCreator& pb_creator,
         pb_creator.fill_pb_error(pbnavitia::Error::unknown_object,
                                  "The entry point: " + destination.uri + " is not valid");
         return;
-    }
-
-    for (const auto& stop_point_iter : *departures) {
-        SpIdx sp_idx = stop_point_iter.first;
-        auto stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
-        LOG4CPLUS_DEBUG(logger, "departure : " << stop_point->uri << " distance : "
-                                               << navitia::str(stop_point_iter.second.total_seconds()));
-    }
-
-    for (const auto& stop_point_iter : *destinations) {
-        SpIdx sp_idx = stop_point_iter.first;
-        auto stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
-        LOG4CPLUS_DEBUG(logger, "destination : " << stop_point->uri << " distance : "
-                                                 << navitia::str(stop_point_iter.second.total_seconds()));
     }
 
     // case 3 : departure or destination are emtpy

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1366,7 +1366,7 @@ void make_response(navitia::PbCreator& pb_creator,
                    const int32_t night_bus_filter_base_factor,
                    const boost::optional<uint32_t>& timeframe_duration,
                    const uint32_t depth) {
-    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
 
     // Create datetime
     auto datetimes = parse_datetimes(raptor, timestamps, pb_creator, clockwise);
@@ -1397,13 +1397,15 @@ void make_response(navitia::PbCreator& pb_creator,
     for (const auto& stop_point_iter : *departures) {
         SpIdx sp_idx = stop_point_iter.first;
         auto stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
-        LOG4CPLUS_TRACE(logger, "departure : " << stop_point->uri << " distance : " << stop_point_iter.second);
+        LOG4CPLUS_DEBUG(logger, "departure : " << stop_point->uri << " distance : "
+                                               << navitia::str(stop_point_iter.second.total_seconds()));
     }
 
     for (const auto& stop_point_iter : *destinations) {
         SpIdx sp_idx = stop_point_iter.first;
         auto stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
-        LOG4CPLUS_TRACE(logger, "destination : " << stop_point->uri << " distance : " << stop_point_iter.second);
+        LOG4CPLUS_DEBUG(logger, "destination : " << stop_point->uri << " distance : "
+                                                 << navitia::str(stop_point_iter.second.total_seconds()));
     }
 
     // case 3 : departure or destination are emtpy

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -135,6 +135,12 @@ static std::vector<Path> call_raptor(navitia::PbCreator& pb_creator,
                                      const int32_t night_bus_filter_base_factor,
                                      const boost::optional<uint32_t>& timeframe_duration) {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+
+    LOG4CPLUS_TRACE(logger, "direct_path_duration : " 
+                            << direct_path_duration.get_value_or(time_duration(boost::date_time::not_a_date_time))
+                            << " max_duration : " << max_duration        
+                    );
+
     std::vector<Path> pathes;
 
     // We loop on datetimes, but in practice there's always only one
@@ -176,6 +182,8 @@ static std::vector<Path> call_raptor(navitia::PbCreator& pb_creator,
 
             // Remove direct path
             filter_direct_path(raptor_journeys);
+
+            LOG4CPLUS_DEBUG(logger, "after filter direct path :  " << raptor_journeys.size() << " solutions");
 
             // filter joureys that are too late.....with the magic formula...
             NightBusFilter::Params params{request_date_secs, clockwise, night_bus_filter_max_factor,
@@ -1385,6 +1393,18 @@ void make_response(navitia::PbCreator& pb_creator,
         pb_creator.fill_pb_error(pbnavitia::Error::unknown_object,
                                  "The entry point: " + destination.uri + " is not valid");
         return;
+    }
+
+    for(const auto stop_point_iter : *departures) {
+        SpIdx sp_idx = stop_point_iter.first;
+        navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
+        LOG4CPLUS_TRACE(logger, "departure : " << stop_point->uri << " distance : " << stop_point_iter.second);
+    }
+
+    for(const auto stop_point_iter : *destinations) {
+        SpIdx sp_idx = stop_point_iter.first;
+        navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
+        LOG4CPLUS_TRACE(logger, "destination : " << stop_point->uri << " distance : " << stop_point_iter.second);
     }
 
     // case 3 : departure or destination are emtpy

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1195,11 +1195,11 @@ DateTime prepare_next_call_for_raptor(const RAPTOR::Journeys& journeys, const bo
         DateTime earliest_arrival = DateTimeUtils::inf;
         DateTime latest_departure = DateTimeUtils::min;
         for (const auto& journey : journeys) {
-            if (journey.arrival_dt <= earliest_arrival) {
+            if (journey.arrival_dt < earliest_arrival) {
                 earliest_arrival = journey.arrival_dt;
-                if (journey.arrival_dt == earliest_arrival && journey.departure_dt > latest_departure) {
-                    latest_departure = journey.departure_dt;
-                }
+                latest_departure = journey.departure_dt;
+            } else if (journey.arrival_dt == earliest_arrival && journey.departure_dt > latest_departure) {
+                latest_departure = journey.departure_dt;
             }
         }
 
@@ -1211,11 +1211,11 @@ DateTime prepare_next_call_for_raptor(const RAPTOR::Journeys& journeys, const bo
         DateTime earliest_arrival = DateTimeUtils::inf;
         DateTime latest_departure = DateTimeUtils::min;
         for (const auto& journey : journeys) {
-            if (journey.departure_dt >= latest_departure) {
+            if (journey.departure_dt > latest_departure) {
                 latest_departure = journey.departure_dt;
-                if (journey.departure_dt == latest_departure && journey.arrival_dt < earliest_arrival) {
-                    earliest_arrival = journey.arrival_dt;
-                }
+                earliest_arrival = journey.arrival_dt;
+            } else if (journey.departure_dt == latest_departure && journey.arrival_dt < earliest_arrival) {
+                earliest_arrival = journey.arrival_dt;
             }
         }
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -136,10 +136,9 @@ static std::vector<Path> call_raptor(navitia::PbCreator& pb_creator,
                                      const boost::optional<uint32_t>& timeframe_duration) {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
 
-    LOG4CPLUS_TRACE(logger, "direct_path_duration : " 
-                            << direct_path_duration.get_value_or(time_duration(boost::date_time::not_a_date_time))
-                            << " max_duration : " << max_duration        
-                    );
+    LOG4CPLUS_TRACE(logger, "direct_path_duration : "
+                                << direct_path_duration.get_value_or(time_duration(boost::date_time::not_a_date_time))
+                                << " max_duration : " << max_duration);
 
     std::vector<Path> pathes;
 
@@ -1395,13 +1394,13 @@ void make_response(navitia::PbCreator& pb_creator,
         return;
     }
 
-    for(const auto stop_point_iter : *departures) {
+    for (const auto stop_point_iter : *departures) {
         SpIdx sp_idx = stop_point_iter.first;
         navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
         LOG4CPLUS_TRACE(logger, "departure : " << stop_point->uri << " distance : " << stop_point_iter.second);
     }
 
-    for(const auto stop_point_iter : *destinations) {
+    for (const auto stop_point_iter : *destinations) {
         SpIdx sp_idx = stop_point_iter.first;
         navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
         LOG4CPLUS_TRACE(logger, "destination : " << stop_point->uri << " distance : " << stop_point_iter.second);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1394,15 +1394,15 @@ void make_response(navitia::PbCreator& pb_creator,
         return;
     }
 
-    for (const auto stop_point_iter : *departures) {
+    for (const auto& stop_point_iter : *departures) {
         SpIdx sp_idx = stop_point_iter.first;
-        navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
+        auto stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
         LOG4CPLUS_TRACE(logger, "departure : " << stop_point->uri << " distance : " << stop_point_iter.second);
     }
 
-    for (const auto stop_point_iter : *destinations) {
+    for (const auto& stop_point_iter : *destinations) {
         SpIdx sp_idx = stop_point_iter.first;
-        navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
+        auto stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
         LOG4CPLUS_TRACE(logger, "destination : " << stop_point->uri << " distance : " << stop_point_iter.second);
     }
 

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -228,17 +228,20 @@ const Journey& make_journey(const PathElt& path, RaptorSolutionReader<Visitor>& 
     j.nb_vj_extentions = count_vj_extentions(j);
 
     // transfer objectives
-    j.transfer_dur = reader.transfer_penalty * (j.sections.size() + j.nb_vj_extentions);
+    j.transfer_dur = reader.transfer_penalty * (j.nb_vj_extentions);
+    j.total_waiting_dur = 0_s;
     if (j.sections.size() > 1) {
         const auto& data = *reader.raptor.data.pt_data;
         const auto first_transfer_waiting = get_transfer_waiting(data, j.sections[0], j.sections[1]);
         j.transfer_dur += first_transfer_waiting.first;
         j.min_waiting_dur = first_transfer_waiting.second;
+        j.total_waiting_dur += first_transfer_waiting.second;
         const auto* prev = &j.sections[1];
         for (auto it = j.sections.begin() + 2; it != j.sections.end(); prev = &*it, ++it) {
             const auto cur_transfer_waiting = get_transfer_waiting(data, *prev, *it);
             j.transfer_dur += cur_transfer_waiting.first;
             j.min_waiting_dur = std::min(j.min_waiting_dur, cur_transfer_waiting.second);
+            j.total_waiting_dur += cur_transfer_waiting.second;
         }
     }
 

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -618,15 +618,15 @@ void read_solutions(const RAPTOR& raptor,
                 make_bound_journey(working_labels.dt_pt(a.first), a.second,
                                    raptor.labels[0].dt_transfer(end_point.sp_idx), end_point_street_network_duration,
                                    count, raptor.data.dataRaptor->min_connection_time, transfer_penalty, v.clockwise());
-            LOG4CPLUS_TRACE(logger, "Journey from " << stop_point->uri << " count : " << count << std::endl << j);
+            LOG4CPLUS_DEBUG(logger, "Journey from " << stop_point->uri << " count : " << count << std::endl << j);
 
             if (reader.solutions.contains_better_than(j)) {
-                LOG4CPLUS_TRACE(logger, "Journey discarded");
+                LOG4CPLUS_DEBUG(logger, "Journey discarded");
 
                 continue;
             }
             try {
-                LOG4CPLUS_TRACE(logger, "try to build journey ");
+                LOG4CPLUS_DEBUG(logger, "try to build journey ");
                 reader.begin_pt(count, a.first, working_labels.dt_pt(a.first));
             } catch (stop_search&) {
             }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -599,6 +599,7 @@ void read_solutions(const RAPTOR& raptor,
     auto reader = RaptorSolutionReader<Visitor>(raptor, solutions, v, departure_datetime, deps, arrs, rt_level,
                                                 accessibilite_params, transfer_penalty, end_point);
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    const auto end_point_street_network_duration = (v.clockwise() ? arrs : deps).at(end_point.sp_idx);
     for (unsigned count = 1; count <= raptor.count; ++count) {
         auto& working_labels = raptor.labels[count];
         for (const auto& a : v.clockwise() ? deps : arrs) {
@@ -616,7 +617,7 @@ void read_solutions(const RAPTOR& raptor,
             // we check that it's worth to explore this possible journey
             auto j = make_bound_journey(working_labels.dt_pt(a.first), a.second,
                                         raptor.labels[0].dt_transfer(end_point.sp_idx),
-                                        navitia::seconds(end_point.fallback_dur), count,
+                                        end_point_street_network_duration, count,
                                         raptor.data.dataRaptor->min_connection_time, transfer_penalty, v.clockwise());
             LOG4CPLUS_TRACE(logger, "Journey from " 
                                     << stop_point->uri

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -606,7 +606,6 @@ void read_solutions(const RAPTOR& raptor,
             SpIdx sp_idx = a.first;
             navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
 
-
             if (!working_labels.pt_is_initialized(a.first)) {
                 continue;
             }
@@ -615,26 +614,19 @@ void read_solutions(const RAPTOR& raptor,
             }
             reader.nb_sol_added = 0;
             // we check that it's worth to explore this possible journey
-            auto j = make_bound_journey(working_labels.dt_pt(a.first), a.second,
-                                        raptor.labels[0].dt_transfer(end_point.sp_idx),
-                                        end_point_street_network_duration, count,
-                                        raptor.data.dataRaptor->min_connection_time, transfer_penalty, v.clockwise());
-            LOG4CPLUS_TRACE(logger, "Journey from " 
-                                    << stop_point->uri
-                                    <<" count : " << count
-                                    << std::endl << j
-            );
+            auto j =
+                make_bound_journey(working_labels.dt_pt(a.first), a.second,
+                                   raptor.labels[0].dt_transfer(end_point.sp_idx), end_point_street_network_duration,
+                                   count, raptor.data.dataRaptor->min_connection_time, transfer_penalty, v.clockwise());
+            LOG4CPLUS_TRACE(logger, "Journey from " << stop_point->uri << " count : " << count << std::endl << j);
 
             if (reader.solutions.contains_better_than(j)) {
-                LOG4CPLUS_TRACE(logger, "Journey  " 
-                                        << " discarded"
-                );
+                LOG4CPLUS_TRACE(logger, "Journey discarded");
 
                 continue;
             }
             try {
-                LOG4CPLUS_TRACE(logger, "try to build journey " 
-                );
+                LOG4CPLUS_TRACE(logger, "try to build journey ");
                 reader.begin_pt(count, a.first, working_labels.dt_pt(a.first));
             } catch (stop_search&) {
             }
@@ -645,15 +637,14 @@ void read_solutions(const RAPTOR& raptor,
 }  // anonymous namespace
 
 std::ostream& operator<<(std::ostream& os, const Journey& j) {
-    os << "([" 
-        << "departure_dt : " << navitia::str(j.departure_dt) << ", " 
-        << "arrival_dt : " << navitia::str(j.arrival_dt) << ", " 
-        << "min_wainting_dur : " << j.min_waiting_dur << ", " 
-        << "transfer_dur : " << j.transfer_dur << "], [" 
-        << "nb sections : " << j.sections.size() << ", " 
-        << "nb extensions : " << unsigned(j.nb_vj_extentions) << "], "
-        << "foot duration : " << j.sn_dur <<")"
-        << std::endl;
+    os << "(["
+       << "departure_dt : " << navitia::str(j.departure_dt) << ", "
+       << "arrival_dt : " << navitia::str(j.arrival_dt) << ", "
+       << "min_wainting_dur : " << j.min_waiting_dur << ", "
+       << "transfer_dur : " << j.transfer_dur << "], ["
+       << "nb sections : " << j.sections.size() << ", "
+       << "nb extensions : " << unsigned(j.nb_vj_extentions) << "], "
+       << "foot duration : " << j.sn_dur << ")" << std::endl;
     for (const auto& s : j.sections) {
         if (s.get_in_st) {
             os << "(" << s.get_in_st->vehicle_journey->route->line->uri << ": " << s.get_in_st->stop_point->uri;

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -644,7 +644,7 @@ std::ostream& operator<<(std::ostream& os, const Journey& j) {
        << "transfer_dur : " << j.transfer_dur << "], ["
        << "nb sections : " << j.sections.size() << ", "
        << "nb extensions : " << unsigned(j.nb_vj_extentions) << "], "
-       << "foot duration : " << j.sn_dur << ")" << std::endl;
+       << "fallback duration : " << j.sn_dur << ")" << std::endl;
     for (const auto& s : j.sections) {
         if (s.get_in_st) {
             os << "(" << s.get_in_st->vehicle_journey->route->line->uri << ": " << s.get_in_st->stop_point->uri;

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -428,7 +428,7 @@ struct RaptorSolutionReader {
         ++nb_sol_added;
         solutions.add(j);
         if (nb_sol_added > 1000) {
-            log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+            log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
             LOG4CPLUS_WARN(logger, "raptor_solution_reader: too much solutions, stopping...");
             throw stop_search();
         }
@@ -598,7 +598,7 @@ void read_solutions(const RAPTOR& raptor,
                     const StartingPointSndPhase& end_point) {
     auto reader = RaptorSolutionReader<Visitor>(raptor, solutions, v, departure_datetime, deps, arrs, rt_level,
                                                 accessibilite_params, transfer_penalty, end_point);
-    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
     const auto end_point_street_network_duration = (v.clockwise() ? arrs : deps).at(end_point.sp_idx);
     for (unsigned count = 1; count <= raptor.count; ++count) {
         auto& working_labels = raptor.labels[count];

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -316,8 +316,9 @@ Journey make_bound_journey(DateTime beg,
     }
 
     // for the rest KPI, we don't know yet the accurate values, so we'll provide the best lb possible
-    journey.transfer_dur = transfer_penalty * count + navitia::seconds((count - 1) * lower_bound_conn);
+    journey.transfer_dur = navitia::seconds((count - 1) * lower_bound_conn);
     journey.min_waiting_dur = navitia::time_duration(boost::date_time::pos_infin);
+    journey.total_waiting_dur = navitia::seconds(0);
     journey.nb_vj_extentions = 0;
     return journey;
 }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -622,8 +622,8 @@ void read_solutions(const RAPTOR& raptor,
                                    raptor.labels[0].dt_transfer(end_point.sp_idx), end_point_street_network_duration,
                                    count, raptor.data.dataRaptor->min_connection_time, transfer_penalty, v.clockwise());
             LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey from " << stop_point->uri << " count : " << count
-                                                                  << std::endl
-                                                                  << j);
+                            //<< std::endl << j
+            );
 
             if (reader.solutions.contains_better_than(j)) {
                 LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey discarded");
@@ -646,6 +646,7 @@ std::ostream& operator<<(std::ostream& os, const Journey& j) {
        << "departure_dt : " << navitia::str(j.departure_dt) << ", "
        << "arrival_dt : " << navitia::str(j.arrival_dt) << ", "
        << "min_waiting_dur : " << j.min_waiting_dur << ", "
+       << "total_waiting_dur : " << j.total_waiting_dur << ", "
        << "transfer_dur : " << j.transfer_dur << "], ["
        << "nb sections : " << j.sections.size() << ", "
        << "nb extensions : " << unsigned(j.nb_vj_extentions) << "], "

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -602,7 +602,6 @@ void read_solutions(const RAPTOR& raptor,
                     const StartingPointSndPhase& end_point) {
     auto reader = RaptorSolutionReader<Visitor>(raptor, solutions, v, departure_datetime, deps, arrs, rt_level,
                                                 accessibilite_params, transfer_penalty, end_point);
-    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
     const auto end_point_street_network_duration = (v.clockwise() ? arrs : deps).at(end_point.sp_idx);
     for (unsigned count = 1; count <= raptor.count; ++count) {
         auto& working_labels = raptor.labels[count];
@@ -622,15 +621,17 @@ void read_solutions(const RAPTOR& raptor,
                 make_bound_journey(working_labels.dt_pt(a.first), a.second,
                                    raptor.labels[0].dt_transfer(end_point.sp_idx), end_point_street_network_duration,
                                    count, raptor.data.dataRaptor->min_connection_time, transfer_penalty, v.clockwise());
-            LOG4CPLUS_DEBUG(logger, "Journey from " << stop_point->uri << " count : " << count << std::endl << j);
+            LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey from " << stop_point->uri << " count : " << count
+                                                                  << std::endl
+                                                                  << j);
 
             if (reader.solutions.contains_better_than(j)) {
-                LOG4CPLUS_DEBUG(logger, "Journey discarded");
+                LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey discarded");
 
                 continue;
             }
             try {
-                LOG4CPLUS_DEBUG(logger, "try to build journey ");
+                LOG4CPLUS_DEBUG(raptor.raptor_logger, "try to build journey ");
                 reader.begin_pt(count, a.first, working_labels.dt_pt(a.first));
             } catch (stop_search&) {
             }
@@ -644,7 +645,7 @@ std::ostream& operator<<(std::ostream& os, const Journey& j) {
     os << "(["
        << "departure_dt : " << navitia::str(j.departure_dt) << ", "
        << "arrival_dt : " << navitia::str(j.arrival_dt) << ", "
-       << "min_wainting_dur : " << j.min_waiting_dur << ", "
+       << "min_waiting_dur : " << j.min_waiting_dur << ", "
        << "transfer_dur : " << j.transfer_dur << "], ["
        << "nb sections : " << j.sections.size() << ", "
        << "nb extensions : " << unsigned(j.nb_vj_extentions) << "], "

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -52,7 +52,25 @@ struct Dominates {
     }
 };
 
-typedef ParetoFront<Journey, Dominates> Solutions;
+
+struct ParetoFrontVisitor {
+    void at_dominated(const Journey& to_insert, const Journey& in_pool){
+        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        LOG4CPLUS_TRACE(logger, "Journey dominated ! " 
+                            << std::endl << to_insert
+                            << "  dominated by : " << std::endl << in_pool);
+    }
+    void at_dominates(const Journey& to_insert, const Journey& in_pool){
+        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        LOG4CPLUS_TRACE(logger, "Journey removed from solution pool " << std::endl << in_pool);
+    }
+    void at_inserted(const Journey& j){
+        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        LOG4CPLUS_TRACE(logger, "Adding  journey to solution pool" << std::endl << j);
+    }
+};
+
+typedef ParetoFront<Journey, Dominates, ParetoFrontVisitor> Solutions;
 
 // deps (resp. arrs) are departure (resp. arrival) stop points and
 // durations (not clockwise dependent).

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -55,7 +55,7 @@ struct Dominates {
     }
 };
 
-#define LOG_PARETO_FRONT
+// #define LOG_PARETO_FRONT
 // to activate logs of the updates of the pareto front of journeys
 // inside raptor
 #ifdef LOG_PARETO_FRONT

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -55,6 +55,11 @@ struct Dominates {
     }
 };
 
+// #define LOG_PARETO_FRONT
+// to activate logs of the updates of the pareto front of journeys
+// inside raptor
+#ifdef LOG_PARETO_FRONT
+
 struct ParetoFrontLogger {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
 
@@ -72,6 +77,12 @@ struct ParetoFrontLogger {
 };
 
 typedef ParetoFront<Journey, Dominates, ParetoFrontLogger> Solutions;
+
+#else
+
+typedef ParetoFront<Journey, Dominates> Solutions;
+
+#endif
 
 // deps (resp. arrs) are departure (resp. arrival) stop points and
 // durations (not clockwise dependent).

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -51,7 +51,7 @@ struct Dominates {
         : request_clockwise(rc), transfer_penalty(transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
         return lhs.better_on_dt(rhs, request_clockwise, transfer_penalty) && lhs.better_on_transfer(rhs)
-               && lhs.better_on_sn(rhs, navitia::time_duration(0, 0, 30, 0));
+               && lhs.better_on_sn(rhs, navitia::time_duration(0, 0, 90, 0));
     }
 };
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -54,17 +54,17 @@ struct Dominates {
 
 struct ParetoFrontVisitor {
     void at_dominated(const Journey& to_insert, const Journey& in_pool) {
-        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         LOG4CPLUS_TRACE(logger, "Journey dominated ! " << std::endl
                                                        << to_insert << "  dominated by : " << std::endl
                                                        << in_pool);
     }
     void at_dominates(const Journey& /*to_insert*/, const Journey& in_pool) {
-        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         LOG4CPLUS_TRACE(logger, "Journey removed from solution pool " << std::endl << in_pool);
     }
     void at_inserted(const Journey& j) {
-        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         LOG4CPLUS_TRACE(logger, "Adding  journey to solution pool" << std::endl << j);
     }
 };

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -51,11 +51,11 @@ struct Dominates {
         : request_clockwise(rc), transfer_penalty(transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
         return lhs.better_on_dt(rhs, request_clockwise, transfer_penalty) && lhs.better_on_transfer(rhs)
-               && lhs.better_on_sn(rhs, navitia::time_duration(0, 0, 90, 0));
+               && lhs.better_on_sn(rhs, navitia::time_duration(0, 0, 120, 0));
     }
 };
 
-// #define LOG_PARETO_FRONT
+#define LOG_PARETO_FRONT
 // to activate logs of the updates of the pareto front of journeys
 // inside raptor
 #ifdef LOG_PARETO_FRONT

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -50,12 +50,12 @@ struct Dominates {
     Dominates(bool rc, navitia::time_duration transfer_penalty)
         : request_clockwise(rc), transfer_penalty(transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
-        return lhs.better_on_dt(rhs, request_clockwise) && lhs.better_on_transfer(rhs)
-               && lhs.better_on_sn(rhs, transfer_penalty);
+        return lhs.better_on_dt(rhs, request_clockwise, transfer_penalty) && lhs.better_on_transfer(rhs)
+               && lhs.better_on_sn(rhs);
     }
 };
 
-// #define LOG_PARETO_FRONT
+#define LOG_PARETO_FRONT
 // to activate logs of the updates of the pareto front of journeys
 // inside raptor
 #ifdef LOG_PARETO_FRONT

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -56,15 +56,15 @@ struct ParetoFrontLogger {
     log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
 
     void at_dominated(const Journey& to_insert, const Journey& in_pool) {
-        LOG4CPLUS_TRACE(logger, "Journey dominated ! " << std::endl
+        LOG4CPLUS_DEBUG(logger, "Journey dominated ! " << std::endl
                                                        << to_insert << "  dominated by : " << std::endl
                                                        << in_pool);
     }
     void at_dominates(const Journey& /*to_insert*/, const Journey& in_pool) {
-        LOG4CPLUS_TRACE(logger, "Journey removed from solution pool " << std::endl << in_pool);
+        LOG4CPLUS_DEBUG(logger, "Journey removed from solution pool " << std::endl << in_pool);
     }
     void at_inserted(const Journey& j) {
-        LOG4CPLUS_TRACE(logger, "Adding  journey to solution pool" << std::endl << j);
+        LOG4CPLUS_DEBUG(logger, "Adding  journey to solution pool" << std::endl << j);
     }
 };
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -51,7 +51,7 @@ struct Dominates {
         : request_clockwise(rc), transfer_penalty(transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
         return lhs.better_on_dt(rhs, request_clockwise, transfer_penalty) && lhs.better_on_transfer(rhs)
-               && lhs.better_on_sn(rhs);
+               && lhs.better_on_sn(rhs, navitia::time_duration(0, 0, 30, 0));
     }
 };
 
@@ -65,7 +65,8 @@ struct ParetoFrontLogger {
 
     void at_dominated(const Journey& to_insert, const Journey& in_pool) {
         LOG4CPLUS_DEBUG(logger, "Journey dominated ! " << std::endl
-                                                       << to_insert << "  dominated by : " << std::endl
+                                                       << to_insert << "\n  dominated by : \n"
+                                                       << std::endl
                                                        << in_pool);
     }
     void at_dominates(const Journey& /*to_insert*/, const Journey& in_pool) {

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -52,19 +52,18 @@ struct Dominates {
     }
 };
 
-
 struct ParetoFrontVisitor {
-    void at_dominated(const Journey& to_insert, const Journey& in_pool){
+    void at_dominated(const Journey& to_insert, const Journey& in_pool) {
         log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
-        LOG4CPLUS_TRACE(logger, "Journey dominated ! " 
-                            << std::endl << to_insert
-                            << "  dominated by : " << std::endl << in_pool);
+        LOG4CPLUS_TRACE(logger, "Journey dominated ! " << std::endl
+                                                       << to_insert << "  dominated by : " << std::endl
+                                                       << in_pool);
     }
-    void at_dominates(const Journey& to_insert, const Journey& in_pool){
+    void at_dominates(const Journey& /*to_insert*/, const Journey& in_pool) {
         log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
         LOG4CPLUS_TRACE(logger, "Journey removed from solution pool " << std::endl << in_pool);
     }
-    void at_inserted(const Journey& j){
+    void at_inserted(const Journey& j) {
         log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
         LOG4CPLUS_TRACE(logger, "Adding  journey to solution pool" << std::endl << j);
     }

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -46,9 +46,12 @@ struct StartingPointSndPhase;
 // by the pool).
 struct Dominates {
     bool request_clockwise;
-    Dominates(bool rc) : request_clockwise(rc) {}
+    navitia::time_duration transfer_penalty;
+    Dominates(bool rc, navitia::time_duration transfer_penalty)
+        : request_clockwise(rc), transfer_penalty(transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
-        return lhs.better_on_dt(rhs, request_clockwise) && lhs.better_on_transfer(rhs) && lhs.better_on_sn(rhs);
+        return lhs.better_on_dt(rhs, request_clockwise) && lhs.better_on_transfer(rhs)
+               && lhs.better_on_sn(rhs, transfer_penalty);
     }
 };
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -52,24 +52,23 @@ struct Dominates {
     }
 };
 
-struct ParetoFrontVisitor {
+struct ParetoFrontLogger {
+    log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+
     void at_dominated(const Journey& to_insert, const Journey& in_pool) {
-        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         LOG4CPLUS_TRACE(logger, "Journey dominated ! " << std::endl
                                                        << to_insert << "  dominated by : " << std::endl
                                                        << in_pool);
     }
     void at_dominates(const Journey& /*to_insert*/, const Journey& in_pool) {
-        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         LOG4CPLUS_TRACE(logger, "Journey removed from solution pool " << std::endl << in_pool);
     }
     void at_inserted(const Journey& j) {
-        log4cplus::Logger logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         LOG4CPLUS_TRACE(logger, "Adding  journey to solution pool" << std::endl << j);
     }
 };
 
-typedef ParetoFront<Journey, Dominates, ParetoFrontVisitor> Solutions;
+typedef ParetoFront<Journey, Dominates, ParetoFrontLogger> Solutions;
 
 // deps (resp. arrs) are departure (resp. arrival) stop points and
 // durations (not clockwise dependent).

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -81,8 +81,8 @@ struct Labels {
         dt_pts = clean.dt_pts;
         dt_transfers = clean.dt_transfers;
 
-        fallback_duration_pts = clean.fallback_duration_pts;
-        fallback_duration_transfers = clean.fallback_duration_transfers;
+        walking_duration_pts = clean.walking_duration_pts;
+        walking_duration_transfers = clean.walking_duration_transfers;
     }
     inline const DateTime& dt_transfer(SpIdx sp_idx) const { return dt_transfers[sp_idx]; }
     inline const DateTime& dt_pt(SpIdx sp_idx) const { return dt_pts[sp_idx]; }
@@ -92,13 +92,11 @@ struct Labels {
     inline bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
     inline bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }
 
-    inline const DateTime& fallback_duration_pt(SpIdx sp_idx) const { return fallback_duration_pts[sp_idx]; }
-    inline const DateTime& fallback_duration_transfer(SpIdx sp_idx) const {
-        return fallback_duration_transfers[sp_idx];
-    }
+    inline const DateTime& walking_duration_pt(SpIdx sp_idx) const { return walking_duration_pts[sp_idx]; }
+    inline const DateTime& walking_duration_transfer(SpIdx sp_idx) const { return walking_duration_transfers[sp_idx]; }
 
-    inline DateTime& mut_fallback_duration_pt(SpIdx sp_idx) { return fallback_duration_pts[sp_idx]; }
-    inline DateTime& mut_fallback_duration_transfer(SpIdx sp_idx) { return fallback_duration_transfers[sp_idx]; }
+    inline DateTime& mut_walking_duration_pt(SpIdx sp_idx) { return walking_duration_pts[sp_idx]; }
+    inline DateTime& mut_walking_duration_transfer(SpIdx sp_idx) { return walking_duration_transfers[sp_idx]; }
 
     const IdxMap<type::StopPoint, DateTime>& get_dt_pts() { return dt_pts; }
 
@@ -107,8 +105,8 @@ private:
         dt_pts.assign(stops, val);
         dt_transfers.assign(stops, val);
 
-        fallback_duration_pts.assign(stops, DateTimeUtils::not_valid);
-        fallback_duration_transfers.assign(stops, DateTimeUtils::not_valid);
+        walking_duration_pts.assign(stops, DateTimeUtils::not_valid);
+        walking_duration_transfers.assign(stops, DateTimeUtils::not_valid);
     }
 
     // All these vectors are indexed by sp_idx
@@ -122,12 +120,12 @@ private:
     // to board a vehicle leaving from stop_point (i.e. a transfer to stop_point has been done).
     IdxMap<type::StopPoint, DateTime> dt_transfers;
 
-    // fallback_duration_pts[stop_point] stores the fallback duration at departure of a
+    // walking_duration_pts[stop_point] stores the total walking duration (fallback + transfers)  of a
     // journey that alight to stop_point at DateTime dt_pts[stop_point]
-    IdxMap<type::StopPoint, DateTime> fallback_duration_pts;
-    // fallback_duration_pts[stop_point] stores the fallback duration at departure of a
+    IdxMap<type::StopPoint, DateTime> walking_duration_pts;
+    // waling_duration_transfers[stop_point] stores the total walking duration (fallback + transfers) of a
     // journey that allows to board a vehicle at stop_point at DateTime transfers_pts[stop_point]
-    IdxMap<type::StopPoint, DateTime> fallback_duration_transfers;
+    IdxMap<type::StopPoint, DateTime> walking_duration_transfers;
 };
 
 }  // namespace routing

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -81,8 +81,8 @@ struct Labels {
         dt_pts = clean.dt_pts;
         dt_transfers = clean.dt_transfers;
 
-        walking_duration_pts = clean.walking_duration_pts;
-        walking_duration_transfers = clean.walking_duration_transfers;
+        fallback_duration_pts = clean.fallback_duration_pts;
+        fallback_duration_transfers = clean.fallback_duration_transfers;
     }
     inline const DateTime& dt_transfer(SpIdx sp_idx) const { return dt_transfers[sp_idx]; }
     inline const DateTime& dt_pt(SpIdx sp_idx) const { return dt_pts[sp_idx]; }
@@ -92,11 +92,13 @@ struct Labels {
     inline bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
     inline bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }
 
-    inline const DateTime& walking_duration_pt(SpIdx sp_idx) const { return walking_duration_pts[sp_idx]; }
-    inline const DateTime& walking_duration_transfer(SpIdx sp_idx) const { return walking_duration_transfers[sp_idx]; }
+    inline const DateTime& fallback_duration_pt(SpIdx sp_idx) const { return fallback_duration_pts[sp_idx]; }
+    inline const DateTime& fallback_duration_transfer(SpIdx sp_idx) const {
+        return fallback_duration_transfers[sp_idx];
+    }
 
-    inline DateTime& mut_walking_duration_pt(SpIdx sp_idx) { return walking_duration_pts[sp_idx]; }
-    inline DateTime& mut_walking_duration_transfer(SpIdx sp_idx) { return walking_duration_transfers[sp_idx]; }
+    inline DateTime& mut_fallback_duration_pt(SpIdx sp_idx) { return fallback_duration_pts[sp_idx]; }
+    inline DateTime& mut_fallback_duration_transfer(SpIdx sp_idx) { return fallback_duration_transfers[sp_idx]; }
 
     const IdxMap<type::StopPoint, DateTime>& get_dt_pts() { return dt_pts; }
 
@@ -105,8 +107,8 @@ private:
         dt_pts.assign(stops, val);
         dt_transfers.assign(stops, val);
 
-        walking_duration_pts.assign(stops, DateTimeUtils::not_valid);
-        walking_duration_transfers.assign(stops, DateTimeUtils::not_valid);
+        fallback_duration_pts.assign(stops, DateTimeUtils::not_valid);
+        fallback_duration_transfers.assign(stops, DateTimeUtils::not_valid);
     }
 
     // All these vectors are indexed by sp_idx
@@ -116,12 +118,12 @@ private:
     // At what time wan we reach this label with a transfer
     IdxMap<type::StopPoint, DateTime> dt_transfers;
 
-    // walking_duration_pts[stop_point] stores the walking duration elapsed during the whole
+    // fallback_duration_pts[stop_point] stores the fallback duration at departure of the
     // journey from the starting point which reaches stop point at DateTime dt_pts[stop_point] with public transport
-    IdxMap<type::StopPoint, DateTime> walking_duration_pts;
-    // walking_duration_pts[stop_point] stores the walking duration elapsed during the whole
+    IdxMap<type::StopPoint, DateTime> fallback_duration_pts;
+    // fallback_duration_pts[stop_point] stores the fallback duration at departure of the
     // journey from the starting point which reaches stop point at DateTime transfers_pts[stop_point] with transfers
-    IdxMap<type::StopPoint, DateTime> walking_duration_transfers;
+    IdxMap<type::StopPoint, DateTime> fallback_duration_transfers;
 };
 
 }  // namespace routing

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -113,16 +113,20 @@ private:
 
     // All these vectors are indexed by sp_idx
     //
-    // At what time can we reach this label with public transport
+    // dt_pts[stop_point] stores the earliest arrival time to stop_point.
+    // More precisely, at time dt_pts[stop_point], we just alighted from
+    // a vehicle going through stop_point, but we need to do a transfer
+    // before being able to board a new vehicle.
     IdxMap<type::StopPoint, DateTime> dt_pts;
-    // At what time wan we reach this label with a transfer
+    // dt_transfers[stop_point] stores the earliest time at which we are able
+    // to board a vehicle leaving from stop_point (i.e. a transfer to stop_point has been done).
     IdxMap<type::StopPoint, DateTime> dt_transfers;
 
-    // fallback_duration_pts[stop_point] stores the fallback duration at departure of the
-    // journey from the starting point which reaches stop point at DateTime dt_pts[stop_point] with public transport
+    // fallback_duration_pts[stop_point] stores the fallback duration at departure of a
+    // journey that alight to stop_point at DateTime dt_pts[stop_point]
     IdxMap<type::StopPoint, DateTime> fallback_duration_pts;
-    // fallback_duration_pts[stop_point] stores the fallback duration at departure of the
-    // journey from the starting point which reaches stop point at DateTime transfers_pts[stop_point] with transfers
+    // fallback_duration_pts[stop_point] stores the fallback duration at departure of a
+    // journey that allows to board a vehicle at stop_point at DateTime transfers_pts[stop_point]
     IdxMap<type::StopPoint, DateTime> fallback_duration_transfers;
 };
 

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -80,6 +80,9 @@ struct Labels {
     inline void clear(const Labels& clean) {
         dt_pts = clean.dt_pts;
         dt_transfers = clean.dt_transfers;
+
+        walking_duration_pts = clean.walking_duration_pts;
+        walking_duration_transfers = clean.walking_duration_transfers;
     }
     inline const DateTime& dt_transfer(SpIdx sp_idx) const { return dt_transfers[sp_idx]; }
     inline const DateTime& dt_pt(SpIdx sp_idx) const { return dt_pts[sp_idx]; }
@@ -89,12 +92,22 @@ struct Labels {
     inline bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
     inline bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }
 
+
+    inline const DateTime & walking_duration_pt(SpIdx sp_idx) const { return walking_duration_pts[sp_idx]; }
+    inline const DateTime & walking_duration_transfer(SpIdx sp_idx) const { return walking_duration_transfers[sp_idx]; }
+
+    inline DateTime & mut_walking_duration_pt(SpIdx sp_idx)  { return walking_duration_pts[sp_idx]; }
+    inline DateTime & mut_walking_duration_transfer(SpIdx sp_idx)  { return walking_duration_transfers[sp_idx]; }
+
     const IdxMap<type::StopPoint, DateTime> & get_dt_pts() { return dt_pts; }
 
 private:
     inline void init(const std::vector<type::StopPoint*>& stops, DateTime val) {
         dt_pts.assign(stops, val);
         dt_transfers.assign(stops, val);
+
+        walking_duration_pts.assign(stops, DateTimeUtils::not_valid);
+        walking_duration_transfers.assign(stops, DateTimeUtils::not_valid);
     }
 
     // All these vectors are indexed by sp_idx
@@ -103,6 +116,13 @@ private:
     IdxMap<type::StopPoint, DateTime> dt_pts;
     // At what time wan we reach this label with a transfer
     IdxMap<type::StopPoint, DateTime> dt_transfers;
+
+    // walking_duration_pts[stop_point] stores the walking duration elapsed during the whole
+    // journey from the starting point which reaches stop point at DateTime dt_pts[stop_point] with public transport
+    IdxMap<type::StopPoint, DateTime> walking_duration_pts;
+    // walking_duration_pts[stop_point] stores the walking duration elapsed during the whole
+    // journey from the starting point which reaches stop point at DateTime transfers_pts[stop_point] with transfers
+    IdxMap<type::StopPoint, DateTime> walking_duration_transfers;
 };
 
 }  // namespace routing

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -92,14 +92,13 @@ struct Labels {
     inline bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
     inline bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }
 
+    inline const DateTime& walking_duration_pt(SpIdx sp_idx) const { return walking_duration_pts[sp_idx]; }
+    inline const DateTime& walking_duration_transfer(SpIdx sp_idx) const { return walking_duration_transfers[sp_idx]; }
 
-    inline const DateTime & walking_duration_pt(SpIdx sp_idx) const { return walking_duration_pts[sp_idx]; }
-    inline const DateTime & walking_duration_transfer(SpIdx sp_idx) const { return walking_duration_transfers[sp_idx]; }
+    inline DateTime& mut_walking_duration_pt(SpIdx sp_idx) { return walking_duration_pts[sp_idx]; }
+    inline DateTime& mut_walking_duration_transfer(SpIdx sp_idx) { return walking_duration_transfers[sp_idx]; }
 
-    inline DateTime & mut_walking_duration_pt(SpIdx sp_idx)  { return walking_duration_pts[sp_idx]; }
-    inline DateTime & mut_walking_duration_transfer(SpIdx sp_idx)  { return walking_duration_transfers[sp_idx]; }
-
-    const IdxMap<type::StopPoint, DateTime> & get_dt_pts() { return dt_pts; }
+    const IdxMap<type::StopPoint, DateTime>& get_dt_pts() { return dt_pts; }
 
 private:
     inline void init(const std::vector<type::StopPoint*>& stops, DateTime val) {

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -89,6 +89,8 @@ struct Labels {
     inline bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
     inline bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }
 
+    const IdxMap<type::StopPoint, DateTime> & get_dt_pts() { return dt_pts; }
+
 private:
     inline void init(const std::vector<type::StopPoint*>& stops, DateTime val) {
         dt_pts.assign(stops, val);

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(direct) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
     res1 = raptor.compute(b.data->pt_data->stop_areas[0], b.data->pt_data->stop_areas[1], 7900, 0,
-                          DateTimeUtils::set(0, 8100), type::RTLevel::Base, 2_min, true);
+                          DateTimeUtils::set(0, 8100 - 1), type::RTLevel::Base, 2_min, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -159,8 +159,8 @@ BOOST_AUTO_TEST_CASE(change) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8500), type::RTLevel::Base,
-                          2_min, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8500 - 1),
+                          type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -203,8 +203,8 @@ BOOST_AUTO_TEST_CASE(change) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400), type::RTLevel::Base,
-                          2_min, true);
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[4], 7900, 0, DateTimeUtils::set(0, 8400 - 1),
+                          type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 /****
@@ -325,7 +325,7 @@ BOOST_AUTO_TEST_CASE(over_midnight) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
-    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22 * 3600, 0, DateTimeUtils::set(1, 20 * 60),
+    res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], 22 * 3600, 0, DateTimeUtils::set(1, 20 * 60 - 1),
                           type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_2) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22 * 3600, 0,
-                          DateTimeUtils::set(1, 20 * 60), type::RTLevel::Base, 2_min, true);
+                          DateTimeUtils::set(1, 20 * 60 - 1), type::RTLevel::Base, 2_min, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(over_midnight_interne) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 1);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22 * 3600, 0,
-                          DateTimeUtils::set(1, 40 * 60), type::RTLevel::Base, 2_min, true);
+                          DateTimeUtils::set(1, 40 * 60 - 1), type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -485,8 +485,8 @@ BOOST_AUTO_TEST_CASE(validity_pattern) {
     BOOST_REQUIRE_EQUAL(res.items.size(), 1);
     BOOST_CHECK_EQUAL(res.items[0].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0, DateTimeUtils::set(0, 9200),
-                          type::RTLevel::Base, 2_min, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7800, 0,
+                          DateTimeUtils::set(0, 9200 - 1), type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 7900, 2, DateTimeUtils::inf,
@@ -577,8 +577,8 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu) {
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 9200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0, DateTimeUtils::set(0, 9200),
-                          type::RTLevel::Base, 2_min, true);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0,
+                          DateTimeUtils::set(0, 9200 - 1), type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -631,7 +631,7 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_pam) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[3].arrival, *(b.data))), 1);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 7900, 0,
-                          DateTimeUtils::set(1, 2 * 3600 + 20), type::RTLevel::Base, 2_min, true);
+                          DateTimeUtils::set(1, 2 * 3600 + 20 - 1), type::RTLevel::Base, 2_min, true);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -717,7 +717,7 @@ BOOST_AUTO_TEST_CASE(test_rattrapage) {
     }));
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 8 * 3600 + 15 * 60, 0,
-                          DateTimeUtils::set(0, 8 * 3600 + 45 * 60), type::RTLevel::Base, 2_min, true);
+                          DateTimeUtils::set(0, 8 * 3600 + 45 * 60 - 1), type::RTLevel::Base, 2_min, true);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2012,7 +2012,14 @@ BOOST_AUTO_TEST_CASE(accessible_on_first_sp) {
 
 // If the direct path duration is better than everything, no journey is returned
 //
-// Here, we have a 10s walk + 1 min pt + 10s walk. We ask with a 15s
+// Here, we have a pt journey  of 10s walk + 1 min pt + 10s walk.
+// The pt journey has one more transfer than the direct path
+
+// so the pt_journey will be better than the direct path if it allows
+// to reduce the walk duration by at least walking_transfer_duration = 1m30s
+// So with a direct path of 110s = 1m50s <= 1m30s + 20s the direct path dominates the pt journey
+// With a direct path of 111s = 1m51s > 1m30s + 20s the pt journey is kept
+// We ask with a 15s
 // direct path, thus we must not have any solution. With a 25s direct
 // path, we have the journey.
 BOOST_AUTO_TEST_CASE(direct_path_filter) {
@@ -2033,23 +2040,23 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
 
     auto res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:00"_t), type::RTLevel::Base, 2_min,
                                   DateTimeUtils::inf, 10, {}, {}, {}, true,
-                                  135_s);  // 135s direct path
+                                  110_s);  // 1s direct path
     BOOST_CHECK_EQUAL(res.size(), 0);
 
     res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:00"_t), type::RTLevel::Base, 2_min,
                              DateTimeUtils::inf, 10, {}, {}, {}, true,
-                             145_s);  // 145s direct path
+                             111_s);  // 145s direct path
     BOOST_CHECK_EQUAL(res.size(), 1);
 
     // reverse clockwise
     res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:05"_t), type::RTLevel::Base, 2_min, 0, 10,
                              {}, {}, {}, false,
-                             135_s);  // 135s direct path
+                             110_s);  // 135s direct path
     BOOST_CHECK_EQUAL(res.size(), 0);
 
     res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:05"_t), type::RTLevel::Base, 2_min, 0, 10,
                              {}, {}, {}, false,
-                             145_s);  // 145s direct path
+                             111_s);  // 145s direct path
     BOOST_CHECK_EQUAL(res.size(), 1);
 }
 

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -38,7 +38,11 @@ www.navitia.io
 #include "utils/logger.h"
 
 struct logger_initialized {
-    logger_initialized() { navitia::init_logger(); }
+    logger_initialized() {
+        navitia::init_logger();
+        auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+        logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
+    }
 };
 BOOST_GLOBAL_FIXTURE(logger_initialized);
 
@@ -293,8 +297,6 @@ BOOST_AUTO_TEST_CASE(over_midnight) {
 
     res1 = raptor.compute(d.stop_areas[0], d.stop_areas[2], "22:00"_t, 0, DateTimeUtils::set(1, 8500),
                           type::RTLevel::Base, 2_min, true);
-    std::cout << d.stop_areas[0]->uri << std::endl;
-    std::cout << d.stop_areas[2]->uri << std::endl;
     BOOST_REQUIRE_EQUAL(res1.size(), 1);
 
     res = res1.back();
@@ -2810,7 +2812,6 @@ BOOST_AUTO_TEST_CASE(optimize_extention_before_min_wait) {
                               "8:00"_t, 0, DateTimeUtils::inf, type::RTLevel::Base, 2_min);
 
     BOOST_REQUIRE_EQUAL(res.size(), 1);
-    res[0].print();
     BOOST_REQUIRE_EQUAL(res[0].items.size(), 4);
     BOOST_CHECK_EQUAL(res[0].items[1].type, ItemType::walking);
     BOOST_CHECK_EQUAL(res[0].items[1].stop_points.front()->uri, "2");

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -40,6 +40,8 @@ www.navitia.io
 struct logger_initialized {
     logger_initialized() {
         navitia::init_logger();
+        auto raptor_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        raptor_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
         auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
         logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
     }

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -2016,9 +2016,9 @@ BOOST_AUTO_TEST_CASE(accessible_on_first_sp) {
 // The pt journey has one more transfer than the direct path
 
 // so the pt_journey will be better than the direct path if it allows
-// to reduce the walk duration by at least walking_transfer_duration = 1m30s
-// So with a direct path of 110s = 1m50s <= 1m30s + 20s the direct path dominates the pt journey
-// With a direct path of 111s = 1m51s > 1m30s + 20s the pt journey is kept
+// to reduce the walk duration by at least walking_transfer_duration = 2mn
+// So with a direct path of 110s = 1mn50s <= 2mn + 20s the direct path dominates the pt journey
+// With a direct path of 141s = 2mn21s > 2mn + 20s the pt journey is kept
 // We ask with a 15s
 // direct path, thus we must not have any solution. With a 25s direct
 // path, we have the journey.
@@ -2040,23 +2040,23 @@ BOOST_AUTO_TEST_CASE(direct_path_filter) {
 
     auto res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:00"_t), type::RTLevel::Base, 2_min,
                                   DateTimeUtils::inf, 10, {}, {}, {}, true,
-                                  110_s);  // 1s direct path
+                                  110_s);  // 110s direct path
     BOOST_CHECK_EQUAL(res.size(), 0);
 
     res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:00"_t), type::RTLevel::Base, 2_min,
                              DateTimeUtils::inf, 10, {}, {}, {}, true,
-                             111_s);  // 145s direct path
+                             141_s);  // 145s direct path
     BOOST_CHECK_EQUAL(res.size(), 1);
 
     // reverse clockwise
     res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:05"_t), type::RTLevel::Base, 2_min, 0, 10,
                              {}, {}, {}, false,
-                             110_s);  // 135s direct path
+                             110_s);  // 110s direct path
     BOOST_CHECK_EQUAL(res.size(), 0);
 
     res = raptor.compute_all(departures, arrivals, DateTimeUtils::set(2, "08:05"_t), type::RTLevel::Base, 2_min, 0, 10,
                              {}, {}, {}, false,
-                             111_s);  // 145s direct path
+                             141_s);  // 145s direct path
     BOOST_CHECK_EQUAL(res.size(), 1);
 }
 

--- a/source/routing/tests/reverse_raptor_test.cpp
+++ b/source/routing/tests/reverse_raptor_test.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(direct) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8050),
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop2"], 9200, 0, DateTimeUtils::set(0, 8051),
                           type::RTLevel::Base, 2_min, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
@@ -183,8 +183,8 @@ BOOST_AUTO_TEST_CASE(change) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].arrival, *(b.data))), 0);
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 0);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0, DateTimeUtils::set(0, 8050),
-                          type::RTLevel::Base, 2_min, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop5"], 13000, 0,
+                          DateTimeUtils::set(0, 8050 + 1), type::RTLevel::Base, 2_min, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[1].arrival, *(b.data))), 1);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22 * 3600, 1,
-                          DateTimeUtils::set(0, 23 * 3600), type::RTLevel::Base, 2_min, false);
+                          DateTimeUtils::set(0, 23 * 3600 + 1), type::RTLevel::Base, 2_min, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_2) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[2].arrival, *(b.data))), 1);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 22 * 3600, 1,
-                          DateTimeUtils::set(0, 23 * 3600), type::RTLevel::Base, 2_min, false);
+                          DateTimeUtils::set(0, 23 * 3600 + 1), type::RTLevel::Base, 2_min, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(passe_minuit_interne) {
     BOOST_CHECK_EQUAL(DateTimeUtils::date(to_datetime(res.items[0].departure, *(b.data))), 0);
 
     res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop3"], 50 * 60, 1,
-                          DateTimeUtils::set(0, 23 * 3600), type::RTLevel::Base, 2_min, false);
+                          DateTimeUtils::set(0, 23 * 3600 + 1), type::RTLevel::Base, 2_min, false);
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }
 
@@ -455,8 +455,8 @@ BOOST_AUTO_TEST_CASE(marche_a_pied_milieu) {
     BOOST_REQUIRE_EQUAL(res.items.size(), 4);
     BOOST_CHECK_EQUAL(res.items[3].arrival.time_of_day().total_seconds(), 19200);
 
-    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0, DateTimeUtils::set(0, 8050),
-                          type::RTLevel::Base, 2_min, false);
+    res1 = raptor.compute(d.stop_areas_map["stop1"], d.stop_areas_map["stop4"], 27900, 0,
+                          DateTimeUtils::set(0, 8050 + 1), type::RTLevel::Base, 2_min, false);
 
     BOOST_REQUIRE_EQUAL(res1.size(), 0);
 }

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -49,7 +49,7 @@ struct logger_initialized {
         auto raptor_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
         raptor_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
         auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
-        logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
+        logger.setLogLevel(log4cplus::DEBUG_LOG_LEVEL);
         auto fare_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("fare"));
         fare_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
     }
@@ -2956,7 +2956,7 @@ BOOST_AUTO_TEST_CASE(journeys_with_min_nb_journeys_with_similar_journeys_filteri
     b.vj("vj4")("stop_point:sa1:s1", "8:00"_t, "8:04"_t)("stop_point:sa3:s1", "8:23"_t, "8:24"_t);
 
     // journey 2
-    b.vj("vj5")("stop_point:sa1:s2", "8:00"_t, "8:05"_t)("stop_point:sa3:s2", "8:15"_t, "8:16"_t);
+    b.vj("vj5")("stop_point:sa1:s2", "8:00"_t, "8:05"_t)("stop_point:sa3:s2", "8:25"_t, "8:26"_t);
 
     b.finish();
     b.data->pt_data->sort_and_index();
@@ -3010,69 +3010,10 @@ BOOST_AUTO_TEST_CASE(journeys_with_min_nb_journeys_with_similar_journeys_filteri
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
     auto section = journey.sections(1);
     BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
-    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s2");
-    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s2");
-    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080500"_pts);
-    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T081500"_pts);
-
-    // Journey 2
-    journey = journeys[1];
-    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
-    section = journey.sections(1);
-    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
     BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s1");
     BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
     BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080100"_pts);
     BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082000"_pts);
-
-    // Journey 3
-    journey = journeys[2];
-    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
-    section = journey.sections(1);
-    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
-    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s1");
-    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
-    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080200"_pts);
-    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082100"_pts);
-
-    // Journey 4
-    journey = journeys[3];
-    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
-    section = journey.sections(1);
-    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
-    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s1");
-    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
-    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080300"_pts);
-    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082200"_pts);
-
-    //-----------------------------------
-    // Case 2 : Request with min_nb_journeys = 4, with clockwise = false
-
-    min_nb_journeys = 4;
-    clockwise = false;
-
-    // send request
-    navitia::PbCreator pb_creator3(data_ptr, "20180309T083000"_dt, null_time_period);
-    make_response(pb_creator3, raptor, origin, destination, {ntest::to_posix_timestamp("20180309T083000")}, clockwise,
-                  navitia::type::AccessibiliteParams(), forbidden, {}, sn_worker, nt::RTLevel::Base, 2_min, 8640, 10, 0,
-                  0, 0, min_nb_journeys);
-
-    // get the response
-    resp = pb_creator3.get_response();
-    BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
-    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 4);
-
-    journeys = sort_journeys_by(resp, JourneySectionCompare());
-
-    // Journey 1
-    journey = journeys[0];
-    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
-    section = journey.sections(1);
-    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
-    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s2");
-    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s2");
-    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080500"_pts);
-    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T081500"_pts);
 
     // Journey 2
     journey = journeys[1];
@@ -3103,6 +3044,65 @@ BOOST_AUTO_TEST_CASE(journeys_with_min_nb_journeys_with_similar_journeys_filteri
     BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
     BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080400"_pts);
     BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082300"_pts);
+
+    //-----------------------------------
+    // Case 2 : Request with min_nb_journeys = 4, with clockwise = false
+
+    min_nb_journeys = 4;
+    clockwise = false;
+
+    // send request
+    navitia::PbCreator pb_creator3(data_ptr, "20180309T083000"_dt, null_time_period);
+    make_response(pb_creator3, raptor, origin, destination, {ntest::to_posix_timestamp("20180309T083000")}, clockwise,
+                  navitia::type::AccessibiliteParams(), forbidden, {}, sn_worker, nt::RTLevel::Base, 2_min, 8640, 10, 0,
+                  0, 0, min_nb_journeys);
+
+    // get the response
+    resp = pb_creator3.get_response();
+    BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 4);
+
+    journeys = sort_journeys_by(resp, JourneySectionCompare());
+
+    // Journey 1
+    journey = journeys[0];
+    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
+    section = journey.sections(1);
+    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
+    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s1");
+    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
+    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080200"_pts);
+    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082100"_pts);
+
+    // Journey 2
+    journey = journeys[1];
+    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
+    section = journey.sections(1);
+    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
+    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s1");
+    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
+    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080300"_pts);
+    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082200"_pts);
+
+    // Journey 3
+    journey = journeys[2];
+    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
+    section = journey.sections(1);
+    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
+    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s1");
+    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s1");
+    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080400"_pts);
+    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082300"_pts);
+
+    // Journey 4
+    journey = journeys[3];
+    BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
+    section = journey.sections(1);
+    BOOST_CHECK_EQUAL(section.type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
+    BOOST_CHECK_EQUAL(section.origin().stop_point().name(), "stop_point:sa1:s2");
+    BOOST_CHECK_EQUAL(section.destination().stop_point().name(), "stop_point:sa3:s2");
+    BOOST_CHECK_EQUAL(section.begin_date_time(), "20180309T080500"_pts);
+    BOOST_CHECK_EQUAL(section.end_date_time(), "20180309T082500"_pts);
 }
 
 namespace {

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -49,7 +49,7 @@ struct logger_initialized {
         auto raptor_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
         raptor_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
         auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
-        logger.setLogLevel(log4cplus::DEBUG_LOG_LEVEL);
+        logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
         auto fare_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("fare"));
         fare_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
     }
@@ -2191,47 +2191,12 @@ BOOST_FIXTURE_TEST_CASE(direct_path_car, streetnetworkmode_fixture<test_speed_pr
     dump_response(resp, "direct_path_car");
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
-    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2);  // 1 direct car + 1 car->bus->walk
-
-    // the car->bus->walk journey
-    auto journey = resp.journeys(0);
-    BOOST_REQUIRE_EQUAL(journey.sections_size(), 5);
-    auto sections = journey.sections();
-
-    // section 0: goto to the station
-    BOOST_CHECK_EQUAL(sections.Get(0).type(), pbnavitia::SectionType::STREET_NETWORK);
-    BOOST_CHECK_EQUAL(sections.Get(0).origin().address().label(), "rue bs (Condom)");
-    BOOST_CHECK_EQUAL(sections.Get(0).destination().poi().label(), "first parking (Condom)");
-    BOOST_CHECK_EQUAL(sections.Get(0).street_network().mode(), pbnavitia::StreetNetworkMode::Car);
-    BOOST_CHECK_EQUAL(sections.Get(0).street_network().duration(), 6);
-
-    // section 1: parking
-    BOOST_CHECK_EQUAL(sections.Get(1).type(), pbnavitia::SectionType::PARK);
-    BOOST_CHECK_EQUAL(sections.Get(1).street_network().duration(), 1);
-
-    // section 2: we walk to the stop point
-    BOOST_CHECK_EQUAL(sections.Get(2).type(), pbnavitia::SectionType::STREET_NETWORK);
-    BOOST_CHECK_EQUAL(sections.Get(2).origin().address().label(), "1 rue bd (Condom)");
-    BOOST_CHECK_EQUAL(sections.Get(2).destination().stop_point().name(), "stop_point:stopB");
-    BOOST_CHECK_EQUAL(sections.Get(2).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
-    BOOST_CHECK_EQUAL(sections.Get(2).street_network().duration(), 10);
-
-    // section 3: PT A->B
-    BOOST_CHECK_EQUAL(sections.Get(3).type(), pbnavitia::SectionType::PUBLIC_TRANSPORT);
-    BOOST_CHECK_EQUAL(sections.Get(3).origin().stop_point().name(), "stop_point:stopB");
-    BOOST_CHECK_EQUAL(sections.Get(3).destination().stop_point().name(), "stop_point:stopA");
-
-    // section 2: go to the destination
-    BOOST_CHECK_EQUAL(sections.Get(4).type(), pbnavitia::SectionType::STREET_NETWORK);
-    BOOST_CHECK_EQUAL(sections.Get(4).origin().stop_point().name(), "stop_point:stopA");
-    BOOST_CHECK_EQUAL(sections.Get(4).destination().address().label(), "1 rue ag (Condom)");
-    BOOST_CHECK_EQUAL(sections.Get(4).street_network().mode(), pbnavitia::StreetNetworkMode::Walking);
-    BOOST_CHECK_EQUAL(sections.Get(4).street_network().duration(), 90);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);  // 1 direct car
 
     // second journey, direct path with a car
-    journey = resp.journeys(1);
+    auto journey = resp.journeys(0);
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
-    sections = journey.sections();
+    auto sections = journey.sections();
 
     // car to the parking
     BOOST_CHECK_EQUAL(sections.Get(0).type(), pbnavitia::SectionType::STREET_NETWORK);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -44,7 +44,15 @@ www.navitia.io
 #include "type/pb_converter.h"
 
 struct logger_initialized {
-    logger_initialized() { navitia::init_logger(); }
+    logger_initialized() {
+        navitia::init_logger();
+        auto raptor_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("raptor"));
+        raptor_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
+        auto logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"));
+        logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
+        auto fare_logger = log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("fare"));
+        fare_logger.setLogLevel(log4cplus::FATAL_LOG_LEVEL);
+    }
 };
 BOOST_GLOBAL_FIXTURE(logger_initialized);
 
@@ -960,8 +968,8 @@ BOOST_FIXTURE_TEST_CASE(biking, streetnetworkmode_fixture<test_speed_provider>) 
     dump_response(resp, "biking");
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
-    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2);
-    auto journey = resp.journeys(1);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
+    auto journey = resp.journeys(0);
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 1);
     auto section = journey.sections(0);
 
@@ -994,38 +1002,15 @@ BOOST_FIXTURE_TEST_CASE(biking, streetnetworkmode_fixture<test_speed_provider>) 
     pathitem = section.street_network().path_items(6);
     BOOST_CHECK_EQUAL(pathitem.name(), "rue ag");
 
-    // co2_emission Tests
-    // First Journey
     // Bike mode
-    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 3);
+    BOOST_REQUIRE_EQUAL(resp.journeys(0).sections_size(), 1);
     BOOST_CHECK_EQUAL(resp.journeys(0).sections(0).has_co2_emission(), true);
     BOOST_CHECK_EQUAL(resp.journeys(0).sections(0).co2_emission().value(), 0.);
     BOOST_CHECK_EQUAL(resp.journeys(0).sections(0).co2_emission().unit(), "gEC");
-    // Tram mode
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(1).pt_display_informations().physical_mode(), "Tramway");
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(1).has_co2_emission(), true);
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(1).co2_emission().value(), 0.58);
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(1).co2_emission().unit(), "gEC");
-
-    // Walk mode
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).has_co2_emission(), true);
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).co2_emission().value(), 0.);
-    BOOST_CHECK_EQUAL(resp.journeys(0).sections(2).street_network().mode(), pbnavitia::StreetNetworkMode::Bike);
     // Aggregator co2_emission
     BOOST_CHECK_EQUAL(resp.journeys(0).has_co2_emission(), true);
-    BOOST_CHECK_EQUAL(resp.journeys(0).co2_emission().value(), 0.58);
+    BOOST_CHECK_EQUAL(resp.journeys(0).co2_emission().value(), 0.);
     BOOST_CHECK_EQUAL(resp.journeys(0).co2_emission().unit(), "gEC");
-
-    // Second Journey
-    // Bike mode
-    BOOST_REQUIRE_EQUAL(resp.journeys(1).sections_size(), 1);
-    BOOST_CHECK_EQUAL(resp.journeys(1).sections(0).has_co2_emission(), true);
-    BOOST_CHECK_EQUAL(resp.journeys(1).sections(0).co2_emission().value(), 0.);
-    BOOST_CHECK_EQUAL(resp.journeys(1).sections(0).co2_emission().unit(), "gEC");
-    // Aggregator co2_emission
-    BOOST_CHECK_EQUAL(resp.journeys(1).has_co2_emission(), true);
-    BOOST_CHECK_EQUAL(resp.journeys(1).co2_emission().value(), 0.);
-    BOOST_CHECK_EQUAL(resp.journeys(1).co2_emission().unit(), "gEC");
 }
 
 // biking


### PR DESCRIPTION
Update the raptor algorithm to remember the walking duration corresponding to the earliest arrival time found.

More precisely, the raptor algorithm computes for each pair (_stop_point_, _nb_of_transfer_) the earliest arrival time at _stop_point_  using _nb_of_transfer_  change of vehicle ([example](https://github.com/CanalTP/navitia/blob/dev/documentation/rfc/doc-routing-algorithm.md#the-first-pass-on-example-1)).
Now, it also stores the walking duration of a journey that achieves this earliest arrival time.

The first commits are logs tracing the behavior of raptor.
The actual modifications of the algorithms are  :

- https://github.com/CanalTP/navitia/commit/297e405d0e8635de62990917088e73a4928e2089 adds storage to raptor Labels to remember the walking duration and updates this walking duration when the arrival time is updated for a pair (_stop_point_, _nb_of_transfer_)

- https://github.com/CanalTP/navitia/commit/6fe7efb250fd81e7dcc171fdc422a2c5c9bc5757 
The raptor algorithm works in "rounds". At round _k_ the earliest arrival time at every stop point using at most _k-1_ transfers is already computed, and the round will compute the earliest arrival time at every stop point using _k_ transfers.
In order to do so, raptor scans each _journey_pattern_ :

  - starting from the _first_stop_point_ of the _journey_pattern_, we embark on the first _vehicule_journey_ that we can catch from the earliest arrival time at _first_stop_point_ using _k-1_ transfers.
  - we "ride" the _vehicle_journey_, which gives new arrival times at each _stop_point_ along the ride. When this yields a better arrival time for a _stop_point_ we update its best known arrival time using _k_ transfers
  - it may happen that with our current ride, we arrive at a _stop_point_ later than the arrival time using _k-1_ transfers. In this case, we check if the arrival time using _k-1_ transfers allows to catch an earlier _vehicle_journey_ for this _journey_pattern_. When this happens, we "leave" the current _vehicle_journey_, embark on the earlier one, and remember the current stop_point as the "boarding" stop point.
Before the commit, the boarding stop_point was updated even if the "earlier vehicle journey" was the same as the current one. 
This commit updates the boarding stop_point if : 
    - it allows to catch a strictly earlier _vehicle_journey_
    - or it allows to catch the same _vehicle_journey_ but with a strictly smaller walking duration

- https://github.com/CanalTP/navitia/commit/64de81c2021043ab47396ea972b0bad3e4893aca 
the _fallback_duration_ of a StartingPointSecondPhase was initialized with the walking duration at the arrival stop point before https://github.com/CanalTP/navitia/commit/297e405d0e8635de62990917088e73a4928e2089 . After, _fallback_duration_ is initialized with the total walking duration.
In solution reader, the _fallback_duration_ of a StartingPointSecondPhase was used as the walking duration at the arrival stop point to build bound journeys. Now, bound journeys use the walking duration at arrival stop point computed before raptor (which is stored in a map_stop_point_duration) rather than _fallback_duration

**do_not_merge** for now as it may modify the output of navitia on several functional tests. More modifications may be needed before merge, and tests may need updates.
- tests on auvergne have been analyzed. When the output changed, it seems to yield better journeys than before. Other tests need to be analyzed.
- routing/raptor_test failed : to be analyzed

**JIRA** https://jira.kisio.org/browse/NAVITIAII-2814