### PR TITLE
jormun: robustify Timeo mechanism with interval errors handling and empty response

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -236,8 +236,10 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
     def record_external_failure(self, message):
         record_external_failure(message, 'realtime', unicode(self.rt_system_id))
 
-    def record_internal_failure(self, message, comment=''):
-        params = {'realtime_system_id': unicode(self.rt_system_id), 'message': message, 'comment': comment}
+    def record_internal_failure(self, message, comment=None):
+        params = {'realtime_system_id': unicode(self.rt_system_id), 'message': message}
+        if comment is not None:
+            params['comment'] = comment
         new_relic.record_custom_event('realtime_internal_failure', params)
 
     def record_call(self, status, **kwargs):

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -236,8 +236,8 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
     def record_external_failure(self, message):
         record_external_failure(message, 'realtime', unicode(self.rt_system_id))
 
-    def record_internal_failure(self, message):
-        params = {'realtime_system_id': unicode(self.rt_system_id), 'message': message}
+    def record_internal_failure(self, message, comment=''):
+        params = {'realtime_system_id': unicode(self.rt_system_id), 'message': message, 'comment': comment}
         new_relic.record_custom_event('realtime_internal_failure', params)
 
     def record_call(self, status, **kwargs):

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -40,6 +40,16 @@ from pytest import raises
 from six.moves import range
 
 
+class MockResponse:
+    def __init__(self, status_code, url, json_data):
+        self.status_code = status_code
+        self.url = url
+        self.json_data = json_data
+
+    def json(self):
+        return self.json_data
+
+
 def make_url_test():
     timeo = Timeo(
         id='tata',
@@ -176,13 +186,30 @@ def get_passages_test():
     with mock.patch(
         'jormungandr.realtime_schedule.timeo.Timeo._get_direction_name', lambda timeo, **kwargs: None
     ):
-        passages = timeo._get_passages(mock_response, current_dt=_dt("02:02"))
+        passages = timeo._get_passages(
+            MockResponse(200, 'http://bob.com/tata', mock_response), current_dt=_dt("02:02")
+        )
 
         assert len(passages) == 3
 
         assert passages[0].datetime == _dt('15:40:04')
         assert passages[1].datetime == _dt('15:55:04')
         assert passages[2].datetime == _dt('16:10:04')
+
+    # http error raise an error
+    with mock.patch(
+        'jormungandr.realtime_schedule.timeo.Timeo._get_direction_name', lambda timeo, **kwargs: None
+    ), raises(RealtimeProxyError):
+        passages = timeo._get_passages(
+            MockResponse(404, 'http://bob.com/tata', mock_response), current_dt=_dt("02:02")
+        )
+
+    with mock.patch(
+        'jormungandr.realtime_schedule.timeo.Timeo._get_direction_name', lambda timeo, **kwargs: None
+    ), raises(RealtimeProxyError):
+        passages = timeo._get_passages(
+            MockResponse(504, 'http://bob.com/tata', mock_response), current_dt=_dt("02:02")
+        )
 
 
 def get_passages_no_passages_test():
@@ -220,7 +247,9 @@ def get_passages_no_passages_test():
     with mock.patch(
         'jormungandr.realtime_schedule.timeo.Timeo._get_direction_name', lambda timeo, **kwargs: None
     ):
-        passages = timeo._get_passages(mock_response, current_dt=_dt("02:02"))
+        passages = timeo._get_passages(
+            MockResponse(200, 'http://bob.com/tata', mock_response), current_dt=_dt("02:02")
+        )
 
         assert len(passages) == 0
 
@@ -243,7 +272,9 @@ def get_passages_wrong_response_test():
     with mock.patch(
         'jormungandr.realtime_schedule.timeo.Timeo._get_direction_name', lambda timeo, **kwargs: None
     ), raises(RealtimeProxyError):
-        passages = timeo._get_passages(mock_response, current_dt=_dt("02:02"))
+        passages = timeo._get_passages(
+            MockResponse(200, 'http://bob.com/tata', mock_response), current_dt=_dt("02:02")
+        )
 
 
 def next_passage_for_route_point_test():

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -133,7 +133,7 @@ def make_url_invalid_code_test():
 def mock_good_timeo_response():
     mock_response = {
         "CorrelationID": "GetNextStopTimesResponse-16022016 15:30",
-        "MessageResponse": [{"ResponseCode": "0", "ResponseComment": "success"}],
+        "MessageResponse": [{"ResponseCode": 0, "ResponseComment": "success"}],
         "StopTimesResponse": [
             {
                 "StopID": "StopPoint_OLS01070201",
@@ -195,7 +195,7 @@ def get_passages_no_passages_test():
 
     mock_response = {
         "CorrelationID": "GetNextStopTimesResponse-16022016 15:30",
-        "MessageResponse": [{"ResponseCode": "0", "ResponseComment": "success"}],
+        "MessageResponse": [{"ResponseCode": 0, "ResponseComment": "success"}],
         "StopTimesResponse": [
             {
                 "StopID": "StopPoint_OLS01070201",

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -221,10 +221,6 @@ class Timeo(RealtimeProxy):
 
         next_st = st_responses[0]['NextStopTimesMessage']
 
-        # if realtime list is empty, only base results will send
-        if 'NextExpectedStopTime' not in next_st:
-            return None
-
         next_passages = []
         for next_expected_st in next_st.get('NextExpectedStopTime', []):
             # for the moment we handle only the NextStop and the direction

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -215,13 +215,15 @@ class Timeo(RealtimeProxy):
                     resp_comment = message_response['ResponseComment']
                 else:
                     resp_comment = ''
-                logging.getLogger(__name__).error(
-                    'Timeo RT internal service error, code: {} - comment: {}'.format(resp_code, resp_comment)
-                )
                 self.record_internal_failure(
-                    'internal timeo error', 'code {} - {}'.format(resp_code, resp_comment)
+                    'Timeo RT internal service error',
+                    'ResponseCode: {} - ResponseComment: {}'.format(resp_code, resp_comment),
                 )
-                raise RealtimeProxyError('Timeo RT internal service error')
+                timeo_internal_error_message = 'Timeo RT internal service error, ResponseCode: {} - ResponseComment: {}'.format(
+                    resp_code, resp_comment
+                )
+                logging.getLogger(__name__).error(timeo_internal_error_message)
+                raise RealtimeProxyError(timeo_internal_error_message)
 
         st_responses = timeo_resp.get('StopTimesResponse')
         # by construction there should be only one StopTimesResponse

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -210,10 +210,16 @@ class Timeo(RealtimeProxy):
                 'ResponseCode' in message_response
                 and message_response['ResponseCode'] >= self.INTERNAL_TIMEO_ERROR_CODE_LIMIT
             ):
+                resp_code = message_response['ResponseCode']
+                if 'ResponseComment' in message_response:
+                    resp_comment = message_response['ResponseComment']
+                else:
+                    resp_comment = ''
                 logging.getLogger(__name__).error(
-                    'Timeo RT internal service error, code: {} - comment: {}'.format(
-                        message_response['ResponseCode'], message_response['ResponseComment']
-                    )
+                    'Timeo RT internal service error, code: {} - comment: {}'.format(resp_code, resp_comment)
+                )
+                self.record_internal_failure(
+                    'internal timeo error', 'code {} - {}'.format(resp_code, resp_comment)
                 )
                 raise RealtimeProxyError('Timeo RT internal service error')
 

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -208,17 +208,14 @@ class TestDepartures(AbstractTestFixture):
 
     def test_stop_schedule_with_rt_empty_list(self):
         """
-        When timeo service responds a empty list, we return base schedule results
+        When timeo service responds a empty list, we return the empty rt list
         """
         query = self.query_template.format(sp='S40', dt='20160102T0900', data_freshness='', c_dt='20160102T0900')
         response = self.query_region(query)
         stop_schedules = response['stop_schedules']
         assert len(stop_schedules) == 1
         stop_times = stop_schedules[0]['date_times']
-        assert len(stop_times) == 1
-        stop_time = stop_times[0]
-        assert stop_time['data_freshness'] == 'base_schedule'
-        assert stop_time['date_time'] == '20160102T110000'
+        assert len(stop_times) == 0
 
     def test_stop_schedule_with_rt_and_without_destination(self):
         query = self.query_template.format(sp='S41', dt='20160102T0900', data_freshness='', c_dt='20160102T0900')

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -89,13 +89,14 @@ class MockTimeo(Timeo):
                         },
                     }
                 ],
+                "MessageResponse": [{"ResponseCode": 0, "ResponseComment": "success"}],
             }
         if url == 'S42':
             json = {
                 "CorrelationID": "AA",
                 "StopTimesResponse": [
                     {
-                        "StopID": "C:S0",
+                        "StopID": "S42",
                         "StopTimeoCode": "AAAAA",
                         "StopLongName": "Malraux",
                         "StopShortName": "Malraux",
@@ -120,6 +121,29 @@ class MockTimeo(Timeo):
                         },
                     }
                 ],
+                "MessageResponse": [{"ResponseCode": 0, "ResponseComment": "success"}],
+            }
+        if url == 'C:S1':
+            json = {"MessageResponse": [{"ResponseCode": 208, "ResponseComment": "no serviceID number found"}]}
+        if url == 'S40':
+            json = {
+                "CorrelationID": "AA",
+                "StopTimesResponse": [
+                    {
+                        "StopID": "S40",
+                        "StopTimeoCode": "AAAAA",
+                        "StopLongName": "Malraux",
+                        "StopShortName": "Malraux",
+                        "StopVocalName": "Malraux",
+                        "ReferenceTime": "09:54:53",
+                        "NextStopTimesMessage": {
+                            "LineID": "AAA",
+                            "Way": "A",
+                            "LineMainDirection": "DIRECTION AA",
+                        },
+                    }
+                ],
+                "MessageResponse": [{"ResponseCode": 0, "ResponseComment": "success"}],
             }
         resp.json = MagicMock(return_value=json)
         return resp
@@ -164,6 +188,37 @@ class TestDepartures(AbstractTestFixture):
         stop_time = stop_times[0]
         assert stop_time['data_freshness'] == 'base_schedule'
         assert stop_time['date_time'] == '20160102T113000'
+
+    def test_stop_schedule_with_rt_in_error(self):
+        """
+        When timeo service responds a error code >= 100 (into MessageResponse.ResponseCode field),
+        we return base schedule results
+        """
+        query = self.query_template.format(
+            sp='C:S1', dt='20160102T0900', data_freshness='', c_dt='20160102T0900'
+        )
+        response = self.query_region(query)
+        stop_schedules = response['stop_schedules']
+        assert len(stop_schedules) == 1
+        stop_times = stop_schedules[0]['date_times']
+        assert len(stop_times) == 1
+        stop_time = stop_times[0]
+        assert stop_time['data_freshness'] == 'base_schedule'
+        assert stop_time['date_time'] == '20160102T123000'
+
+    def test_stop_schedule_with_rt_empty_list(self):
+        """
+        When timeo service responds a empty list, we return base schedule results
+        """
+        query = self.query_template.format(sp='S40', dt='20160102T0900', data_freshness='', c_dt='20160102T0900')
+        response = self.query_region(query)
+        stop_schedules = response['stop_schedules']
+        assert len(stop_schedules) == 1
+        stop_times = stop_schedules[0]['date_times']
+        assert len(stop_times) == 1
+        stop_time = stop_times[0]
+        assert stop_time['data_freshness'] == 'base_schedule'
+        assert stop_time['date_time'] == '20160102T110000'
 
     def test_stop_schedule_with_rt_and_without_destination(self):
         query = self.query_template.format(sp='S41', dt='20160102T0900', data_freshness='', c_dt='20160102T0900')


### PR DESCRIPTION
**Goals:**

- Display base schedule results list, when there is an internal timeo service error
- If timeo service return 0 errors (error code < 100) with an empty list, the empty list is return (seen with @SGrenet )
  It was obvious for me the return the base schedule in this case, but it seems to be wrong. That just says there is no next departures. And even if it is not normal, it is timeo side). I see this case 80% of the time

**JIRA** : https://jira.kisio.org/browse/NAVITIAII-2895