### PR TITLE
Kraken: Strong-type Rank<> for StopTime and JourneyPatternPoint

### DIFF
--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -206,7 +206,7 @@ std::vector<const type::Route*> get_matching_routes(const type::Data* data,
         if (r->line != line) {
             continue;
         }
-        for (const auto& next_jpp_idx : boost::make_iterator_range(jp.jpps.begin() + jpp.order, jp.jpps.end())) {
+        for (const auto& next_jpp_idx : boost::make_iterator_range(jp.jpps_begin() + jpp.order, jp.jpps_end())) {
             const auto next_jpp = data_raptor->jp_container.get(next_jpp_idx);
             const auto sp = data->get_data<nt::StopPoint>()[next_jpp.sp_idx.val];
             if (contains(possible_stop_points, sp) || contains(possible_stop_areas, sp->stop_area)) {

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -57,7 +57,7 @@ void dataRAPTOR::JppsFromSp::load(const type::PT_Data& data, const JourneyPatter
     for (const auto jp : jp_container.get_jps()) {
         for (const auto& jpp_idx : jp.second.jpps) {
             const auto& jpp = jp_container.get(jpp_idx);
-            jpps_from_sp[jpp.sp_idx].push_back({jpp_idx, jp.first, jpp.order});
+            jpps_from_sp[jpp.sp_idx].push_back({jpp_idx, jp.first, jpp.order.val});
         }
     }
     for (auto& jpps : jpps_from_sp.values()) {

--- a/source/routing/get_stop_times.cpp
+++ b/source/routing/get_stop_times.cpp
@@ -172,7 +172,7 @@ std::vector<std::pair<uint32_t, const type::StopTime*>> get_all_calendar_stop_ti
     std::vector<std::pair<DateTime, const type::StopTime*>> res;
     for (const auto vj : vjs) {
         // loop through stop times for stop jpp->stop_point
-        const auto& st = vj->get_corresponding_stop_time(jpp.order);
+        const auto& st = get_corresponding_stop_time(*vj, jpp.order);
         if (!st.vehicle_journey->accessible(vehicle_properties)) {
             continue;  // the stop time must be accessible
         }

--- a/source/routing/get_stop_times.cpp
+++ b/source/routing/get_stop_times.cpp
@@ -172,7 +172,7 @@ std::vector<std::pair<uint32_t, const type::StopTime*>> get_all_calendar_stop_ti
     std::vector<std::pair<DateTime, const type::StopTime*>> res;
     for (const auto vj : vjs) {
         // loop through stop times for stop jpp->stop_point
-        const auto& st = vj->stop_time_list[jpp.order.val];
+        const auto& st = vj->get_corresponding_stop_time(jpp.order);
         if (!st.vehicle_journey->accessible(vehicle_properties)) {
             continue;  // the stop time must be accessible
         }

--- a/source/routing/get_stop_times.cpp
+++ b/source/routing/get_stop_times.cpp
@@ -172,7 +172,7 @@ std::vector<std::pair<uint32_t, const type::StopTime*>> get_all_calendar_stop_ti
     std::vector<std::pair<DateTime, const type::StopTime*>> res;
     for (const auto vj : vjs) {
         // loop through stop times for stop jpp->stop_point
-        const auto& st = vj->stop_time_list[jpp.order];
+        const auto& st = vj->stop_time_list[jpp.order.val];
         if (!st.vehicle_journey->accessible(vehicle_properties)) {
             continue;  // the stop time must be accessible
         }

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -96,10 +96,10 @@ bool Journey::operator!=(const Journey& rhs) const {
 }
 
 size_t SectionHash::operator()(const Journey::Section& s, size_t seed) const {
-    boost::hash_combine(seed, s.get_in_st->order());
+    boost::hash_combine(seed, s.get_in_st->order().val);
     boost::hash_combine(seed, s.get_in_st->vehicle_journey);
     boost::hash_combine(seed, s.get_in_dt);
-    boost::hash_combine(seed, s.get_out_st->order());
+    boost::hash_combine(seed, s.get_out_st->order().val);
     boost::hash_combine(seed, s.get_out_st->vehicle_journey);
     boost::hash_combine(seed, s.get_out_dt);
 

--- a/source/routing/journey_pattern_container.cpp
+++ b/source/routing/journey_pattern_container.cpp
@@ -213,7 +213,7 @@ JpIdx JourneyPatternContainer::make_jp(const JpKey& key) {
     JourneyPattern jp;
     jp.route_idx = key.route_idx;
     jp.phy_mode_idx = key.phy_mode_idx;
-    uint16_t order = 0;
+    Rank<JourneyPatternPoint> order(0);
     for (const auto& jpp_key : key.jpp_keys) {
         jp.jpps.push_back(make_jpp(jp_idx, jpp_key.sp_idx, order++));
     }
@@ -223,7 +223,9 @@ JpIdx JourneyPatternContainer::make_jp(const JpKey& key) {
     return jp_idx;
 }
 
-JppIdx JourneyPatternContainer::make_jpp(const JpIdx& jp_idx, const SpIdx& sp_idx, uint16_t order) {
+JppIdx JourneyPatternContainer::make_jpp(const JpIdx& jp_idx,
+                                         const SpIdx& sp_idx,
+                                         const Rank<JourneyPatternPoint>& order) {
     const auto idx = JppIdx(jpps.size());
     jpps.push_back({jp_idx, sp_idx, order});
     return idx;

--- a/source/routing/journey_pattern_container.cpp
+++ b/source/routing/journey_pattern_container.cpp
@@ -38,6 +38,11 @@ namespace routing {
 
 namespace nt = navitia::type;
 
+const type::StopTime& get_corresponding_stop_time(const type::VehicleJourney& vj,
+                                                  const RankJourneyPatternPoint& order) {
+    return vj.stop_time_list.at(order.val);
+}
+
 template <>
 std::vector<const nt::DiscreteVehicleJourney*>& JourneyPattern::get_vjs<nt::DiscreteVehicleJourney>() {
     return discrete_vjs;

--- a/source/routing/journey_pattern_container.cpp
+++ b/source/routing/journey_pattern_container.cpp
@@ -73,7 +73,7 @@ void JourneyPatternContainer::load(const nt::PT_Data& pt_data) {
 
 const JppIdx& JourneyPatternContainer::get_jpp(const type::StopTime& st) const {
     const auto& jp = get(jp_from_vj[VjIdx(*st.vehicle_journey)]);
-    return jp.jpps.at(st.order());
+    return jp.jpps.at(st.order().val);
 }
 
 std::string JourneyPatternContainer::get_id(const JpIdx& jp_idx) const {

--- a/source/routing/journey_pattern_container.cpp
+++ b/source/routing/journey_pattern_container.cpp
@@ -53,6 +53,10 @@ std::ostream& operator<<(std::ostream& os, const JourneyPattern& jp) {
     return os << "Jp(" << jp.jpps << ", " << jp.discrete_vjs << ", " << jp.freq_vjs << ")";
 }
 
+const JppIdx& JourneyPattern::get_jpp_idx(const RankJourneyPatternPoint& order) const {
+    return jpps.at(order.val);
+}
+
 void JourneyPatternContainer::load(const nt::PT_Data& pt_data) {
     map.clear();
     jps.clear();
@@ -213,7 +217,7 @@ JpIdx JourneyPatternContainer::make_jp(const JpKey& key) {
     JourneyPattern jp;
     jp.route_idx = key.route_idx;
     jp.phy_mode_idx = key.phy_mode_idx;
-    Rank<JourneyPatternPoint> order(0);
+    RankJourneyPatternPoint order(0);
     for (const auto& jpp_key : key.jpp_keys) {
         jp.jpps.push_back(make_jpp(jp_idx, jpp_key.sp_idx, order++));
     }
@@ -225,7 +229,7 @@ JpIdx JourneyPatternContainer::make_jp(const JpKey& key) {
 
 JppIdx JourneyPatternContainer::make_jpp(const JpIdx& jp_idx,
                                          const SpIdx& sp_idx,
-                                         const Rank<JourneyPatternPoint>& order) {
+                                         const RankJourneyPatternPoint& order) {
     const auto idx = JppIdx(jpps.size());
     jpps.push_back({jp_idx, sp_idx, order});
     return idx;

--- a/source/routing/journey_pattern_container.h
+++ b/source/routing/journey_pattern_container.h
@@ -48,11 +48,13 @@ struct StopTime;
 namespace navitia {
 namespace routing {
 
+using RankJourneyPatternPoint = Rank<JourneyPatternPoint>;
+
 // TODO: constructor private with JourneyPatternContainer friend?
 struct JourneyPatternPoint {
     JpIdx jp_idx;
     SpIdx sp_idx;
-    Rank<JourneyPatternPoint> order;
+    RankJourneyPatternPoint order;
     bool operator==(const JourneyPatternPoint& other) const { return sp_idx == other.sp_idx && order == other.order; }
 };
 std::ostream& operator<<(std::ostream&, const JourneyPatternPoint&);
@@ -65,6 +67,9 @@ struct JourneyPattern {
     RouteIdx route_idx;
     PhyModeIdx phy_mode_idx;
 
+    std::vector<JppIdx>::const_iterator jpps_begin() const { return jpps.begin(); }
+    std::vector<JppIdx>::const_iterator jpps_end() const { return jpps.end(); }
+    const JppIdx& get_jpp_idx(const RankJourneyPatternPoint& order) const;
     bool operator==(const JourneyPattern& other) const {
         return jpps == other.jpps && discrete_vjs == other.discrete_vjs && freq_vjs == other.freq_vjs
                && route_idx == other.route_idx;
@@ -194,7 +199,7 @@ private:
     template <typename VJ>
     static JpKey make_key(const VJ&);
     JpIdx make_jp(const JpKey&);
-    JppIdx make_jpp(const JpIdx&, const SpIdx&, const Rank<JourneyPatternPoint>& order);
+    JppIdx make_jpp(const JpIdx&, const SpIdx&, const RankJourneyPatternPoint& order);
     JourneyPattern& get_mut(const JpIdx&);
 };
 

--- a/source/routing/journey_pattern_container.h
+++ b/source/routing/journey_pattern_container.h
@@ -32,6 +32,7 @@ www.navitia.io
 
 #include "raptor_utils.h"
 #include <boost/optional.hpp>
+#include "utils/rank.h"
 
 namespace navitia {
 namespace type {
@@ -51,7 +52,7 @@ namespace routing {
 struct JourneyPatternPoint {
     JpIdx jp_idx;
     SpIdx sp_idx;
-    uint16_t order;
+    Rank<JourneyPatternPoint> order;
     bool operator==(const JourneyPatternPoint& other) const { return sp_idx == other.sp_idx && order == other.order; }
 };
 std::ostream& operator<<(std::ostream&, const JourneyPatternPoint&);
@@ -193,7 +194,7 @@ private:
     template <typename VJ>
     static JpKey make_key(const VJ&);
     JpIdx make_jp(const JpKey&);
-    JppIdx make_jpp(const JpIdx&, const SpIdx&, uint16_t order);
+    JppIdx make_jpp(const JpIdx&, const SpIdx&, const Rank<JourneyPatternPoint>& order);
     JourneyPattern& get_mut(const JpIdx&);
 };
 

--- a/source/routing/journey_pattern_container.h
+++ b/source/routing/journey_pattern_container.h
@@ -50,6 +50,9 @@ namespace routing {
 
 using RankJourneyPatternPoint = Rank<JourneyPatternPoint>;
 
+// Accessor method to retrieve the StopTime of a VJ corresponding to a given JPP rank
+const type::StopTime& get_corresponding_stop_time(const type::VehicleJourney& vj, const RankJourneyPatternPoint& order);
+
 // TODO: constructor private with JourneyPatternContainer friend?
 struct JourneyPatternPoint {
     JpIdx jp_idx;

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -62,7 +62,7 @@ void NextStopTimeData::TimesStopTimes<Getter>::init(const JourneyPattern& jp, co
     const auto jpp_order = jpp.order;
     stop_times.reserve(jp.discrete_vjs.size());
     for (const auto& vj : jp.discrete_vjs) {
-        const auto& st = vj->get_corresponding_stop_time(jpp_order);
+        const auto& st = get_corresponding_stop_time(*vj, jpp_order);
         if (!getter.is_valid(st)) {
             continue;
         }
@@ -165,7 +165,7 @@ static std::pair<const type::StopTime*, DateTime> next_valid_frequency(const Sto
 
     while (best.first == nullptr && base_dt <= bound) {
         for (const auto& freq_vj : jp.freq_vjs) {
-            const auto& st = freq_vj->get_corresponding_stop_time(jpp.order);
+            const auto& st = get_corresponding_stop_time(*freq_vj, jpp.order);
 
             if (!freq_vj->accessible(vehicle_props)) {
                 continue;
@@ -202,7 +202,7 @@ static std::pair<const type::StopTime*, DateTime> previous_valid_frequency(const
 
     while (best.first == nullptr && base_dt >= bound) {
         for (const auto& freq_vj : jp.freq_vjs) {
-            const auto& st = freq_vj->get_corresponding_stop_time(jpp.order);
+            const auto& st = get_corresponding_stop_time(*freq_vj, jpp.order);
 
             if (!freq_vj->accessible(vehicle_props)) {
                 continue;

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -62,7 +62,7 @@ void NextStopTimeData::TimesStopTimes<Getter>::init(const JourneyPattern& jp, co
     const auto jpp_order = jpp.order;
     stop_times.reserve(jp.discrete_vjs.size());
     for (const auto& vj : jp.discrete_vjs) {
-        const auto& st = vj->stop_time_list[jpp_order.val];
+        const auto& st = vj->get_corresponding_stop_time(jpp_order);
         if (!getter.is_valid(st)) {
             continue;
         }
@@ -165,7 +165,7 @@ static std::pair<const type::StopTime*, DateTime> next_valid_frequency(const Sto
 
     while (best.first == nullptr && base_dt <= bound) {
         for (const auto& freq_vj : jp.freq_vjs) {
-            const auto& st = freq_vj->stop_time_list[jpp.order.val];
+            const auto& st = freq_vj->get_corresponding_stop_time(jpp.order);
 
             if (!freq_vj->accessible(vehicle_props)) {
                 continue;
@@ -202,7 +202,7 @@ static std::pair<const type::StopTime*, DateTime> previous_valid_frequency(const
 
     while (best.first == nullptr && base_dt >= bound) {
         for (const auto& freq_vj : jp.freq_vjs) {
-            const auto& st = freq_vj->stop_time_list[jpp.order.val];
+            const auto& st = freq_vj->get_corresponding_stop_time(jpp.order);
 
             if (!freq_vj->accessible(vehicle_props)) {
                 continue;
@@ -381,9 +381,9 @@ static void fill_cache(const DateTime from,
                 continue;
             }
             const auto shift = navitia::DateTimeUtils::SECONDS_PER_DAY * day;
-            size_t i = 0;
+            RankJourneyPatternPoint i{0};
             for (const auto& st : vj->stop_time_list) {
-                auto jpp_idx = jp.jpps[i];
+                auto jpp_idx = jp.get_jpp_idx(i);
                 auto loop_impl = [&](long freq_shift) {
                     if (st.drop_off_allowed()) {
                         auto arrival_time = st.alighting_time + shift + freq_shift;

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -59,10 +59,10 @@ bool NextStopTimeData::Arrival::is_valid(const type::StopTime& st) const {
 template <typename Getter>
 void NextStopTimeData::TimesStopTimes<Getter>::init(const JourneyPattern& jp, const JourneyPatternPoint& jpp) {
     // collect the stop times at the given jpp
-    const size_t jpp_order = jpp.order;
+    const auto jpp_order = jpp.order;
     stop_times.reserve(jp.discrete_vjs.size());
     for (const auto& vj : jp.discrete_vjs) {
-        const auto& st = vj->stop_time_list[jpp_order];
+        const auto& st = vj->stop_time_list[jpp_order.val];
         if (!getter.is_valid(st)) {
             continue;
         }
@@ -165,7 +165,7 @@ static std::pair<const type::StopTime*, DateTime> next_valid_frequency(const Sto
 
     while (best.first == nullptr && base_dt <= bound) {
         for (const auto& freq_vj : jp.freq_vjs) {
-            const auto& st = freq_vj->stop_time_list[jpp.order];
+            const auto& st = freq_vj->stop_time_list[jpp.order.val];
 
             if (!freq_vj->accessible(vehicle_props)) {
                 continue;
@@ -202,7 +202,7 @@ static std::pair<const type::StopTime*, DateTime> previous_valid_frequency(const
 
     while (best.first == nullptr && base_dt >= bound) {
         for (const auto& freq_vj : jp.freq_vjs) {
-            const auto& st = freq_vj->stop_time_list[jpp.order];
+            const auto& st = freq_vj->stop_time_list[jpp.order.val];
 
             if (!freq_vj->accessible(vehicle_props)) {
                 continue;

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -263,7 +263,7 @@ std::vector<VehicleSection> get_vjs(const Journey::Section& section) {
     DateTime current_dep;
     DateTime current_arr;
 
-    size_t order = current_st->order();
+    auto order = current_st->order();
     for (const auto* vj = current_st->vehicle_journey; vj; vj = vj->next_vj) {
         if (!res.empty()) {
             // only update base_dt for vj extensions
@@ -272,7 +272,7 @@ std::vector<VehicleSection> get_vjs(const Journey::Section& section) {
         res.emplace_back(section, current_st->vehicle_journey);
 
         for (const auto& st :
-             boost::make_iterator_range(vj->stop_time_list.begin() + order, vj->stop_time_list.end())) {
+             boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
             current_dep = st.departure(base_dt);
             current_arr = st.arrival(base_dt);
             res.back().stop_times_and_dt.emplace_back(st, current_dep + st.get_boarding_duration(),
@@ -282,7 +282,7 @@ std::vector<VehicleSection> get_vjs(const Journey::Section& section) {
                 return res;
             }
         }
-        order = 0;  // for the stay in vj's, we start from the first stop time
+        order = Rank<type::StopTime>(0);  // for the stay in vj's, we start from the first stop time
     }
     throw navitia::recoverable_exception("impossible to rebuild path");
 }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -282,7 +282,7 @@ std::vector<VehicleSection> get_vjs(const Journey::Section& section) {
                 return res;
             }
         }
-        order = Rank<type::StopTime>(0);  // for the stay in vj's, we start from the first stop time
+        order = type::RankStopTime(0);  // for the stay in vj's, we start from the first stop time
     }
     throw navitia::recoverable_exception("impossible to rebuild path");
 }

--- a/source/routing/raptor_visitors.h
+++ b/source/routing/raptor_visitors.h
@@ -22,7 +22,7 @@ struct raptor_visitor {
 
     inline stop_time_range st_range(const type::StopTime& st) const {
         const type::VehicleJourney* vj = st.vehicle_journey;
-        return boost::make_iterator_range(vj->stop_time_list.begin() + st.order(), vj->stop_time_list.end());
+        return boost::make_iterator_range(vj->stop_time_list.begin() + st.order().val, vj->stop_time_list.end());
     }
 
     template <typename T1, typename T2>
@@ -77,7 +77,7 @@ struct raptor_reverse_visitor {
 
     inline stop_time_range st_range(const type::StopTime& st) const {
         const type::VehicleJourney* vj = st.vehicle_journey;
-        return boost::make_iterator_range(vj->stop_time_list.rbegin() + vj->stop_time_list.size() - st.order() - 1,
+        return boost::make_iterator_range(vj->stop_time_list.rbegin() + vj->stop_time_list.size() - st.order().val - 1,
                                           vj->stop_time_list.rend());
     }
 

--- a/source/routing/tests/get_stop_times_test.cpp
+++ b/source/routing/tests/get_stop_times_test.cpp
@@ -62,17 +62,17 @@ BOOST_AUTO_TEST_CASE(test1) {
                                  navitia::DateTimeUtils::set(1, 0), 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == 0; }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(0); }));
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == 1; }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(1); }));
 
     result = get_stop_times(StopEvent::drop_off, jpps, navitia::DateTimeUtils::set(0, 86399),
                             navitia::DateTimeUtils::min, 100, *b.data, nt::RTLevel::Base, {});
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == 1; }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(1); }));
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == 2; }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(2); }));
 }
 
 /**

--- a/source/routing/tests/get_stop_times_test.cpp
+++ b/source/routing/tests/get_stop_times_test.cpp
@@ -62,17 +62,17 @@ BOOST_AUTO_TEST_CASE(test1) {
                                  navitia::DateTimeUtils::set(1, 0), 100, *b.data, nt::RTLevel::Base);
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(0); }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == nt::RankStopTime(0); }));
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(1); }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == nt::RankStopTime(1); }));
 
     result = get_stop_times(StopEvent::drop_off, jpps, navitia::DateTimeUtils::set(0, 86399),
                             navitia::DateTimeUtils::min, 100, *b.data, nt::RTLevel::Base, {});
     BOOST_REQUIRE_EQUAL(result.size(), 2);
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(1); }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == nt::RankStopTime(1); }));
     BOOST_CHECK(std::any_of(result.begin(), result.end(),
-                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == Rank<nt::StopTime>(2); }));
+                            [](datetime_stop_time& dt_st) { return dt_st.second->order() == nt::RankStopTime(2); }));
 }
 
 /**

--- a/source/routing/tests/journey_pattern_container_test.cpp
+++ b/source/routing/tests/journey_pattern_container_test.cpp
@@ -53,16 +53,16 @@ static void check_vj(const nr::JourneyPatternContainer& jp_container,
     BOOST_CHECK_EQUAL(jp_container.get_jp_from_vj()[nr::VjIdx(vj)], jp.first);
 
     // jpps checks
-    uint16_t order = 0;
+    navitia::Rank<nr::JourneyPatternPoint> order(0);
     BOOST_REQUIRE_EQUAL(jp.second.jpps.size(), vj.stop_time_list.size());
     for (const auto& jpp_idx : jp.second.jpps) {
         const auto& jpp = jp_container.get(jpp_idx);
-        BOOST_CHECK_EQUAL(jpp.order, order);                                            // order is coherent
-        BOOST_CHECK_EQUAL(jpp.jp_idx, jp.first);                                        // jpp.jp_idx is coherent
-        BOOST_CHECK_EQUAL(jp_container.get_jpp(vj.stop_time_list.at(order)), jpp_idx);  // st->jpp
+        BOOST_CHECK_EQUAL(jpp.order, order);                                                // order is coherent
+        BOOST_CHECK_EQUAL(jpp.jp_idx, jp.first);                                            // jpp.jp_idx is coherent
+        BOOST_CHECK_EQUAL(jp_container.get_jpp(vj.stop_time_list.at(order.val)), jpp_idx);  // st->jpp
 
         // stop point of the jpp is coherent with the vj
-        BOOST_CHECK_EQUAL(jpp.sp_idx, nr::SpIdx(*vj.stop_time_list.at(order).stop_point));
+        BOOST_CHECK_EQUAL(jpp.sp_idx, nr::SpIdx(*vj.stop_time_list.at(order.val).stop_point));
         ++order;
     }
 }

--- a/source/routing/tests/journey_pattern_container_test.cpp
+++ b/source/routing/tests/journey_pattern_container_test.cpp
@@ -53,16 +53,16 @@ static void check_vj(const nr::JourneyPatternContainer& jp_container,
     BOOST_CHECK_EQUAL(jp_container.get_jp_from_vj()[nr::VjIdx(vj)], jp.first);
 
     // jpps checks
-    navitia::Rank<nr::JourneyPatternPoint> order(0);
+    nr::RankJourneyPatternPoint order(0);
     BOOST_REQUIRE_EQUAL(jp.second.jpps.size(), vj.stop_time_list.size());
     for (const auto& jpp_idx : jp.second.jpps) {
         const auto& jpp = jp_container.get(jpp_idx);
-        BOOST_CHECK_EQUAL(jpp.order, order);                                                // order is coherent
-        BOOST_CHECK_EQUAL(jpp.jp_idx, jp.first);                                            // jpp.jp_idx is coherent
-        BOOST_CHECK_EQUAL(jp_container.get_jpp(vj.stop_time_list.at(order.val)), jpp_idx);  // st->jpp
+        BOOST_CHECK_EQUAL(jpp.order, order);      // order is coherent
+        BOOST_CHECK_EQUAL(jpp.jp_idx, jp.first);  // jpp.jp_idx is coherent
+        BOOST_CHECK_EQUAL(jp_container.get_jpp(vj.get_corresponding_stop_time(order)), jpp_idx);  // st->jpp
 
         // stop point of the jpp is coherent with the vj
-        BOOST_CHECK_EQUAL(jpp.sp_idx, nr::SpIdx(*vj.stop_time_list.at(order.val).stop_point));
+        BOOST_CHECK_EQUAL(jpp.sp_idx, nr::SpIdx(*vj.get_corresponding_stop_time(order).stop_point));
         ++order;
     }
 }

--- a/source/routing/tests/journey_pattern_container_test.cpp
+++ b/source/routing/tests/journey_pattern_container_test.cpp
@@ -59,10 +59,10 @@ static void check_vj(const nr::JourneyPatternContainer& jp_container,
         const auto& jpp = jp_container.get(jpp_idx);
         BOOST_CHECK_EQUAL(jpp.order, order);      // order is coherent
         BOOST_CHECK_EQUAL(jpp.jp_idx, jp.first);  // jpp.jp_idx is coherent
-        BOOST_CHECK_EQUAL(jp_container.get_jpp(vj.get_corresponding_stop_time(order)), jpp_idx);  // st->jpp
+        BOOST_CHECK_EQUAL(jp_container.get_jpp(get_corresponding_stop_time(vj, order)), jpp_idx);  // st->jpp
 
         // stop point of the jpp is coherent with the vj
-        BOOST_CHECK_EQUAL(jpp.sp_idx, nr::SpIdx(*vj.get_corresponding_stop_time(order).stop_point));
+        BOOST_CHECK_EQUAL(jpp.sp_idx, nr::SpIdx(*get_corresponding_stop_time(vj, order).stop_point));
         ++order;
     }
 }

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -76,7 +76,7 @@ struct PassagesVisitor {
                 }
                 return jpp_idx == jp.jpps.back();
             case StopEvent::drop_off:
-                return jpp.order == 0;
+                return jpp.order == navitia::Rank<navitia::routing::JourneyPatternPoint>(0);
         }
     }
 };

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -76,7 +76,7 @@ struct PassagesVisitor {
                 }
                 return jpp_idx == jp.jpps.back();
             case StopEvent::drop_off:
-                return jpp.order == navitia::Rank<navitia::routing::JourneyPatternPoint>(0);
+                return jpp.order == navitia::routing::RankJourneyPatternPoint(0);
         }
     }
 };

--- a/source/type/comment_container.h
+++ b/source/type/comment_container.h
@@ -29,7 +29,6 @@ www.navitia.io
 */
 
 #include "utils/serialization_fusion_map.h"
-#include "utils/rank.h"
 #include "type/fwd_type.h"
 #include <vector>
 #include <map>
@@ -76,7 +75,7 @@ private:
     template <typename T>
     using fusion_pair_comment_map = boost::fusion::pair<T, pt_object_comment_map<T>>;
 
-    using stop_time_key = std::pair<const navitia::type::VehicleJourney*, Rank<StopTime>>;
+    using stop_time_key = std::pair<const navitia::type::VehicleJourney*, RankStopTime>;
 
     template <typename T>
     const T* get_as_key(const T& obj) const {

--- a/source/type/comment_container.h
+++ b/source/type/comment_container.h
@@ -29,6 +29,7 @@ www.navitia.io
 */
 
 #include "utils/serialization_fusion_map.h"
+#include "utils/rank.h"
 #include "type/fwd_type.h"
 #include <vector>
 #include <map>
@@ -75,7 +76,7 @@ private:
     template <typename T>
     using fusion_pair_comment_map = boost::fusion::pair<T, pt_object_comment_map<T>>;
 
-    using stop_time_key = std::pair<const navitia::type::VehicleJourney*, uint16_t>;
+    using stop_time_key = std::pair<const navitia::type::VehicleJourney*, Rank<StopTime>>;
 
     template <typename T>
     const T* get_as_key(const T& obj) const {

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -29,13 +29,13 @@ www.navitia.io
 */
 #pragma once
 
-#include "utils/rank.h"
-
 // forward declare
 //
 template <class DATATYPE, class ELEMTYPE, int NUMDIMS, class ELEMTYPEREAL, int TMAXNODES, int TMINNODES>
 class RTree;
 namespace navitia {
+template <typename T>
+struct Rank;
 namespace georef {
 struct GeoRef;
 struct POI;

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -29,6 +29,8 @@ www.navitia.io
 */
 #pragma once
 
+#include "utils/rank.h"
+
 // forward declare
 //
 template <class DATATYPE, class ELEMTYPE, int NUMDIMS, class ELEMTYPEREAL, int TMAXNODES, int TMINNODES>
@@ -61,6 +63,7 @@ struct ValidityPattern;
 struct Route;
 struct VehicleJourney;
 struct StopTime;
+using RankStopTime = Rank<StopTime>;
 struct Dataset;
 struct StopPoint;
 struct ExceptionDate;

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -130,7 +130,7 @@ bool HeadsignHandler::has_headsign_or_name(const VehicleJourney& vj, const std::
         return false;
     }
 
-    auto has_headsign = [&](const std::pair<Rank<StopTime>, std::string>& it_change) {
+    auto has_headsign = [&](const std::pair<RankStopTime, std::string>& it_change) {
         return it_change.second == headsign;
     };
     if (navitia::contains_if(it_vj_changes->second, has_headsign)) {

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -84,7 +84,7 @@ const std::string& HeadsignHandler::get_headsign(const StopTime& stop_time) cons
 
     // otherwise use headsign change map
     const auto& map_stop_time_headsign_change = headsign_changes.at(stop_time.vehicle_journey);
-    uint16_t order_stop_time = stop_time.order();
+    auto order_stop_time = stop_time.order();
 
     // if no headsign change stored: return name
     if (map_stop_time_headsign_change.empty()) {
@@ -113,7 +113,7 @@ std::set<std::string> HeadsignHandler::get_all_headsigns(const VehicleJourney* v
     }
     for (const auto& change : it_changes->second) {
         // ignore last headsign (vj.name) as it does not concern a stop_time
-        if (change.first < vj->stop_time_list.size()) {
+        if (change.first.val < vj->stop_time_list.size()) {
             res.insert(change.second);
         }
     }
@@ -130,7 +130,9 @@ bool HeadsignHandler::has_headsign_or_name(const VehicleJourney& vj, const std::
         return false;
     }
 
-    auto has_headsign = [&](const std::pair<uint16_t, std::string>& it_change) { return it_change.second == headsign; };
+    auto has_headsign = [&](const std::pair<Rank<StopTime>, std::string>& it_change) {
+        return it_change.second == headsign;
+    };
     if (navitia::contains_if(it_vj_changes->second, has_headsign)) {
         return true;
     }
@@ -162,7 +164,7 @@ void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time, co
         return;
     }
 
-    uint16_t order = stop_time.order();
+    auto order = stop_time.order();
     auto& vj_headsign_changes = headsign_changes[vj];
     // erase change if exists
     if (navitia::contains(vj_headsign_changes, order)) {
@@ -192,10 +194,10 @@ void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time, co
 }
 
 void HeadsignHandler::forget_vj(const VehicleJourney*) {
-    // actually we never wants to forget vj
+    // currently we never want to forget VJ
     // it would be MANDATORY to do it if we added realtime vjs to the headsigns handler,
     // but for the moment we only index base schedule VJ
-    // if that change be sure to add the mechanism here to remove the useless VJ before we delete it
+    // if that changes be sure to add the mechanism here to remove the useless VJ before we delete it
 }
 
 }  // namespace type

--- a/source/type/headsign_handler.h
+++ b/source/type/headsign_handler.h
@@ -29,6 +29,7 @@ www.navitia.io
 */
 
 #include "type/fwd_type.h"
+#include "utils/rank.h"
 #include <boost/container/flat_map.hpp>
 #include <unordered_map>
 #include <unordered_set>
@@ -73,7 +74,7 @@ protected:
     // stop times       : 1 2 3 4 5 6 7 8 (potential 9)
     // headsigns        : A A A B B C B B
     // headsign_changes :       B   C B   A
-    std::unordered_map<const VehicleJourney*, boost::container::flat_map<uint16_t, std::string>> headsign_changes;
+    std::unordered_map<const VehicleJourney*, boost::container::flat_map<Rank<StopTime>, std::string>> headsign_changes;
     // headsign to meta-vj map
     std::unordered_map<std::string, std::unordered_set<const MetaVehicleJourney*>> headsign_mvj;
 };

--- a/source/type/headsign_handler.h
+++ b/source/type/headsign_handler.h
@@ -29,7 +29,6 @@ www.navitia.io
 */
 
 #include "type/fwd_type.h"
-#include "utils/rank.h"
 #include <boost/container/flat_map.hpp>
 #include <unordered_map>
 #include <unordered_set>
@@ -74,7 +73,7 @@ protected:
     // stop times       : 1 2 3 4 5 6 7 8 (potential 9)
     // headsigns        : A A A B B C B B
     // headsign_changes :       B   C B   A
-    std::unordered_map<const VehicleJourney*, boost::container::flat_map<Rank<StopTime>, std::string>> headsign_changes;
+    std::unordered_map<const VehicleJourney*, boost::container::flat_map<RankStopTime, std::string>> headsign_changes;
     // headsign to meta-vj map
     std::unordered_map<std::string, std::unordered_set<const MetaVehicleJourney*>> headsign_mvj;
 };

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -266,7 +266,7 @@ bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
             if (idx.val >= nb_aux) {
                 return true;
             }
-            const auto& amended_st = aux_info.stop_times.at(idx.val).stop_time;
+            const auto& amended_st = aux_info.get_stop_time_update(idx).stop_time;
             if (base_st->arrival_time != amended_st.arrival_time) {
                 return true;
             }
@@ -347,7 +347,7 @@ std::set<StopPoint*> LineSection::get_stop_points_section() const {
                 return true;
             } else {
                 for (const auto& rank : ranks) {
-                    res.insert(vj.stop_time_list.at(rank.val).stop_point);
+                    res.insert(vj.get_stop_time(rank).stop_point);
                 }
             }
             return false;

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -263,10 +263,10 @@ bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
                 return true;
             }
             const auto idx = base_st->order();
-            if (idx >= nb_aux) {
+            if (idx.val >= nb_aux) {
                 return true;
             }
-            const auto& amended_st = aux_info.stop_times.at(idx).stop_time;
+            const auto& amended_st = aux_info.stop_times.at(idx.val).stop_time;
             if (base_st->arrival_time != amended_st.arrival_time) {
                 return true;
             }
@@ -347,7 +347,7 @@ std::set<StopPoint*> LineSection::get_stop_points_section() const {
                 return true;
             } else {
                 for (const auto& rank : ranks) {
-                    res.insert(vj.stop_time_list.at(rank).stop_point);
+                    res.insert(vj.stop_time_list.at(rank.val).stop_point);
                 }
             }
             return false;

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -41,6 +41,7 @@ www.navitia.io
 #include <set>
 
 #include "utils/exception.h"
+#include "utils/rank.h"
 
 #include "type/type_interfaces.h"
 #include "type/fwd_type.h"
@@ -411,8 +412,8 @@ public:
 struct ImpactedVJ {
     const VehicleJourney* vj;  // vj before impact
     ValidityPattern new_vp;
-    std::set<uint16_t> impacted_ranks;
-    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<uint16_t> r)
+    std::set<Rank<StopTime>> impacted_ranks;
+    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<Rank<StopTime>> r)
         : vj(vj), new_vp(vp), impacted_ranks(std::move(r)) {}
 };
 /*

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -41,7 +41,6 @@ www.navitia.io
 #include <set>
 
 #include "utils/exception.h"
-#include "utils/rank.h"
 
 #include "type/type_interfaces.h"
 #include "type/fwd_type.h"
@@ -263,6 +262,7 @@ struct AuxInfoForMetaVJ {
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);
+    const StopTimeUpdate& get_stop_time_update(const RankStopTime& order) const { return stop_times.at(order.val); }
 };
 }  // namespace detail
 
@@ -412,8 +412,8 @@ public:
 struct ImpactedVJ {
     const VehicleJourney* vj;  // vj before impact
     ValidityPattern new_vp;
-    std::set<Rank<StopTime>> impacted_ranks;
-    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<Rank<StopTime>> r)
+    std::set<RankStopTime> impacted_ranks;
+    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<RankStopTime> r)
         : vj(vj), new_vp(vp), impacted_ranks(std::move(r)) {}
 };
 /*

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1005,7 +1005,7 @@ void PbCreator::Filler::fill_pb_object(const jp_pair* jp, pbnavitia::JourneyPatt
 
 void PbCreator::Filler::fill_pb_object(const jpp_pair* jpp, pbnavitia::JourneyPatternPoint* journey_pattern_point) {
     journey_pattern_point->set_uri(pb_creator.data->dataRaptor->jp_container.get_id(jpp->first));
-    journey_pattern_point->set_order(jpp->second.order);
+    journey_pattern_point->set_order(jpp->second.order.val);
 
     if (depth > 0) {
         fill(pb_creator.data->pt_data->stop_points[jpp->second.sp_idx.val], journey_pattern_point);

--- a/source/type/stop_time.h
+++ b/source/type/stop_time.h
@@ -77,14 +77,14 @@ struct StopTime {
     inline void set_odt(bool value) { properties[ODT] = value; }
     inline void set_is_frequency(bool value) { properties[IS_FREQUENCY] = value; }
     inline void set_date_time_estimated(bool value) { properties[DATE_TIME_ESTIMATED] = value; }
-    inline uint16_t order() const {
+    inline Rank<StopTime> order() const {
         static_assert(std::is_same<decltype(vehicle_journey->stop_time_list), std::vector<StopTime>>::value,
                       "vehicle_journey->stop_time_list must be a std::vector<StopTime>");
         assert(vehicle_journey);
         // as vehicle_journey->stop_time_list is a vector, pointer
         // arithmetic gives us the order of the stop time in the
         // vector.
-        return this - &vehicle_journey->stop_time_list.front();
+        return Rank<StopTime>(this - &vehicle_journey->stop_time_list.front());
     }
 
     StopTime clone() const;

--- a/source/type/stop_time.h
+++ b/source/type/stop_time.h
@@ -77,14 +77,14 @@ struct StopTime {
     inline void set_odt(bool value) { properties[ODT] = value; }
     inline void set_is_frequency(bool value) { properties[IS_FREQUENCY] = value; }
     inline void set_date_time_estimated(bool value) { properties[DATE_TIME_ESTIMATED] = value; }
-    inline Rank<StopTime> order() const {
+    inline RankStopTime order() const {
         static_assert(std::is_same<decltype(vehicle_journey->stop_time_list), std::vector<StopTime>>::value,
                       "vehicle_journey->stop_time_list must be a std::vector<StopTime>");
         assert(vehicle_journey);
         // as vehicle_journey->stop_time_list is a vector, pointer
         // arithmetic gives us the order of the stop time in the
         // vector.
-        return Rank<StopTime>(this - &vehicle_journey->stop_time_list.front());
+        return RankStopTime(this - &vehicle_journey->stop_time_list.front());
     }
 
     StopTime clone() const;

--- a/source/type/stop_time.h
+++ b/source/type/stop_time.h
@@ -35,6 +35,7 @@ www.navitia.io
 #include "type/rt_level.h"
 #include "type/datetime.h"
 #include "type/vehicle_journey.h"  //required to inline order()
+#include "utils/rank.h"
 
 namespace navitia {
 namespace type {

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -110,7 +110,8 @@ BOOST_FIXTURE_TEST_CASE(headsign_handler_functionnal_test, HeadsignFixture) {
 }
 
 struct HeadsignHandlerTest : nt::HeadsignHandler {
-    const std::unordered_map<const nt::VehicleJourney*, boost::container::flat_map<uint16_t, std::string>>&
+    const std::unordered_map<const nt::VehicleJourney*,
+                             boost::container::flat_map<navitia::Rank<nt::StopTime>, std::string>>&
     get_headsign_changes() const {
         return headsign_changes;
     }

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -110,8 +110,7 @@ BOOST_FIXTURE_TEST_CASE(headsign_handler_functionnal_test, HeadsignFixture) {
 }
 
 struct HeadsignHandlerTest : nt::HeadsignHandler {
-    const std::unordered_map<const nt::VehicleJourney*,
-                             boost::container::flat_map<navitia::Rank<nt::StopTime>, std::string>>&
+    const std::unordered_map<const nt::VehicleJourney*, boost::container::flat_map<nt::RankStopTime, std::string>>&
     get_headsign_changes() const {
         return headsign_changes;
     }

--- a/source/type/tests/test.cpp
+++ b/source/type/tests/test.cpp
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(get_sections_ranks) {
 
     auto sa = [&](const std::string& id) { return b.get<type::StopArea>(id); };
 
-    using rst = Rank<StopTime>;
+    using rst = RankStopTime;
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //       *
     BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("1")), std::set<rst>({rst(2)}));

--- a/source/type/tests/test.cpp
+++ b/source/type/tests/test.cpp
@@ -239,27 +239,30 @@ BOOST_AUTO_TEST_CASE(get_sections_ranks) {
 
     auto sa = [&](const std::string& id) { return b.get<type::StopArea>(id); };
 
+    using rst = Rank<StopTime>;
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //       *
-    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("1")), std::set<uint16_t>({2}));
+    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("1")), std::set<rst>({rst(2)}));
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //       ********
-    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("3")), std::set<uint16_t>({2, 3, 4, 5}));
+    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("1"), sa("3")), std::set<rst>({rst(2), rst(3), rst(4), rst(5)}));
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //
     // 4 is after 0 -> empty
-    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("4"), sa("0")), std::set<uint16_t>({}));
+    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("4"), sa("0")), std::set<rst>());
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     // ** **   **     ** ** **
     // route point, only the corresponding stop point
-    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("0")), std::set<uint16_t>({0, 1, 3, 6, 7, 8}));
+    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("0")),
+                      std::set<rst>({rst(0), rst(1), rst(3), rst(6), rst(7), rst(8)}));
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //         ******
     // shortest sections, thus we don't have 1
-    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("3")), std::set<uint16_t>({3, 4, 5}));
+    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("3")), std::set<rst>({rst(3), rst(4), rst(5)}));
     // 0a 0b 1 0a 2 3 0a 0b 0c 4 2 5 2
     //         ****   ************
     // shortest sections, thus we don't have 1, 3 and 5
     // We still have 0a 0b 0c in the second section since they are in the same area
-    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("2")), std::set<uint16_t>({3, 4, 6, 7, 8, 9, 10}));
+    BOOST_CHECK_EQUAL(vj->get_sections_ranks(sa("0"), sa("2")),
+                      std::set<rst>({rst(3), rst(4), rst(6), rst(7), rst(8), rst(9), rst(10)}));
 }

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -233,10 +233,6 @@ const StopTime& VehicleJourney::get_stop_time(const RankStopTime& order) const {
     return stop_time_list.at(order.val);
 }
 
-const StopTime& VehicleJourney::get_corresponding_stop_time(const routing::RankJourneyPatternPoint& jpp_order) const {
-    return stop_time_list.at(jpp_order.val);
-}
-
 std::set<RankStopTime> VehicleJourney::get_sections_ranks(const StopArea* start_sa, const StopArea* end_sa) const {
     /*
      * Identify all the smallest sections starting with start_sa and

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -199,7 +199,7 @@ ValidityPattern VehicleJourney::get_vp_of_sp(const StopPoint& sp,
     return vp_for_stop_time;
 }
 
-ValidityPattern VehicleJourney::get_vp_for_section(const std::set<uint16_t>& section,
+ValidityPattern VehicleJourney::get_vp_for_section(const std::set<Rank<StopTime>>& section,
                                                    RTLevel rt_level,
                                                    const boost::posix_time::time_period& period) const {
     ValidityPattern vp_for_section{validity_patterns[rt_level]->beginning_date};
@@ -229,7 +229,7 @@ ValidityPattern VehicleJourney::get_vp_for_section(const std::set<uint16_t>& sec
     return vp_for_section;
 }
 
-std::set<uint16_t> VehicleJourney::get_sections_ranks(const StopArea* start_sa, const StopArea* end_sa) const {
+std::set<Rank<StopTime>> VehicleJourney::get_sections_ranks(const StopArea* start_sa, const StopArea* end_sa) const {
     /*
      * Identify all the smallest sections starting with start_sa and
      * ending with end_sa. Then we return the list of ranks
@@ -278,8 +278,8 @@ std::set<uint16_t> VehicleJourney::get_sections_ranks(const StopArea* start_sa, 
      *  - s1/s2 from the 5th to the 10th,
      *  - s1/s2/s5 from the 11th to the 15th
      * */
-    std::set<uint16_t> res;
-    boost::optional<uint16_t> section_start_rank;
+    std::set<Rank<StopTime>> res;
+    boost::optional<Rank<StopTime>> section_start_rank;
     bool section_starting = false, section_ending = false;
     const auto* base_vj = this->get_corresponding_base();
     const auto* vj = base_vj ? base_vj : this;
@@ -293,7 +293,7 @@ std::set<uint16_t> VehicleJourney::get_sections_ranks(const StopArea* start_sa, 
         // Must close section before potentially starting a new one
         // Keep going if where are still in the end stop area
         if (section_ending && end_sa->idx != sa->idx) {
-            for (uint16_t i = *section_start_rank, last = st.order() - 1; i <= last; ++i) {
+            for (auto i = *section_start_rank, last = st.order() - 1; i <= last; ++i) {
                 res.insert(i);
             }
             // the section is finished, we are no more in a section
@@ -324,7 +324,7 @@ std::set<uint16_t> VehicleJourney::get_sections_ranks(const StopArea* start_sa, 
 
     // Must close a potential section
     if (section_ending) {
-        for (uint16_t i = *section_start_rank; i <= vj->stop_time_list.size() - 1; ++i) {
+        for (auto i = *section_start_rank; i <= Rank<StopTime>(vj->stop_time_list.size() - 1); ++i) {
             res.insert(i);
         }
     }

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -301,7 +301,7 @@ std::set<RankStopTime> VehicleJourney::get_sections_ranks(const StopArea* start_
         // Must close section before potentially starting a new one
         // Keep going if where are still in the end stop area
         if (section_ending && end_sa->idx != sa->idx) {
-            for (auto i = *section_start_rank, last = st.order() - 1; i <= last; ++i) {
+            for (auto i = *section_start_rank; i < st.order(); ++i) {
                 res.insert(i);
             }
             // the section is finished, we are no more in a section
@@ -332,7 +332,7 @@ std::set<RankStopTime> VehicleJourney::get_sections_ranks(const StopArea* start_
 
     // Must close a potential section
     if (section_ending) {
-        for (auto i = *section_start_rank; i <= RankStopTime(vj->stop_time_list.size() - 1); ++i) {
+        for (auto i = *section_start_rank; i < RankStopTime(vj->stop_time_list.size()); ++i) {
             res.insert(i);
         }
     }

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -199,7 +199,7 @@ ValidityPattern VehicleJourney::get_vp_of_sp(const StopPoint& sp,
     return vp_for_stop_time;
 }
 
-ValidityPattern VehicleJourney::get_vp_for_section(const std::set<Rank<StopTime>>& section,
+ValidityPattern VehicleJourney::get_vp_for_section(const std::set<RankStopTime>& section,
                                                    RTLevel rt_level,
                                                    const boost::posix_time::time_period& period) const {
     ValidityPattern vp_for_section{validity_patterns[rt_level]->beginning_date};
@@ -229,7 +229,15 @@ ValidityPattern VehicleJourney::get_vp_for_section(const std::set<Rank<StopTime>
     return vp_for_section;
 }
 
-std::set<Rank<StopTime>> VehicleJourney::get_sections_ranks(const StopArea* start_sa, const StopArea* end_sa) const {
+const StopTime& VehicleJourney::get_stop_time(const RankStopTime& order) const {
+    return stop_time_list.at(order.val);
+}
+
+const StopTime& VehicleJourney::get_corresponding_stop_time(const routing::RankJourneyPatternPoint& jpp_order) const {
+    return stop_time_list.at(jpp_order.val);
+}
+
+std::set<RankStopTime> VehicleJourney::get_sections_ranks(const StopArea* start_sa, const StopArea* end_sa) const {
     /*
      * Identify all the smallest sections starting with start_sa and
      * ending with end_sa. Then we return the list of ranks
@@ -278,8 +286,8 @@ std::set<Rank<StopTime>> VehicleJourney::get_sections_ranks(const StopArea* star
      *  - s1/s2 from the 5th to the 10th,
      *  - s1/s2/s5 from the 11th to the 15th
      * */
-    std::set<Rank<StopTime>> res;
-    boost::optional<Rank<StopTime>> section_start_rank;
+    std::set<RankStopTime> res;
+    boost::optional<RankStopTime> section_start_rank;
     bool section_starting = false, section_ending = false;
     const auto* base_vj = this->get_corresponding_base();
     const auto* vj = base_vj ? base_vj : this;
@@ -324,7 +332,7 @@ std::set<Rank<StopTime>> VehicleJourney::get_sections_ranks(const StopArea* star
 
     // Must close a potential section
     if (section_ending) {
-        for (auto i = *section_start_rank; i <= Rank<StopTime>(vj->stop_time_list.size() - 1); ++i) {
+        for (auto i = *section_start_rank; i <= RankStopTime(vj->stop_time_list.size() - 1); ++i) {
             res.insert(i);
         }
     }

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -37,11 +37,6 @@ www.navitia.io
 #include <boost/serialization/split_member.hpp>
 
 namespace navitia {
-
-namespace routing {
-using RankJourneyPatternPoint = Rank<JourneyPatternPoint>;
-}
-
 namespace type {
 
 // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1
@@ -138,7 +133,6 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
                                        const boost::posix_time::time_period& period) const;
 
     const StopTime& get_stop_time(const RankStopTime& order) const;
-    const StopTime& get_corresponding_stop_time(const routing::RankJourneyPatternPoint& jpp_order) const;
 
     // return all the sections of the base vj between the 2 stop areas
     std::set<RankStopTime> get_sections_ranks(const StopArea*, const StopArea*) const;

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -33,9 +33,9 @@ www.navitia.io
 #include "type/fwd_type.h"
 #include "type/rt_level.h"
 #include "validity_pattern.h"
-#include "utils/rank.h"
 #include <set>
 #include <boost/serialization/split_member.hpp>
+#include "routing/journey_pattern_container.h"
 
 namespace navitia {
 namespace type {
@@ -129,12 +129,15 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
                                  const boost::posix_time::time_period& period) const;
 
     // Return the vp for all the stops of the section
-    ValidityPattern get_vp_for_section(const std::set<Rank<StopTime>>& bounds_st,
+    ValidityPattern get_vp_for_section(const std::set<RankStopTime>& bounds_st,
                                        RTLevel rt_level,
                                        const boost::posix_time::time_period& period) const;
 
+    const StopTime& get_stop_time(const RankStopTime& order) const;
+    const StopTime& get_corresponding_stop_time(const routing::RankJourneyPatternPoint& jpp_order) const;
+
     // return all the sections of the base vj between the 2 stop areas
-    std::set<Rank<StopTime>> get_sections_ranks(const StopArea*, const StopArea*) const;
+    std::set<RankStopTime> get_sections_ranks(const StopArea*, const StopArea*) const;
 
     // return the time period of circulation of the vj for one day
     boost::posix_time::time_period execution_period(const boost::gregorian::date& date) const;

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -33,6 +33,7 @@ www.navitia.io
 #include "type/fwd_type.h"
 #include "type/rt_level.h"
 #include "validity_pattern.h"
+#include "utils/rank.h"
 #include <set>
 #include <boost/serialization/split_member.hpp>
 
@@ -128,12 +129,12 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
                                  const boost::posix_time::time_period& period) const;
 
     // Return the vp for all the stops of the section
-    ValidityPattern get_vp_for_section(const std::set<uint16_t>& bounds_st,
+    ValidityPattern get_vp_for_section(const std::set<Rank<StopTime>>& bounds_st,
                                        RTLevel rt_level,
                                        const boost::posix_time::time_period& period) const;
 
     // return all the sections of the base vj between the 2 stop areas
-    std::set<uint16_t> get_sections_ranks(const StopArea*, const StopArea*) const;
+    std::set<Rank<StopTime>> get_sections_ranks(const StopArea*, const StopArea*) const;
 
     // return the time period of circulation of the vj for one day
     boost::posix_time::time_period execution_period(const boost::gregorian::date& date) const;

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -35,9 +35,13 @@ www.navitia.io
 #include "validity_pattern.h"
 #include <set>
 #include <boost/serialization/split_member.hpp>
-#include "routing/journey_pattern_container.h"
 
 namespace navitia {
+
+namespace routing {
+using RankJourneyPatternPoint = Rank<JourneyPatternPoint>;
+}
+
 namespace type {
 
 // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1


### PR DESCRIPTION
After https://github.com/CanalTP/navitia/pull/2959#discussion_r331155584

For safety and readability, add strong-type for ranks.
:warning: Did not strong-type cache structure `dataRAPTOR::JppsFromSp::Jpp`, though.

:mag: Review by commit+message advised.

TODO (`do_not_merge`):
- [x] Merge #2959 then rebase
- [x] Merge https://github.com/CanalTP/utils/pull/83 then update submodule
- [x] Explore if it is easy and perf-friendly to do the same for JourneyPatternPoint
  > It looks like it does not affect perfs visibly on a local "classic" benchmark_full.