### PR TITLE
Jormun: disable thread in procfile

### DIFF
--- a/source/jormungandr/Procfile
+++ b/source/jormungandr/Procfile
@@ -1,1 +1,1 @@
-web: FLASK_DEBUG=1 FLASK_APP=jormungandr:app flask run
+web: FLASK_DEBUG=1 FLASK_APP=jormungandr:app flask run --without-threads


### PR DESCRIPTION
Since flask 1.0 the development server is multithreaded,
mixing thread and greenlet doesn't work well, so this PR disable
threading in jormun