### PR TITLE
Kraken: Clang tidy on kraken

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -107,6 +107,9 @@ struct apply_impacts_visitor : public boost::static_visitor<> {
 
     virtual ~apply_impacts_visitor() = default;
     apply_impacts_visitor(const apply_impacts_visitor&) = default;
+    apply_impacts_visitor(apply_impacts_visitor&&) = default;
+    apply_impacts_visitor& operator=(const apply_impacts_visitor& other) = delete;
+    apply_impacts_visitor& operator=(apply_impacts_visitor&& other) noexcept = delete;
 
     virtual void operator()(nt::MetaVehicleJourney*, nt::Route* = nullptr) = 0;
 
@@ -208,9 +211,6 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                         const nt::MetaData& meta,
                         nt::RTLevel l)
         : apply_impacts_visitor(impact, pt_data, meta, "add", l) {}
-
-    ~add_impacts_visitor() override = default;
-    add_impacts_visitor(const add_impacts_visitor&) = default;
 
     using apply_impacts_visitor::operator();
 
@@ -607,6 +607,12 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
                            const nt::MetaData& meta,
                            nt::RTLevel l)
         : apply_impacts_visitor(impact, pt_data, meta, "delete", l) {}
+
+    delete_impacts_visitor(const delete_impacts_visitor&) = delete;
+    delete_impacts_visitor& operator=(const delete_impacts_visitor&) = delete;
+
+    delete_impacts_visitor(delete_impacts_visitor&&) = delete;
+    delete_impacts_visitor& operator=(delete_impacts_visitor&&) = delete;
 
     ~delete_impacts_visitor() override {
         for (const auto& i : disruptions_collection) {

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -29,38 +29,39 @@ www.navitia.io
 */
 
 #include "apply_disruption.h"
-#include "utils/logger.h"
-#include "utils/map_find.h"
+
 #include "type/datetime.h"
 #include "type/type.h"
+#include "utils/logger.h"
+#include "utils/map_find.h"
 
-#include <boost/make_shared.hpp>
-#include <boost/variant/static_visitor.hpp>
-#include <boost/variant/apply_visitor.hpp>
-#include <boost/range/algorithm/for_each.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/range/algorithm_ext/erase.hpp>
 #include <boost/container/flat_set.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/range/algorithm/for_each.hpp>
+#include <boost/range/algorithm_ext/erase.hpp>
+#include <boost/variant/apply_visitor.hpp>
+#include <boost/variant/static_visitor.hpp>
+
 #include <algorithm>
+#include <utility>
 
 namespace navitia {
 
 namespace nt = navitia::type;
 namespace nu = navitia::utils;
 namespace ndtu = navitia::DateTimeUtils;
-namespace bt = boost::posix_time;
-namespace bg = boost::gregorian;
 
 namespace {
 
-static nt::VehicleJourney* create_vj_from_old_vj(nt::MetaVehicleJourney* mvj,
-                                                 const nt::VehicleJourney* vj,
-                                                 const std::string& new_vj_uri,
-                                                 nt::RTLevel rt_level,
-                                                 nt::ValidityPattern new_vp,
-                                                 std::vector<nt::StopTime> new_stop_times,
-                                                 nt::PT_Data& pt_data) {
+nt::VehicleJourney* create_vj_from_old_vj(nt::MetaVehicleJourney* mvj,
+                                          const nt::VehicleJourney* vj,
+                                          const std::string& new_vj_uri,
+                                          nt::RTLevel rt_level,
+                                          const nt::ValidityPattern& new_vp,
+                                          std::vector<nt::StopTime> new_stop_times,
+                                          nt::PT_Data& pt_data) {
     auto* company = vj->company;
     auto vehicle_journey_type = vj->vehicle_journey_type;
     auto odt_message = vj->odt_message;
@@ -97,27 +98,27 @@ struct apply_impacts_visitor : public boost::static_visitor<> {
     nt::RTLevel rt_level;  // level of the impacts
     log4cplus::Logger log = log4cplus::Logger::getInstance("log");
 
-    apply_impacts_visitor(const boost::shared_ptr<nt::disruption::Impact>& impact,
+    apply_impacts_visitor(boost::shared_ptr<nt::disruption::Impact> impact,
                           nt::PT_Data& pt_data,
                           const nt::MetaData& meta,
                           std::string action,
                           nt::RTLevel l)
-        : impact(impact), pt_data(pt_data), meta(meta), action(action), rt_level(l) {}
+        : impact(std::move(impact)), pt_data(pt_data), meta(meta), action(std::move(action)), rt_level(l) {}
 
-    virtual ~apply_impacts_visitor() {}
+    virtual ~apply_impacts_visitor() = default;
     apply_impacts_visitor(const apply_impacts_visitor&) = default;
 
     virtual void operator()(nt::MetaVehicleJourney*, nt::Route* = nullptr) = 0;
 
-    void log_start_action(std::string uri) {
-        LOG4CPLUS_TRACE(log, "Start to " << action << " impact " << impact.get()->uri << " on object " << uri);
+    void log_start_action(const std::string& uri) {
+        LOG4CPLUS_TRACE(log, "Start to " << action << " impact " << impact->uri << " on object " << uri);
     }
 
-    void log_end_action(std::string uri) {
-        LOG4CPLUS_TRACE(log, "Finished to " << action << " impact " << impact.get()->uri << " on object " << uri);
+    void log_end_action(const std::string& uri) {
+        LOG4CPLUS_TRACE(log, "Finished to " << action << " impact " << impact->uri << " on object " << uri);
     }
 
-    void operator()(nt::disruption::UnknownPtObj&) {}
+    void operator()(nt::disruption::UnknownPtObj& /*unused*/) {}
 
     void operator()(nt::Network* network) {
         this->log_start_action(network->uri);
@@ -154,9 +155,8 @@ struct apply_impacts_visitor : public boost::static_visitor<> {
 };
 
 // Computes the vp corresponding to the days where base vj's are disrupted
-static type::ValidityPattern compute_base_disrupted_vp(
-    const std::vector<boost::posix_time::time_period>& disrupted_vj_periods,
-    const boost::gregorian::date_period& production_period) {
+type::ValidityPattern compute_base_disrupted_vp(const std::vector<boost::posix_time::time_period>& disrupted_vj_periods,
+                                                const boost::gregorian::date_period& production_period) {
     type::ValidityPattern vp{production_period.begin()};  // bitset are all initialised to 0
     for (const auto& period : disrupted_vj_periods) {
         auto start_date = period.begin().date();
@@ -170,7 +170,7 @@ static type::ValidityPattern compute_base_disrupted_vp(
     return vp;
 }
 
-static std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
+std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
     std::stringstream impacts_uris;
     for (auto& mvj_impacts : mvj.modified_by) {
         if (auto i = mvj_impacts.lock()) {
@@ -182,7 +182,7 @@ static std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
     return impacts_uris.str();
 }
 
-static nt::Route* get_or_create_route(const nt::disruption::Impact& impact, nt::PT_Data& pt_data) {
+nt::Route* get_or_create_route(const nt::disruption::Impact& impact, nt::PT_Data& pt_data) {
     nt::Network* network = pt_data.get_or_create_network("network:additional_service", "additional service");
     nt::CommercialMode* comm_mode =
         pt_data.get_or_create_commercial_mode("commercial_mode:additional_service", "additional service");
@@ -209,12 +209,12 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                         nt::RTLevel l)
         : apply_impacts_visitor(impact, pt_data, meta, "add", l) {}
 
-    ~add_impacts_visitor() {}
+    ~add_impacts_visitor() override = default;
     add_impacts_visitor(const add_impacts_visitor&) = default;
 
     using apply_impacts_visitor::operator();
 
-    void operator()(nt::MetaVehicleJourney* mvj, nt::Route* r = nullptr) {
+    void operator()(nt::MetaVehicleJourney* mvj, nt::Route* r = nullptr) override {
         log_start_action(mvj->uri);
         if (impact->severity->effect == nt::disruption::Effect::NO_SERVICE) {
             LOG4CPLUS_TRACE(log, "canceling " << mvj->uri);
@@ -565,7 +565,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
     }
 };
 
-static bool is_modifying_effect(nt::disruption::Effect e) {
+bool is_modifying_effect(nt::disruption::Effect e) {
     // check if the effect needs to modify the model
     return contains({nt::disruption::Effect::NO_SERVICE, nt::disruption::Effect::UNKNOWN_EFFECT,
                      nt::disruption::Effect::SIGNIFICANT_DELAYS, nt::disruption::Effect::MODIFIED_SERVICE,
@@ -574,7 +574,9 @@ static bool is_modifying_effect(nt::disruption::Effect e) {
                     e);
 }
 
-void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact, nt::PT_Data& pt_data, const nt::MetaData& meta) {
+void apply_impact(const boost::shared_ptr<nt::disruption::Impact>& impact,
+                  nt::PT_Data& pt_data,
+                  const nt::MetaData& meta) {
     if (!is_modifying_effect(impact->severity->effect)) {
         LOG4CPLUS_DEBUG(log4cplus::Logger::getInstance("log"),
                         "Ingoring impact: " << impact->uri << " the effect is not handled");
@@ -589,7 +591,7 @@ void apply_impact(boost::shared_ptr<nt::disruption::Impact> impact, nt::PT_Data&
 
 using impact_sptr = boost::shared_ptr<nt::disruption::Impact>;
 
-static auto comp = [](const impact_sptr& lhs, const impact_sptr& rhs) {
+auto comp = [](const impact_sptr& lhs, const impact_sptr& rhs) {
     // lexical sort by update datetime then uri
     if (lhs->updated_at != rhs->updated_at) {
         return lhs->updated_at < rhs->updated_at;
@@ -600,7 +602,7 @@ static auto comp = [](const impact_sptr& lhs, const impact_sptr& rhs) {
 struct delete_impacts_visitor : public apply_impacts_visitor {
     size_t nb_vj_reassigned = 0;
     std::set<impact_sptr, decltype(comp)> disruptions_collection{comp};
-    delete_impacts_visitor(boost::shared_ptr<nt::disruption::Impact> impact,
+    delete_impacts_visitor(const boost::shared_ptr<nt::disruption::Impact>& impact,
                            nt::PT_Data& pt_data,
                            const nt::MetaData& meta,
                            nt::RTLevel l)
@@ -709,7 +711,7 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
         apply_impacts_visitor::operator()(route);
     }
 
-    void operator()(nt::disruption::LineSection&) {
+    void operator()(nt::disruption::LineSection& /*unused*/) {
         auto find_impact = [&](const boost::weak_ptr<nt::disruption::Impact>& weak_ptr) {
             if (auto i = weak_ptr.lock()) {
                 return i->uri == impact->uri;
@@ -724,15 +726,17 @@ struct delete_impacts_visitor : public apply_impacts_visitor {
     }
 };
 
-void delete_impact(boost::shared_ptr<nt::disruption::Impact> impact, nt::PT_Data& pt_data, const nt::MetaData& meta) {
+void delete_impact(const boost::shared_ptr<nt::disruption::Impact>& impact,
+                   nt::PT_Data& pt_data,
+                   const nt::MetaData& meta) {
     if (!is_modifying_effect(impact->severity->effect)) {
         return;
     }
     auto log = log4cplus::Logger::getInstance("log");
-    LOG4CPLUS_DEBUG(log, "Deleting impact: " << impact.get()->uri);
+    LOG4CPLUS_DEBUG(log, "Deleting impact: " << impact->uri);
     delete_impacts_visitor v(impact, pt_data, meta, impact->disruption->rt_level);
     boost::for_each(impact->mut_informed_entities(), boost::apply_visitor(v));
-    LOG4CPLUS_DEBUG(log, impact.get()->uri << " deleted");
+    LOG4CPLUS_DEBUG(log, impact->uri << " deleted");
 }
 
 }  // anonymous namespace

--- a/source/kraken/apply_disruption.h
+++ b/source/kraken/apply_disruption.h
@@ -35,6 +35,7 @@ www.navitia.io
 #include "type/chaos.pb.h"
 #include "type/gtfs-realtime.pb.h"
 #include "type/meta_data.h"
+
 #include <memory>
 
 namespace navitia {

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -29,11 +29,14 @@ www.navitia.io
 */
 
 #include "configuration.h"
+
 #include "utils/exception.h"
-#include <fstream>
-#include <boost/optional.hpp>
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/optional.hpp>
+
+#include <fstream>
 #include <iostream>
 
 namespace po = boost::program_options;
@@ -41,9 +44,9 @@ namespace po = boost::program_options;
 namespace navitia {
 namespace kraken {
 
-po::options_description get_options_description(const boost::optional<std::string> name,
-                                                const boost::optional<std::string> zmq,
-                                                const boost::optional<bool> display_contributors) {
+po::options_description get_options_description(const boost::optional<std::string>& name,
+                                                const boost::optional<std::string>& zmq,
+                                                const boost::optional<bool>& display_contributors) {
     po::options_description desc("Allowed options");
     // clang-format off
     desc.add_options()

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -39,7 +39,7 @@ class Configuration {
     boost::program_options::variables_map vm;
 
 public:
-    void load(const std::string& file);
+    void load(const std::string& filename);
     std::vector<std::string> load_from_command_line(const boost::program_options::options_description&,
                                                     int argc,
                                                     const char* const argv[]);
@@ -78,9 +78,9 @@ public:
 };
 
 boost::program_options::options_description get_options_description(
-    const boost::optional<std::string> name = {},
-    const boost::optional<std::string> zmq = {},
-    const boost::optional<bool> display_contributors = {});
+    const boost::optional<std::string>& name = {},
+    const boost::optional<std::string>& zmq = {},
+    const boost::optional<bool>& display_contributors = {});
 
 }  // namespace kraken
 }  // namespace navitia

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -38,11 +38,12 @@ www.navitia.io
 #include "gperftools/malloc_extension.h"
 #endif
 
+#include <boost/make_shared.hpp>
+#include <boost/optional.hpp>
+
 #include <memory>
 #include <iostream>
 #include <atomic>
-#include <boost/make_shared.hpp>
-#include <boost/optional.hpp>
 
 template <typename Data>
 void data_deleter(const Data* data) {

--- a/source/kraken/fill_disruption_from_database.h
+++ b/source/kraken/fill_disruption_from_database.h
@@ -30,12 +30,14 @@ www.navitia.io
 */
 
 #pragma once
-#include <string>
-#include <memory>
 #include "type/pt_data.h"
-#include "pqxx/result.hxx"
 #include "type/chaos.pb.h"
 #include "make_disruption_from_chaos.h"
+
+#include <pqxx/result.hxx>
+
+#include <string>
+#include <memory>
 
 namespace navitia {
 #define FILL_NULLABLE_(var_name, arg_name, col_name, type_name) \

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -27,20 +27,20 @@ channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
+#include "kraken_zmq.h"
 
 #include "conf.h"
 #include "type/type.pb.h"
-#include <google/protobuf/descriptor.h>
+#include "utils/functions.h"  //navitia::absolute_path function
+#include "utils/init.h"
+#include "utils/zmq.h"
 
 #include <boost/thread.hpp>
-#include <functional>
-#include <string>
-#include <iostream>
-#include "utils/init.h"
-#include "kraken_zmq.h"
-#include "utils/zmq.h"
-#include "utils/functions.h"  //navitia::absolute_path function
+#include <google/protobuf/descriptor.h>
 
+#include <functional>
+#include <iostream>
+#include <string>
 #include <sys/resource.h>  // Posix dependencies for getrlimit
 
 namespace {
@@ -93,10 +93,10 @@ int main(int argn, char** argv) {
             auto opt_desc = navitia::kraken::get_options_description();
             show_usage(argv[0], opt_desc);
             return 0;
-        } else {
-            // The first argument is the path to the configuration file
-            conf_file = arg;
         }
+        // The first argument is the path to the configuration file
+        conf_file = arg;
+
     } else {
         conf_file = path + application + ".ini";
     }

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -33,14 +33,14 @@ www.navitia.io
 #include "maintenance_worker.h"
 #include "kraken/data_manager.h"
 #include "utils/logger.h"
-#include <utils/zmq.h>
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include "utils/zmq.h"
 #include "kraken/configuration.h"
 #include "type/meta_data.h"
-#include <log4cplus/ndc.h>
 #include "metrics.h"
-
 #include "utils/deadline.h"
+
+#include <log4cplus/ndc.h>
+#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/optional/optional_io.hpp>
 
 static void respond(zmq::socket_t& socket, const std::string& address, const pbnavitia::Response& response) {

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -30,10 +30,11 @@ www.navitia.io
 
 #pragma once
 
-#include <SimpleAmqpClient/SimpleAmqpClient.h>
 #include "type/data.h"
 #include "kraken/data_manager.h"
 #include "kraken/configuration.h"
+
+#include <SimpleAmqpClient/SimpleAmqpClient.h>
 
 #include <memory>
 

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -28,10 +28,12 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 #include "make_disruption_from_chaos.h"
+
 #include "apply_disruption.h"
-#include "utils/logger.h"
-#include <boost/make_shared.hpp>
 #include "type/line.h"
+#include "utils/logger.h"
+
+#include <boost/make_shared.hpp>
 
 namespace bt = boost::posix_time;
 
@@ -217,7 +219,7 @@ static std::vector<nt::disruption::PtObj> make_pt_objects(
                 break;
             case chaos::PtObject_Type_line_section:
                 if (auto line_section = make_line_section(chaos_pt_object, pt_data)) {
-                    res.push_back(*line_section);
+                    res.emplace_back(*line_section);
                 }
                 break;
             case chaos::PtObject_Type_line:
@@ -230,7 +232,7 @@ static std::vector<nt::disruption::PtObj> make_pt_objects(
                 res.push_back(make_pt_obj(nt::Type_e::MetaVehicleJourney, chaos_pt_object.uri(), pt_data));
                 break;
             case chaos::PtObject_Type_unkown_type:
-                res.push_back(UnknownPtObj());
+                res.emplace_back(UnknownPtObj());
                 break;
         }
         // no created_at and updated_at?
@@ -312,7 +314,8 @@ static boost::shared_ptr<nt::disruption::Impact> make_impact(const chaos::Impact
     return impact;
 }
 
-bool is_publishable(transit_realtime::TimeRange publication_period, boost::posix_time::time_period production_period) {
+bool is_publishable(const transit_realtime::TimeRange& publication_period,
+                    boost::posix_time::time_period production_period) {
     // Publication period should have a valid start date
     if (publication_period.start() == 0) {
         return false;

--- a/source/kraken/make_disruption_from_chaos.h
+++ b/source/kraken/make_disruption_from_chaos.h
@@ -33,6 +33,7 @@ www.navitia.io
 #include "type/message.h"
 #include "type/chaos.pb.h"
 #include "type/meta_data.h"
+
 #include <memory>
 
 namespace navitia {
@@ -54,6 +55,7 @@ void make_and_apply_disruption(const chaos::Disruption& chaos_disruption,
 boost::optional<type::disruption::LineSection> make_line_section(const chaos::PtObject& chaos_section,
                                                                  nt::PT_Data& pt_data);
 
-bool is_publishable(transit_realtime::TimeRange publication_period, boost::posix_time::time_period production_period);
+bool is_publishable(const transit_realtime::TimeRange& publication_period,
+                    boost::posix_time::time_period production_period);
 
 }  // namespace navitia

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -51,14 +51,15 @@ InFlightGuard::~InFlightGuard() {
     }
 }
 
-InFlightGuard::InFlightGuard(InFlightGuard&& other) {
+InFlightGuard::InFlightGuard(InFlightGuard&& other) noexcept {
     this->gauge = other.gauge;
     other.gauge = nullptr;
 }
 
-void InFlightGuard::operator=(InFlightGuard&& other) {
+InFlightGuard& InFlightGuard::operator=(InFlightGuard&& other) noexcept {
     this->gauge = other.gauge;
     other.gauge = nullptr;
+    return *this;
 }
 
 static prometheus::Histogram::BucketBoundaries create_exponential_buckets(double start, double factor, int count) {

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -29,12 +29,13 @@ www.navitia.io
 */
 
 #include "metrics.h"
-#include "utils/functions.h"
 
+#include "utils/functions.h"
+#include "utils/logger.h"
+
+#include <prometheus/counter.h>
 #include <prometheus/exposer.h>
 #include <prometheus/registry.h>
-#include <prometheus/counter.h>
-#include "utils/logger.h"
 
 namespace navitia {
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -30,17 +30,16 @@ www.navitia.io
 
 #pragma once
 
-#include <memory>
-#include <map>
+#include "type/type.pb.h"
 
 #include <boost/optional.hpp>
 #include <boost/utility.hpp>
-
-#include "type/type.pb.h"
-
 #include <prometheus/exposer.h>
 #include <prometheus/counter.h>
 #include <prometheus/gauge.h>
+
+#include <memory>
+#include <map>
 
 // forward declare
 namespace prometheus {

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -56,9 +56,9 @@ class InFlightGuard {
 public:
     explicit InFlightGuard(prometheus::Gauge* gauge);
     InFlightGuard(InFlightGuard& other) = delete;
-    InFlightGuard(InFlightGuard&& other);
+    InFlightGuard(InFlightGuard&& other) noexcept;
     void operator=(InFlightGuard& other) = delete;
-    void operator=(InFlightGuard&& other);
+    InFlightGuard& operator=(InFlightGuard&& other) noexcept;
     ~InFlightGuard();
 };
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -28,20 +28,22 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 #include "realtime.h"
-#include "utils/logger.h"
+
+#include "kraken/apply_disruption.h"
 #include "type/data.h"
+#include "type/datetime.h"
+#include "type/kirin.pb.h"
+#include "type/meta_data.h"
 #include "type/pt_data.h"
 #include "type/type.h"
-#include "type/meta_data.h"
-#include "type/datetime.h"
-#include "kraken/apply_disruption.h"
-#include "type/kirin.pb.h"
+#include "utils/functions.h"
+#include "utils/logger.h"
 
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
+
 #include <chrono>
-#include "utils/functions.h"
 
 namespace navitia {
 
@@ -50,66 +52,44 @@ namespace nd = type::disruption;
 static bool base_vj_exists_the_same_day(const type::Data& data, const transit_realtime::TripUpdate& trip_update) {
     const auto& mvj = *data.pt_data->get_or_create_meta_vehicle_journey(trip_update.trip().trip_id(),
                                                                         data.pt_data->get_main_timezone());
-    if (mvj.get_base_vj_circulating_at_date(
-            boost::gregorian::from_undelimited_string(trip_update.trip().start_date()))) {
-        return true;
-    } else {
-        return false;
-    }
+    return mvj.get_base_vj_circulating_at_date(
+        boost::gregorian::from_undelimited_string(trip_update.trip().start_date()));
 }
 
 static bool is_cancelled_trip(const transit_realtime::TripUpdate& trip_update) {
     if (trip_update.HasExtension(kirin::effect)) {
-        if (trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_NO_SERVICE) {
-            return true;
-        } else {
-            return false;
-        }
-    } else {  // TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
-        if (trip_update.trip().schedule_relationship()
-            == transit_realtime::TripDescriptor_ScheduleRelationship_CANCELED) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+        return trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_NO_SERVICE;
+    }  // TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
+    return trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_CANCELED;
 }
 
 static bool is_circulating_trip(const transit_realtime::TripUpdate& trip_update) {
     if (trip_update.HasExtension(kirin::effect)) {
-        if ((trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_REDUCED_SERVICE
-             || trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_UNKNOWN_EFFECT
-             || trip_update.GetExtension(kirin::effect)
-                    == transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS
-             || trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_DETOUR
-             || trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE
-             || trip_update.GetExtension(kirin::effect)
-                    == transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE)
-            && trip_update.stop_time_update_size()) {
-            return true;
-        } else {
-            return false;
-        }
-    } else {  // TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
-        if ((trip_update.trip().schedule_relationship()
-                 == transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED
-             || trip_update.trip().schedule_relationship()
-                    == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED)
-            && trip_update.stop_time_update_size()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
+        return (trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_REDUCED_SERVICE
+                || trip_update.GetExtension(kirin::effect)
+                       == transit_realtime::Alert_Effect::Alert_Effect_UNKNOWN_EFFECT
+                || trip_update.GetExtension(kirin::effect)
+                       == transit_realtime::Alert_Effect::Alert_Effect_SIGNIFICANT_DELAYS
+                || trip_update.GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_DETOUR
+                || trip_update.GetExtension(kirin::effect)
+                       == transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE
+                || trip_update.GetExtension(kirin::effect)
+                       == transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE)
+               && trip_update.stop_time_update_size();
+    }  // TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
+    return (trip_update.trip().schedule_relationship()
+                == transit_realtime::TripDescriptor_ScheduleRelationship_SCHEDULED
+            || trip_update.trip().schedule_relationship()
+                   == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED)
+           && trip_update.stop_time_update_size();
 }
 
 static bool is_deleted(const transit_realtime::TripUpdate_StopTimeEvent& event) {
     if (event.HasExtension(kirin::stop_time_event_status)) {
         return contains({kirin::StopTimeEventStatus::DELETED, kirin::StopTimeEventStatus::DELETED_FOR_DETOUR},
                         event.GetExtension(kirin::stop_time_event_status));
-    } else {
-        return false;
     }
+    return false;
 }
 
 static bool check_trip_update(const transit_realtime::TripUpdate& trip_update) {
@@ -268,13 +248,11 @@ static nt::disruption::StopTimeUpdate::Status get_status(const transit_realtime:
     }
     if (!event.has_delay() || event.delay() != 0) {
         return nt::disruption::StopTimeUpdate::Status::DELAYED;
-    } else {
-        return nt::disruption::StopTimeUpdate::Status::UNCHANGED;
     }
+    return nt::disruption::StopTimeUpdate::Status::UNCHANGED;
 }
 
 static bool is_added_trip(const transit_realtime::TripUpdate& trip_update) {
-    namespace trt = transit_realtime;
     auto log = log4cplus::Logger::getInstance("realtime");
 
     if (trip_update.HasExtension(kirin::effect)) {
@@ -282,21 +260,18 @@ static bool is_added_trip(const transit_realtime::TripUpdate& trip_update) {
             == transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE) {
             LOG4CPLUS_TRACE(log, "Disruption has ADDITIONAL_SERVICE effect");
             return true;
-        } else {
-            return false;
         }
-    } else {  // TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
-        if (trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED) {
-            LOG4CPLUS_TRACE(log, "Disruption has ADDITIONAL_SERVICE effect");
-            return true;
-        } else {
-            return false;
-        }
+        return false;
+
+    }  // TODO: remove this deprecated code (for retrocompatibility with Kirin < 0.8.0 only)
+    if (trip_update.trip().schedule_relationship() == transit_realtime::TripDescriptor_ScheduleRelationship_ADDED) {
+        LOG4CPLUS_TRACE(log, "Disruption has ADDITIONAL_SERVICE effect");
+        return true;
     }
+    return false;
 }
 
 static bool is_added_stop_time(const transit_realtime::TripUpdate& trip_update) {
-    namespace trt = transit_realtime;
     auto log = log4cplus::Logger::getInstance("realtime");
     using nt::disruption::StopTimeUpdate;
 
@@ -460,7 +435,6 @@ static const type::disruption::Disruption* create_disruption(const std::string& 
                                                              const transit_realtime::TripUpdate& trip_update,
                                                              const type::Data& data) {
     namespace bpt = boost::posix_time;
-    namespace trt = transit_realtime;
     auto log = log4cplus::Logger::getInstance("realtime");
 
     LOG4CPLUS_DEBUG(log, "Creating disruption");
@@ -599,7 +573,7 @@ static const type::disruption::Disruption* create_disruption(const std::string& 
                 most_important_stoptime_status =
                     std::max({most_important_stoptime_status, departure_status, arrival_status});
 
-                StopTimeUpdate st_update{std::move(stop_time), message, departure_status, arrival_status};
+                StopTimeUpdate st_update{stop_time, message, departure_status, arrival_status};
                 impact->aux_info.stop_times.emplace_back(std::move(st_update));
             }
 
@@ -616,13 +590,13 @@ static const type::disruption::Disruption* create_disruption(const std::string& 
         std::string wording = get_wordings(trip_effect);
 
         end_app_period = std::max(end_app_period, begin_app_period);  // make sure that start <= end
-        impact->application_periods.push_back({begin_app_period, end_app_period});
+        impact->application_periods.emplace_back(begin_app_period, end_app_period);
         impact->severity = make_severity(id, std::move(wording), trip_effect, timestamp, holder);
         nd::Impact::link_informed_entity(
             nd::make_pt_obj(nt::Type_e::MetaVehicleJourney, trip_update.trip().trip_id(), *data.pt_data), impact,
             data.meta->production_date, nt::RTLevel::RealTime);
         // messages
-        disruption.add_impact(std::move(impact), holder);
+        disruption.add_impact(impact, holder);
     }
     // localization
     // tags

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -1133,7 +1133,7 @@ void Worker::nearest_stop_points(const pbnavitia::NearestStopPointsRequest& requ
     entry_point.streetnetwork_params.max_duration = navitia::seconds(request.max_duration());
     street_network_worker->init(entry_point, {});
     // kraken don't handle reverse isochrone
-    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, false);
+    auto result = routing::get_stop_points(entry_point, *data, *street_network_worker, 0u);
     if (!result) {
         this->pb_creator.fill_pb_error(pbnavitia::Error::unknown_object,
                                        "The entry point: " + entry_point.uri + " is not valid");

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -62,8 +62,13 @@ namespace {
 // local exception, only used in this file
 struct coord_conversion_exception : public recoverable_exception {
     explicit coord_conversion_exception(const std::string& msg) : recoverable_exception(msg) {}
+
     coord_conversion_exception(const coord_conversion_exception&) = default;
     coord_conversion_exception& operator=(const coord_conversion_exception&) = default;
+
+    coord_conversion_exception(coord_conversion_exception&&) = default;
+    coord_conversion_exception& operator=(coord_conversion_exception&&) = default;
+
     ~coord_conversion_exception() noexcept override = default;
 };
 }  // namespace

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -56,7 +56,7 @@ struct JourneysArg {
     type::AccessibiliteParams accessibilite_params;
     std::vector<std::string> forbidden;
     std::vector<std::string> allowed;
-    type::RTLevel rt_level;
+    type::RTLevel rt_level = type::RTLevel::Base;
     type::EntryPoints destinations;
     std::vector<uint64_t> datetimes;
     boost::optional<type::EntryPoint> isochrone_center;


### PR DESCRIPTION
I've used clang-tidy 6.0 on kraken with the following command :
`clang-tidy -checks='*, -fuchsia-overloaded-operator, -fuchsia-default-arguments,-google*, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -hicpp-no-array-decay, -readability-implicit-bool-conversion, -misc-macro-parentheses' ../source/kraken/worker.cpp  -header-filter="*.pb.h" -fix -fix-errors`

It fixes a lot of basics things. There is still some warnings that may take a lot more effort to fix ourselves.

`-checks='*, -fuchsia-overloaded-operator, -fuchsia-default-arguments,-google*, -cppcoreguidelines-pro-bounds-array-to-pointer-decay, -hicpp-no-array-decay, -readability-implicit-bool-conversion, -misc-macro-parentheses'` runs all available checks except :

- `fuchsia-overloaded-operator` : just yell at us for overloading operators...
- all of google checks because they have some weird conventions sometime like passing a non const pointer instead of a nonconst reference in a function. Their reasoning is that it makes it clear that it is an in-out parameter. Meh...
- `cppcoreguidelines-pro-bounds-array-to-pointer-decay` : yell at us for using all of the `LOG4CPLUS` macros. May be a good thing to fix it someday
- `hicpp-no-array-decay` : same as above.
- `readability-implicit-bool-conversion` : replace all test of pointers from `if (pointer)` to `if (pointer != nullptr)` and all returns of function from `if function()` to `if function() == 0u` which is very dull...
- `misc-macro-parentheses` which destroy most of the macros...

I've also reordered the included files following this order:

- .h file of the acutal .cpp file
- .h from our project
- .h from external sources
- system includes