### PR TITLE
Jormun: Use serpy fork from pypi

### DIFF
--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -32,7 +32,7 @@ future==0.15.2
 zeep==1.1.0
 gevent==1.3.7
 Flask-Caching==1.7.2
-git+https://github.com/canaltp/serpy.git@ctp
+serpy-ctp==0.2.1
 python-json-logger==0.1.7
 jmespath==0.9.3
 shortuuid==0.5.0


### PR DESCRIPTION
no more dependency directly on github, this will facilitate a migration to something else than pip to manage dependencies