### PR TITLE
Kraken: Using clang-tidy on kraken

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -29,11 +29,14 @@ www.navitia.io
 */
 
 #include "configuration.h"
+
 #include "utils/exception.h"
-#include <fstream>
-#include <boost/optional.hpp>
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/optional.hpp>
+
+#include <fstream>
 #include <iostream>
 
 namespace po = boost::program_options;
@@ -41,9 +44,9 @@ namespace po = boost::program_options;
 namespace navitia {
 namespace kraken {
 
-po::options_description get_options_description(const boost::optional<std::string> name,
-                                                const boost::optional<std::string> zmq,
-                                                const boost::optional<bool> display_contributors) {
+po::options_description get_options_description(const boost::optional<std::string>& name,
+                                                const boost::optional<std::string>& zmq,
+                                                const boost::optional<bool>& display_contributors) {
     po::options_description desc("Allowed options");
     // clang-format off
     desc.add_options()
@@ -214,7 +217,7 @@ int Configuration::broker_sleeptime() const {
 }
 
 std::string Configuration::broker_queue(const std::string& default_queue) const {
-    if (vm.count("BROKER.queue")) {
+    if (vm.count("BROKER.queue") != 0u) {
         return this->vm["BROKER.queue"].as<std::string>();
     }
     return default_queue;
@@ -225,7 +228,7 @@ bool Configuration::broker_queue_auto_delete() const {
 }
 
 std::vector<std::string> Configuration::rt_topics() const {
-    if (!this->vm.count("BROKER.rt_topics")) {
+    if (this->vm.count("BROKER.rt_topics") == 0u) {
         return std::vector<std::string>();
     }
     return this->vm["BROKER.rt_topics"].as<std::vector<std::string>>();
@@ -236,7 +239,7 @@ int Configuration::kirin_retry_timeout() const {
 }
 
 bool Configuration::display_contributors() const {
-    if (!this->vm.count("GENERAL.display_contributors")) {
+    if (this->vm.count("GENERAL.display_contributors") == 0u) {
         return false;
     }
     return vm["GENERAL.display_contributors"].as<bool>();
@@ -251,7 +254,7 @@ bool Configuration::enable_request_deadline() const {
 }
 
 size_t Configuration::raptor_cache_size() const {
-    if (!vm.count("GENERAL.raptor_cache_size")) {
+    if (vm.count("GENERAL.raptor_cache_size") == 0u) {
         return 10;
     }
     int raptor_cache_size = vm["GENERAL.raptor_cache_size"].as<int>();

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -39,7 +39,7 @@ class Configuration {
     boost::program_options::variables_map vm;
 
 public:
-    void load(const std::string& file);
+    void load(const std::string& filename);
     std::vector<std::string> load_from_command_line(const boost::program_options::options_description&,
                                                     int argc,
                                                     const char* const argv[]);
@@ -78,9 +78,9 @@ public:
 };
 
 boost::program_options::options_description get_options_description(
-    const boost::optional<std::string> name = {},
-    const boost::optional<std::string> zmq = {},
-    const boost::optional<bool> display_contributors = {});
+    const boost::optional<std::string>& name = {},
+    const boost::optional<std::string>& zmq = {},
+    const boost::optional<bool>& display_contributors = {});
 
 }  // namespace kraken
 }  // namespace navitia

--- a/source/kraken/fill_disruption_from_database.h
+++ b/source/kraken/fill_disruption_from_database.h
@@ -30,12 +30,14 @@ www.navitia.io
 */
 
 #pragma once
+#include "make_disruption_from_chaos.h"
+#include "type/pt_data.h"
+#include "type/chaos.pb.h"
+
+#include <pqxx/result.hxx>
+
 #include <string>
 #include <memory>
-#include "type/pt_data.h"
-#include "pqxx/result.hxx"
-#include "type/chaos.pb.h"
-#include "make_disruption_from_chaos.h"
 
 namespace navitia {
 #define FILL_NULLABLE_(var_name, arg_name, col_name, type_name) \

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -58,7 +58,7 @@ void show_usage(const std::string& name, const boost::program_options::options_d
 
 void set_core_file_size_limit(int max_core_file_size, log4cplus::Logger& logger) {
     if (max_core_file_size != 0) {
-        rlimit limit{};
+        rlimit limit;
 
         if (getrlimit(RLIMIT_CORE, &limit) == -1) {
             LOG4CPLUS_ERROR(logger, "Fail to call system 'getrlimit()'");

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -28,20 +28,21 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
+#include "kraken_zmq.h"
+
 #include "conf.h"
 #include "type/type.pb.h"
-#include <google/protobuf/descriptor.h>
-
-#include <boost/thread.hpp>
-#include <functional>
-#include <string>
-#include <iostream>
-#include "utils/init.h"
-#include "kraken_zmq.h"
-#include "utils/zmq.h"
 #include "utils/functions.h"  //navitia::absolute_path function
+#include "utils/init.h"
+#include "utils/zmq.h"
 
+#include <google/protobuf/descriptor.h>
+#include <boost/thread.hpp>
 #include <sys/resource.h>  // Posix dependencies for getrlimit
+
+#include <functional>
+#include <iostream>
+#include <string>
 
 namespace {
 void show_usage(const std::string& name, const boost::program_options::options_description& descr) {
@@ -57,7 +58,7 @@ void show_usage(const std::string& name, const boost::program_options::options_d
 
 void set_core_file_size_limit(int max_core_file_size, log4cplus::Logger& logger) {
     if (max_core_file_size != 0) {
-        rlimit limit;
+        rlimit limit{};
 
         if (getrlimit(RLIMIT_CORE, &limit) == -1) {
             LOG4CPLUS_ERROR(logger, "Fail to call system 'getrlimit()'");
@@ -93,10 +94,10 @@ int main(int argn, char** argv) {
             auto opt_desc = navitia::kraken::get_options_description();
             show_usage(argv[0], opt_desc);
             return 0;
-        } else {
-            // The first argument is the path to the configuration file
-            conf_file = arg;
         }
+        // The first argument is the path to the configuration file
+        conf_file = arg;
+
     } else {
         conf_file = path + application + ".ini";
     }

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -30,21 +30,23 @@ www.navitia.io
 
 #include "maintenance_worker.h"
 
-#include "make_disruption_from_chaos.h"
 #include "apply_disruption.h"
+#include "make_disruption_from_chaos.h"
+#include "metrics.h"
 #include "realtime.h"
-#include "type/task.pb.h"
 #include "type/pt_data.h"
+#include "type/task.pb.h"
+#include "utils/get_hostname.h"
+
+#include <SimpleAmqpClient/Envelope.h>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/optional.hpp>
 #include <boost/thread/thread.hpp>
-#include <sys/stat.h>
-#include <signal.h>
-#include <SimpleAmqpClient/Envelope.h>
+
 #include <chrono>
+#include <csignal>
+#include <sys/stat.h>
 #include <thread>
-#include "utils/get_hostname.h"
-#include "metrics.h"
 
 namespace nt = navitia::type;
 namespace pt = boost::posix_time;
@@ -89,7 +91,7 @@ void MaintenanceWorker::load_realtime() {
     task.set_action(pbnavitia::LOAD_REALTIME);
     auto* lr = task.mutable_load_realtime();
     lr->set_queue_name(queue_name);
-    for (auto topic : conf.rt_topics()) {
+    for (const auto& topic : conf.rt_topics()) {
         lr->add_contributors(topic);
     }
     auto data = data_manager.get_data();
@@ -211,7 +213,7 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         auto duration = pt::microsec_clock::universal_time() - begin;
         this->metrics.observe_handle_rt(duration.total_seconds());
         LOG4CPLUS_INFO(logger, "data updated " << envelopes.size() << " disruption applied in " << duration);
-    } else if (envelopes.size() > 0) {
+    } else if (!envelopes.empty()) {
         // we didn't had to update Data because there is no change but we want to track that realtime data
         // is being processed as it should because "nothing has changed" isn't the same thing
         // than "I don't known what's happening"
@@ -224,7 +226,7 @@ std::vector<AmqpClient::Envelope::ptr_t> MaintenanceWorker::consume_in_batch(con
                                                                              size_t max_nb,
                                                                              size_t timeout_ms,
                                                                              bool no_ack) {
-    assert(consume_tag != "");
+    assert(!consume_tag.empty());
     assert(max_nb);
 
     std::vector<AmqpClient::Envelope::ptr_t> envelopes;
@@ -238,13 +240,15 @@ std::vector<AmqpClient::Envelope::ptr_t> MaintenanceWorker::consume_in_batch(con
          * BasicConsumeMessage() timeout.
          * */
         bool queue_is_empty = !channel->BasicConsumeMessage(consume_tag, envelope, timeout_ms);
-        if (queue_is_empty)
+        if (queue_is_empty) {
             break;
+        }
 
         if (envelope) {
             envelopes.push_back(envelope);
-            if (!no_ack)
+            if (!no_ack) {
                 channel->BasicAck(envelope);
+            }
             ++consumed_nb;
         }
     }
@@ -342,7 +346,7 @@ void MaintenanceWorker::init_rabbitmq() {
         LOG4CPLUS_INFO(logger, "queue for disruptions: " << this->queue_name_rt);
         // binding the queue to the exchange for all task for this instance
         LOG4CPLUS_INFO(logger, "subscribing to [" << boost::algorithm::join(conf.rt_topics(), ", ") << "]");
-        for (auto topic : conf.rt_topics()) {
+        for (const auto& topic : conf.rt_topics()) {
             channel->BindQueue(queue_name_rt, exchange_name, topic);
         }
         is_initialized = true;
@@ -355,7 +359,7 @@ MaintenanceWorker::MaintenanceWorker(DataManager<type::Data>& data_manager,
                                      const Metrics& metrics)
     : data_manager(data_manager),
       logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("background"))),
-      conf(conf),
+      conf(std::move(conf)),
       metrics(metrics),
       next_try_realtime_loading(pt::microsec_clock::universal_time()) {
     // Connect Rabbitmq

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -30,10 +30,11 @@ www.navitia.io
 
 #pragma once
 
-#include <SimpleAmqpClient/SimpleAmqpClient.h>
 #include "type/data.h"
 #include "kraken/data_manager.h"
 #include "kraken/configuration.h"
+
+#include <SimpleAmqpClient/SimpleAmqpClient.h>
 
 #include <memory>
 

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -28,10 +28,12 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 #include "make_disruption_from_chaos.h"
+
 #include "apply_disruption.h"
-#include "utils/logger.h"
-#include <boost/make_shared.hpp>
 #include "type/line.h"
+#include "utils/logger.h"
+
+#include <boost/make_shared.hpp>
 
 namespace bt = boost::posix_time;
 
@@ -217,7 +219,7 @@ static std::vector<nt::disruption::PtObj> make_pt_objects(
                 break;
             case chaos::PtObject_Type_line_section:
                 if (auto line_section = make_line_section(chaos_pt_object, pt_data)) {
-                    res.push_back(*line_section);
+                    res.emplace_back(*line_section);
                 }
                 break;
             case chaos::PtObject_Type_line:
@@ -230,7 +232,7 @@ static std::vector<nt::disruption::PtObj> make_pt_objects(
                 res.push_back(make_pt_obj(nt::Type_e::MetaVehicleJourney, chaos_pt_object.uri(), pt_data));
                 break;
             case chaos::PtObject_Type_unkown_type:
-                res.push_back(UnknownPtObj());
+                res.emplace_back(UnknownPtObj());
                 break;
         }
         // no created_at and updated_at?
@@ -291,7 +293,7 @@ static boost::shared_ptr<nt::disruption::Impact> make_impact(const chaos::Impact
     impact->uri = chaos_impact.id();
     impact->created_at = from_posix(chaos_impact.created_at());
     auto updated_at = chaos_impact.updated_at();
-    impact->updated_at = updated_at ? from_posix(updated_at) : impact->created_at;
+    impact->updated_at = updated_at != 0u ? from_posix(updated_at) : impact->created_at;
     for (const auto& chaos_ap : chaos_impact.application_periods()) {
         impact->application_periods.emplace_back(from_posix(chaos_ap.start()), from_posix(chaos_ap.end()));
     }
@@ -312,7 +314,8 @@ static boost::shared_ptr<nt::disruption::Impact> make_impact(const chaos::Impact
     return impact;
 }
 
-bool is_publishable(transit_realtime::TimeRange publication_period, boost::posix_time::time_period production_period) {
+bool is_publishable(const transit_realtime::TimeRange& publication_period,
+                    boost::posix_time::time_period production_period) {
     // Publication period should have a valid start date
     if (publication_period.start() == 0) {
         return false;

--- a/source/kraken/make_disruption_from_chaos.h
+++ b/source/kraken/make_disruption_from_chaos.h
@@ -33,6 +33,7 @@ www.navitia.io
 #include "type/message.h"
 #include "type/chaos.pb.h"
 #include "type/meta_data.h"
+
 #include <memory>
 
 namespace navitia {
@@ -54,6 +55,7 @@ void make_and_apply_disruption(const chaos::Disruption& chaos_disruption,
 boost::optional<type::disruption::LineSection> make_line_section(const chaos::PtObject& chaos_section,
                                                                  nt::PT_Data& pt_data);
 
-bool is_publishable(transit_realtime::TimeRange publication_period, boost::posix_time::time_period production_period);
+bool is_publishable(const transit_realtime::TimeRange& publication_period,
+                    boost::posix_time::time_period production_period);
 
 }  // namespace navitia

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -29,12 +29,13 @@ www.navitia.io
 */
 
 #include "metrics.h"
-#include "utils/functions.h"
 
+#include "utils/functions.h"
+#include "utils/logger.h"
+
+#include <prometheus/counter.h>
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
-#include <prometheus/counter.h>
-#include "utils/logger.h"
 
 namespace navitia {
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -30,17 +30,16 @@ www.navitia.io
 
 #pragma once
 
-#include <memory>
-#include <map>
+#include "type/type.pb.h"
 
 #include <boost/optional.hpp>
 #include <boost/utility.hpp>
-
-#include "type/type.pb.h"
-
 #include <prometheus/exposer.h>
 #include <prometheus/counter.h>
 #include <prometheus/gauge.h>
+
+#include <memory>
+#include <map>
 
 // forward declare
 namespace prometheus {

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -30,21 +30,21 @@ www.navitia.io
 
 #include "worker.h"
 
-#include "routing/raptor_api.h"
 #include "autocomplete/autocomplete_api.h"
-
+#include "routing/raptor_api.h"
+#include "calendar/calendar_api.h"
+#include "disruption/line_reports_api.h"
+#include "disruption/traffic_reports_api.h"
+#include "equipment/equipment_api.h"
 #include "proximity_list/proximitylist_api.h"
 #include "ptreferential/ptreferential.h"
 #include "ptreferential/ptreferential_api.h"
-#include "time_tables/route_schedules.h"
-#include "time_tables/passages.h"
-#include "time_tables/departure_boards.h"
-#include "disruption/traffic_reports_api.h"
-#include "disruption/line_reports_api.h"
-#include "calendar/calendar_api.h"
 #include "routing/raptor.h"
+#include "time_tables/departure_boards.h"
+#include "time_tables/passages.h"
+#include "time_tables/route_schedules.h"
 #include "type/meta_data.h"
-#include "equipment/equipment_api.h"
+
 #include <numeric>
 
 namespace nt = navitia::type;
@@ -60,10 +60,10 @@ namespace navitia {
 namespace {
 // local exception, only used in this file
 struct coord_conversion_exception : public recoverable_exception {
-    coord_conversion_exception(const std::string& msg) : recoverable_exception(msg) {}
+    explicit coord_conversion_exception(const std::string& msg) : recoverable_exception(msg) {}
     coord_conversion_exception(const coord_conversion_exception&) = default;
     coord_conversion_exception& operator=(const coord_conversion_exception&) = default;
-    virtual ~coord_conversion_exception() noexcept {}
+    ~coord_conversion_exception() noexcept override = default;
 };
 }  // namespace
 
@@ -188,6 +188,7 @@ static nt::OdtLevel_e get_odt_level(pbnavitia::OdtLevel pb_odt_level) {
 template <class T>
 std::vector<nt::Type_e> vector_of_pb_types(const T& pb_object) {
     std::vector<nt::Type_e> result;
+    result.reserve(pb_object.types_size());
     for (int i = 0; i < pb_object.types_size(); ++i) {
         result.push_back(get_type(pb_object.types(i)));
     }
@@ -210,6 +211,7 @@ static type::RTLevel get_realtime_level(pbnavitia::RTLevel pb_level) {
 template <class T>
 std::vector<std::string> vector_of_admins(const T& admin) {
     std::vector<std::string> result;
+    result.reserve(admin.admin_uris_size());
     for (int i = 0; i < admin.admin_uris_size(); ++i) {
         result.push_back(admin.admin_uris(i));
     }
@@ -217,9 +219,9 @@ std::vector<std::string> vector_of_admins(const T& admin) {
 }
 
 Worker::Worker(kraken::Configuration conf)
-    : conf(conf), logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"))) {}
+    : conf(std::move(conf)), logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("logger"))) {}
 
-Worker::~Worker() {}
+Worker::~Worker() = default;
 
 static std::string get_string_status(const nt::Data* data) {
     if (data->loaded) {
@@ -394,8 +396,10 @@ void Worker::pt_object(const pbnavitia::PtobjectRequest& request) {
 void Worker::traffic_reports(const pbnavitia::TrafficReportsRequest& request) {
     const auto* data = this->pb_creator.data;
     std::vector<std::string> forbidden_uris;
-    for (int i = 0; i < request.forbidden_uris_size(); ++i)
+    forbidden_uris.reserve(request.forbidden_uris_size());
+    for (int i = 0; i < request.forbidden_uris_size(); ++i) {
         forbidden_uris.push_back(request.forbidden_uris(i));
+    }
     navitia::disruption::traffic_reports(this->pb_creator, *data, request.depth(), request.count(),
                                          request.start_page(), request.filter(), forbidden_uris);
 }
@@ -415,16 +419,20 @@ void Worker::line_reports(const pbnavitia::LineReportsRequest& request) {
 void Worker::calendars(const pbnavitia::CalendarsRequest& request) {
     const auto* data = this->pb_creator.data;
     std::vector<std::string> forbidden_uris;
-    for (int i = 0; i < request.forbidden_uris_size(); ++i)
+    forbidden_uris.reserve(request.forbidden_uris_size());
+    for (int i = 0; i < request.forbidden_uris_size(); ++i) {
         forbidden_uris.push_back(request.forbidden_uris(i));
+    }
     navitia::calendar::calendars(this->pb_creator, *data, request.start_date(), request.end_date(), request.depth(),
                                  request.count(), request.start_page(), request.filter(), forbidden_uris);
 }
 
 void Worker::next_stop_times(const pbnavitia::NextStopTimeRequest& request, pbnavitia::API api) {
     std::vector<std::string> forbidden_uri;
-    for (int i = 0; i < request.forbidden_uri_size(); ++i)
+    forbidden_uri.reserve(request.forbidden_uri_size());
+    for (int i = 0; i < request.forbidden_uri_size(); ++i) {
         forbidden_uri.push_back(request.forbidden_uri(i));
+    }
 
     bt::ptime from_datetime = bt::from_time_t(request.from_datetime());
 
@@ -645,14 +653,14 @@ JourneysArg::JourneysArg(type::EntryPoints origins,
                          std::vector<uint64_t> datetimes,
                          boost::optional<type::EntryPoint> isochrone_center)
     : origins(std::move(origins)),
-      accessibilite_params(std::move(accessibilite_params)),
+      accessibilite_params(accessibilite_params),
       forbidden(std::move(forbidden)),
       allowed(std::move(allowed)),
       rt_level(rt_level),
       destinations(std::move(destinations)),
       datetimes(std::move(datetimes)),
-      isochrone_center(isochrone_center) {}
-JourneysArg::JourneysArg() {}
+      isochrone_center(std::move(isochrone_center)) {}
+JourneysArg::JourneysArg() = default;
 
 navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest& request) {
     const auto* data = this->pb_creator.data;
@@ -668,16 +676,19 @@ navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest& req
     }
 
     std::vector<std::string> forbidden;
+    forbidden.reserve(request.forbidden_uris_size());
     for (int i = 0; i < request.forbidden_uris_size(); ++i) {
         forbidden.push_back(request.forbidden_uris(i));
     }
 
     std::vector<std::string> allowed;
+    allowed.reserve(request.allowed_id_size());
     for (int i = 0; i < request.allowed_id_size(); ++i) {
         allowed.push_back(request.allowed_id(i));
     }
 
     std::vector<uint64_t> datetimes;
+    datetimes.reserve(request.datetimes_size());
     for (int i = 0; i < request.datetimes_size(); ++i) {
         datetimes.push_back(request.datetimes(i));
     }
@@ -697,8 +708,8 @@ navitia::JourneysArg Worker::fill_journeys(const pbnavitia::JourneysRequest& req
                                       ? create_journeys_entry_point(request.isochrone_center(), sn_params, data, true)
                                       : boost::optional<type::EntryPoint>{};
 
-    return JourneysArg(std::move(origins), std::move(accessibilite_params), std::move(forbidden), std::move(allowed),
-                       rt_level, std::move(destinations), std::move(datetimes), std::move(isochrone_center));
+    return JourneysArg(std::move(origins), accessibilite_params, std::move(forbidden), std::move(allowed), rt_level,
+                       std::move(destinations), std::move(datetimes), isochrone_center);
 }
 
 void Worker::err_msg_isochron(navitia::PbCreator& pb_creator, const std::string& err_msg) {
@@ -780,6 +791,7 @@ void Worker::isochrone(const pbnavitia::JourneysRequest& request) {
 void Worker::pt_ref(const pbnavitia::PTRefRequest& request) {
     const auto* data = this->pb_creator.data;
     std::vector<std::string> forbidden_uri;
+    forbidden_uri.reserve(request.forbidden_uri_size());
     for (int i = 0; i < request.forbidden_uri_size(); ++i) {
         forbidden_uri.push_back(request.forbidden_uri(i));
     }
@@ -810,7 +822,8 @@ bool Worker::set_journeys_args(const pbnavitia::JourneysRequest& request, Journe
     if (!arg.origins.empty() && !request.clockwise()) {
         err_msg_isochron(this->pb_creator, name + " works only for clockwise request");
         return false;
-    } else if (arg.origins.empty() && request.clockwise()) {
+    }
+    if (arg.origins.empty() && request.clockwise()) {
         err_msg_isochron(this->pb_creator, "reverse " + name + " works only for anti-clockwise request");
         return false;
     }
@@ -818,7 +831,7 @@ bool Worker::set_journeys_args(const pbnavitia::JourneysRequest& request, Journe
 }
 
 void Worker::graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest& request) {
-    auto request_journey = request.journeys_request();
+    const auto& request_journey = request.journeys_request();
     navitia::JourneysArg arg = JourneysArg();
     if (!set_journeys_args(request_journey, arg, "isochrone")) {
         return;
@@ -826,10 +839,11 @@ void Worker::graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest& req
 
     auto const center_and_stop_points = get_center_and_stop_points(arg);
     std::vector<DateTime> boundary_duration;
+    boundary_duration.reserve(request.boundary_duration_size());
     for (int i = 0; i < request.boundary_duration_size(); ++i) {
         boundary_duration.push_back(request.boundary_duration(i));
     }
-    const auto sn = request_journey.streetnetwork_params();
+    const auto& sn = request_journey.streetnetwork_params();
     const auto end_mode_iso = request_journey.clockwise() ? sn.destination_mode() : sn.origin_mode();
     const auto end_mode = type::static_data::get()->modeByCaption(end_mode_iso);
     const double end_speed = get_speed(sn, end_mode);
@@ -840,14 +854,14 @@ void Worker::graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest& req
 }
 
 void Worker::heat_map(const pbnavitia::HeatMapRequest& request) {
-    auto request_journey = request.journeys_request();
+    const auto& request_journey = request.journeys_request();
     navitia::JourneysArg arg;
     if (!set_journeys_args(request_journey, arg, "heat_map")) {
         return;
     }
 
     auto const center_and_stop_points = get_center_and_stop_points(arg);
-    auto streetnetwork = request_journey.streetnetwork_params();
+    const auto& streetnetwork = request_journey.streetnetwork_params();
     auto end_mode_iso = request_journey.clockwise() ? streetnetwork.destination_mode() : streetnetwork.origin_mode();
     auto end_mode = type::static_data::get()->modeByCaption(end_mode_iso);
     auto end_speed = get_speed(streetnetwork, end_mode);
@@ -1118,7 +1132,7 @@ void Worker::nearest_stop_points(const pbnavitia::NearestStopPointsRequest& requ
     entry_point.streetnetwork_params.max_duration = navitia::seconds(request.max_duration());
     street_network_worker->init(entry_point, {});
     // kraken don't handle reverse isochrone
-    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, false);
+    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, 0u);
     if (!result) {
         this->pb_creator.fill_pb_error(pbnavitia::Error::unknown_object,
                                        "The entry point: " + entry_point.uri + " is not valid");
@@ -1162,7 +1176,7 @@ void Worker::get_matching_routes(const pbnavitia::MatchingRoute& matching_route)
 }
 
 void Worker::equipment_reports(const pbnavitia::EquipmentReportsRequest& equipment_reports) {
-    const auto proto_uris = equipment_reports.forbidden_uris();
+    const auto& proto_uris = equipment_reports.forbidden_uris();
     std::vector<std::string> forbidden_uris(proto_uris.begin(), proto_uris.end());
 
     equipment::equipment_reports(this->pb_creator, equipment_reports.filter(), equipment_reports.count(),


### PR DESCRIPTION
I've used clang-tidy 6.0 on kraken with the following command :
`clang-tidy -checks='*, -fuchsia-overloaded-operator, -fuchsia-default-arguments,-google*, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -hicpp-no-array-decay' ../source/kraken/*.cpp  -header-filter="*.pb.h" -fix`

It fixes a lot of basics things. There is still some warnings that may take a lot more effort to fix ourselves.

`-checks='*, -fuchsia-overloaded-operator, -fuchsia-default-arguments,-google*, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -hicpp-no-array-decay'` runs all available checks except :

- `fuchsia-overloaded-operator` : just yell at us for overloading operators...
- all of google checks because they have some weird conventions sometime like passing a non const pointer instead of a nonconst reference in a function. Their reasoning is that it makes it clear that it is an in-out parameter. Meh...
- `cppcoreguidelines-pro-bounds-array-to-pointer-decay` : yell at us for using all of the `LOG4CPLUS` macros. May be a good thing to fix it someday
- `hicpp-no-array-decay` : same as above.

There is also an other check that a partially used : `readability-implicit-bool-conversion`. It found some good things like here https://github.com/CanalTP/navitia/compare/dev...AurelienLP:clang_tidy_on_kraken?expand=1#diff-04e391bedc0175c758164a98a2915889L1121. But it changed all tested pointers from `if (pointer)` to `if (pointer != nullptr)` which I found really dull... So I manually reverted this changes back.

I've also reordered the included files following this order:

- .h file of the acutal .cpp file
- .h from our project
- .h from external sources
- system includes

A PR @benoit-bst would certainly love :smile: 