### PR TITLE
[Kraken] Fix A* heuristic cost

### DIFF
--- a/source/georef/astar_path_finder.cpp
+++ b/source/georef/astar_path_finder.cpp
@@ -66,7 +66,7 @@ void AstarPathFinder::start_distance_or_target_astar(const navitia::time_duratio
     // We start astar from source and target nodes
     try {
         astar({starting_edge[source_e], starting_edge[target_e]},
-              astar_distance_heuristic(geo_ref.graph, dest_projected, 1. / double(default_speed[mode] * speed_factor)),
+              astar_distance_heuristic(geo_ref.graph, dest_projected, 1. / double(default_speed[mode])),
               astar_distance_or_target_visitor(radius, distances, destinations));
     } catch (DestinationFound&) {
     }


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVITIAII-2916

The bug is a little bit tricky to explain...

Here is why

![CodeCogsEqn](https://user-images.githubusercontent.com/6093486/67000901-ecebf680-f0d8-11e9-981b-81b32ddc85ac.gif)


When combining the current_duration and the heuristic_duration, the heuristic_duration is actually divided by factor_speed __TWICE__!! That can violate the optimality condition of A* when factor_speed is too small !!! 

The correct formula of  heuristic_duration should be:

![CodeCogsEqn(1)](https://user-images.githubusercontent.com/6093486/67001021-2de40b00-f0d9-11e9-9d7c-9a117d744234.gif)

