### PR TITLE
[Jormungandr] Update comfort criteria

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -68,7 +68,7 @@ from jormungandr.scenarios.qualifier import (
     has_walk,
     and_filters,
     get_ASAP_journey,
-    comfort,
+    comfort_crit,
 )
 import numpy as np
 import collections
@@ -704,7 +704,7 @@ def type_journeys(resp, req):
     # Then, we want something like the old types
     trip_caracs = [
         # comfort tends to limit the number of transfers and fallback
-        ("comfort", trip_carac([has_no_car], [comfort, best_crit, duration_crit])),
+        ("comfort", trip_carac([has_no_car], [comfort_crit, best_crit, duration_crit])),
         # for car we want at most one journey, the earliest one
         (
             "car",

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -68,6 +68,7 @@ from jormungandr.scenarios.qualifier import (
     has_walk,
     and_filters,
     get_ASAP_journey,
+    comfort,
 )
 import numpy as np
 import collections
@@ -703,7 +704,7 @@ def type_journeys(resp, req):
     # Then, we want something like the old types
     trip_caracs = [
         # comfort tends to limit the number of transfers and fallback
-        ("comfort", trip_carac([has_no_car], [transfers_crit, nonTC_crit, best_crit, duration_crit])),
+        ("comfort", trip_carac([has_no_car], [comfort, best_crit, duration_crit])),
         # for car we want at most one journey, the earliest one
         (
             "car",

--- a/source/jormungandr/jormungandr/scenarios/qualifier.py
+++ b/source/jormungandr/jormungandr/scenarios/qualifier.py
@@ -233,3 +233,19 @@ def duration_crit(j_1, j_2):
 def get_ASAP_journey(journeys, req):
     best_crit = arrival_crit if req["clockwise"] else departure_crit
     return min_from_criteria(journeys, [best_crit, duration_crit, transfers_crit, nonTC_crit])
+
+
+def comfort(j_1, j_2):
+    # this filter tends to limit the nb of transfers
+    # Case 1:
+    #   if j_1 and j_2 have PT sections and nb_transfers ARE NOT equal: return the journey has minimum nb transfer
+    # Case 2:
+    #   if j_1 and j_2 have PT sections and nb_transfers ARE equal: return the journey has minimum non tc duration
+    # Case 3:
+    #   if one of journeys is direct_path: return the journey has minimum non tc duration
+    transfer = compare_minus(j_1.nb_transfers, j_2.nb_transfers)
+    # j_2 has less transfers than j_1 and j_1 has pt sections
+    if transfer != 0 and has_pt(j_1) and has_pt(j_2):
+        return transfer
+    # j_1 is better than j_2 and j_1 is not pt
+    return nonTC_crit(j_1, j_2)

--- a/source/jormungandr/jormungandr/scenarios/qualifier.py
+++ b/source/jormungandr/jormungandr/scenarios/qualifier.py
@@ -230,12 +230,7 @@ def duration_crit(j_1, j_2):
     return compare_minus(j_1.duration, j_2.duration)
 
 
-def get_ASAP_journey(journeys, req):
-    best_crit = arrival_crit if req["clockwise"] else departure_crit
-    return min_from_criteria(journeys, [best_crit, duration_crit, transfers_crit, nonTC_crit])
-
-
-def comfort(j_1, j_2):
+def comfort_crit(j_1, j_2):
     # this filter tends to limit the nb of transfers
     # Case 1:
     #   if j_1 and j_2 have PT sections and nb_transfers ARE NOT equal: return the journey has minimum nb transfer
@@ -243,9 +238,14 @@ def comfort(j_1, j_2):
     #   if j_1 and j_2 have PT sections and nb_transfers ARE equal: return the journey has minimum non tc duration
     # Case 3:
     #   if one of journeys is direct_path: return the journey has minimum non tc duration
+
     transfer = compare_minus(j_1.nb_transfers, j_2.nb_transfers)
-    # j_2 has less transfers than j_1 and j_1 has pt sections
     if transfer != 0 and has_pt(j_1) and has_pt(j_2):
         return transfer
     # j_1 is better than j_2 and j_1 is not pt
     return nonTC_crit(j_1, j_2)
+
+
+def get_ASAP_journey(journeys, req):
+    best_crit = arrival_crit if req["clockwise"] else departure_crit
+    return min_from_criteria(journeys, [best_crit, duration_crit, transfers_crit, nonTC_crit])


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVITIAII-2900

In Scenario distributed, there'll be always a direct_path present in the final response, which make the 'comfort' criteria no longer working. 

In artemis_idfm, the type of certain journeys change from 'comfort' to 'rapid'...   as shown in the ticket.

:warning:  With this PR, Artemis_idfm OK (comfort type), still needs to be tested on Artemis 