### PR TITLE
Expose http status, reasons and response to NewRelic on Ridesharing

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
@@ -275,7 +275,7 @@ class InstantSystem(AbstractRidesharingService):
                 resp.url,
                 extra={'ridesharing_service_id': self._get_rs_id(), 'status_code': resp.status_code},
             )
-            raise RidesharingServiceError('non 200 response')
+            raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
 
         if resp:
             r = self._make_response(resp.json())

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
@@ -37,7 +37,19 @@ from collections import namedtuple
 
 
 class RidesharingServiceError(RuntimeError):
-    pass
+    def __init__(self, reason, http_status=None, http_reason=None, http_txt=None):
+        super(RuntimeError, self).__init__(reason)
+        self.http_status = http_status
+        self.http_reason = http_reason
+        self.http_txt = http_txt
+
+    def get_params(self):
+        return {
+            'reason': str(self),
+            'http_status': self.http_status,
+            'http_reason': self.http_reason,
+            'http_response': self.http_txt,
+        }
 
 
 RsFeedPublisher = namedtuple('RsFeedPublisher', ['id', 'name', 'license', 'url'])
@@ -66,7 +78,7 @@ class AbstractRidesharingService(object):
 
             return journeys, feed_publisher
         except RidesharingServiceError as e:
-            self.record_call('failure', reason=str(e))
+            self.record_call('failure', **e.get_params())
             return [], None
 
     @abc.abstractmethod

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
@@ -33,7 +33,11 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 
 from jormungandr.scenarios.ridesharing.instant_system import InstantSystem, DEFAULT_INSTANT_SYSTEM_FEED_PUBLISHER
 from jormungandr.scenarios.ridesharing.ridesharing_journey import Gender
-from jormungandr.scenarios.ridesharing.ridesharing_service import Ridesharing, RsFeedPublisher
+from jormungandr.scenarios.ridesharing.ridesharing_service import (
+    Ridesharing,
+    RsFeedPublisher,
+    RidesharingServiceError,
+)
 
 import mock
 from jormungandr.tests import utils_test
@@ -325,3 +329,29 @@ def instant_system_test():
         assert ridesharing_journeys[1].available_seats == 4
 
         assert feed_publisher == RsFeedPublisher(**DUMMY_INSTANT_SYSTEM_FEED_PUBLISHER)
+
+
+import requests_mock
+import pytest
+
+
+def test_request_journeys_should_raise_on_non_200():
+    with requests_mock.Mocker() as mock:
+        instant_system = InstantSystem(
+            DummyInstance(), service_url='http://instant.sys', api_key='ApiKey', network='Network'
+        )
+
+        mock.get('http://instant.sys', status_code=401, text='{this is the http response}')
+
+        with pytest.raises(RidesharingServiceError) as e:
+            instant_system._request_journeys(
+                '1.2,3.4',
+                '5.6,7.8',
+                utils.PeriodExtremity(
+                    datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+                ),
+            )
+
+        exception_params = e.value.get_params().values()
+        assert 401 in exception_params
+        assert '{this is the http response}' in exception_params

--- a/source/jormungandr/tests/instant_system_new_default_routing_tests.py
+++ b/source/jormungandr/tests/instant_system_new_default_routing_tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2001-2017, Canal TP and/or its affiliates. All rights reserved.
 #
 # This file is part of Navitia,


### PR DESCRIPTION
Improve NewRelic reporting error on a RideSharing service http failure. 

We have a `ridesharing_status` custom event on NewRelic that only says `non 200 response` when a HTTP request to the ridesharing service returns something else the 200... This is not ideal for troubleshooting :(

I propose to add 3 new fields to the `ridesharing_status` custom event to help understanding issues when things are going downhill :
* http_status (eg. 401)
* http_reason (eg. Unauthorized)
* http_txt (eg. `{"message":"No API key found in request"}`)
