### PR TITLE
Release: major version number to match data_version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ you may also run `make docker_test` for important contributions), and have a wee
 For a proposed PR, we require 2 approvals by repository owners.
 If you have the rights, once your PR has 2 approvals, you are encouraged to merge it yourself.
 
+
 ## Build Navitia
 
 If you want to build navitia, please refer to the
@@ -38,6 +39,7 @@ navitia_dir/run/jormungandr/jormungandr_settings.jon
 navitia_dir/run/jormungandr/venv_jormungandr/
 ```
 
+
 ## Code Organisation
 
 At the root of the repository, several directories can be found:
@@ -47,6 +49,18 @@ At the root of the repository, several directories can be found:
 3. release: contains [script_release.py](https://github.com/canaltp/navitia/blob/dev/release/script_release.py) to run the release process
 4. scripts: different useful scripts
 
+### `data_version` management
+
+The data_version stored into [source/type/data.cpp](source/type/data.cpp) is used to know if a given `nav` file
+is readable using a given kraken (both contain their version).
+
+So this number **must** be incremented when data serialization changes.  
+In case multiple changes occur between 2 releases, only one increment is enough.
+
+This number is also used to tag major versions of Navitia.  
+Major version is tracked externally to know if nav-files must be regenerated.  
+So please update this `data_version` to indicate a need for re-binarization.
+
 
 ## Tools
 
@@ -54,6 +68,10 @@ At the root of the repository, several directories can be found:
 * CMake for the build system
 * Python for the api
 
+
+## Release a new version
+
+Please follow instructions from [readme_release.md](readme_release.md).
 
 ## Git hooks
 
@@ -65,7 +83,7 @@ Then, install the hooks with:
 pre-commit install
 ```
 
-## Python formatting
+### Python formatting
 
 Python source code in this project is formatted using [Black](https://black.readthedocs.io/en/stable/)
 You should enable the pre-commit git hook to make sure it's being run before commiting your changes, it's
@@ -81,7 +99,7 @@ pre-commit run black --all
 You can also [install Black traditionally](https://black.readthedocs.io/en/stable/installation_and_usage.html)
 But bare in mind, it requires python 3.6+ to run.
 
-## C++ formatting
+### C++ formatting
 
 Our pre-commit hooks are running [Clang-format](https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html) to format our c++ codebase. You'll need version 6.0 in order to pass our CI.
 ```sh

--- a/readme_release.md
+++ b/readme_release.md
@@ -1,6 +1,10 @@
 # HOWTO Release navitia
 
-## "Normal" release (minor)
+## "Regular" release
+
+This lets the script decide if it's major or minor release.
+The decision is based on the data_version located in source/type/data.cpp
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how data_version is managed.
 
 First have a look on github's repo at PRs about to be released https://github.com/CanalTP/navitia/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc
 * Check that `not_in_changelog` and `hotfix` labels are correct and none is missing on PRs that are gonna be released
@@ -11,21 +15,15 @@ Then the script should take over:
 cd <path/to/repo/navitia>
 # to be sure to trigger the correct version of the release script
 git fetch <canaltp_distant_repo_name> && git rebase <canaltp_distant_repo_name>/dev dev
-./release_navitia.sh minor <canaltp_distant_repo_name>
+./release_navitia.sh regular <canaltp_distant_repo_name>
 ```
 Then follow the instructions given by the script, and also:
 * pay attention to the changelog, remove useless PR (small doc) and check that every important PR is there
 * don't forget to make `git submodule update --recursive` when necessary
 * check that `release` branch COMPILES and TESTS (unit, docker and tyr) before pushing it!
 
-## Other releases
+## For hotfix
 
-### For a major release, same as minor, but major:
-```sh
-./release_navitia.sh major <canaltp_distant_repo_name>
-```
-
-### For hotfix:
 Note: It is preferable but not mandatory to merge the hotfix PR before.
 ```sh
 ./release_navitia.sh hotfix <canaltp_distant_repo_name>

--- a/readme_release.md
+++ b/readme_release.md
@@ -22,6 +22,8 @@ Then follow the instructions given by the script, and also:
 * don't forget to make `git submodule update --recursive` when necessary
 * check that `release` branch COMPILES and TESTS (unit, docker and tyr) before pushing it!
 
+Nota: `major` and `minor` invocations are possible but deprecated.
+
 ## For hotfix
 
 Note: It is preferable but not mandatory to merge the hotfix PR before.

--- a/release/script_release.py
+++ b/release/script_release.py
@@ -150,17 +150,33 @@ class ReleaseManager:
                 exit(1)
             elif self.version[0] < self.dev_data_version:  # major version
                 self.version[0] = self.dev_data_version
-                self.version[1] = version_n[2] = 0
+                self.version[1] = version[2] = 0
             else:  # versions equal: minor version
                 self.version[0] = self.dev_data_version
                 self.version[1] += 1
                 self.version[2] = 0
+
+        elif self.release_type == "major":
+            self.version[0] += 1
+            self.version[1] = version[2] = 0
+
+        elif self.release_type == "minor":
+            self.version[1] += 1
+            self.version[2] = 0
 
         elif self.release_type == "hotfix":
             self.version[2] += 1
 
         else:
             exit(5)
+
+        if self.version[0] > self.dev_data_version:
+            print(
+                "ABORTING: data_version {d} is < to tag {t} to be published".format(
+                    d=self.dev_data_version, t=self.latest_tag
+                )
+            )
+            exit(1)
 
         self.str_version = "{maj}.{min}.{hf}".format(
             maj=self.version[0], min=self.version[1], hf=self.version[2]
@@ -171,10 +187,10 @@ class ReleaseManager:
 
     def checkout_parent_branch(self):
         parent = ""
-        if self.release_type == "regular":
-            parent = "dev"
-        else:
+        if self.release_type == "hotfix":
             parent = "release"
+        else:
+            parent = "dev"
 
         self.git.checkout(parent)
         self.git.submodule('update', '--recursive')
@@ -398,7 +414,7 @@ class ReleaseManager:
 if __name__ == '__main__':
 
     if len(argv) < 2:
-        print("mandatory argument: {regular|hotfix}")
+        print("mandatory argument: {regular|major|minor|hotfix}")
         print("possible additional argument: remote (default is CanalTP)")
         exit(5)
 

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -63,7 +63,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 72;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 3;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),


### PR DESCRIPTION
Brace yourself for regular major version jumps :-)

I would really like a look of @kinnou02 on the doc (how to manage data_version/bina)

:white_check_mark: did some tests locally: seems OK.

JIRA: https://jira.kisio.org/browse/NAVP-1435