### PR TITLE
Osm2ed: do not put transport object from OSM in autocompletion

### DIFF
--- a/source/ed/connectors/osm_tags_reader.cpp
+++ b/source/ed/connectors/osm_tags_reader.cpp
@@ -73,6 +73,7 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
     int bike_direct = unknown;
     int bike_reverse = unknown;
     int foot = unknown;
+    bool visible = true;
 
     for (std::pair<std::string, std::string> pair : tags) {
         std::string key = pair.first, val = pair.second;
@@ -205,6 +206,15 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
                 foot = foot_allowed;
             }
         }
+
+        // We do not want to autocomplete on public transport objects
+        if (key == "public_transport") {
+            visible = false;
+        } else if (key == "railway") {
+            if (val == "platform") {
+                visible = false;
+            }
+        }
     }
 
     update_if_unknown(car_reverse, car_direct);
@@ -222,6 +232,9 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
     result[CAR_BWD] = (car_reverse != car_forbiden);
     result[FOOT_FWD] = (foot != foot_forbiden);
     result[FOOT_BWD] = (foot != foot_forbiden);
+    if (result.any()) {  // only set visibility if the road is usable
+        result[VISIBLE] = visible;
+    }
     return result;
 }
 

--- a/source/ed/connectors/osm_tags_reader.h
+++ b/source/ed/connectors/osm_tags_reader.h
@@ -42,6 +42,7 @@ constexpr uint8_t CAR_FWD = 2;
 constexpr uint8_t CAR_BWD = 3;
 constexpr uint8_t FOOT_FWD = 4;
 constexpr uint8_t FOOT_BWD = 5;
+constexpr uint8_t VISIBLE = 6;
 
 /// return properties on modes and directions that are possible on a way
 std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags);

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -396,7 +396,7 @@ void OSMCache::insert_ways() {
         values.push_back(way.name);
         values.push_back("way:" + std::to_string(way.osm_id));
         values.push_back("");
-        values.push_back("true");
+        values.push_back(way.visible() ? "true" : "false");
         this->lotus->insert(values);
         ++n_inserted;
         if ((n_inserted % max_n_inserted) == 0) {

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -165,6 +165,7 @@ struct OSMWay {
     const static uint8_t CAR_BWD = 3;
     const static uint8_t FOOT_FWD = 4;
     const static uint8_t FOOT_BWD = 5;
+    const static uint8_t VISIBLE = 6;
 
     const u_int64_t osm_id;
 
@@ -178,7 +179,9 @@ struct OSMWay {
     mutable ls_type ls;
     mutable const OSMWay* way_ref = nullptr;
 
-    OSMWay(const u_int64_t osm_id) : osm_id(osm_id) {}
+    OSMWay(const u_int64_t osm_id) : osm_id(osm_id) {
+        properties[VISIBLE] = true;  // By default way are visible
+    }
     OSMWay(const u_int64_t osm_id, const std::bitset<8>& properties, const std::string& name)
         : osm_id(osm_id), properties(properties), name(name) {}
 
@@ -194,6 +197,9 @@ struct OSMWay {
     void set_properties(const std::bitset<8>& properties) const { this->properties = properties; }
 
     void set_name(const std::string& name) const { this->name = name; }
+
+    void set_visible(bool visible) { properties[VISIBLE] = visible; }
+    bool visible() const { return properties[VISIBLE]; }
 
     std::string coord_to_string() const {
         std::stringstream geog;

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -197,7 +197,7 @@ struct OSMWay {
     void set_properties(const std::bitset<8>& properties) const { this->properties = properties; }
 
     void set_name(const std::string& name) const { this->name = name; }
-    
+
     bool visible() const { return properties[VISIBLE]; }
 
     std::string coord_to_string() const {

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -197,8 +197,7 @@ struct OSMWay {
     void set_properties(const std::bitset<8>& properties) const { this->properties = properties; }
 
     void set_name(const std::string& name) const { this->name = name; }
-
-    void set_visible(bool visible) { properties[VISIBLE] = visible; }
+    
     bool visible() const { return properties[VISIBLE]; }
 
     std::string coord_to_string() const {


### PR DESCRIPTION
OSM contains some transport objects, like quay: https://www.openstreetmap.org/way/364024146#map=19/45.76195/4.85761
We do not want to show these object in the autocompletion as we already
have them from our transport datasets. This PR changes the way these
objects are imported to make them invisible, this way they won't be
shown in the autocompletion but will still be used for routing.

Hand testes with lyon and transilien, a few hundred way are imported as
invisible, all of them look like stops.

Refer to: https://jira.kisio.org/browse/NAVITIAII-2880