### PR TITLE
jormun: migration to python3

### DIFF
--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -40,6 +40,7 @@ import datetime
 import base64
 from navitiacommon.models import User, Instance, Key
 from jormungandr import cache, memory_cache, app as current_app
+import six
 
 
 def authentication_required(func):
@@ -250,7 +251,7 @@ def get_used_coverages():
 
 
 def register_used_coverages(coverages):
-    if hasattr(coverages, '__iter__'):
+    if hasattr(coverages, '__iter__') and not isinstance(coverages, six.text_type):
         g.used_coverages = coverages
     else:
         g.used_coverages = [coverages]

--- a/source/jormungandr/jormungandr/equipments/sytral.py
+++ b/source/jormungandr/jormungandr/equipments/sytral.py
@@ -38,6 +38,7 @@ import pybreaker
 import logging
 import jmespath
 import requests as requests
+import six
 
 
 class SytralProvider(object):
@@ -172,7 +173,7 @@ class SytralProvider(object):
             Because we report equipments on a stop area basis, we  don't want them duplicated
             """
 
-            unique_codes = {unicode(code): code for st in sae.stop_area.stop_points for code in st.codes}
+            unique_codes = {six.text_type(code): code for st in sae.stop_area.stop_points for code in st.codes}
             for code in unique_codes.values():
                 if code.type in self.code_types:
                     equipments_list = jmespath.search("equipments_details[?id=='{}']".format(code.value), data)

--- a/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/equipments/tests/equipment_provider_manager_test.py
@@ -55,7 +55,7 @@ def equipments_provider_manager_env_test():
     manager.init_providers(['SytralRT'])
     assert not manager._equipment_providers
     assert len(manager._equipment_providers_legacy) == 1
-    assert manager._equipment_providers_legacy.keys()[0] == 'SytralRT'
+    assert list(manager._equipment_providers_legacy)[0] == 'SytralRT'
     assert manager._get_providers() == {'SytralRT': 'Provider'}
 
     # Provider already created
@@ -174,7 +174,7 @@ def equipments_provider_manager_env_vs_db_test():
     manager.init_providers(['sytral'])
     assert not manager._equipment_providers
     assert len(manager._equipment_providers_legacy) == 1
-    assert manager._equipment_providers_legacy.keys()[0] == 'sytral'
+    assert list(manager._equipment_providers_legacy)[0] == 'sytral'
 
     # Provider 'sytral' will be created in providers list and deleted from legacy
     manager._providers_getter = providers_getter_ok

--- a/source/jormungandr/jormungandr/init.py
+++ b/source/jormungandr/jormungandr/init.py
@@ -32,6 +32,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
 import os, sys
+from jormungandr import logging_utils  # Imported to be used by configuration, py3 doesn't load it...
 
 """
     Import in this module should be done as late as possible to prevent side effect with the monkey patching

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -89,7 +89,7 @@ class Places(ResourceUri):
         self.parsers["get"].add_argument("q", type=six.text_type, required=True, help="The data to search")
         self.parsers["get"].add_argument(
             "type[]",
-            type=OptionValue(list(places_type.keys())),
+            type=OptionValue(list(places_type)),
             action="append",
             default=["stop_area", "address", "poi", "administrative_region"],
             help="The type of data to search",

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -108,7 +108,7 @@ class BssProviderManager(AbstractProviderManager):
     def _get_providers(self):
         self.update_config()
         # providers from the database have priority on legacies providers
-        return self._bss_providers.values() + self._bss_providers_legacy
+        return list(self._bss_providers.values()) + self._bss_providers_legacy
 
     def get_providers(self):
         return self._get_providers()

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/common_bss_provider.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/common_bss_provider.py
@@ -30,6 +30,7 @@ from jormungandr import new_relic
 from jormungandr.parking_space_availability import AbstractParkingPlacesProvider
 from abc import abstractmethod
 from jormungandr.parking_space_availability.bss.stands import Stands, StandsStatus
+import six
 
 
 class BssProxyError(RuntimeError):
@@ -55,6 +56,6 @@ class CommonBssProvider(AbstractParkingPlacesProvider):
         """
         status can be in: ok, failure
         """
-        params = {'bss_system_id': unicode(self.network), 'status': status}
+        params = {'bss_system_id': six.text_type(self.network), 'status': status}
         params.update(kwargs)
         new_relic.record_custom_event('bss_status', params)

--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -37,6 +37,7 @@ import requests as requests
 from jormungandr import cache, app
 from jormungandr.schedule import RealTimePassage
 from datetime import datetime
+import six
 
 
 class Cleverage(RealtimeProxy):
@@ -183,7 +184,7 @@ class Cleverage(RealtimeProxy):
 
     def status(self):
         return {
-            'id': unicode(self.rt_system_id),
+            'id': six.text_type(self.rt_system_id),
             'timeout': self.timeout,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -234,10 +234,10 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         pass
 
     def record_external_failure(self, message):
-        record_external_failure(message, 'realtime', unicode(self.rt_system_id))
+        record_external_failure(message, 'realtime', six.text_type(self.rt_system_id))
 
     def record_internal_failure(self, message, comment=None):
-        params = {'realtime_system_id': unicode(self.rt_system_id), 'message': message}
+        params = {'realtime_system_id': six.text_type(self.rt_system_id), 'message': message}
         if comment is not None:
             params['comment'] = comment
         new_relic.record_custom_event('realtime_internal_failure', params)
@@ -246,7 +246,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         """
         status can be in: ok, failure
         """
-        params = {'realtime_system_id': unicode(self.rt_system_id), 'status': status}
+        params = {'realtime_system_id': six.text_type(self.rt_system_id), 'status': status}
         params.update(kwargs)
         new_relic.record_custom_event('realtime_status', params)
 
@@ -254,6 +254,6 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         """
         status can be in: ok, failure
         """
-        params = {'realtime_system_id': unicode(self.rt_system_id), 'status': status}
+        params = {'realtime_system_id': six.text_type(self.rt_system_id), 'status': status}
         params.update(kwargs)
         new_relic.record_custom_event('realtime_proxy_additional_info', params)

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -40,6 +40,7 @@ import xml.etree.ElementTree as et
 import aniso8601
 from datetime import datetime
 from flask_restful.inputs import boolean
+import six
 
 
 def to_bool(b):
@@ -179,7 +180,7 @@ class Siri(RealtimeProxy):
 
     def status(self):
         return {
-            'id': unicode(self.rt_system_id),
+            'id': six.text_type(self.rt_system_id),
             'timeout': self.timeout,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,

--- a/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri_lite.py
@@ -37,6 +37,7 @@ import requests as requests
 from jormungandr import cache, app
 from jormungandr.schedule import RealTimePassage
 from datetime import datetime
+import six
 
 
 class SiriLite(RealtimeProxy):
@@ -201,7 +202,7 @@ class SiriLite(RealtimeProxy):
 
     def status(self):
         return {
-            'id': unicode(self.rt_system_id),
+            'id': six.text_type(self.rt_system_id),
             'timeout': self.timeout,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -44,6 +44,7 @@ from navitiacommon.ratelimit import RateLimiter, FakeRateLimiter
 from navitiacommon import type_pb2
 from navitiacommon.parser_args_type import DateTimeFormat
 import redis
+import six
 
 
 class SyntheseRoutePoint(object):
@@ -259,7 +260,7 @@ class Synthese(RealtimeProxy):
 
     def status(self):
         return {
-            'id': unicode(self.rt_system_id),
+            'id': six.text_type(self.rt_system_id),
             'timeout': self.timeout,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -37,6 +37,7 @@ import requests as requests
 from jormungandr import cache, app
 from jormungandr.schedule import RealTimePassage
 import aniso8601
+import six
 
 
 class Sytral(RealtimeProxy):
@@ -89,7 +90,7 @@ class Sytral(RealtimeProxy):
         if not stop_id_list:
             logging.getLogger(__name__).debug(
                 'missing realtime id for {obj}: stop code={s}'.format(obj=route_point, s=stop_id_list),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             self.record_internal_failure('missing id')
             return None
@@ -107,25 +108,26 @@ class Sytral(RealtimeProxy):
         """
         logging.getLogger(__name__).debug(
             'systralRT RT service , call url : {}'.format(self.service_url),
-            extra={'rt_system_id': unicode(self.rt_system_id)},
+            extra={'rt_system_id': six.text_type(self.rt_system_id)},
         )
         try:
             return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
                 'systralRT service dead, using base ' 'schedule (error: {}'.format(e),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error(
                 'systralRT service timeout, using base ' 'schedule (error: {}'.format(t),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('timeout')
         except Exception as e:
             logging.getLogger(__name__).exception(
-                'systralRT RT error, using base schedule', extra={'rt_system_id': unicode(self.rt_system_id)}
+                'systralRT RT error, using base schedule',
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError(str(e))
 
@@ -138,7 +140,7 @@ class Sytral(RealtimeProxy):
 
     def _get_passages(self, route_point, resp):
         logging.getLogger(__name__).debug(
-            'sytralrt response: {}'.format(resp), extra={'rt_system_id': unicode(self.rt_system_id)}
+            'sytralrt response: {}'.format(resp), extra={'rt_system_id': six.text_type(self.rt_system_id)}
         )
 
         # One line navitia can be multiple lines on the SAE side
@@ -168,7 +170,7 @@ class Sytral(RealtimeProxy):
         if r.status_code != requests.codes.ok:
             logging.getLogger(__name__).error(
                 'sytralrt service unavailable, impossible to query : {}'.format(r.url),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('non 200 response')
 
@@ -176,7 +178,7 @@ class Sytral(RealtimeProxy):
 
     def status(self):
         return {
-            'id': unicode(self.rt_system_id),
+            'id': six.text_type(self.rt_system_id),
             'timeout': self.timeout,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -38,6 +38,7 @@ from jormungandr.realtime_schedule.realtime_proxy import RealtimeProxy, Realtime
 from jormungandr.schedule import RealTimePassage
 from datetime import datetime, time
 from navitiacommon.ratelimit import RateLimiter, FakeRateLimiter
+import six
 
 
 def _to_duration(hour_str):
@@ -137,18 +138,18 @@ class Timeo(RealtimeProxy):
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
                 'Timeo RT service dead, using base schedule (error: {}'.format(e),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error(
                 'Timeo RT service timeout, using base schedule (error: {}'.format(t),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('timeout')
         except Exception as e:
             logging.getLogger(__name__).exception(
-                'Timeo RT error, using base schedule', extra={'rt_system_id': unicode(self.rt_system_id)}
+                'Timeo RT error, using base schedule', extra={'rt_system_id': six.text_type(self.rt_system_id)}
             )
             raise RealtimeProxyError(str(e))
 
@@ -171,14 +172,15 @@ class Timeo(RealtimeProxy):
         if self._is_tomorrow(from_dt, current_dt):
             logging.getLogger(__name__).info(
                 'Timeo RT service , Can not call Timeo for tomorrow.',
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             return None
         url = self._make_url(route_point, count, from_dt)
         if not url:
             return None
         logging.getLogger(__name__).debug(
-            'Timeo RT service , call url : {}'.format(url), extra={'rt_system_id': unicode(self.rt_system_id)}
+            'Timeo RT service , call url : {}'.format(url),
+            extra={'rt_system_id': six.text_type(self.rt_system_id)},
         )
         r = self._call_timeo(url)
         if not r:
@@ -187,19 +189,18 @@ class Timeo(RealtimeProxy):
         return self._get_passages(r, current_dt, route_point.fetch_line_uri())
 
     def _get_passages(self, response, current_dt, line_uri=None):
-
         status_code = response.status_code
         timeo_resp = response.json()
 
         logging.getLogger(__name__).debug(
-            'timeo response: {}'.format(timeo_resp), extra={'rt_system_id': unicode(self.rt_system_id)}
+            'timeo response: {}'.format(timeo_resp), extra={'rt_system_id': six.text_type(self.rt_system_id)}
         )
 
         # Handling http error
         if status_code != 200:
             logging.getLogger(__name__).error(
                 'Timeo RT service unavailable, impossible to query : {}'.format(response.url),
-                extra={'rt_system_id': unicode(self.rt_system_id), 'status_code': status_code},
+                extra={'rt_system_id': six.text_type(self.rt_system_id), 'status_code': status_code},
             )
             raise RealtimeProxyError('non 200 response')
 
@@ -230,7 +231,7 @@ class Timeo(RealtimeProxy):
         if not st_responses or len(st_responses) != 1:
             logging.getLogger(__name__).warning(
                 'invalid timeo response: {}'.format(timeo_resp),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('invalid response')
 
@@ -276,7 +277,7 @@ class Timeo(RealtimeProxy):
             logging.getLogger(__name__).debug(
                 'missing realtime id for {obj}: '
                 'stop code={s}, line code={l}, route code={r}'.format(obj=route_point, s=stop, l=line, r=route),
-                extra={'rt_system_id': unicode(self.rt_system_id)},
+                extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             self.record_internal_failure('missing id')
             return None
@@ -328,7 +329,7 @@ class Timeo(RealtimeProxy):
 
     def status(self):
         return {
-            'id': unicode(self.rt_system_id),
+            'id': six.text_type(self.rt_system_id),
             'timeout': self.timeout,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/complete_pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/complete_pt_journey.py
@@ -47,11 +47,11 @@ def wait_and_get_pt_journeys(future_pt_journey, has_valid_direct_paths):
 
     if (
         pt_journeys
-        and pt_journeys.HasField(b"error")
+        and pt_journeys.HasField(str("error"))
         and pt_journeys.error.id != response_pb2.Error.error_id.Value('bad_format')
     ):
         if pt_journeys.error.id == response_pb2.Error.error_id.Value('no_solution') and has_valid_direct_paths:
-            pt_journeys.ClearField(b"error")
+            pt_journeys.ClearField(str("error"))
         elif pt_journeys.error.id == response_pb2.Error.error_id.Value('date_out_of_bounds'):
             raise InvalidDateBoundException(pt_journeys)
         else:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -37,6 +37,7 @@ from .helper_exceptions import *
 import copy
 import logging
 import six
+from functools import cmp_to_key
 
 
 def _create_crowfly(pt_journey, crowfly_origin, crowfly_destination, begin, end, mode):
@@ -142,7 +143,7 @@ def _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, f
         fallback_sections[0].origin.CopyFrom(journey.sections[-1].destination)
 
     journey.sections.extend(fallback_sections)
-    journey.sections.sort(SectionSorter())
+    journey.sections.sort(key=cmp_to_key(SectionSorter()))
 
 
 def _get_fallback_logic(fallback_type):
@@ -223,7 +224,7 @@ def _build_crowflies(pt_journeys, orig, dest):
         crowflies = [c for c in crowflies if c]
 
         pt_journey.sections.extend(crowflies)
-        pt_journey.sections.sort(SectionSorter())
+        pt_journey.sections.sort(key=cmp_to_key(SectionSorter()))
         pt_journey.departure_date_time = pt_journey.sections[0].begin_date_time
         pt_journey.arrival_date_time = pt_journey.sections[-1].end_date_time
 

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
@@ -112,7 +112,7 @@ class PtJourney:
         for j in resp.journeys:
             j.internal_id = str(utils.generate_id())
 
-        if resp.HasField(b"error"):
+        if resp.HasField(str("error")):
             logger.debug("pt journey has error dep_mode: %s and arr_mode: %s", self._dep_mode, self._arr_mode)
             # Here needs to modify error message of no_solution
             if not orig_fallback_durations:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
@@ -33,6 +33,7 @@ from navitiacommon import response_pb2
 from collections import namedtuple
 import copy
 import logging
+from functools import cmp_to_key
 
 PtPoolElement = namedtuple('PtPoolElement', ['dep_mode', 'arr_mode', 'pt_journey'])
 
@@ -299,7 +300,7 @@ class PtJourneyPool:
 
             self._value.append(PtPoolElement(dep_mode, arr_mode, pt_journey))
 
-        self._value.sort(_PtJourneySorter())
+        self._value.sort(key=cmp_to_key(_PtJourneySorter()))
 
     def __iter__(self):
         return self._value.__iter__()

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -85,6 +85,7 @@ from jormungandr import fallback_modes
 from six.moves import filter
 from six.moves import range
 from six.moves import zip
+from functools import cmp_to_key
 
 SECTION_TYPES_TO_RETAIN = {response_pb2.PUBLIC_TRANSPORT, response_pb2.STREET_NETWORK}
 JOURNEY_TYPES_TO_RETAIN = ['best', 'comfort', 'non_pt_walk', 'non_pt_bike', 'non_pt_bss']
@@ -237,7 +238,7 @@ def _has_pt(j):
 
 def sort_journeys(resp, journey_order, clockwise):
     if resp.journeys:
-        resp.journeys.sort(journey_sorter[journey_order](clockwise=clockwise))
+        resp.journeys.sort(key=cmp_to_key(journey_sorter[journey_order](clockwise=clockwise)))
 
 
 def compute_car_co2_emission(pb_resp, api_request, instance):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -404,10 +404,7 @@ def _get_sorted_solutions_indexes(selected_sections_matrix, nb_journeys_to_find,
         i, c = pair
         selected_journeys_matrix[i] = c
 
-    # replace line by line
-    from itertools import izip
-
-    map(f, izip(xrange(shape[0]), gen_all_combin(selected_sections_matrix.shape[0], nb_journeys_to_find)))
+    map(f, zip(range(shape[0]), gen_all_combin(selected_sections_matrix.shape[0], nb_journeys_to_find)))
     """
     We should cut out those combinations that don't contain must-keep journeys
     """

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
@@ -35,7 +35,6 @@ class Gender(object):
     Used as an enum
     """
 
-    __slots__ = ('UNKNOWN', 'MALE', 'FEMALE')
     UNKNOWN = 0
     MALE = 1
     FEMALE = 2

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
@@ -96,7 +96,7 @@ class AbstractRidesharingService(object):
         pass
 
     def _get_rs_id(self):
-        return '{}_{}'.format(unicode(self.system_id), unicode(self.network))
+        return '{}_{}'.format(six.text_type(self.system_id), six.text_type(self.network))
 
     def record_internal_failure(self, message):
         params = {'ridesharing_service_id': self._get_rs_id(), 'message': message}

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -426,7 +426,8 @@ class Scenario(object):
             return
 
         # NOTE: we use request.args and not the parser parameters not to have the default values of the params
-        cloned_params = dict(request.args)
+        # request.args is a MultiDict, we want to flatten it by having list as value when needed (flat=True)
+        cloned_params = request.args.to_dict(flat=False)
         cloned_params['region'] = instance.name  # we add the region in the args to have fully qualified links
 
         self._add_next_link(resp, cloned_params, clockwise)

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -325,10 +325,10 @@ class MixedSchedule(object):
             rt_proxy._update_passages(resp.next_departures, route_point, template, next_rt_passages)
 
         # sort
-        def comparator(p1, p2):
-            return cmp(p1.stop_date_time.departure_date_time, p2.stop_date_time.departure_date_time)
+        def sorter(p):
+            return p.stop_date_time.departure_date_time
 
-        resp.next_departures.sort(comparator)
+        resp.next_departures.sort(key=sorter)
         count = request['count']
         if len(resp.next_departures) > count:
             del resp.next_departures[count:]

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -31,6 +31,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 from typing import Text, List, Optional, Any
+import six
 
 import logging
 from jormungandr import utils
@@ -197,7 +198,7 @@ class MixedSchedule(object):
         if not route_point:
             return None
 
-        rt_system_code = unicode(get_realtime_system_code(route_point))
+        rt_system_code = six.text_type(get_realtime_system_code(route_point))
         if not rt_system_code:
             return None
 
@@ -229,7 +230,8 @@ class MixedSchedule(object):
                 'failure while requesting next passages to external RT system {}'.format(rt_system.rt_system_id)
             )
             new_relic.record_custom_event(
-                'realtime_internal_failure', {'rt_system_id': unicode(rt_system.rt_system_id), 'message': str(e)}
+                'realtime_internal_failure',
+                {'rt_system_id': six.text_type(rt_system.rt_system_id), 'message': str(e)},
             )
 
         if next_rt_passages is None:

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -63,7 +63,7 @@ class Asgard(Kraken):
 
     def status(self):
         return {
-            'id': unicode(self.sn_system_id),
+            'id': six.text_type(self.sn_system_id),
             'class': self.__class__.__name__,
             'modes': self.modes,
             'timeout': self.timeout,

--- a/source/jormungandr/jormungandr/street_network/geovelo.py
+++ b/source/jormungandr/jormungandr/street_network/geovelo.py
@@ -32,6 +32,7 @@ import logging
 import requests as requests
 import pybreaker
 import ujson
+import six
 
 import itertools
 import sys
@@ -78,7 +79,7 @@ class Geovelo(AbstractStreetNetworkService):
 
     def status(self):
         return {
-            'id': unicode(self.sn_system_id),
+            'id': six.text_type(self.sn_system_id),
             'class': self.__class__.__name__,
             'modes': self.modes,
             'timeout': self.timeout,

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -39,6 +39,7 @@ from jormungandr.exceptions import TechnicalError
 from jormungandr.utils import get_pt_object_coord
 from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathKey
 from jormungandr.ptref import FeedPublisher
+from six import text_type
 
 DEFAULT_HERE_FEED_PUBLISHER = {
     'id': 'here',
@@ -101,12 +102,12 @@ class Here(AbstractStreetNetworkService):
             reset_timeout=app.config['CIRCUIT_BREAKER_HERE_TIMEOUT_S'],
         )
 
-        self.log = logging.LoggerAdapter(logging.getLogger(__name__), extra={'streetnetwork_id': unicode(id)})
+        self.log = logging.LoggerAdapter(logging.getLogger(__name__), extra={'streetnetwork_id': text_type(id)})
         self._feed_publisher = FeedPublisher(**feed_publisher) if feed_publisher else None
 
     def status(self):
         return {
-            'id': unicode(self.sn_system_id),
+            'id': text_type(self.sn_system_id),
             'class': self.__class__.__name__,
             'modes': self.modes,
             'timeout': self.timeout,

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -41,6 +41,7 @@ from jormungandr.street_network.street_network import (
 )
 from jormungandr import utils
 import six
+from functools import cmp_to_key
 
 
 class Kraken(AbstractStreetNetworkService):
@@ -66,7 +67,7 @@ class Kraken(AbstractStreetNetworkService):
                 s.destination.CopyFrom(o)
                 s.end_date_time = previous_section_begin
                 previous_section_begin = s.begin_date_time = s.end_date_time - s.duration
-            j.sections.sort(utils.SectionSorter())
+            j.sections.sort(key=cmp_to_key(utils.SectionSorter()))
         return response
 
     def _direct_path(

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -40,6 +40,7 @@ from jormungandr.street_network.street_network import (
     StreetNetworkPathKey,
 )
 from jormungandr import utils
+import six
 
 
 class Kraken(AbstractStreetNetworkService):
@@ -49,7 +50,7 @@ class Kraken(AbstractStreetNetworkService):
         self.sn_system_id = id or 'kraken'
 
     def status(self):
-        return {'id': unicode(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
+        return {'id': six.text_type(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
 
     def _reverse_journeys(self, response):
         if not getattr(response, "journeys"):

--- a/source/jormungandr/jormungandr/street_network/ridesharing.py
+++ b/source/jormungandr/jormungandr/street_network/ridesharing.py
@@ -29,6 +29,7 @@
 
 from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathType
 from jormungandr import utils, fallback_modes as fm
+import six
 
 
 class Ridesharing(AbstractStreetNetworkService):
@@ -49,7 +50,7 @@ class Ridesharing(AbstractStreetNetworkService):
 
     def status(self):
         return {
-            'id': unicode(self.sn_system_id),
+            'id': six.text_type(self.sn_system_id),
             'class': self.__class__.__name__,
             'modes': self.modes,
             'backend_class': self.street_network.__class__.__name__,

--- a/source/jormungandr/jormungandr/street_network/street_network.py
+++ b/source/jormungandr/jormungandr/street_network/street_network.py
@@ -34,6 +34,7 @@ import logging
 from jormungandr import utils, new_relic
 import abc
 from enum import Enum
+import six
 
 # Using abc.ABCMeta in a way it is compatible both with Python 2.7 and Python 3.x
 # http://stackoverflow.com/a/38668373/1614576
@@ -121,13 +122,13 @@ class AbstractStreetNetworkService(ABC):  # type: ignore
         return None
 
     def record_external_failure(self, message):
-        utils.record_external_failure(message, 'streetnetwork', unicode(self.sn_system_id))
+        utils.record_external_failure(message, 'streetnetwork', six.text_type(self.sn_system_id))
 
     def record_call(self, status, **kwargs):
         """
         status can be in: ok, failure
         """
-        params = {'streetnetwork_id': unicode(self.sn_system_id), 'status': status}
+        params = {'streetnetwork_id': six.text_type(self.sn_system_id), 'status': status}
         params.update(kwargs)
         new_relic.record_custom_event('streetnetwork', params)
 

--- a/source/jormungandr/jormungandr/street_network/taxi.py
+++ b/source/jormungandr/jormungandr/street_network/taxi.py
@@ -34,6 +34,7 @@ import copy
 from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathType
 from jormungandr import utils, fallback_modes as fm
 from jormungandr.utils import SectionSorter
+from functools import cmp_to_key
 
 
 from navitiacommon import response_pb2
@@ -173,7 +174,7 @@ class Taxi(AbstractStreetNetworkService):
         journey.arrival_date_time += additional_section.duration
 
         journey.sections.extend([additional_section])
-        journey.sections.sort(SectionSorter())
+        journey.sections.sort(key=cmp_to_key(SectionSorter()))
 
         journey.nb_sections += 1
 

--- a/source/jormungandr/jormungandr/street_network/taxi.py
+++ b/source/jormungandr/jormungandr/street_network/taxi.py
@@ -28,6 +28,7 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 
+import six
 import logging
 import copy
 from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathType
@@ -57,7 +58,7 @@ class Taxi(AbstractStreetNetworkService):
 
     def status(self):
         return {
-            'id': unicode(self.sn_system_id),
+            'id': six.text_type(self.sn_system_id),
             'class': self.__class__.__name__,
             'modes': self.modes,
             'backend_class': self.street_network.__class__.__name__,

--- a/source/jormungandr/jormungandr/street_network/tests/__init__.py
+++ b/source/jormungandr/jormungandr/street_network/tests/__init__.py
@@ -27,5 +27,7 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from streetnetwork_test_utils import MockKraken
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from jormungandr.street_network.tests.streetnetwork_test_utils import MockKraken
 from jormungandr.street_network.tests.streetnetwork_backend_mock import StreetNetworkBackendMock

--- a/source/jormungandr/jormungandr/street_network/valhalla.py
+++ b/source/jormungandr/jormungandr/street_network/valhalla.py
@@ -42,6 +42,7 @@ from jormungandr.street_network.street_network import (
     StreetNetworkPathKey,
     StreetNetworkPathType,
 )
+import six
 
 
 def fill_park_section(section, point, type, begin_dt, duration):
@@ -78,7 +79,7 @@ class Valhalla(AbstractStreetNetworkService):
 
     def status(self):
         return {
-            'id': unicode(self.sn_system_id),
+            'id': six.text_type(self.sn_system_id),
             'class': self.__class__.__name__,
             'modes': self.modes,
             'timeout': self.timeout,

--- a/source/jormungandr/jormungandr/street_network/with_parking.py
+++ b/source/jormungandr/jormungandr/street_network/with_parking.py
@@ -32,6 +32,7 @@ import itertools
 from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathType
 from jormungandr import utils
 from jormungandr.utils import get_pt_object_coord
+import six
 
 from navitiacommon import response_pb2
 
@@ -52,7 +53,7 @@ class WithParking(AbstractStreetNetworkService):
         self.street_network = utils.create_object(config)
 
     def status(self):
-        return {'id': unicode(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
+        return {'id': six.text_type(self.sn_system_id), 'class': self.__class__.__name__, 'modes': self.modes}
 
     def _direct_path(
         self,

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -49,6 +49,7 @@ import flask
 from contextlib import contextmanager
 import functools
 import sys
+import six
 
 PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
@@ -425,7 +426,7 @@ def get_pt_object_coord(pt_object):
 
 
 def record_external_failure(message, connector_type, connector_name):
-    params = {'{}_system_id'.format(connector_type): unicode(connector_name), 'message': message}
+    params = {'{}_system_id'.format(connector_type): six.text_type(connector_name), 'message': message}
     new_relic.record_custom_event('{}_external_failure'.format(connector_type), params)
 
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -194,43 +194,6 @@ def walk_dict(tree, visitor):
 
     if the visitor returns True, stop the search
 
-    >>> bob = {'tutu': 1,
-    ... 'tata': [1, 2],
-    ... 'toto': {'bob':12, 'bobette': 13, 'nested_bob': {'bob': 3}},
-    ... 'tete': ('tuple1', ['ltuple1', 'ltuple2']),
-    ... 'titi': [{'a':1}, {'b':1}]}
-
-    >>> def my_visitor(name, val):
-    ...     print("{}={}".format(name, val))
-
-    >>> walk_dict(bob, my_visitor)
-    titi={u'b': 1}
-    b=1
-    titi={u'a': 1}
-    a=1
-    tete=ltuple2
-    tete=ltuple1
-    tete=tuple1
-    tutu=1
-    toto={u'bobette': 13, u'bob': 12, u'nested_bob': {u'bob': 3}}
-    nested_bob={u'bob': 3}
-    bob=3
-    bob=12
-    bobette=13
-    tata=2
-    tata=1
-
-    >>> def my_stoper_visitor(name, val):
-    ...     print("{}={}".format(name, val))
-    ...     if name == 'tete':
-    ...         return True
-
-    >>> walk_dict(bob, my_stoper_visitor)
-    titi={u'b': 1}
-    b=1
-    titi={u'a': 1}
-    a=1
-    tete=ltuple2
     """
     queue = deque()
 
@@ -487,19 +450,6 @@ def make_namedtuple(typename, *fields, **fields_with_default):
     :param fields_with_default: positional arguments with fields and their default value
     :return: the namedtuple
 
-    >>> Bob = make_namedtuple('Bob', 'a', 'b', c=2, d=14)
-    >>> Bob(b=14, a=12)
-    Bob(a=12, b=14, c=2, d=14)
-    >>> Bob(14, 12)  # non named argument also works
-    Bob(a=14, b=12, c=2, d=14)
-    >>> Bob(12, b=14, d=123)
-    Bob(a=12, b=14, c=2, d=123)
-    >>> Bob(a=12)  # Note: the error message is not the same in python 3 (they are better in python 3)
-    Traceback (most recent call last):
-    TypeError: __new__() takes at least 3 arguments (2 given)
-    >>> Bob()
-    Traceback (most recent call last):
-    TypeError: __new__() takes at least 3 arguments (1 given)
     """
     import collections
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -41,7 +41,7 @@ import logging
 from jormungandr.exceptions import ConfigException, UnableToParse, InvalidArguments
 from six.moves.urllib.parse import urlparse
 from jormungandr import new_relic
-from six.moves import zip
+from six.moves import zip, range
 from jormungandr.exceptions import TechnicalError
 from flask import request
 import re
@@ -327,7 +327,7 @@ def realtime_level_to_pbf(level):
 # we can't use reverse(enumerate(list)) without creating a temporary
 # list, so we define our own reverse enumerate
 def reverse_enumerate(l):
-    return zip(xrange(len(l) - 1, -1, -1), reversed(l))
+    return zip(range(len(l) - 1, -1, -1), reversed(l))
 
 
 def pb_del_if(l, pred):

--- a/source/jormungandr/requirements_dev.txt
+++ b/source/jormungandr/requirements_dev.txt
@@ -4,7 +4,7 @@
 swagger-spec-validator==2.1.0
 mock==1.0.1
 validators==0.10
-pytest==3.7.2
+pytest==4.6.5
 pytest-mock==1.10.0
 pytest-cov==2.5.1
 requests-mock==1.0.0

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -384,13 +384,6 @@ def query_from_str(str):
     """
     for convenience, convert a url to a dict
 
-    >>> query_from_str("toto/tata?bob=toto&bobette=tata&bobinos=tutu")
-    {u'bobette': u'tata', u'bobinos': u'tutu', u'bob': u'toto'}
-    >>> query_from_str("toto/tata?bob=toto&bob=tata&bob=titi&bob=tata&bobinos=tutu")
-    {u'bobinos': u'tutu', u'bob': [u'toto', u'tata', u'titi', u'tata']}
-    >>> query_from_str("?bob%5B%5D=toto titi&bob[]=tata%2Btutu")
-    {u'bob[]': [u'toto titi', u'tata+tutu']}
-
     Note: the query can be encoded, so the split it either on the encoded or the decoded value
     """
     query = {}

--- a/source/jormungandr/tests/check_utils_tests.py
+++ b/source/jormungandr/tests/check_utils_tests.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2002-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+from . import check_utils
+
+
+def test_query_from_str():
+    r = check_utils.query_from_str("toto/tata?bob=toto&bobette=tata&bobinos=tutu")
+    assert r == {'bobette': 'tata', 'bobinos': 'tutu', 'bob': u'toto'}
+    r = check_utils.query_from_str("toto/tata?bob=toto&bob=tata&bob=titi&bob=tata&bobinos=tutu")
+    assert r == {'bobinos': 'tutu', 'bob': ['toto', 'tata', 'titi', 'tata']}
+    r = check_utils.query_from_str("?bob%5B%5D=toto titi&bob[]=tata%2Btutu")
+    assert r == {'bob[]': ['toto titi', 'tata+tutu']}

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -29,7 +29,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 
 from six.moves.urllib.parse import quote
-import itertools
+from six.moves import zip_longest
 from .tests_mechanism import AbstractTestFixture, dataset
 from .check_utils import *
 import datetime
@@ -636,7 +636,7 @@ def check_stop_schedule(response, reference):
             and r.route == get_not_null(get_not_null(resp, 'route'), 'id')
         )
 
-        for (resp_dt, ref_st) in itertools.izip_longest(resp['date_times'], ref.date_times):
+        for (resp_dt, ref_st) in zip_longest(resp['date_times'], ref.date_times):
             assert get_not_null(resp_dt, 'date_time') == ref_st.dt
             assert get_not_null(resp_dt, 'links')[0]['id'] == ref_st.vj
 
@@ -645,7 +645,7 @@ def check_departures(response, reference):
     """
     check the values in a departures
     """
-    for (resp, ref) in itertools.izip_longest(response, reference):
+    for (resp, ref) in zip_longest(response, reference):
         assert get_not_null(get_not_null(resp, 'stop_point'), 'id') == ref.sp
         assert get_not_null(get_not_null(resp, 'route'), 'id') == ref.route
         assert get_not_null(get_not_null(resp, 'stop_date_time'), 'departure_date_time') == ref.dt

--- a/source/jormungandr/tests/graphical_isochrones_tests.py
+++ b/source/jormungandr/tests/graphical_isochrones_tests.py
@@ -351,7 +351,7 @@ class TestGraphicalIsochrone(AbstractTestFixture):
         normal_response, error_code = self.query_no_assert(q)
 
         assert error_code == 400
-        assert 'Unable to parse datetime, year is out of range' in normal_response['message']
+        assert 'Unable to parse datetime, year' in normal_response['message']
 
         p = "v1/coverage/main_routing_test/isochrones?datetime={}&from={}&max_duration={}"
         p = p.format('toto', s_coord, 3600)

--- a/source/jormungandr/tests/heat_maps_tests.py
+++ b/source/jormungandr/tests/heat_maps_tests.py
@@ -228,7 +228,7 @@ class TestHeatMap(AbstractTestFixture):
         normal_response, error_code = self.query_no_assert(q)
 
         assert error_code == 400
-        assert 'Unable to parse datetime, year is out of range' in normal_response['message']
+        assert 'Unable to parse datetime, year' in normal_response['message']
 
         p = "v1/coverage/main_routing_test/heat_maps?datetime={}&from={}&max_duration={}"
         p = p.format('toto', s_coord, 3600)

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -189,14 +189,8 @@ class JourneyCommon(object):
 
         assert status == 400, "the response should not be valid"
 
-        m = (
-            "parameter \"type\" invalid: The type argument must be in list [u'all', u'non_pt_bss', "
-            "u'non_pt_bike', u'fastest', u'less_fallback_bss', u'best', u'less_fallback_bike', "
-            "u'rapid', u'car', u'comfort', u'no_train', u'less_fallback_walk', u'non_pt_walk'], "
-            "you gave sponge_bob\n"
-            "type description: DEPRECATED, desired type of journey."
-        )
-        assert response['message'] == m
+        m = 'parameter "type" invalid: The type argument must be in list'
+        assert m in response['message']
 
     def test_journeys_no_bss_and_walking(self):
         query = journey_basic_query + "&first_section_mode=walking&first_section_mode=bss"
@@ -350,7 +344,7 @@ class JourneyCommon(object):
 
         assert not 'journeys' in response
         assert 'message' in response
-        assert "Unable to parse datetime, year is out of range" in response['message']
+        assert "Unable to parse datetime, year" in response['message']
 
     def test_journeys_do_not_loose_precision(self):
         """do we have a good precision given back in the id"""

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -159,7 +159,7 @@ class TestLineSections(AbstractTestFixture):
             'F_1': False,
             'F_2': False,
         }
-        for stop_point, result in scenario.iteritems():
+        for stop_point, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'line_section_on_line_1')
 
         # line_section_on_line_1_other_effect
@@ -179,7 +179,7 @@ class TestLineSections(AbstractTestFixture):
             'F_1': True,
             'F_2': False,
         }
-        for stop_point, result in scenario.iteritems():
+        for stop_point, result in scenario.items():
             assert result == self.has_disruption(
                 ObjGetter('stop_points', stop_point), 'line_section_on_line_1_other_effect'
             )
@@ -201,7 +201,7 @@ class TestLineSections(AbstractTestFixture):
             'F_1': True,
             'F_2': False,
         }
-        for stop_point, result in scenario.iteritems():
+        for stop_point, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'line_section_on_line_2')
 
     def test_on_vehicle_journeys(self):
@@ -217,7 +217,7 @@ class TestLineSections(AbstractTestFixture):
             'vehicle_journey:vj:2': False,
             'vehicle_journey:vj:3': False,
         }
-        for vj, result in scenario.iteritems():
+        for vj, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'line_section_on_line_1')
 
         # line_section_on_line_1_other_effect
@@ -228,7 +228,7 @@ class TestLineSections(AbstractTestFixture):
             'vehicle_journey:vj:2': False,
             'vehicle_journey:vj:3': False,
         }
-        for vj, result in scenario.iteritems():
+        for vj, result in scenario.items():
             assert result == self.has_disruption(
                 ObjGetter('vehicle_journeys', vj), 'line_section_on_line_1_other_effect'
             )
@@ -241,7 +241,7 @@ class TestLineSections(AbstractTestFixture):
             'vehicle_journey:vj:2': True,
             'vehicle_journey:vj:3': False,
         }
-        for vj, result in scenario.iteritems():
+        for vj, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'line_section_on_line_2')
 
     def test_traffic_reports_on_stop_areas(self):
@@ -252,7 +252,7 @@ class TestLineSections(AbstractTestFixture):
         # line_section_on_line_1
         scenario = {'A': False, 'B': False, 'C': True, 'D': True, 'E': True, 'F': False}
 
-        for sa, result in scenario.iteritems():
+        for sa, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'stop_areas/{}/traffic_reports'.format(sa), 'line_section_on_line_1'
             )
@@ -263,7 +263,7 @@ class TestLineSections(AbstractTestFixture):
         # line_section_on_line_1_other_effect
         scenario = {'A': False, 'B': False, 'C': False, 'D': False, 'E': True, 'F': True}
 
-        for sa, result in scenario.iteritems():
+        for sa, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'stop_areas/{}/traffic_reports'.format(sa), 'line_section_on_line_1_other_effect'
             )
@@ -276,7 +276,7 @@ class TestLineSections(AbstractTestFixture):
         # line_section_on_line_2
         scenario = {'A': False, 'B': True, 'C': False, 'D': False, 'E': False, 'F': True}
 
-        for sa, result in scenario.iteritems():
+        for sa, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'stop_areas/{}/traffic_reports'.format(sa), 'line_section_on_line_2'
             )
@@ -315,7 +315,7 @@ class TestLineSections(AbstractTestFixture):
             # 'line:3': False,
         }
 
-        for line, result in scenario.iteritems():
+        for line, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'lines/{}/traffic_reports'.format(line), 'line_section_on_line_1'
             )
@@ -335,7 +335,7 @@ class TestLineSections(AbstractTestFixture):
             'line:3': False,
         }
 
-        for line, result in scenario.iteritems():
+        for line, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'lines/{}/traffic_reports'.format(line), 'line_section_on_line_1_other_effect'
             )
@@ -357,7 +357,7 @@ class TestLineSections(AbstractTestFixture):
             'line:3': False,
         }
 
-        for line, result in scenario.iteritems():
+        for line, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'lines/{}/traffic_reports'.format(line), 'line_section_on_line_2'
             )
@@ -404,7 +404,7 @@ class TestLineSections(AbstractTestFixture):
             # 'route:line:3:1': False,
         }
 
-        for route, result in scenario.iteritems():
+        for route, result in scenario.items():
             assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'line_section_on_line_1')
 
         # line_section_on_line_1_other_effect
@@ -416,7 +416,7 @@ class TestLineSections(AbstractTestFixture):
             'route:line:3:1': False,
         }
 
-        for route, result in scenario.iteritems():
+        for route, result in scenario.items():
             assert result == self.has_dis(
                 'routes/{}/traffic_reports'.format(route), 'line_section_on_line_1_other_effect'
             )
@@ -430,7 +430,7 @@ class TestLineSections(AbstractTestFixture):
             'route:line:3:1': False,
         }
 
-        for route, result in scenario.iteritems():
+        for route, result in scenario.items():
             assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'line_section_on_line_2')
 
     @pytest.mark.xfail(
@@ -468,7 +468,7 @@ class TestLineSections(AbstractTestFixture):
             # 'vehicle_journey:vj:3': False,
         }
 
-        for vj, result in scenario.iteritems():
+        for vj, result in scenario.items():
             assert result == self.has_dis(
                 'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_1'
             )
@@ -482,7 +482,7 @@ class TestLineSections(AbstractTestFixture):
             'vehicle_journey:vj:3': False,
         }
 
-        for vj, result in scenario.iteritems():
+        for vj, result in scenario.items():
             assert result == self.has_dis(
                 'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_1_other_effect'
             )
@@ -496,7 +496,7 @@ class TestLineSections(AbstractTestFixture):
             'vehicle_journey:vj:3': False,
         }
 
-        for vj, result in scenario.iteritems():
+        for vj, result in scenario.items():
             assert result == self.has_dis(
                 'vehicle_journeys/{}/traffic_reports'.format(vj), 'line_section_on_line_2'
             )
@@ -547,7 +547,7 @@ class TestLineSections(AbstractTestFixture):
             'F_2': False,
         }
 
-        for sp, result in scenario.iteritems():
+        for sp, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'stop_points/{}/traffic_reports'.format(sp), 'line_section_on_line_1'
             )
@@ -575,7 +575,7 @@ class TestLineSections(AbstractTestFixture):
             'F_2': False,
         }
 
-        for sp, result in scenario.iteritems():
+        for sp, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'stop_points/{}/traffic_reports'.format(sp), 'line_section_on_line_1_other_effect'
             )
@@ -603,7 +603,7 @@ class TestLineSections(AbstractTestFixture):
             'F_2': False,
         }
 
-        for sp, result in scenario.iteritems():
+        for sp, result in scenario.items():
             assert result == self.has_tf_disruption(
                 'stop_points/{}/traffic_reports'.format(sp), 'line_section_on_line_2'
             )
@@ -650,7 +650,7 @@ class TestLineSections(AbstractTestFixture):
         assert get_used_vj(r) == [['vehicle_journey:vj:1:1']]
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
 
         # A -> C
@@ -665,7 +665,7 @@ class TestLineSections(AbstractTestFixture):
         assert get_used_vj(r) == [['vehicle_journey:vj:1:1']]
         d = get_all_element_disruptions(r['journeys'], r)
         assert impacted_headsigns(d) == {'vj:1:1'}
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
 
         # B -> C
@@ -679,7 +679,7 @@ class TestLineSections(AbstractTestFixture):
         assert get_used_vj(r) == [['vehicle_journey:vj:1:1']]
         d = get_all_element_disruptions(r['journeys'], r)
         assert impacted_headsigns(d) == {'vj:1:1'}
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
 
         # C -> D
@@ -692,7 +692,7 @@ class TestLineSections(AbstractTestFixture):
         assert get_used_vj(r) == [['vehicle_journey:vj:1:1']]
         d = get_all_element_disruptions(r['journeys'], r)
         assert impacted_headsigns(d) == {'vj:1:1'}
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
 
         # D -> F
@@ -705,7 +705,7 @@ class TestLineSections(AbstractTestFixture):
         assert get_used_vj(r) == [['vehicle_journey:vj:1:1']]
         d = get_all_element_disruptions(r['journeys'], r)
         assert impacted_headsigns(d) == {'vj:1:1'}
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
 
         # A -> F
@@ -720,7 +720,7 @@ class TestLineSections(AbstractTestFixture):
         assert get_used_vj(r) == [['vehicle_journey:vj:1:1']]
         d = get_all_element_disruptions(r['journeys'], r)
         assert impacted_headsigns(d) == {'vj:1:1'}
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
 
     def test_journeys_use_vj_not_impacted_by_line_section(self):
@@ -757,7 +757,7 @@ class TestLineSections(AbstractTestFixture):
         # we check the used vj to be certain we took the right vj
         assert get_used_vj(r) == [['vehicle_journey:vj:1:2']]
         d = get_all_element_disruptions(r['journeys'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert not d
 
@@ -770,7 +770,7 @@ class TestLineSections(AbstractTestFixture):
         r = journeys(_from='C', to='D')
         assert get_used_vj(r) == [['vehicle_journey:vj:1:2']]
         d = get_all_element_disruptions(r['journeys'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert not d
 
@@ -783,7 +783,7 @@ class TestLineSections(AbstractTestFixture):
         r = journeys(_from='B', to='E')
         assert get_used_vj(r) == [['vehicle_journey:vj:1:2']]
         d = get_all_element_disruptions(r['journeys'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert not d
 
@@ -796,7 +796,7 @@ class TestLineSections(AbstractTestFixture):
         r = journeys(_from='C', to='A')
         assert get_used_vj(r) == [['vehicle_journey:vj:3']]
         d = get_all_element_disruptions(r['journeys'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert not d
 
@@ -818,7 +818,7 @@ class TestLineSections(AbstractTestFixture):
             }
             r = self.query_region(query.format(sa='A', cur=cur, d=dt, f=fresh, q=q))
             d = get_all_element_disruptions(r[q], r)
-            for disruption, result in scenario.iteritems():
+            for disruption, result in scenario.items():
                 assert result == (disruption in d)
             assert not impacted_ids(d)
 
@@ -830,7 +830,7 @@ class TestLineSections(AbstractTestFixture):
             }
             r = self.query_region(query.format(sa='B', cur=cur, d=dt, f=fresh, q=q))
             d = get_all_element_disruptions(r[q], r)
-            for disruption, result in scenario.iteritems():
+            for disruption, result in scenario.items():
                 assert result == (disruption in d)
             if q == 'departures':
                 assert impacted_headsigns(d) == {'vj:2'}
@@ -845,7 +845,7 @@ class TestLineSections(AbstractTestFixture):
             }
             r = self.query_region(query.format(sa='C', cur=cur, d=dt, f=fresh, q=q))
             d = get_all_element_disruptions(r[q], r)
-            for disruption, result in scenario.iteritems():
+            for disruption, result in scenario.items():
                 assert result == (disruption in d)
             # the impact is linked in the response to the stop point and the vj
             if q == 'departures':
@@ -861,7 +861,7 @@ class TestLineSections(AbstractTestFixture):
             }
             r = self.query_region(query.format(sa='D', cur=cur, d=dt, f=fresh, q=q))
             d = get_all_element_disruptions(r[q], r)
-            for disruption, result in scenario.iteritems():
+            for disruption, result in scenario.items():
                 assert result == (disruption in d)
             if q == 'departures':
                 assert impacted_headsigns(d) == {'vj:1:1'}
@@ -876,7 +876,7 @@ class TestLineSections(AbstractTestFixture):
             }
             r = self.query_region(query.format(sa='E', cur=cur, d=dt, f=fresh, q=q))
             d = get_all_element_disruptions(r[q], r)
-            for disruption, result in scenario.iteritems():
+            for disruption, result in scenario.items():
                 assert result == (disruption in d)
             if q == 'departures':
                 assert impacted_headsigns(d) == {'vj:1:1'}
@@ -891,7 +891,7 @@ class TestLineSections(AbstractTestFixture):
             }
             r = self.query_region(query.format(sa='F', cur=cur, d=dt, f=fresh, q=q))
             d = get_all_element_disruptions(r[q], r)
-            for disruption, result in scenario.iteritems():
+            for disruption, result in scenario.items():
                 assert result == (disruption in d)
             if q == 'departures':
                 assert not impacted_headsigns(d)
@@ -912,7 +912,7 @@ class TestLineSections(AbstractTestFixture):
         }
         r = self.query_region(query.format(l='line:1', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert impacted_headsigns(d) == {'vj:1:1'}
 
@@ -924,7 +924,7 @@ class TestLineSections(AbstractTestFixture):
         }
         r = self.query_region(query.format(l='line:2', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert impacted_headsigns(d) == {'vj:2'}
 
@@ -936,7 +936,7 @@ class TestLineSections(AbstractTestFixture):
         }
         r = self.query_region(query.format(l='line:3', cur=cur, d=dt, f=fresh))
         d = get_all_element_disruptions(r['departures'], r)
-        for disruption, result in scenario.iteritems():
+        for disruption, result in scenario.items():
             assert result == (disruption in d)
         assert not impacted_headsigns(d)
 
@@ -944,17 +944,17 @@ class TestLineSections(AbstractTestFixture):
         # line_section_on_line_1
         scenario = {'line:1': True, 'line:2': False, 'line:3': False}
 
-        for line, result in scenario.iteritems():
+        for line, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('lines', line), 'line_section_on_line_1')
 
         # line_section_on_line_1_other_effect
         scenario = {'line:1': True, 'line:2': False, 'line:3': False}
 
-        for line, result in scenario.iteritems():
+        for line, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('lines', line), 'line_section_on_line_1_other_effect')
 
         # line_section_on_line_2
         scenario = {'line:1': False, 'line:2': True, 'line:3': False}
 
-        for line, result in scenario.iteritems():
+        for line, result in scenario.items():
             assert result == self.has_disruption(ObjGetter('lines', line), 'line_section_on_line_2')

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -295,4 +295,4 @@ class TestPlaces(AbstractTestFixture):
         response = self.query_region("places?q=rue ab")
         places = response['places']
         assert len(places) == 1
-        assert places[0].has_key('distance') == False
+        assert 'distance' not in places[0]

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -37,7 +37,9 @@ import flex
 from flex.exceptions import ValidationError
 
 from tests.tests_mechanism import dataset, AbstractTestFixture, mock_bss_providers, mock_car_park_providers
-from itertools import chain, ifilter
+from itertools import chain
+from six.moves import filter
+import six
 
 
 def get_params(schema):
@@ -133,8 +135,8 @@ class SchemaChecker:
             )
             assert param.has_key('type')
 
-            assert type(param['name']) is unicode
-            assert type(param['description']) is unicode
+            assert type(param['name']) is six.text_type
+            assert type(param['description']) is six.text_type
 
             assert any(
                 param['type'] == t

--- a/source/navitiacommon/navitiacommon/parser_args_type.py
+++ b/source/navitiacommon/navitiacommon/parser_args_type.py
@@ -35,6 +35,7 @@ import geojson
 import flask
 from dateutil import parser
 from flask_restful.inputs import boolean
+import six
 
 
 class TypeSchema(object):
@@ -83,11 +84,12 @@ class BooleanType(CustomSchemaType):
 
 class OptionValue(CustomSchemaType):
     def __init__(self, optional_values):
+
         self.optional_values = optional_values
 
     def __call__(self, value, name):
         # if input value is iterable
-        if hasattr(value, '__iter__'):
+        if hasattr(value, '__iter__') and not isinstance(value, six.text_type):
             if not all((v in self.optional_values for v in value)):
                 error = "The {} argument must be in list {}, you gave {}".format(
                     name, str(self.optional_values), value
@@ -107,7 +109,7 @@ class OptionValue(CustomSchemaType):
 class DescribedOptionValue(OptionValue):
     def __init__(self, optional_values):
         self.description = "Possible values:\n"
-        self.description += '\n'.join([" * '{}' - {}".format(k, v) for k, v in optional_values.iteritems()])
+        self.description += '\n'.join([" * '{}' - {}".format(k, v) for k, v in optional_values.items()])
         super(DescribedOptionValue, self).__init__(optional_values.keys())
 
     def schema(self):

--- a/source/scripts/build_protobuf.sh
+++ b/source/scripts/build_protobuf.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 pushd source/navitia-proto
 protoc --python_out=../navitiacommon/navitiacommon  type.proto response.proto request.proto task.proto stat.proto
+2to3 -w ../navitiacommon/navitiacommon/*_pb2.py
 popd

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -59,6 +59,7 @@ add_custom_command(OUTPUT ${PROTO_HDRS} ${PROTO_SRCS}
 add_custom_command (OUTPUT ${NAVITIACOMMON_PROTO_PY}
     COMMAND protoc ARGS "--python_out=${NAVITIACOMMON_DIR}"
     type.proto response.proto request.proto task.proto stat.proto
+    COMMAND 2to3 -w ${NAVITIACOMMON_PROTO_PY}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/navitia-proto" VERBATIM
     DEPENDS ${PROTO_FILES})
 
@@ -66,6 +67,7 @@ add_custom_command (OUTPUT ${NAVITIACOMMON_PROTO_PY}
 add_custom_command (OUTPUT ${MONITOR_KRAKEN_PROTO_PY}
     COMMAND protoc ARGS "--python_out=${MONITOR_KRAKEN_DIR}"
     type.proto response.proto request.proto
+    COMMAND 2to3 -w ${MONITOR_KRAKEN_PROTO_PY}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/navitia-proto" VERBATIM
     DEPENDS ${PROTO_FILES})
 
@@ -73,6 +75,7 @@ add_custom_command (OUTPUT ${MONITOR_KRAKEN_PROTO_PY}
 add_custom_command (OUTPUT ${JORMUNGANDR_TEST_PY}
     COMMAND protoc ARGS "--python_out=${JORMUNGANDR_TEST_DIR}"
     chaos.proto gtfs-realtime.proto kirin.proto
+    COMMAND 2to3 -w ${JORMUNGANDR_TEST_PY}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/chaos-proto" VERBATIM
     DEPENDS ${PROTO_FILES})
 

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -2,7 +2,7 @@
 -r ../../requirements_pre-commit.txt
 
 docker==3.4.1
-pytest==3.7.2
+pytest==4.6.5
 python-dateutil==2.5.3
 mock==1.0.1
 jmespath==0.9.3


### PR DESCRIPTION
This start the migration process to python 3

This PR doesn't (yet?) address the fact that protoc doesn't generate python code that works with python3...

There is a few hack that need to be improved before merging.
Each commit should be understandable. 
Call to `cmp_to_key` should be replaced by an implementation that works natively with `key`. 

At this point all integration tests are OK, jormun unittest remains KO :(

TODO:
  - [ ] understand (and improve) https://github.com/CanalTP/navitia/pull/2989/commits/65e7e4f40949d41bb1dd4b77edd1694795d20a0c
  - [x] make protobuf file ok (probably with `2to3`)
  - [ ] CI

Obviously this still works with python 2