### PR TITLE
Fix A* heuristic cost

### DIFF
--- a/source/georef/astar_path_finder.cpp
+++ b/source/georef/astar_path_finder.cpp
@@ -66,7 +66,7 @@ void AstarPathFinder::start_distance_or_target_astar(const navitia::time_duratio
     // We start astar from source and target nodes
     try {
         astar({starting_edge[source_e], starting_edge[target_e]},
-              astar_distance_heuristic(geo_ref.graph, dest_projected, 1. / double(default_speed[mode] * speed_factor)),
+              astar_distance_heuristic(geo_ref.graph, dest_projected, 1. / double(default_speed[mode])),
               astar_distance_or_target_visitor(radius, distances, destinations));
     } catch (DestinationFound&) {
     }


### PR DESCRIPTION
Reverts CanalTP/navitia#3007

The original PR https://github.com/CanalTP/navitia/pull/3002 has broken our business tests Artemis. In order not to block the release process, we've decided to revert the original one before we could be sure of what's really going on. 

Since every failed tests have been checked and updated, we can merge this fix into dev definitively