### PR TITLE
[Kraken] set nb_nearest_vertices to -1

### DIFF
--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -702,8 +702,7 @@ edge_t GeoRef::nearest_edge(const type::GeographicalCoord& coordinates,
     // The number indicates the number of nearest vertices that should be returned by find_with
     // This number is determined by balancing the performance and the practical results (Artemis)
     // The bigger the number is, the better the projection will be and slower it will run.
-    // With 30, we have broken less than 1% tests on Artemis_idfm.
-    constexpr int nb_nearest_vertices = 30;
+    constexpr int nb_nearest_vertices = 50;
 
     for (const auto& u : prox.find_within<proximitylist::IndexOnly>(coordinates, horizon, nb_nearest_vertices)) {
         BOOST_FOREACH (const edge_t& e, boost::out_edges(u, graph)) {

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -698,11 +698,10 @@ edge_t GeoRef::nearest_edge(const type::GeographicalCoord& coordinates,
     float min_dist = 0., cur_dist = 0.;
     double coslat = ::cos(coordinates.lat() * type::GeographicalCoord::N_DEG_TO_RAD);
 
-    // Magic Number!
-    // The number indicates the number of nearest vertices that should be returned by find_with
-    // This number is determined by balancing the performance and the practical results (Artemis)
-    // The bigger the number is, the better the projection will be and slower it will run.
-    constexpr int nb_nearest_vertices = 50;
+    // TODO: set different nb for different modes
+    // we can set -1 for both walking and bike mode
+    // set smaller number (ex: 50) for car
+    constexpr int nb_nearest_vertices = -1;
 
     for (const auto& u : prox.find_within<proximitylist::IndexOnly>(coordinates, horizon, nb_nearest_vertices)) {
         BOOST_FOREACH (const edge_t& e, boost::out_edges(u, graph)) {


### PR DESCRIPTION
This little is due to these tickets: https://jira.kisio.org/browse/NAVITIAII-2950 https://jira.kisio.org/browse/NAVITIAII-2956

The projection was wrong because this number is big enough. In order not to impact the performance, we use 50.