### PR TITLE
osm2ed: import car speed in ed database

### DIFF
--- a/source/ed/connectors/CMakeLists.txt
+++ b/source/ed/connectors/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(SOURCE_LIB
     gtfs_parser.cpp
     fusio_parser.cpp
     osm_tags_reader.cpp
+    speed_parser.cpp
     poi_parser.cpp
     fare_parser.cpp
     fare_utils.cpp

--- a/source/ed/connectors/osm_tags_reader.cpp
+++ b/source/ed/connectors/osm_tags_reader.cpp
@@ -40,17 +40,16 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
-
 static void update_if_unknown(int& target, const int& source) {
     if (target == -1) {
         target = source;
     }
 }
 
-
-boost::optional<float> parse_way_speed(const std::map<std::string, std::string>& tags, const SpeedsParser& default_speed) {
+boost::optional<float> parse_way_speed(const std::map<std::string, std::string>& tags,
+                                       const SpeedsParser& default_speed) {
     if (!tags.count("highway")) {
-        return 0;
+        return boost::none;
     }
     boost::optional<std::string> max_speed;
     std::string highway;
@@ -70,7 +69,6 @@ boost::optional<float> parse_way_speed(const std::map<std::string, std::string>&
 
     return default_speed.get_speed(highway, max_speed);
 }
-
 
 std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
     // if no highway tag, we can do nothing on it

--- a/source/ed/connectors/osm_tags_reader.h
+++ b/source/ed/connectors/osm_tags_reader.h
@@ -44,8 +44,13 @@ constexpr uint8_t FOOT_FWD = 4;
 constexpr uint8_t FOOT_BWD = 5;
 constexpr uint8_t VISIBLE = 6;
 
+class SpeedsParser;
+
 /// return properties on modes and directions that are possible on a way
 std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags);
+
+
+boost::optional<float> parse_way_speed(const std::map<std::string, std::string>& tags, const SpeedsParser& default_speed);
 
 ed::types::Poi fill_poi(const uint64_t osm_id,
                         const double lon,

--- a/source/ed/connectors/osm_tags_reader.h
+++ b/source/ed/connectors/osm_tags_reader.h
@@ -49,8 +49,8 @@ class SpeedsParser;
 /// return properties on modes and directions that are possible on a way
 std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags);
 
-
-boost::optional<float> parse_way_speed(const std::map<std::string, std::string>& tags, const SpeedsParser& default_speed);
+boost::optional<float> parse_way_speed(const std::map<std::string, std::string>& tags,
+                                       const SpeedsParser& default_speed);
 
 ed::types::Poi fill_poi(const uint64_t osm_id,
                         const double lon,

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -40,11 +40,11 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
-constexpr float kmh_to_ms(float val){
+constexpr float kmh_to_ms(float val) {
     return val / 3.6;
 }
 
-template<typename T>
+template <typename T>
 static void update_if_unknown(boost::optional<T>& target, const T& source) {
     if (!target) {
         target = source;
@@ -105,40 +105,42 @@ SpeedsParser::SpeedsParser() {
     speed_factor_by_type["unclassified"] = 0.5;
 }
 
-boost::optional<float> SpeedsParser::get_speed(const std::string& highway, const boost::optional<std::string>& max_speed) const{
+boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
+                                               const boost::optional<std::string>& max_speed) const {
     boost::optional<float> speed;
     boost::optional<float> factor;
 
-    if(max_speed){
+    if (max_speed) {
         std::string s = boost::algorithm::trim_copy(max_speed.get());
         auto it = implicit_speeds.find(s);
-        if(it != implicit_speeds.end()){
+        if (it != implicit_speeds.end()) {
             speed = it->second;
-        }else{
-            try{
+        } else {
+            try {
                 // todo handle value not in km/h.
                 // if there is no unit the value is in km/h else cast will fail
                 speed = kmh_to_ms(boost::lexical_cast<float>(s));
-            }catch(const std::exception&){
+            } catch (const std::exception&) {
                 std::cerr << "impossible to convert \"" << max_speed << "\" in speed" << std::endl;
             }
         }
     }
 
     auto it = max_speeds_by_type.find(highway);
-    if(it != max_speeds_by_type.end()){
+    if (it != max_speeds_by_type.end()) {
         update_if_unknown(speed, it->second);
-    }else{
+    } else {
         std::cerr << highway << " not handled" << std::endl;
     }
 
     auto it_factor = speed_factor_by_type.find(highway);
-    if(it_factor != speed_factor_by_type.end() && speed){
+    if (it_factor != speed_factor_by_type.end() && speed) {
         speed = speed.get() * it_factor->second;
-    }else{
+    } else {
         std::cerr << highway << " not handled" << std::endl;
     }
     return speed;
 }
 
-}}
+}  // namespace connectors
+}  // namespace ed

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -53,7 +53,7 @@ static void update_if_unknown(boost::optional<T>& target, const T& source) {
 
 // https://www.openstreetmap.org/relation/934933
 // default values for France
-SpeedsParser::SpeedsParser() {
+SpeedsParser SpeedsParser::defaults() {
     const float walking_speed = kmh_to_ms(4);
     const float urban_speed = kmh_to_ms(50);
     const float rural_speed = kmh_to_ms(80);
@@ -61,54 +61,62 @@ SpeedsParser::SpeedsParser() {
     const float trunk_speed = kmh_to_ms(110);
     const float living_street_speed = kmh_to_ms(20);
 
-    implicit_speeds["fr:walk"] = walking_speed;
-    implicit_speeds["fr:urban"] = urban_speed;
-    implicit_speeds["fr:rural"] = rural_speed;
-    implicit_speeds["fr:motorway"] = motorway_speed;
+    SpeedsParser parser;
 
-    max_speeds_by_type["motorway"] = motorway_speed;
-    max_speeds_by_type["motorway_link"] = urban_speed;
-    max_speeds_by_type["trunk"] = trunk_speed;
-    max_speeds_by_type["trunk_link"] = urban_speed;
-    max_speeds_by_type["primary"] = rural_speed;
-    max_speeds_by_type["secondary"] = urban_speed;
-    max_speeds_by_type["tertiary"] = urban_speed;
-    max_speeds_by_type["primary_link"] = urban_speed;
-    max_speeds_by_type["secondary_link"] = urban_speed;
-    max_speeds_by_type["tertiary_link"] = urban_speed;
-    max_speeds_by_type["unclassified"] = urban_speed;
-    max_speeds_by_type["road"] = urban_speed;
-    max_speeds_by_type["residential"] = urban_speed;
-    max_speeds_by_type["living_street"] = living_street_speed;
-    max_speeds_by_type["service"] = urban_speed;
-    max_speeds_by_type["track"] = walking_speed;
-    max_speeds_by_type["path"] = walking_speed;
-    max_speeds_by_type["unclassified"] = urban_speed;
+    parser.implicit_speeds["fr:walk"] = walking_speed;
+    parser.implicit_speeds["fr:urban"] = urban_speed;
+    parser.implicit_speeds["fr:rural"] = rural_speed;
+    parser.implicit_speeds["fr:motorway"] = motorway_speed;
 
-    speed_factor_by_type["motorway"] = 0.9;
-    speed_factor_by_type["motorway_link"] = 0.5;
-    speed_factor_by_type["trunk"] = 0.8;
-    speed_factor_by_type["trunk_link"] = 0.5;
-    speed_factor_by_type["primary"] = 0.8;
-    speed_factor_by_type["secondary"] = 0.6;
-    speed_factor_by_type["tertiary"] = 0.6;
-    speed_factor_by_type["primary_link"] = 0.5;
-    speed_factor_by_type["secondary_link"] = 0.5;
-    speed_factor_by_type["tertiary_link"] = 0.5;
-    speed_factor_by_type["unclassified"] = 0.5;
-    speed_factor_by_type["road"] = 0.5;
-    speed_factor_by_type["residential"] = 0.5;
-    speed_factor_by_type["living_street"] = 0.5;
-    speed_factor_by_type["service"] = 0.2;
-    speed_factor_by_type["track"] = 0.2;
-    speed_factor_by_type["path"] = 0.2;
-    speed_factor_by_type["unclassified"] = 0.5;
+    parser.max_speeds_by_type["motorway"] = motorway_speed;
+    parser.max_speeds_by_type["motorway_link"] = urban_speed;
+    parser.max_speeds_by_type["trunk"] = trunk_speed;
+    parser.max_speeds_by_type["trunk_link"] = urban_speed;
+    parser.max_speeds_by_type["primary"] = rural_speed;
+    parser.max_speeds_by_type["secondary"] = urban_speed;
+    parser.max_speeds_by_type["tertiary"] = urban_speed;
+    parser.max_speeds_by_type["primary_link"] = urban_speed;
+    parser.max_speeds_by_type["secondary_link"] = urban_speed;
+    parser.max_speeds_by_type["tertiary_link"] = urban_speed;
+    parser.max_speeds_by_type["unclassified"] = urban_speed;
+    parser.max_speeds_by_type["road"] = urban_speed;
+    parser.max_speeds_by_type["residential"] = urban_speed;
+    parser.max_speeds_by_type["living_street"] = living_street_speed;
+    parser.max_speeds_by_type["service"] = urban_speed;
+    parser.max_speeds_by_type["track"] = walking_speed;
+    parser.max_speeds_by_type["path"] = walking_speed;
+    parser.max_speeds_by_type["unclassified"] = urban_speed;
+
+    parser.speed_factor_by_type["motorway"] = 0.9;
+    parser.speed_factor_by_type["motorway_link"] = 0.5;
+    parser.speed_factor_by_type["trunk"] = 0.8;
+    parser.speed_factor_by_type["trunk_link"] = 0.5;
+    parser.speed_factor_by_type["primary"] = 0.8;
+    parser.speed_factor_by_type["secondary"] = 0.6;
+    parser.speed_factor_by_type["tertiary"] = 0.6;
+    parser.speed_factor_by_type["primary_link"] = 0.5;
+    parser.speed_factor_by_type["secondary_link"] = 0.5;
+    parser.speed_factor_by_type["tertiary_link"] = 0.5;
+    parser.speed_factor_by_type["unclassified"] = 0.5;
+    parser.speed_factor_by_type["road"] = 0.5;
+    parser.speed_factor_by_type["residential"] = 0.5;
+    parser.speed_factor_by_type["living_street"] = 0.5;
+    parser.speed_factor_by_type["service"] = 0.2;
+    parser.speed_factor_by_type["track"] = 0.2;
+    parser.speed_factor_by_type["path"] = 0.2;
+    parser.speed_factor_by_type["unclassified"] = 0.5;
+
+    return parser;
 }
 
 boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
                                                const boost::optional<std::string>& max_speed) const {
     boost::optional<float> speed;
     boost::optional<float> factor;
+
+    if(max_speeds_by_type.empty() && speed_factor_by_type.empty()){
+        return boost::none;
+    }
 
     if (max_speed) {
         std::string s = boost::algorithm::trim_copy(max_speed.get());

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -1,0 +1,144 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "speed_parser.h"
+#include "utils/functions.h"
+#include <boost/lexical_cast.hpp>
+#include <iostream>
+#include <algorithm>
+#include "utils/exception.h"
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/optional/optional_io.hpp>
+
+namespace ed {
+namespace connectors {
+
+constexpr float kmh_to_ms(float val){
+    return val / 3.6;
+}
+
+template<typename T>
+static void update_if_unknown(boost::optional<T>& target, const T& source) {
+    if (!target) {
+        target = source;
+    }
+}
+
+// https://www.openstreetmap.org/relation/934933
+// default values for France
+SpeedsParser::SpeedsParser() {
+    const float walking_speed = kmh_to_ms(4);
+    const float urban_speed = kmh_to_ms(50);
+    const float rural_speed = kmh_to_ms(80);
+    const float motorway_speed = kmh_to_ms(130);
+    const float trunk_speed = kmh_to_ms(110);
+    const float living_street_speed = kmh_to_ms(20);
+
+    implicit_speeds["fr:walk"] = walking_speed;
+    implicit_speeds["fr:urban"] = urban_speed;
+    implicit_speeds["fr:rural"] = rural_speed;
+    implicit_speeds["fr:motorway"] = motorway_speed;
+
+    max_speeds_by_type["motorway"] = motorway_speed;
+    max_speeds_by_type["motorway_link"] = urban_speed;
+    max_speeds_by_type["trunk"] = trunk_speed;
+    max_speeds_by_type["trunk_link"] = urban_speed;
+    max_speeds_by_type["primary"] = rural_speed;
+    max_speeds_by_type["secondary"] = urban_speed;
+    max_speeds_by_type["tertiary"] = urban_speed;
+    max_speeds_by_type["primary_link"] = urban_speed;
+    max_speeds_by_type["secondary_link"] = urban_speed;
+    max_speeds_by_type["tertiary_link"] = urban_speed;
+    max_speeds_by_type["unclassified"] = urban_speed;
+    max_speeds_by_type["road"] = urban_speed;
+    max_speeds_by_type["residential"] = urban_speed;
+    max_speeds_by_type["living_street"] = living_street_speed;
+    max_speeds_by_type["service"] = urban_speed;
+    max_speeds_by_type["track"] = walking_speed;
+    max_speeds_by_type["path"] = walking_speed;
+    max_speeds_by_type["unclassified"] = urban_speed;
+
+    speed_factor_by_type["motorway"] = 0.9;
+    speed_factor_by_type["motorway_link"] = 0.5;
+    speed_factor_by_type["trunk"] = 0.8;
+    speed_factor_by_type["trunk_link"] = 0.5;
+    speed_factor_by_type["primary"] = 0.8;
+    speed_factor_by_type["secondary"] = 0.6;
+    speed_factor_by_type["tertiary"] = 0.6;
+    speed_factor_by_type["primary_link"] = 0.5;
+    speed_factor_by_type["secondary_link"] = 0.5;
+    speed_factor_by_type["tertiary_link"] = 0.5;
+    speed_factor_by_type["unclassified"] = 0.5;
+    speed_factor_by_type["road"] = 0.5;
+    speed_factor_by_type["residential"] = 0.5;
+    speed_factor_by_type["living_street"] = 0.5;
+    speed_factor_by_type["service"] = 0.2;
+    speed_factor_by_type["track"] = 0.2;
+    speed_factor_by_type["path"] = 0.2;
+    speed_factor_by_type["unclassified"] = 0.5;
+}
+
+boost::optional<float> SpeedsParser::get_speed(const std::string& highway, const boost::optional<std::string>& max_speed) const{
+    boost::optional<float> speed;
+    boost::optional<float> factor;
+
+    if(max_speed){
+        std::string s = boost::algorithm::trim_copy(max_speed.get());
+        auto it = implicit_speeds.find(s);
+        if(it != implicit_speeds.end()){
+            speed = it->second;
+        }else{
+            try{
+                // todo handle value not in km/h.
+                // if there is no unit the value is in km/h else cast will fail
+                speed = kmh_to_ms(boost::lexical_cast<float>(s));
+            }catch(const std::exception&){
+                std::cerr << "impossible to convert \"" << max_speed << "\" in speed" << std::endl;
+            }
+        }
+    }
+
+    auto it = max_speeds_by_type.find(highway);
+    if(it != max_speeds_by_type.end()){
+        update_if_unknown(speed, it->second);
+    }else{
+        std::cerr << highway << " not handled" << std::endl;
+    }
+
+    auto it_factor = speed_factor_by_type.find(highway);
+    if(it_factor != speed_factor_by_type.end() && speed){
+        speed = speed.get() * it_factor->second;
+    }else{
+        std::cerr << highway << " not handled" << std::endl;
+    }
+    return speed;
+}
+
+}}

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -132,7 +132,7 @@ boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
     boost::optional<float> speed;
     boost::optional<float> factor;
 
-    if(max_speeds_by_type.empty() && speed_factor_by_type.empty()){
+    if (max_speeds_by_type.empty() && speed_factor_by_type.empty()) {
         return boost::none;
     }
 

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -86,6 +86,15 @@ SpeedsParser SpeedsParser::defaults() {
     parser.max_speeds_by_type["track"] = walking_speed;
     parser.max_speeds_by_type["path"] = walking_speed;
     parser.max_speeds_by_type["unclassified"] = urban_speed;
+    // useless but prevent warnings
+    parser.max_speeds_by_type["footway"] = walking_speed;
+    parser.max_speeds_by_type["steps"] = walking_speed;
+    parser.max_speeds_by_type["pedestrian"] = walking_speed;
+    parser.max_speeds_by_type["cycleway"] = walking_speed;
+    parser.max_speeds_by_type["bus_stop"] = walking_speed;
+    parser.max_speeds_by_type["platform"] = walking_speed;
+    parser.max_speeds_by_type["construction"] = walking_speed;
+    parser.max_speeds_by_type["bridleway"] = walking_speed;
 
     parser.speed_factor_by_type["motorway"] = 0.9;
     parser.speed_factor_by_type["motorway_link"] = 0.5;
@@ -105,6 +114,15 @@ SpeedsParser SpeedsParser::defaults() {
     parser.speed_factor_by_type["track"] = 0.2;
     parser.speed_factor_by_type["path"] = 0.2;
     parser.speed_factor_by_type["unclassified"] = 0.5;
+    // useless but prevent warnings
+    parser.speed_factor_by_type["footway"] = 1;
+    parser.speed_factor_by_type["steps"] = 1;
+    parser.speed_factor_by_type["pedestrian"] = 1;
+    parser.speed_factor_by_type["cycleway"] = 1;
+    parser.speed_factor_by_type["bus_stop"] = 1;
+    parser.speed_factor_by_type["platform"] = 1;
+    parser.speed_factor_by_type["construction"] = 1;
+    parser.speed_factor_by_type["bridleway"] = 1;
 
     return parser;
 }

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -159,11 +159,13 @@ boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
         std::cerr << highway << " not handled" << std::endl;
     }
 
-    auto it_factor = speed_factor_by_type.find(highway);
-    if (it_factor != speed_factor_by_type.end() && speed) {
-        speed = speed.get() * it_factor->second;
-    } else {
-        std::cerr << highway << " not handled" << std::endl;
+    if (speed) {
+        auto it_factor = speed_factor_by_type.find(highway);
+        if (it_factor != speed_factor_by_type.end()) {
+            speed = speed.get() * it_factor->second;
+        } else {
+            speed = speed.get() * default_speed_factor;
+        }
     }
     return speed;
 }

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -40,8 +40,12 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
-constexpr float kmh_to_ms(float val) {
+constexpr float kmh_to_ms(long double val) {
     return val / 3.6;
+}
+
+constexpr float operator"" _kmh(long double val) {
+    return kmh_to_ms(val);
 }
 
 template <typename T>
@@ -54,12 +58,12 @@ static void update_if_unknown(boost::optional<T>& target, const T& source) {
 // https://www.openstreetmap.org/relation/934933
 // default values for France
 SpeedsParser SpeedsParser::defaults() {
-    const float walking_speed = kmh_to_ms(4);
-    const float urban_speed = kmh_to_ms(50);
-    const float rural_speed = kmh_to_ms(80);
-    const float motorway_speed = kmh_to_ms(130);
-    const float trunk_speed = kmh_to_ms(110);
-    const float living_street_speed = kmh_to_ms(20);
+    const float walking_speed = 4.0_kmh;
+    const float urban_speed = 50.0_kmh;
+    const float rural_speed = 80.0_kmh;
+    const float motorway_speed = 130.0_kmh;
+    const float trunk_speed = 110.0_kmh;
+    const float living_street_speed = 20.0_kmh;
 
     SpeedsParser parser;
 
@@ -130,7 +134,6 @@ SpeedsParser SpeedsParser::defaults() {
 boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
                                                const boost::optional<std::string>& max_speed) const {
     boost::optional<float> speed;
-    boost::optional<float> factor;
 
     if (max_speeds_by_type.empty() && speed_factor_by_type.empty()) {
         return boost::none;

--- a/source/ed/connectors/speed_parser.h
+++ b/source/ed/connectors/speed_parser.h
@@ -1,0 +1,48 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include <map>
+#include <string>
+#include <boost/optional.hpp>
+
+namespace ed {
+namespace connectors {
+
+class SpeedsParser{
+    std::map<std::string, float> implicit_speeds;
+    std::map<std::string, float> max_speeds_by_type;
+    std::map<std::string, float> speed_factor_by_type;
+
+public:
+    SpeedsParser();
+    boost::optional<float> get_speed(const std::string& highway, const boost::optional<std::string>& max_speed) const;
+};
+
+}}

--- a/source/ed/connectors/speed_parser.h
+++ b/source/ed/connectors/speed_parser.h
@@ -35,7 +35,7 @@ www.navitia.io
 namespace ed {
 namespace connectors {
 
-class SpeedsParser{
+class SpeedsParser {
     std::map<std::string, float> implicit_speeds;
     std::map<std::string, float> max_speeds_by_type;
     std::map<std::string, float> speed_factor_by_type;
@@ -45,4 +45,5 @@ public:
     boost::optional<float> get_speed(const std::string& highway, const boost::optional<std::string>& max_speed) const;
 };
 
-}}
+}  // namespace connectors
+}  // namespace ed

--- a/source/ed/connectors/speed_parser.h
+++ b/source/ed/connectors/speed_parser.h
@@ -41,7 +41,7 @@ class SpeedsParser {
     std::map<std::string, float> speed_factor_by_type;
 
 public:
-    SpeedsParser();
+    static SpeedsParser defaults();
     boost::optional<float> get_speed(const std::string& highway, const boost::optional<std::string>& max_speed) const;
 };
 

--- a/source/ed/connectors/speed_parser.h
+++ b/source/ed/connectors/speed_parser.h
@@ -39,6 +39,7 @@ class SpeedsParser {
     std::map<std::string, float> implicit_speeds;
     std::map<std::string, float> max_speeds_by_type;
     std::map<std::string, float> speed_factor_by_type;
+    float default_speed_factor = 0.5;
 
 public:
     static SpeedsParser defaults();

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -1193,7 +1193,6 @@ int osm2ed(int argc, const char** argv) {
         speed_parser = SpeedsParser::defaults();
     }
 
-
     boost::optional<std::string> cities_cnx = boost::none;
     if (vm.count("cities-connection-string")) {
         cities_cnx = {vm["cities-connection-string"].as<std::string>()};

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -424,9 +424,9 @@ void OSMCache::insert_edges() {
         return;
     }
 
-    this->lotus->prepare_bulk_insert("georef.edge", {"source_node_id", "target_node_id", "way_id", "the_geog",
-                                                     "pedestrian_allowed", "cycles_allowed", "cars_allowed", 
-                                                     "car_speed"});
+    this->lotus->prepare_bulk_insert("georef.edge",
+                                     {"source_node_id", "target_node_id", "way_id", "the_geog", "pedestrian_allowed",
+                                      "cycles_allowed", "cars_allowed", "car_speed"});
     nt::LineString coords;
     std::stringstream wkt;
     wkt.precision(10);
@@ -437,7 +437,7 @@ void OSMCache::insert_edges() {
         const auto ref_way_id = way.way_ref == nullptr ? way.osm_id : way.way_ref->osm_id;
 
         std::string speed = lotus->null_value;
-        if(way.car_speed){
+        if (way.car_speed) {
             speed = std::to_string(way.car_speed.get());
         }
         for (const auto& node : way.nodes) {
@@ -458,8 +458,7 @@ void OSMCache::insert_edges() {
                                      std::to_string(ref_way_id), wkt.str(),
                                      std::to_string(way.properties[OSMWay::FOOT_FWD]),
                                      std::to_string(way.properties[OSMWay::CYCLE_FWD]),
-                                     std::to_string(way.properties[OSMWay::CAR_FWD]),
-                                     speed});
+                                     std::to_string(way.properties[OSMWay::CAR_FWD]), speed});
                 // In most of the case we need the reversal,
                 // that'll be wrong for some in case in car
                 // We need to work on it
@@ -470,8 +469,7 @@ void OSMCache::insert_edges() {
                                      std::to_string(ref_way_id), wkt.str(),
                                      std::to_string(way.properties[OSMWay::FOOT_BWD]),
                                      std::to_string(way.properties[OSMWay::CYCLE_BWD]),
-                                     std::to_string(way.properties[OSMWay::CAR_BWD]),
-                                     speed});
+                                     std::to_string(way.properties[OSMWay::CAR_BWD]), speed});
                 prev_node = nodes.end();
                 n_inserted = n_inserted + 2;
             }
@@ -484,9 +482,9 @@ void OSMCache::insert_edges() {
         if ((n_inserted % max_n_inserted) == 0) {
             this->lotus->finish_bulk_insert();
             LOG4CPLUS_INFO(logger, n_inserted << " edges inserted");
-            this->lotus->prepare_bulk_insert("georef.edge", {"source_node_id", "target_node_id", "way_id", "the_geog",
-                                                             "pedestrian_allowed", "cycles_allowed", "cars_allowed",
-                                                             "car_speed"});
+            this->lotus->prepare_bulk_insert(
+                "georef.edge", {"source_node_id", "target_node_id", "way_id", "the_geog", "pedestrian_allowed",
+                                "cycles_allowed", "cars_allowed", "car_speed"});
         }
     }
     this->lotus->finish_bulk_insert();

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -327,7 +327,8 @@ struct ReadWaysVisitor {
     SpeedsParser speed_parser;
 
     ReadWaysVisitor(OSMCache& cache, const PoiTypeParams& poi_params) : cache(cache), poi_params(poi_params) {}
-    ReadWaysVisitor(OSMCache& cache, const PoiTypeParams& poi_params, const SpeedsParser& parser) : cache(cache), poi_params(poi_params), speed_parser(parser) {}
+    ReadWaysVisitor(OSMCache& cache, const PoiTypeParams& poi_params, const SpeedsParser& parser)
+        : cache(cache), poi_params(poi_params), speed_parser(parser) {}
     ~ReadWaysVisitor();
 
     void node_callback(uint64_t, double, double, const CanalTP::Tags&) {}

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -186,7 +186,10 @@ struct OSMWay {
     OSMWay(const u_int64_t osm_id) : osm_id(osm_id) {
         properties[VISIBLE] = true;  // By default way are visible
     }
-    OSMWay(const u_int64_t osm_id, const std::bitset<8>& properties, const std::string& name, boost::optional<float> car_speed=boost::none)
+    OSMWay(const u_int64_t osm_id,
+           const std::bitset<8>& properties,
+           const std::string& name,
+           boost::optional<float> car_speed = boost::none)
         : osm_id(osm_id), properties(properties), name(name), car_speed(car_speed) {}
 
     void add_node(std::set<OSMNode>::const_iterator node) const {

--- a/source/ed/osm2ed.h
+++ b/source/ed/osm2ed.h
@@ -327,6 +327,7 @@ struct ReadWaysVisitor {
     SpeedsParser speed_parser;
 
     ReadWaysVisitor(OSMCache& cache, const PoiTypeParams& poi_params) : cache(cache), poi_params(poi_params) {}
+    ReadWaysVisitor(OSMCache& cache, const PoiTypeParams& poi_params, const SpeedsParser& parser) : cache(cache), poi_params(poi_params), speed_parser(parser) {}
     ~ReadWaysVisitor();
 
     void node_callback(uint64_t, double, double, const CanalTP::Tags&) {}

--- a/source/ed/readme.md
+++ b/source/ed/readme.md
@@ -1,4 +1,4 @@
-# Various data import components
+#Various data import components
 
 As a reminder here is a simplified version of the architecture:
 

--- a/source/ed/tests/CMakeLists.txt
+++ b/source/ed/tests/CMakeLists.txt
@@ -55,3 +55,8 @@ ADD_BOOST_TEST(ed2nav_test)
 add_executable(route_main_destination_test route_main_destination_test.cpp)
 target_link_libraries(route_main_destination_test ed ${ED_TESTS_LINK_LIBS})
 ADD_BOOST_TEST(route_main_destination_test)
+
+
+add_executable(speed_parser_test speed_parser_test.cpp)
+target_link_libraries(speed_parser_test ${ED_TESTS_LINK_LIBS})
+ADD_BOOST_TEST(speed_parser_test)

--- a/source/ed/tests/speed_parser_test.cpp
+++ b/source/ed/tests/speed_parser_test.cpp
@@ -1,0 +1,63 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "boost/optional/optional.hpp"
+#include "ed/data.h"
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE test_speed_parser
+#include <boost/test/unit_test.hpp>
+#include "ed/connectors/speed_parser.h"
+#include "tests/utils_test.h"
+#include <boost/optional/optional_io.hpp>`
+struct logger_initialized {
+    logger_initialized() { navitia::init_logger(); }
+};
+BOOST_GLOBAL_FIXTURE(logger_initialized);
+
+BOOST_AUTO_TEST_CASE(empty_speed_parser_test) {
+    ed::connectors::SpeedsParser parser;
+    BOOST_CHECK_EQUAL(parser.get_speed("primary", boost::none), boost::none);
+    BOOST_CHECK_EQUAL(parser.get_speed("primary", boost::make_optional(std::string("50"))), boost::none);
+}
+
+BOOST_AUTO_TEST_CASE(france_speed_parser_test) {
+    auto parser = ed::connectors::SpeedsParser::defaults();
+    BOOST_CHECK_CLOSE(parser.get_speed("primary", boost::none).get(), 17.77, 0.1);
+    BOOST_CHECK_CLOSE(parser.get_speed("primary", boost::make_optional(std::string("50"))).get(), 11.11, 0.1);
+    BOOST_CHECK_CLOSE(parser.get_speed("primary", boost::make_optional(std::string("fr:urban"))).get(), 11.11, 0.1);
+
+    BOOST_CHECK_CLOSE(parser.get_speed("motorway", boost::none).get(), 32.5, 0.1);
+    BOOST_CHECK_CLOSE(parser.get_speed("motorway", boost::make_optional(std::string("70"))).get(), 17.5, 0.1);
+
+    // not existing highway
+    BOOST_CHECK_EQUAL(parser.get_speed("noway", boost::none), boost::none);
+    // no factor applied but we take the maxspeed into account
+    BOOST_CHECK_CLOSE(parser.get_speed("noway", boost::make_optional(std::string("70"))).get(), 19.44, 0.1);
+}

--- a/source/ed/tests/speed_parser_test.cpp
+++ b/source/ed/tests/speed_parser_test.cpp
@@ -58,6 +58,6 @@ BOOST_AUTO_TEST_CASE(france_speed_parser_test) {
 
     // not existing highway
     BOOST_CHECK_EQUAL(parser.get_speed("noway", boost::none), boost::none);
-    // no factor applied but we take the maxspeed into account
-    BOOST_CHECK_CLOSE(parser.get_speed("noway", boost::make_optional(std::string("70"))).get(), 19.44, 0.1);
+    // no factor applied but we take the maxspeed into account and applied default speed factor
+    BOOST_CHECK_CLOSE(parser.get_speed("noway", boost::make_optional(std::string("70"))).get(), 9.72, 0.1);
 }

--- a/source/sql/alembic/versions/844a9fa86ad2_add_car_speed_on_edges.py
+++ b/source/sql/alembic/versions/844a9fa86ad2_add_car_speed_on_edges.py
@@ -1,0 +1,25 @@
+"""add car speed on edges
+
+Revision ID: 844a9fa86ad2
+Revises: 25b7f3ace052
+Create Date: 2019-12-09 13:52:27.533052
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '844a9fa86ad2'
+down_revision = '25b7f3ace052'
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2 as ga
+
+
+def upgrade():
+    op.add_column('edge',
+        sa.Column('car_speed', sa.Float(), nullable=True),
+        schema='georef')
+
+
+def downgrade():
+    op.add_column('edge', 'car_speed', schema='georef')

--- a/source/sql/alembic/versions/844a9fa86ad2_add_car_speed_on_edges.py
+++ b/source/sql/alembic/versions/844a9fa86ad2_add_car_speed_on_edges.py
@@ -16,9 +16,7 @@ import geoalchemy2 as ga
 
 
 def upgrade():
-    op.add_column('edge',
-        sa.Column('car_speed', sa.Float(), nullable=True),
-        schema='georef')
+    op.add_column('edge', sa.Column('car_speed', sa.Float(), nullable=True), schema='georef')
 
 
 def downgrade():


### PR DESCRIPTION
This PR import car speed on every edges of the routing graph.
The tag `maxspeed` is used if present else a speed is chosen from the
highway type.
A factor is applied on max speed to get a somewhat realistic speed for
the edge.

Default value are valid for France and should be configurable if we want
to use it internationally. Rural zone vs urban zone isn't handled so
secondary and tertiary highway have a max speed of 50km/h everywhere if
not specified by a tag, primary are at 80km/h so sometime max speed is
higher than the legal value :/

TODO:
  - [x] add tests
  - [x] add flag to disable import
  - [x] format & rebase