### PR TITLE
jormun: external_code finally works with coverage on every Uri API

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -163,9 +163,9 @@ class Uri(ResourceUri, ResourceUtc):
         if "odt_level" in args and args["odt_level"] != "all" and "lines" not in self.collection:
             abort(404, message="bad request: odt_level filter can only be applied to lines")
 
-        if region is None and lat is None and lon is None:
-            if "external_code" in args and args["external_code"]:
-                type_ = collections_to_resource_type[self.collection]
+        if "external_code" in args and args["external_code"]:
+            type_ = collections_to_resource_type[self.collection]
+            if region is None and lat is None and lon is None:
                 for instance in i_manager.get_regions():
                     res = i_manager.instances[instance].has_external_code(type_, args["external_code"])
                     if res:
@@ -175,7 +175,7 @@ class Uri(ResourceUri, ResourceUtc):
                 if not region:
                     abort(404, message="Unable to find an object for the uri %s" % args["external_code"])
             else:
-                abort(503, message="Not implemented yet")
+                id = i_manager.instances[region].has_external_code(type_, args["external_code"])
 
         self.region = i_manager.get_region(region, lon, lat)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -173,11 +173,15 @@ class Uri(ResourceUri, ResourceUtc):
                         id = res
                         break
                 if not region:
-                    abort(404, message="Unable to find an object for the uri %s" % args["external_code"])
+                    abort(
+                        404, message="Unable to find an object for the external_code %s" % args["external_code"]
+                    )
             else:
                 id = i_manager.instances[region].has_external_code(type_, args["external_code"])
                 if id == None:
-                    abort(404, message="Unable to find an object for the uri %s" % args["external_code"])
+                    abort(
+                        404, message="Unable to find an object for the external_code %s" % args["external_code"]
+                    )
 
         self.region = i_manager.get_region(region, lon, lat)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -176,6 +176,8 @@ class Uri(ResourceUri, ResourceUtc):
                     abort(404, message="Unable to find an object for the uri %s" % args["external_code"])
             else:
                 id = i_manager.instances[region].has_external_code(type_, args["external_code"])
+                if id == None:
+                    abort(404, message="Unable to find an object for the uri %s" % args["external_code"])
 
         self.region = i_manager.get_region(region, lon, lat)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -163,9 +163,9 @@ class Uri(ResourceUri, ResourceUtc):
         if "odt_level" in args and args["odt_level"] != "all" and "lines" not in self.collection:
             abort(404, message="bad request: odt_level filter can only be applied to lines")
 
-        if "external_code" in args and args["external_code"]:
+        if args.get("external_code") is not None:
             type_ = collections_to_resource_type[self.collection]
-            if region is None and lat is None and lon is None:
+            if all(obj is None for obj in (region, lat, lon)):
                 for instance in i_manager.get_regions():
                     res = i_manager.instances[instance].has_external_code(type_, args["external_code"])
                     if res:

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -811,6 +811,17 @@ class TestPtRef(AbstractTestFixture):
         assert len(networks) == 1
         assert networks[0]['id'] == 'network:A'
 
+        response, code = self.query_no_assert("v1/networks?external_code=wrong_code")
+        assert code == 404
+        message = get_not_null(response, 'message')
+        assert 'Unable to find an object for the uri wrong_code' in message
+
+        # Without coverage, networks have to work with external_code
+        response, code = self.query_no_assert("v1/networks")
+        assert code == 400
+        message = get_not_null(response, 'message')
+        assert 'parameter \"external_code\" invalid: Missing required parameter' in message
+
 
 @dataset({"main_ptref_test": {}, "main_routing_test": {}})
 class TestPtRefRoutingAndPtrefCov(AbstractTestFixture):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -804,6 +804,13 @@ class TestPtRef(AbstractTestFixture):
         networks = get_not_null(response, 'networks')
         assert len(networks) == 4
 
+        # without coverage
+        response, code = self.query_no_assert("v1/networks?external_code=A")
+        assert code == 200
+        networks = get_not_null(response, 'networks')
+        assert len(networks) == 1
+        assert networks[0]['id'] == 'network:A'
+
 
 @dataset({"main_ptref_test": {}, "main_routing_test": {}})
 class TestPtRefRoutingAndPtrefCov(AbstractTestFixture):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -778,8 +778,8 @@ class TestPtRef(AbstractTestFixture):
         )
         assert len(response['disruptions']) == 1
 
-    def test_networks(self):
-        """test networks API"""
+    def test_networks_with_external_code(self):
+        """test networks with external_code parameter"""
         response = self.query_region("networks")
         networks = get_not_null(response, 'networks')
         assert len(networks) == 4
@@ -788,8 +788,6 @@ class TestPtRef(AbstractTestFixture):
         assert networks[2]['id'] == 'network:CaRoule'
         assert networks[3]['id'] == 'network:freq'
 
-    def test_networks_with_external_code(self):
-        """test networks with external_code parameter"""
         response = self.query_region("networks?external_code=A")
         networks = get_not_null(response, 'networks')
         assert len(networks) == 1
@@ -818,6 +816,79 @@ class TestPtRef(AbstractTestFixture):
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/networks")
+        assert code == 400
+        message = get_not_null(response, 'message')
+        assert 'parameter \"external_code\" invalid: Missing required parameter' in message
+
+    def test_lines_with_external_code(self):
+        """test lines with external_code parameter"""
+        response = self.query_region("lines")
+        lines = get_not_null(response, 'lines')
+        assert len(lines) == 4
+        assert lines[0]['id'] == 'line:A'
+        assert lines[1]['id'] == 'line:B'
+        assert lines[2]['id'] == 'line:Ça roule'
+        assert lines[3]['id'] == 'line:freq'
+
+        response = self.query_region("lines?external_code=A")
+        lines = get_not_null(response, 'lines')
+        assert len(lines) == 1
+        assert lines[0]['id'] == 'line:A'
+
+        response = self.query_region("lines?external_code=wrong_code")
+        lines = get_not_null(response, 'lines')
+        assert len(lines) == 4
+
+        # without coverage
+        response, code = self.query_no_assert("v1/lines?external_code=A")
+        assert code == 200
+        lines = get_not_null(response, 'lines')
+        assert len(lines) == 1
+        assert lines[0]['id'] == 'line:A'
+
+        response, code = self.query_no_assert("v1/lines?external_code=wrong_code")
+        assert code == 404
+        message = get_not_null(response, 'message')
+        assert 'Unable to find an object for the uri wrong_code' in message
+
+        # Without coverage, networks have to work with external_code
+        response, code = self.query_no_assert("v1/lines")
+        assert code == 400
+        message = get_not_null(response, 'message')
+        assert 'parameter \"external_code\" invalid: Missing required parameter' in message
+
+    def test_stop_points_with_external_code(self):
+        """test stop_points with external_code parameter"""
+        response = self.query_region("stop_points")
+        stop_points = get_not_null(response, 'stop_points')
+        assert len(stop_points) == 3
+        assert stop_points[0]['id'] == 'stop_area:stop1'
+        assert stop_points[1]['id'] == 'stop_area:stop2'
+        assert stop_points[2]['id'] == 'stop_point:stop_with name bob " , é'
+
+        response = self.query_region("stop_points?external_code=stop1_code")
+        stop_points = get_not_null(response, 'stop_points')
+        assert len(stop_points) == 1
+        assert stop_points[0]['id'] == 'stop_area:stop1'
+
+        response = self.query_region("stop_points?external_code=wrong_code")
+        stop_points = get_not_null(response, 'stop_points')
+        assert len(stop_points) == 3
+
+        # without coverage
+        response, code = self.query_no_assert("v1/stop_points?external_code=stop1_code")
+        assert code == 200
+        stop_points = get_not_null(response, 'stop_points')
+        assert len(stop_points) == 1
+        assert stop_points[0]['id'] == 'stop_area:stop1'
+
+        response, code = self.query_no_assert("v1/stop_points?external_code=wrong_code")
+        assert code == 404
+        message = get_not_null(response, 'message')
+        assert 'Unable to find an object for the uri wrong_code' in message
+
+        # Without coverage, networks have to work with external_code
+        response, code = self.query_no_assert("v1/stop_points")
         assert code == 400
         message = get_not_null(response, 'message')
         assert 'parameter \"external_code\" invalid: Missing required parameter' in message

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -798,9 +798,10 @@ class TestPtRef(AbstractTestFixture):
         assert len(networks) == 1
         assert networks[0]['id'] == 'network:B'
 
-        response = self.query_region("networks?external_code=wrong_code")
-        networks = get_not_null(response, 'networks')
-        assert len(networks) == 4
+        response, code = self.query_no_assert("v1/coverage/main_ptref_test/networks?external_code=wrong_code")
+        assert code == 404
+        message = get_not_null(response, 'message')
+        assert 'Unable to find an object for the uri wrong_code' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/networks?external_code=A")
@@ -835,9 +836,10 @@ class TestPtRef(AbstractTestFixture):
         assert len(lines) == 1
         assert lines[0]['id'] == 'line:A'
 
-        response = self.query_region("lines?external_code=wrong_code")
-        lines = get_not_null(response, 'lines')
-        assert len(lines) == 4
+        response, code = self.query_no_assert("v1/coverage/main_ptref_test/lines?external_code=wrong_code")
+        assert code == 404
+        message = get_not_null(response, 'message')
+        assert 'Unable to find an object for the uri wrong_code' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/lines?external_code=A")
@@ -871,9 +873,10 @@ class TestPtRef(AbstractTestFixture):
         assert len(stop_points) == 1
         assert stop_points[0]['id'] == 'stop_area:stop1'
 
-        response = self.query_region("stop_points?external_code=wrong_code")
-        stop_points = get_not_null(response, 'stop_points')
-        assert len(stop_points) == 3
+        response, code = self.query_no_assert("v1/coverage/main_ptref_test/stop_points?external_code=wrong_code")
+        assert code == 404
+        message = get_not_null(response, 'message')
+        assert 'Unable to find an object for the uri wrong_code' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/stop_points?external_code=stop1_code")

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -574,14 +574,14 @@ class TestPtRef(AbstractTestFixture):
         is_valid_pt_objects_response(response)
         pt_objs = get_not_null(response, 'pt_objects')
         assert len(pt_objs) == 1
-        assert get_not_null(pt_objs[0], 'name') == 'base_network Car line:A'
+        assert get_not_null(pt_objs[0], 'name') == 'network:A Car line:A'
         self.check_context(response)
 
         response = self.query_region('pt_objects?q=line:Ca roule&type[]=line')
         pt_objs = get_not_null(response, 'pt_objects')
         assert len(pt_objs) == 1
         # not valid as there is no commercial mode (which impacts name)
-        assert get_not_null(pt_objs[0], 'name') == 'base_network line:Ça roule'
+        assert get_not_null(pt_objs[0], 'name') == 'network:CaRoule line:Ça roule'
 
     def test_query_with_strange_char(self):
         q = u'stop_points/stop_point:stop_with name bob \" , é'.encode('utf-8')
@@ -777,6 +777,32 @@ class TestPtRef(AbstractTestFixture):
             'pt_objects?q=line:A&type[]=line&_current_datetime=20140115T235959' '&disable_disruption=false'
         )
         assert len(response['disruptions']) == 1
+
+    def test_networks(self):
+        """test networks API"""
+        response = self.query_region("networks")
+        networks = get_not_null(response, 'networks')
+        assert len(networks) == 4
+        assert networks[0]['id'] == 'network:A'
+        assert networks[1]['id'] == 'network:B'
+        assert networks[2]['id'] == 'network:CaRoule'
+        assert networks[3]['id'] == 'network:freq'
+
+    def test_networks_with_external_code(self):
+        """test networks with external_code parameter"""
+        response = self.query_region("networks?external_code=A")
+        networks = get_not_null(response, 'networks')
+        assert len(networks) == 1
+        assert networks[0]['id'] == 'network:A'
+
+        response = self.query_region("networks?external_code=B")
+        networks = get_not_null(response, 'networks')
+        assert len(networks) == 1
+        assert networks[0]['id'] == 'network:B'
+
+        response = self.query_region("networks?external_code=wrong_code")
+        networks = get_not_null(response, 'networks')
+        assert len(networks) == 4
 
 
 @dataset({"main_ptref_test": {}, "main_routing_test": {}})

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -801,7 +801,7 @@ class TestPtRef(AbstractTestFixture):
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/networks?external_code=wrong_code")
         assert code == 404
         message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the uri wrong_code' in message
+        assert 'Unable to find an object for the external_code wrong_code' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/networks?external_code=A")
@@ -813,7 +813,7 @@ class TestPtRef(AbstractTestFixture):
         response, code = self.query_no_assert("v1/networks?external_code=wrong_code")
         assert code == 404
         message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the uri wrong_code' in message
+        assert 'Unable to find an object for the external_code wrong_code' in message
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/networks")
@@ -839,7 +839,7 @@ class TestPtRef(AbstractTestFixture):
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/lines?external_code=wrong_code")
         assert code == 404
         message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the uri wrong_code' in message
+        assert 'Unable to find an object for the external_code wrong_code' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/lines?external_code=A")
@@ -851,7 +851,7 @@ class TestPtRef(AbstractTestFixture):
         response, code = self.query_no_assert("v1/lines?external_code=wrong_code")
         assert code == 404
         message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the uri wrong_code' in message
+        assert 'Unable to find an object for the external_code wrong_code' in message
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/lines")
@@ -876,7 +876,7 @@ class TestPtRef(AbstractTestFixture):
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/stop_points?external_code=wrong_code")
         assert code == 404
         message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the uri wrong_code' in message
+        assert 'Unable to find an object for the external_code wrong_code' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/stop_points?external_code=stop1_code")
@@ -888,7 +888,7 @@ class TestPtRef(AbstractTestFixture):
         response, code = self.query_no_assert("v1/stop_points?external_code=wrong_code")
         assert code == 404
         message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the uri wrong_code' in message
+        assert 'Unable to find an object for the external_code wrong_code' in message
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/stop_points")

--- a/source/tests/mock-kraken/main_ptref_test.cpp
+++ b/source/tests/mock-kraken/main_ptref_test.cpp
@@ -78,7 +78,7 @@ struct data_set {
         // add lines
         b.sa("stop_area:stop1", 9, 9, false, true)("stop_area:stop1", 9, 9);
         b.sa("stop_area:stop2", 10, 10, false, true)("stop_area:stop2", 10, 10);
-        b.vj("line:A", "", "", true, "vj1", "", "physical_mode:Car")(
+        b.vj_with_network("network:A", "line:A", "", "", true, "vj1", "", "physical_mode:Car")(
             "stop_area:stop1", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)("stop_area:stop2", 11 * 3600 + 10 * 60,
                                                                          11 * 3600 + 10 * 60);
         b.lines["line:A"]->calendar_list.push_back(wednesday_cal);
@@ -86,11 +86,12 @@ struct data_set {
 
         // we add a stop area with a strange name (with space and special char)
         b.sa("stop_with name bob \" , é", 20, 20);
-        b.vj("line:B").physical_mode("physical_mode:Car")("stop_point:stop_with name bob \" , é", "8:00"_t)(
-            "stop_area:stop1", "9:00"_t);
+        b.vj_with_network("network:B", "line:B")
+            .physical_mode("physical_mode:Car")("stop_point:stop_with name bob \" , é", "8:00"_t)("stop_area:stop1",
+                                                                                                  "9:00"_t);
 
         // add a line with a unicode name
-        b.vj("line:Ça roule")
+        b.vj_with_network("network:CaRoule", "line:Ça roule")
             .name("vj_b")("stop_area:stop2", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)(
                 "stop_area:stop1", 11 * 3600 + 10 * 60, 11 * 3600 + 10 * 60);
         b.lines["line:Ça roule"]->commercial_mode = nullptr;  // remove commercial_mode to allow label testing
@@ -139,6 +140,8 @@ struct data_set {
         b.data->pt_data->codes.add(b.lines["line:A"], "codeB", "Bise");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeC", "C");
         b.data->pt_data->codes.add(b.sps.at("stop_area:stop1"), "code_uic", "bobette");
+        b.data->pt_data->codes.add(b.lines["line:A"]->network, "external_code", "A");
+        b.data->pt_data->codes.add(b.lines["line:B"]->network, "external_code", "B");
 
         b.data->build_uri();
 

--- a/source/tests/mock-kraken/main_ptref_test.cpp
+++ b/source/tests/mock-kraken/main_ptref_test.cpp
@@ -140,6 +140,7 @@ struct data_set {
         b.data->pt_data->codes.add(b.lines["line:A"], "codeB", "Bise");
         b.data->pt_data->codes.add(b.lines["line:A"], "codeC", "C");
         b.data->pt_data->codes.add(b.sps.at("stop_area:stop1"), "code_uic", "bobette");
+        b.data->pt_data->codes.add(b.sps.at("stop_area:stop1"), "external_code", "stop1_code");
         b.data->pt_data->codes.add(b.lines["line:A"]->network, "external_code", "A");
         b.data->pt_data->codes.add(b.lines["line:B"]->network, "external_code", "B");
 


### PR DESCRIPTION
**JIRA**: https://jira.kisio.org/browse/NAVP-1441

Before the fix, it was only possible to filter networks API response with **external_code**, if the coverage was not fill.
Now it works with coverage param too.
I added some Tests for networks API and external_code option
Tested in real life in local

- [ ] Waiting on Custom Artemis Build to pass to validate the PR ([custom build #111](https://ci.navitia.io/job/custom_navitia_pull_request_build/111/))