### PR TITLE
ed : grid_calendars files follow NTFS norm with backward compatibility

### DIFF
--- a/fixtures/ed/ntfs_dst/grid_calendars.txt
+++ b/fixtures/ed/ntfs_dst/grid_calendars.txt
@@ -1,4 +1,4 @@
-id,name,monday,tuesday,wednesday,thursday,friday,saturday,sunday
+grid_calendar_id,name,monday,tuesday,wednesday,thursday,friday,saturday,sunday
 REG_LaV,lundi a vendredi,1,1,1,1,1,0,0
 REG_S,samedi,0,0,0,0,0,1,0
 REG_DJF,dimanche et jour feriés,0,0,0,0,0,0,1

--- a/fixtures/ed/ntfs_dst/grid_exception_dates.txt
+++ b/fixtures/ed/ntfs_dst/grid_exception_dates.txt
@@ -1,4 +1,4 @@
-calendar_id,date,type
+grid_calendar_id,date,type
 REG_LaV,20150223,0
 REG_LaV,20150224,0
 REG_LaV,20150225,0

--- a/fixtures/ed/ntfs_dst/grid_periods.txt
+++ b/fixtures/ed/ntfs_dst/grid_periods.txt
@@ -1,4 +1,4 @@
-calendar_id,begin_date,end_date
+grid_calendar_id,begin_date,end_date
 REG_LaV,20150223,20150531
 REG_S,20150223,20150531
 REG_DJF,20150223,20150531

--- a/fixtures/ed/ntfs_dst/grid_periods.txt
+++ b/fixtures/ed/ntfs_dst/grid_periods.txt
@@ -1,4 +1,4 @@
-grid_calendar_id,begin_date,end_date
+grid_calendar_id,start_date,end_date
 REG_LaV,20150223,20150531
 REG_S,20150223,20150531
 REG_DJF,20150223,20150531

--- a/fixtures/ed/ntfs_dst/grid_rel_calendar_line.txt
+++ b/fixtures/ed/ntfs_dst/grid_rel_calendar_line.txt
@@ -1,4 +1,4 @@
-line_external_code,calendar_id
+line_external_code,grid_calendar_id
 extNav55,REG_LaV
 Nav56,REG_LaV
 Nav57,REG_LaV

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1330,7 +1330,10 @@ void PeriodFusioHandler::init(Data&) {
     if (id_c == UNKNOWN_COLUMN) {
         id_c = csv.get_pos_col("calendar_id");
     }
-    begin_c = csv.get_pos_col("begin_date");
+    begin_c = csv.get_pos_col("start_date");
+    if (begin_c == UNKNOWN_COLUMN) {
+        begin_c = csv.get_pos_col("begin_date");
+    }
     end_c = csv.get_pos_col("end_date");
 }
 

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1330,17 +1330,16 @@ void PeriodFusioHandler::init(Data&) {
     if (id_c == UNKNOWN_COLUMN) {
         id_c = csv.get_pos_col("calendar_id");
     }
-    begin_c = csv.get_pos_col("start_date");
-    if (begin_c == UNKNOWN_COLUMN) {
-        begin_c = csv.get_pos_col("begin_date");
+    start_c = csv.get_pos_col("start_date");
+    if (start_c == UNKNOWN_COLUMN) {
+        start_c = csv.get_pos_col("begin_date");
     }
     end_c = csv.get_pos_col("end_date");
 }
 
 void PeriodFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line) {
     if (!is_first_line && !has_col(id_c, row)) {
-        LOG4CPLUS_FATAL(logger, "Error while reading " << csv.filename
-                                                       << "  file has more than one period and no calendar_id column");
+        LOG4CPLUS_FATAL(logger, "Error while reading " << csv.filename << " column id : " << id_c << " not available");
         throw InvalidHeaders(csv.filename);
     }
     auto cal = gtfs_data.calendars_map.find(row[id_c]);
@@ -1349,8 +1348,8 @@ void PeriodFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_li
         return;
     }
     boost::gregorian::date begin_date, end_date;
-    if (has_col(begin_c, row)) {
-        begin_date = parse_date(row[begin_c]);
+    if (has_col(start_c, row)) {
+        begin_date = parse_date(row[start_c]);
     }
     if (has_col(end_c, row)) {
         end_date = parse_date(row[end_c]);
@@ -1382,8 +1381,7 @@ void GridCalendarFusioHandler::init(Data&) {
 
 void GridCalendarFusioHandler::handle_line(Data& data, const csv_row& row, bool is_first_line) {
     if (!is_first_line && !has_col(id_c, row)) {
-        LOG4CPLUS_FATAL(logger,
-                        "Error while reading " + csv.filename + "  file has more than one calendar and no id column");
+        LOG4CPLUS_FATAL(logger, "Error while reading " << csv.filename << " column id : " << id_c << " not available");
         throw InvalidHeaders(csv.filename);
     }
     if (has_col(id_c, row) && row[id_c].empty()) {
@@ -1417,8 +1415,7 @@ void ExceptionDatesFusioHandler::init(Data&) {
 
 void ExceptionDatesFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line) {
     if (!is_first_line && !has_col(id_c, row)) {
-        LOG4CPLUS_FATAL(
-            logger, "Error while reading " + csv.filename + "  file has more than one calendar_id and no id column");
+        LOG4CPLUS_FATAL(logger, "Error while reading " << csv.filename << " column id : " << id_c << " not available");
         throw InvalidHeaders(csv.filename);
     }
     auto cal = gtfs_data.calendars_map.find(row[id_c]);
@@ -1465,8 +1462,7 @@ void CalendarLineFusioHandler::init(Data&) {
 
 void CalendarLineFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line) {
     if (!is_first_line && !has_col(id_c, row)) {
-        LOG4CPLUS_FATAL(logger, "CalendarLineFusioHandler: Error while reading " + csv.filename
-                                    + "  file has more than one calendar_id and no id column");
+        LOG4CPLUS_FATAL(logger, "Error while reading " << csv.filename << " column id : " << id_c << " not available");
         throw InvalidHeaders(csv.filename);
     }
 

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1326,20 +1326,23 @@ static boost::gregorian::date parse_date(const std::string& str) {
 namespace grid_calendar {
 
 void PeriodFusioHandler::init(Data&) {
-    calendar_c = csv.get_pos_col("calendar_id");
+    id_c = csv.get_pos_col("grid_calendar_id");
+    if (id_c == UNKNOWN_COLUMN) {
+        id_c = csv.get_pos_col("calendar_id");
+    }
     begin_c = csv.get_pos_col("begin_date");
     end_c = csv.get_pos_col("end_date");
 }
 
 void PeriodFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line) {
-    if (!is_first_line && !has_col(calendar_c, row)) {
+    if (!is_first_line && !has_col(id_c, row)) {
         LOG4CPLUS_FATAL(logger, "Error while reading " << csv.filename
                                                        << "  file has more than one period and no calendar_id column");
         throw InvalidHeaders(csv.filename);
     }
-    auto cal = gtfs_data.calendars_map.find(row[calendar_c]);
+    auto cal = gtfs_data.calendars_map.find(row[id_c]);
     if (cal == gtfs_data.calendars_map.end()) {
-        LOG4CPLUS_ERROR(logger, "GridCalPeriodFusioHandler : Impossible to find the calendar " << row[calendar_c]);
+        LOG4CPLUS_ERROR(logger, "GridCalPeriodFusioHandler : Impossible to find the calendar " << row[id_c]);
         return;
     }
     boost::gregorian::date begin_date, end_date;
@@ -1350,7 +1353,7 @@ void PeriodFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_li
         end_date = parse_date(row[end_c]);
     }
     if (begin_date.is_not_a_date() || end_date.is_not_a_date()) {
-        LOG4CPLUS_ERROR(logger, "period invalid, not added for calendar " << row[calendar_c]);
+        LOG4CPLUS_ERROR(logger, "period invalid, not added for calendar " << row[id_c]);
         return;
     }
     // the end of a gregorian period not in the period (it's the day after)
@@ -1360,7 +1363,10 @@ void PeriodFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_li
 }
 
 void GridCalendarFusioHandler::init(Data&) {
-    id_c = csv.get_pos_col("id");
+    id_c = csv.get_pos_col("grid_calendar_id");
+    if (id_c == UNKNOWN_COLUMN) {
+        id_c = csv.get_pos_col("id");
+    }
     name_c = csv.get_pos_col("name");
     monday_c = csv.get_pos_col("monday");
     tuesday_c = csv.get_pos_col("tuesday");
@@ -1398,24 +1404,27 @@ void GridCalendarFusioHandler::handle_line(Data& data, const csv_row& row, bool 
 }
 
 void ExceptionDatesFusioHandler::init(Data&) {
-    calendar_c = csv.get_pos_col("calendar_id");
+    id_c = csv.get_pos_col("grid_calendar_id");
+    if (id_c == UNKNOWN_COLUMN) {
+        id_c = csv.get_pos_col("calendar_id");
+    }
     datetime_c = csv.get_pos_col("date");
     type_c = csv.get_pos_col("type");
 }
 
 void ExceptionDatesFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line) {
-    if (!is_first_line && !has_col(calendar_c, row)) {
+    if (!is_first_line && !has_col(id_c, row)) {
         LOG4CPLUS_FATAL(
             logger, "Error while reading " + csv.filename + "  file has more than one calendar_id and no id column");
         throw InvalidHeaders(csv.filename);
     }
-    auto cal = gtfs_data.calendars_map.find(row[calendar_c]);
+    auto cal = gtfs_data.calendars_map.find(row[id_c]);
     if (cal == gtfs_data.calendars_map.end()) {
-        LOG4CPLUS_WARN(logger, "ExceptionDatesFusioHandler : Impossible to find the calendar " << row[calendar_c]);
+        LOG4CPLUS_WARN(logger, "ExceptionDatesFusioHandler : Impossible to find the calendar " << row[id_c]);
         return;
     }
     if (!has_col(type_c, row)) {
-        LOG4CPLUS_WARN(logger, "ExceptionDatesFusioHandler: No column type for calendar " << row[calendar_c]);
+        LOG4CPLUS_WARN(logger, "ExceptionDatesFusioHandler: No column type for calendar " << row[id_c]);
         return;
     }
     if (row[type_c] != "0" && row[type_c] != "1") {
@@ -1423,13 +1432,13 @@ void ExceptionDatesFusioHandler::handle_line(Data&, const csv_row& row, bool is_
         return;
     }
     if (!has_col(datetime_c, row)) {
-        LOG4CPLUS_WARN(logger, "ExceptionDatesFusioHandler: No column datetime for calendar " << row[calendar_c]);
+        LOG4CPLUS_WARN(logger, "ExceptionDatesFusioHandler: No column datetime for calendar " << row[id_c]);
         return;
     }
     boost::gregorian::date date(parse_date(row[datetime_c]));
     if (date.is_not_a_date()) {
-        LOG4CPLUS_ERROR(
-            logger, "date format not valid, we do not add the exception " << row[type_c] << " for " << row[calendar_c]);
+        LOG4CPLUS_ERROR(logger,
+                        "date format not valid, we do not add the exception " << row[type_c] << " for " << row[id_c]);
         return;
     }
     navitia::type::ExceptionDate exception_date;
@@ -1440,7 +1449,10 @@ void ExceptionDatesFusioHandler::handle_line(Data&, const csv_row& row, bool is_
 }
 
 void CalendarLineFusioHandler::init(Data&) {
-    calendar_c = csv.get_pos_col("calendar_id");
+    id_c = csv.get_pos_col("grid_calendar_id");
+    if (id_c == UNKNOWN_COLUMN) {
+        id_c = csv.get_pos_col("calendar_id");
+    }
     line_c = csv.get_pos_col("line_id");
     if (line_c == UNKNOWN_COLUMN) {
         line_id_is_present = false;
@@ -1449,19 +1461,19 @@ void CalendarLineFusioHandler::init(Data&) {
 }
 
 void CalendarLineFusioHandler::handle_line(Data&, const csv_row& row, bool is_first_line) {
-    if (!is_first_line && !has_col(calendar_c, row)) {
+    if (!is_first_line && !has_col(id_c, row)) {
         LOG4CPLUS_FATAL(logger, "CalendarLineFusioHandler: Error while reading " + csv.filename
                                     + "  file has more than one calendar_id and no id column");
         throw InvalidHeaders(csv.filename);
     }
 
-    auto cal = gtfs_data.calendars_map.find(row[calendar_c]);
+    auto cal = gtfs_data.calendars_map.find(row[id_c]);
     if (cal == gtfs_data.calendars_map.end()) {
-        LOG4CPLUS_ERROR(logger, "CalendarLineFusioHandler: Impossible to find the calendar " << row[calendar_c]);
+        LOG4CPLUS_ERROR(logger, "CalendarLineFusioHandler: Impossible to find the calendar " << row[id_c]);
         return;
     }
     if (!has_col(line_c, row)) {
-        LOG4CPLUS_WARN(logger, "CalendarLineFusioHandler: No line column for calendar : " << row[calendar_c]);
+        LOG4CPLUS_WARN(logger, "CalendarLineFusioHandler: No line column for calendar : " << row[id_c]);
         return;
     }
     std::unordered_map<std::string, ed::types::Line*>::iterator it;

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -255,7 +255,7 @@ struct PeriodFusioHandler : public GenericHandler {
     int id_c, begin_c, end_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);
-    const std::vector<std::string> required_headers() const { return {"begin_date", "end_date"}; }
+    const std::vector<std::string> required_headers() const { return {"end_date"}; }
 };
 
 struct GridCalendarFusioHandler : public GenericHandler {

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -252,7 +252,7 @@ struct TripPropertiesFusioHandler : public GenericHandler {
 namespace grid_calendar {
 struct PeriodFusioHandler : public GenericHandler {
     PeriodFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int id_c, begin_c, end_c;
+    int id_c, start_c, end_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"end_date"}; }

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -255,7 +255,7 @@ struct PeriodFusioHandler : public GenericHandler {
     int id_c, begin_c, end_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);
-    const std::vector<std::string> required_headers() const { return {"calendar_id", "begin_date", "end_date"}; }
+    const std::vector<std::string> required_headers() const { return {"begin_date", "end_date"}; }
 };
 
 struct GridCalendarFusioHandler : public GenericHandler {
@@ -264,7 +264,7 @@ struct GridCalendarFusioHandler : public GenericHandler {
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
     const std::vector<std::string> required_headers() const {
-        return {"id", "name", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"};
+        return {"name", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"};
     }
 };
 
@@ -273,7 +273,7 @@ struct ExceptionDatesFusioHandler : public GenericHandler {
     int id_c, datetime_c, type_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
-    const std::vector<std::string> required_headers() const { return {"calendar_id", "date", "type"}; }
+    const std::vector<std::string> required_headers() const { return {"date", "type"}; }
 };
 
 struct CalendarLineFusioHandler : public GenericHandler {
@@ -283,7 +283,7 @@ struct CalendarLineFusioHandler : public GenericHandler {
     bool line_id_is_present;
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
-    const std::vector<std::string> required_headers() const { return {"calendar_id"}; }
+    const std::vector<std::string> required_headers() const { return {}; }
 };
 
 struct CalendarTripFusioHandler : public GenericHandler {

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -252,7 +252,7 @@ struct TripPropertiesFusioHandler : public GenericHandler {
 namespace grid_calendar {
 struct PeriodFusioHandler : public GenericHandler {
     PeriodFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int calendar_c, begin_c, end_c;
+    int id_c, begin_c, end_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"calendar_id", "begin_date", "end_date"}; }
@@ -270,7 +270,7 @@ struct GridCalendarFusioHandler : public GenericHandler {
 
 struct ExceptionDatesFusioHandler : public GenericHandler {
     ExceptionDatesFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int calendar_c, datetime_c, type_c;
+    int id_c, datetime_c, type_c;
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);
     const std::vector<std::string> required_headers() const { return {"calendar_id", "date", "type"}; }
@@ -279,7 +279,7 @@ struct ExceptionDatesFusioHandler : public GenericHandler {
 struct CalendarLineFusioHandler : public GenericHandler {
     CalendarLineFusioHandler(GtfsData& gdata, CsvReader& reader)
         : GenericHandler(gdata, reader), line_id_is_present(true) {}
-    int calendar_c, line_c;
+    int id_c, line_c;
     bool line_id_is_present;
     void init(Data&);
     void handle_line(Data& data, const csv_row& row, bool is_first_line);


### PR DESCRIPTION
**Thematic** : Update ED reader to follow the [NTFS norm](https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#grid_calendarstxt-optionnel) for grid_calendars* files. Backward compatibility is mandatory for this change 

**JIRA** : https://jira.kisio.org/browse/NAVITIAII-2855

Only updated current tests and data set.
The attached test files inside JIRA ticket works well with fusio2ed binary.
Docker tests are green :green_apple: 