### PR TITLE
jormun: use flask_restful from upstream

### DIFF
--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.1
-git+https://github.com/CanalTP/flask-restful.git@76346f65ca12a8edb9b32688cdc192ad391fa686
+flask_restful==0.3.7
 Flask-SQLAlchemy==2.4
 Flask-Cors==1.9.0
 geojson==1.3.3

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -1,6 +1,6 @@
 Flask==1.1.1
 Flask-Migrate==2.5.2
-git+https://github.com/CanalTP/flask-restful.git@76346f65ca12a8edb9b32688cdc192ad391fa686
+flask_restful==0.3.7
 Flask-SQLAlchemy==2.4
 Flask-Script==0.6.7
 geojson==1.3.3


### PR DESCRIPTION
We do not need this ugly fork since we only updated some marshal stuff