### PR TITLE
[Kraken] Update metadatas for /status requests

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -999,6 +999,8 @@ void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {
     // These api can respond even if the data isn't loaded
     if (request.requested_api() == pbnavitia::STATUS) {
         status();
+        // Metadatas are needed for /status requests to update timezone
+        metadatas();
         return;
     }
     if (request.requested_api() == pbnavitia::METADATAS) {

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -589,19 +589,13 @@ class Instance(db.Model):  # type: ignore
 
         if not result:
             return 0
-        job_list = {}
         for dataset, job in result:
             # Cascade Delete not working so delete Metric associated manually
             db.session.query(Metric).filter(Metric.dataset_id == dataset.id).delete()
             db.session.delete(dataset)
 
             # Delete a job without any dataset
-            if job.id not in job_list:
-                job_list[job.id] = 1
-            else:
-                job_list[job.id] += 1
-
-            if not (len(job.data_sets.all()) - job_list[job.id]):
+            if not len(job.data_sets.all()):
                 db.session.delete(job)
 
         db.session.commit()


### PR DESCRIPTION
For ArtemisNG, the first request /journeys had a time-shifted response due to the timezone not set in the coverage.
As /status request is made before, it will now update metadatas

Sidequest:
Remove warning from Tyr test and update model ORM request
After SQLAlchemy update, `db.session.autoflush=True` which according to the doc `flush() creates its own transaction and commits it.` 
-> Previously, the request job.data_sets.all() wasn't updated without the db.commit() so we had to calculate the remaining datasets associated.
-> Now, the request job.data_sets.all() takes into the account the deletion so it already returns the remaining datasets associated.