### PR TITLE
[Distributed] handle max_{mode}_direct_path_duration in kraken

### DIFF
--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -96,12 +96,12 @@ class Kraken(AbstractStreetNetworkService):
             from jormungandr.fallback_modes import FallbackModes as fm
 
             kraken_mode = 'car_no_park' if mode in (fm.taxi.name, fm.ridesharing.name) else mode
-            new_request['max_{mode}_duration_to_pt'.format(mode=kraken_mode)] = int(
-                new_request['max_{mode}_direct_path_duration'.format(mode=mode)] / 2
+            direct_path_request['max_{mode}_duration_to_pt'.format(mode=kraken_mode)] = int(
+                direct_path_request['max_{mode}_direct_path_duration'.format(mode=mode)] / 2
             )
 
         req = self._create_direct_path_request(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, new_request
+            mode, pt_object_origin, pt_object_destination, fallback_extremity, direct_path_request
         )
 
         response = instance.send_and_receive(req)

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -86,7 +86,7 @@ class Kraken(AbstractStreetNetworkService):
         if should_invert_journey:
             pt_object_origin, pt_object_destination = pt_object_destination, pt_object_origin
 
-        new_request = copy.deepcopy(request)
+        direct_path_request = copy.deepcopy(request)
         if direct_path_type == StreetNetworkPathType.DIRECT:
             # in distributed scenario, we allow the street network calculator to compute a very long direct path
             # in case of Kraken, the stop condition of direct path in Kraken is defined as

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -86,8 +86,22 @@ class Kraken(AbstractStreetNetworkService):
         if should_invert_journey:
             pt_object_origin, pt_object_destination = pt_object_destination, pt_object_origin
 
+        new_request = copy.deepcopy(request)
+        if direct_path_type == StreetNetworkPathType.DIRECT:
+            # in distributed scenario, we allow the street network calculator to compute a very long direct path
+            # in case of Kraken, the stop condition of direct path in Kraken is defined as
+            # max_{mode}_duration_to_pt * 2.
+            # When it comes to a direct path request, we override this parameter with
+            # max_{mode}_direct_path_duration / 2.0
+            from jormungandr.fallback_modes import FallbackModes as fm
+
+            kraken_mode = 'car_no_park' if mode in (fm.taxi.name, fm.ridesharing.name) else mode
+            new_request['max_{mode}_duration_to_pt'.format(mode=kraken_mode)] = int(
+                new_request['max_{mode}_direct_path_duration'.format(mode=mode)] / 2
+            )
+
         req = self._create_direct_path_request(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, request
+            mode, pt_object_origin, pt_object_destination, fallback_extremity, new_request
         )
 
         response = instance.send_and_receive(req)

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -443,6 +443,11 @@ class JourneyCommon(object):
 
         query = "journeys?from=stop_point:uselessA&to=stop_point:stopB&datetime=20120615T080000"
 
+        if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
+            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # code for new_defatul
+            query += "&max_walking_direct_path_duration=0"
+
         # with street network desactivated
         response = self.query_region(query + "&max_duration_to_pt=0")
         assert 'journeys' not in response
@@ -461,6 +466,12 @@ class JourneyCommon(object):
 
         query = "journeys?from=stop_point:stopA&to=stop_point:stopB&datetime=20120615T080000"
         query += "&max_duration_to_pt=0"
+
+        if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
+            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # code for new_defatul
+            query += "&max_walking_direct_path_duration=0"
+
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
@@ -648,6 +659,11 @@ class JourneyCommon(object):
         assert len(response['journeys']) == 2
 
         query += "&max_duration_to_pt=0"
+        if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
+            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # code for new_defatul
+            query += "&max_walking_direct_path_duration=0"
+
         # There is no direct_path but a journey using Metro
         response = self.query_region(query)
         check_best(response)
@@ -667,6 +683,11 @@ class JourneyCommon(object):
         assert len(response['journeys']) == 2
 
         query += "&max_duration_to_pt=0"
+        if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
+            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # code for new_defatul
+            query += "&max_walking_direct_path_duration=0"
+
         response = self.query_region(query)
         check_best(response)
         self.is_valid_journey_response(response, query)
@@ -855,6 +876,10 @@ class JourneyCommon(object):
             to_coord="0.00188646;0.00071865",  # coordinate out of range in the dataset
             datetime="20120901T220000",
         )
+        if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
+            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # code for new_defatul
+            query += "&max_walking_direct_path_duration=0"
 
         response, status = self.query_region(query + "&max_duration=1&max_duration_to_pt=100", check=False)
 
@@ -923,6 +948,11 @@ class JourneyCommon(object):
         query = "journeys?from={from_sa}&to={to_sa}&datetime={datetime}&debug=true&max_duration_to_pt=0".format(
             from_sa="stopA", to_sa="stopB", datetime="20120614T223000"
         )
+
+        if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
+            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # code for new_defatul
+            query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)
         check_best(response)

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -445,7 +445,7 @@ class JourneyCommon(object):
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we must deactivate direct path so that we can reuse the same
-            # code for new_default
+            # test code for all scenarios
             query += "&max_walking_direct_path_duration=0"
 
         # with street network desactivated
@@ -469,7 +469,7 @@ class JourneyCommon(object):
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we must deactivate direct path so that we can reuse the same
-            # code for new_default
+            # test code for all scenarios
             query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)
@@ -661,7 +661,7 @@ class JourneyCommon(object):
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we must deactivate direct path so that we can reuse the same
-            # code for new_default
+            # test code for all scenarios
             query += "&max_walking_direct_path_duration=0"
 
         # There is no direct_path but a journey using Metro
@@ -685,7 +685,7 @@ class JourneyCommon(object):
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we must deactivate direct path so that we can reuse the same
-            # code for new_default
+            # test code for all scenarios
             query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)
@@ -878,7 +878,7 @@ class JourneyCommon(object):
         )
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we must deactivate direct path so that we can reuse the same
-            # code for new_default
+            # test code for all scenarios
             query += "&max_walking_direct_path_duration=0"
 
         response, status = self.query_region(query + "&max_duration=1&max_duration_to_pt=100", check=False)
@@ -951,7 +951,7 @@ class JourneyCommon(object):
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we must deactivate direct path so that we can reuse the same
-            # code for new_default
+            # test code for all scenarios
             query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -469,7 +469,7 @@ class JourneyCommon(object):
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we should deactivate direct path so that we can reuse the same
-            # code for new_defatul
+            # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)
@@ -661,7 +661,7 @@ class JourneyCommon(object):
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we should deactivate direct path so that we can reuse the same
-            # code for new_defatul
+            # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
         # There is no direct_path but a journey using Metro
@@ -685,7 +685,7 @@ class JourneyCommon(object):
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we should deactivate direct path so that we can reuse the same
-            # code for new_defatul
+            # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)
@@ -878,7 +878,7 @@ class JourneyCommon(object):
         )
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we should deactivate direct path so that we can reuse the same
-            # code for new_defatul
+            # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
         response, status = self.query_region(query + "&max_duration=1&max_duration_to_pt=100", check=False)
@@ -951,7 +951,7 @@ class JourneyCommon(object):
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we should deactivate direct path so that we can reuse the same
-            # code for new_defatul
+            # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
         response = self.query_region(query)

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -445,7 +445,7 @@ class JourneyCommon(object):
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
             # In distributed scenario, we should deactivate direct path so that we can reuse the same
-            # code for new_defatul
+            # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
         # with street network desactivated

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -444,7 +444,7 @@ class JourneyCommon(object):
         query = "journeys?from=stop_point:uselessA&to=stop_point:stopB&datetime=20120615T080000"
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
-            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # In distributed scenario, we must deactivate direct path so that we can reuse the same
             # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
@@ -468,7 +468,7 @@ class JourneyCommon(object):
         query += "&max_duration_to_pt=0"
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
-            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # In distributed scenario, we must deactivate direct path so that we can reuse the same
             # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
@@ -660,7 +660,7 @@ class JourneyCommon(object):
 
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
-            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # In distributed scenario, we must deactivate direct path so that we can reuse the same
             # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
@@ -684,7 +684,7 @@ class JourneyCommon(object):
 
         query += "&max_duration_to_pt=0"
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
-            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # In distributed scenario, we must deactivate direct path so that we can reuse the same
             # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
@@ -877,7 +877,7 @@ class JourneyCommon(object):
             datetime="20120901T220000",
         )
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
-            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # In distributed scenario, we must deactivate direct path so that we can reuse the same
             # code for new_default
             query += "&max_walking_direct_path_duration=0"
 
@@ -950,7 +950,7 @@ class JourneyCommon(object):
         )
 
         if self.data_sets.get('main_routing_test', {}).get('scenario') == 'distributed':
-            # In distributed scenario, we should deactivate direct path so that we can reuse the same
+            # In distributed scenario, we must deactivate direct path so that we can reuse the same
             # code for new_default
             query += "&max_walking_direct_path_duration=0"
 

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -309,7 +309,7 @@ class TestDistributedTimeFrameDuration(JourneysTimeFrameDuration, NewDefaultScen
     pass
 
 
-def _make_function_test_over_upper_limit(from_coord, to_coord, mode, op):
+def _make_function_over_upper_limit(from_coord, to_coord, mode, op):
     def test_ko_direct_path_longer_than_max_mode_direct_path_duration(self):
         query = (
             'journeys?'
@@ -350,17 +350,17 @@ class TestDistributedMaxDurationForDirectPathUpperLimit(NewDefaultScenarioAbstra
 
     s = '8.98311981954709e-05;8.98311981954709e-05'
     r = '0.0018864551621048887;0.0007186495855637672'
-    test_max_walking_direct_path_duration = _make_function_upper_limit(s, r, 'walking', operator.truth)
-    test_max_car_direct_path_duration = _make_function_upper_limit(s, r, 'car', operator.truth)
-    test_max_bss_direct_path_duration = _make_function_upper_limit(s, r, 'bss', operator.truth)
-    test_max_bike_direct_path_duration = _make_function_upper_limit(s, r, 'bike', operator.truth)
+    test_max_walking_direct_path_duration = _make_function_over_upper_limit(s, r, 'walking', operator.truth)
+    test_max_car_direct_path_duration = _make_function_over_upper_limit(s, r, 'car', operator.truth)
+    test_max_bss_direct_path_duration = _make_function_over_upper_limit(s, r, 'bss', operator.truth)
+    test_max_bike_direct_path_duration = _make_function_over_upper_limit(s, r, 'bike', operator.truth)
 
     a = '0.001077974378345651;0.0007186495855637672'
     b = '8.98311981954709e-05;0.0002694935945864127'
-    test_max_taxi_direct_path_duration = _make_function_upper_limit(a, b, 'taxi', operator.truth)
+    test_max_taxi_direct_path_duration = _make_function_over_upper_limit(a, b, 'taxi', operator.truth)
 
 
-def _make_function_test_under_upper_limit(from_coord, to_coord, mode):
+def _make_function_under_upper_limit(from_coord, to_coord, mode):
     def test_get_direct_path_smaller_than_max_mode_direct_path_duration(self):
         query = (
             'journeys?'
@@ -396,14 +396,14 @@ class TestDistributedMaxDurationForDirectPathLowerLimit(NewDefaultScenarioAbstra
 
     s = '8.98311981954709e-05;8.98311981954709e-05'
     r = '0.0018864551621048887;0.0007186495855637672'
-    test_max_walking_direct_path_duration = _make_function_lower_limit(s, r, 'walking')
-    test_max_car_direct_path_duration = _make_function_lower_limit(s, r, 'car')
-    test_max_bss_direct_path_duration = _make_function_lower_limit(s, r, 'bss')
-    test_max_bike_direct_path_duration = _make_function_lower_limit(s, r, 'bike')
+    test_max_walking_direct_path_duration = _make_function_under_upper_limit(s, r, 'walking')
+    test_max_car_direct_path_duration = _make_function_under_upper_limit(s, r, 'car')
+    test_max_bss_direct_path_duration = _make_function_under_upper_limit(s, r, 'bss')
+    test_max_bike_direct_path_duration = _make_function_under_upper_limit(s, r, 'bike')
 
     a = '0.001077974378345651;0.0007186495855637672'
     b = '8.98311981954709e-05;0.0002694935945864127'
-    test_max_taxi_direct_path_duration = _make_function_lower_limit(a, b, 'taxi')
+    test_max_taxi_direct_path_duration = _make_function_under_upper_limit(a, b, 'taxi')
 
 
 @dataset({"main_routing_test": {"scenario": "new_default"}})
@@ -414,10 +414,10 @@ class TestNewDefaultMaxDurationForDirectPath(NewDefaultScenarioAbstractTestFixtu
 
     s = '8.98311981954709e-05;8.98311981954709e-05'
     r = '0.0018864551621048887;0.0007186495855637672'
-    test_max_walking_direct_path_duration = _make_function_upper_limit(s, r, 'walking', operator.not_)
-    test_max_car_direct_path_duration = _make_function_upper_limit(s, r, 'car', operator.not_)
-    test_max_bss_direct_path_duration = _make_function_upper_limit(s, r, 'bss', operator.not_)
-    test_max_bike_direct_path_duration = _make_function_upper_limit(s, r, 'bike', operator.not_)
+    test_max_walking_direct_path_duration = _make_function_over_upper_limit(s, r, 'walking', operator.not_)
+    test_max_car_direct_path_duration = _make_function_over_upper_limit(s, r, 'car', operator.not_)
+    test_max_bss_direct_path_duration = _make_function_over_upper_limit(s, r, 'bss', operator.not_)
+    test_max_bike_direct_path_duration = _make_function_over_upper_limit(s, r, 'bike', operator.not_)
 
 
 @config(

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -309,7 +309,7 @@ class TestDistributedTimeFrameDuration(JourneysTimeFrameDuration, NewDefaultScen
     pass
 
 
-def _make_function_upper_limit(from_coord, to_coord, mode, op):
+def _make_function_test_over_upper_limit(from_coord, to_coord, mode, op):
     def test_ko_direct_path_longer_than_max_mode_direct_path_duration(self):
         query = (
             'journeys?'
@@ -360,7 +360,7 @@ class TestDistributedMaxDurationForDirectPathUpperLimit(NewDefaultScenarioAbstra
     test_max_taxi_direct_path_duration = _make_function_upper_limit(a, b, 'taxi', operator.truth)
 
 
-def _make_function_lower_limit(from_coord, to_coord, mode):
+def _make_function_test_under_upper_limit(from_coord, to_coord, mode):
     def test_get_direct_path_smaller_than_max_mode_direct_path_duration(self):
         query = (
             'journeys?'

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -309,7 +309,7 @@ class TestDistributedTimeFrameDuration(JourneysTimeFrameDuration, NewDefaultScen
     pass
 
 
-def _make_function(from_coord, to_coord, mode, op):
+def _make_function_upper_limit(from_coord, to_coord, mode, op):
     def test_max_mode_direct_path_duration(self):
         query = (
             'journeys?'
@@ -333,25 +333,77 @@ def _make_function(from_coord, to_coord, mode, op):
             mode=mode, max_dp_duration=direct_path_duration - 1
         )
         response = self.query_region(query)
-
-        assert len(response['journeys']) == 1
-        assert op('deleted_because_too_long_direct_path' in response['journeys'][0]['tags'])
+        # New Default -> 'journeys' in response
+        # Distributed -> 'journeys' not in response
+        assert op('journeys' not in response)
 
     return test_max_mode_direct_path_duration
 
 
 @dataset({"main_routing_test": {"scenario": "distributed"}})
-class TestDistributedMaxDurationForDirectPath(NewDefaultScenarioAbstractTestFixture):
+class TestDistributedMaxDurationForDirectPathUpperLimit(NewDefaultScenarioAbstractTestFixture):
+    """
+    Test max_{mode}_direct_path_duration's upper limit
+
+    Direct path should be filtered if its duration is greater than max_{mode}_direct_path_duration
+    """
+
     s = '8.98311981954709e-05;8.98311981954709e-05'
     r = '0.0018864551621048887;0.0007186495855637672'
-    test_max_walking_direct_path_duration = _make_function(s, r, 'walking', operator.truth)
-    test_max_car_direct_path_duration = _make_function(s, r, 'car', operator.truth)
-    test_max_bss_direct_path_duration = _make_function(s, r, 'bss', operator.truth)
-    test_max_bike_direct_path_duration = _make_function(s, r, 'bike', operator.truth)
+    test_max_walking_direct_path_duration = _make_function_upper_limit(s, r, 'walking', operator.truth)
+    test_max_car_direct_path_duration = _make_function_upper_limit(s, r, 'car', operator.truth)
+    test_max_bss_direct_path_duration = _make_function_upper_limit(s, r, 'bss', operator.truth)
+    test_max_bike_direct_path_duration = _make_function_upper_limit(s, r, 'bike', operator.truth)
 
     a = '0.001077974378345651;0.0007186495855637672'
     b = '8.98311981954709e-05;0.0002694935945864127'
-    test_max_taxi_direct_path_duration = _make_function(a, b, 'taxi', operator.truth)
+    test_max_taxi_direct_path_duration = _make_function_upper_limit(a, b, 'taxi', operator.truth)
+
+
+def _make_function_lower_limit(from_coord, to_coord, mode):
+    def test_max_mode_direct_path_duration(self):
+        query = (
+            'journeys?'
+            'from={from_coord}'
+            '&to={to_coord}'
+            '&datetime={datetime}'
+            '&first_section_mode[]={mode}'
+            '&last_section_mode[]={mode}'
+            '&max_duration=0'
+            '&{mode}_speed=1'
+            '&max_{mode}_direct_path_duration={max_dp_duration}'
+        ).format(
+            from_coord=from_coord, to_coord=to_coord, datetime="20120614T080000", mode=mode, max_dp_duration=3600
+        )
+
+        response = self.query_region(query)
+
+        assert len(response['journeys']) == 1
+        assert mode in response['journeys'][0]['tags']
+        assert 'non_pt' in response['journeys'][0]['tags']
+
+    return test_max_mode_direct_path_duration
+
+
+@dataset({"main_routing_test": {"scenario": "distributed"}})
+class TestDistributedMaxDurationForDirectPathLowerLimit(NewDefaultScenarioAbstractTestFixture):
+    """
+    Test max_{mode}_direct_path_duration's lower limit
+
+    Direct path should be found if its duration is lower than max_{mode}_direct_path_duration.
+    Especially, when the direct path's duration is large and the street network calculator is Kraken
+    """
+
+    s = '8.98311981954709e-05;8.98311981954709e-05'
+    r = '0.0018864551621048887;0.0007186495855637672'
+    test_max_walking_direct_path_duration = _make_function_lower_limit(s, r, 'walking')
+    test_max_car_direct_path_duration = _make_function_lower_limit(s, r, 'car')
+    test_max_bss_direct_path_duration = _make_function_lower_limit(s, r, 'bss')
+    test_max_bike_direct_path_duration = _make_function_lower_limit(s, r, 'bike')
+
+    a = '0.001077974378345651;0.0007186495855637672'
+    b = '8.98311981954709e-05;0.0002694935945864127'
+    test_max_taxi_direct_path_duration = _make_function_lower_limit(a, b, 'taxi')
 
 
 @dataset({"main_routing_test": {"scenario": "new_default"}})
@@ -362,10 +414,10 @@ class TestNewDefaultMaxDurationForDirectPath(NewDefaultScenarioAbstractTestFixtu
 
     s = '8.98311981954709e-05;8.98311981954709e-05'
     r = '0.0018864551621048887;0.0007186495855637672'
-    test_max_walking_direct_path_duration = _make_function(s, r, 'walking', operator.not_)
-    test_max_car_direct_path_duration = _make_function(s, r, 'car', operator.not_)
-    test_max_bss_direct_path_duration = _make_function(s, r, 'bss', operator.not_)
-    test_max_bike_direct_path_duration = _make_function(s, r, 'bike', operator.not_)
+    test_max_walking_direct_path_duration = _make_function_upper_limit(s, r, 'walking', operator.not_)
+    test_max_car_direct_path_duration = _make_function_upper_limit(s, r, 'car', operator.not_)
+    test_max_bss_direct_path_duration = _make_function_upper_limit(s, r, 'bss', operator.not_)
+    test_max_bike_direct_path_duration = _make_function_upper_limit(s, r, 'bike', operator.not_)
 
 
 @config(

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -310,7 +310,7 @@ class TestDistributedTimeFrameDuration(JourneysTimeFrameDuration, NewDefaultScen
 
 
 def _make_function_upper_limit(from_coord, to_coord, mode, op):
-    def test_max_mode_direct_path_duration(self):
+    def test_ko_direct_path_longer_than_max_mode_direct_path_duration(self):
         query = (
             'journeys?'
             'from={from_coord}'
@@ -337,7 +337,7 @@ def _make_function_upper_limit(from_coord, to_coord, mode, op):
         # Distributed -> 'journeys' not in response
         assert op('journeys' not in response)
 
-    return test_max_mode_direct_path_duration
+    return test_ko_direct_path_longer_than_max_mode_direct_path_duration
 
 
 @dataset({"main_routing_test": {"scenario": "distributed"}})
@@ -361,7 +361,7 @@ class TestDistributedMaxDurationForDirectPathUpperLimit(NewDefaultScenarioAbstra
 
 
 def _make_function_lower_limit(from_coord, to_coord, mode):
-    def test_max_mode_direct_path_duration(self):
+    def test_get_direct_path_smaller_than_max_mode_direct_path_duration(self):
         query = (
             'journeys?'
             'from={from_coord}'
@@ -382,7 +382,7 @@ def _make_function_lower_limit(from_coord, to_coord, mode):
         assert mode in response['journeys'][0]['tags']
         assert 'non_pt' in response['journeys'][0]['tags']
 
-    return test_max_mode_direct_path_duration
+    return test_get_direct_path_smaller_than_max_mode_direct_path_duration
 
 
 @dataset({"main_routing_test": {"scenario": "distributed"}})


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVITIAII-2847

:warning:
 
**This PR will change the behavior of "/journeys" in distributed scenario with Kraken as street network calculator. We want all direct paths, if asked, to be present in the response, as long as their durations are lower than `max_{mode}_direct_path_duration`.**  

The problem is, when using Kraken as street network calculator, the searching limit is computed based on `max_{mode}_duration_pt * 2`. So in this PR, `max_{mode}_duration_pt`  is overwritten by `max_{mode}_direct_path_duration / 2`.

