### PR TITLE
[Jormun] GeoJson geometry to be configured to a car park provider

### DIFF
--- a/source/jormungandr/jormungandr/parking_space_availability/abstract_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/abstract_provider_manager.py
@@ -82,7 +82,7 @@ class AbstractProviderManager(six.with_metaclass(ABCMeta, object)):
 
     def _find_provider(self, poi):
         for provider in self._get_providers():
-            if provider.support_poi(poi):
+            if provider.handle_poi(poi):
                 return provider
         return None
 

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_mock.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/tests/bss_mock.py
@@ -35,6 +35,7 @@ from jormungandr.ptref import FeedPublisher
 
 class BssMockProvider(AbstractParkingPlacesProvider):
     def __init__(self, network=None, *args, **kwargs):
+        super(BssMockProvider, self).__init__(*args, **kwargs)
         self.network = network
 
     def support_poi(self, poi):

--- a/source/jormungandr/jormungandr/parking_space_availability/car/common_car_park_provider.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/common_car_park_provider.py
@@ -43,8 +43,7 @@ from abc import abstractmethod
 
 class CommonCarParkProvider(AbstractParkingPlacesProvider):
     def __init__(self, url, operators, dataset, timeout, feed_publisher, **kwargs):
-
-        AbstractParkingPlacesProvider.__init__(self, **kwargs)
+        super(CommonCarParkProvider, self).__init__(**kwargs)
         self.ws_service_template = url + '?dataset={}'
         self.operators = [o.lower() for o in operators]
         self.timeout = timeout

--- a/source/jormungandr/jormungandr/parking_space_availability/car/common_car_park_provider.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/common_car_park_provider.py
@@ -73,38 +73,13 @@ class CommonCarParkProvider(AbstractParkingPlacesProvider):
         if data:
             return self.process_data(data, poi)
 
-    def _is_poi_coords_within_shape(self, poi):
-
-        if self.has_boundary_shape() == False:
-            '''
-            We assume that a POI is within a provider with no shape to be backward compatible.
-            So that we don't have to configure a shape for every single provier.
-            '''
-            return True
-
-        try:
-            coord = poi['coord']
-            lon = float(coord['lon'])
-            lat = float(coord['lat'])
-            return self.is_coord_within_boundary_shape(lon, lat)
-        except KeyError as e:
-            self.log.error(
-                "Coords illformed, 'poi' needs a coord dict with 'lon' and 'lat' attributes': ", str(e)
-            )
-        except ValueError as e:
-            self.log.error("Cannot convert POI's coord to float : ", str(e))
-        except Exception as e:
-            self.log.error("Cannot find if coords is within shape: ", str(e))
-
-        return False
-
     def _has_supported_poi_operator(self, poi):
         properties = poi.get('properties', {})
         operator = properties.get('operator', '').lower()
         return operator in self.operators
 
     def support_poi(self, poi):
-        return self._has_supported_poi_operator(poi) and self._is_poi_coords_within_shape(poi)
+        return self._has_supported_poi_operator(poi)
 
     @cache.memoize(app.config.get(str('CACHE_CONFIGURATION'), {}).get(str('TIMEOUT_CAR_PARK'), 30))
     def _call_webservice(self, request_url):

--- a/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
@@ -37,6 +37,9 @@ from jormungandr.parking_space_availability.car.common_car_park_provider import 
 
 
 class CommonCarParkProviderTest(CommonCarParkProvider):
+    def __init__(self, **kwargs):
+        CommonCarParkProvider.__init__(self, **kwargs)
+
     def process_data(self, data, poi):
         pass
 
@@ -58,7 +61,7 @@ def carParkProvider(defaultCarParkParameters):
 
 
 def test_create_default_common_car_park_provider_with_no_shape(carParkProvider):
-    assert carParkProvider.boundary_shape == None
+    assert carParkProvider.has_boundary_shape() == False
 
 
 def test_default_car_park_provider_should_handle_poi(carParkProvider):
@@ -88,7 +91,7 @@ def carParkProviderWithGeometry(defaultCarParkParameters):
 
 
 def test_car_park_provider_with_geometry_should_have_shape(carParkProviderWithGeometry):
-    assert carParkProviderWithGeometry.boundary_shape != None
+    assert carParkProviderWithGeometry.has_boundary_shape() == True
 
 
 def test_car_park_provider_with_shape_should_not_support_poi_with_no_coords(carParkProviderWithGeometry):
@@ -121,7 +124,7 @@ def test_car_park_provider_with_wrong_geojson_should_have_no_shape(defaultCarPar
     defaultCarParkParameters['geometry'] = {'type': 'no_idea', 'coordinates': ['blah', 'blah', 'blah']}
 
     parkProvider = CommonCarParkProviderTest(**defaultCarParkParameters)
-    assert parkProvider.boundary_shape == None
+    assert parkProvider.has_boundary_shape() == False
 
 
 def test_car_park_provider_with_falty_geometry_shape(defaultCarParkParameters):
@@ -129,4 +132,4 @@ def test_car_park_provider_with_falty_geometry_shape(defaultCarParkParameters):
     params['geometry'] = {'type': 'Unknow_type', 'coordinates': [[]]}
 
     car_park = CommonCarParkProviderTest(**params)
-    assert car_park.boundary_shape == None
+    assert car_park.has_boundary_shape() == False

--- a/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
@@ -58,7 +58,7 @@ def carParkProvider(defaultCarParkParameters):
 
 
 def test_create_default_common_car_park_provider_with_no_shape(carParkProvider):
-    assert carParkProvider.shape == None
+    assert carParkProvider.boundary_shape == None
 
 
 def test_default_car_park_provider_should_handle_poi(carParkProvider):
@@ -88,7 +88,7 @@ def carParkProviderWithGeometry(defaultCarParkParameters):
 
 
 def test_car_park_provider_with_geometry_should_have_shape(carParkProviderWithGeometry):
-    assert carParkProviderWithGeometry.shape != None
+    assert carParkProviderWithGeometry.boundary_shape != None
 
 
 def test_car_park_provider_with_shape_should_not_support_poi_with_no_coords(carParkProviderWithGeometry):
@@ -121,4 +121,12 @@ def test_car_park_provider_with_wrong_geojson_should_have_no_shape(defaultCarPar
     defaultCarParkParameters['geometry'] = {'type': 'no_idea', 'coordinates': ['blah', 'blah', 'blah']}
 
     parkProvider = CommonCarParkProviderTest(**defaultCarParkParameters)
-    assert parkProvider.shape == None
+    assert parkProvider.boundary_shape == None
+
+
+def test_car_park_provider_with_falty_geometry_shape(defaultCarParkParameters):
+    params = defaultCarParkParameters
+    params['geometry'] = {'type': 'Unknow_type', 'coordinates': [[]]}
+
+    car_park = CommonCarParkProviderTest(**params)
+    assert car_park.boundary_shape == None

--- a/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
@@ -1,0 +1,124 @@
+# encoding: utf-8
+# Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+import pytest
+import copy
+
+from jormungandr.parking_space_availability.car.common_car_park_provider import CommonCarParkProvider
+
+
+class CommonCarParkProviderTest(CommonCarParkProvider):
+    def process_data(self, data, poi):
+        pass
+
+
+@pytest.fixture
+def defaultCarParkParameters():
+    return {
+        'url': 'http://test.com',
+        'operators': ["Tank"],
+        'dataset': "data",
+        'timeout': 1,
+        'feed_publisher': {'id': 'fp1', 'name': 'feedpub'},
+    }
+
+
+@pytest.fixture
+def carParkProvider(defaultCarParkParameters):
+    return CommonCarParkProviderTest(**defaultCarParkParameters)
+
+
+def test_create_default_common_car_park_provider_with_no_shape(carParkProvider):
+    assert carParkProvider.shape == None
+
+
+def test_default_car_park_provider_should_handle_poi(carParkProvider):
+    assert carParkProvider.support_poi({'properties': {'operator': 'TANK'}}) == True
+
+    assert carParkProvider.support_poi({}) == False
+    assert carParkProvider.support_poi({'properties': {}}) == False
+    assert carParkProvider.support_poi({'properties': {'operator': 'other_operator'}}) == False
+
+
+@pytest.fixture
+def carParkProviderWithGeometry(defaultCarParkParameters):
+    params = defaultCarParkParameters
+    params['geometry'] = {
+        'type': 'Polygon',
+        'coordinates': [
+            [
+                [3.97131347656250, 47.27224096817965],
+                [5.10486602783203, 47.27224096817966],
+                [5.10486602783203, 47.36743170534774],
+                [4.97131347656250, 47.36743170534774],
+                [4.97131347656250, 47.27224096817966],
+            ]
+        ],
+    }
+    return CommonCarParkProviderTest(**params)
+
+
+def test_car_park_provider_with_geometry_should_have_shape(carParkProviderWithGeometry):
+    assert carParkProviderWithGeometry.shape != None
+
+
+def test_car_park_provider_with_shape_should_not_support_poi_with_no_coords(carParkProviderWithGeometry):
+    assert carParkProviderWithGeometry.support_poi({}) == False
+    assert carParkProviderWithGeometry.support_poi({}) == False
+    assert carParkProviderWithGeometry.support_poi({'properties': {}}) == False
+    assert carParkProviderWithGeometry.support_poi({'properties': {'operator': 'other_operator'}}) == False
+    assert carParkProviderWithGeometry.support_poi({'properties': {'operator': 'TANK'}}) == False
+
+
+def test_car_park_provider_with_shape_should_support_poi_with_coords(carParkProviderWithGeometry):
+    poi = {'properties': {'operator': 'TANK'}}
+
+    '''
+    The coord is a point INSIDE the car park provider polygon
+    '''
+    poi_inside = copy.copy(poi)
+    poi_inside['coord'] = {'lon': '5.041351318359375', 'lat': '47.32881751198527'}
+    assert carParkProviderWithGeometry.support_poi(poi_inside) == True
+
+    '''
+    The coord is this time, OUTSIDE the car park provider polygon
+    '''
+    poi_outside = copy.copy(poi)
+    poi_outside['coord'] = {'lon': '1.041351318359375', 'lat': '1.32881751198527'}
+    assert carParkProviderWithGeometry.support_poi(poi_outside) == False
+
+
+def test_car_park_provider_with_wrong_geojson_should_have_no_shape(defaultCarParkParameters):
+    defaultCarParkParameters['geometry'] = {'type': 'no_idea', 'coordinates': ['blah', 'blah', 'blah']}
+
+    parkProvider = CommonCarParkProviderTest(**defaultCarParkParameters)
+    assert parkProvider.shape == None

--- a/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/car/tests/common_car_park_provider_test.py
@@ -38,7 +38,7 @@ from jormungandr.parking_space_availability.car.common_car_park_provider import 
 
 class CommonCarParkProviderTest(CommonCarParkProvider):
     def __init__(self, **kwargs):
-        CommonCarParkProvider.__init__(self, **kwargs)
+        super(CommonCarParkProviderTest, self).__init__(**kwargs)
 
     def process_data(self, data, poi):
         pass

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -507,7 +507,6 @@ from jormungandr.ptref import FeedPublisher
 
 class MockBssProvider(AbstractParkingPlacesProvider):
     def __init__(self, pois_supported, name='mock bss provider'):
-        AbstractParkingPlacesProvider.__init__(self)
         self.pois_supported = pois_supported
         self.name = name
 

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -507,6 +507,7 @@ from jormungandr.ptref import FeedPublisher
 
 class MockBssProvider(AbstractParkingPlacesProvider):
     def __init__(self, pois_supported, name='mock bss provider'):
+        AbstractParkingPlacesProvider.__init__(self)
         self.pois_supported = pois_supported
         self.name = name
 

--- a/source/tyr/tyr/validations.py
+++ b/source/tyr/tyr/validations.py
@@ -1,7 +1,4 @@
 from datetime import datetime
-import geojson
-import json
-import flask_restful
 
 
 def datetime_format(value):


### PR DESCRIPTION
A GeoJson shape can now be configured for a car park provider. In our case,
a polygon (even with holes) can be used.

A POI will have its coordinates check against that geometric shape to
define if it belongs to the provider or not.

The shape can be of any geometric object supported by GeoJson like rectangle, polygon, multipolygon etc... as long as a Point (the poi's coordinate) could be defined as 'inside' or 'outside' of the say shape.

http://geojson.io 
https://fr.wikipedia.org/wiki/GeoJSON
https://jira.kisio.org/browse/NAVP-1445