### PR TITLE
[Cmake] Clean Lib dependencies

### DIFF
--- a/source/autocomplete/CMakeLists.txt
+++ b/source/autocomplete/CMakeLists.txt
@@ -3,9 +3,6 @@ add_library(autocomplete autocomplete.cpp autocomplete_api.cpp utils.cpp)
 target_link_libraries(autocomplete pb_lib)
 add_dependencies(autocomplete protobuf_files)
 
-SET(BOOST_LIBS ${BOOST_LIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_REGEX_LIBRARY})
 add_executable(autocomplete_test tests/test.cpp tests/test_utils.cpp)
-target_link_libraries(autocomplete_test georef data autocomplete pb_lib types thermometer fare routing ed utils ${BOOST_LIBS} protobuf)
+target_link_libraries(autocomplete_test autocomplete ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_REGEX_LIBRARY})
 ADD_BOOST_TEST(autocomplete_test)

--- a/source/calendar/CMakeLists.txt
+++ b/source/calendar/CMakeLists.txt
@@ -3,5 +3,4 @@ SET(CALENDAR_SRC
     calendar.cpp
 )
 add_library(calendar_api ${CALENDAR_SRC})
-add_dependencies(calendar_api protobuf_files)
 add_subdirectory(tests)

--- a/source/calendar/tests/CMakeLists.txt
+++ b/source/calendar/tests/CMakeLists.txt
@@ -1,10 +1,3 @@
-#We use the BOOST_LIBS define is the parent
-SET(BOOST_LIBS ${BOOST_LIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_REGEX_LIBRARY})
-
 add_executable(calendar_api_test calendar_api_test.cpp)
-
-target_link_libraries(calendar_api_test calendar_api types ptreferential pb_lib thermometer data fare routing ed georef autocomplete utils ${BOOST_LIBS} pthread protobuf)
-
+target_link_libraries(calendar_api_test calendar_api pb_lib ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 ADD_BOOST_TEST(calendar_api_test)

--- a/source/cities/CMakeLists.txt
+++ b/source/cities/CMakeLists.txt
@@ -2,8 +2,7 @@ SET(BOOST_LIBS ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_SYSTEM_LIBRARY} )
 
 add_executable(cities cities.cpp)
-target_link_libraries(cities transportation_data_import connectors types ${PQXX_LIB} ${OSMPBF} pb_lib utils
-    ${BOOST_LIBS} log4cplus z protobuf ${NAVITIA_ALLOCATOR})
+target_link_libraries(cities utils config ${Boost_PROGRAM_OPTIONS_LIBRARY} ${OSMPBF} protobuf z)
 install(TARGETS cities DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(FILES alembic.ini alembic/env.py DESTINATION ${CMAKE_INSTALL_PREFIX}/share/navitia/cities/alembic)
 

--- a/source/cmake_modules/ThirdParty.cmake
+++ b/source/cmake_modules/ThirdParty.cmake
@@ -22,6 +22,7 @@ set(BUILD_EXAMPLES OFF CACHE BOOL "don't build example of librabbimq-c")
 set(BUILD_TOOLS OFF CACHE BOOL "don't build tool of librabbimq-c")
 set(BUILD_TESTS OFF CACHE BOOL "don't build tests of librabbimq-c")
 set(Rabbitmqc_INCLUDE_DIRS "${CMAKE_SOURCE_DIR}/third_party/librabbitmq-c/librabbitmq/")
+set(Rabbitmqc_LIBRARY rabbitmq-static)
 add_subdirectory(third_party/librabbitmq-c EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/SimpleAmqpClient EXCLUDE_FROM_ALL)
 

--- a/source/disruption/CMakeLists.txt
+++ b/source/disruption/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(disruption_api traffic_reports_api.cpp line_reports_api.cpp)
-add_dependencies(disruption_api protobuf_files)
+target_link_libraries(disruption_api pb_lib)
 add_subdirectory(tests)

--- a/source/disruption/tests/CMakeLists.txt
+++ b/source/disruption/tests/CMakeLists.txt
@@ -1,11 +1,3 @@
-#We use the BOOST_LIBS define is the parent
-SET(BOOST_LIBS ${BOOST_LIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_REGEX_LIBRARY})
-
 add_executable(disruption_test disruption_test.cpp)
-
-target_link_libraries(disruption_test disruption_api types ptreferential pb_lib thermometer data fare routing ed georef autocomplete utils ${BOOST_LIBS} pthread protobuf)
-
-
+target_link_libraries(disruption_test disruption_api ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 ADD_BOOST_TEST(disruption_test)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -4,51 +4,50 @@ SET(SOURCE_LIB
         build_helper.cpp
 )
 
-
 add_library(ed ${SOURCE_LIB})
-
-SET(BOOST_LIBS ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_REGEX_LIBRARY})
-
+target_link_libraries(ed types fare)
 
 FIND_LIBRARY(OSMPBF osmpbf)
 
 add_library(osm2ed_lib osm2ed.cpp)
+target_link_libraries(osm2ed_lib ed transportation_data_import ${OSMPBF} protobuf z ${Boost_PROGRAM_OPTIONS_LIBRARY})
 add_executable(osm2ed osm2ed_main.cpp)
-target_link_libraries(osm2ed osm2ed_lib transportation_data_import ed connectors types ${PQXX_LIB} ${OSMPBF}
-  pb_lib utils ${BOOST_LIBS} log4cplus z protobuf ${NAVITIA_ALLOCATOR})
-
-
+target_link_libraries(osm2ed
+    osm2ed_lib
+)
 
 add_library(transportation_data_import ed_persistor.cpp)
-target_link_libraries(transportation_data_import ed fare types ${PQXX_LIB} data utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(transportation_data_import connectors ${PQXX_LIB} utils)
 
 add_executable(gtfs2ed gtfs2ed.cpp)
-target_link_libraries(gtfs2ed transportation_data_import connectors ${NAVITIA_ALLOCATOR})
+target_link_libraries(gtfs2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_executable(fusio2ed fusio2ed.cpp)
-target_link_libraries(fusio2ed transportation_data_import connectors ${NAVITIA_ALLOCATOR})
+target_link_libraries(fusio2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_library(fare2ed_lib fare2ed.cpp)
+target_link_libraries(fare2ed_lib transportation_data_import)
+
 add_executable(fare2ed fare2ed_main.cpp)
-target_link_libraries(fare2ed fare2ed_lib transportation_data_import connectors ${NAVITIA_ALLOCATOR})
+target_link_libraries(fare2ed fare2ed_lib ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_library(ed2nav_lib ed2nav.cpp ed_reader.cpp)
+target_link_libraries(ed2nav_lib connectors types)
+
 add_executable(ed2nav ed2nav_main.cpp)
-target_link_libraries(ed2nav ed2nav_lib types connectors ${PQXX_LIB} data georef routing fare pb_lib utils autocomplete ${BOOST_LIBS} log4cplus protobuf ${NAVITIA_ALLOCATOR})
+target_link_libraries(ed2nav ed2nav_lib ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_subdirectory(tests)
 add_subdirectory(connectors)
 
 add_executable(geopal2ed geopal2ed.cpp)
-target_link_libraries(geopal2ed transportation_data_import connectors ${NAVITIA_ALLOCATOR})
+target_link_libraries(geopal2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_executable(poi2ed poi2ed.cpp)
-target_link_libraries(poi2ed transportation_data_import connectors ${NAVITIA_ALLOCATOR})
+target_link_libraries(poi2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 add_executable(synonym2ed synonym2ed.cpp)
-target_link_libraries(synonym2ed transportation_data_import connectors ${NAVITIA_ALLOCATOR})
+target_link_libraries(synonym2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 
 set(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -11,43 +11,44 @@ FIND_LIBRARY(OSMPBF osmpbf)
 
 add_library(osm2ed_lib osm2ed.cpp)
 target_link_libraries(osm2ed_lib ed transportation_data_import ${OSMPBF} protobuf z ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
+set(ED_LINK_LIBS ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+
 add_executable(osm2ed osm2ed_main.cpp)
-target_link_libraries(osm2ed
-    osm2ed_lib
-)
+target_link_libraries(osm2ed osm2ed_lib ${ED_LINK_LIBS})
 
 add_library(transportation_data_import ed_persistor.cpp)
 target_link_libraries(transportation_data_import connectors ${PQXX_LIB} utils)
 
 add_executable(gtfs2ed gtfs2ed.cpp)
-target_link_libraries(gtfs2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(gtfs2ed transportation_data_import ${ED_LINK_LIBS})
 
 add_executable(fusio2ed fusio2ed.cpp)
-target_link_libraries(fusio2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(fusio2ed transportation_data_import ${ED_LINK_LIBS})
 
 add_library(fare2ed_lib fare2ed.cpp)
 target_link_libraries(fare2ed_lib transportation_data_import)
 
 add_executable(fare2ed fare2ed_main.cpp)
-target_link_libraries(fare2ed fare2ed_lib ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(fare2ed fare2ed_lib ${ED_LINK_LIBS})
 
 add_library(ed2nav_lib ed2nav.cpp ed_reader.cpp)
 target_link_libraries(ed2nav_lib connectors types)
 
 add_executable(ed2nav ed2nav_main.cpp)
-target_link_libraries(ed2nav ed2nav_lib ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(ed2nav ed2nav_lib ${ED_LINK_LIBS})
 
 add_subdirectory(tests)
 add_subdirectory(connectors)
 
 add_executable(geopal2ed geopal2ed.cpp)
-target_link_libraries(geopal2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(geopal2ed transportation_data_import ${ED_LINK_LIBS})
 
 add_executable(poi2ed poi2ed.cpp)
-target_link_libraries(poi2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(poi2ed transportation_data_import ${ED_LINK_LIBS})
 
 add_executable(synonym2ed synonym2ed.cpp)
-target_link_libraries(synonym2ed transportation_data_import ${NAVITIA_ALLOCATOR} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(synonym2ed transportation_data_import ${ED_LINK_LIBS})
 
 set(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/source/ed/connectors/CMakeLists.txt
+++ b/source/ed/connectors/CMakeLists.txt
@@ -17,6 +17,5 @@ SET(SOURCE_LIB
 )
 
 add_library(connectors ${SOURCE_LIB})
-target_link_libraries(connectors ${PROJ})
-
+target_link_libraries(connectors fare ed types ${PROJ})
 

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -46,7 +46,7 @@ add_custom_target(datanav_files DEPENDS ${FILES_CREATED})
 SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
 add_executable(ed_integration_test ed_integration_tests.cpp)
-target_link_libraries(ed_integration_test data georef types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(ed_integration_test ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
 
 # the test is not added with 'add_test', because we don't want 'make test' to handle it
 # it is added as a post build command to 'make docker_test', called after all the build

--- a/source/ed/tests/CMakeLists.txt
+++ b/source/ed/tests/CMakeLists.txt
@@ -1,55 +1,57 @@
-#We use the BOOST_LIBS define is the parent
-SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+set(ED_TESTS_LINK_LIBS
+    connectors
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+)
+
 
 add_executable(jpp_shape_test jpp_shape_test.cpp)
-target_link_libraries(jpp_shape_test ed data types ${BOOST_LIBS})
+target_link_libraries(jpp_shape_test ed ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(jpp_shape_test)
 
 add_executable(gtfs_parser_test gtfsparser_test.cpp)
-target_link_libraries(gtfs_parser_test connectors data ed types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(gtfs_parser_test ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(gtfs_parser_test)
 
 add_executable(fusio_parser_test fusioparser_test.cpp)
-target_link_libraries(fusio_parser_test connectors data ed types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(fusio_parser_test ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(fusio_parser_test)
 
 add_executable(osm_tags_reader_test osm_tags_reader_test.cpp)
-target_link_libraries(osm_tags_reader_test connectors data ed types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(osm_tags_reader_test ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(osm_tags_reader_test)
 
 add_executable(associated_calendar_test associated_calendar_test.cpp)
-target_link_libraries(associated_calendar_test ed data types routing fare georef autocomplete utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(associated_calendar_test ed ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(associated_calendar_test)
 
 add_executable(fare_parser_test fare_parser_test.cpp)
-target_link_libraries(fare_parser_test connectors fare utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(fare_parser_test ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(fare_parser_test)
 
 add_executable(conv_coord_test conv_coord_test.cpp)
-target_link_libraries(conv_coord_test connectors types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(conv_coord_test ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(conv_coord_test)
 
 add_executable(shift_stop_times_test shift_stop_times.cpp)
-target_link_libraries(shift_stop_times_test ed types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(shift_stop_times_test ed ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(shift_stop_times_test)
 
 add_executable(osm2ed_test osm2ed_test.cpp)
-target_link_libraries(osm2ed_test osm2ed_lib transportation_data_import ed connectors types ${PQXX_LIB} ${OSMPBF}
-  pb_lib utils ${BOOST_LIBS} log4cplus z protobuf)
+target_link_libraries(osm2ed_test osm2ed_lib ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(osm2ed_test)
 
 add_executable(poi2ed_test poi2ed_test.cpp)
-target_link_libraries(poi2ed_test ed connectors types ${PQXX_LIB} ${OSMPBF}
-  pb_lib utils ${BOOST_LIBS} log4cplus z protobuf)
+target_link_libraries(poi2ed_test ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(poi2ed_test "${FIXTURES_DIR}/ed/poi/poi")
 
 add_executable(fare2ed_test fare2ed_test.cpp)
-target_link_libraries(fare2ed_test fare2ed_lib transportation_data_import connectors ${BOOST_LIBS} log4cplus)
+target_link_libraries(fare2ed_test fare2ed_lib ${ED_TESTS_LINK_LIBS})
 
 add_executable(ed2nav_test ed2nav_test.cpp)
-target_link_libraries(ed2nav_test ed2nav_lib types connectors ${PQXX_LIB} data georef routing fare pb_lib utils autocomplete ${BOOST_LIBS} log4cplus protobuf)
+target_link_libraries(ed2nav_test ed2nav_lib ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(ed2nav_test)
 
 add_executable(route_main_destination_test route_main_destination_test.cpp)
-target_link_libraries(route_main_destination_test ed types utils ${BOOST_LIBS} log4cplus)
+target_link_libraries(route_main_destination_test ed ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(route_main_destination_test)

--- a/source/equipment/CMakeLists.txt
+++ b/source/equipment/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_library(equipment_api equipment_api.cpp)
-add_dependencies(equipment_api protobuf_files)
+target_link_libraries(equipment_api pb_lib)
 add_subdirectory(tests)

--- a/source/equipment/tests/CMakeLists.txt
+++ b/source/equipment/tests/CMakeLists.txt
@@ -1,6 +1,3 @@
-SET(BOOST_LIBS ${BOOST_LIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
 add_executable(equipment_test equipment_api_tests.cpp)
-target_link_libraries(equipment_test
-    equipment_api ed data georef utils ${BOOST_LIBS} protobuf)
+target_link_libraries(equipment_test equipment_api ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 ADD_BOOST_TEST(equipment_test)

--- a/source/fare/CMakeLists.txt
+++ b/source/fare/CMakeLists.txt
@@ -4,5 +4,5 @@ SET(GEOREF_SRC
 )
 
 add_library(fare ${GEOREF_SRC})
-
+target_link_libraries(fare pb_lib)
 add_subdirectory(tests)

--- a/source/fare/tests/CMakeLists.txt
+++ b/source/fare/tests/CMakeLists.txt
@@ -1,12 +1,8 @@
 add_executable(fare_test fare_test.cpp)
-target_link_libraries(fare_test fare connectors data georef routing types autocomplete utils
-        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY}
-    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus)
+target_link_libraries(fare_test fare config connectors ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 ADD_BOOST_TEST(fare_test)
 
 add_executable(fare_integration_test fare_integration_test.cpp)
-target_link_libraries(fare_integration_test fare ed connectors data georef routing types pb_lib thermometer autocomplete utils
-        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY}
-    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} ${Boost_DATE_TIME_LIBRARY} log4cplus pthread protobuf)
+target_link_libraries(fare_integration_test pb_converter ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
 ADD_BOOST_TEST(fare_integration_test)
 

--- a/source/georef/CMakeLists.txt
+++ b/source/georef/CMakeLists.txt
@@ -14,7 +14,5 @@ SET(GEOREF_SRC
 )
 
 add_library(georef ${GEOREF_SRC})
-
-target_link_libraries(georef types proximitylist utils)
-
+target_link_libraries(georef proximitylist )
 add_subdirectory(tests)

--- a/source/georef/tests/CMakeLists.txt
+++ b/source/georef/tests/CMakeLists.txt
@@ -2,22 +2,18 @@ SET(GEOREF_SRC_TEST
     builder.h
     builder.cpp
 )
+
 add_library(georef_test_utils ${GEOREF_SRC_TEST})
+target_link_libraries(georef_test_utils georef)
 
 add_executable(georef_test georef_test.cpp)
-target_link_libraries(georef_test georef_test_utils ed fare georef utils data
-        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY}
-    ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} log4cplus protobuf)
+target_link_libraries(georef_test georef_test_utils ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
 ADD_BOOST_TEST(georef_test)
 
 add_executable(street_network_test street_network_test.cpp)
-target_link_libraries(street_network_test georef_test_utils georef data routing fare autocomplete pb_lib utils
-        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY}
-        ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} log4cplus protobuf)
+target_link_libraries(street_network_test georef_test_utils ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
 ADD_BOOST_TEST(street_network_test)
 
 add_executable(path_finder_test path_finder_test.cpp)
-target_link_libraries(path_finder_test georef_test_utils georef data routing fare autocomplete pb_lib utils
-        ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_THREAD_LIBRARY} ${Boost_SYSTEM_LIBRARY}
-        ${Boost_REGEX_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} log4cplus protobuf)
+target_link_libraries(path_finder_test georef_test_utils ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
 ADD_BOOST_TEST(path_finder_test)

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -1,33 +1,37 @@
 add_library(apply_disruption apply_disruption.cpp)
-add_dependencies(apply_disruption protobuf_files)
-target_link_libraries(apply_disruption data pb_lib protobuf)
+target_link_libraries(apply_disruption types config)
 
 add_library(make_disruption_from_chaos make_disruption_from_chaos.cpp)
-add_dependencies(make_disruption_from_chaos protobuf_files)
-target_link_libraries(make_disruption_from_chaos apply_disruption data pb_lib protobuf)
+target_link_libraries(make_disruption_from_chaos apply_disruption )
 
 add_library(rt_handling realtime.cpp)
-add_dependencies(rt_handling protobuf_files)
-target_link_libraries(rt_handling data pb_lib protobuf)
+target_link_libraries(rt_handling apply_disruption )
 
 add_library(workers worker.cpp maintenance_worker.cpp configuration.cpp metrics.cpp)
-add_dependencies(workers protobuf_files)
-target_link_libraries(workers apply_disruption make_disruption_from_chaos rt_handling ${PQXX_LIB}
-  SimpleAmqpClient equipment_api disruption_api calendar_api ptreferential autocomplete georef
-  routing time_tables prometheus-cpp-core prometheus-cpp-pull)
+target_link_libraries(workers
+    rt_handling
+    SimpleAmqpClient
+    equipment_api
+    disruption_api
+    calendar_api
+    time_tables
+    prometheus-cpp-pull
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+)
 
 add_library(fill_disruption_from_database fill_disruption_from_database.cpp)
-target_link_libraries(fill_disruption_from_database make_disruption_from_chaos data types pb_lib
-  ${PQXX_LIB} ${Boost_SERIALIZATION_LIBRARY} ${Boost_FORMAT_LIBRARY} protobuf)
+target_link_libraries(fill_disruption_from_database
+    make_disruption_from_chaos
+    data
+    types
+    pb_lib
+    ${PQXX_LIB}
+    ${Boost_SERIALIZATION_LIBRARY}
+    ${Boost_FORMAT_LIBRARY}
+)
 
 add_executable(kraken kraken_zmq.cpp)
-target_link_libraries(kraken workers types proximitylist
-    ptreferential time_tables data pb_lib routing fare utils SimpleAmqpClient
-    rabbitmq-static log4cplus ${Boost_THREAD_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_REGEX_LIBRARY} ${Boost_CHRONO_LIBRARY}
-    ${Boost_FILESYSTEM_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} protobuf
-    ${NAVITIA_ALLOCATOR})
+target_link_libraries(kraken workers ${NAVITIA_ALLOCATOR} ${Boost_THREAD_LIBRARY})
 add_dependencies(kraken protobuf_files)
 
 install(TARGETS kraken DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)

--- a/source/kraken/tests/CMakeLists.txt
+++ b/source/kraken/tests/CMakeLists.txt
@@ -1,39 +1,41 @@
-#We use the BOOST_LIBS define is the parent
-SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+set(KRAKEN_TEST_LINK_LIBS
+    workers
+    ${NAVITIA_ALLOCATOR}
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+)
+
 add_executable(data_manager_test data_manager_test.cpp)
-target_link_libraries(data_manager_test types utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES})
+target_link_libraries(data_manager_test types ${NAVITIA_ALLOCATOR} ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(data_manager_test)
 
 add_executable(data_manager_with_type_data_test data_manager_with_type_data_test.cpp)
-target_link_libraries(data_manager_with_type_data_test make_disruption_from_chaos workers log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES})
+target_link_libraries(data_manager_with_type_data_test make_disruption_from_chaos ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(data_manager_with_type_data_test)
 
 add_executable(disruption_reader_test disruption_reader_test.cpp)
-target_link_libraries(disruption_reader_test workers data types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(disruption_reader_test ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(disruption_reader_test)
 
 add_executable(fill_disruption_from_chaos_tests fill_disruption_from_chaos_tests.cpp)
-target_link_libraries(fill_disruption_from_chaos_tests make_disruption_from_chaos ed workers data types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(fill_disruption_from_chaos_tests make_disruption_from_chaos ed ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(fill_disruption_from_chaos_tests)
 
 add_executable(worker_test worker_test.cpp)
-target_link_libraries(worker_test make_disruption_from_chaos ed workers data types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(worker_test ed ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(worker_test)
 
 add_executable(realtime_test realtime_test.cpp)
-target_link_libraries(realtime_test disruption_api ed workers data types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(realtime_test ed disruption_api rt_handling ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(realtime_test)
 
 add_executable(apply_disruption_test apply_disruption_test.cpp)
-target_link_libraries(apply_disruption_test make_disruption_from_chaos apply_disruption ed workers data types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(apply_disruption_test apply_disruption ed rt_handling ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(apply_disruption_test)
 
 add_executable(direct_path_test direct_path_test.cpp)
-target_link_libraries(direct_path_test workers make_disruption_from_chaos apply_disruption
-  ed data types routing fare pb_lib thermometer georef
-  autocomplete utils  ${BOOST_LIBS} log4cplus pthread protobuf ${NAVITIA_ALLOCATOR})
+target_link_libraries(direct_path_test ed ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(direct_path_test)
 
 add_executable(disruption_periods_test disruption_periods_test.cpp)
-target_link_libraries(disruption_periods_test workers data ed types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(disruption_periods_test apply_disruption ed ${KRAKEN_TEST_LINK_LIBS})
 ADD_BOOST_TEST(disruption_periods_test)

--- a/source/lz4_filter/tests/CMakeLists.txt
+++ b/source/lz4_filter/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable (lz4_tests test.cpp "${CMAKE_SOURCE_DIR}/third_party/lz4/lz4.c")
-target_link_libraries(lz4_tests ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-    ${Boost_IOSTREAMS_LIBRARY})
-
+target_link_libraries(lz4_tests
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+    ${Boost_IOSTREAMS_LIBRARY}
+)
 ADD_BOOST_TEST(lz4_tests)
 

--- a/source/proximity_list/CMakeLists.txt
+++ b/source/proximity_list/CMakeLists.txt
@@ -1,5 +1,10 @@
 # the lz4 is required by Flann, even though we don't use it's own archive method
-add_library(proximitylist proximity_list.cpp proximitylist_api.cpp ${CMAKE_SOURCE_DIR}/third_party/lz4/lz4hc.c ${CMAKE_SOURCE_DIR}/third_party/lz4/lz4.c)
+add_library(proximitylist
+    proximity_list.cpp
+    proximitylist_api.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/lz4/lz4hc.c
+    ${CMAKE_SOURCE_DIR}/third_party/lz4/lz4.c
+)
 add_dependencies(proximitylist protobuf_files)
-target_link_libraries(proximitylist)
+target_link_libraries(proximitylist types utils)
 add_subdirectory(tests)

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -31,7 +31,6 @@ www.navitia.io
 #include "proximitylist_api.h"
 #include "type/pb_converter.h"
 #include "utils/paginate.h"
-#include "ptreferential/ptreferential.h"
 
 namespace navitia {
 namespace proximitylist {

--- a/source/proximity_list/tests/CMakeLists.txt
+++ b/source/proximity_list/tests/CMakeLists.txt
@@ -1,9 +1,3 @@
 add_executable (proximity_list_test test.cpp)
-
-SET(BOOST_LIBS ${Boost_THREAD_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY}
-    ${Boost_SERIALIZATION_LIBRARY} ${Boost_FILESYSTEM_LIBRARY} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
-target_link_libraries(proximity_list_test proximitylist ptreferential routing georef pb_lib thermometer data fare types routing autocomplete utils ${BOOST_LIBS} log4cplus pthread protobuf)
-
+target_link_libraries(proximity_list_test proximitylist ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 ADD_BOOST_TEST(proximity_list_test)

--- a/source/ptreferential/CMakeLists.txt
+++ b/source/ptreferential/CMakeLists.txt
@@ -5,5 +5,5 @@ SET(PTREF_SRC
   ptreferential_api.cpp
   ptref_graph.cpp)
 add_library(ptreferential ${PTREF_SRC})
-
+target_link_libraries(ptreferential pb_converter data)
 add_subdirectory(tests)

--- a/source/ptreferential/tests/CMakeLists.txt
+++ b/source/ptreferential/tests/CMakeLists.txt
@@ -1,26 +1,24 @@
-
+set(PTREF_TEST_LINK_LIBS
+    ed
+    ptreferential
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+)
 add_executable(ptref_test ptref_test.cpp)
-target_link_libraries(ptref_test ed ptreferential data ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
+target_link_libraries(ptref_test ${PTREF_TEST_LINK_LIBS})
 ADD_BOOST_TEST(ptref_test)
 
 add_executable(ptref_ng_test ptref_ng_test.cpp)
-target_link_libraries(ptref_ng_test ed data ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
+target_link_libraries(ptref_ng_test ${PTREF_TEST_LINK_LIBS})
 ADD_BOOST_TEST(ptref_ng_test)
 
 add_executable(ptref_odt_level_test ptref_odt_level_test.cpp)
-target_link_libraries(ptref_odt_level_test ed data  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
+target_link_libraries(ptref_odt_level_test ${PTREF_TEST_LINK_LIBS})
 ADD_BOOST_TEST(ptref_odt_level_test)
 
-
 add_executable(ptref_companies_test ptref_companies_test.cpp)
-target_link_libraries(ptref_companies_test ed data ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
+target_link_libraries(ptref_companies_test ${PTREF_TEST_LINK_LIBS})
 ADD_BOOST_TEST(ptref_companies_test)
 
 add_executable(vehicle_journey_test vehicle_journey_test.cpp)
-target_link_libraries(vehicle_journey_test ed data ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-
+target_link_libraries(vehicle_journey_test ${PTREF_TEST_LINK_LIBS})
 ADD_BOOST_TEST(vehicle_journey_test)

--- a/source/routing/CMakeLists.txt
+++ b/source/routing/CMakeLists.txt
@@ -1,6 +1,3 @@
-SET(BOOST_LIBS
-  ${Boost_THREAD_LIBRARY} ${Boost_DATE_TIME_LIBRARY} ${Boost_SYSTEM_LIBRARY} ${Boost_REGEX_LIBRARY}
-  ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} ${Boost_FILESYSTEM_LIBRARY})
 
 SET(ROUTING_SRC
   routing.cpp raptor_solution_reader.cpp raptor.cpp raptor_api.cpp
@@ -9,18 +6,15 @@ SET(ROUTING_SRC
   journey.cpp)
 
 add_library(routing ${ROUTING_SRC})
-add_dependencies(routing protobuf_files)
-target_link_libraries(routing types fare georef utils autocomplete ${BOOST_LIBS})
+target_link_libraries(routing fare georef autocomplete pthread)
 
 add_executable(benchmark benchmark.cpp)
-target_link_libraries(benchmark routing  boost_program_options data routing)
+target_link_libraries(benchmark data boost_program_options)
 
 add_executable(benchmark_raptor_cache benchmark_raptor_cache.cpp)
-target_link_libraries(benchmark_raptor_cache routing  boost_program_options data profiler)
+target_link_libraries(benchmark_raptor_cache boost_program_options data profiler)
 
 add_executable(benchmark_full benchmark_full.cpp)
-target_link_libraries(benchmark_full
-  routing  boost_program_options data fare routing georef utils autocomplete time_tables
-  ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(benchmark_full boost_program_options data)
 
 add_subdirectory(tests)

--- a/source/routing/tests/CMakeLists.txt
+++ b/source/routing/tests/CMakeLists.txt
@@ -1,58 +1,54 @@
-#We use the BOOST_LIBS define is the parent: routing
-SET(BOOST_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+set(RAPTOR_LINK_LIBS
+    routing
+    ed
+    workers
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+    ${NAVITIA_ALLOCATOR}
+)
 add_executable(raptor_test raptor_test.cpp)
-target_link_libraries(raptor_test ${Boost_LIBRARIES} ed data fare routing georef
-    autocomplete utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(raptor_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(raptor_test)
 
 add_executable(reverse_raptor_test reverse_raptor_test.cpp)
-target_link_libraries(reverse_raptor_test ed data fare routing georef autocomplete
-    utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(reverse_raptor_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(reverse_raptor_test)
 
 add_executable(frequency_raptor_test frequency_raptor_test.cpp)
-target_link_libraries(frequency_raptor_test ed data fare routing georef autocomplete
-    utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(frequency_raptor_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(frequency_raptor_test)
 
 add_executable(routing_api_test routing_api_test.cpp)
-target_link_libraries(routing_api_test ed data types routing fare pb_lib thermometer georef
-    autocomplete utils  ${BOOST_LIBS} log4cplus pthread protobuf)
+target_link_libraries(routing_api_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(routing_api_test)
 
 add_executable(next_stop_time_test next_stop_time_test.cpp)
-target_link_libraries(next_stop_time_test ed connectors data fare types routing
-    autocomplete pb_lib thermometer autocomplete georef utils ${BOOST_LIBS} log4cplus protobuf)
+target_link_libraries(next_stop_time_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(next_stop_time_test)
 
 add_executable(disruptions_test disruptions_test.cpp)
-target_link_libraries(disruptions_test ed data types routing fare pb_lib thermometer georef
-  autocomplete utils workers
-  ${BOOST_LIBS} log4cplus pthread protobuf ${NAVITIA_ALLOCATOR})
+target_link_libraries(disruptions_test ${RAPTOR_LINK_LIBS} ${Boost_PROGRAM_OPTIONS_LIBRARY})
 ADD_BOOST_TEST(disruptions_test)
 
 add_executable(co2_emission_test co2_emission_test.cpp)
-target_link_libraries(co2_emission_test ed data types routing fare pb_lib thermometer georef
-  autocomplete utils workers
-  ${BOOST_LIBS} log4cplus pthread protobuf)
+target_link_libraries(co2_emission_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(co2_emission_test)
 
 add_executable(journey_pattern_container_test journey_pattern_container_test.cpp)
-target_link_libraries(journey_pattern_container_test ${BOOST_LIBS} routing ed data)
+target_link_libraries(journey_pattern_container_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(journey_pattern_container_test)
 
 add_executable(get_stop_times_test get_stop_times_test.cpp)
-target_link_libraries(get_stop_times_test ed data fare georef routing types utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(get_stop_times_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(get_stop_times_test)
 
 add_executable(isochrone_test isochrone_test.cpp)
-target_link_libraries(isochrone_test ed data fare georef routing types utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(isochrone_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(isochrone_test)
 
 add_executable(heat_map_test heat_map_test.cpp)
-target_link_libraries(heat_map_test ed data fare georef routing types utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(heat_map_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(heat_map_test)
 
 add_executable(journey_test journey_test.cpp)
-target_link_libraries(journey_test ed data fare georef routing types utils ${BOOST_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(journey_test ${RAPTOR_LINK_LIBS})
 ADD_BOOST_TEST(journey_test)

--- a/source/tests/chaos/CMakeLists.txt
+++ b/source/tests/chaos/CMakeLists.txt
@@ -2,7 +2,12 @@
 ## Setup the BOOST tests that will exercise Chaos database
 #
 add_executable(chaos_db_tests chaos_db_tests.cpp)
-target_link_libraries(chaos_db_tests make_disruption_from_chaos apply_disruption ed workers data types pb_lib utils log4cplus ${NAVITIA_ALLOCATOR} ${Boost_LIBRARIES} ${Boost_DATE_TIME_LIBRARY} protobuf)
+target_link_libraries(chaos_db_tests
+    make_disruption_from_chaos
+    ed
+    workers
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+)
 
 target_link_libraries(chaos_db_tests ${ALL_LIBS})
 

--- a/source/tests/mock-kraken/CMakeLists.txt
+++ b/source/tests/mock-kraken/CMakeLists.txt
@@ -1,8 +1,11 @@
 include_directories("..")
 
-set(ALL_LIBS workers ed disruption_api calendar_api time_tables types autocomplete proximitylist
-    ptreferential time_tables data routing fare types georef utils SimpleAmqpClient
-    rabbitmq-static log4cplus ${Boost_LIBRARIES} protobuf ${NAVITIA_ALLOCATOR})
+set(ALL_LIBS
+    workers
+    ed
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+    ${NAVITIA_ALLOCATOR}
+)
 
 # every tests will produce an executable used in jormungandr integration tests
 

--- a/source/time_tables/CMakeLists.txt
+++ b/source/time_tables/CMakeLists.txt
@@ -1,12 +1,8 @@
 add_library(thermometer thermometer.cpp)
-target_link_libraries(thermometer types)
 
 SET(TIME_TABLES_SRC passages.cpp route_schedules.cpp departure_boards.cpp request_handle.cpp)
 add_library(time_tables ${TIME_TABLES_SRC})
-#TODO: a static lib doesn't need to be linked with is dependency
-target_link_libraries(time_tables utils types routing autocomplete proximitylist ptreferential georef thermometer)
-
-
+target_link_libraries(time_tables routing thermometer)
 add_subdirectory(tests)
 
 

--- a/source/time_tables/tests/CMakeLists.txt
+++ b/source/time_tables/tests/CMakeLists.txt
@@ -5,21 +5,24 @@ SET(BOOST_LIBS ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_FILESYSTEM_LIBRARY}
 
 
 add_executable(thermometer_test thermometer.cpp)
-target_link_libraries(thermometer_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus protobuf)
+target_link_libraries(thermometer_test thermometer ${BOOST_LIBS})
 ADD_BOOST_TEST(thermometer_test)
 
-
+set(TIME_TABLE_LINK_LIBS
+    time_tables
+    ed
+    data
+    ${BOOST_LIBS}
+)
 add_executable(departure_boards_test departure_boards_test.cpp)
-target_link_libraries(departure_boards_test rt_handling time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
+target_link_libraries(departure_boards_test rt_handling ${TIME_TABLE_LINK_LIBS})
 ADD_BOOST_TEST(departure_boards_test)
 
-
-
 add_executable(route_schedules_test route_schedules_test.cpp)
-target_link_libraries(route_schedules_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
+target_link_libraries(route_schedules_test ${TIME_TABLE_LINK_LIBS})
 ADD_BOOST_TEST(route_schedules_test)
 
 
 add_executable(passages_test passages_test.cpp)
-target_link_libraries(passages_test time_tables ptreferential ed data fare routing utils pb_lib thermometer georef ${BOOST_LIBS} log4cplus pthread protobuf)
+target_link_libraries(passages_test ${TIME_TABLE_LINK_LIBS})
 ADD_BOOST_TEST(passages_test)

--- a/source/tools/CMakeLists.txt
+++ b/source/tools/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(dumpsn dumpsn.cpp)
-target_link_libraries(dumpsn data)
+target_link_libraries(dumpsn data ${Boost_PROGRAM_OPTIONS_LIBRARY})

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -91,8 +91,11 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 SET_SOURCE_FILES_PROPERTIES(${PROTO_SRCS} PROPERTIES COMPILE_FLAGS ${PROTO_CMAKE_CXX_FLAGS})
 
-add_library(pb_lib ${PROTO_SRCS} pb_converter.cpp)
-target_link_libraries(pb_lib thermometer vptranslator pthread ${PROTOBUF_LIBRARY})
+add_library(pb_lib ${PROTO_SRCS})
+target_link_libraries(pb_lib ${PROTOBUF_LIBRARY})
+
+add_library(pb_converter pb_converter.cpp)
+target_link_libraries(pb_converter thermometer vptranslator pthread pb_lib)
 
 add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp
     validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp calendar.cpp stop_area.cpp network.cpp
@@ -109,67 +112,71 @@ SET(DATA_SRC
     headsign_handler.cpp
 )
 
-SET(BOOST_LIBS ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY} ${Boost_SERIALIZATION_LIBRARY}
-    ${Boost_DATE_TIME_LIBRARY} ${Boost_REGEX_LIBRARY} ${Boost_THREAD_LIBRARY})
-
-SET(BOOST_DEV_LIBS ${BOOST_LIBS} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 
 add_library(data ${DATA_SRC})
-target_link_libraries(data types fill_disruption_from_database fare routing autocomplete ${BOOST_LIBS})
+target_link_libraries(data
+    fill_disruption_from_database
+    routing
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_DATE_TIME_LIBRARY}
+    ${Boost_SYSTEM_LIBRARY}
+)
 
 # >>>>> Tests <<<<<
+set(TYPES_TEST_LINK_LIBS
+    ed
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+)
 
 add_executable(fill_pb_placemark_test tests/fill_pb_placemark_test.cpp)
-target_link_libraries(fill_pb_placemark_test ed data types routing fare georef autocomplete utils ${BOOST_DEV_LIBS} log4cplus pb_lib thermometer protobuf)
+target_link_libraries(fill_pb_placemark_test
+    routing
+    thermometer
+    pb_converter
+    ${TYPES_TEST_LINK_LIBS}
+)
 ADD_BOOST_TEST(fill_pb_placemark_test)
 
 add_executable(type_test tests/test.cpp)
-target_link_libraries(type_test types data ed utils ${BOOST_DEV_LIBS} log4cplus)
-add_dependencies(type_test protobuf_files)
+target_link_libraries(type_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(type_test)
 
 add_executable(datetime_test tests/datetime.cpp)
-target_link_libraries(datetime_test types ${BOOST_DEV_LIBS} log4cplus)
+target_link_libraries(datetime_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(datetime_test)
 
-
 add_executable(accessible_test tests/accessible.cpp)
-target_link_libraries(accessible_test ${BOOST_DEV_LIBS} log4cplus utils)
-add_dependencies(accessible_test protobuf_files)
+target_link_libraries(accessible_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(accessible_test)
 
 add_executable(multi_polygon_map_test tests/multi_polygon_map_test.cpp)
-target_link_libraries(multi_polygon_map_test ${BOOST_DEV_LIBS} log4cplus)
+target_link_libraries(multi_polygon_map_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(multi_polygon_map_test)
 
-
 add_executable(fill_pb_object_tests tests/fill_pb_object_tests.cpp)
-target_link_libraries(fill_pb_object_tests pb_lib ed thermometer time_tables data types fare routing georef autocomplete ${BOOST_DEV_LIBS} log4cplus)
-add_dependencies(fill_pb_object_tests protobuf_files)
+target_link_libraries(fill_pb_object_tests pb_converter ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(fill_pb_object_tests)
 
-
 add_executable(aggregation_odt_test tests/aggregation_odt_test.cpp)
-target_link_libraries(aggregation_odt_test ed data types georef autocomplete utils ${BOOST_DEV_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(aggregation_odt_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(aggregation_odt_test)
 
 add_executable(comments_test tests/comments_test.cpp)
-target_link_libraries(comments_test ed data types georef autocomplete utils ${BOOST_DEV_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(comments_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(comments_test)
 
 add_executable(data_test tests/data_test.cpp)
-target_link_libraries(data_test ed data types utils ${BOOST_DEV_LIBS} log4cplus)
+target_link_libraries(data_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(data_test)
 
 add_executable(code_container_test tests/code_container_test.cpp)
-target_link_libraries(code_container_test ${BOOST_DEV_LIBS})
+target_link_libraries(code_container_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(code_container_test)
 
 add_executable(headsign_test tests/headsign_test.cpp)
-target_link_libraries(headsign_test ed data types georef autocomplete utils ${BOOST_DEV_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(headsign_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(headsign_test)
 
 add_executable(create_vj_test tests/create_vj_test.cpp)
-target_link_libraries(create_vj_test ed data types georef autocomplete utils ${BOOST_DEV_LIBS} log4cplus pb_lib protobuf)
+target_link_libraries(create_vj_test ${TYPES_TEST_LINK_LIBS})
 ADD_BOOST_TEST(create_vj_test)

--- a/source/vptranslator/CMakeLists.txt
+++ b/source/vptranslator/CMakeLists.txt
@@ -2,10 +2,9 @@ SET(vptranslator_src
     vptranslator.h
     vptranslator.cpp)
 add_library(vptranslator ${vptranslator_src})
-target_link_libraries(vptranslator types ${Boost_DATE_TIME_LIBRARY} ${Boost_SERIALIZATION_LIBRARY} data)
-
+target_link_libraries(vptranslator types)
 
 add_executable (vptranslator_test test.cpp)
-target_link_libraries(vptranslator_test types ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} vptranslator)
+target_link_libraries(vptranslator_test types ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 ADD_BOOST_TEST(vptranslator_test)
 


### PR DESCRIPTION
This is what the libraries dependencies between ours modules used to be: [previous_dependency_graph.pdf](https://github.com/CanalTP/navitia/files/3805049/graph.prev.pdf)

This is now what it looks like: [graph.pdf](https://github.com/CanalTP/navitia/files/3805000/graph.pdf)

### The main goals for this work:
 * Speed up development time by only rebuilding what's necessary.
 * Speed up linking time by removing unwanted libs.
 * Clearer dependency graph to help organise the code better.

Here is what Kraken depends on : [graph.kraken.pdf](https://github.com/CanalTP/navitia/files/3805091/graph.kraken.pdf). A few things could be done around `types` `utils` and `data`.

### Cmake tips of the day: 
To generate the previous graphs, I've used :
```bash
cmake --graphviz=graphviz.dot ../path/to/navitia/source
dot -Tpdf -o graph.pdf graphviz.dot
```
 
## Requirements
- [x] https://github.com/CanalTP/SimpleAmqpClient/pull/1
- [x] https://github.com/CanalTP/utils/pull/84
