### PR TITLE
kraken: disable case insensitive test in fare

### DIFF
--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -75,14 +75,14 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
     // dummy transition
     fare::Transition transitionA;
     fare::State endA;
-    endA.line = "A";
+    endA.line = "a";
     transitionA.ticket_key = "price1";
     auto endA_v = boost::add_vertex(endA, b.data->fare->g);
     boost::add_edge(b.data->fare->begin_v, endA_v, transitionA, b.data->fare->g);
 
     fare::Transition transitionB;
     fare::State endB;
-    endB.line = "B";
+    endB.line = "b";
     transitionB.ticket_key = "price2";
     auto endB_v = boost::add_vertex(endB, b.data->fare->g);
     boost::add_edge(b.data->fare->begin_v, endB_v, transitionB, b.data->fare->g);

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -501,7 +501,7 @@ struct routing_api_data {
 
             navitia::fare::Transition ticket_transition;
             navitia::fare::State ticket_state;
-            ticket_state.line = "M";
+            ticket_state.line = "m";
             ticket_transition.ticket_key = "M-Ticket";
 
             auto ticket_state_v = boost::add_vertex(ticket_state, b.data->fare->g);


### PR DESCRIPTION
they are slow, very very slow...
During import all fare attributes are already converted to lower case, so only the sectionKey need to be converted to lowercase as is contains ntfs ids
TODO:
  - [x] check that fr-idf still works
  - [x] handle case-insensitive test at data integration if possible