### PR TITLE
Jormun: Refacto planner for future graphical isochrone implementations

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/GraphicalIsochrone.py
@@ -66,6 +66,8 @@ class GraphicalIsochrone(JourneyCommon):
             abort(400, message="you should provide a 'from' or a 'to' argument")
         if not args['max_duration'] and not args["boundary_duration[]"]:
             abort(400, message="you should provide a 'boundary_duration[]' or a 'max_duration' argument")
+        if args["boundary_duration[]"] and len(args["boundary_duration[]"]) > 10:
+            abort(400, message="you cannot provide more than 10 'boundary_duration[]'")
         if args['destination'] and args['origin']:
             abort(400, message="you cannot provide a 'from' and a 'to' argument")
         if 'ridesharing' in args['origin_mode'] or 'ridesharing' in args['destination_mode']:

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -305,8 +305,6 @@ class Scenario(object):
         else:
             journey_req.max_duration = max(request["boundary_duration[]"], key=int)
         if request.get("boundary_duration[]"):
-            if len(request["boundary_duration[]"]) > 10:
-                abort(400, message="you cannot provide more than 10 'boundary_duration[]'")
             for duration in sorted(request["boundary_duration[]"], key=int, reverse=True):
                 if request["min_duration"] < duration < journey_req.max_duration:
                     req.isochrone.boundary_duration.append(duration)

--- a/source/jormungandr/jormungandr/tests/planner_test.py
+++ b/source/jormungandr/jormungandr/tests/planner_test.py
@@ -1,0 +1,103 @@
+# encoding: utf-8
+
+#  Copyright (c) 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+import pytest
+from jormungandr.planner import JourneyParameters, GraphicalIsochronesParameters, Kraken
+from jormungandr.utils import str_to_time_stamp
+import navitiacommon.type_pb2 as type_pb2
+
+
+def check_basic_journeys_request(journeys_req):
+    assert len(journeys_req.origin) == 1
+    assert journeys_req.origin[0].place == "Kisio Digital"
+    assert journeys_req.origin[0].access_duration == 42
+
+    assert len(journeys_req.destination) == 1
+    assert journeys_req.destination[0].place == "Somewhere"
+    assert journeys_req.destination[0].access_duration == 666
+
+    assert journeys_req.night_bus_filter_max_factor == 1.5
+    assert journeys_req.night_bus_filter_base_factor == 900
+    assert len(journeys_req.datetimes) == 1
+    assert journeys_req.datetimes[0] == str_to_time_stamp("20120614T080000")
+    assert journeys_req.clockwise == True
+    assert journeys_req.realtime_level == type_pb2.BASE_SCHEDULE
+    assert journeys_req.max_duration == 86400
+    assert journeys_req.max_transfers == 10
+    assert journeys_req.wheelchair == False
+    assert journeys_req.max_extra_second_pass == 0
+    assert journeys_req.forbidden_uris == []
+    assert journeys_req.allowed_id == []
+    assert journeys_req.direct_path_duration == 0
+    assert journeys_req.bike_in_pt == False
+    assert journeys_req.min_nb_journeys == False
+    assert journeys_req.timeframe_duration == 0
+    assert journeys_req.depth == 1
+    assert journeys_req.isochrone_center.place == ""
+    assert journeys_req.isochrone_center.access_duration == 0
+
+
+def check_graphical_isochrones_request(isochrone_request):
+    check_basic_journeys_request(isochrone_request.journeys_request)
+
+    assert len(isochrone_request.boundary_duration) == 2
+
+    # To make sure the values are always in the same order.
+    isochrone_request.boundary_duration.sort()
+    assert isochrone_request.boundary_duration[0] == 0
+    assert isochrone_request.boundary_duration[1] == 86400
+
+
+def create_journeys_request_test():
+    origin = {"Kisio Digital": 42}
+    destination = {"Somewhere": 666}
+    journey_parameters = JourneyParameters()
+    datetime = str_to_time_stamp("20120614T080000")
+    planner = Kraken(None)
+
+    req = planner._create_journeys_request(origin, destination, datetime, True, journey_parameters, False)
+
+    assert req.requested_api == type_pb2.pt_planner
+    check_basic_journeys_request(req.journeys)
+
+
+def create_graphical_isochrones_request_test():
+    origin = {"Kisio Digital": 42}
+    destination = {"Somewhere": 666}
+    graphical_isochrones_parameters = GraphicalIsochronesParameters()
+    datetime = str_to_time_stamp("20120614T080000")
+    planner = Kraken(None)
+
+    req = planner._create_graphical_isochrones_request(
+        origin, destination, datetime, True, graphical_isochrones_parameters, False
+    )
+
+    assert req.requested_api == type_pb2.graphical_isochrone
+    check_graphical_isochrones_request(req.isochrone)


### PR DESCRIPTION
In distributed, `planner.py` is responsible of creating the pbf request and send it to the street_network_backend used.

This PR focus on multiple things:

1) Implementing `_create_graphical_isochrones_request`. To do so I've refactored the code responsible of creating a `journeys_request`. In the pfb, a `GraphicalIsochroneRequests` contains a `JourneysRequest`, so I've followed the same logic and created a `GraphicalIsochronesParameters` containing a `JourneyParameters`.

2) Adding some basic Unit Tests.

3) Replacing some hard coded values in `planner.py` by declared values in `default_values.py`.

4) Moving an abort during the process of a graphical_isochrone_request for new_default which should have been done much earlier in the code.