### PR TITLE
[Ed2Nav] Add admins fetched from Cities db to Rtree for significant speed up.

### DIFF
--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -123,12 +123,18 @@ struct FindAdminWithCities {
         r["lon"] >> lon;
         r["lat"] >> lat;
         admin->coord = navitia::type::GeographicalCoord(lon, lat);
-        admin->idx = georef.admins.size() - 1;
+        admin->idx = georef.admins.size();
         admin->from_original_dataset = false;
         std::string post_codes = r["post_code"].c_str();
         boost::split(admin->postal_codes, post_codes, boost::is_any_of("-"));
         std::string boundary = r["boundary"].c_str();
         boost::geometry::read_wkt(boundary, admin->boundary);
+
+        // Add admins to added list
+        added_admins[admin->uri] = admin;
+        // Add admins to georef's admins list
+        georef.admins.push_back(admin);
+
         return admin;
     }
 
@@ -209,10 +215,6 @@ struct FindAdminWithCities {
 
         // Add admins to RTree cache
         boost::range::for_each(new_admins, add_admin_to_cache);
-        // Add admins to added list
-        boost::range::for_each(new_admins, [&](const auto& admin) { added_admins[admin->uri] = admin; });
-        // Add admins to georef's admins list
-        boost::range::copy(new_admins, std::back_inserter(georef.admins));
 
         return georef.find_admins(c, admin_tree);
     }

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -130,7 +130,7 @@ struct FindAdminWithCities {
     template <class Results>
     result_type get_admin_from_cities(const Results& db_result, georef::AdminRtree& admin_tree) {
         result_type res;
-        for (auto row : db_result) {
+        for (const auto& row : db_result) {
             georef::Admin* admin = nullptr;
             // we try to find the admin in georef by using it's insee code (only work in France)
             std::string insee = row["insee"].c_str();

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -34,6 +34,7 @@ www.navitia.io
 #include "type/type_interfaces.h"
 
 #include <boost/geometry/geometries/polygon.hpp>
+#include <boost/geometry/geometries/box.hpp>
 #include <RTree/RTree.h>
 
 #include <unordered_map>
@@ -45,6 +46,7 @@ namespace navitia {
 namespace georef {
 typedef boost::geometry::model::polygon<navitia::type::GeographicalCoord> polygon_type;
 typedef boost::geometry::model::multi_polygon<polygon_type> multi_polygon_type;
+typedef boost::geometry::model::box<navitia::type::GeographicalCoord> Box;
 
 struct Admin : nt::Header, nt::Nameable {
     const static type::Type_e type = type::Type_e::Admin;

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -198,6 +198,8 @@ struct ProjectionData;
 struct POI;
 struct POIType;
 
+std::vector<Admin*> search_admins(const type::GeographicalCoord& coord, AdminRtree& admins_tree);
+
 /** All you need about the street network */
 struct GeoRef {
     // parameters


### PR DESCRIPTION
Requesting Cities db is significantly slow (up to 200ms). We can't
afford to do this for all POI/stop points/stop areas that can possibly be loaded.

Adding Admins coming from Cities to the Rtree used for (GeoRef admins
lookup) significantly improves performances.

In the case of Furet coverage, ed2nav was taking up to 6h. With this
improvement, it takes now ~25 minutes.

-------
To be merged, this PR needs:
 - [x] https://github.com/CanalTP/utils/pull/93
 - [x] https://github.com/CanalTP/artemis_references/pull/210