### PR TITLE
jormun: add direction_type parameter for departures/arrivals/stop_schedules/route_schedules Api

### DIFF
--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -82,7 +82,7 @@ In the following table, if the invocation starts with `collection`, any collecti
 |`poi.within(distance, coord)`|all the POIs within `distance` meters from `coord`|`distance` in a positive integer, `coord` is a navitia coord (`lon;lat`)|
 |`stop_area.within(distance, coord)`|as above for the stop areas|as above|
 |`stop_point.within(distance, coord)`|as above for the stop points|as above|
-|`route.has_direction_type(type1, type2, ...)`|all the `route` containing a given `direction_type` into list|at least one direction type must be given|
+|`route.has_direction_type(type1, type2, ...)`|all the routes whose `direction_type` is any of those provided|at least one direction type must be given|
 
 #### Interpretation
 

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1438,15 +1438,16 @@ access it via that kind of url: <https://api.navitia.io/v1/{a_path_to_a_resource
 
 ### Parameters
 
-Required | Name               | Type      | Description                                                                              | Default Value
----------|--------------------|-----------|------------------------------------------------------------------------------------------|--------------
-nop      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                    | the current datetime
-nop      | duration           | int       | Maximum duration in seconds between from_datetime and the retrieved datetimes.           | 86400
-nop      | depth              | int       | Json response [depth](#depth)                                                            | 1
-nop      | items_per_schedule | int       | Maximum number of columns per schedule.                                                  |
-nop      | forbidden_uris[]   | id        | If you want to avoid lines, modes, networks, etc.                                        |
-nop      | data_freshness     | enum      | Define the freshness of data to use<br><ul><li>realtime</li><li>base_schedule</li></ul>  | base_schedule
-nop      | disable_geojson    | boolean   | remove geojson fields from the response                                                  | False
+Required | Name               | Type      | Description                                                                                                                | Default Value
+---------|--------------------|-----------|----------------------------------------------------------------------------------------------------------------------------|--------------
+nop      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                      | the current datetime
+nop      | duration           | int       | Maximum duration in seconds between from_datetime and the retrieved datetimes.                                             | 86400
+nop      | depth              | int       | Json response [depth](#depth)                                                                                              | 1
+nop      | items_per_schedule | int       | Maximum number of columns per schedule.                                                                                    |
+nop      | forbidden_uris[]   | id        | If you want to avoid lines, modes, networks, etc.                                                                          |
+nop      | data_freshness     | enum      | Define the freshness of data to use<br><ul><li>realtime</li><li>base_schedule</li></ul>                                    | base_schedule
+nop      | disable_geojson    | boolean   | remove geojson fields from the response                                                                                    | False
+nop      | direction_type     | enum      | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul> | all
 
 ### Objects
 
@@ -1571,15 +1572,16 @@ See how disruptions affect stop schedules in the [real time](#realtime) section.
 
 ### Parameters
 
-Required | Name               | Type                            | Description        | Default Value
----------|--------------------|---------------------------------|--------------------|--------------
-nop      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules | the current datetime
-nop      | duration           | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                            | 86400
-nop      | depth              | int                             | Json response [depth](#depth) | 1
-nop      | forbidden_uris[]   | id                              | If you want to avoid lines, modes, networks, etc.    |
-nop      | items_per_schedule | int                             | Maximum number of datetimes per schedule.                                                  |
-nop      | data_freshness     | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul> | realtime
-nop      | disable_geojson    | boolean                         | remove geojson fields from the response | False
+Required | Name               | Type                            | Description                                                                                                                | Default Value
+---------|--------------------|---------------------------------|----------------------------------------------------------------------------------------------------------------------------|--------------
+nop      | from_datetime      | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                                            | the current datetime
+nop      | duration           | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                                             | 86400
+nop      | depth              | int                             | Json response [depth](#depth)                                                                                              | 1
+nop      | forbidden_uris[]   | id                              | If you want to avoid lines, modes, networks, etc.                                                                          |
+nop      | items_per_schedule | int                             | Maximum number of datetimes per schedule.                                                                                  |
+nop      | data_freshness     | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul>                   | realtime
+nop      | disable_geojson    | boolean                         | remove geojson fields from the response                                                                                    | False
+nop      | direction_type     | enum                            | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul> | all
 
 
 ### <a name="stop-schedule"></a>Stop_schedule object

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1672,15 +1672,16 @@ See how disruptions affect the next departures in the [real time](#realtime) sec
 
 ### Parameters
 
-Required | Name             | Type                            | Description                                                                                              | Default Value
----------|------------------|---------------------------------|----------------------------------------------------------------------------------------------------------|--------------
-nop      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                          | the current datetime
-nop      | duration         | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                           | 86400
-nop      | count            | int                             | Maximum number of results.                                                                               | 10
-nop      | depth            | int                             | Json response [depth](#depth)                                                                            | 1
-nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                        |
-nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul> | realtime
-nop      | disable_geojson  | boolean                         | remove geojson fields from the response                                                                  | false
+Required | Name             | Type                            | Description                                                                                                                           | Default Value
+---------|------------------|---------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|--------------
+nop      | from_datetime    | [iso-date-time](#iso-date-time) | The date_time from which you want the schedules                                                                                       | the current datetime
+nop      | duration         | int                             | Maximum duration in seconds between from_datetime and the retrieved datetimes.                                                        | 86400
+nop      | count            | int                             | Maximum number of results.                                                                                                            | 10
+nop      | depth            | int                             | Json response [depth](#depth)                                                                                                         | 1
+nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                                                     |
+nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul>                              | realtime
+nop      | disable_geojson  | boolean                         | remove geojson fields from the response                                                                                               | false
+nop      | direction_type   | enum                            | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul>            | all
 
 
 ### Departure objects

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1447,7 +1447,7 @@ nop      | items_per_schedule | int       | Maximum number of columns per schedu
 nop      | forbidden_uris[]   | id        | If you want to avoid lines, modes, networks, etc.                                                                          |
 nop      | data_freshness     | enum      | Define the freshness of data to use<br><ul><li>realtime</li><li>base_schedule</li></ul>                                    | base_schedule
 nop      | disable_geojson    | boolean   | remove geojson fields from the response                                                                                    | False
-nop      | direction_type     | enum      | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul> | all
+nop      | direction_type     | enum      | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul>Note: forward is equivalent to clockwise and inbound. When you select forward, you filter with: [forward, clockwise, inbound].<br>backward is equivalent to anticlockwise and outbound. when you select backward, you filter with: [backward, anticlockwise, outbound] | all
 
 ### Objects
 
@@ -1581,7 +1581,7 @@ nop      | forbidden_uris[]   | id                              | If you want to
 nop      | items_per_schedule | int                             | Maximum number of datetimes per schedule.                                                                                  |
 nop      | data_freshness     | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul>                   | realtime
 nop      | disable_geojson    | boolean                         | remove geojson fields from the response                                                                                    | False
-nop      | direction_type     | enum                            | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul> | all
+nop      | direction_type     | enum                            | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul>Note: forward is equivalent to clockwise and inbound. When you select forward, you filter with: [forward, clockwise, inbound].<br>backward is equivalent to anticlockwise and outbound. When you select backward, you filter with: [backward, anticlockwise, outbound] | all
 
 
 ### <a name="stop-schedule"></a>Stop_schedule object
@@ -1683,7 +1683,7 @@ nop      | depth            | int                             | Json response [d
 nop      | forbidden_uris[] | id                              | If you want to avoid lines, modes, networks, etc.                                                                                     |
 nop      | data_freshness   | enum                            | Define the freshness of data to use to compute journeys <ul><li>realtime</li><li>base_schedule</li></ul>                              | realtime
 nop      | disable_geojson  | boolean                         | remove geojson fields from the response                                                                                               | false
-nop      | direction_type   | enum                            | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul>            | all
+nop      | direction_type   | enum                            | Allow to filter the response with the route direction type property <ul><li>all</li><li>forward</li><li>backward</li></ul>Note: forward is equivalent to clockwise and inbound. When you select forward, you filter with: [forward, clockwise, inbound].<br>backward is equivalent to anticlockwise and outbound. When you select backward, you filter with: [backward, anticlockwise, outbound] | all
 
 
 ### Departure objects

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -157,7 +157,7 @@ class Schedules(ResourceUri, ResourceUtc):
         )
         parser_get.add_argument(
             "direction_type",
-            help='Provide a route direction to filter results.',
+            help='Provide a route direction type to filter results.',
             type=OptionValue(['all', 'forward', 'backward']),
         )
 
@@ -186,10 +186,10 @@ class Schedules(ResourceUri, ResourceUtc):
                         direction_type
                     ),
                 )
-            return "route.has_direction_type(" + values + ")"
+            return 'route.has_direction_type({})'.format(values)
 
-        if filter != "":
-            return filter + " and " + create_direction_type_filter(direction_type)
+        if filter:
+            return '({}) and ({})'.format(filter, create_direction_type_filter(direction_type))
         else:
             return create_direction_type_filter(direction_type)
 
@@ -237,7 +237,7 @@ class Schedules(ResourceUri, ResourceUtc):
         # create direction type filter
         if args['direction_type'] and args['direction_type'] != 'all':
             args['filter'] = self._add_direction_type_filter(args['direction_type'], args['filter'])
-        logging.getLogger(__name__).debug("Schedule filter: {}".format(args["filter"]))
+        logging.getLogger(__name__).debug("Schedule filter: %s", args["filter"])
 
         if not args["from_datetime"] and not args["until_datetime"]:
             # no datetime given, default is the current time, and we activate the realtime

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -30,7 +30,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from flask_restful import reqparse
+from flask_restful import reqparse, abort
 from flask import request, g
 from jormungandr import i_manager, utils
 from jormungandr import timezone
@@ -57,6 +57,7 @@ from navitiacommon.parser_args_type import (
 )
 from jormungandr.exceptions import InvalidArguments
 import six
+import logging
 
 
 class Schedules(ResourceUri, ResourceUtc):
@@ -154,6 +155,11 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "disable_geojson", type=BooleanType(), default=False, help="remove geojson from the response"
         )
+        parser_get.add_argument(
+            "direction_type",
+            help='Provide a route direction to filter results.',
+            type=OptionValue(['all', 'forward', 'backward']),
+        )
 
         self.get_decorators.insert(0, ManageError())
         self.get_decorators.insert(1, get_obj_serializer(self))
@@ -161,6 +167,31 @@ class Schedules(ResourceUri, ResourceUtc):
 
     def options(self, **kwargs):
         return self.api_description(**kwargs)
+
+    def _add_direction_type_filter(self, direction_type, filter):
+
+        # (forward, clokwise, inbound) are equivalent and
+        # (backward, anticlokwise, outbound) are equivalent too.
+        def create_direction_type_filter(direction_type):
+            if direction_type == 'forward':
+                values = 'forward,clockwise,inbound'
+            elif direction_type == 'backward':
+                values = 'backward,anticlockwise,outbound'
+            elif direction_type == 'all':
+                values = 'all'
+            else:
+                abort(
+                    404,
+                    message='wrong direction type parameter selected : {}, it should be [forward, backward, all]]'.format(
+                        direction_type
+                    ),
+                )
+            return "route.has_direction_type(" + values + ")"
+
+        if filter != "":
+            return filter + " and " + create_direction_type_filter(direction_type)
+        else:
+            return create_direction_type_filter(direction_type)
 
     def _get_default_freshness(self):
         # The data freshness depends on the endpoint
@@ -202,6 +233,11 @@ class Schedules(ResourceUri, ResourceUtc):
             args["filter"] = self.get_filter(split_uri(uri), args)
             self.region = i_manager.get_region(region, lon, lat)
         timezone.set_request_timezone(self.region)
+
+        # create direction type filter
+        if args['direction_type'] and args['direction_type'] != 'all':
+            args['filter'] = self._add_direction_type_filter(args['direction_type'], args['filter'])
+        logging.getLogger(__name__).debug("Schedule filter: {}".format(args["filter"]))
 
         if not args["from_datetime"] and not args["until_datetime"]:
             # no datetime given, default is the current time, and we activate the realtime

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -157,7 +157,11 @@ class Schedules(ResourceUri, ResourceUtc):
         )
         parser_get.add_argument(
             "direction_type",
-            help='Provide a route direction type to filter results.',
+            help='Provide a route direction type to filter results. '
+            'Note: forward is equivalent to clockwise and inbound. '
+            'When you select forward, you filter with: [forward, clockwise, inbound]. '
+            'On the other hand, backward is equivalent to anticlockwise and outbound. '
+            'When you select backward, you filter with: [backward, anticlockwise, outbound].',
             type=OptionValue(['all', 'forward', 'backward']),
         )
 
@@ -170,8 +174,8 @@ class Schedules(ResourceUri, ResourceUtc):
 
     def _add_direction_type_filter(self, direction_type, filter):
 
-        # (forward, clokwise, inbound) are equivalent and
-        # (backward, anticlokwise, outbound) are equivalent too.
+        # (forward, clockwise, inbound) are equivalent and
+        # (backward, anticlockwise, outbound) are equivalent too.
         def create_direction_type_filter(direction_type):
             if direction_type == 'forward':
                 values = 'forward,clockwise,inbound'

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -174,6 +174,10 @@ class Schedules(ResourceUri, ResourceUtc):
 
     def _add_direction_type_filter(self, direction_type, filter):
 
+        # Don't need a direction type filter
+        if direction_type == 'all':
+            return filter
+
         # (forward, clockwise, inbound) are equivalent and
         # (backward, anticlockwise, outbound) are equivalent too.
         def create_direction_type_filter(direction_type):
@@ -181,8 +185,6 @@ class Schedules(ResourceUri, ResourceUtc):
                 values = 'forward,clockwise,inbound'
             elif direction_type == 'backward':
                 values = 'backward,anticlockwise,outbound'
-            elif direction_type == 'all':
-                values = 'all'
             else:
                 abort(
                     404,
@@ -239,7 +241,7 @@ class Schedules(ResourceUri, ResourceUtc):
         timezone.set_request_timezone(self.region)
 
         # create direction type filter
-        if args['direction_type'] and args['direction_type'] != 'all':
+        if args['direction_type']:
             args['filter'] = self._add_direction_type_filter(args['direction_type'], args['filter'])
         logging.getLogger(__name__).debug("Schedule filter: %s", args["filter"])
 

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -931,6 +931,42 @@ class TestSchedules(AbstractTestFixture):
         assert not [l for l in response.get('links') if l.get('rel') == 'next']
         self.check_departure_rt_sol(departures)
 
+    def test_departures_with_direction_type(self):
+        """
+        Test direction type parameter for filtering departures response
+        data contains :
+           - route A (direction type = forward)
+                * 3 departures on stop uri : S1
+           - route B (direction type = backward)
+                * 1 departure on stop uri : S1
+        """
+
+        # Without direction type parameter
+        response = self.query_region("stop_points/S1/departures?_current_datetime=20160101T080000")
+        assert "departures" in response
+        assert len(response["departures"]) == 4
+
+        # With direction type = all (same as without direction type parameter)
+        response = self.query_region(
+            "stop_points/S1/departures?direction_type=all&_current_datetime=20160101T080000"
+        )
+        assert "departures" in response
+        assert len(response["departures"]) == 4
+
+        # With direction type = forward
+        response = self.query_region(
+            "stop_points/S1/departures?direction_type=forward&_current_datetime=20160101T080000"
+        )
+        assert "departures" in response
+        assert len(response["departures"]) == 3
+
+        # With direction type = backward
+        response = self.query_region(
+            "stop_points/S1/departures?direction_type=backward&_current_datetime=20160101T080000"
+        )
+        assert "departures" in response
+        assert len(response["departures"]) == 1
+
     def test_departure_base_sched(self):
         """
         test a departure, no date time and base schedule, we should get base schedule

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -138,7 +138,7 @@ class TestDepartures(AbstractTestFixture):
         response = self.query_region(query)
 
         stop_schedule_A = response['stop_schedules'][0]
-        assert stop_schedule_A['route']['name'] == 'A'
+        assert stop_schedule_A['route']['name'] == 'A:0'
         next_passage_dts = [dt["date_time"] for dt in stop_schedule_A['date_times']]
         next_passage_base_dts = [dt["base_date_time"] for dt in stop_schedule_A['date_times']]
         values = ['20160102T110000', '20160103T090000', '20160103T100000']
@@ -149,7 +149,7 @@ class TestDepartures(AbstractTestFixture):
             assert dt['data_freshness'] == 'base_schedule'
 
         stop_schedule_B = response['stop_schedules'][1]
-        assert stop_schedule_B['route']['name'] == 'B'
+        assert stop_schedule_B['route']['name'] == 'B:1'
         next_passage_dts = [dt["date_time"] for dt in stop_schedule_B['date_times']]
         assert ['20160102T113000'] == next_passage_dts
 

--- a/source/ptreferential/tests/ptref_ng_test.cpp
+++ b/source/ptreferential/tests/ptref_ng_test.cpp
@@ -76,8 +76,8 @@ BOOST_AUTO_TEST_CASE(parse_pred) {
         R"#(vehicle_journey . has_code_type ( external_code ) )#",
         R"#(vehicle_journey.has_code_type("external_code"))#");
     assert_expr(
-        R"#(route . has_code_type ( forward ) )#",
-        R"#(route.has_code_type("forward"))#");
+        R"#(route . has_direction_type ( forward ) )#",
+        R"#(route.has_direction_type("forward"))#");
     assert_expr(R"#(stop_area . uri ( "OIF:42" ) )#", R"#(stop_area.uri("OIF:42"))#");
     assert_expr(R"#(stop_area . uri = "OIF:42" )#", R"#(stop_area.uri("OIF:42"))#");
     assert_expr(R"#(stop_area . uri = OIF:42 )#", R"#(stop_area.uri("OIF:42"))#");

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -39,11 +39,13 @@ struct departure_board_fixture {
     departure_board_fixture() : b("20160101") {
         b.sa("SA1")("S1")("S2");
 
-        b.vj("A").name("A:vj1")("A:s", "08:00"_t)("S1", "09:00"_t)("S2", "10:00"_t)("A:e", "11:00"_t);
+        b.vj("A")
+            .route("A:0", "forward")
+            .name("A:vj1")("A:s", "08:00"_t)("S1", "09:00"_t)("S2", "10:00"_t)("A:e", "11:00"_t);
         b.vj("A").name("A:vj2")("A:s", "09:00"_t)("S1", "10:00"_t)("S2", "11:00"_t)("A:e", "12:00"_t);
         b.vj("A").name("A:vj3")("A:s", "10:00"_t)("S1", "11:00"_t)("S2", "12:00"_t)("A:e", "13:00"_t);
 
-        b.vj("B").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
+        b.vj("B").route("B:1", "backward").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
 
         b.vj("C").name("C:vj1")("C:S0", "11:30"_t)("C:S1", "12:30"_t)("C:S2", "13:30"_t);
         b.lines.find("C")->second->properties["realtime_system"] = "Kisio数字";

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -45,7 +45,7 @@ struct departure_board_fixture {
         b.vj("A").name("A:vj2")("A:s", "09:00"_t)("S1", "10:00"_t)("S2", "11:00"_t)("A:e", "12:00"_t);
         b.vj("A").name("A:vj3")("A:s", "10:00"_t)("S1", "11:00"_t)("S2", "12:00"_t)("A:e", "13:00"_t);
 
-        b.vj("B").route("B:1", "backward").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
+        b.vj("B").route("B:1", "anticlockwise").name("B:vj1")("B:s", "10:30"_t)("S1", "11:30"_t)("B:e", "12:30"_t);
 
         b.vj("C").name("C:vj1")("C:S0", "11:30"_t)("C:S1", "12:30"_t)("C:S2", "13:30"_t);
         b.lines.find("C")->second->properties["realtime_system"] = "Kisio数字";


### PR DESCRIPTION
**Feature** : Allow to filter `/departures`, `/arrivals`, `/stop_schedules`, `/route_schedules` results with direction type parameter (all, forward, backward)
JIRA : https://jira.kisio.org/browse/NAVP-1087

The first part of the work (update ptref filter) was added here : https://github.com/CanalTP/navitia/pull/2960

- Docker tests are Green.
- I know what you will say: There is no tests for `/arrivals` Api. But don't worry about that, because _departures_ and _arrival_ use the same **Schedule** **class**.

**QA part**:
Tested on fr-se-lyon, several request with different data type (forward and backward) and it seems to be ok for all params (forward, backward, all, without param) :tada: 