### PR TITLE
Kraken: POC for smarter directions in stop_schedules

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -618,6 +618,7 @@ class RouteDisplayInformationSerializer(PbNestedSerializer):
     name = jsonschema.Field(schema_type=str)
     links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
     text_color = jsonschema.Field(schema_type=str)
+    description = jsonschema.Field(schema_type=str)
 
 
 class VJDisplayInformationSerializer(RouteDisplayInformationSerializer):

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -40,6 +40,7 @@ namespace type {
 struct StopPoint;
 struct StopTime;
 struct Route;
+struct Line;
 struct VehicleJourney;
 struct MetaVehicleJourney;
 struct PhysicalMode;
@@ -53,6 +54,7 @@ using JppIdx = Idx<JourneyPatternPoint>;
 using JpIdx = Idx<JourneyPattern>;
 using SpIdx = Idx<type::StopPoint>;
 using RouteIdx = Idx<type::Route>;
+using LineIdx = Idx<type::Line>;
 using VjIdx = Idx<type::VehicleJourney>;
 using MvjIdx = Idx<type::MetaVehicleJourney>;
 using PhyModeIdx = Idx<type::PhysicalMode>;


### PR DESCRIPTION
### Short description

Stop grouping departure times by {route, stop_point} as there can be too much or too few (dumb) routes in data.

Instead, group them observing all the stations being served after considered stop_point:  
If after the same stop_point, a vehicle serves the same stations in the same order (maybe serving more on the way and after), then they are grouped.

JIRA: https://jira.kisio.org/browse/NAVP-1086

----

### Results

#### Perfs
:heavy_check_mark: No issue about that so far: on "big" requests, request duration is shorter (less protobuf to fill and serialize)

#### RER B at Gare du Nord
Before: ![BeforeRerB](https://user-images.githubusercontent.com/12812530/66057113-737cd180-e538-11e9-93d4-de38e4571df2.png)
After: ![rerBapres](https://user-images.githubusercontent.com/12812530/66057228-9f985280-e538-11e9-846b-7113f0f18876.png)
The terminus duplicated are because starting stop_points differs (surface vs. RER)

#### RER C at Saint-Michel Notre dame
Before: ![rerCavant](https://user-images.githubusercontent.com/12812530/66057436-faca4500-e538-11e9-9587-f95d1e3e8deb.png)
After: ![rerCapres](https://user-images.githubusercontent.com/12812530/66057444-ff8ef900-e538-11e9-8860-a028d2eabd75.png)
The terminus duplicated (Dourdan) is because some vehicles are serving between Ivry and Athis, some other serving between Savigny and St-Michel-sur-Orge, but none is serving both, so they stay separated (even if geographically, they are on the same path).

#### Metro 13 at Montparnasse
Before: ![metro13avant](https://user-images.githubusercontent.com/12812530/66057839-aa071c00-e539-11e9-9951-e7a44da78888.png)
After: ![metro13apres](https://user-images.githubusercontent.com/12812530/66057855-affcfd00-e539-11e9-9fb2-271a455621f7.png)
Route toward North is deduplicated as no vehicle is serving both branches (geographically separated)

#### Metro 13 at Asnières-Gennevilliers
Before: ![metro13terminusAvant](https://user-images.githubusercontent.com/12812530/66058265-5d701080-e53a-11e9-9108-2acffe651fa1.png)
After: ![metro13terminusApres](https://user-images.githubusercontent.com/12812530/66058279-64971e80-e53a-11e9-8a1b-1b2c139c64a5.png)
No vehicle is **ever** departing from station direction North, so the direction does not appear.

#### SNCF at Montparnasse
Before: ![sncfMontparAvant](https://user-images.githubusercontent.com/12812530/66132456-6245ca80-e5f5-11e9-982e-09ee686871ec.png)
After: ![sncfMontparApres](https://user-images.githubusercontent.com/12812530/66132474-696cd880-e5f5-11e9-8f73-6666ef5811b7.png)
It does improve a bit (mostly removes 52 terminus empty cases, win 7 in merge/expand process). Not so much improvement as stop points are different between ouigo, inoui and "classic" TGV so omnibus lines are not merging much.