### PR TITLE
[Kraken] Only re-index VJ from the deleted one

### DIFF
--- a/source/type/meta_vehicle_journey.cpp
+++ b/source/type/meta_vehicle_journey.cpp
@@ -106,7 +106,7 @@ void cleanup_useless_vj_link(const nt::VehicleJourney* vj, nt::PT_Data& pt_data)
     // remove the vj from the global list/map
     erase_vj_from_list(vj, pt_data.vehicle_journeys);
     // afterward, we MUST reindex all vehicle journeys
-    std::for_each(pt_data.vehicle_journeys.begin(), pt_data.vehicle_journeys.end(), Indexer<nt::idx_t>());
+    std::for_each(pt_data.vehicle_journeys.begin() + vj->idx, pt_data.vehicle_journeys.end(), Indexer<nt::idx_t>(vj));
 
     pt_data.vehicle_journeys_map.erase(vj->uri);
 }


### PR DESCRIPTION
We spend a whole lot of time re-indexing VJ on huge disruption. We can
spend up to ~95% doing it. This is a problem as it takes a couple of hours to start a kraken in production during French Strikes. 

```asm
        │       template<class T>
        │       void operator()(T obj){obj->idx = idx; idx++;}
 12,44% │738:   mov    (%rsi,%rax,8),%rcx
 86,83% │       mov    %eax,0x8(%rcx)
  0,65% │       add    $0x1,%rax
```
Let's re-index only from the VJ that is being deleted.