### PR TITLE
Kraken: Fix warnings found by scan-build

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -586,10 +586,11 @@ builder::builder(const std::string& date,
 }
 
 void builder::connection(const std::string& name1, const std::string& name2, float length) {
-    navitia::type::StopPointConnection* connexion = new navitia::type::StopPointConnection();
-    connexion->idx = data->pt_data->stop_point_connections.size();
-    if (sps.count(name1) == 0 || sps.count(name2) == 0)
+    if (sps.count(name1) == 0 || sps.count(name2) == 0) {
         return;
+    }
+    auto* connexion = new navitia::type::StopPointConnection();
+    connexion->idx = data->pt_data->stop_point_connections.size();
     connexion->departure = (*(sps.find(name1))).second;
     connexion->destination = (*(sps.find(name2))).second;
 

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -1083,11 +1083,11 @@ void CompanyFusioHandler::handle_line(Data& data, const csv_row& row, bool is_fi
                                     + "  file has more than one company and no company_id column");
         throw InvalidHeaders(csv.filename);
     }
-    ed::types::Company* company = new ed::types::Company();
     if (!is_valid(id_c, row)) {
         LOG4CPLUS_WARN(logger, "CompanyFusioHandler : Invalid company id " << row[id_c]);
         return;
     }
+    auto* company = new ed::types::Company();
     company->uri = row[id_c];
     company->name = row[name_c];
     if (is_valid(company_address_name_c, row))

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -3331,7 +3331,6 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     // We have a timeframe duration = 10 min related to the first journeys (08:00:00),
     // Even though, the second journey's departure is later than the timeframe's limit
     // we still keep it, because it satisfies the min_nb_journey criteria
-    uint32_t min_nb_journeys = 0;
     uint64_t timeframe_duration = 10 * 60;
     clockwise = true;
 
@@ -3366,7 +3365,6 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     // journeys (08:30:00), as explained above, even though some journeys' arrivals are
     // not in the interval, we still keep them
     // The response must contain at least 2 journeys.
-    min_nb_journeys = 0;
     timeframe_duration = 20 * 60;
     clockwise = false;
 
@@ -3415,7 +3413,6 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     // We don't have 20 journeys in 1H, so we continue until 20 journeys as
     // min_nb_journeys is the limiting criteria.
     // The response must contain 20 journeys.
-    min_nb_journeys = 20;
     timeframe_duration = 1 * 60 * 60;
     clockwise = true;
 
@@ -3423,7 +3420,7 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     navitia::PbCreator pb_creator_case4(data_ptr, "20180309T075900"_dt, null_time_period);
     make_response(pb_creator_case4, raptor, origin, destination, {ntest::to_posix_timestamp("20180309T075900")},
                   clockwise, navitia::type::AccessibiliteParams(), forbidden, {}, sn_worker, nt::RTLevel::Base, 2_min,
-                  24 * 60 * 60, 10, 0, 0, 0, min_nb_journeys, 3, 6000, timeframe_duration);
+                  24 * 60 * 60, 10, 0, 0, 0, 20, 3, 6000, timeframe_duration);
 
     // get the response
     resp = pb_creator_case4.get_response();
@@ -3439,7 +3436,6 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     // the limit max is less than timeframe_duration.
     // We compute until the max limit
     // The response must contain only 6 journeys.
-    min_nb_journeys = 0;
     timeframe_duration = 60 * 60 * 4;  // 4H
     clockwise = true;
     uint32_t timeframe_max_duration = 60 * 60;
@@ -3458,12 +3454,11 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     //-----------------------------------
     // Case 6 :
     // clockwise = true
-    // min_nb_journeys = 2
+    // min_nb_journeys = none
     // timeframe_duration = 40*60 (40min)
     // timeframe_max_bound = 1H
     //
     // the reponse should contain at least 4 journeys
-    min_nb_journeys = 2;
     timeframe_duration = 40 * 60;  // 40 min
     clockwise = true;
     timeframe_max_duration = 60 * 60;
@@ -3484,14 +3479,13 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     //-----------------------------------
     // Case 7 :
     // clockwise = true
-    // min_nb_journeys = 10
+    // min_nb_journeys = none
     // timeframe_duration = 1 day
     // timeframe_max_bound = 10 min
     //
     // We test the case where max_duraion < timeframe_duration
     // Even though we ask for 10 journeys, the search bound is limited to 10min
     // Raptor can find only one solution within ten minutes
-    min_nb_journeys = 10;
     timeframe_duration = 24 * 60 * 60;  // 1 day
     clockwise = true;
     timeframe_max_duration = 10 * 60;  // 10min
@@ -3513,12 +3507,11 @@ BOOST_AUTO_TEST_CASE(journeys_with_time_frame_duration) {
     //-----------------------------------
     // Case 8 :
     // clockwise = true
-    // min_nb_journeys = 5
+    // min_nb_journeys = none
     // timeframe_duration = 1 day
     // timeframe_max_bound = 10s
     //
     // max_duration is too small, no solution is found
-    min_nb_journeys = 5;
     timeframe_duration = 24 * 60 * 60;  // 1 day
     clockwise = true;
     timeframe_max_duration = 10;  // 10 seconds


### PR DESCRIPTION
I've been playing with clang's analyzer scan build (https://clang-analyzer.llvm.org/scan-build.html).

It found 2 warnings :
- `warning: Potential leak of memory pointed to by` in `build_helper.cpp` and `fusio_parser.cpp` 
- `warning: min_nb_journeys is never read` in `routing_api_test.cpp`

Why not fix them ?