### PR TITLE
kraken: replace type.h header by smaller headers for ptref

### DIFF
--- a/source/ptreferential/ptref_graph.h
+++ b/source/ptreferential/ptref_graph.h
@@ -30,9 +30,8 @@ www.navitia.io
 
 #pragma once
 
-#include "type/type.h"
+#include "type/type_interfaces.h"
 #include <boost/graph/adjacency_list.hpp>
-#include "utils/flat_enum_map.h"
 
 namespace navitia {
 namespace ptref {

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -416,7 +416,7 @@ std::string make_request(const Type_e requested_type,
                          const boost::optional<boost::posix_time::ptime>& until,
                          const type::RTLevel rt_level,
                          const type::Data& data) {
-    auto* static_data = navitia::type::static_data::get();
+    const auto* static_data = navitia::type::static_data::get();
     std::string res = request.empty() ? std::string("all") : request;
 
     switch (requested_type) {

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -37,8 +37,8 @@ www.navitia.io
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix.hpp>
 #include "type/line.h"
-#include "type/type.h"  //TODO: move static_data
-
+#include "type/type_interfaces.h"
+#include "type/static_data.h"
 namespace qi = boost::spirit::qi;
 namespace ascii = boost::spirit::ascii;
 using navitia::type::Indexes;
@@ -416,7 +416,7 @@ std::string make_request(const Type_e requested_type,
                          const boost::optional<boost::posix_time::ptime>& until,
                          const type::RTLevel rt_level,
                          const type::Data& data) {
-    type::static_data* static_data = type::static_data::get();
+    auto* static_data = navitia::type::static_data::get();
     std::string res = request.empty() ? std::string("all") : request;
 
     switch (requested_type) {

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -79,9 +79,8 @@ Indexes get_corresponding(Indexes indexes, Type_e from, const Type_e to, const D
 }
 
 Type_e type_by_caption(const std::string& type) {
-    type::static_data* static_data = type::static_data::get();
     try {
-        return static_data->typeByCaption(type);
+        return navitia::type::static_data::get()->typeByCaption(type);
     } catch (...) {
         throw parsing_error(parsing_error::error_type::unknown_object, "Filter Unknown object type: " + type);
     }

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -100,7 +100,7 @@ target_link_libraries(pb_converter thermometer vptranslator pthread pb_lib)
 add_library(types type.cpp message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp
     validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp calendar.cpp stop_area.cpp network.cpp
     contributor.cpp dataset.cpp company.cpp commercial_mode.cpp physical_mode.cpp line.cpp route.cpp
-    vehicle_journey.cpp stop_time.cpp type_interfaces.cpp comment_container.cpp odt_properties.cpp comment.cpp)
+    vehicle_journey.cpp stop_time.cpp type_interfaces.cpp comment_container.cpp odt_properties.cpp comment.cpp static_data.cpp)
 target_link_libraries(types ptreferential utils pb_lib protobuf)
 add_dependencies(types protobuf_files)
 

--- a/source/type/static_data.cpp
+++ b/source/type/static_data.cpp
@@ -1,0 +1,84 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#include "static_data.h"
+#include "utils/exception.h"
+
+#include <boost/assign.hpp>
+
+namespace navitia {
+namespace type {
+
+static_data* static_data::instance = nullptr;
+
+static_data* static_data::get() {
+    if (instance == nullptr) {
+        static_data* temp = new static_data();
+
+        boost::assign::insert(temp->types_string)(Type_e::ValidityPattern, "validity_pattern")(Type_e::Line, "line")(
+            Type_e::LineGroup, "line_group")(Type_e::JourneyPattern, "journey_pattern")(
+            Type_e::VehicleJourney, "vehicle_journey")(Type_e::StopPoint, "stop_point")(Type_e::StopArea, "stop_area")(
+            Type_e::Network, "network")(Type_e::PhysicalMode, "physical_mode")(
+            Type_e::CommercialMode, "commercial_mode")(Type_e::Connection, "connection")(
+            Type_e::JourneyPatternPoint, "journey_pattern_point")(Type_e::Company, "company")(Type_e::Route, "route")(
+            Type_e::POI, "poi")(Type_e::POIType, "poi_type")(Type_e::Contributor, "contributor")(
+            Type_e::Calendar, "calendar")(Type_e::MetaVehicleJourney, "trip")(Type_e::Impact, "disruption")(
+            Type_e::Dataset, "dataset");
+
+        boost::assign::insert(temp->modes_string)(Mode_e::Walking, "walking")(Mode_e::Bike, "bike")(Mode_e::Car, "car")(
+            Mode_e::Bss, "bss")(Mode_e::CarNoPark, "ridesharing")(Mode_e::CarNoPark, "car_no_park")(Mode_e::CarNoPark,
+                                                                                                    "taxi");
+        instance = temp;
+    }
+    return instance;
+}
+
+Type_e static_data::typeByCaption(const std::string& type_str) {
+    const auto it_type = instance->types_string.right.find(type_str);
+    if (it_type == instance->types_string.right.end()) {
+        throw navitia::recoverable_exception("The type " + type_str + " is not managed by kraken");
+    }
+    return it_type->second;
+}
+
+std::string static_data::captionByType(Type_e type) {
+    return instance->types_string.left.at(type);
+}
+
+Mode_e static_data::modeByCaption(const std::string& mode_str) {
+    const auto it_mode = instance->modes_string.right.find(mode_str);
+    if (it_mode == instance->modes_string.right.end()) {
+        throw navitia::recoverable_exception("The mode " + mode_str + " is not managed by kraken");
+    }
+    return it_mode->second;
+}
+
+}  // namespace type
+
+}  // namespace navitia

--- a/source/type/static_data.h
+++ b/source/type/static_data.h
@@ -43,7 +43,6 @@ private:
 
 public:
     static static_data* get();
-    // static std::string getListNameByType(Type_e type);
     static boost::posix_time::ptime parse_date_time(const std::string& s);
     static Type_e typeByCaption(const std::string& type_str);
     static std::string captionByType(Type_e type);

--- a/source/type/static_data.h
+++ b/source/type/static_data.h
@@ -1,0 +1,57 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+#pragma once
+
+#include "type_interfaces.h"
+
+#include <boost/bimap.hpp>
+#include <boost/bimap/multiset_of.hpp>
+
+namespace navitia {
+namespace type {
+
+struct static_data {
+private:
+    static static_data* instance;
+
+public:
+    static static_data* get();
+    // static std::string getListNameByType(Type_e type);
+    static boost::posix_time::ptime parse_date_time(const std::string& s);
+    static Type_e typeByCaption(const std::string& type_str);
+    static std::string captionByType(Type_e type);
+    boost::bimap<Type_e, std::string> types_string;
+    static Mode_e modeByCaption(const std::string& mode_str);
+    boost::bimap<boost::bimaps::multiset_of<Mode_e>, boost::bimaps::set_of<std::string>> modes_string;
+};
+
+}  // namespace type
+
+}  // namespace navitia

--- a/source/type/type.cpp
+++ b/source/type/type.cpp
@@ -315,49 +315,6 @@ void MetaVehicleJourney::push_unique_impact(const boost::shared_ptr<disruption::
     }
 }
 
-static_data* static_data::instance = nullptr;
-static_data* static_data::get() {
-    if (instance == nullptr) {
-        static_data* temp = new static_data();
-
-        boost::assign::insert(temp->types_string)(Type_e::ValidityPattern, "validity_pattern")(Type_e::Line, "line")(
-            Type_e::LineGroup, "line_group")(Type_e::JourneyPattern, "journey_pattern")(
-            Type_e::VehicleJourney, "vehicle_journey")(Type_e::StopPoint, "stop_point")(Type_e::StopArea, "stop_area")(
-            Type_e::Network, "network")(Type_e::PhysicalMode, "physical_mode")(
-            Type_e::CommercialMode, "commercial_mode")(Type_e::Connection, "connection")(
-            Type_e::JourneyPatternPoint, "journey_pattern_point")(Type_e::Company, "company")(Type_e::Route, "route")(
-            Type_e::POI, "poi")(Type_e::POIType, "poi_type")(Type_e::Contributor, "contributor")(
-            Type_e::Calendar, "calendar")(Type_e::MetaVehicleJourney, "trip")(Type_e::Impact, "disruption")(
-            Type_e::Dataset, "dataset");
-
-        boost::assign::insert(temp->modes_string)(Mode_e::Walking, "walking")(Mode_e::Bike, "bike")(Mode_e::Car, "car")(
-            Mode_e::Bss, "bss")(Mode_e::CarNoPark, "ridesharing")(Mode_e::CarNoPark, "car_no_park")(Mode_e::CarNoPark,
-                                                                                                    "taxi");
-        instance = temp;
-    }
-    return instance;
-}
-
-Type_e static_data::typeByCaption(const std::string& type_str) {
-    const auto it_type = instance->types_string.right.find(type_str);
-    if (it_type == instance->types_string.right.end()) {
-        throw navitia::recoverable_exception("The type " + type_str + " is not managed by kraken");
-    }
-    return it_type->second;
-}
-
-std::string static_data::captionByType(Type_e type) {
-    return instance->types_string.left.at(type);
-}
-
-Mode_e static_data::modeByCaption(const std::string& mode_str) {
-    const auto it_mode = instance->modes_string.right.find(mode_str);
-    if (it_mode == instance->modes_string.right.end()) {
-        throw navitia::recoverable_exception("The mode " + mode_str + " is not managed by kraken");
-    }
-    return it_mode->second;
-}
-
 EntryPoint::EntryPoint(const Type_e type, const std::string& uri, int access_duration)
     : type(type), uri(uri), access_duration(access_duration) {
     if (type == Type_e::Address) {
@@ -394,7 +351,7 @@ void StreetNetworkParams::set_filter(const std::string& param_uri) {
         type_filter = Type_e::Unknown;
     else {
         uri_filter = param_uri;
-        type_filter = static_data::get()->typeByCaption(param_uri.substr(0, pos));
+        type_filter = navitia::type::static_data::get()->typeByCaption(param_uri.substr(0, pos));
     }
 }
 

--- a/source/type/type.h
+++ b/source/type/type.h
@@ -45,8 +45,6 @@ www.navitia.io
 
 #include <boost/weak_ptr.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/bimap.hpp>
-#include <boost/bimap/multiset_of.hpp>
 #include <boost/range/algorithm/for_each.hpp>
 #include "type/fwd_type.h"
 #include "type/stop_point.h"
@@ -63,6 +61,7 @@ www.navitia.io
 #include "type/route.h"
 #include "type/vehicle_journey.h"
 #include "type/stop_time.h"
+#include "type/static_data.h"
 
 namespace navitia {
 namespace type {
@@ -165,21 +164,6 @@ private:
                        PT_Data&);
 
     navitia::flat_enum_map<RTLevel, std::vector<std::unique_ptr<VehicleJourney>>> rtlevel_to_vjs_map;
-};
-
-struct static_data {
-private:
-    static static_data* instance;
-
-public:
-    static static_data* get();
-    // static std::string getListNameByType(Type_e type);
-    static boost::posix_time::ptime parse_date_time(const std::string& s);
-    static Type_e typeByCaption(const std::string& type_str);
-    static std::string captionByType(Type_e type);
-    boost::bimap<Type_e, std::string> types_string;
-    static Mode_e modeByCaption(const std::string& mode_str);
-    boost::bimap<boost::bimaps::multiset_of<Mode_e>, boost::bimaps::set_of<std::string>> modes_string;
 };
 
 /**


### PR DESCRIPTION
I would like start cleaning **type.h** header inside navitia. 
Nevertheless, it is hard to complete the task in one PR, given the width of the problem. Effectively, it is included 46 times. 

```
#grep results
source/ptreferential/ptref_graph.h|33 col 11| #include "type/type.h"
source/ptreferential/ptreferential_ng.cpp|40 col 11| #include "type/type.h"  //TODO: move static_data
source/equipment/equipment_api.h|33 col 11| #include "type/type.h"
...
source/kraken/tests/disruption_reader_test.cpp|35 col 11| #include "type/type.h"
source/kraken/tests/worker_test.cpp|42 col 11| #include "type/type.h"
source/autocomplete/tests/test.cpp|44 col 11| #include "type/type.h"
source/routing/tests/next_stop_time_test.cpp|39 col 11| #include "type/type.h"
```
This work is the continuity of previous PRs _(Split type.h into several headers and cleaning dependencies_).
To avoid conflicts and increase readibility, I perfer to split in different batch of PRs. 
So. I am focusing on ptref for now :
```
source/ptreferential/ptref_graph.h|33 col 11| #include "type/type.h"
source/ptreferential/ptreferential_ng.cpp|40 col 11| #include "type/type.h"  //TODO: move static_data
```
The main task is to **extract static_data from type.h**

TODO : it remains **44** after that... :hammer: 
