### PR TITLE
jormun & kraken: Add direction type parameter for filtering departures API result.

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1671,15 +1671,16 @@ See how disruptions affect the next departures in the [real time](#realtime) sec
 
 ### Parameters
 
-Required | Name             | Type                            | Description                                                                                              | Default Value
----------|------------------|---------------------------------|----------------------------------------------------------------------------------------------------------|--------------
-nop      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                          | the current datetime
-nop      | duration         | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                           | 86400
-nop      | count            | int                             | Maximum number of results.                                                                               | 10
-nop      | depth            | int                             | Json response [depth](#depth)                                                                            | 1
-nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                        |
-nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul> | realtime
-nop      | disable_geojson  | boolean                         | remove geojson fields from the response                                                                  | false
+Required | Name             | Type                            | Description                                                                                                      | Default Value
+---------|------------------|---------------------------------|------------------------------------------------------------------------------------------------------------------|--------------
+nop      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                                  | the current datetime
+nop      | duration         | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                                   | 86400
+nop      | count            | int                             | Maximum number of results.                                                                                       | 10
+nop      | depth            | int                             | Json response [depth](#depth)                                                                                    | 1
+nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                                |
+nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul>         | realtime
+nop      | disable_geojson  | boolean                         | remove geojson fields from the response                                                                          | false
+nop      | direction_type   | enum                            | Allow to filter the response with direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul> | all
 
 
 ### Departure objects

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -102,10 +102,10 @@ nt::VehicleJourney* VJ::make() {
         } else {
             // Create a new one based on the name of the line
             const auto route_uri = line_name + ":" + std::to_string(pt_data.routes.size());
-            route = pt_data.get_or_create_route(route_uri, line_name, line);
+            route = pt_data.get_or_create_route(route_uri, line_name, line, nullptr, _direction_type);
         }
     } else {
-        route = pt_data.get_or_create_route(_route_name, _route_name, line);
+        route = pt_data.get_or_create_route(_route_name, _route_name, line, nullptr, _direction_type);
     }
 
     std::string mvj_name;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -131,7 +131,7 @@ struct VJ {
         return *this;
     }
 
-    VJ& route(const std::string& r, const std::string& d = "forward") {
+    VJ& route(const std::string& r, const std::string& d = "") {
         _route_name = r;
         _direction_type = d;
         return *this;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -131,11 +131,8 @@ struct VJ {
         return *this;
     }
 
-    VJ& route(const std::string& r) {
+    VJ& route(const std::string& r, const std::string& d = "forward") {
         _route_name = r;
-        return *this;
-    }
-    VJ& direction_type(const std::string& d) {
         _direction_type = d;
         return *this;
     }

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -68,6 +68,7 @@ struct VJ {
     const std::string line_name;
     std::string _block_id;
     std::string _route_name;
+    std::string _direction_type = "";
     const bool is_frequency;
     const bool wheelchair_boarding;
     std::string _name;
@@ -132,6 +133,10 @@ struct VJ {
 
     VJ& route(const std::string& r) {
         _route_name = r;
+        return *this;
+    }
+    VJ& direction_type(const std::string& d) {
+        _direction_type = d;
         return *this;
     }
     VJ& bike_accepted(bool b) {

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -154,7 +154,11 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "disable_geojson", type=BooleanType(), default=False, help="remove geojson from the response"
         )
-
+        parser_get.add_argument(
+            "direction_type",
+            help='Provide a direction to filter results.',
+            type=OptionValue(['all', 'forward', 'backward']),
+        )
         self.get_decorators.insert(0, ManageError())
         self.get_decorators.insert(1, get_obj_serializer(self))
         self.get_decorators.append(complete_links(self))

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -268,6 +268,8 @@ class MixedSchedule(object):
         if request.get("calendar"):
             st.calendar = request["calendar"]
         st.realtime_level = utils.realtime_level_to_pbf(request['data_freshness'])
+        if request.get("direction_type"):
+            st.direction_type = utils.direction_type_to_pbf(request['direction_type'])
         resp = self.instance.send_and_receive(req)
 
         return resp

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -323,6 +323,17 @@ def realtime_level_to_pbf(level):
         raise ValueError('Impossible to convert in pbf')
 
 
+def direction_type_to_pbf(direction_type):
+    if direction_type == 'all':
+        return type_pb2.ALL
+    elif direction_type == 'forward':
+        return type_pb2.FORWARD
+    elif direction_type == 'backward':
+        return type_pb2.BACKWARD
+    else:
+        raise ValueError('Impossible to convert in pbf')
+
+
 # we can't use reverse(enumerate(list)) without creating a temporary
 # list, so we define our own reverse enumerate
 def reverse_enumerate(l):

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -931,6 +931,42 @@ class TestSchedules(AbstractTestFixture):
         assert not [l for l in response.get('links') if l.get('rel') == 'next']
         self.check_departure_rt_sol(departures)
 
+    def test_departures_with_direction_type(self):
+        """
+        Test direction type parameter for filtering departures response
+        data contains :
+           - route A (direction type = forward)
+                * 3 departures on stop uri : S1
+           - route B (direction type = backward)
+                * 1 departure on stop uri : S1
+        """
+
+        # Without direction type parameter
+        response = self.query_region("stop_points/S1/departures?_current_datetime=20160101T080000")
+        assert "departures" in response
+        assert len(response["departures"]) == 4
+
+        # With direction type = all (same as without direction type parameter)
+        response = self.query_region(
+            "stop_points/S1/departures?direction_type=all&_current_datetime=20160101T080000"
+        )
+        assert "departures" in response
+        assert len(response["departures"]) == 4
+
+        # With direction type = forward
+        response = self.query_region(
+            "stop_points/S1/departures?direction_type=forward&_current_datetime=20160101T080000"
+        )
+        assert "departures" in response
+        assert len(response["departures"]) == 3
+
+        # With direction type = backward
+        response = self.query_region(
+            "stop_points/S1/departures?direction_type=backward&_current_datetime=20160101T080000"
+        )
+        assert "departures" in response
+        assert len(response["departures"]) == 1
+
     def test_departure_base_sched(self):
         """
         test a departure, no date time and base schedule, we should get base schedule

--- a/source/jormungandr/tests/proxy_realtime_sytral_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_sytral_integration_tests.py
@@ -66,7 +66,7 @@ class TestSytralSchedules(AbstractTestFixture):
     def test_stop_schedule_with_realtime_only(self):
         mock_requests = MockRequests(
             {
-                'http://XXXX?stop_id=syn_stoppoint1': (
+                'http://XXXX?stop_id=syn_stoppoint1&direction_type=forward': (
                     {
                         "departures": [
                             {
@@ -74,6 +74,7 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
+                                "direction_type": "forward",
                                 "datetime": "2016-01-02T10:17:17+02:00",
                                 "type": "E",
                             },
@@ -82,6 +83,7 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
+                                "direction_type": "forward",
                                 "type": "E",
                                 "datetime": "2016-01-02T11:17:17+02:00",
                             },
@@ -114,7 +116,7 @@ class TestSytralSchedules(AbstractTestFixture):
     def test_stop_schedule_with_theoric_and_realtime(self):
         mock_requests = MockRequests(
             {
-                'http://XXXX?stop_id=syn_stoppoint1': (
+                'http://XXXX?stop_id=syn_stoppoint1&direction_type=forward': (
                     {
                         "departures": [
                             {
@@ -122,6 +124,7 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
+                                "direction_type": "forward",
                                 "datetime": "2016-01-02T09:17:17+01:00",
                                 "type": "E",
                             },
@@ -130,6 +133,7 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
+                                "direction_type": "forward",
                                 "datetime": "2016-01-02T10:17:17+01:00",
                                 "type": "T",
                             },

--- a/source/jormungandr/tests/proxy_realtime_sytral_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_sytral_integration_tests.py
@@ -66,7 +66,7 @@ class TestSytralSchedules(AbstractTestFixture):
     def test_stop_schedule_with_realtime_only(self):
         mock_requests = MockRequests(
             {
-                'http://XXXX?stop_id=syn_stoppoint1&direction_type=forward': (
+                'http://XXXX?stop_id=syn_stoppoint1': (
                     {
                         "departures": [
                             {
@@ -74,7 +74,6 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
-                                "direction_type": "forward",
                                 "datetime": "2016-01-02T10:17:17+02:00",
                                 "type": "E",
                             },
@@ -83,7 +82,6 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
-                                "direction_type": "forward",
                                 "type": "E",
                                 "datetime": "2016-01-02T11:17:17+02:00",
                             },
@@ -116,7 +114,7 @@ class TestSytralSchedules(AbstractTestFixture):
     def test_stop_schedule_with_theoric_and_realtime(self):
         mock_requests = MockRequests(
             {
-                'http://XXXX?stop_id=syn_stoppoint1&direction_type=forward': (
+                'http://XXXX?stop_id=syn_stoppoint1': (
                     {
                         "departures": [
                             {
@@ -124,7 +122,6 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
-                                "direction_type": "forward",
                                 "datetime": "2016-01-02T09:17:17+01:00",
                                 "type": "E",
                             },
@@ -133,7 +130,6 @@ class TestSytralSchedules(AbstractTestFixture):
                                 "stop": "syn_stoppoint1",
                                 "direction_id": "3341",
                                 "direction_name": "Piscine Chambéry",
-                                "direction_type": "forward",
                                 "datetime": "2016-01-02T10:17:17+01:00",
                                 "type": "T",
                             },

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -138,7 +138,7 @@ class TestDepartures(AbstractTestFixture):
         response = self.query_region(query)
 
         stop_schedule_A = response['stop_schedules'][0]
-        assert stop_schedule_A['route']['name'] == 'A'
+        assert stop_schedule_A['route']['name'] == 'A:0'
         next_passage_dts = [dt["date_time"] for dt in stop_schedule_A['date_times']]
         next_passage_base_dts = [dt["base_date_time"] for dt in stop_schedule_A['date_times']]
         values = ['20160102T110000', '20160103T090000', '20160103T100000']
@@ -149,7 +149,7 @@ class TestDepartures(AbstractTestFixture):
             assert dt['data_freshness'] == 'base_schedule'
 
         stop_schedule_B = response['stop_schedules'][1]
-        assert stop_schedule_B['route']['name'] == 'B'
+        assert stop_schedule_B['route']['name'] == 'B:1'
         next_passage_dts = [dt["date_time"] for dt in stop_schedule_B['date_times']]
         assert ['20160102T113000'] == next_passage_dts
 

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -432,13 +432,12 @@ void Worker::next_stop_times(const pbnavitia::NextStopTimeRequest& request, pbna
     try {
         switch (api) {
             case pbnavitia::NEXT_DEPARTURES:
-                timetables::passages(
-                    this->pb_creator, request.departure_filter(), forbidden_uri, from_datetime, request.duration(),
-                    request.nb_stoptimes(), request.depth(), type::AccessibiliteParams(), rt_level, api,
-                    request.count(), request.start_page(),
-                    request.has_direction_type()
-                        ? boost::make_optional<nt::DirectionType>(nt::get_direction_type(request.direction_type()))
-                        : boost::none);
+                timetables::passages(this->pb_creator, request.departure_filter(), forbidden_uri, from_datetime,
+                                     request.duration(), request.nb_stoptimes(), request.depth(),
+                                     type::AccessibiliteParams(), rt_level, api, request.count(), request.start_page(),
+                                     request.has_direction_type()
+                                         ? boost::make_optional<pbnavitia::DirectionType>(request.direction_type())
+                                         : boost::none);
                 break;
             case pbnavitia::NEXT_ARRIVALS:
                 timetables::passages(this->pb_creator, request.arrival_filter(), forbidden_uri, from_datetime,

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -432,9 +432,13 @@ void Worker::next_stop_times(const pbnavitia::NextStopTimeRequest& request, pbna
     try {
         switch (api) {
             case pbnavitia::NEXT_DEPARTURES:
-                timetables::passages(this->pb_creator, request.departure_filter(), forbidden_uri, from_datetime,
-                                     request.duration(), request.nb_stoptimes(), request.depth(),
-                                     type::AccessibiliteParams(), rt_level, api, request.count(), request.start_page());
+                timetables::passages(
+                    this->pb_creator, request.departure_filter(), forbidden_uri, from_datetime, request.duration(),
+                    request.nb_stoptimes(), request.depth(), type::AccessibiliteParams(), rt_level, api,
+                    request.count(), request.start_page(),
+                    request.has_direction_type()
+                        ? boost::make_optional<nt::DirectionType>(nt::get_direction_type(request.direction_type()))
+                        : boost::none);
                 break;
             case pbnavitia::NEXT_ARRIVALS:
                 timetables::passages(this->pb_creator, request.arrival_filter(), forbidden_uri, from_datetime,

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -133,7 +133,7 @@ void passages(PbCreator& pb_creator,
               const pbnavitia::API api_pb,
               const uint32_t count,
               const uint32_t start_page,
-              const boost::optional<type::DirectionType>& direction_type) {
+              const boost::optional<pbnavitia::DirectionType>& direction_type) {
     const PassagesVisitor vis{api_pb, *pb_creator.data};
     RequestHandle handler(pb_creator, datetime, duration, {}, true);
     handler.init_jpp(request, forbidden_uris);
@@ -156,7 +156,7 @@ void passages(PbCreator& pb_creator,
     std::sort(passages_dt_st.begin(), passages_dt_st.end(), sort_predicate);
 
     auto is_handleable_with_direction_type = [&direction_type](const type::VehicleJourney* vj) {
-        return !direction_type || (direction_type && *direction_type == type::DirectionType::All)
+        return !direction_type || (direction_type && *direction_type == pbnavitia::DirectionType::ALL)
                || (direction_type && *direction_type == type::get_direction_type(vj->route->direction_type));
     };
 

--- a/source/time_tables/passages.h
+++ b/source/time_tables/passages.h
@@ -30,6 +30,7 @@ www.navitia.io
 
 #pragma once
 #include "type/pb_converter.h"
+#include "type/type_utils.h"
 namespace navitia {
 namespace timetables {
 
@@ -44,6 +45,7 @@ void passages(PbCreator& pb_creator,
               const type::RTLevel rt_level,
               const pbnavitia::API api_pb,
               const uint32_t count,
-              const uint32_t start_page);
+              const uint32_t start_page,
+              const boost::optional<type::DirectionType>& direction_type = boost::none);
 }
 }  // namespace navitia

--- a/source/time_tables/passages.h
+++ b/source/time_tables/passages.h
@@ -46,6 +46,6 @@ void passages(PbCreator& pb_creator,
               const pbnavitia::API api_pb,
               const uint32_t count,
               const uint32_t start_page,
-              const boost::optional<type::DirectionType>& direction_type = boost::none);
+              const boost::optional<pbnavitia::DirectionType>& direction_type = boost::none);
 }
 }  // namespace navitia

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -39,12 +39,13 @@ struct departure_board_fixture {
     departure_board_fixture() : b("20160101") {
         b.sa("SA1")("S1")("S2");
 
-        b.vj("A").direction_type("forward").name("A:vj1")("A:s", "08:00"_t)("S1", "09:00"_t)("S2", "10:00"_t)(
-            "A:e", "11:00"_t);
+        b.vj("A")
+            .route("A:0", "forward")
+            .name("A:vj1")("A:s", "08:00"_t)("S1", "09:00"_t)("S2", "10:00"_t)("A:e", "11:00"_t);
         b.vj("A").name("A:vj2")("A:s", "09:00"_t)("S1", "10:00"_t)("S2", "11:00"_t)("A:e", "12:00"_t);
         b.vj("A").name("A:vj3")("A:s", "10:00"_t)("S1", "11:00"_t)("S2", "12:00"_t)("A:e", "13:00"_t);
 
-        b.vj("B").direction_type("backward").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
+        b.vj("B").route("B:1", "backward").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
 
         b.vj("C").name("C:vj1")("C:S0", "11:30"_t)("C:S1", "12:30"_t)("C:S2", "13:30"_t);
         b.lines.find("C")->second->properties["realtime_system"] = "Kisio数字";

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -39,11 +39,12 @@ struct departure_board_fixture {
     departure_board_fixture() : b("20160101") {
         b.sa("SA1")("S1")("S2");
 
-        b.vj("A").name("A:vj1")("A:s", "08:00"_t)("S1", "09:00"_t)("S2", "10:00"_t)("A:e", "11:00"_t);
+        b.vj("A").direction_type("forward").name("A:vj1")("A:s", "08:00"_t)("S1", "09:00"_t)("S2", "10:00"_t)(
+            "A:e", "11:00"_t);
         b.vj("A").name("A:vj2")("A:s", "09:00"_t)("S1", "10:00"_t)("S2", "11:00"_t)("A:e", "12:00"_t);
         b.vj("A").name("A:vj3")("A:s", "10:00"_t)("S1", "11:00"_t)("S2", "12:00"_t)("A:e", "13:00"_t);
 
-        b.vj("B").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
+        b.vj("B").direction_type("backward").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
 
         b.vj("C").name("C:vj1")("C:S0", "11:30"_t)("C:S1", "12:30"_t)("C:S2", "13:30"_t);
         b.lines.find("C")->second->properties["realtime_system"] = "Kisio数字";

--- a/source/time_tables/tests/passages_test.cpp
+++ b/source/time_tables/tests/passages_test.cpp
@@ -110,42 +110,99 @@ BOOST_AUTO_TEST_CASE(next_passages_on_last_production_day) {
 }
 
 BOOST_AUTO_TEST_CASE(passages_with_direction_type) {
-    ed::builder b("20190101");
+    // direction_type = forward
+    {
+        ed::builder b("20190101");
 
-    // Add forward direction type for L1 route
-    b.vj("L1")
-        .route("route1", "forward")
-        .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
-            "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
-    b.vj("L1").name("vj:1")("stop1", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, true, 0, 900)(
-        "stop2", "8:15"_t, "8:16"_t, std::numeric_limits<uint16_t>::max(), true, false, 0, 900);
+        // Add forward direction type for L1 route
+        b.vj("L1")
+            .route("route1", "forward")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+        b.vj("L1").name("vj:1")("stop1", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, true, 0, 900)(
+            "stop2", "8:15"_t, "8:16"_t, std::numeric_limits<uint16_t>::max(), true, false, 0, 900);
 
-    b.make();
+        b.make();
 
-    // Direction type request param = All, direction type into data = Forward
-    // Return All next departures for stop2
-    navitia::PbCreator pb_creator_all(b.data.get(), bt::second_clock::universal_time(), null_time_period);
-    passages(pb_creator_all, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
-             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
-             pbnavitia::DirectionType::ALL);
-    auto resp = pb_creator_all.get_response();
-    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
+        // Direction type request param = All, direction type into data = Forward
+        // Return All next departures for stop1
+        navitia::PbCreator pb_creator_all(b.data.get(), bt::second_clock::universal_time(), null_time_period);
+        passages(pb_creator_all, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
+                 navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
+                 pbnavitia::DirectionType::ALL);
+        auto resp = pb_creator_all.get_response();
+        BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
 
-    // Direction type request param = Forward, direction type into data = Forward
-    // Return All next departures for stop2
-    navitia::PbCreator pb_creator_forward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
-    passages(pb_creator_forward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
-             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
-             pbnavitia::DirectionType::FORWARD);
-    resp = pb_creator_forward.get_response();
-    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
+        // Direction type request param = Forward, direction type into data = Forward
+        // Return All next departures for stop1
+        navitia::PbCreator pb_creator_forward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
+        passages(pb_creator_forward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
+                 navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
+                 pbnavitia::DirectionType::FORWARD);
+        resp = pb_creator_forward.get_response();
+        BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
 
-    // Direction type request param = Backward, direction type into data = Forward
-    // There is no results, all are filtered.
-    navitia::PbCreator pb_creator_backward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
-    passages(pb_creator_backward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
-             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
-             pbnavitia::DirectionType::BACKWARD);
-    resp = pb_creator_backward.get_response();
-    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 0);
+        // Direction type request param = Backward, direction type into data = Forward
+        // There is no results, all are filtered.
+        navitia::PbCreator pb_creator_backward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
+        passages(pb_creator_backward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
+                 navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
+                 pbnavitia::DirectionType::BACKWARD);
+        resp = pb_creator_backward.get_response();
+        BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 0);
+    }
+    // direction_type = forward = clockwise = inbound
+    {
+        ed::builder b("20190101");
+
+        b.vj("L1")
+            .route("route1", "forward")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+        b.vj("L2")
+            .route("route2", "clockwise")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+        b.vj("L3")
+            .route("route3", "inbound")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+
+        b.make();
+
+        // Return All next departures for stop1
+        navitia::PbCreator pb_creator_forward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
+        passages(pb_creator_forward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
+                 navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
+                 pbnavitia::DirectionType::FORWARD);
+        auto resp = pb_creator_forward.get_response();
+        BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 3);
+    }
+    // direction_type = bacward = anticlockwise = outbound
+    {
+        ed::builder b("20190101");
+
+        b.vj("L1")
+            .route("route1", "backward")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+        b.vj("L2")
+            .route("route2", "anticlockwise")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+        b.vj("L3")
+            .route("route3", "outbound")
+            .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+                "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+
+        b.make();
+
+        // Return All next departures for stop1
+        navitia::PbCreator pb_creator_forward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
+        passages(pb_creator_forward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
+                 navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
+                 pbnavitia::DirectionType::BACKWARD);
+        auto resp = pb_creator_forward.get_response();
+        BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 3);
+    }
 }

--- a/source/time_tables/tests/passages_test.cpp
+++ b/source/time_tables/tests/passages_test.cpp
@@ -113,9 +113,10 @@ BOOST_AUTO_TEST_CASE(passages_with_direction_type) {
     ed::builder b("20190101");
 
     // Add forward direction type for L1 route
-    b.vj("L1").direction_type("forward").name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(),
-                                                      true, true, 900, 0)(
-        "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
+    b.vj("L1")
+        .route("route1", "forward")
+        .name("vj:0")("stop1", "8:05"_t, "8:06"_t, std::numeric_limits<uint16_t>::max(), true, true, 900, 0)(
+            "stop2", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, false, 900, 0);
     b.vj("L1").name("vj:1")("stop1", "8:10"_t, "8:11"_t, std::numeric_limits<uint16_t>::max(), true, true, 0, 900)(
         "stop2", "8:15"_t, "8:16"_t, std::numeric_limits<uint16_t>::max(), true, false, 0, 900);
 
@@ -126,7 +127,7 @@ BOOST_AUTO_TEST_CASE(passages_with_direction_type) {
     navitia::PbCreator pb_creator_all(b.data.get(), bt::second_clock::universal_time(), null_time_period);
     passages(pb_creator_all, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
              navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
-             navitia::type::DirectionType::All);
+             pbnavitia::DirectionType::ALL);
     auto resp = pb_creator_all.get_response();
     BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
 
@@ -135,7 +136,7 @@ BOOST_AUTO_TEST_CASE(passages_with_direction_type) {
     navitia::PbCreator pb_creator_forward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
     passages(pb_creator_forward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
              navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
-             navitia::type::DirectionType::Forward);
+             pbnavitia::DirectionType::FORWARD);
     resp = pb_creator_forward.get_response();
     BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
 
@@ -144,7 +145,7 @@ BOOST_AUTO_TEST_CASE(passages_with_direction_type) {
     navitia::PbCreator pb_creator_backward(b.data.get(), bt::second_clock::universal_time(), null_time_period);
     passages(pb_creator_backward, "stop_point.uri=stop1", {}, "20190101T073000"_dt, 86400, 10, 3,
              navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0,
-             navitia::type::DirectionType::Backward);
+             pbnavitia::DirectionType::BACKWARD);
     resp = pb_creator_backward.get_response();
     BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 0);
 }

--- a/source/type/type_utils.cpp
+++ b/source/type/type_utils.cpp
@@ -82,4 +82,33 @@ pbnavitia::RTLevel to_pb_realtime_level(const navitia::type::RTLevel realtime_le
             throw navitia::exception("realtime level case not handled");
     }
 }
+
+namespace type {
+
+type::DirectionType get_direction_type(pbnavitia::DirectionType direction_type) {
+    switch (direction_type) {
+        case pbnavitia::DirectionType::ALL:
+            return type::DirectionType::All;
+        case pbnavitia::DirectionType::FORWARD:
+            return type::DirectionType::Forward;
+        case pbnavitia::DirectionType::BACKWARD:
+            return type::DirectionType::Backward;
+        default:
+            throw navitia::recoverable_exception("unhandled protobuf direction type");
+    }
+}
+
+type::DirectionType get_direction_type(std::string& direction_type) {
+    if (boost::iequals(direction_type, "all")) {
+        return type::DirectionType::All;
+    } else if (boost::iequals(direction_type, "forward")) {
+        return type::DirectionType::Forward;
+    } else if (boost::iequals(direction_type, "backward")) {
+        return type::DirectionType::Backward;
+    } else {
+        throw navitia::recoverable_exception("unhandled direction type string");
+    }
+}
+
+}  // namespace type
 }  // namespace navitia

--- a/source/type/type_utils.cpp
+++ b/source/type/type_utils.cpp
@@ -85,28 +85,17 @@ pbnavitia::RTLevel to_pb_realtime_level(const navitia::type::RTLevel realtime_le
 
 namespace type {
 
-type::DirectionType get_direction_type(pbnavitia::DirectionType direction_type) {
-    switch (direction_type) {
-        case pbnavitia::DirectionType::ALL:
-            return type::DirectionType::All;
-        case pbnavitia::DirectionType::FORWARD:
-            return type::DirectionType::Forward;
-        case pbnavitia::DirectionType::BACKWARD:
-            return type::DirectionType::Backward;
-        default:
-            throw navitia::recoverable_exception("unhandled protobuf direction type");
-    }
-}
-
-type::DirectionType get_direction_type(std::string& direction_type) {
-    if (boost::iequals(direction_type, "all")) {
-        return type::DirectionType::All;
-    } else if (boost::iequals(direction_type, "forward")) {
-        return type::DirectionType::Forward;
-    } else if (boost::iequals(direction_type, "backward")) {
-        return type::DirectionType::Backward;
+pbnavitia::DirectionType get_direction_type(std::string& direction_type) {
+    if (direction_type == "all") {
+        return pbnavitia::DirectionType::ALL;
+    } else if ((direction_type == "forward") || (direction_type == "clockwise") || (direction_type == "inbound")) {
+        return pbnavitia::DirectionType::FORWARD;
+    } else if ((direction_type == "backward") || (direction_type == "anticlockwise")
+               || (direction_type == "outbound")) {
+        return pbnavitia::DirectionType::BACKWARD;
     } else {
-        throw navitia::recoverable_exception("unhandled direction type string");
+        // by default we select all direction
+        return pbnavitia::DirectionType::ALL;
     }
 }
 

--- a/source/type/type_utils.h
+++ b/source/type/type_utils.h
@@ -52,10 +52,7 @@ pbnavitia::RTLevel to_pb_realtime_level(const navitia::type::RTLevel realtime_le
 
 namespace type {
 
-enum class DirectionType { All = 0, Forward, Backward };
-
-type::DirectionType get_direction_type(pbnavitia::DirectionType direction_type);
-type::DirectionType get_direction_type(std::string& direction_type);
+pbnavitia::DirectionType get_direction_type(std::string& direction_type);
 
 }  // namespace type
 

--- a/source/type/type_utils.h
+++ b/source/type/type_utils.h
@@ -28,6 +28,7 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
+#pragma once
 #include "type/fwd_type.h"
 #include "type/rt_level.h"
 #include "type/type.pb.h"
@@ -48,5 +49,14 @@ boost::posix_time::ptime get_date_time(const routing::StopEvent stop_event,
 const type::StopTime& earliest_stop_time(const std::vector<type::StopTime>& sts);
 
 pbnavitia::RTLevel to_pb_realtime_level(const navitia::type::RTLevel realtime_level);
+
+namespace type {
+
+enum class DirectionType { All = 0, Forward, Backward };
+
+type::DirectionType get_direction_type(pbnavitia::DirectionType direction_type);
+type::DirectionType get_direction_type(std::string& direction_type);
+
+}  // namespace type
 
 }  // namespace navitia


### PR DESCRIPTION
**Feature** : Allow to filter `/departures` results with _direction type_ parameter (**All**, **Forward**, **Backward**)
**JIRA** : https://jira.kisio.org/browse/NAVP-1087

**QA part**:
Tested on fr-se-lyon, several request with different data type (**forward** and **backward**) and it seems to be ok for all params :ok_hand: 


