### PR TITLE
Kraken : Isochrone distributed part3

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -642,14 +642,16 @@ JourneysArg::JourneysArg(std::vector<type::EntryPoint> origins,
                          std::vector<std::string> allowed,
                          type::RTLevel rt_level,
                          std::vector<type::EntryPoint> destinations,
-                         std::vector<uint64_t> datetimes)
-    : origins(origins),
-      accessibilite_params(accessibilite_params),
-      forbidden(forbidden),
-      allowed(allowed),
+                         std::vector<uint64_t> datetimes,
+                         boost::optional<type::EntryPoint> isochrone_center)
+    : origins(std::move(origins)),
+      accessibilite_params(std::move(accessibilite_params)),
+      forbidden(std::move(forbidden)),
+      allowed(std::move(allowed)),
       rt_level(rt_level),
-      destinations(destinations),
-      datetimes(datetimes) {}
+      destinations(std::move(destinations)),
+      datetimes(std::move(datetimes)),
+      isochrone_center(isochrone_center) {}
 JourneysArg::JourneysArg() {}
 
 navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest& request) {
@@ -691,8 +693,12 @@ navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest& req
 
     type::RTLevel rt_level = get_realtime_level(request.realtime_level());
 
+    const auto isochrone_center = request.has_isochrone_center()
+                                      ? create_journeys_entry_point(request.isochrone_center(), sn_params, data, true)
+                                      : boost::optional<type::EntryPoint>{};
+
     return JourneysArg(std::move(origins), std::move(accessibilite_params), std::move(forbidden), std::move(allowed),
-                       rt_level, std::move(destinations), std::move(datetimes));
+                       rt_level, std::move(destinations), std::move(datetimes), std::move(isochrone_center));
 }
 
 void Worker::err_msg_isochron(navitia::PbCreator& pb_creator, const std::string& err_msg) {

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -112,6 +112,7 @@ private:
     JourneysArg fill_journeys(const pbnavitia::JourneysRequest& request);
     void err_msg_isochron(navitia::PbCreator& pb_creator, const std::string& err_msg);
     void journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API api);
+    void isochrone(const pbnavitia::JourneysRequest& request);
     void pt_ref(const pbnavitia::PTRefRequest& request);
     void traffic_reports(const pbnavitia::TrafficReportsRequest& request);
     void line_reports(const pbnavitia::LineReportsRequest& request);

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -59,13 +59,15 @@ struct JourneysArg {
     type::RTLevel rt_level;
     std::vector<type::EntryPoint> destinations;
     std::vector<uint64_t> datetimes;
+    boost::optional<type::EntryPoint> isochrone_center;
     JourneysArg(std::vector<type::EntryPoint> origins,
                 type::AccessibiliteParams accessibilite_params,
                 std::vector<std::string> forbidden,
                 std::vector<std::string> allowed,
                 type::RTLevel rt_level,
                 std::vector<type::EntryPoint> destinations,
-                std::vector<uint64_t> datetimes);
+                std::vector<uint64_t> datetimes,
+                boost::optional<type::EntryPoint> isochrone_center);
     JourneysArg();
 };
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1461,7 +1461,7 @@ static const boost::optional<IsochroneCommon> make_isochrone_common(
     georef::StreetNetwork& worker,
     PbCreator& pb_creator,
     const boost::optional<routing::map_stop_point_duration>& stop_points) {
-    auto const tmp_datetime = parse_datetimes(raptor, {departure_datetime}, pb_creator, clockwise);
+    const auto tmp_datetime = parse_datetimes(raptor, {departure_datetime}, pb_creator, clockwise);
     if (pb_creator.has_error() || tmp_datetime.size() == 0
         || pb_creator.has_response_type(pbnavitia::DATE_OUT_OF_BOUNDS)) {
         return boost::optional<IsochroneCommon>{};
@@ -1473,9 +1473,9 @@ static const boost::optional<IsochroneCommon> make_isochrone_common(
         return boost::optional<IsochroneCommon>{};
     }
 
-    auto const datetime = tmp_datetime.front();
-    auto const init_dt = to_datetime(datetime, raptor.data);
-    auto const bound = build_bound(clockwise, max_duration, init_dt);
+    const auto datetime = tmp_datetime.front();
+    const auto init_dt = to_datetime(datetime, raptor.data);
+    const auto bound = build_bound(clockwise, max_duration, init_dt);
     raptor.isochrone(*departures, init_dt, bound, max_transfers, accessibilite_params, forbidden, allowed, clockwise,
                      rt_level);
     return IsochroneCommon(clockwise, center.coordinates, *departures, init_dt, center, bound, datetime);
@@ -1494,7 +1494,7 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     const int max_duration,
                     const uint32_t max_transfers,
                     const boost::optional<routing::map_stop_point_duration>& stop_points) {
-    auto const isochrone_common =
+    const auto isochrone_common =
         make_isochrone_common(raptor, center, datetime_timestamp, max_duration, max_transfers, accessibilite_params,
                               forbidden, allowed, clockwise, rt_level, worker, pb_creator, stop_points);
 
@@ -1594,7 +1594,7 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               georef::StreetNetwork& worker,
                               const double& speed,
                               const boost::optional<routing::map_stop_point_duration>& stop_points) {
-    auto const isochrone_common = make_isochrone_common(raptor, center, departure_datetime, boundary_duration[0],
+    const auto isochrone_common = make_isochrone_common(raptor, center, departure_datetime, boundary_duration[0],
                                                         max_transfers, accessibilite_params, forbidden, allowed,
                                                         clockwise, rt_level, worker, pb_creator, stop_points);
 
@@ -1629,7 +1629,7 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    const navitia::type::Mode_e end_mode,
                    const uint32_t resolution,
                    const boost::optional<routing::map_stop_point_duration>& stop_points) {
-    auto const isochrone_common =
+    const auto isochrone_common =
         make_isochrone_common(raptor, center, departure_datetime, max_duration, max_transfers, accessibilite_params,
                               forbidden, allowed, clockwise, rt_level, worker, pb_creator, stop_points);
     if (!isochrone_common) {

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -103,7 +103,7 @@ void make_response(navitia::PbCreator& pb_creator,
 
 void make_isochrone(navitia::PbCreator& pb_creator,
                     RAPTOR& raptor,
-                    const type::EntryPoint& origin,
+                    const type::EntryPoint& center,
                     const uint64_t datetime,
                     const bool clockwise,
                     const type::AccessibiliteParams& accessibilite_params,
@@ -112,7 +112,8 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     georef::StreetNetwork& worker,
                     const type::RTLevel rt_level,
                     const int max_duration = 3600,
-                    const uint32_t max_transfers = std::numeric_limits<uint32_t>::max());
+                    const uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
+                    const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
 
 /**
  * @brief Used for Pt with distributed mode
@@ -192,7 +193,7 @@ DateTime prepare_next_call_for_raptor(const RAPTOR::Journeys& journeys, const bo
 
 void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               RAPTOR& raptor_max,
-                              const type::EntryPoint& origin,
+                              const type::EntryPoint& center,
                               const uint64_t departure_datetime,
                               const std::vector<DateTime>& boundary_duration,
                               const uint32_t max_transfers,
@@ -202,7 +203,8 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               const bool clockwise,
                               const nt::RTLevel rt_level,
                               georef::StreetNetwork& worker,
-                              const double& speed);
+                              const double& speed,
+                              const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
 
 void make_heat_map(navitia::PbCreator& pb_creator,
                    RAPTOR& raptor,
@@ -218,7 +220,8 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    georef::StreetNetwork& worker,
                    const double& speed,
                    const navitia::type::Mode_e mode,
-                   const uint32_t resolution);
+                   const uint32_t resolution,
+                   const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
 
 void make_pathes(PbCreator& pb_creator,
                  const std::vector<navitia::routing::Path>& paths,

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -113,7 +113,7 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     const type::RTLevel rt_level,
                     const int max_duration = 3600,
                     const uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
-                    const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
+                    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
 
 /**
  * @brief Used for Pt with distributed mode
@@ -204,7 +204,7 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               const nt::RTLevel rt_level,
                               georef::StreetNetwork& worker,
                               const double& speed,
-                              const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
+                              const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
 
 void make_heat_map(navitia::PbCreator& pb_creator,
                    RAPTOR& raptor,
@@ -221,7 +221,7 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    const double& speed,
                    const navitia::type::Mode_e mode,
                    const uint32_t resolution,
-                   const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
+                   const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
 
 void make_pathes(PbCreator& pb_creator,
                  const std::vector<navitia::routing::Path>& paths,

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1912,6 +1912,27 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     BOOST_CHECK_EQUAL(result.journeys(0).arrival_date_time(), "20150615T083500"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).departure_date_time(), "20150615T082000"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).arrival_date_time(), "20150615T093500"_pts);
+
+    {
+        // We ask the same request with stop_point == center
+        // And check that the response are exactly equivalent
+        nr::map_stop_point_duration stop_points;
+        stop_points.emplace(*b.sps[ep.uri], navitia::seconds(0));
+        navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+        nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
+                           nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
+        BOOST_CHECK_EQUAL(result.DebugString(), pb_creator.get_response().DebugString());
+    }
+    {
+        // We ask the same request with different stop_points
+        // And check that the responses are not the same
+        nr::map_stop_point_duration stop_points;
+        stop_points.emplace(*b.sps["B"], navitia::seconds(0));
+        navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+        nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
+                           nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
+        BOOST_CHECK_NE(result.DebugString(), pb_creator.get_response().DebugString());
+    }
 }
 
 /**
@@ -1934,6 +1955,28 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     BOOST_CHECK_EQUAL(result.journeys(0).arrival_date_time(), "20150615T110000"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).departure_date_time(), "20150615T082600"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).arrival_date_time(), "20150615T110000"_pts);
+
+    {
+        // We ask the same request with stop_point == center
+        // And check that the responses are exactly equivalent
+        nr::map_stop_point_duration stop_points;
+        stop_points.emplace(*b.sps[ep.uri], navitia::seconds(0));
+        navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+        nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
+                           nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
+        BOOST_CHECK_EQUAL(result.DebugString(), pb_creator.get_response().DebugString());
+    }
+
+    {
+        // We ask the same request with different stop_points
+        // And check that the responses are not the same
+        nr::map_stop_point_duration stop_points;
+        stop_points.emplace(*b.sps["C"], navitia::seconds(0));
+        navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+        nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
+                           nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
+        BOOST_CHECK_NE(result.DebugString(), pb_creator.get_response().DebugString());
+    }
 }
 
 /**

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1916,8 +1916,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     {
         // We ask the same request with stop_point == center
         // And check that the response are exactly equivalent
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps[ep.uri], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{ep}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1926,8 +1925,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     {
         // We ask the same request with different stop_points
         // And check that the responses are not the same
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps["B"], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{navitia::type::Type_e::StopPoint, "B"}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1959,8 +1957,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     {
         // We ask the same request with stop_point == center
         // And check that the responses are exactly equivalent
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps[ep.uri], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{ep}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1970,8 +1967,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     {
         // We ask the same request with different stop_points
         // And check that the responses are not the same
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps["C"], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{navitia::type::Type_e::StopPoint, "C"}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);


### PR DESCRIPTION
In the pbf request, we receive a `std::vector<EntryPoint>` and not a already computed `map_stop_point_duration`.

This PR aims to correct that AND to parse the `isochrone_center` and the `stop_points` from the request.

I especially want to discuss this part.
`const auto& center = arg.isochrone_center ? *arg.isochrone_center : (arg.origins.empty() ? arg.destinations[0] 
: arg.origins[0]);`

`const auto& stop_points = arg.isochrone_center ? (arg.origins.empty() ? arg.destinations : arg.origins)`

@pbougue proposition is to add a field `is_street_network_allowed_at_center` in the PBF to make this part more understandable.