### PR TITLE
Fix instabilities in fares

### DIFF
--- a/source/fare/CMakeLists.txt
+++ b/source/fare/CMakeLists.txt
@@ -1,8 +1,8 @@
-SET(GEOREF_SRC
+SET(FARE_SRC
     fare.h
     fare.cpp
 )
 
-add_library(fare ${GEOREF_SRC})
-target_link_libraries(fare pb_lib)
+add_library(fare ${FARE_SRC})
+target_link_libraries(fare routing pb_lib)
 add_subdirectory(tests)

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -134,7 +134,7 @@ results Fare::compute_fare(const routing::Path& path) const {
     results res;
     int nb_nodes = boost::num_vertices(g);
 
-    LOG4CPLUS_TRACE(logger, "Computing fare for journey : \n" << path);
+    LOG4CPLUS_DEBUG(logger, "Computing fare for journey : \n" << path);
 
     if (nb_nodes < 2) {
         LOG4CPLUS_TRACE(logger, "no fare data loaded, cannot compute fare");

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -39,6 +39,9 @@ www.navitia.io
 #include "type/datetime.h"
 #include "routing/routing.h"
 
+#define FARE_LOG_ENABLED false
+
+
 namespace greg = boost::gregorian;
 
 namespace navitia {
@@ -70,10 +73,14 @@ static Label next_label(Label label, Ticket ticket, const SectionKey& section) {
         // empty ticket, it is juste a change
         // we have to update the number of changes and the duration with the same ticket
         if (ticket.caption == "" && ticket.value == 0) {
-            LOG4CPLUS_TRACE(logger, "Empty ticket, free change");
+            #if(FARE_LOG_ENABLED)
+                LOG4CPLUS_TRACE(logger, "Empty ticket, free change");
+            #endif
             label.nb_changes++;
         } else {
-            LOG4CPLUS_TRACE(logger, "We buy a new ticket");
+            #if(FARE_LOG_ENABLED)
+                LOG4CPLUS_TRACE(logger, "We buy a new ticket");
+            #endif
             // we bought a new ticket
             // we save the global cost, and we reset the number of changes and duration
             if (ticket.value.undefined)
@@ -134,7 +141,9 @@ results Fare::compute_fare(const routing::Path& path) const {
     results res;
     int nb_nodes = boost::num_vertices(g);
 
-    LOG4CPLUS_DEBUG(logger, "Computing fare for journey : \n" << path);
+    #if(FARE_LOG_ENABLED)
+        LOG4CPLUS_DEBUG(logger, "Computing fare for journey : \n" << path);
+    #endif
 
     if (nb_nodes < 2) {
         LOG4CPLUS_TRACE(logger, "no fare data loaded, cannot compute fare");
@@ -150,8 +159,9 @@ results Fare::compute_fare(const routing::Path& path) const {
             section_idx++;
             continue;
         }
-
-        LOG4CPLUS_TRACE(logger, "In section " << section_idx << " : \n" << item);
+        #if(FARE_LOG_ENABLED)
+            LOG4CPLUS_TRACE(logger, "In section " << section_idx << " : \n" << item);
+        #endif
         SectionKey section_key(item, section_idx++);
 
         std::vector<std::vector<Label>> new_labels(nb_nodes);
@@ -163,20 +173,26 @@ results Fare::compute_fare(const routing::Path& path) const {
                 if (!valid(g[v], section_key)) {
                     continue;
                 }
-                    
-                LOG4CPLUS_TRACE(logger, "Trying transition : \n " << g[e] 
+                #if(FARE_LOG_ENABLED)
+                    LOG4CPLUS_TRACE(logger, "Trying transition : \n " << g[e] 
                                         << "\n from node : " << u << "\n  " << g[u] 
                                         << "\n to node :   " << v << "\n  " << g[v]);
-                
+                #endif
 
                 for (const Label& label : labels[u]) {
-                    LOG4CPLUS_TRACE(logger, "Looking at label  : \n" << label);
+                    #if(FARE_LOG_ENABLED)
+                        LOG4CPLUS_TRACE(logger, "Looking at label  : \n" << label);
+                    #endif
                     Ticket ticket;
                     const Transition& transition = g[e];
                     if (valid(g[u], label) && transition.valid(section_key, label)) {
-                        LOG4CPLUS_TRACE(logger, " Transition accept this (section, label) \n");
+                        #if(FARE_LOG_ENABLED)
+                            LOG4CPLUS_TRACE(logger, " Transition accept this (section, label) \n");
+                        #endif
                         if (transition.ticket_key != "") {
-                            LOG4CPLUS_TRACE(logger, " Transition ticket key is not blank : " << transition.ticket_key);
+                            #if(FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, " Transition ticket key is not blank : " << transition.ticket_key);
+                            #endif
                             bool ticket_found = false;  // TODO refactor this, optional is way better
                             auto it = fare_map.find(transition.ticket_key);
                             try {
@@ -185,18 +201,24 @@ results Fare::compute_fare(const routing::Path& path) const {
                                     ticket_found = true;
                                 }
                             } catch (no_ticket) {  // the ticket_found bool is still false
-                            LOG4CPLUS_TRACE(logger, " Throw no ticket \n");
+                            #if(FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, " Throw no ticket \n");
+                            #endif
                             }
                             if (!ticket_found) {
                                 ticket = make_default_ticket();
                             }
                         }
                         if (transition.global_condition == Transition::GlobalCondition::exclusive) {
-                            LOG4CPLUS_TRACE(logger, " Throw Ticket \n");
+                            #if(FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, " Throw Ticket \n");
+                            #endif
                             throw ticket;
                         }
                         else if (transition.global_condition == Transition::GlobalCondition::with_changes) {
-                            LOG4CPLUS_TRACE(logger, " ODFare ticket \n");
+                            #if(FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, " ODFare ticket \n");
+                            #endif
                             ticket.type = Ticket::ODFare;
                         }
                         Label next = next_label(label, ticket, section_key);
@@ -214,22 +236,30 @@ results Fare::compute_fare(const routing::Path& path) const {
                                 n.cost += ticket_od.value;
                                 n.tickets.back() = ticket_od;
                                 n.current_type = Ticket::FlatFare;
-                                LOG4CPLUS_TRACE(logger, "Adding ODFare label to node 0 : \n" << n);
+                                #if(FARE_LOG_ENABLED)
+                                    LOG4CPLUS_TRACE(logger, "Adding ODFare label to node 0 : \n" << n);
+                                #endif
                                 new_labels[0].push_back(n);
                             } catch (no_ticket) {
-                                LOG4CPLUS_TRACE(logger, "Unable to get the OD ticket SA="
+                                #if(FARE_LOG_ENABLED)
+                                    LOG4CPLUS_TRACE(logger, "Unable to get the OD ticket SA="
                                                             << next.stop_area << ", zone=" << next.zone
                                                             << ", section start_zone=" << section_key.start_zone
                                                             << ", dest_zone=" << section_key.dest_zone
                                                             << ", start_sa=" << section_key.start_stop_area
                                                             << ", dest_sa=" << section_key.dest_stop_area
                                                             << ", mode=" << section_key.mode);
+                                #endif
                             }
                         } else {
-                            LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
+                            #if(FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
+                            #endif
                             new_labels[0].push_back(next);
                         }
-                        LOG4CPLUS_TRACE(logger, "Adding label to node " << v <<" {" << g[v] << "} : \n" << next);
+                        #if(FARE_LOG_ENABLED)
+                            LOG4CPLUS_TRACE(logger, "Adding label to node " << v <<" {" << g[v] << "} : \n" << next);
+                        #endif
                         new_labels[v].push_back(next);
                     }
                 }
@@ -237,7 +267,9 @@ results Fare::compute_fare(const routing::Path& path) const {
         }
         // exclusive segment, we have to use that ticket
         catch (const Ticket& ticket) {
-            LOG4CPLUS_TRACE(logger, "\texclusive section for fare");
+            #if(FARE_LOG_ENABLED)
+                LOG4CPLUS_TRACE(logger, "\texclusive section for fare");
+            #endif
             new_labels.clear();
             new_labels.resize(nb_nodes);
             for (Label label : labels.at(0)) {
@@ -249,10 +281,12 @@ results Fare::compute_fare(const routing::Path& path) const {
 
     // We look for the cheapest label
     // if 2 label have the same cost, we take the one with the least number of tickets
-    LOG4CPLUS_DEBUG(logger, "Bests labels : \n");
-    for (const Label& label : labels.at(0)) {
-        LOG4CPLUS_DEBUG(logger, " " << label);
-    }
+    #if(FARE_LOG_ENABLED)
+        LOG4CPLUS_DEBUG(logger, "Bests labels : \n");
+        for (const Label& label : labels.at(0)) {
+            LOG4CPLUS_DEBUG(logger, " " << label);
+        }
+    #endif
     boost::optional<Label> best_label;
     for (const Label& label : labels.at(0)) {
         if (!best_label || label < (*best_label)) {
@@ -262,7 +296,9 @@ results Fare::compute_fare(const routing::Path& path) const {
             best_label = label;
         }
     }
-    LOG4CPLUS_DEBUG(logger, "Result label : \n" << (*best_label));
+    #if(FARE_LOG_ENABLED)
+        LOG4CPLUS_DEBUG(logger, "Result label : \n" << (*best_label));
+    #endif
 
     return res;
 }

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -468,6 +468,10 @@ DateTicket Fare::get_od(const Label& label, const SectionKey& section) const {
     return ticket;
 }
 
+Fare::Fare() {
+    add_default_ticket();
+}
+
 size_t Fare::nb_transitions() const {
     return boost::num_edges(g);
 }

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -159,10 +159,15 @@ results Fare::compute_fare(const routing::Path& path) const {
             BOOST_FOREACH (edge_t e, boost::edges(g)) {
                 vertex_t u = boost::source(e, g);
                 vertex_t v = boost::target(e, g);
-                if (!valid(g[v], section_key))
+                
+                if (!valid(g[v], section_key)) {
                     continue;
-
-                LOG4CPLUS_TRACE(logger, "Trying transition  from node : " << u << " to node : " << v << ", : " << g[e]);
+                }
+                    
+                LOG4CPLUS_TRACE(logger, "Trying transition : \n " << g[e] 
+                                        << "\n from node : " << u << "\n  " << g[u] 
+                                        << "\n to node :   " << v << "\n  " << g[v]);
+                
 
                 for (const Label& label : labels[u]) {
                     LOG4CPLUS_TRACE(logger, "Looking at label  : \n" << label);
@@ -191,6 +196,7 @@ results Fare::compute_fare(const routing::Path& path) const {
                             throw ticket;
                         }
                         else if (transition.global_condition == Transition::GlobalCondition::with_changes) {
+                            LOG4CPLUS_TRACE(logger, " ODFare ticket \n");
                             ticket.type = Ticket::ODFare;
                         }
                         Label next = next_label(label, ticket, section_key);
@@ -208,7 +214,7 @@ results Fare::compute_fare(const routing::Path& path) const {
                                 n.cost += ticket_od.value;
                                 n.tickets.back() = ticket_od;
                                 n.current_type = Ticket::FlatFare;
-                                LOG4CPLUS_TRACE(logger, "Adding ODFare label to node 0 : " << next);
+                                LOG4CPLUS_TRACE(logger, "Adding ODFare label to node 0 : \n" << n);
                                 new_labels[0].push_back(n);
                             } catch (no_ticket) {
                                 LOG4CPLUS_TRACE(logger, "Unable to get the OD ticket SA="
@@ -220,10 +226,10 @@ results Fare::compute_fare(const routing::Path& path) const {
                                                             << ", mode=" << section_key.mode);
                             }
                         } else {
-                            LOG4CPLUS_TRACE(logger, "Adding label to node 0 : " << next);
+                            LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
                             new_labels[0].push_back(next);
                         }
-                        LOG4CPLUS_TRACE(logger, "Adding label to node " << v << " : " << next);
+                        LOG4CPLUS_TRACE(logger, "Adding label to node " << v <<" {" << g[v] << "} : \n" << next);
                         new_labels[v].push_back(next);
                     }
                 }

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -243,9 +243,9 @@ results Fare::compute_fare(const routing::Path& path) const {
 
     // We look for the cheapest label
     // if 2 label have the same cost, we take the one with the least number of tickets
-    LOG4CPLUS_TRACE(logger, "Bests labels : \n");
+    LOG4CPLUS_DEBUG(logger, "Bests labels : \n");
     for (const Label& label : labels.at(0)) {
-        LOG4CPLUS_TRACE(logger, " " << label);
+        LOG4CPLUS_DEBUG(logger, " " << label);
     }
     boost::optional<Label> best_label;
     for (const Label& label : labels.at(0)) {
@@ -256,7 +256,7 @@ results Fare::compute_fare(const routing::Path& path) const {
             best_label = label;
         }
     }
-    LOG4CPLUS_TRACE(logger, "Result label : \n" << (*best_label));
+    LOG4CPLUS_DEBUG(logger, "Result label : \n" << (*best_label));
 
     return res;
 }

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -41,7 +41,6 @@ www.navitia.io
 
 #define FARE_LOG_ENABLED false
 
-
 namespace greg = boost::gregorian;
 
 namespace navitia {
@@ -73,14 +72,14 @@ static Label next_label(Label label, Ticket ticket, const SectionKey& section) {
         // empty ticket, it is juste a change
         // we have to update the number of changes and the duration with the same ticket
         if (ticket.caption == "" && ticket.value == 0) {
-            #if(FARE_LOG_ENABLED)
-                LOG4CPLUS_TRACE(logger, "Empty ticket, free change");
-            #endif
+#if (FARE_LOG_ENABLED)
+            LOG4CPLUS_TRACE(logger, "Empty ticket, free change");
+#endif
             label.nb_changes++;
         } else {
-            #if(FARE_LOG_ENABLED)
-                LOG4CPLUS_TRACE(logger, "We buy a new ticket");
-            #endif
+#if (FARE_LOG_ENABLED)
+            LOG4CPLUS_TRACE(logger, "We buy a new ticket");
+#endif
             // we bought a new ticket
             // we save the global cost, and we reset the number of changes and duration
             if (ticket.value.undefined)
@@ -141,9 +140,9 @@ results Fare::compute_fare(const routing::Path& path) const {
     results res;
     int nb_nodes = boost::num_vertices(g);
 
-    #if(FARE_LOG_ENABLED)
-        LOG4CPLUS_DEBUG(logger, "Computing fare for journey : \n" << path);
-    #endif
+#if (FARE_LOG_ENABLED)
+    LOG4CPLUS_DEBUG(logger, "Computing fare for journey : \n" << path);
+#endif
 
     if (nb_nodes < 2) {
         LOG4CPLUS_TRACE(logger, "no fare data loaded, cannot compute fare");
@@ -154,14 +153,14 @@ results Fare::compute_fare(const routing::Path& path) const {
     labels[0].push_back(Label());
     size_t section_idx(0);
 
-    for (const navitia::routing::PathItem & item : path.items) {
+    for (const navitia::routing::PathItem& item : path.items) {
         if (item.type != routing::ItemType::public_transport) {
             section_idx++;
             continue;
         }
-        #if(FARE_LOG_ENABLED)
-            LOG4CPLUS_TRACE(logger, "In section " << section_idx << " : \n" << item);
-        #endif
+#if (FARE_LOG_ENABLED)
+        LOG4CPLUS_TRACE(logger, "In section " << section_idx << " : \n" << item);
+#endif
         SectionKey section_key(item, section_idx++);
 
         std::vector<std::vector<Label>> new_labels(nb_nodes);
@@ -169,30 +168,29 @@ results Fare::compute_fare(const routing::Path& path) const {
             BOOST_FOREACH (edge_t e, boost::edges(g)) {
                 vertex_t u = boost::source(e, g);
                 vertex_t v = boost::target(e, g);
-                
+
                 if (!valid(g[v], section_key)) {
                     continue;
                 }
-                #if(FARE_LOG_ENABLED)
-                    LOG4CPLUS_TRACE(logger, "Trying transition : \n " << g[e] 
-                                        << "\n from node : " << u << "\n  " << g[u] 
-                                        << "\n to node :   " << v << "\n  " << g[v]);
-                #endif
+#if (FARE_LOG_ENABLED)
+                LOG4CPLUS_TRACE(logger, "Trying transition : \n " << g[e] << "\n from node : " << u << "\n  " << g[u]
+                                                                  << "\n to node :   " << v << "\n  " << g[v]);
+#endif
 
                 for (const Label& label : labels[u]) {
-                    #if(FARE_LOG_ENABLED)
-                        LOG4CPLUS_TRACE(logger, "Looking at label  : \n" << label);
-                    #endif
+#if (FARE_LOG_ENABLED)
+                    LOG4CPLUS_TRACE(logger, "Looking at label  : \n" << label);
+#endif
                     Ticket ticket;
                     const Transition& transition = g[e];
                     if (valid(g[u], label) && transition.valid(section_key, label)) {
-                        #if(FARE_LOG_ENABLED)
-                            LOG4CPLUS_TRACE(logger, " Transition accept this (section, label) \n");
-                        #endif
+#if (FARE_LOG_ENABLED)
+                        LOG4CPLUS_TRACE(logger, " Transition accept this (section, label) \n");
+#endif
                         if (transition.ticket_key != "") {
-                            #if(FARE_LOG_ENABLED)
-                                LOG4CPLUS_TRACE(logger, " Transition ticket key is not blank : " << transition.ticket_key);
-                            #endif
+#if (FARE_LOG_ENABLED)
+                            LOG4CPLUS_TRACE(logger, " Transition ticket key is not blank : " << transition.ticket_key);
+#endif
                             bool ticket_found = false;  // TODO refactor this, optional is way better
                             auto it = fare_map.find(transition.ticket_key);
                             try {
@@ -201,24 +199,23 @@ results Fare::compute_fare(const routing::Path& path) const {
                                     ticket_found = true;
                                 }
                             } catch (no_ticket) {  // the ticket_found bool is still false
-                            #if(FARE_LOG_ENABLED)
+#if (FARE_LOG_ENABLED)
                                 LOG4CPLUS_TRACE(logger, " Throw no ticket \n");
-                            #endif
+#endif
                             }
                             if (!ticket_found) {
                                 ticket = make_default_ticket();
                             }
                         }
                         if (transition.global_condition == Transition::GlobalCondition::exclusive) {
-                            #if(FARE_LOG_ENABLED)
-                                LOG4CPLUS_TRACE(logger, " Throw Ticket \n");
-                            #endif
+#if (FARE_LOG_ENABLED)
+                            LOG4CPLUS_TRACE(logger, " Throw Ticket \n");
+#endif
                             throw ticket;
-                        }
-                        else if (transition.global_condition == Transition::GlobalCondition::with_changes) {
-                            #if(FARE_LOG_ENABLED)
-                                LOG4CPLUS_TRACE(logger, " ODFare ticket \n");
-                            #endif
+                        } else if (transition.global_condition == Transition::GlobalCondition::with_changes) {
+#if (FARE_LOG_ENABLED)
+                            LOG4CPLUS_TRACE(logger, " ODFare ticket \n");
+#endif
                             ticket.type = Ticket::ODFare;
                         }
                         Label next = next_label(label, ticket, section_key);
@@ -236,30 +233,30 @@ results Fare::compute_fare(const routing::Path& path) const {
                                 n.cost += ticket_od.value;
                                 n.tickets.back() = ticket_od;
                                 n.current_type = Ticket::FlatFare;
-                                #if(FARE_LOG_ENABLED)
-                                    LOG4CPLUS_TRACE(logger, "Adding ODFare label to node 0 : \n" << n);
-                                #endif
+#if (FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, "Adding ODFare label to node 0 : \n" << n);
+#endif
                                 new_labels[0].push_back(n);
                             } catch (no_ticket) {
-                                #if(FARE_LOG_ENABLED)
-                                    LOG4CPLUS_TRACE(logger, "Unable to get the OD ticket SA="
+#if (FARE_LOG_ENABLED)
+                                LOG4CPLUS_TRACE(logger, "Unable to get the OD ticket SA="
                                                             << next.stop_area << ", zone=" << next.zone
                                                             << ", section start_zone=" << section_key.start_zone
                                                             << ", dest_zone=" << section_key.dest_zone
                                                             << ", start_sa=" << section_key.start_stop_area
                                                             << ", dest_sa=" << section_key.dest_stop_area
                                                             << ", mode=" << section_key.mode);
-                                #endif
+#endif
                             }
                         } else {
-                            #if(FARE_LOG_ENABLED)
-                                LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
-                            #endif
+#if (FARE_LOG_ENABLED)
+                            LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
+#endif
                             new_labels[0].push_back(next);
                         }
-                        #if(FARE_LOG_ENABLED)
-                            LOG4CPLUS_TRACE(logger, "Adding label to node " << v <<" {" << g[v] << "} : \n" << next);
-                        #endif
+#if (FARE_LOG_ENABLED)
+                        LOG4CPLUS_TRACE(logger, "Adding label to node " << v << " {" << g[v] << "} : \n" << next);
+#endif
                         new_labels[v].push_back(next);
                     }
                 }
@@ -267,9 +264,9 @@ results Fare::compute_fare(const routing::Path& path) const {
         }
         // exclusive segment, we have to use that ticket
         catch (const Ticket& ticket) {
-            #if(FARE_LOG_ENABLED)
-                LOG4CPLUS_TRACE(logger, "\texclusive section for fare");
-            #endif
+#if (FARE_LOG_ENABLED)
+            LOG4CPLUS_TRACE(logger, "\texclusive section for fare");
+#endif
             new_labels.clear();
             new_labels.resize(nb_nodes);
             for (Label label : labels.at(0)) {
@@ -279,14 +276,14 @@ results Fare::compute_fare(const routing::Path& path) const {
         labels = std::move(new_labels);
     }
 
-    // We look for the cheapest label
-    // if 2 label have the same cost, we take the one with the least number of tickets
-    #if(FARE_LOG_ENABLED)
-        LOG4CPLUS_DEBUG(logger, "Bests labels : \n");
-        for (const Label& label : labels.at(0)) {
-            LOG4CPLUS_DEBUG(logger, " " << label);
-        }
-    #endif
+// We look for the cheapest label
+// if 2 label have the same cost, we take the one with the least number of tickets
+#if (FARE_LOG_ENABLED)
+    LOG4CPLUS_DEBUG(logger, "Bests labels : \n");
+    for (const Label& label : labels.at(0)) {
+        LOG4CPLUS_DEBUG(logger, " " << label);
+    }
+#endif
     boost::optional<Label> best_label;
     for (const Label& label : labels.at(0)) {
         if (!best_label || label < (*best_label)) {
@@ -296,9 +293,9 @@ results Fare::compute_fare(const routing::Path& path) const {
             best_label = label;
         }
     }
-    #if(FARE_LOG_ENABLED)
-        LOG4CPLUS_DEBUG(logger, "Result label : \n" << (*best_label));
-    #endif
+#if (FARE_LOG_ENABLED)
+    LOG4CPLUS_DEBUG(logger, "Result label : \n" << (*best_label));
+#endif
 
     return res;
 }
@@ -531,94 +528,73 @@ void Fare::add_default_ticket() {
     fare_map.insert({default_ticket.key, dticket});
 }
 
-std::ostream& operator<<(std::ostream& ss, const Label & l) {
-    ss << "  cost : " << l.cost
-       << ", nb_undef_cost : " << l.nb_undefined_sub_cost
-       << ", start time : " << l.start_time
-       << ", nb_changes : " << l.nb_changes
-       << ", stop_area : " << l.stop_area
-       << ", zone : " << l.zone
-       << ", mode : " << l.mode
-       << ", line : " << l.line
-       << ", network : " << l.network
-       << ", current_type " << l.current_type;
-    
+std::ostream& operator<<(std::ostream& ss, const Label& l) {
+    ss << "  cost : " << l.cost << ", nb_undef_cost : " << l.nb_undefined_sub_cost << ", start time : " << l.start_time
+       << ", nb_changes : " << l.nb_changes << ", stop_area : " << l.stop_area << ", zone : " << l.zone
+       << ", mode : " << l.mode << ", line : " << l.line << ", network : " << l.network << ", current_type "
+       << l.current_type;
+
     ss << ", Tickets :\n";
-    for(auto ticket : l.tickets) {
-        ss <<"  * " << ticket << "\n";
+    for (auto ticket : l.tickets) {
+        ss << "  * " << ticket << "\n";
     }
-       
+
     return ss;
 }
 
 std::ostream& operator<<(std::ostream& ss, const Ticket& t) {
-    ss << "  key : " << t.key
-       << ", caption : " << t.caption
-       << ", currency : " << t.currency
-       << ", value : " << t.value
-       << ", comment : " << t.comment
-       << ", type : " << t.type;
+    ss << "  key : " << t.key << ", caption : " << t.caption << ", currency : " << t.currency << ", value : " << t.value
+       << ", comment : " << t.comment << ", type : " << t.type;
 
-    ss << ", sections :\n" ;
-    for(const SectionKey & section_key : t.sections) {
+    ss << ", sections :\n";
+    for (const SectionKey& section_key : t.sections) {
         ss << "      * " << section_key << "\n";
     }
     return ss;
 }
 
-std::ostream& operator<<(std::ostream& ss, const SectionKey & k){
-    ss << "  network : " << k.network
-       << ", start_stop_area : " << k.start_stop_area
-       << ", dest_stop_area : " << k.dest_stop_area
-       << ", line : " << k.line
-    //    << ", start_time : " << k.start_time
-    //    << ", dest_time : " << k.dest_time
-    //    << ", start_zone : " << k.start_zone
-    //    << ", dest_zone : " << k.dest_zone
-       << ", mode : " << k.mode
-       << ", date : " << k.date
-       << ", path_item_idx : " << k.path_item_idx;
-       
+std::ostream& operator<<(std::ostream& ss, const SectionKey& k) {
+    ss << "  network : " << k.network << ", start_stop_area : " << k.start_stop_area
+       << ", dest_stop_area : " << k.dest_stop_area << ", line : "
+       << k.line
+       //    << ", start_time : " << k.start_time
+       //    << ", dest_time : " << k.dest_time
+       //    << ", start_zone : " << k.start_zone
+       //    << ", dest_zone : " << k.dest_zone
+       << ", mode : " << k.mode << ", date : " << k.date << ", path_item_idx : " << k.path_item_idx;
+
     return ss;
 }
 
+std::ostream& operator<<(std::ostream& ss, const State& k) {
+    ss << "  mode : " << k.mode << ", zone : " << k.zone << ", stop_area : " << k.stop_area << ", line : " << k.line
+       << ", network : " << k.network << ", ticket : " << k.ticket;
 
-std::ostream& operator<<(std::ostream& ss, const State & k){
-    ss << "  mode : " << k.mode
-       << ", zone : " << k.zone
-       << ", stop_area : " << k.stop_area
-       << ", line : " << k.line
-       << ", network : " << k.network
-       << ", ticket : " << k.ticket;
-       
     return ss;
 }
 
-std::ostream& operator<<(std::ostream& ss, const Transition & k){
+std::ostream& operator<<(std::ostream& ss, const Transition& k) {
     ss << "  ticket_key : " << k.ticket_key;
     ss << ", global_cond : ";
-    switch (k.global_condition)
-    {
-    case Transition::GlobalCondition::nothing: {
-        ss <<" nothing, ";
-        break;
+    switch (k.global_condition) {
+        case Transition::GlobalCondition::nothing: {
+            ss << " nothing, ";
+            break;
+        }
+        case Transition::GlobalCondition::exclusive: {
+            ss << "exclusive, ";
+            break;
+        }
+        case Transition::GlobalCondition::with_changes: {
+            ss << "with_changes, ";
+            break;
+        }
+        default:
+            break;
     }
-    case Transition::GlobalCondition::exclusive: {
-        ss << "exclusive, ";
-        break;
-    }
-    case Transition::GlobalCondition::with_changes: {
-        ss << "with_changes, ";
-        break;
-    }
-    default:
-        break;
-    }
-  
+
     return ss;
 }
-
-
 
 }  // namespace fare
 }  // namespace navitia

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -352,7 +352,7 @@ struct Fare {
     Graph g;
     Fare::vertex_t begin_v;  // begin vertex descriptor
 
-    Fare() { add_default_ticket(); }
+    Fare();
 
     /// Effectue la recherche du meilleur tarif
     /// Retourne une liste de billets à acheter

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -119,8 +119,7 @@ struct Ticket {
     }
 };
 
-
-std::ostream& operator<<(std::ostream& ss, const Ticket & t); 
+std::ostream& operator<<(std::ostream& ss, const Ticket& t);
 
 inline Ticket make_default_ticket() {
     Ticket default_t("unknown_ticket", "unknown ticket", 0, "unknown ticket");
@@ -203,7 +202,7 @@ struct State {
     }
 };
 
-std::ostream& operator<<(std::ostream& ss, const State & k);
+std::ostream& operator<<(std::ostream& ss, const State& k);
 
 /// Type de comparaison possible entre un arc et une valeur
 enum class Comp_e { EQ, NEQ, LT, GT, LTE, GTE, True };
@@ -264,16 +263,15 @@ struct Label {
             return nb_undefined_sub_cost < l.nb_undefined_sub_cost;
         if (cost.value != l.cost.value)
             return cost.value < l.cost.value;
-        if (tickets.size() !=  l.tickets.size()) {
+        if (tickets.size() != l.tickets.size()) {
             return tickets.size() < l.tickets.size();
         }
 
         return nb_changes < l.nb_changes;
-        
     }
 };
 
-std::ostream& operator<<(std::ostream& ss, const Label & l);
+std::ostream& operator<<(std::ostream& ss, const Label& l);
 
 /// Contient les données retournées par navitia
 struct SectionKey {
@@ -294,7 +292,7 @@ struct SectionKey {
     int duration_at_end(int ticket_start_time) const;
 };
 
-std::ostream& operator<<(std::ostream& ss, const SectionKey & k); 
+std::ostream& operator<<(std::ostream& ss, const SectionKey& k);
 
 /// Représente un transition possible et l'achat éventuel d'un billet
 struct Transition {
@@ -313,7 +311,7 @@ struct Transition {
     }
 };
 
-std::ostream& operator<<(std::ostream& ss, const Transition & k);
+std::ostream& operator<<(std::ostream& ss, const Transition& k);
 
 struct OD_key {
     enum od_type { Zone, StopArea, Mode };  // NOTE: don't forget to change the bdd enum if this change

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -203,6 +203,8 @@ struct State {
     }
 };
 
+std::ostream& operator<<(std::ostream& ss, const State & k);
+
 /// Type de comparaison possible entre un arc et une valeur
 enum class Comp_e { EQ, NEQ, LT, GT, LTE, GTE, True };
 
@@ -305,6 +307,8 @@ struct Transition {
         ar& start_conditions& end_conditions& ticket_key& global_condition;
     }
 };
+
+std::ostream& operator<<(std::ostream& ss, const Transition & k);
 
 struct OD_key {
     enum od_type { Zone, StopArea, Mode };  // NOTE: don't forget to change the bdd enum if this change

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -264,7 +264,12 @@ struct Label {
             return nb_undefined_sub_cost < l.nb_undefined_sub_cost;
         if (cost.value != l.cost.value)
             return cost.value < l.cost.value;
+        if (tickets.size() !=  l.tickets.size()) {
+            return tickets.size() < l.tickets.size();
+        }
+
         return nb_changes < l.nb_changes;
+        
     }
 };
 

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -119,6 +119,9 @@ struct Ticket {
     }
 };
 
+
+std::ostream& operator<<(std::ostream& ss, const Ticket & t); 
+
 inline Ticket make_default_ticket() {
     Ticket default_t("unknown_ticket", "unknown ticket", 0, "unknown ticket");
     default_t.value = Cost();  // undefined cost
@@ -263,6 +266,8 @@ struct Label {
     }
 };
 
+std::ostream& operator<<(std::ostream& ss, const Label & l);
+
 /// Contient les données retournées par navitia
 struct SectionKey {
     std::string network;
@@ -281,6 +286,8 @@ struct SectionKey {
     int duration_at_begin(int ticket_start_time) const;
     int duration_at_end(int ticket_start_time) const;
 };
+
+std::ostream& operator<<(std::ostream& ss, const SectionKey & k); 
 
 /// Représente un transition possible et l'achat éventuel d'un billet
 struct Transition {

--- a/source/routing/CMakeLists.txt
+++ b/source/routing/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(ROUTING_SRC
   journey.cpp)
 
 add_library(routing ${ROUTING_SRC})
-target_link_libraries(routing fare georef autocomplete pthread)
+target_link_libraries(routing  georef autocomplete pthread)
 
 add_executable(benchmark benchmark.cpp)
 target_link_libraries(benchmark data boost_program_options)

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -37,48 +37,7 @@ namespace routing {
 std::string PathItem::print() const {
     std::stringstream ss;
 
-    const navitia::type::StopArea* start = stop_points.front()->stop_area;
-    const navitia::type::StopArea* dest = stop_points.back()->stop_area;
-    switch (type) {
-        case ItemType::public_transport:
-            ss << "public transport";
-            break;
-        case ItemType::walking:
-            ss << "walking";
-            break;
-        case ItemType::stay_in:
-            ss << "stay in";
-            break;
-        case ItemType::waiting:
-            ss << "waiting";
-            break;
-        case ItemType::boarding:
-            ss << "boarding";
-            break;
-        case ItemType::alighting:
-            ss << "alighting";
-            break;
-        default:
-            ss << "unknown";
-            break;
-    }
-    ss << " section\n";
-
-    if (type == ItemType::public_transport && !stop_times.empty()) {
-        const navitia::type::StopTime* st = stop_times.front();
-        const navitia::type::VehicleJourney* vj = st->vehicle_journey;
-        const navitia::type::Route* route = vj->route;
-        const navitia::type::Line* line = route->line;
-        ss << "Line : " << line->name << " (" << line->uri << " " << line->idx << "), "
-           << "Route : " << route->name << " (" << route->uri << " " << route->idx << "), "
-           << "Vehicle journey " << vj->idx << "\n";
-    }
-    ss << "From " << start->name << "(" << start->uri << " " << start->idx << ") at " << departure << "\n";
-    for (auto sp : stop_points) {
-        ss << "    " << sp->name << " (" << sp->uri << " " << sp->idx << ")"
-           << "\n";
-    }
-    ss << "To " << dest->name << "(" << dest->uri << " " << dest->idx << ") at " << arrival << "\n";
+    ss << *this;
     return ss.str();
 }
 
@@ -123,6 +82,9 @@ bool use_crow_fly(const type::EntryPoint& point,
         return false;
     }
 }
+
+
+
 
 }  // namespace routing
 }  // namespace navitia

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -83,5 +83,59 @@ bool use_crow_fly(const type::EntryPoint& point,
     }
 }
 
+std::ostream& operator<<(std::ostream& ss, const PathItem& t) {
+    const navitia::type::StopArea* start = t.stop_points.front()->stop_area;
+    const navitia::type::StopArea* dest = t.stop_points.back()->stop_area;
+    switch (t.type) {
+        case navitia::routing::ItemType::public_transport:
+            ss << "public transport";
+            break;
+        case navitia::routing::ItemType::walking:
+            ss << "walking";
+            break;
+        case navitia::routing::ItemType::stay_in:
+            ss << "stay in";
+            break;
+        case navitia::routing::ItemType::waiting:
+            ss << "waiting";
+            break;
+        case navitia::routing::ItemType::boarding:
+            ss << "boarding";
+            break;
+        case navitia::routing::ItemType::alighting:
+            ss << "alighting";
+            break;
+        default:
+            ss << "unknown";
+            break;
+    }
+    ss << " section\n";
+
+    if (t.type == navitia::routing::ItemType::public_transport && !t.stop_times.empty()) {
+        const navitia::type::StopTime* st = t.stop_times.front();
+        const navitia::type::VehicleJourney* vj = st->vehicle_journey;
+        const navitia::type::Route* route = vj->route;
+        const navitia::type::Line* line = route->line;
+        ss << "Line : " << line->name << " (" << line->uri << " " << line->idx << "), "
+           << "Route : " << route->name << " (" << route->uri << " " << route->idx << "), "
+           << "Vehicle journey " << vj->idx << "\n";
+    }
+    ss << "From " << start->name << "(" << start->uri << " " << start->idx << ") at " << t.departure << "\n";
+    for (auto sp : t.stop_points) {
+        ss << "    " << sp->name << " (" << sp->uri << " " << sp->idx << ")"
+           << "\n";
+    }
+    ss << "To " << dest->name << "(" << dest->uri << " " << dest->idx << ") at " << t.arrival << "\n";
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, const Path& t) {
+    for (auto item : t.items) {
+        ss << item;
+    }
+
+    return ss;
+}
+
 }  // namespace routing
 }  // namespace navitia

--- a/source/routing/routing.cpp
+++ b/source/routing/routing.cpp
@@ -83,8 +83,5 @@ bool use_crow_fly(const type::EntryPoint& point,
     }
 }
 
-
-
-
 }  // namespace routing
 }  // namespace navitia

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -112,52 +112,7 @@ struct PathItem {
     }
 };
 
-inline std::ostream& operator<<(std::ostream& ss, const PathItem& t) {
-    const navitia::type::StopArea* start = t.stop_points.front()->stop_area;
-    const navitia::type::StopArea* dest = t.stop_points.back()->stop_area;
-    switch (t.type) {
-        case navitia::routing::ItemType::public_transport:
-            ss << "public transport";
-            break;
-        case navitia::routing::ItemType::walking:
-            ss << "walking";
-            break;
-        case navitia::routing::ItemType::stay_in:
-            ss << "stay in";
-            break;
-        case navitia::routing::ItemType::waiting:
-            ss << "waiting";
-            break;
-        case navitia::routing::ItemType::boarding:
-            ss << "boarding";
-            break;
-        case navitia::routing::ItemType::alighting:
-            ss << "alighting";
-            break;
-        default:
-            ss << "unknown";
-            break;
-    }
-    ss << " section\n";
-
-    if (t.type == navitia::routing::ItemType::public_transport && !t.stop_times.empty()) {
-        const navitia::type::StopTime* st = t.stop_times.front();
-        const navitia::type::VehicleJourney* vj = st->vehicle_journey;
-        const navitia::type::Route* route = vj->route;
-        const navitia::type::Line* line = route->line;
-        ss << "Line : " << line->name << " (" << line->uri << " " << line->idx << "), "
-           << "Route : " << route->name << " (" << route->uri << " " << route->idx << "), "
-           << "Vehicle journey " << vj->idx << "\n";
-    }
-    ss << "From " << start->name << "(" << start->uri << " " << start->idx << ") at " << t.departure << "\n";
-    for (auto sp : t.stop_points) {
-        ss << "    " << sp->name << " (" << sp->uri << " " << sp->idx << ")"
-           << "\n";
-    }
-    ss << "To " << dest->name << "(" << dest->uri << " " << dest->idx << ") at " << t.arrival << "\n";
-    return ss;
-}
-
+std::ostream& operator<<(std::ostream& ss, const PathItem& t);
 /** Un itinéraire complet */
 struct Path {
     navitia::time_duration duration = boost::posix_time::pos_infin;
@@ -179,13 +134,7 @@ struct Path {
     }
 };
 
-inline std::ostream& operator<<(std::ostream& ss, const Path& t) {
-    for (auto item : t.items) {
-        ss << item;
-    }
-
-    return ss;
-}
+std::ostream& operator<<(std::ostream& ss, const Path& t);
 
 bool operator==(const PathItem& a, const PathItem& b);
 

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -112,10 +112,8 @@ struct PathItem {
     }
 };
 
-
-
-inline std::ostream& operator<<(std::ostream& ss, const PathItem & t) {
-const navitia::type::StopArea* start = t.stop_points.front()->stop_area;
+inline std::ostream& operator<<(std::ostream& ss, const PathItem& t) {
+    const navitia::type::StopArea* start = t.stop_points.front()->stop_area;
     const navitia::type::StopArea* dest = t.stop_points.back()->stop_area;
     switch (t.type) {
         case navitia::routing::ItemType::public_transport:
@@ -181,15 +179,13 @@ struct Path {
     }
 };
 
-
-inline std::ostream& operator<<(std::ostream& ss, const Path & t) {
+inline std::ostream& operator<<(std::ostream& ss, const Path& t) {
     for (auto item : t.items) {
         ss << item;
     }
 
     return ss;
 }
- 
 
 bool operator==(const PathItem& a, const PathItem& b);
 

--- a/source/routing/routing.h
+++ b/source/routing/routing.h
@@ -112,6 +112,54 @@ struct PathItem {
     }
 };
 
+
+
+inline std::ostream& operator<<(std::ostream& ss, const PathItem & t) {
+const navitia::type::StopArea* start = t.stop_points.front()->stop_area;
+    const navitia::type::StopArea* dest = t.stop_points.back()->stop_area;
+    switch (t.type) {
+        case navitia::routing::ItemType::public_transport:
+            ss << "public transport";
+            break;
+        case navitia::routing::ItemType::walking:
+            ss << "walking";
+            break;
+        case navitia::routing::ItemType::stay_in:
+            ss << "stay in";
+            break;
+        case navitia::routing::ItemType::waiting:
+            ss << "waiting";
+            break;
+        case navitia::routing::ItemType::boarding:
+            ss << "boarding";
+            break;
+        case navitia::routing::ItemType::alighting:
+            ss << "alighting";
+            break;
+        default:
+            ss << "unknown";
+            break;
+    }
+    ss << " section\n";
+
+    if (t.type == navitia::routing::ItemType::public_transport && !t.stop_times.empty()) {
+        const navitia::type::StopTime* st = t.stop_times.front();
+        const navitia::type::VehicleJourney* vj = st->vehicle_journey;
+        const navitia::type::Route* route = vj->route;
+        const navitia::type::Line* line = route->line;
+        ss << "Line : " << line->name << " (" << line->uri << " " << line->idx << "), "
+           << "Route : " << route->name << " (" << route->uri << " " << route->idx << "), "
+           << "Vehicle journey " << vj->idx << "\n";
+    }
+    ss << "From " << start->name << "(" << start->uri << " " << start->idx << ") at " << t.departure << "\n";
+    for (auto sp : t.stop_points) {
+        ss << "    " << sp->name << " (" << sp->uri << " " << sp->idx << ")"
+           << "\n";
+    }
+    ss << "To " << dest->name << "(" << dest->uri << " " << dest->idx << ") at " << t.arrival << "\n";
+    return ss;
+}
+
 /** Un itinéraire complet */
 struct Path {
     navitia::time_duration duration = boost::posix_time::pos_infin;
@@ -132,6 +180,16 @@ struct Path {
             std::cout << item.print() << std::endl;
     }
 };
+
+
+inline std::ostream& operator<<(std::ostream& ss, const Path & t) {
+    for (auto item : t.items) {
+        ss << item;
+    }
+
+    return ss;
+}
+ 
 
 bool operator==(const PathItem& a, const PathItem& b);
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -120,6 +120,7 @@ add_library(data ${DATA_SRC})
 target_link_libraries(data
     fill_disruption_from_database
     routing
+    fare
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
@@ -133,6 +134,7 @@ set(TYPES_TEST_LINK_LIBS
 
 add_executable(fill_pb_placemark_test tests/fill_pb_placemark_test.cpp)
 target_link_libraries(fill_pb_placemark_test
+    data
     routing
     thermometer
     pb_converter

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -41,6 +41,7 @@ www.navitia.io
 #include "utils/obj_factory.h"
 #include "utils/ptime.h"
 #include "type/fwd_type.h"
+#include "fare/fare.h"
 
 // workaround missing "is_trivially_copyable" in g++ < 5.0
 #if __GNUG__ && __GNUC__ < 5

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1712,18 +1712,14 @@ void PbCreator::fill_fare_section(pbnavitia::Journey* pb_journey, const fare::re
 
         pbnavitia::Ticket* pb_ticket = nullptr;
         if (ticket.is_default_ticket()) {
-            if (!unknown_ticket) {
-                pb_ticket = response.add_tickets();
-                pb_ticket->set_name(ticket.caption);
-                pb_ticket->set_found(false);
-                pb_ticket->set_id("unknown_ticket");
-                pb_ticket->set_source_id(ticket.key);
-                pb_ticket->set_comment("unknown ticket");
-                //unknown_ticket = pb_ticket;
-                pb_fare->add_ticket_id(pb_ticket->id());
-            } else {
-                pb_ticket = unknown_ticket;
-            }
+            pb_ticket = response.add_tickets();
+            pb_ticket->set_name(ticket.caption);
+            pb_ticket->set_found(false);
+            pb_ticket->set_id("unknown_ticket");
+            pb_ticket->set_source_id(ticket.key);
+            pb_ticket->set_comment("unknown ticket");
+            pb_fare->add_ticket_id(pb_ticket->id());
+
         } else {
             pb_ticket = response.add_tickets();
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1719,7 +1719,7 @@ void PbCreator::fill_fare_section(pbnavitia::Journey* pb_journey, const fare::re
                 pb_ticket->set_id("unknown_ticket");
                 pb_ticket->set_source_id(ticket.key);
                 pb_ticket->set_comment("unknown ticket");
-                unknown_ticket = pb_ticket;
+                //unknown_ticket = pb_ticket;
                 pb_fare->add_ticket_id(pb_ticket->id());
             } else {
                 pb_ticket = unknown_ticket;

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -200,7 +200,6 @@ struct PbCreator {
     // Raptor api
     size_t nb_sections = 0;
     std::map<std::pair<pbnavitia::Journey*, size_t>, std::string> routing_section_map;
-    pbnavitia::Ticket* unknown_ticket = nullptr;  // we want only one unknown ticket
 
     PbCreator() = default;
 
@@ -235,7 +234,6 @@ struct PbCreator {
         this->impacts.clear();
         this->routing_section_map.clear();
         this->response.Clear();
-        this->unknown_ticket = nullptr;
     }
 
     PbCreator(const PbCreator&) = delete;


### PR DESCRIPTION
Fare calculation sometimes return two tickets for a journey whereas one would be enough.
This was due to a bad comparison operator in fare computation.
Fixed in https://github.com/CanalTP/navitia/pull/3049/commits/ab4e1d44887a4cb8ee332428d2ffe899260be8df
Relates to https://jira.kisio.org/browse/NDTMA-57

Sometimes the fare calculator cannot find an appropriate ticket. In this case, an "unknown_ticket" is
returned for some sections of a journey.
These "unkown_ticket"s sometimes disappear in the response obtained by jormungandr.
It seems to be due to the pointer in PbCreator.unknown_ticket https://github.com/CanalTP/navitia/blob/ed565e0e87caddfd3af94461cdd5b838f978a4fc/source/type/pb_converter.h#L203
The first time an unknown_ticket is found, this PbCreator.unknown_ticket is assigned to a pointer to a Ticket object in PbCreator::fill_fare_section https://github.com/CanalTP/navitia/blob/ed565e0e87caddfd3af94461cdd5b838f978a4fc/source/type/pb_converter.cpp#L1722

This ticket object is destroyed to the next call to journeys  https://github.com/CanalTP/navitia/blob/ed565e0e87caddfd3af94461cdd5b838f978a4fc/source/kraken/worker.cpp#L378
After that, PbCreator.unknown_ticket points to deallocated memory.
However, in the next call to fill_fare_section, this dealllocated memory is read and put in the protobuf response. I guess that protobuf reject this object as invalid, and thus does not appear in the response.
Fixed in https://github.com/CanalTP/navitia/pull/3049/commits/c6640d4918c3b2d8ae0ef8101e2cbf1bebf4949f
Fix https://jira.kisio.org/browse/NAVP-1467
