### PR TITLE
[Eitri] Fix cities file type

### DIFF
--- a/source/eitri/eitri.py
+++ b/source/eitri/eitri.py
@@ -124,10 +124,7 @@ def get_params():
         help="the output file path (default: './data.nav.lz4')",
     )
     parser.add_argument(
-        '-i',
-        '--cities-file',
-        type=argparse.FileType,
-        help='the path to the "cities" file to load  (usually a *.osm.pbf)',
+        '-i', '--cities-file', type=str, help='the path to the "cities" file to load  (usually a *.osm.pbf)'
     )
     parser.add_argument(
         '-f', '--cities-dir', type=is_directory, help='the path to the directory containing the "cities" binary'


### PR DESCRIPTION
The cities binary expects the path to the cities file as a `str`.
Eitri retrieves this info as a `FileType` so it fails when using the argument `-i CITIES_FILE, --cities-file CITIES_FILE`
-> `TypeError: sequence item 1: expected string, FileType found`

Eitri will now retrieve the cities file path as a `str` and pass it directly to the cities binary