### PR TITLE
ptref: Add new method for filtering route direction type

### DIFF
--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -82,6 +82,7 @@ In the following table, if the invocation starts with `collection`, any collecti
 |`poi.within(distance, coord)`|all the POIs within `distance` meters from `coord`|`distance` in a positive integer, `coord` is a navitia coord (`lon;lat`)|
 |`stop_area.within(distance, coord)`|as above for the stop areas|as above|
 |`stop_point.within(distance, coord)`|as above for the stop points|as above|
+|`route.has_direction_type(type1, type2, ...)`|all the `route` containing a given `direction_type` into list|at least one direction type must be given|
 
 #### Interpretation
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -102,10 +102,10 @@ nt::VehicleJourney* VJ::make() {
         } else {
             // Create a new one based on the name of the line
             const auto route_uri = line_name + ":" + std::to_string(pt_data.routes.size());
-            route = pt_data.get_or_create_route(route_uri, line_name, line);
+            route = pt_data.get_or_create_route(route_uri, line_name, line, nullptr, _direction_type);
         }
     } else {
-        route = pt_data.get_or_create_route(_route_name, _route_name, line);
+        route = pt_data.get_or_create_route(_route_name, _route_name, line, nullptr, _direction_type);
     }
 
     std::string mvj_name;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -68,6 +68,7 @@ struct VJ {
     const std::string line_name;
     std::string _block_id;
     std::string _route_name;
+    std::string _direction_type;
     const bool is_frequency;
     const bool wheelchair_boarding;
     std::string _name;
@@ -130,8 +131,9 @@ struct VJ {
         return *this;
     }
 
-    VJ& route(const std::string& r) {
+    VJ& route(const std::string& r, const std::string d = "") {
         _route_name = r;
+        _direction_type = d;
         return *this;
     }
     VJ& bike_accepted(bool b) {

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -346,8 +346,8 @@ struct Eval : boost::static_visitor<Indexes> {
             indexes = get_indexes_from_code(type, f.args.at(0), f.args.at(1), data);
         } else if (f.method == "has_code_type") {
             indexes = get_indexes_from_code_type(type, f.args, data);
-        } else if (f.method == "has_direction_type") {
-            indexes = get_indexes_from_direction_type(type, f.args, data);
+        } else if ((type == Type_e::Route) && (f.method == "has_direction_type")) {
+            indexes = get_indexes_from_route_direction_type(f.args, data);
         } else {
             std::stringstream ss;
             ss << "Unknown function: " << f;

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -346,6 +346,8 @@ struct Eval : boost::static_visitor<Indexes> {
             indexes = get_indexes_from_code(type, f.args.at(0), f.args.at(1), data);
         } else if (f.method == "has_code_type") {
             indexes = get_indexes_from_code_type(type, f.args, data);
+        } else if (f.method == "has_direction_type") {
+            indexes = get_indexes_from_direction_type(type, f.args, data);
         } else {
             std::stringstream ss;
             ss << "Unknown function: " << f;

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -332,43 +332,18 @@ type::Indexes get_indexes_from_code_type(const type::Type_e type,
     }
 }
 
-using SupportedTypesForDirectionType = boost::mpl::vector<navitia::type::Route>;
-
-template <typename T>
-static typename boost::enable_if<typename boost::mpl::contains<SupportedTypesForDirectionType, T>::type, Indexes>::type
-get_indexes_from_direction_type(const std::vector<std::string>& keys, const Data& data) {
+type::Indexes get_indexes_from_route_direction_type(const std::vector<std::string>& keys, const type::Data& data) {
     Indexes indexes;
-    auto collection = data.pt_data->collection<T>();
-    for (const auto* obj : collection) {
-        auto direction_type = obj->direction_type;
+    for (const auto* route : data.pt_data->routes) {
         for (const auto& key : keys) {
-            if ((key == direction_type) || (key == "all")) {
-                indexes.insert(obj->idx);
+            if (key == route->direction_type) {
+                indexes.insert(route->idx);
                 break;
             }
         }
     }
 
     return indexes;
-}
-template <typename T>
-static typename boost::disable_if<typename boost::mpl::contains<SupportedTypesForDirectionType, T>::type, Indexes>::type
-get_indexes_from_direction_type(const std::vector<std::string>&, const Data&) {
-    // there is no code for unsupported types, thus the result is empty
-    return Indexes{};
-}
-type::Indexes get_indexes_from_direction_type(const type::Type_e type,
-                                              const std::vector<std::string>& keys,
-                                              const type::Data& data) {
-    switch (type) {
-#define GET_INDEXES(type_name, collection_name) \
-    case Type_e::type_name:                     \
-        return get_indexes_from_direction_type<type::type_name>(keys, data);
-        ITERATE_NAVITIA_PT_TYPES(GET_INDEXES)
-#undef GET_INDEXES
-        default:
-            return Indexes{};  // no code supported, empty result
-    }
 }
 
 type::Indexes get_indexes_from_id(const type::Type_e type, const std::string& id, const type::Data& data) {

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -335,11 +335,8 @@ type::Indexes get_indexes_from_code_type(const type::Type_e type,
 type::Indexes get_indexes_from_route_direction_type(const std::vector<std::string>& keys, const type::Data& data) {
     Indexes indexes;
     for (const auto* route : data.pt_data->routes) {
-        for (const auto& key : keys) {
-            if (key == route->direction_type) {
-                indexes.insert(route->idx);
-                break;
-            }
+        if (contains(keys, route->direction_type)) {
+            indexes.insert(route->idx);
         }
     }
 

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -64,6 +64,9 @@ type::Indexes get_indexes_from_name(const type::Type_e type, const std::string& 
 type::Indexes get_indexes_from_code_type(const type::Type_e type,
                                          const std::vector<std::string>& keys,
                                          const type::Data& data);
+type::Indexes get_indexes_from_direction_type(const type::Type_e type,
+                                              const std::vector<std::string>& keys,
+                                              const type::Data& data);
 
 }  // namespace ptref
 }  // namespace navitia

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -64,9 +64,7 @@ type::Indexes get_indexes_from_name(const type::Type_e type, const std::string& 
 type::Indexes get_indexes_from_code_type(const type::Type_e type,
                                          const std::vector<std::string>& keys,
                                          const type::Data& data);
-type::Indexes get_indexes_from_direction_type(const type::Type_e type,
-                                              const std::vector<std::string>& keys,
-                                              const type::Data& data);
+type::Indexes get_indexes_from_route_direction_type(const std::vector<std::string>& keys, const type::Data& data);
 
 }  // namespace ptref
 }  // namespace navitia

--- a/source/ptreferential/tests/ptref_ng_test.cpp
+++ b/source/ptreferential/tests/ptref_ng_test.cpp
@@ -75,6 +75,9 @@ BOOST_AUTO_TEST_CASE(parse_pred) {
     assert_expr(
         R"#(vehicle_journey . has_code_type ( external_code ) )#",
         R"#(vehicle_journey.has_code_type("external_code"))#");
+    assert_expr(
+        R"#(route . has_code_type ( forward ) )#",
+        R"#(route.has_code_type("forward"))#");
     assert_expr(R"#(stop_area . uri ( "OIF:42" ) )#", R"#(stop_area.uri("OIF:42"))#");
     assert_expr(R"#(stop_area . uri = "OIF:42" )#", R"#(stop_area.uri("OIF:42"))#");
     assert_expr(R"#(stop_area . uri = OIF:42 )#", R"#(stop_area.uri("OIF:42"))#");

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -826,15 +826,14 @@ BOOST_AUTO_TEST_CASE(direction_type_request) {
                      R"(route.has_direction_type(backward))", *(b.data));
     BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Route>(res, *b.data), std::set<std::string>({"route5"}));
 
+    res = make_query(nt::Type_e::Route,
+                     R"(route.has_direction_type(forward, clockwise, inbound))", *(b.data));
+    BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Route>(res, *b.data),
+                            std::set<std::string>({"route1", "route2", "route3", "route4"}));
+
     res = make_query(nt::Type_e::Line,
                      R"(route.has_direction_type(clockwise, backward, outbound))", *(b.data));
     BOOST_CHECK_EQUAL_RANGE(get_uris<nt::Line>(res, *b.data), std::set<std::string>({"L3", "L5", "L7"}));
-
-    res = make_query(nt::Type_e::Route,
-                     R"(route.has_direction_type(all))", *(b.data));
-    BOOST_CHECK_EQUAL_RANGE(
-        get_uris<nt::Route>(res, *b.data),
-        std::set<std::string>({"route1", "route2", "route3", "route4", "route5", "route6", "route7"}));
 
     BOOST_CHECK_THROW(make_query(nt::Type_e::Route,
                                  R"(route.has_direction_type(direction_type_doesnt_exist))", *(b.data)),


### PR DESCRIPTION
First part for **JIRA** : https://jira.kisio.org/browse/NAVP-1087, _Add new method for filtering route_ **direction type**.
The method is specialized onfy for **route** like `route.has_direction_type(blabla)`
I started to create a generic method but it was useless for this special _route case_ (it was in the first commit for this PR).
This is **case-sensitive**. The filter value has to match perfectly with the direction type format inside the data. Into the data, it seems to be _lower style_.
RFC doc updated.
An UTest was added and it demonstrates several case.

**QA part** :
Tested several request like 
```
url/v1/coverage/fr-idf/stop_areas/id_stop_area/departures?filter=route.has_direction_type(forward)
url/v1/coverage/fr-idf/stop_areas/id_stop_area/departures?filter=route.has_direction_type(backward)

url/v1/coverage/fr-idf/stop_areas/id_stop_area/arrivals?filter=route.has_direction_type(forward)
url/v1/coverage/fr-idf/stop_areas/id_stop_area/arrivals?filter=route.has_direction_type(backward)


url/v1/coverage/fr-idf/lines/id_lines/lines?filter=route.has_direction_type(forward)
```
And it works
