### PR TITLE
Jormun: Add isochrone distributed jormun

### DIFF
--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -38,6 +38,7 @@ class JourneyParameters(object):
         min_nb_journeys=None,
         timeframe=None,
         depth=1,
+        isochrone_center=None,
     ):
 
         self.max_duration = max_duration
@@ -53,6 +54,7 @@ class JourneyParameters(object):
         self.min_nb_journeys = min_nb_journeys
         self.timeframe = timeframe
         self.depth = depth
+        self.isochrone_center = isochrone_center
 
 
 class Kraken(object):
@@ -62,15 +64,17 @@ class Kraken(object):
     def journeys(self, origins, destinations, datetime, clockwise, journey_parameters, bike_in_pt):
         req = request_pb2.Request()
         req.requested_api = type_pb2.pt_planner
-        for stop_point_id, access_duration in origins.items():
-            location = req.journeys.origin.add()
-            location.place = stop_point_id
-            location.access_duration = access_duration
+        if origins:
+            for stop_point_id, access_duration in origins.items():
+                location = req.journeys.origin.add()
+                location.place = stop_point_id
+                location.access_duration = access_duration
 
-        for stop_point_id, access_duration in destinations.items():
-            location = req.journeys.destination.add()
-            location.place = stop_point_id
-            location.access_duration = access_duration
+        if destinations:
+            for stop_point_id, access_duration in destinations.items():
+                location = req.journeys.destination.add()
+                location.place = stop_point_id
+                location.access_duration = access_duration
 
         req.journeys.night_bus_filter_max_factor = journey_parameters.night_bus_filter_max_factor
         req.journeys.night_bus_filter_base_factor = journey_parameters.night_bus_filter_base_factor
@@ -103,5 +107,10 @@ class Kraken(object):
 
         if journey_parameters.depth:
             req.journeys.depth = journey_parameters.depth
+
+        if journey_parameters.isochrone_center:
+            req.journeys.isochrone_center.place = journey_parameters.isochrone_center
+            req.journeys.isochrone_center.access_duration = 0
+            req.requested_api = type_pb2.isochrone_distributed
 
         return self.instance.send_and_receive(req)

--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -109,6 +109,6 @@ class Kraken(object):
         if journey_parameters.isochrone_center:
             req.journeys.isochrone_center.place = journey_parameters.isochrone_center
             req.journeys.isochrone_center.access_duration = 0
-            req.requested_api = type_pb2.isochrone_distributed
+            req.requested_api = type_pb2.ISOCHRONE
 
         return self.instance.send_and_receive(req)

--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -64,17 +64,15 @@ class Kraken(object):
     def journeys(self, origins, destinations, datetime, clockwise, journey_parameters, bike_in_pt):
         req = request_pb2.Request()
         req.requested_api = type_pb2.pt_planner
-        if origins:
-            for stop_point_id, access_duration in origins.items():
-                location = req.journeys.origin.add()
-                location.place = stop_point_id
-                location.access_duration = access_duration
+        for stop_point_id, access_duration in origins.items():
+            location = req.journeys.origin.add()
+            location.place = stop_point_id
+            location.access_duration = access_duration
 
-        if destinations:
-            for stop_point_id, access_duration in destinations.items():
-                location = req.journeys.destination.add()
-                location.place = stop_point_id
-                location.access_duration = access_duration
+        for stop_point_id, access_duration in destinations.items():
+            location = req.journeys.destination.add()
+            location.place = stop_point_id
+            location.access_duration = access_duration
 
         req.journeys.night_bus_filter_max_factor = journey_parameters.night_bus_filter_max_factor
         req.journeys.night_bus_filter_base_factor = journey_parameters.night_bus_filter_base_factor

--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -46,6 +46,7 @@ from jormungandr.scenarios.helper_classes.complete_pt_journey import (
 from jormungandr.scenarios.utils import fill_uris, switch_back_to_ridesharing
 from jormungandr.new_relic import record_custom_parameter
 from navitiacommon import type_pb2
+from flask_restful import abort
 
 
 class PartialResponseContext(object):
@@ -79,7 +80,7 @@ class Distributed(object):
             for pt_j in e.pt_journeys.journeys
         }
 
-    def _compute_all(self, future_manager, request, instance, krakens_call, context):
+    def _compute_journeys(self, future_manager, request, instance, krakens_call, context):
         """
         For all krakens_call, call the kraken and aggregate the responses
 
@@ -384,7 +385,9 @@ class Scenario(new_default.Scenario):
                 if request_type == type_pb2.ISOCHRONE:
                     return self._scenario._compute_isochrone(future_manager, request, instance, krakens_call)
                 elif request_type == type_pb2.PLANNER:
-                    return self._scenario._compute_all(future_manager, request, instance, krakens_call, context)
+                    return self._scenario._compute_journeys(
+                        future_manager, request, instance, krakens_call, context
+                    )
                 else:
                     abort(400, message="This type of request is not supported with distributed")
         except PtException as e:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/complete_pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/complete_pt_journey.py
@@ -45,7 +45,11 @@ def wait_and_get_pt_journeys(future_pt_journey, has_valid_direct_paths):
     """
     pt_journeys = future_pt_journey.wait_and_get()
 
-    if pt_journeys and pt_journeys.HasField(b"error"):
+    if (
+        pt_journeys
+        and pt_journeys.HasField(b"error")
+        and pt_journeys.error.id != response_pb2.Error.error_id.Value('bad_format')
+    ):
         if pt_journeys.error.id == response_pb2.Error.error_id.Value('no_solution') and has_valid_direct_paths:
             pt_journeys.ClearField(b"error")
         elif pt_journeys.error.id == response_pb2.Error.error_id.Value('date_out_of_bounds'):

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
@@ -128,7 +128,6 @@ class PtJourney:
 
     def _do_isochrone_request(self):
         logger = logging.getLogger(__name__)
-
         fallback_durations_pool = (
             self._orig_fallback_durtaions_pool
             if self._orig_fallback_durtaions_pool is not None
@@ -143,13 +142,13 @@ class PtJourney:
 
         fallback_durations = {k: v.duration for k, v in fallback_duration_status.items()}
 
-        if (
-            not fallback_durations
-            or not self._request.get('max_duration', 0)
-        ):
+        if not fallback_durations or not self._request.get('max_duration', 0):
             return None
 
-        resp = self._journeys(self._instance.planner, fallback_durations, None)
+        if self._orig_fallback_durtaions_pool is not None:
+            resp = self._journeys(self._instance.planner, fallback_durations, {})
+        else:
+            resp = self._journeys(self._instance.planner, {}, fallback_durations)
 
         for j in resp.journeys:
             j.internal_id = str(utils.generate_id())

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
@@ -157,8 +157,12 @@ class PtJourney:
             logger.debug("pt journey has error mode: %s", mode)
             # Here needs to modify error message of no_solution
             if not fallback_durations:
-                resp.error.id = response_pb2.Error.no_origin
-                resp.error.message = "no origin point"
+                if self._orig_fallback_durtaions_pool is not None:
+                    resp.error.id = response_pb2.Error.no_origin
+                    resp.error.message = "no origin point"
+                else:
+                    resp.error.id = response_pb2.Error.no_destination
+                    resp.error.message = "no destination point"
 
         logger.debug("finish public transport journey with mode: %s", mode)
         return resp

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
@@ -55,6 +55,7 @@ class PtJourney:
         journey_params,
         bike_in_pt,
         request,
+        isochrone_center,
     ):
         self._future_manager = future_manager
         self._instance = instance
@@ -67,6 +68,7 @@ class PtJourney:
         self._bike_in_pt = bike_in_pt
         self._request = request
         self._value = None
+        self._isochrone_center = isochrone_center
 
         self._async_request()
 
@@ -81,7 +83,7 @@ class PtJourney:
             self._bike_in_pt,
         )
 
-    def _do_request(self):
+    def _do_journeys_request(self):
         logger = logging.getLogger(__name__)
         logger.debug("waiting for orig fallback durations with %s", self._dep_mode)
         orig_fallback_duration_status = self._orig_fallback_durtaions_pool.wait_and_get(self._dep_mode)
@@ -124,8 +126,49 @@ class PtJourney:
         )
         return resp
 
+    def _do_isochrone_request(self):
+        logger = logging.getLogger(__name__)
+
+        fallback_durations_pool = (
+            self._orig_fallback_durtaions_pool
+            if self._orig_fallback_durtaions_pool is not None
+            else self._dest_fallback_durations_pool
+        )
+        mode = self._dep_mode if self._orig_fallback_durtaions_pool else self._arr_mode
+
+        logger.debug("waiting for fallback durations with %s", mode)
+        fallback_duration_status = fallback_durations_pool.wait_and_get(mode)
+
+        logger.debug("requesting public transport journey with dep_mode: %s", mode)
+
+        fallback_durations = {k: v.duration for k, v in fallback_duration_status.items()}
+
+        if (
+            not fallback_durations
+            or not self._request.get('max_duration', 0)
+        ):
+            return None
+
+        resp = self._journeys(self._instance.planner, fallback_durations, None)
+
+        for j in resp.journeys:
+            j.internal_id = str(utils.generate_id())
+
+        if resp.HasField(b"error"):
+            logger.debug("pt journey has error mode: %s", mode)
+            # Here needs to modify error message of no_solution
+            if not fallback_durations:
+                resp.error.id = response_pb2.Error.no_origin
+                resp.error.message = "no origin point"
+
+        logger.debug("finish public transport journey with mode: %s", mode)
+        return resp
+
     def _async_request(self):
-        self._value = self._future_manager.create_future(self._do_request)
+        if self._isochrone_center:
+            self._value = self._future_manager.create_future(self._do_isochrone_request)
+        else:
+            self._value = self._future_manager.create_future(self._do_journeys_request)
 
     def wait_and_get(self):
         return self._value.wait_and_get()
@@ -176,6 +219,7 @@ class PtJourneyPool:
         orig_fallback_durations_pool,
         dest_fallback_durations_pool,
         request,
+        isochrone_center=None,
     ):
         self._future_manager = future_manager
         self._instance = instance
@@ -185,14 +229,15 @@ class PtJourneyPool:
         self._krakens_call = krakens_call
         self._orig_fallback_durations_pool = orig_fallback_durations_pool
         self._dest_fallback_durations_pool = dest_fallback_durations_pool
-        self._journey_params = self._create_parameters(request)
+        self._isochrone_center = isochrone_center
+        self._journey_params = self._create_parameters(request, self._isochrone_center)
         self._request = request
         self._value = []
 
         self._async_request()
 
     @staticmethod
-    def _create_parameters(request):
+    def _create_parameters(request, isochrone_center):
         from jormungandr.planner import JourneyParameters
 
         return JourneyParameters(
@@ -209,6 +254,7 @@ class PtJourneyPool:
             min_nb_journeys=request['min_nb_journeys'],
             timeframe=request['timeframe_duration'],
             depth=request['depth'],
+            isochrone_center=isochrone_center,
         )
 
     def _async_request(self):
@@ -218,18 +264,20 @@ class PtJourneyPool:
             if dp_type == "only":
                 continue
 
-            dp = self._streetnetwork_path_pool.wait_and_get(
-                self._requested_orig_obj,
-                self._requested_dest_obj,
-                dep_mode,
-                periode_extremity,
-                direct_path_type,
-                request=self._request,
-            )
-            if dp and dp.journeys:
-                self._journey_params.direct_path_duration = dp.journeys[0].durations.total
-            else:
-                self._journey_params.direct_path_duration = None
+            # We don't need direct_paths in isochrone
+            if not self._isochrone_center:
+                dp = self._streetnetwork_path_pool.wait_and_get(
+                    self._requested_orig_obj,
+                    self._requested_dest_obj,
+                    dep_mode,
+                    periode_extremity,
+                    direct_path_type,
+                    request=self._request,
+                )
+                if dp and dp.journeys:
+                    self._journey_params.direct_path_duration = dp.journeys[0].durations.total
+                else:
+                    self._journey_params.direct_path_duration = None
 
             bike_in_pt = dep_mode == 'bike' and arr_mode == 'bike'
             pt_journey = PtJourney(
@@ -243,6 +291,7 @@ class PtJourneyPool:
                 journey_params=self._journey_params,
                 bike_in_pt=bike_in_pt,
                 request=self._request,
+                isochrone_center=self._isochrone_center,
             )
 
             self._value.append(PtPoolElement(dep_mode, arr_mode, pt_journey))

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1116,8 +1116,11 @@ class Scenario(simple.Scenario):
         updated_request_with_default(request, instance)
         # we don't want to filter anything!
         krakens_call = get_kraken_calls(request)
+        # Initialize a context for distributed
+        distributed_context = self.get_context()
         resp = merge_responses(
-            self.call_kraken(type_pb2.ISOCHRONE, request, instance, krakens_call), request['debug']
+            self.call_kraken(type_pb2.ISOCHRONE, request, instance, krakens_call, distributed_context),
+            request['debug'],
         )
         if not request['debug']:
             # on isochrone we can filter the number of max journeys

--- a/source/jormungandr/tests/isochrone_tests.py
+++ b/source/jormungandr/tests/isochrone_tests.py
@@ -29,7 +29,7 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import logging
 
-from .tests_mechanism import AbstractTestFixture, dataset
+from .tests_mechanism import AbstractTestFixture, dataset, config, NewDefaultScenarioAbstractTestFixture
 from .check_utils import *
 
 
@@ -162,3 +162,8 @@ class TestIsochrone(AbstractTestFixture):
         response, code = self.query_no_assert(query)
         assert code == 400
         assert "invalid literal for int() with base 10: 'toto'" in response['message']
+
+
+@config({"scenario": "distributed"})
+class TestIsochroneDistributed(TestIsochrone, NewDefaultScenarioAbstractTestFixture):
+    pass

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -75,7 +75,7 @@ class TestJourneysDistributedWithMock(JourneyMinBikeMinCar, NewDefaultScenarioAb
         response = self.query_region(query)
         check_best(response)
 
-        # Without optimization (context.partial_response_is_empty = True in distributed._compute_all()
+        # Without optimization (context.partial_response_is_empty = True in distributed._compute_journeys()
         # journey count = 18 / direct_path_call_count = 26 / routing_matrix_call_count = 20
         # get_directpath_count_by_mode(response, 'walking') == 5
         # get_directpath_count_by_mode(response, 'bike') == 5
@@ -107,7 +107,7 @@ class TestJourneysDistributedWithMock(JourneyMinBikeMinCar, NewDefaultScenarioAb
         response = self.query_region(query)
         check_best(response)
 
-        # Without optimization (context.partial_response_is_empty = True in distributed._compute_all()
+        # Without optimization (context.partial_response_is_empty = True in distributed._compute_journeys()
         # journey count = 18 / direct_path_call_count = 26 / routing_matrix_call_count = 20
         # get_directpath_count_by_mode(response, 'walking') == 5
         # get_directpath_count_by_mode(response, 'bike') == 5
@@ -293,7 +293,6 @@ class TestDistributedJourneysWithPtref(JourneysWithPtref, NewDefaultScenarioAbst
 
 @config({"scenario": "distributed"})
 class TestDistributedOnBasicRouting(OnBasicRouting, NewDefaultScenarioAbstractTestFixture):
-    @skip("temporarily disabled")
     def test_isochrone(self):
         super(TestDistributedOnBasicRouting, self).test_isochrone()
 


### PR DESCRIPTION
In Jormun, we create the request for isochrone_distributed. 

`_compute_isochrone` is a lot like `_compute_journeys` but with one `origins` or `destinations`, plus `isochrone_center`.

A lot of the code is about handling if we have `origins` or  `destinations` filled in the request.

TUs for isochrone_distributed which were disabled are now enabled back !