### PR TITLE
[Jormun] Remove underlying call to places_nearby call on a Coord

### DIFF
--- a/source/jormungandr/tests/end_point_tests.py
+++ b/source/jormungandr/tests/end_point_tests.py
@@ -249,3 +249,8 @@ class TestEndPoint(AbstractTestFixture):
         assert all(
             r.get_json()['address']['name'] == address_name for r in resp
         ), 'All requests should return the same result...'
+
+    def test_coord_without_region_shouldnt_call_places_nearby(self):
+        r1 = self.tester.get('v1/coverage/main_routing_test/coord/0.001077974378345651;0.0005839027882705609')
+        r2 = self.tester.get('v1/coord/0.001077974378345651;0.0005839027882705609')
+        assert r1.get_json()['address'] == r2.get_json()['address']


### PR DESCRIPTION
As of today, requesting `v1/coord/<lon>;<lat>/` will do a `places_nearby` call on Kraken with a `count = 1` 

When requesting `v1/coverage/<cov>/coord/<lon>;<lat>` calls  `places_by_uri` for a reverse.

Because `places_by_uri` and `places_nearby` share the same output interface, this isn't so much of a problem like in:
 * [/v1/coord/2.37720;48.84685/](http://canaltp.github.io/navitia-playground/play.html?request=http%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoord%2F2.37720%253B48.84685%2F%3F) 
 * [/v1/coverage/stif/coord/2.37720;48.84685](http://canaltp.github.io/navitia-playground/play.html?request=http%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fstif%2Fcoord%2F2.37720%253B48.84685%2F%3F)

But this now is a problem with a Geocoder that doesn't format addresses the same way Kraken does. Like Bragi in NL for instance :
 * [/v1/coord/4.857479;52.334274](http://canaltp.github.io/navitia-playground/play.html?request=http%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoord%2F4.857479%253B52.334274%2F%3F)
 * [/v1/coverage/nl-c/coord/4.857479;52.334274](http://canaltp.github.io/navitia-playground/play.html?request=http%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fnl-c%2Fcoord%2F4.857479%253B52.334274%2F%3F)

This was probably making sense back then, when the autocompletion was wacky. But calling `places_nearby` with a count of 1 is exactly the same as performing a reverse.

[NAVITIAII-2924](https://jira.kisio.org/browse/NAVITIAII-2924)  