### PR TITLE
Kraken: Parse center and stop points for isochrone

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -767,7 +767,7 @@ void Worker::isochrone(const pbnavitia::JourneysRequest& request) {
 
     navitia::routing::make_isochrone(this->pb_creator, *planner, center, request.datetimes(0), request.clockwise(),
                                      arg.accessibilite_params, arg.forbidden, arg.allowed, *street_network_worker,
-                                     arg.rt_level, request.max_duration(), request.max_transfers(), *stop_points);
+                                     arg.rt_level, request.max_duration(), request.max_transfers(), stop_points);
 }
 
 void Worker::pt_ref(const pbnavitia::PTRefRequest& request) {
@@ -834,7 +834,7 @@ void Worker::graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest& req
     navitia::routing::make_graphical_isochrone(
         this->pb_creator, *planner, center, request_journey.datetimes(0), boundary_duration,
         request_journey.max_transfers(), arg.accessibilite_params, arg.forbidden, arg.allowed,
-        request_journey.clockwise(), arg.rt_level, *street_network_worker, end_speed, *stop_points);
+        request_journey.clockwise(), arg.rt_level, *street_network_worker, end_speed, stop_points);
 }
 
 void Worker::heat_map(const pbnavitia::HeatMapRequest& request) {
@@ -858,7 +858,7 @@ void Worker::heat_map(const pbnavitia::HeatMapRequest& request) {
                                     request_journey.max_duration(), request_journey.max_transfers(),
                                     arg.accessibilite_params, arg.forbidden, arg.allowed, request_journey.clockwise(),
                                     arg.rt_level, *street_network_worker, end_speed, end_mode, request.resolution(),
-                                    *stop_points);
+                                    stop_points);
 }
 
 void Worker::car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request) {

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -636,12 +636,12 @@ static type::EntryPoint create_journeys_entry_point(const ::pbnavitia::LocationC
     return entry_point;
 }
 
-JourneysArg::JourneysArg(std::vector<type::EntryPoint> origins,
+JourneysArg::JourneysArg(type::EntryPoints origins,
                          type::AccessibiliteParams accessibilite_params,
                          std::vector<std::string> forbidden,
                          std::vector<std::string> allowed,
                          type::RTLevel rt_level,
-                         std::vector<type::EntryPoint> destinations,
+                         type::EntryPoints destinations,
                          std::vector<uint64_t> datetimes,
                          boost::optional<type::EntryPoint> isochrone_center)
     : origins(std::move(origins)),
@@ -656,13 +656,13 @@ JourneysArg::JourneysArg() {}
 
 navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest& request) {
     const auto* data = this->pb_creator.data;
-    std::vector<type::EntryPoint> origins;
+    type::EntryPoints origins;
     const auto* sn_params = request.has_streetnetwork_params() ? &request.streetnetwork_params() : nullptr;
     for (int i = 0; i < request.origin().size(); i++) {
         origins.push_back(create_journeys_entry_point(request.origin(i), sn_params, data, true));
     }
 
-    std::vector<type::EntryPoint> destinations;
+    type::EntryPoints destinations;
     for (int i = 0; i < request.destination().size(); i++) {
         destinations.push_back(create_journeys_entry_point(request.destination(i), sn_params, data, false));
     }
@@ -752,14 +752,14 @@ void Worker::journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API 
     }
 }
 
-static std::pair<const type::EntryPoint, const boost::optional<const std::vector<type::EntryPoint>&>>
-get_center_and_stop_points(const JourneysArg& arg) {
+static std::pair<const type::EntryPoint, const boost::optional<const type::EntryPoints&>> get_center_and_stop_points(
+    const JourneysArg& arg) {
     // If we have a center
     // Origins or destinations are already computed stop_points
     const auto& center =
         arg.isochrone_center ? *arg.isochrone_center : (arg.origins.empty() ? arg.destinations[0] : arg.origins[0]);
     const auto& stop_points = arg.isochrone_center ? (arg.origins.empty() ? arg.destinations : arg.origins)
-                                                   : boost::optional<const std::vector<type::EntryPoint>&>{};
+                                                   : boost::optional<const type::EntryPoints&>{};
 
     return std::make_pair(center, stop_points);
 }

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -756,8 +756,8 @@ static std::pair<const type::EntryPoint, const boost::optional<const type::Entry
     const JourneysArg& arg) {
     // If we have a center
     // Origins or destinations are already computed stop_points
-    const auto& center =
-        arg.isochrone_center ? *arg.isochrone_center : (arg.origins.empty() ? arg.destinations[0] : arg.origins[0]);
+    const auto& center = arg.isochrone_center ? *arg.isochrone_center
+                                              : (arg.origins.empty() ? arg.destinations.front() : arg.origins.front());
     const auto& stop_points = arg.isochrone_center ? (arg.origins.empty() ? arg.destinations : arg.origins)
                                                    : boost::optional<const type::EntryPoints&>{};
 

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -52,20 +52,20 @@ struct RAPTOR;
 namespace navitia {
 
 struct JourneysArg {
-    std::vector<type::EntryPoint> origins;
+    type::EntryPoints origins;
     type::AccessibiliteParams accessibilite_params;
     std::vector<std::string> forbidden;
     std::vector<std::string> allowed;
     type::RTLevel rt_level;
-    std::vector<type::EntryPoint> destinations;
+    type::EntryPoints destinations;
     std::vector<uint64_t> datetimes;
     boost::optional<type::EntryPoint> isochrone_center;
-    JourneysArg(std::vector<type::EntryPoint> origins,
+    JourneysArg(type::EntryPoints origins,
                 type::AccessibiliteParams accessibilite_params,
                 std::vector<std::string> forbidden,
                 std::vector<std::string> allowed,
                 type::RTLevel rt_level,
-                std::vector<type::EntryPoint> destinations,
+                type::EntryPoints destinations,
                 std::vector<uint64_t> datetimes,
                 boost::optional<type::EntryPoint> isochrone_center);
     JourneysArg();

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -112,6 +112,7 @@ private:
     JourneysArg fill_journeys(const pbnavitia::JourneysRequest& request);
     void err_msg_isochron(navitia::PbCreator& pb_creator, const std::string& err_msg);
     void journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API api);
+    void isochrone(const pbnavitia::JourneysRequest& request);
     void pt_ref(const pbnavitia::PTRefRequest& request);
     void traffic_reports(const pbnavitia::TrafficReportsRequest& request);
     void line_reports(const pbnavitia::LineReportsRequest& request);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1124,14 +1124,30 @@ boost::optional<routing::map_stop_point_duration> get_stop_points(const type::En
     return result;
 }
 
-static boost::optional<routing::map_stop_point_duration> get_stop_points_if_not_already_done(
+static routing::map_stop_point_duration make_map_stop_point_duration(
+    const std::vector<type::EntryPoint>& entryPointList,
+    const std::unordered_map<std::string, type::StopPoint*>& raptor_stop_points_map) {
+    routing::map_stop_point_duration results;
+    for (const auto& entryPoint : entryPointList) {
+        utils::make_map_find(raptor_stop_points_map, entryPoint.uri)
+            .if_found(
+                [&](const type::StopPoint* sp) { results[SpIdx{*sp}] = navitia::seconds(entryPoint.access_duration); })
+            .if_not_found([&]() {
+                // for now we throw, maybe we should ignore them
+                throw navitia::recoverable_exception("stop_point " + entryPoint.uri + " not found");
+            });
+    }
+    return results;
+}
+
+static const boost::optional<routing::map_stop_point_duration> get_stop_points_if_not_already_done(
     const navitia::type::EntryPoint& center,
     const navitia::type::Data& data,
     navitia::georef::StreetNetwork& worker,
-    const boost::optional<routing::map_stop_point_duration>& stop_points) {
+    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
     // If stop_points have already been computed, we don't need to do it here again.
     if (stop_points) {
-        return stop_points;
+        return make_map_stop_point_duration(*stop_points, data.pt_data->stop_points_map);
     }
 
     worker.init(center);
@@ -1196,22 +1212,6 @@ static std::vector<bt::ptime> parse_datetimes(const RAPTOR& raptor,
         std::sort(datetimes.begin(), datetimes.end());
 
     return datetimes;
-}
-
-static routing::map_stop_point_duration make_map_stop_point_duration(
-    const std::vector<type::EntryPoint>& entryPointList,
-    const std::unordered_map<std::string, type::StopPoint*>& raptor_stop_points_map) {
-    routing::map_stop_point_duration results;
-    for (const auto& entryPoint : entryPointList) {
-        utils::make_map_find(raptor_stop_points_map, entryPoint.uri)
-            .if_found(
-                [&](const type::StopPoint* sp) { results[SpIdx{*sp}] = navitia::seconds(entryPoint.access_duration); })
-            .if_not_found([&]() {
-                // for now we throw, maybe we should ignore them
-                throw navitia::recoverable_exception("stop_point " + entryPoint.uri + " not found");
-            });
-    }
-    return results;
 }
 
 void make_pt_response(navitia::PbCreator& pb_creator,
@@ -1459,7 +1459,7 @@ static const boost::optional<IsochroneCommon> make_isochrone_common(
     const nt::RTLevel rt_level,
     georef::StreetNetwork& worker,
     PbCreator& pb_creator,
-    const boost::optional<routing::map_stop_point_duration>& stop_points) {
+    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
     const auto tmp_datetime = parse_datetimes(raptor, {departure_datetime}, pb_creator, clockwise);
     if (pb_creator.has_error() || tmp_datetime.size() == 0
         || pb_creator.has_response_type(pbnavitia::DATE_OUT_OF_BOUNDS)) {
@@ -1492,7 +1492,7 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     const type::RTLevel rt_level,
                     const int max_duration,
                     const uint32_t max_transfers,
-                    const boost::optional<routing::map_stop_point_duration>& stop_points) {
+                    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
     const auto isochrone_common =
         make_isochrone_common(raptor, center, datetime_timestamp, max_duration, max_transfers, accessibilite_params,
                               forbidden, allowed, clockwise, rt_level, worker, pb_creator, stop_points);
@@ -1592,7 +1592,7 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               const nt::RTLevel rt_level,
                               georef::StreetNetwork& worker,
                               const double& speed,
-                              const boost::optional<routing::map_stop_point_duration>& stop_points) {
+                              const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
     const auto isochrone_common = make_isochrone_common(raptor, center, departure_datetime, boundary_duration[0],
                                                         max_transfers, accessibilite_params, forbidden, allowed,
                                                         clockwise, rt_level, worker, pb_creator, stop_points);
@@ -1627,7 +1627,7 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    const double& end_speed,
                    const navitia::type::Mode_e end_mode,
                    const uint32_t resolution,
-                   const boost::optional<routing::map_stop_point_duration>& stop_points) {
+                   const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
     const auto isochrone_common =
         make_isochrone_common(raptor, center, departure_datetime, max_duration, max_transfers, accessibilite_params,
                               forbidden, allowed, clockwise, rt_level, worker, pb_creator, stop_points);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1125,7 +1125,7 @@ boost::optional<routing::map_stop_point_duration> get_stop_points(const type::En
 }
 
 static routing::map_stop_point_duration make_map_stop_point_duration(
-    const std::vector<type::EntryPoint>& entryPointList,
+    const type::EntryPoints& entryPointList,
     const std::unordered_map<std::string, type::StopPoint*>& raptor_stop_points_map) {
     routing::map_stop_point_duration results;
     for (const auto& entryPoint : entryPointList) {
@@ -1144,7 +1144,7 @@ static const boost::optional<routing::map_stop_point_duration> get_stop_points_i
     const navitia::type::EntryPoint& center,
     const navitia::type::Data& data,
     navitia::georef::StreetNetwork& worker,
-    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
+    const boost::optional<const type::EntryPoints&>& stop_points) {
     // If stop_points have already been computed, we don't need to do it here again.
     if (stop_points) {
         return make_map_stop_point_duration(*stop_points, data.pt_data->stop_points_map);
@@ -1216,8 +1216,8 @@ static std::vector<bt::ptime> parse_datetimes(const RAPTOR& raptor,
 
 void make_pt_response(navitia::PbCreator& pb_creator,
                       RAPTOR& raptor,
-                      const std::vector<type::EntryPoint>& origins,
-                      const std::vector<type::EntryPoint>& destinations,
+                      const type::EntryPoints& origins,
+                      const type::EntryPoints& destinations,
                       const uint64_t timestamp,
                       const bool clockwise,
                       const type::AccessibiliteParams& accessibilite_params,
@@ -1459,7 +1459,7 @@ static const boost::optional<IsochroneCommon> make_isochrone_common(
     const nt::RTLevel rt_level,
     georef::StreetNetwork& worker,
     PbCreator& pb_creator,
-    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
+    const boost::optional<const type::EntryPoints&>& stop_points) {
     const auto tmp_datetime = parse_datetimes(raptor, {departure_datetime}, pb_creator, clockwise);
     if (pb_creator.has_error() || tmp_datetime.size() == 0
         || pb_creator.has_response_type(pbnavitia::DATE_OUT_OF_BOUNDS)) {
@@ -1492,7 +1492,7 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     const type::RTLevel rt_level,
                     const int max_duration,
                     const uint32_t max_transfers,
-                    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
+                    const boost::optional<const type::EntryPoints&>& stop_points) {
     const auto isochrone_common =
         make_isochrone_common(raptor, center, datetime_timestamp, max_duration, max_transfers, accessibilite_params,
                               forbidden, allowed, clockwise, rt_level, worker, pb_creator, stop_points);
@@ -1592,7 +1592,7 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               const nt::RTLevel rt_level,
                               georef::StreetNetwork& worker,
                               const double& speed,
-                              const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
+                              const boost::optional<const type::EntryPoints&>& stop_points) {
     const auto isochrone_common = make_isochrone_common(raptor, center, departure_datetime, boundary_duration[0],
                                                         max_transfers, accessibilite_params, forbidden, allowed,
                                                         clockwise, rt_level, worker, pb_creator, stop_points);
@@ -1627,7 +1627,7 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    const double& end_speed,
                    const navitia::type::Mode_e end_mode,
                    const uint32_t resolution,
-                   const boost::optional<const std::vector<type::EntryPoint>&>& stop_points) {
+                   const boost::optional<const type::EntryPoints&>& stop_points) {
     const auto isochrone_common =
         make_isochrone_common(raptor, center, departure_datetime, max_duration, max_transfers, accessibilite_params,
                               forbidden, allowed, clockwise, rt_level, worker, pb_creator, stop_points);

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -113,15 +113,15 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     const type::RTLevel rt_level,
                     const int max_duration = 3600,
                     const uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
-                    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
+                    const boost::optional<const type::EntryPoints&>& stop_points = boost::none);
 
 /**
  * @brief Used for Pt with distributed mode
  */
 void make_pt_response(navitia::PbCreator& pb_creator,
                       RAPTOR& raptor,
-                      const std::vector<type::EntryPoint>& origins,
-                      const std::vector<type::EntryPoint>& destinations,
+                      const type::EntryPoints& origins,
+                      const type::EntryPoints& destinations,
                       const uint64_t timestamp,
                       const bool clockwise,
                       const type::AccessibiliteParams& accessibilite_params,
@@ -204,7 +204,7 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               const nt::RTLevel rt_level,
                               georef::StreetNetwork& worker,
                               const double& speed,
-                              const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
+                              const boost::optional<const type::EntryPoints&>& stop_points = boost::none);
 
 void make_heat_map(navitia::PbCreator& pb_creator,
                    RAPTOR& raptor,
@@ -221,7 +221,7 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    const double& speed,
                    const navitia::type::Mode_e mode,
                    const uint32_t resolution,
-                   const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
+                   const boost::optional<const type::EntryPoints&>& stop_points = boost::none);
 
 void make_pathes(PbCreator& pb_creator,
                  const std::vector<navitia::routing::Path>& paths,

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -113,7 +113,7 @@ void make_isochrone(navitia::PbCreator& pb_creator,
                     const type::RTLevel rt_level,
                     const int max_duration = 3600,
                     const uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
-                    const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
+                    const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
 
 /**
  * @brief Used for Pt with distributed mode
@@ -204,7 +204,7 @@ void make_graphical_isochrone(navitia::PbCreator& pb_creator,
                               const nt::RTLevel rt_level,
                               georef::StreetNetwork& worker,
                               const double& speed,
-                              const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
+                              const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
 
 void make_heat_map(navitia::PbCreator& pb_creator,
                    RAPTOR& raptor,
@@ -221,7 +221,7 @@ void make_heat_map(navitia::PbCreator& pb_creator,
                    const double& speed,
                    const navitia::type::Mode_e mode,
                    const uint32_t resolution,
-                   const boost::optional<routing::map_stop_point_duration>& stop_points = boost::none);
+                   const boost::optional<const std::vector<type::EntryPoint>&>& stop_points = boost::none);
 
 void make_pathes(PbCreator& pb_creator,
                  const std::vector<navitia::routing::Path>& paths,

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -52,6 +52,7 @@ namespace nr = navitia::routing;
 namespace ntest = navitia::test;
 namespace bt = boost::posix_time;
 namespace ng = navitia::georef;
+namespace nt = navitia::type;
 using navitia::type::disruption::ChannelType;
 
 static void dump_response(pbnavitia::Response resp, std::string test_name, bool debug_info = false) {
@@ -1916,7 +1917,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     {
         // We ask the same request with stop_point == center
         // And check that the response are exactly equivalent
-        const std::vector<navitia::type::EntryPoint> stop_points{{ep}};
+        const navitia::type::EntryPoints stop_points{{ep}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1925,7 +1926,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     {
         // We ask the same request with different stop_points
         // And check that the responses are not the same
-        const std::vector<navitia::type::EntryPoint> stop_points{{navitia::type::Type_e::StopPoint, "B"}};
+        const navitia::type::EntryPoints stop_points{{navitia::type::Type_e::StopPoint, "B"}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1957,7 +1958,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     {
         // We ask the same request with stop_point == center
         // And check that the responses are exactly equivalent
-        const std::vector<navitia::type::EntryPoint> stop_points{{ep}};
+        const navitia::type::EntryPoints stop_points{{ep}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1967,7 +1968,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     {
         // We ask the same request with different stop_points
         // And check that the responses are not the same
-        const std::vector<navitia::type::EntryPoint> stop_points{{navitia::type::Type_e::StopPoint, "C"}};
+        const navitia::type::EntryPoints stop_points{{navitia::type::Type_e::StopPoint, "C"}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1916,8 +1916,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     {
         // We ask the same request with stop_point == center
         // And check that the response are exactly equivalent
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps[ep.uri], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{ep}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1926,8 +1925,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     {
         // We ask the same request with different stop_points
         // And check that the responses are not the same
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps["B"], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{navitia::type::Type_e::StopPoint, "B"}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1959,8 +1957,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     {
         // We ask the same request with stop_point == center
         // And check that the responses are exactly equivalent
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps[ep.uri], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{ep}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);
@@ -1970,8 +1967,7 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     {
         // We ask the same request with different stop_points
         // And check that the responses are not the same
-        nr::map_stop_point_duration stop_points;
-        stop_points.emplace(*b.sps["C"], navitia::seconds(0));
+        const std::vector<navitia::type::EntryPoint> stop_points{{navitia::type::Type_e::StopPoint, "C"}};
         navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
         nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker,
                            nt::RTLevel::Base, 3 * 60 * 60, std::numeric_limits<uint32_t>::max(), stop_points);

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -256,6 +256,8 @@ struct EntryPoint {
     static bool is_coord(const std::string&);
 };
 
+using EntryPoints = std::vector<EntryPoint>;
+
 template <typename T>
 std::string get_admin_name(const T* v) {
     std::string admin_name = "";


### PR DESCRIPTION
Readable commit by commit.

In the pbf request, we receive a `std::vector<EntryPoint>` and not a already computed `map_stop_point_duration`.

This PR aims to correct that AND to parse the `isochrone_center` and the `stop_points` from the request.

@pbougue proposition is to add a field `is_street_network_allowed_at_center` in the PBF to make this part more understandable.