### PR TITLE
Initialize default boundary for admin tree

### DIFF
--- a/source/georef/adminref.cpp
+++ b/source/georef/adminref.cpp
@@ -65,15 +65,17 @@ std::string Admin::postal_codes_to_string() const {
 
 AdminRtree build_admins_tree(const std::vector<Admin*> admins) {
     AdminRtree admins_tree;
-    double min[2];
-    double max[2];
+    double min[2] = {0., 0.};
+    double max[2] = {0., 0.};
     for (auto* admin : admins) {
-        boost::geometry::model::box<nt::GeographicalCoord> box;
-        boost::geometry::envelope(admin->boundary, box);
-        min[0] = box.min_corner().lon();
-        min[1] = box.min_corner().lat();
-        max[0] = box.max_corner().lon();
-        max[1] = box.max_corner().lat();
+        if (admin->boundary.size() > 0) {
+            boost::geometry::model::box<nt::GeographicalCoord> box;
+            boost::geometry::envelope(admin->boundary, box);
+            min[0] = box.min_corner().lon();
+            min[1] = box.min_corner().lat();
+            max[0] = box.max_corner().lon();
+            max[1] = box.max_corner().lat();
+        }
         admins_tree.Insert(min, max, admin);
     }
     return admins_tree;

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "utils/logger.h"
 
 #include "georef/georef.h"
+#include "georef/adminref.h"
 #include "tests/utils_test.h"
 #include "type/data.h"
 #include "builder.h"
@@ -1526,4 +1527,21 @@ BOOST_AUTO_TEST_CASE(projection_data_not_found) {
 
     BOOST_CHECK_THROW(proj[source_e], navitia::proximitylist::NotFound);
     BOOST_CHECK_THROW(proj[target_e], navitia::proximitylist::NotFound);
+}
+
+BOOST_AUTO_TEST_CASE(build_admin_tree_from_admin_with_no_boundary) {
+    std::vector<Admin*> admins;
+    Admin no_boundary;
+    admins.push_back(&no_boundary);
+
+    auto admin_tree = build_admins_tree(admins);
+
+    AdminRtree::Iterator it;
+    admin_tree.GetFirst(it);
+
+    double x, y;
+    it.GetBounds(&x, &y);
+
+    BOOST_CHECK_EQUAL(x, 0.);
+    BOOST_CHECK_EQUAL(y, 0.);
 }


### PR DESCRIPTION
Uninitialised values are baaaaaaaaaaaaaaaaaaaaaaaaaad !

When inserting 8 admins without boundary into an admin_tree, an ASSERT was raised inside the RTtree library :sob: 

This was causing `ed2nav` to fail on `debug` mode with artemis' Idfm coverage.  