### PR TITLE
[jorm] reduce simplification of coverage shapes used by bragi

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -658,7 +658,7 @@ class Instance(object):
             self.geojson = None
             return
         # simplify the geom to prevent slow query on bragi
-        geom = self.geom.simplify(tolerance=0.1)
+        geom = self.geom.simplify(tolerance=0.01)
         self.geojson = geometry.mapping(geom)
 
     def init(self):


### PR DESCRIPTION
`0.1` exclude a lot of the coverage :(

![image](https://user-images.githubusercontent.com/448185/70807381-be7b5680-1dbd-11ea-9bbc-94196e3d7fd2.png)
red is the original shape, green is simplified with a tolerance of `0.1` and purple with `0.01`