### PR TITLE
All: Update python versions for precommits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,6 @@ matrix:
     - python: "3.6"
       before_script:
         - pip install -r requirements_pre-commit.txt
-        - pip install pre-commit
         - pre-commit install
         - bash source/scripts/build_protobuf.sh
       script:

--- a/requirements_pre-commit.txt
+++ b/requirements_pre-commit.txt
@@ -1,5 +1,5 @@
-black==18.9b0; python_version > '3.6'
-mypy==0.670; python_version > '3.0'
-mypy-extensions==0.4.1; python_version > '3.0'
+black==18.9b0; python_version >= '3.6'
+mypy==0.670; python_version >= '3.5'
+mypy-extensions==0.4.1; python_version >= '3.5'
 flake8==3.5.0
 pre-commit==1.18.3


### PR DESCRIPTION
It's possible to use python3.6 for pre-commit, so follow python requirements from github repositories:
https://github.com/psf/black#installation
https://github.com/python/mypy#requirements