### PR TITLE
Draft isochrone distributed

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1106,8 +1106,10 @@ class Scenario(simple.Scenario):
         updated_request_with_default(request, instance)
         # we don't want to filter anything!
         krakens_call = get_kraken_calls(request)
+        # Initialize a context for distributed
+        distributed_context = self.get_context()
         resp = merge_responses(
-            self.call_kraken(type_pb2.ISOCHRONE, request, instance, krakens_call), request['debug']
+            self.call_kraken(type_pb2.ISOCHRONE, request, instance, krakens_call, distributed_context), request['debug']
         )
         if not request['debug']:
             # on isochrone we can filter the number of max journeys

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -992,13 +992,12 @@ void Worker::direct_path(const pbnavitia::Request& request) {
 
 void Worker::isochrone_distributed(const pbnavitia::JourneysRequest& request) {
     navitia::JourneysArg arg = fill_journeys(request);
-    auto departures = journeys
 
-        // This doesn't compile beacause isochrone_origin does not exist in journeyRequest.
-        routing::make_isochrone_distributed(this->pb_creator, *planner, request.isochrone_origin(), arg.origins,
-                                            request.datetimes(0), request.clockwise(), arg.accessibilite_params,
-                                            arg.forbidden, arg.allowed, *street_network_worker, arg.rt_level,
-                                            request.max_duration(), request.max_transfers());
+    // This doesn't compile beacause isochrone_origin does not exist in journeyRequest.
+    routing::make_isochrone_distributed(this->pb_creator, *planner, request.isochrone_origin(), arg.origins,
+                                        request.datetimes(0), request.clockwise(), arg.accessibilite_params,
+                                        arg.forbidden, arg.allowed, *street_network_worker, arg.rt_level,
+                                        request.max_duration(), request.max_transfers());
 }
 
 void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -990,6 +990,17 @@ void Worker::direct_path(const pbnavitia::Request& request) {
                              dp_request.clockwise());
 }
 
+void Worker::isochrone_distributed(const pbnavitia::JourneysRequest& request) {
+    navitia::JourneysArg arg = fill_journeys(request);
+    auto departures = journeys
+
+        // This doesn't compile beacause isochrone_origin does not exist in journeyRequest.
+        routing::make_isochrone_distributed(this->pb_creator, *planner, request.isochrone_origin(), arg.origins,
+                                            request.datetimes(0), request.clockwise(), arg.accessibilite_params,
+                                            arg.forbidden, arg.allowed, *street_network_worker, arg.rt_level,
+                                            request.max_duration(), request.max_transfers());
+}
+
 void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {
     bool disable_geojson = get_geojson_state(request);
     boost::posix_time::ptime current_datetime = bt::from_time_t(request._current_datetime());
@@ -1080,6 +1091,8 @@ void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {
         case pbnavitia::equipment_reports:
             equipment_reports(request.equipment_reports());
             break;
+        case pbnavitia::isochrone_distributed:
+            isochrone_distributed(request.journeys());
         default:
             LOG4CPLUS_WARN(logger, "Unknown API : " + API_Name(request.requested_api()));
             this->pb_creator.fill_pb_error(pbnavitia::Error::unknown_api, "Unknown API");

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -122,7 +122,7 @@ private:
     void heat_map(const pbnavitia::HeatMapRequest& request);
     void car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request);
     void direct_path(const pbnavitia::Request& request);
-    void isochrone_distributed(const pbnavitia::Request& request);
+    void isochrone_distributed(const pbnavitia::JourneysRequest& request);
 
     /*
      * Given N origins and M destinations and street network mode, it returns a NxM matrix which contains durations

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -122,6 +122,7 @@ private:
     void heat_map(const pbnavitia::HeatMapRequest& request);
     void car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request);
     void direct_path(const pbnavitia::Request& request);
+    void isochrone_distributed(const pbnavitia::Request& request);
 
     /*
      * Given N origins and M destinations and street network mode, it returns a NxM matrix which contains durations

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1451,6 +1451,7 @@ void make_isochrone(navitia::PbCreator& pb_creator,
 
 void make_isochrone_distributed(navitia::PbCreator& pb_creator,
                                 RAPTOR& raptor,
+                                const type::EntryPoint& isochrone_origin,
                                 const std::vector<type::EntryPoint>& origins,
                                 const uint64_t datetime_timestamp,
                                 bool clockwise,
@@ -1478,10 +1479,8 @@ void make_isochrone_distributed(navitia::PbCreator& pb_creator,
     raptor.isochrone(departures, init_dt, bound, max_transfers, accessibilite_params, forbidden, allowed, clockwise,
                      rt_level);
 
-    // DOES NOT COMPILE
-    // origin must be en EntryPoint, not a vector
-    add_isochrone_response(raptor, origin, pb_creator, raptor.data.pt_data->stop_points, clockwise, init_dt, bound,
-                           max_duration);
+    add_isochrone_response(raptor, isochrone_origin, pb_creator, raptor.data.pt_data->stop_points, clockwise, init_dt,
+                           bound, max_duration);
     pb_creator.sort_journeys();
     if (pb_creator.empty_journeys()) {
         pb_creator.fill_pb_error(pbnavitia::Error::no_solution, pbnavitia::NO_SOLUTION,

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -114,6 +114,19 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     int max_duration = 3600,
                     uint32_t max_transfers = std::numeric_limits<uint32_t>::max());
 
+void make_isochrone_distributed(navitia::PbCreator& pb_creator,
+                                RAPTOR& raptor,
+                                const type::EntryPoint& isochrone_origin,
+                                const std::vector<type::EntryPoint>& origins,
+                                const uint64_t datetime_timestamp,
+                                bool clockwise,
+                                const type::AccessibiliteParams& accessibilite_params,
+                                std::vector<std::string> forbidden,
+                                std::vector<std::string> allowed,
+                                const type::RTLevel rt_level,
+                                int max_duration = 3600,
+                                uint32_t max_transfers = std::numeric_limits<uint32_t>::max());
+
 /**
  * @brief Used for Pt with distributed mode
  */


### PR DESCRIPTION
This does not compile at all, it just gives a rough idea of what I want to do for this implementation!

In distributed mode, the call to isochrone (/journeys with one from or to) is redirected to new_default.

In distributed mode, we want to call a `street_network_matrix` AND call `raptor.isochrone` with that.
The problem is that in `make_isochrone` in kraken, `add_isochrone_response` take `origin` as the `from` or `to` of the request. 

We don't send this parameter in distributed mode since we are supposed to send the result of the street_network_routing_matrix (like we do when calling pt_planner).

I have two choice :

1) Implement a new `add_isochrone_response` and do more processing in Jormun to recreate the full reponse with the result of sn_matrix and the result of raptor.isochrone
2) Send this origin (`from` or `to` of request) when calling isochrone in distributed mode and don't do anything more

We'll have the same issue for `graphical_isochrone` by the way.
Please, someone, help me.