### PR TITLE
CI: Using a fixed number of tries instead of time for the init of mock kraken

### DIFF
--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -223,7 +223,9 @@ class AbstractTestFixture(unittest.TestCase):
             instance = i_manager.instances[name]
             try:
                 retrying.Retrying(
-                    stop_max_attempt_number=5, retry_on_result=lambda x: not instance.is_initialized
+                    stop_max_attempt_number=5,
+                    wait_fixed=10,
+                    retry_on_result=lambda x: not instance.is_initialized,
                 ).call(instance.init)
             except RetryError:
                 logging.exception('impossible to start kraken {}'.format(name))

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -222,10 +222,8 @@ class AbstractTestFixture(unittest.TestCase):
         for name in cls.krakens_pool:
             instance = i_manager.instances[name]
             try:
-                # Stopping after 10 seconds, Wait 1200 ms between retries
-                # wait_fixed > timeout of _send_and_receive in instance.
                 retrying.Retrying(
-                    stop_max_delay=10000, wait_fixed=1200, retry_on_result=lambda x: not instance.is_initialized
+                    stop_max_attempt_number=5, retry_on_result=lambda x: not instance.is_initialized
                 ).call(instance.init)
             except RetryError:
                 logging.exception('impossible to start kraken {}'.format(name))

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -127,7 +127,7 @@ class AbstractTestFixture(unittest.TestCase):
                 if kraken_process.returncode is not None:
                     logging.error('kraken is dead, check errors, return code = %s', kraken_process.returncode)
                     assert False, 'kraken is dead, check errors, return code'
-            kraken_process.kill()
+            kraken_process.terminate()
             kraken_process.communicate()  # read stdout and stderr to prevent zombie processes
 
     @classmethod

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -222,8 +222,10 @@ class AbstractTestFixture(unittest.TestCase):
         for name in cls.krakens_pool:
             instance = i_manager.instances[name]
             try:
+                # Stopping after 10 seconds, Wait 1200 ms between retries
+                # wait_fixed > timeout of _send_and_receive in instance.
                 retrying.Retrying(
-                    stop_max_delay=5000, wait_fixed=10, retry_on_result=lambda x: not instance.is_initialized
+                    stop_max_delay=10000, wait_fixed=1200, retry_on_result=lambda x: not instance.is_initialized
                 ).call(instance.init)
             except RetryError:
                 logging.exception('impossible to start kraken {}'.format(name))


### PR DESCRIPTION
For the Jormungandr_integration tests, we use multiple mocks of Kraken (main_routing_test, basic_schedule_test...).

In test_mechanism, we launch them and initialize them asking them their metadatas and updating their properties. We use `retry` in `test_mechanism.py` to do so, every 10 ms up until 5 seconds.

Since `_send_and_receive` already has a timeout, let's just use a fixed number of tries instead of handling an interval and an other timeout. We would have less trouble this way.