### PR TITLE
/addresses collection has never been implemented.

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/uri.py
+++ b/source/jormungandr/jormungandr/interfaces/uri.py
@@ -40,7 +40,6 @@ collections_to_resource_type = {
     "stop_areas": "stop_area",
     "lines": "line",
     "line_groups": "line_group",
-    "addresses": "address",
     "coords": "coord",
     "trips": "trip",
     "contributors": "contributor",

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -504,16 +504,6 @@ def datasets(is_collection):
     return Datasets
 
 
-def addresses(is_collection):
-    class Addresses(Coord):
-
-        """ Not implemented yet"""
-
-        pass
-
-    return Addresses
-
-
 def coords(is_collection):
     class Coords(Coord):
         """ Not implemented yet"""

--- a/source/jormungandr/jormungandr/interfaces/v1/converters_collection_type.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/converters_collection_type.py
@@ -39,7 +39,6 @@ collections_to_resource_type = {
     "stop_areas": "stop_area",
     "lines": "line",
     "line_groups": "line_group",
-    "addresses": "address",
     "coords": "coord",
     "coord": "coord",
     "journey_pattern_points": "journey_pattern_point",

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -227,3 +227,15 @@ class TestEndPoint(AbstractTestFixture):
         self.check_context(response)
         assert response.get("equipment_reports", None) is not None
         assert response['context']['timezone'] == 'UTC'
+
+    def test_region_coord_addresses(self):
+        '''
+        To get an address, you have to use the reverse API as in : /coord/<lat>;<lon>.
+        '''
+        response = self.tester.get(
+            'v1/coverage/main_routing_test/coord/0.001077974378345651;0.0005839027882705609/addresses'
+        )
+        assert response.status_code == 404, '/addresses has never been supported, and is now deprecated'
+
+        response = self.query('v1/coverage/main_routing_test/coord/0.001077974378345651;0.0005839027882705609/')
+        assert response.has_key('address')


### PR DESCRIPTION
:mushroom::mushroom::mushroom:
Long time ago, in 2013, was introduced `/addresses` has a place holder to prepare for an implementation. As of today, 6 years later, we are still waiting for it to be implemented......

In the meantime, `Places` and reverse geocoding were developed to fulfil that same purpose. So instead of using `/addresses` to get an address, we have to use `/coord` (`/coords`) like in :
```
/v1/coord/<lon:lon>;<lat:lat>/
/v1/coords/<lon:lon>;<lat:lat>/
/v1/coverage/
/v1/coverage/<lon:lon>;<lat:lat>/
/v1/coverage/<lon:lon>;<lat:lat>/coords
/v1/coverage/<lon:lon>;<lat:lat>/<uri:uri>/coords
/v1/coverage/<region:region>/
/v1/coverage/<region:region>/coords
/v1/coverage/<region:region>/<uri:uri>/coords
```

I suggest to drop the support of `/addresses` as an Uri (:mushroom:)

[NAVITIAII-2924](https://jira.kisio.org/browse/NAVITIAII-2924)
