### PR TITLE
Ed: Adding logs in ed2nav

### DIFF
--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -166,25 +166,30 @@ struct FindAdminWithCities {
 
 bool rename_file(const std::string& source_name, const std::string& dest_name) {
     auto logger = log4cplus::Logger::getInstance("ed2nav::rename_file");
+    LOG4CPLUS_INFO(logger, "Trying to rename " << source_name << " to " << dest_name);
     if (boost::filesystem::exists(source_name)) {
         if (rename(source_name.c_str(), dest_name.c_str()) != 0) {
             LOG4CPLUS_ERROR(logger, "Unable to rename data file: " << source_name << std::strerror(errno));
             return false;
         }
     }
+    LOG4CPLUS_INFO(logger, "Renaming file success");
     return true;
 }
 
-template <class T = navitia::type::Data>
+template <class T>
 bool write_data_to_file(const std::string& output_filename, const T& data) {
     std::string temp_output_filename = output_filename + ".temp";
     std::string backup_output_filename = output_filename + ".bak";
-    if (!try_save_file(temp_output_filename, data))
+    if (!try_save_file(temp_output_filename, data)) {
         return false;
-    if (!rename_file(output_filename, backup_output_filename))
+    }
+    if (!rename_file(output_filename, backup_output_filename)) {
         return false;
-    if (!rename_file(temp_output_filename, output_filename))
+    }
+    if (!rename_file(temp_output_filename, output_filename)) {
         return false;
+    }
     return true;
 }
 
@@ -298,6 +303,7 @@ int ed2nav(int argc, const char* argv[]) {
     start = pt::microsec_clock::local_time();
 
     if (!write_data_to_file(output, data)) {
+        LOG4CPLUS_ERROR(logger, "Exiting ed2nav with errors");
         return 1;
     }
     save = (pt::microsec_clock::local_time() - start).total_milliseconds();

--- a/source/ed/ed2nav.h
+++ b/source/ed/ed2nav.h
@@ -45,6 +45,7 @@ namespace ed {
 template <class T = navitia::type::Data>
 bool try_save_file(const std::string& filename, const T& data) {
     auto logger = log4cplus::Logger::getInstance("ed2nav::try_save_file");
+    LOG4CPLUS_INFO(logger, "Trying to save " << filename);
     try {
         data.save(filename);
     } catch (const navitia::exception& e) {
@@ -52,11 +53,9 @@ bool try_save_file(const std::string& filename, const T& data) {
         LOG4CPLUS_ERROR(logger, e.what());
         return false;
     }
+    LOG4CPLUS_INFO(logger, "File " << filename << " has been saved");
     return true;
 }
-
-bool rename_old_file(const std::string& output_filename, const std::string& backup_output_filename);
-bool rename_temp_file(const std::string& temp_output_filename, const std::string& output_filename);
 
 template <class T = navitia::type::Data>
 bool write_data_to_file(const std::string& output_filename, const T& data);


### PR DESCRIPTION
Right now ed2nav is exiting after the log `Begin to save...` without any more logs or information.

This PR aims to add more logs to have more info on that problem.

Also fix compilation with Clang.