### PR TITLE
jormungandr: Use params for sytral-rt request

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -101,16 +101,16 @@ class Sytral(RealtimeProxy):
         return params
 
     @cache.memoize(app.config['CACHE_CONFIGURATION'].get('TIMEOUT_SYTRAL', 30))
-    def _call(self, url, **kwargs):
+    def _call(self, params):
         """
         http call to sytralRT
         """
         logging.getLogger(__name__).debug(
-            'systralRT RT service , call url : {}'.format(url),
+            'systralRT RT service , call url : {}'.format(self.service_url),
             extra={'rt_system_id': unicode(self.rt_system_id)},
         )
         try:
-            return self.breaker.call(requests.get, url, **kwargs)
+            return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
                 'systralRT service dead, using base ' 'schedule (error: {}'.format(e),
@@ -163,8 +163,7 @@ class Sytral(RealtimeProxy):
         params = self._make_params(route_point)
         if not params:
             return None
-        kwargs = {"params": params, "timeout": self.timeout}
-        r = self._call(self.service_url, **kwargs)
+        r = self._call(params)
 
         if r.status_code != requests.codes.ok:
             logging.getLogger(__name__).error(

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/sytral_test.py
@@ -30,6 +30,7 @@
 from __future__ import absolute_import, print_function, division
 import mock
 from jormungandr.realtime_schedule.sytral import Sytral
+from jormungandr.tests.utils_test import MockRequests
 import validators
 import datetime
 import pytz
@@ -77,24 +78,6 @@ class MockResponse(object):
 
     def json(self):
         return self.data
-
-
-class MockRequests(object):
-    def __init__(self, responses):
-        self.responses = responses
-
-    def get(self, url, *args, **kwargs):
-        params = kwargs.get('params')
-        if params:
-            from six.moves.urllib.parse import urlencode
-
-            url += "?{}".format(urlencode(params, doseq=True))
-
-        r = self.responses.get(url)
-        if r:
-            return MockResponse(r[0], r[1], url)
-        else:
-            raise Exception("impossible to find mock response for url {}".format(url))
 
 
 @pytest.fixture(scope="module")
@@ -430,7 +413,7 @@ def next_passage_for_route_point_with_direction_type_test(mock_direction_type_is
     sytral = Sytral(id='tata', service_url='http://bob.com/')
 
     mock_requests = MockRequests(
-        {'http://bob.com/?stop_id=42&direction_type=forward': (mock_direction_type_is_forward_response, 200)}
+        {'http://bob.com/?direction_type=forward&stop_id=42': (mock_direction_type_is_forward_response, 200)}
     )
 
     route_point = MockRoutePoint(line_code='05', stop_id='42', direction_type='forward')


### PR DESCRIPTION
Reshape _Sytral-RT_ **GET** with _pybreaker params_.
Now, **URL** is not written with handmade concatenation, but incorporated inside a _GET params struct_.

- UTests are updated
- Tested locally with a **Sytral-Rt** instance and it works. URL transits with params :tada: 