### PR TITLE
Handle disruption with multiple stop_points in same area / repeated stop_points

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -364,11 +364,13 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             std::vector<nt::StopTime> new_stop_times;
             const auto* vj = impacted_vj.vj;
             auto& new_vp = impacted_vj.new_vp;
-            const auto& stop_points_section = impacted_vj.impacted_stops;
 
             for (const auto& st : vj->stop_time_list) {
+                // We need to get the associated base stop_time to compare its rank
+                const auto base_st = st.get_base_stop_time();
                 // stop is ignored if its stop_point is not in impacted_stops
-                if (stop_points_section.count(st.stop_point)) {
+                // if we don't find an associated base we keep it
+                if (base_st && impacted_vj.impacted_ranks.count(base_st->order())) {
                     LOG4CPLUS_TRACE(log, "Ignoring stop " << st.stop_point->uri << "on " << vj->uri);
                     continue;
                 }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1438,7 +1438,7 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_cancelling_vj) {
 
 /*
  * In case we have a pretty complex line with repeated stops, since a line_section is only defined by
- * a line, two stop areas and an optional list of routes, we're impacting the longest section possible for each
+ * a line, two stop areas and an optional list of routes, we're impacting the shortest sections possible for each
  * route. Let's take a look at the line A below, with 4 routes, all departing from s1 and ending at s6.
  *
  * 1st route s1/s2/s3/s2/s3/s4/s5/s4/s5/s6 :
@@ -1563,7 +1563,8 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     base_vp = vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
+    // 6 stop_times since we don't impact the first iteration of each loop
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 6);
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "s1");
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "s6");
 

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -1565,8 +1565,12 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // 6 stop_times since we don't impact the first iteration of each loop
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 6);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "s1");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "s6");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(0).stop_point->uri, "s1");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "s2");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "s3");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(3).stop_point->uri, "s4");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(4).stop_point->uri, "s5");
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(5).stop_point->uri, "s6");
 
     vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:2:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
     BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
@@ -2533,13 +2537,13 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have 3 stop_times
-    // But since the previous vj is adapted we must found the base stop time associated to the adapted
+    // But since the previous vj is adapted we must find the base stop time associated to the adapted
     // one to impact it.
     // However each stop_time have the same departure_time, so we are finding the base stop_time
     // of rank 1 for the stop_time initially of rank 3 (both are on stop_point:20).
     // We are lead to believe it is impacted even if it is not in reality.
     // Nothing we can do really since there is no hard link between the adapted stop_time and base one
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2); // Should be 3 [10, 20, 40]
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -2543,7 +2543,7 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     // of rank 1 for the stop_time initially of rank 3 (both are on stop_point:20).
     // We are lead to believe it is impacted even if it is not in reality.
     // Nothing we can do really since there is no hard link between the adapted stop_time and base one
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2); // Should be 3 [10, 20, 40]
+    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);  // Should be 3 [10, 20, 40]
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 }

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -411,9 +411,9 @@ public:
 struct ImpactedVJ {
     const VehicleJourney* vj;  // vj before impact
     ValidityPattern new_vp;
-    std::set<StopPoint*> impacted_stops;
-    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<StopPoint*> r)
-        : vj(vj), new_vp(vp), impacted_stops(std::move(r)) {}
+    std::set<uint16_t> impacted_ranks;
+    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<uint16_t> r)
+        : vj(vj), new_vp(vp), impacted_ranks(std::move(r)) {}
 };
 /*
  * return the list of vehicle journey that are impacted by the linesection

--- a/source/type/tests/test.cpp
+++ b/source/type/tests/test.cpp
@@ -227,10 +227,10 @@ BOOST_AUTO_TEST_CASE(tz_handler_overflow_test) {
 BOOST_AUTO_TEST_CASE(get_sections_ranks) {
     ed::builder b("20120614");
 
-    b.sa("0", 0, 0, false, true)("01")("02")("03");
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
-    const auto* vj = b.vj("A")("01", "09:00"_t)("02", "09:00"_t)("1", "09:00"_t)("01", "09:00"_t)("2", "09:00"_t)(
-                          "3", "09:00"_t)("01", "09:00"_t)("02", "09:00"_t)("03", "09:00"_t)("4", "09:00"_t)(
+    b.sa("0", 0, 0, false, true)("0a")("0b")("0c");
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
+    const auto* vj = b.vj("A")("0a", "09:00"_t)("0b", "09:00"_t)("1", "09:00"_t)("0a", "09:00"_t)("2", "09:00"_t)(
+                          "3", "09:00"_t)("0a", "09:00"_t)("0b", "09:00"_t)("0c", "09:00"_t)("4", "09:00"_t)(
                           "2", "09:00"_t)("5", "09:00"_t)("2", "09:00"_t)
                          .make();
     b.data->pt_data->sort_and_index();
@@ -239,27 +239,27 @@ BOOST_AUTO_TEST_CASE(get_sections_ranks) {
 
     auto sa = [&](const std::string& id) { return b.get<type::StopArea>(id); };
 
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //       *
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("1")), std::set<uint16_t>({2}));
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //       ********
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("3")), std::set<uint16_t>({2, 3, 4, 5}));
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //
     // 4 is after 0 -> empty
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("4"), sa("0")), std::set<uint16_t>({}));
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     // ** **   **     ** ** **
     // route point, only the corresponding stop point
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("0")), std::set<uint16_t>({0, 1, 3, 6, 7, 8}));
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //         ******
     // shortest sections, thus we don't have 1
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("3")), std::set<uint16_t>({3, 4, 5}));
-    // 01 02 1 01 2 3 01 02 03 4 2 5 2
+    // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //         ****   ************
     // shortest sections, thus we don't have 1, 3 and 5
-    // We still have 01 02 03 in the second section since they are in the same area
+    // We still have 0a 0b 0c in the second section since they are in the same area
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("2")), std::set<uint16_t>({3, 4, 6, 7, 8, 9, 10}));
 }

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -199,14 +199,16 @@ ValidityPattern VehicleJourney::get_vp_of_sp(const StopPoint& sp,
     return vp_for_stop_time;
 }
 
-ValidityPattern VehicleJourney::get_vp_for_section(const std::set<StopPoint*>& section,
+ValidityPattern VehicleJourney::get_vp_for_section(const std::set<uint16_t>& section,
                                                    RTLevel rt_level,
                                                    const boost::posix_time::time_period& period) const {
     ValidityPattern vp_for_section{validity_patterns[rt_level]->beginning_date};
 
     auto pass_in_the_section = [&](const nt::StopTime& stop_time) {
-        // Return if not in the section
-        if (!section.count(stop_time.stop_point)) {
+        // We need to get the associated base stop_time to compare its rank
+        const auto base_st = stop_time.get_base_stop_time();
+        // Return if not in the section or associated base not found
+        if (!base_st || !section.count(base_st->order())) {
             return;
         }
         const auto& beginning_date = validity_patterns[rt_level]->beginning_date;
@@ -227,17 +229,26 @@ ValidityPattern VehicleJourney::get_vp_for_section(const std::set<StopPoint*>& s
     return vp_for_section;
 }
 
-std::set<StopPoint*> VehicleJourney::get_sections_stop_points(const StopArea* start_stop,
-                                                              const StopArea* end_stop) const {
+std::set<uint16_t> VehicleJourney::get_sections_ranks(const StopArea* start_stop, const StopArea* end_stop) const {
     /*
      * Identify all the smallest sections starting with start_stop and
-     * ending with end_stop. Then we return the set of stop points
+     * ending with end_stop. Then we return the list of ranks
      * corresponding to the identified sections.
      *
      * For example, if we want the section A B:
      *    A B C D E A B
      *    ***       ***
      * we return {A, B} (not everything)
+     *
+     * Since sections are defined by two stop_areas not stop_points we want to return the smallest
+     * sections between stop_areas. If we have consecutive stop_points in one of the starting or
+     * ending area we need to take them all.
+     *
+     * Same example for A B :
+     * A1 A2 B1 C1 D1 E1 A1 A2 B1 B2
+     *  ******            *********
+     *
+     * we return {A1, A2, B1} and {A1, A2, B1, B2}
      *
      * Note:
      *
@@ -267,8 +278,10 @@ std::set<StopPoint*> VehicleJourney::get_sections_stop_points(const StopArea* st
      *  - s1/s2 from the 5th to the 10th,
      *  - s1/s2/s5 from the 11th to the 15th
      * */
-    std::set<StopPoint*> res;
+    std::set<uint16_t> res;
     boost::optional<uint16_t> start_idx;
+    boost::optional<uint16_t> last_area_idx;
+    bool section_ending = false;
     const auto* base_vj = this->get_corresponding_base();
     const auto* vj = base_vj ? base_vj : this;
     for (const auto& st : vj->stop_time_list) {
@@ -276,22 +289,38 @@ std::set<StopPoint*> VehicleJourney::get_sections_stop_points(const StopArea* st
         if (!st.stop_point || !st.stop_point->stop_area) {
             continue;
         }
+        const auto* sa = st.stop_point->stop_area;
+
+        // Must close section before potentially starting a new one
+        if (section_ending && *last_area_idx != sa->idx) {
+            for (uint16_t i = *start_idx, last = st.order() - 1; i <= last; ++i) {
+                res.insert(i);
+            }
+            // the section is finished, we are no more in a section
+            start_idx = boost::none;
+            section_ending = false;
+        }
 
         // we want the shortest section, thus, we set the idx each
-        // time we see it
-        if (st.stop_point->stop_area->idx == start_stop->idx) {
+        // time we see it, except if we are in the same area than the start idx
+        // Reset start_idx if the previous area was different
+        if (sa->idx == start_stop->idx && (!start_idx || !last_area_idx || *last_area_idx != sa->idx)) {
             start_idx = st.order();
         }
 
-        // we want the shortest section, thus, we finish the section
-        // as soon as we see the end stop
-        if (start_idx && st.stop_point->stop_area->idx == end_stop->idx) {
-            for (uint16_t i = *start_idx, last = st.order(); i <= last; ++i) {
-                res.insert(vj->stop_time_list[i].stop_point);
-            }
+        // we want the shortest section, thus, we mark the section
+        // as ending as soon as we see the end stop
+        // We must continue until we leave the stop_area
+        if (start_idx && sa->idx == end_stop->idx) {
+            section_ending = true;
+        }
+        last_area_idx = sa->idx;
+    }
 
-            // the section is finished, we are no more in a section
-            start_idx = boost::none;
+    // Must close a potential section
+    if (section_ending) {
+        for (uint16_t i = *start_idx; i <= vj->stop_time_list.size() - 1; ++i) {
+            res.insert(i);
         }
     }
     return res;

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -128,12 +128,12 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
                                  const boost::posix_time::time_period& period) const;
 
     // Return the vp for all the stops of the section
-    ValidityPattern get_vp_for_section(const std::set<StopPoint*>& bounds_st,
+    ValidityPattern get_vp_for_section(const std::set<uint16_t>& bounds_st,
                                        RTLevel rt_level,
                                        const boost::posix_time::time_period& period) const;
 
-    // return all the stoppoints of the base vj between the 2 stop areas
-    std::set<StopPoint*> get_sections_stop_points(const StopArea*, const StopArea*) const;
+    // return all the sections of the base vj between the 2 stop areas
+    std::set<uint16_t> get_sections_ranks(const StopArea*, const StopArea*) const;
 
     // return the time period of circulation of the vj for one day
     boost::posix_time::time_period execution_period(const boost::gregorian::date& date) const;


### PR DESCRIPTION
Hello,

I tried to separate my commits to be as clear as possible, it might be easier to look at the two or three tests I've added to understand the problem.

We have a few cases when disruptions on line_section were not exactly working as intended.
The first case was on a vj where the last two stop_points are in the same area (can be generalized to two consecutive stop_points in the same_area at the start / end of a section) :

![Screenshot_20190919-162853](https://user-images.githubusercontent.com/5136553/65257919-51c82700-db02-11e9-8327-1e8b9d3fb24f.png)

If we had a line_section disruption between a previous area X and this area Z, only the "drop off stop" was impacted by the disruption. We were still able to make a journey between a stop before X and Z.

This is because we take the shortest section, so we reset the start of the section while we see it and close the section as soon as we found a stop_time in the end area.
To solve this I just don't reset the start_idx of the section if I am in the same_area, and keep iterating over the stop_times before inserting the stops of the section until I'm outside of the end area.

While I was fixing this I found another particular case. If we have a vj `A -> B-> C-> D-> E-> B-> F` for example. If we were to disrupt the section `B -> D` the method will return a set `(B,C,D)`. Problem is, the adapted VJ will be `A/E/F`. Since we only take the shortest section it should be `A/E/B/F`, no reason to impact the second occurrence of `B`.
To solve this I changed the way we get the stop_points impacted by a section. Currently we were getting a set of stop_points to impact and iterating over every stop_time to see if its stop_point was in the set. Now we get the ranks of the stop_times impacted on the base vj.

It's not totally perfect. Since we don't have a hard link between a non-base stop_time and its base stop_time when we use [get_base_stop_time](https://github.com/Tisseo/navitia/blob/handle_repeated_stop_points_disruption/source/type/stop_time.cpp#L62), if it's not a base VJ we are impacting, we need to loop on all stop_times, and it could be wrong in a few cases.
I highlighted this limitation in a unit test, since `get_base_stop_time` is not perfect, we could be impacting some stop_times which are not supposed to be, but it's some really ~~dumb~~ specific cases (non consecutive stop_times with same stop_points and same departure / arrival times).

Let me know what you think and if there is improvements to be made!