### PR TITLE
utils: replace in() function by contains() to standardize

### DIFF
--- a/source/autocomplete/tests/test.cpp
+++ b/source/autocomplete/tests/test.cpp
@@ -392,8 +392,8 @@ BOOST_AUTO_TEST_CASE(Faute_de_frappe_One) {
     auto res1 = ac.find_partial_with_pattern("gare patea", word_weight, nbmax, [](int) { return true; }, ghostwords);
     BOOST_REQUIRE_EQUAL(res1.size(), 3);
     std::initializer_list<unsigned> best_res = {1, 4};  // they are equivalent
-    BOOST_CHECK(in(res1.at(0).idx, best_res));
-    BOOST_CHECK(in(res1.at(1).idx, best_res));
+    BOOST_CHECK(navitia::contains(best_res, res1.at(0).idx));
+    BOOST_CHECK(navitia::contains(best_res, res1.at(1).idx));
     BOOST_CHECK_NE(res1.at(0).idx, res1.at(1).idx);
     BOOST_CHECK_EQUAL(res1.at(2).idx, 0);
     BOOST_CHECK_EQUAL(res1.at(0).quality, 94);

--- a/source/cities/cities.cpp
+++ b/source/cities/cities.cpp
@@ -257,7 +257,7 @@ void OSMRelation::build_polygon(OSMCache& cache, OSMId osm_id) {
     std::set<u_int64_t> explored_ids;
     auto is_outer_way = [](const CanalTP::Reference& r) {
         return r.member_type == OSMPBF::Relation_MemberType::Relation_MemberType_WAY
-               && in(r.role, {"outer", "enclave", ""});
+               && contains({"outer", "enclave", ""}, r.role);
     };
     auto pickable_way = [&](const CanalTP::Reference& r) {
         return is_outer_way(r) && explored_ids.count(r.member_id) == 0;
@@ -381,7 +381,7 @@ void OSMRelation::build_geometry(OSMCache& cache, OSMId osm_id) {
             if (!node_it->second.is_defined()) {
                 continue;
             }
-            if (in(ref.role, {"admin_centre", "admin_center"})) {
+            if (contains({"admin_centre", "admin_center"}, ref.role)) {
                 set_centre(node_it->second.lon(), node_it->second.lat());
                 this->add_postal_code(node_it->second.postal_code);
                 break;

--- a/source/ed/connectors/osm_tags_reader.cpp
+++ b/source/ed/connectors/osm_tags_reader.cpp
@@ -80,7 +80,7 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
         std::transform(val.begin(), val.end(), val.begin(), ::tolower);
 
         if (key == "highway") {
-            if (in(val, {"footway", "pedestrian"})) {
+            if (navitia::contains({"footway", "pedestrian"}, val)) {
                 update_if_unknown(foot, foot_allowed);
             } else if (val == "cycleway") {
                 update_if_unknown(bike_direct, bike_track);
@@ -92,37 +92,39 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
                 update_if_unknown(foot, foot_allowed);
             } else if (val == "steps") {
                 update_if_unknown(foot, foot_allowed);
-            } else if (in(val, {"primary", "primary_link"})) {
+            } else if (navitia::contains({"primary", "primary_link"}, val)) {
                 update_if_unknown(car_direct, car_primary);
                 update_if_unknown(foot, foot_allowed);
                 update_if_unknown(bike_direct, bike_allowed);
-            } else if (in(val, {"secondary", "secondary_link"})) {
+            } else if (navitia::contains({"secondary", "secondary_link"}, val)) {
                 update_if_unknown(car_direct, car_secondary);
                 update_if_unknown(foot, foot_allowed);
                 update_if_unknown(bike_direct, bike_allowed);
-            } else if (in(val, {"tertiary", "tertiary_link"})) {
+            } else if (navitia::contains({"tertiary", "tertiary_link"}, val)) {
                 update_if_unknown(car_direct, car_tertiary);
                 update_if_unknown(foot, foot_allowed);
                 update_if_unknown(bike_direct, bike_allowed);
-            } else if (in(val, {"unclassified", "residential", "living_street", "road", "service", "track"})) {
+            } else if (navitia::contains({"unclassified", "residential", "living_street", "road", "service", "track"},
+                                         val)) {
                 update_if_unknown(car_direct, car_residential);
                 update_if_unknown(foot, foot_allowed);
                 update_if_unknown(bike_direct, bike_allowed);
-            } else if (in(val, {"motorway", "motorway_link"})) {
+            } else if (navitia::contains({"motorway", "motorway_link"}, val)) {
                 update_if_unknown(car_direct, car_motorway);
                 update_if_unknown(foot, foot_forbiden);
                 update_if_unknown(bike_direct, bike_forbiden);
-            } else if (in(val, {"trunk", "trunk_link"})) {
+            } else if (navitia::contains({"trunk", "trunk_link"}, val)) {
                 update_if_unknown(car_direct, car_trunk);
                 update_if_unknown(foot, foot_forbiden);
                 update_if_unknown(bike_direct, bike_forbiden);
             }
         }
 
-        else if (in(key, {"pedestrian", "foot"})) {
-            if (in(val, {"yes", "designated", "permissive", "lane", "official", "allowed", "destination"})) {
+        else if (navitia::contains({"pedestrian", "foot"}, key)) {
+            if (navitia::contains({"yes", "designated", "permissive", "lane", "official", "allowed", "destination"},
+                                  val)) {
                 foot = foot_allowed;
-            } else if (in(val, {"no", "private"})) {
+            } else if (navitia::contains({"no", "private"}, val)) {
                 foot = foot_forbiden;
             } else {
                 std::cerr << "I don't know what to do with: " << key << "=" << val << std::endl;
@@ -163,9 +165,9 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
         }
 
         else if (key == "busway") {
-            if (in(val, {"yes", "track", "lane"})) {
+            if (navitia::contains({"yes", "track", "lane"}, val)) {
                 update_if_unknown(bike_direct, bike_busway);
-            } else if (in(val, {"opposite_lane", "opposite_track"})) {
+            } else if (navitia::contains({"opposite_lane", "opposite_track"}, val)) {
                 update_if_unknown(bike_reverse, bike_busway);
             } else {
                 update_if_unknown(bike_direct, bike_busway);

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -282,8 +282,8 @@ void Data::complete() {
     // set StopPoint from old zonal ODT to is_zonal
     for (const auto* vj : vehicle_journeys) {
         using nt::VehicleJourneyType;
-        if (in(vj->vehicle_journey_type,
-               {VehicleJourneyType::adress_to_stop_point, VehicleJourneyType::odt_point_to_point})) {
+        if (navitia::contains({VehicleJourneyType::adress_to_stop_point, VehicleJourneyType::odt_point_to_point},
+                              vj->vehicle_journey_type)) {
             for (const auto* st : vj->stop_time_list) {
                 st->stop_point->is_zonal = true;
             }

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -670,7 +670,7 @@ void OSMAdminRelation::build_polygon(OSMCache& cache) {
     std::set<u_int64_t> explored_ids;
     auto is_outer_way = [](const CanalTP::Reference& r) {
         return r.member_type == OSMPBF::Relation_MemberType::Relation_MemberType_WAY
-               && in(r.role, {"outer", "enclave", ""});
+               && navitia::contains({"outer", "enclave", ""}, r.role);
     };
     auto pickable_way = [&](const CanalTP::Reference& r) {
         return is_outer_way(r) && explored_ids.count(r.member_id) == 0;

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -565,10 +565,11 @@ struct add_impacts_visitor : public apply_impacts_visitor {
 
 static bool is_modifying_effect(nt::disruption::Effect e) {
     // check if the effect needs to modify the model
-    return in(e, {nt::disruption::Effect::NO_SERVICE, nt::disruption::Effect::UNKNOWN_EFFECT,
-                  nt::disruption::Effect::SIGNIFICANT_DELAYS, nt::disruption::Effect::MODIFIED_SERVICE,
-                  nt::disruption::Effect::DETOUR, nt::disruption::Effect::REDUCED_SERVICE,
-                  nt::disruption::Effect::ADDITIONAL_SERVICE});
+    return contains({nt::disruption::Effect::NO_SERVICE, nt::disruption::Effect::UNKNOWN_EFFECT,
+                     nt::disruption::Effect::SIGNIFICANT_DELAYS, nt::disruption::Effect::MODIFIED_SERVICE,
+                     nt::disruption::Effect::DETOUR, nt::disruption::Effect::REDUCED_SERVICE,
+                     nt::disruption::Effect::ADDITIONAL_SERVICE},
+                    e);
 }
 
 void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact, nt::PT_Data& pt_data, const nt::MetaData& meta) {

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -491,8 +491,8 @@ void Data::aggregate_odt() {
         }
         // we add it for the ODT type where the vehicle comes directly to the user
         route->for_each_vehicle_journey([&](const VehicleJourney& vj) {
-            if (in(vj.vehicle_journey_type,
-                   {VehicleJourneyType::adress_to_stop_point, VehicleJourneyType::odt_point_to_point})) {
+            if (contains({VehicleJourneyType::adress_to_stop_point, VehicleJourneyType::odt_point_to_point},
+                         vj.vehicle_journey_type)) {
                 for (const auto& st : vj.stop_time_list) {
                     for (auto* admin : st.stop_point->admin_list) {
                         odt_stops_by_admin[admin].insert(st.stop_point);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -99,10 +99,11 @@ struct PbCreator::Filler::PtObjVisitor : public boost::static_visitor<> {
     }
 
     bool is_detour(nd::StopTimeUpdate::Status dep_status, nd::StopTimeUpdate::Status arr_status) const {
-        return (in(dep_status,
-                   {nd::StopTimeUpdate::Status::ADDED_FOR_DETOUR, nd::StopTimeUpdate::Status::DELETED_FOR_DETOUR})
-                || in(arr_status,
-                      {nd::StopTimeUpdate::Status::ADDED_FOR_DETOUR, nd::StopTimeUpdate::Status::DELETED_FOR_DETOUR}));
+        return (
+            contains({nd::StopTimeUpdate::Status::ADDED_FOR_DETOUR, nd::StopTimeUpdate::Status::DELETED_FOR_DETOUR},
+                     dep_status)
+            || contains({nd::StopTimeUpdate::Status::ADDED_FOR_DETOUR, nd::StopTimeUpdate::Status::DELETED_FOR_DETOUR},
+                        arr_status));
     }
 
     void operator()(const nd::UnknownPtObj&) const {}


### PR DESCRIPTION
Cleaning action :shower:  : Simply replace in all the code, `in() by contains()`
`Contains()` is generic. It covers more cases than `in()`.
[source/utils](https://github.com/CanalTP/utils/pull/82) was updated with `std::initializer_list` for `contains()` method

Docker tests are Green