### PR TITLE
Fix 500 error returned when combining coords with addresses

### DIFF
--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -128,7 +128,14 @@ class V1Routing(AModule):
 
         self.add_resource(Coverage.Coverage, coverage, region, coord, endpoint='coverage')
 
-        self.add_resource(Coord.Coord, '/coord/' + lon_lat, '/coords/' + lon_lat, endpoint='coord')
+        self.add_resource(
+            Coord.Coord,
+            '/coord/' + lon_lat,
+            '/coords/' + lon_lat,
+            region + 'coord/' + lon_lat + 'addresses',
+            region + 'coords/' + lon_lat + 'addresses',
+            endpoint='coord',
+        )
 
         collecs = list(converters_collection_type.collections_to_resource_type.keys())
         for collection in collecs:

--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -227,3 +227,25 @@ class TestEndPoint(AbstractTestFixture):
         self.check_context(response)
         assert response.get("equipment_reports", None) is not None
         assert response['context']['timezone'] == 'UTC'
+
+    def test_region_coord_addresses(self):
+        resp = [
+            self.tester.get('v1/coverage/main_routing_test/coord/0.001077974378345651;0.0005839027882705609'),
+            self.tester.get('v1/coverage/main_routing_test/coords/0.001077974378345651;0.0005839027882705609'),
+            self.tester.get(
+                'v1/coverage/main_routing_test/addresses/0.001077974378345651;0.0005839027882705609'
+            ),
+            self.tester.get(
+                'v1/coverage/main_routing_test/coord/0.001077974378345651;0.0005839027882705609/addresses'
+            ),
+            self.tester.get(
+                'v1/coverage/main_routing_test/coords/0.001077974378345651;0.0005839027882705609/addresses'
+            ),
+        ]
+        assert all(r.status_code < 300 for r in resp)
+        assert all('address' in r.get_json() for r in resp)
+
+        address_name = resp[0].get_json()['address']['name']
+        assert all(
+            r.get_json()['address']['name'] == address_name for r in resp
+        ), 'All requests should return the same result...'

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -356,25 +356,13 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
 
     def test_schema_parameters_sctructure(self):
         """
-        Get the main schema, extract all path with no parameter, or only {region}
-        and check for each endpoint the schema's structure
+        Check for each endpoint the schema's structure
         """
         schema = self.get_schema()
         paths = schema['paths']
 
-        # Filter endpoints with a parameter (ie. /v1/coverage/{lon}:{lat}/...)
-        def endpoints_with_no_param(path):
-            return '{' not in path
-
-        # Filter endpoints with only a {region} parameter (ie. /v1/coverage/{region}/journeys)
-        def endpoints_with_only_region_param(path):
-            other_param = any(elem in path for elem in ['{id}', '{uri}'])
-            return '{region}' in path and not other_param
-
-        urls = chain(ifilter(endpoints_with_no_param, paths), ifilter(endpoints_with_only_region_param, paths))
-
-        for u in urls:
-            url = '/v1' + u.format(region='main_routing_test') + '?schema=true'
+        for u in paths:
+            url = '/v1' + u.format(region='main_routing_test', lon=0, lat=0, id=0, uri='_') + '?schema=true'
             self.check_schema_parameters_structure(url)
 
 


### PR DESCRIPTION
Add the following routes as they were returning 500 errors :
```
v1.coord    GET    /v1/coverage/<region:region>/coords/<lon:lon>;<lat:lat>/addresses
v1.coord    GET    /v1/coverage/<region:region>/coord/<lon:lon>;<lat:lat>/addresses
```
[NAVITIAII-2920](https://jira.kisio.org/browse/NAVITIAII-2920)