### PR TITLE
Enable mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,30 @@
+pull_request_rules:
+  - name: automatic merge when CI passes and 2 reviews
+    conditions:
+      - "#approved-reviews-by>=2"
+      - "#review-requested=0"
+      - "#changes-requested-reviews-by=0"
+      - "#commented-reviews-by=0"
+      - status-success=Travis CI - Pull Request
+      - status-success=default
+      - status-success=codecov/project
+      - status-success=codecov/patch
+      - base=dev
+      - label!=dot_not_merge
+      - label!=wip
+      - label!=waiting
+      - label!=merge_after_release
+      - author=@CoreTeam
+    actions:
+      merge:
+        method: merge
+        strict: true
+  - name: delete head branch after merge
+    conditions: []
+    actions:
+      delete_head_branch: {}
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews: {}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"
-      - status-success=Travis CI - Pull Request
+      - status-success=continuous-integration/travis-ci/pr
       - status-success=default
       - status-success=codecov/project
       - status-success=codecov/patch

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,7 +14,7 @@ pull_request_rules:
       - label!=wip
       - label!=waiting
       - label!=merge_after_release
-      - author=@CoreTeam
+      - author=@coreteam
     actions:
       merge:
         method: merge


### PR DESCRIPTION
Automatically merge PR done by @CanalTP/coreteam that have
  - at least 2 approved reviews
  - no comment or reuqest for change reviews
  - all requested reviewver have approved
  - all CI tests are ok
  - no label wip, dot_not_merge, etc...

PR are rebased on `dev` if needed and tests are rerun before merge.

Reviews are dismissed when a push occurs.