### PR TITLE
[Fare] update fare engine to handle fare v2 to fare v1 conversion

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -626,7 +626,7 @@ void builder::add_ticket(const std::string& ticket_id,
 
     navitia::fare::Transition ticket_transition;
     navitia::fare::State ticket_state;
-    ticket_state.line = boost::algorithm::to_lower_copy(line);
+    ticket_state.line = line;
     ticket_transition.ticket_key = ticket_id;
 
     auto ticket_state_v = boost::add_vertex(ticket_state, data->fare->g);

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -31,6 +31,7 @@ www.navitia.io
 #include "fare_parser.h"
 #include "utils/csv.h"
 #include "utils/base64_encode.h"
+#include "utils/functions.h"
 #include "ed/data.h"
 #include "fare_utils.h"
 
@@ -114,13 +115,8 @@ void fare_parser::load_transitions() {
 
 bool fare_parser::is_valid(const navitia::fare::State& state) {
     if (!state.mode.empty()) {
-        bool found = false;
-        for (const auto& mode : data.physical_modes) {
-            if (mode->uri == state.mode) {
-                found = true;
-                break;
-            }
-        }
+        bool found =
+            navitia::contains_if(data.physical_modes, [&](const auto& mode) { return mode->uri == state.mode; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the mode "
                                        << state.mode << " but this mode does not appears in the data.");
@@ -129,13 +125,8 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
     }
 
     if (!state.stop_area.empty()) {
-        bool found = false;
-        for (const auto& stop_area : data.stop_areas) {
-            if (stop_area->uri == state.stop_area) {
-                found = true;
-                break;
-            }
-        }
+        bool found = navitia::contains_if(data.stop_areas,
+                                          [&](const auto& stop_area) { return stop_area->uri == state.stop_area; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the stop_area "
                                        << state.stop_area << " but this stop_area does not appears in the data.");
@@ -144,13 +135,7 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
     }
 
     if (!state.line.empty()) {
-        bool found = false;
-        for (const auto& line : data.lines) {
-            if (line->uri == state.line) {
-                found = true;
-                break;
-            }
-        }
+        bool found = navitia::contains_if(data.lines, [&](const auto& line) { return line->uri == state.line; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the line "
                                        << state.line << " but this line does not appears in the data.");
@@ -159,13 +144,8 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
     }
 
     if (!state.network.empty()) {
-        bool found = false;
-        for (const auto& network : data.networks) {
-            if (network->uri == state.network) {
-                found = true;
-                break;
-            }
-        }
+        bool found =
+            navitia::contains_if(data.networks, [&](const auto& network) { return network->uri == state.network; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the network "
                                        << state.network << " but this network does not appears in the data.");
@@ -174,13 +154,8 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
     }
 
     if (!state.zone.empty()) {
-        bool found = false;
-        for (const auto& stop_point : data.stop_points) {
-            if (stop_point->fare_zone == state.zone) {
-                found = true;
-                break;
-            }
-        }
+        bool found = navitia::contains_if(data.stop_points,
+                                          [&](const auto& stop_point) { return stop_point->fare_zone == state.zone; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the zone "
                                        << state.zone << " but this zone does not appears in the data.");
@@ -203,13 +178,8 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
     }
 
     if (condition.key == "zone") {
-        bool found = false;
-        for (const auto& stop_point : data.stop_points) {
-            if (stop_point->fare_zone == condition.value) {
-                found = true;
-                break;
-            }
-        }
+        bool found = navitia::contains_if(
+            data.stop_points, [&](const auto& stop_point) { return stop_point->fare_zone == condition.value; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition has a condition with the zone "
                                        << condition.value << " but this zone does not appears in the data.");
@@ -217,13 +187,8 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
         }
     }
     if (condition.key == "stoparea") {
-        bool found = false;
-        for (const auto& stop_area : data.stop_areas) {
-            if (stop_area->uri == condition.value) {
-                found = true;
-                break;
-            }
-        }
+        bool found = navitia::contains_if(data.stop_areas,
+                                          [&](const auto& stop_area) { return stop_area->uri == condition.value; });
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition has a condition with the stop_area "
                                        << condition.value << " but this stop_area does not appears in the data.");

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -207,7 +207,11 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
     }
     if (condition.key == "nb_changes") {
         try {
-            boost::lexical_cast<int>(condition.value);
+            int nb_changes = boost::lexical_cast<int>(condition.value);
+            if (nb_changes <= -1) {
+                LOG4CPLUS_WARN(logger, "A transition has a condition with a nb_changes equals to "
+                                           << condition.value << " which is <= -1 .");
+            }
         } catch (boost::bad_lexical_cast) {
             LOG4CPLUS_WARN(logger, "A transition has a condition with a nb_changes "
                                        << condition.value << " but this string is not parsable as an integer.");

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -206,6 +206,11 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
         }
     }
     if (condition.key == "nb_changes") {
+        if (condition.comparaison != navitia::fare::Comp_e::LT || condition.comparaison != navitia::fare::Comp_e::LTE) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition on nb_changes  which is not a < or <= condition. "
+                                       << condition.to_string());
+            return false;
+        }
         try {
             int nb_changes = boost::lexical_cast<int>(condition.value);
             if (nb_changes <= -1) {

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -172,7 +172,7 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
         return true;
     }
     if (condition.key != "zone" && condition.key != "stoparea" && condition.key != "duration"
-        && condition.key != "nb_changes" && condition.key != "ticket") {
+        && condition.key != "nb_changes" && condition.key != "ticket" && condition.key != "line") {
         LOG4CPLUS_WARN(logger, "A transition has a condition with an invalid key : \"" << condition.key << "\"");
         return false;
     }
@@ -222,7 +222,14 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
             return false;
         }
     }
-
+    if (condition.key == "line") {
+        bool found = navitia::contains_if(data.lines, [&](const auto& line) { return line->uri == condition.value; });
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition with the line "
+                                       << condition.value << " but this line does not appears in the data.");
+            return false;
+        }
+    }
     return true;
 }
 

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -171,9 +171,9 @@ bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
     if (condition.key.empty()) {
         return true;
     }
-    if (condition.key != "zone" || condition.key != "stoparea" || condition.key != "duration"
-        || condition.key != "nb_changes" || condition.key != "ticket") {
-        LOG4CPLUS_WARN(logger, "A transition has a condition with an invalid key " << condition.key);
+    if (condition.key != "zone" && condition.key != "stoparea" && condition.key != "duration"
+        && condition.key != "nb_changes" && condition.key != "ticket") {
+        LOG4CPLUS_WARN(logger, "A transition has a condition with an invalid key : \"" << condition.key << "\"");
         return false;
     }
 

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -135,8 +135,6 @@ void fare_parser::load_od() {
         }
         std::string start_saec = boost::algorithm::trim_copy(row[0]);
         std::string dest_saec = boost::algorithm::trim_copy(row[3]);
-        boost::algorithm::to_lower(start_saec, locale);
-        boost::algorithm::to_lower(dest_saec, locale);
         // col 1 and 4 are the human readable name of the start/end, and are not used
 
         std::string start_mode = boost::algorithm::trim_copy(row[2]);

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -69,12 +69,8 @@ void fare_parser::load_transitions() {
         fa::State start = parse_state(row.at(0));
         fa::State end = parse_state(row.at(1));
 
-        if (!is_valid(start)) {
-            continue;
-        }
-        if (!is_valid(end)) {
-            continue;
-        }
+        is_valid(start);
+        is_valid(end);
 
         fa::Transition transition;
         transition.start_conditions = parse_conditions(row.at(2));
@@ -127,8 +123,7 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
         }
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the mode "
-                                       << state.mode << " but this mode does not appears in the data."
-                                       << " I'll ignore this transition");
+                                       << state.mode << " but this mode does not appears in the data.");
             return false;
         }
     }
@@ -143,8 +138,7 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
         }
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the stop_area "
-                                       << state.stop_area << " but this stop_area does not appears in the data."
-                                       << " I'll ignore this transition");
+                                       << state.stop_area << " but this stop_area does not appears in the data.");
             return false;
         }
     }
@@ -159,8 +153,7 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
         }
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the line "
-                                       << state.line << " but this line does not appears in the data."
-                                       << " I'll ignore this transition");
+                                       << state.line << " but this line does not appears in the data.");
             return false;
         }
     }
@@ -175,8 +168,7 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
         }
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the network "
-                                       << state.network << " but this network does not appears in the data."
-                                       << " I'll ignore this transition");
+                                       << state.network << " but this network does not appears in the data.");
             return false;
         }
     }
@@ -191,8 +183,7 @@ bool fare_parser::is_valid(const navitia::fare::State& state) {
         }
         if (!found) {
             LOG4CPLUS_WARN(logger, "A transition is valid only for the zone "
-                                       << state.zone << " but this zone does not appears in the data."
-                                       << " I'll ignore this transition");
+                                       << state.zone << " but this zone does not appears in the data.");
             return false;
         }
     }

--- a/source/ed/connectors/fare_parser.cpp
+++ b/source/ed/connectors/fare_parser.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 
 #include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 
 namespace fa = navitia::fare;
 
@@ -68,6 +69,13 @@ void fare_parser::load_transitions() {
         fa::State start = parse_state(row.at(0));
         fa::State end = parse_state(row.at(1));
 
+        if (!is_valid(start)) {
+            continue;
+        }
+        if (!is_valid(end)) {
+            continue;
+        }
+
         fa::Transition transition;
         transition.start_conditions = parse_conditions(row.at(2));
         transition.end_conditions = parse_conditions(row.at(3));
@@ -90,6 +98,13 @@ void fare_parser::load_transitions() {
             continue;
         }
 
+        for (const navitia::fare::Condition& condition : transition.start_conditions) {
+            is_valid(condition);
+        }
+        for (const navitia::fare::Condition& condition : transition.end_conditions) {
+            is_valid(condition);
+        }
+
         data.transitions.push_back(std::make_tuple(start, end, transition));
 
         if (symetric) {
@@ -99,6 +114,160 @@ void fare_parser::load_transitions() {
             data.transitions.push_back(std::make_tuple(start, end, sym_transition));
         }
     }
+}
+
+bool fare_parser::is_valid(const navitia::fare::State& state) {
+    if (!state.mode.empty()) {
+        bool found = false;
+        for (const auto& mode : data.physical_modes) {
+            if (mode->uri == state.mode) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition is valid only for the mode "
+                                       << state.mode << " but this mode does not appears in the data."
+                                       << " I'll ignore this transition");
+            return false;
+        }
+    }
+
+    if (!state.stop_area.empty()) {
+        bool found = false;
+        for (const auto& stop_area : data.stop_areas) {
+            if (stop_area->uri == state.stop_area) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition is valid only for the stop_area "
+                                       << state.stop_area << " but this stop_area does not appears in the data."
+                                       << " I'll ignore this transition");
+            return false;
+        }
+    }
+
+    if (!state.line.empty()) {
+        bool found = false;
+        for (const auto& line : data.lines) {
+            if (line->uri == state.line) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition is valid only for the line "
+                                       << state.line << " but this line does not appears in the data."
+                                       << " I'll ignore this transition");
+            return false;
+        }
+    }
+
+    if (!state.network.empty()) {
+        bool found = false;
+        for (const auto& network : data.networks) {
+            if (network->uri == state.network) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition is valid only for the network "
+                                       << state.network << " but this network does not appears in the data."
+                                       << " I'll ignore this transition");
+            return false;
+        }
+    }
+
+    if (!state.zone.empty()) {
+        bool found = false;
+        for (const auto& stop_point : data.stop_points) {
+            if (stop_point->fare_zone == state.zone) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition is valid only for the zone "
+                                       << state.zone << " but this zone does not appears in the data."
+                                       << " I'll ignore this transition");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool fare_parser::is_valid(const navitia::fare::Condition& condition) {
+    // a condition with no key corresponds to an "always true" condition
+    if (condition.key.empty()) {
+        return true;
+    }
+    if (condition.key != "zone" || condition.key != "stoparea" || condition.key != "duration"
+        || condition.key != "nb_changes" || condition.key != "ticket") {
+        LOG4CPLUS_WARN(logger, "A transition has a condition with an invalid key " << condition.key);
+        return false;
+    }
+
+    if (condition.key == "zone") {
+        bool found = false;
+        for (const auto& stop_point : data.stop_points) {
+            if (stop_point->fare_zone == condition.value) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition with the zone "
+                                       << condition.value << " but this zone does not appears in the data.");
+            return false;
+        }
+    }
+    if (condition.key == "stoparea") {
+        bool found = false;
+        for (const auto& stop_area : data.stop_areas) {
+            if (stop_area->uri == condition.value) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition with the stop_area "
+                                       << condition.value << " but this stop_area does not appears in the data.");
+            return false;
+        }
+    }
+
+    if (condition.key == "duration") {
+        try {
+            boost::lexical_cast<int>(condition.value);
+        } catch (boost::bad_lexical_cast) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition with a duration "
+                                       << condition.value << " but this string is not parsable as an integer.");
+            return false;
+        }
+    }
+    if (condition.key == "nb_changes") {
+        try {
+            boost::lexical_cast<int>(condition.value);
+        } catch (boost::bad_lexical_cast) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition with a nb_changes "
+                                       << condition.value << " but this string is not parsable as an integer.");
+            return false;
+        }
+    }
+
+    if (condition.key == "ticket") {
+        if (data.fare_map.find(condition.value) == data.fare_map.end()) {
+            LOG4CPLUS_WARN(logger, "A transition has a condition with a ticket id "
+                                       << condition.value << " but this ticket id does not appear in data.");
+            return false;
+        }
+    }
+
+    return true;
 }
 
 void fare_parser::load_prices() {

--- a/source/ed/connectors/fare_parser.h
+++ b/source/ed/connectors/fare_parser.h
@@ -62,6 +62,9 @@ private:
 
     void load_od();
 
+    bool is_valid(const navitia::fare::State&);
+    bool is_valid(const navitia::fare::Condition&);
+
     log4cplus::Logger logger = log4cplus::Logger::getInstance("log");
 };
 

--- a/source/ed/connectors/fare_utils.cpp
+++ b/source/ed/connectors/fare_utils.cpp
@@ -64,8 +64,9 @@ navitia::fare::Condition parse_condition(const std::string& condition_str) {
     boost::algorithm::replace_all(str, " ", "");
     navitia::fare::Condition cond;
 
-    if (str.empty() || str == "true")
+    if (str.empty() || boost::algorithm::to_lower_copy(str) == "true") {
         return cond;
+    }
 
     // Match du texte : du alphanumérique et quelques chars spéciaux
     qi::rule<std::string::iterator, std::string()> txt = +(qi::alnum | qi::char_("_:-"));

--- a/source/ed/connectors/fare_utils.cpp
+++ b/source/ed/connectors/fare_utils.cpp
@@ -60,7 +60,7 @@ namespace qi = ::boost::spirit::qi;
 namespace ph = ::boost::phoenix;
 
 navitia::fare::Condition parse_condition(const std::string& condition_str) {
-    std::string str = boost::algorithm::to_lower_copy(condition_str);
+    std::string str(condition_str);
     boost::algorithm::replace_all(str, " ", "");
     navitia::fare::Condition cond;
 

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -1377,7 +1377,7 @@ void EdPersistor::insert_transitions(const ed::Data& data) {
             continue;
         }
 
-        LOG4CPLUS_INFO(logger, "transition : " << boost::algorithm::join(values, ";"));
+        LOG4CPLUS_TRACE(logger, "transition : " << boost::algorithm::join(values, ";"));
         this->lotus.insert(values);
     }
     this->lotus.finish_bulk_insert();

--- a/source/ed/tests/fare_parser_test.cpp
+++ b/source/ed/tests/fare_parser_test.cpp
@@ -51,7 +51,6 @@ BOOST_AUTO_TEST_CASE(parse_state_test) {
     BOOST_CHECK(parse_state("*") == state);
     BOOST_CHECK(parse_state("") == state);
 
-    // on n'est pas case sensitive
     BOOST_CHECK(parse_state("mode=metro").mode == navitia::encode_uri("metro"));
 
     BOOST_CHECK(parse_state("zone=1").zone == "1");

--- a/source/ed/tests/fare_parser_test.cpp
+++ b/source/ed/tests/fare_parser_test.cpp
@@ -58,6 +58,7 @@ BOOST_AUTO_TEST_CASE(parse_state_test) {
     // on ignore les espaces
     BOOST_CHECK(parse_state(" mode = metro  ").mode == navitia::encode_uri("metro"));
     BOOST_CHECK(parse_state("line=l1").line == navitia::encode_uri("l1"));
+    BOOST_CHECK(parse_state(" mode = Metro ").mode == navitia::encode_uri("Metro"));
     // parse_state("stop_area=chatelet").stop_area;
     std::cout << parse_state("stoparea=chatelet").stop_area << std::endl;
     std::cout << navitia::encode_uri("chatelet") << std::endl;

--- a/source/ed/tests/fare_parser_test.cpp
+++ b/source/ed/tests/fare_parser_test.cpp
@@ -52,13 +52,13 @@ BOOST_AUTO_TEST_CASE(parse_state_test) {
     BOOST_CHECK(parse_state("") == state);
 
     // on n'est pas case sensitive
-    BOOST_CHECK(parse_state("mode=Metro").mode == navitia::encode_uri("metro"));
+    BOOST_CHECK(parse_state("mode=metro").mode == navitia::encode_uri("metro"));
 
     BOOST_CHECK(parse_state("zone=1").zone == "1");
 
     // on ignore les espaces
-    BOOST_CHECK(parse_state(" mode = Metro  ").mode == navitia::encode_uri("metro"));
-    BOOST_CHECK(parse_state("line=L1").line == navitia::encode_uri("l1"));
+    BOOST_CHECK(parse_state(" mode = metro  ").mode == navitia::encode_uri("metro"));
+    BOOST_CHECK(parse_state("line=l1").line == navitia::encode_uri("l1"));
     // parse_state("stop_area=chatelet").stop_area;
     std::cout << parse_state("stoparea=chatelet").stop_area << std::endl;
     std::cout << navitia::encode_uri("chatelet") << std::endl;

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -223,8 +223,10 @@ results Fare::compute_fare(const routing::Path& path) const {
                                                             << ", mode=" << section_key.mode);
                             }
                         } else {
-                            LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
-                            new_labels[0].push_back(next);
+                            if (v != 0) {
+                                LOG4CPLUS_TRACE(logger, "Adding label to node 0 : \n" << next);
+                                new_labels[0].push_back(next);
+                            }
                         }
                         LOG4CPLUS_TRACE(logger, "Adding label to node " << v << " {" << g[v] << "} : \n" << next);
                         new_labels[v].push_back(next);

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -583,6 +583,23 @@ std::ostream& operator<<(std::ostream& ss, const Transition& k) {
             break;
     }
 
+    ss << "\n Start conditions : ";
+    for (const Condition& condition : k.start_conditions) {
+        ss << "\n   " << condition;
+    }
+    ss << "\n End conditions : ";
+    for (const Condition& condition : k.end_conditions) {
+        ss << "\n   " << condition;
+    }
+    ss << "\n";
+
+    return ss;
+}
+
+std::ostream& operator<<(std::ostream& ss, const Condition& condition) {
+    ss << condition.key << " " << comp_to_string(condition.comparaison) << " " << condition.value
+       << " ticket : " << condition.ticket;
+
     return ss;
 }
 

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -395,9 +395,10 @@ bool Transition::valid(const SectionKey& section, const Label& label) const {
 
             int current_nb_of_changes = label.nb_changes;
             int nb_of_changes_after_transition = current_nb_of_changes + 1;
-            // if the ticket key is not empty, it means we are punching a new ticket
+            // if the ticket_key is not empty, it means we are punching a new ticket
             // hence, after this transition, we will have made 0 changes with the last ticket
-            if (!this->ticket_key.empty()) {
+            // similarly, if label->tickets is empty, it means that we are punching a new ticket
+            if (!this->ticket_key.empty() || label.tickets.empty()) {
                 assert(current_nb_of_changes == 0);
                 nb_of_changes_after_transition = 0;
             }

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -385,12 +385,19 @@ bool Transition::valid(const SectionKey& section, const Label& label) const {
                 return false;
             }
         } else if (cond.key == "nb_changes") {
+            LOG4CPLUS_TRACE(logger, "nb changes " << cond.value << " vs " << label.nb_changes);
             auto nb_changes = boost::lexical_cast<int>(cond.value);
-            if (!compare(label.nb_changes, nb_changes, cond.comparaison)) {
+            // we are checking whether we can extend `label` using this Transition.
+            // for now, in the label, we have made `label.nb_changes` changes of public transport
+            // if this Transition is used to extend the label, we will have `label.nb_changes + 1`
+            // changes. So we must compare `cond.value` with `label.nb_changes + 1`
+            // and not `label.nb_changes`
+            if (!compare(label.nb_changes + 1, nb_changes, cond.comparaison)) {
                 return false;
             }
         } else if (cond.key == "ticket" && !label.tickets.empty()) {
-            LOG4CPLUS_TRACE(logger, "ticket " << cond.value << " vs " << label.tickets.back().key);
+            LOG4CPLUS_TRACE(logger, "ticket " << cond.value << " " << comp_to_string(cond.comparaison) << " "
+                                              << label.tickets.back().key);
 
             if (!compare(label.tickets.back().key, cond.value, cond.comparaison)) {
                 return false;

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -389,6 +389,10 @@ bool Transition::valid(const SectionKey& section, const Label& label) const {
             if (!compare(label.tickets.back().key, cond.value, cond.comparaison)) {
                 return false;
             }
+        } else if (cond.key == "line") {
+            if (!compare(section.line, cond.value, cond.comparaison)) {
+                return false;
+            }
         }
     }
     for (const Condition& cond : this->end_conditions) {

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -235,6 +235,8 @@ struct Condition {
     }
 };
 
+std::ostream& operator<<(std::ostream& ss, const Condition& k);
+
 /// Structure représentant une étiquette
 struct Label {
     Cost cost = 0;  //< Coût cummulé

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -75,14 +75,14 @@ BOOST_AUTO_TEST_CASE(test_protobuff) {
     // dummy transition
     fare::Transition transitionA;
     fare::State endA;
-    endA.line = "a";
+    endA.line = "A";
     transitionA.ticket_key = "price1";
     auto endA_v = boost::add_vertex(endA, b.data->fare->g);
     boost::add_edge(b.data->fare->begin_v, endA_v, transitionA, b.data->fare->g);
 
     fare::Transition transitionB;
     fare::State endB;
-    endB.line = "b";
+    endB.line = "B";
     transitionB.ticket_key = "price2";
     auto endB_v = boost::add_vertex(endB, b.data->fare->g);
     boost::add_edge(b.data->fare->begin_v, endB_v, transitionB, b.data->fare->g);

--- a/source/fare/tests/fare_test.cpp
+++ b/source/fare/tests/fare_test.cpp
@@ -183,6 +183,9 @@ struct fare_load_fixture {
                                            std::string(navitia::config::fixtures_dir) + "/fare/tarifs_od.csv");
         parser.load();
         f = load_fare_from_ed(parser.data);
+
+        // uncomment to activate logs in fare computation
+        // log4cplus::Logger::getInstance("fare").setLogLevel(log4cplus::TRACE_LOG_LEVEL);
     }
 
     std::vector<std::string> keys;

--- a/source/fare/tests/fare_test.cpp
+++ b/source/fare/tests/fare_test.cpp
@@ -81,9 +81,9 @@ static boost::gregorian::date parse_nav_date(const std::string& date_str) {
 static navitia::routing::Path string_to_path(const std::vector<std::string>& keys) {
     navitia::routing::Path p;
     for (const auto& key : keys) {
-        std::string lower_key = boost::algorithm::to_lower_copy(key);
+        std::string key_copy(key);
         std::vector<std::string> string_vec;
-        boost::algorithm::split(string_vec, lower_key, boost::algorithm::is_any_of(";"));
+        boost::algorithm::split(string_vec, key_copy, boost::algorithm::is_any_of(";"));
         if (string_vec.size() != 10)
             throw std::string("Nombre incorrect d'éléments dans une section :"
                               + boost::lexical_cast<std::string>(string_vec.size()) + " sur 10 attendus. " + key);
@@ -214,7 +214,7 @@ BOOST_FIXTURE_TEST_CASE(simple_journey, fare_load_fixture) {
     BOOST_CHECK_EQUAL(res.tickets.size(), 2);
 
     // Correspondance Tramwayway-bus autant qu'on veut
-    keys.push_back("Filbleu;FILURSE-2;FILNav31;FILGATO-2;2011|07|01;02|50;03|30;1;1;tramway");
+    keys.push_back("Filbleu;FILURSE-2;FILNav31;FILGATO-2;2011|07|01;02|50;03|30;1;1;Tramway");
     keys.push_back("Filbleu;FILURSE-2;FILNav31;FILGATO-2;2011|07|01;03|30;04|20;1;1;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 2);
@@ -377,9 +377,9 @@ BOOST_FIXTURE_TEST_CASE(natio_filgato, fare_load_fixture) {
     BOOST_CHECK_EQUAL(res.tickets.at(0).sections.size(), 3);
 
     keys.clear();
-    keys.push_back("5604:127;11:120;050050023:23;8727622;2011|07|31;09|28;09|39;4;4;Bus");
-    keys.push_back(";8727622;800:D;8775890;2011|07|31;09|47;10|09;4;1;RapidTransit");
-    keys.push_back(";8775860;100110007:7;R_0007;2011|07|31;10|20;10|21;1;1;Metro");
+    keys.push_back("5604:127;11:120;050050023:23;8727622;2011|07|31;09|28;09|39;4;4;bus");
+    keys.push_back(";8727622;800:D;8775890;2011|07|31;09|47;10|09;4;1;rapidtransit");
+    keys.push_back(";8775860;100110007:7;R_0007;2011|07|31;10|20;10|21;1;1;metro");
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 2);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -391,7 +391,7 @@ BOOST_FIXTURE_TEST_CASE(natio_filgato, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(rer_in_paris, fare_load_fixture) {
     // On prend le RER intramuros
     keys.clear();
-    keys.push_back(";8727141;RER B;8770870;2011|07|31;09|28;09|39;1;1;RapidTransit");  // Aulnay -> CDG "intramuros"
+    keys.push_back(";8727141;RER B;8770870;2011|07|31;09|28;09|39;1;1;rapidtransit");  // Aulnay -> CDG "intramuros"
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -400,16 +400,16 @@ BOOST_FIXTURE_TEST_CASE(rer_in_paris, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(tram_with_od, fare_load_fixture) {
     // 13/10/2011 : youpppiiii on peut prendre "parfois" le tramway avec un ticket O/D
     keys.clear();
-    keys.push_back(";8711388;800:T4;8727141;2011|07|31;09|28;09|39;4;4;tramway");      // L'abbaye -> Aulnay
-    keys.push_back(";8727141;RER B;8770870;2011|07|31;09|28;09|39;4;4;RapidTransit");  // Aulnay -> CDG
+    keys.push_back(";8711388;800:T4;8727141;2011|07|31;09|28;09|39;4;4;Tramway");      // L'abbaye -> Aulnay
+    keys.push_back(";8727141;RER B;8770870;2011|07|31;09|28;09|39;4;4;rapidtransit");  // Aulnay -> CDG
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 545);  // code 13 et 84 => 305 + 240
 
     keys.clear();
-    keys.push_back(";bled_paumé;bus_magique;8711388;2011|07|31;09|28;09|39;4;4;Bus");  // Bled Paumé -> L'Abbaye
-    keys.push_back(";8711388;800:T4;8727141;2011|07|31;09|40;09|50;4;4;tramway");      // L'abbaye -> Aulnay
-    keys.push_back(";8727141;RER B;8770870;2011|07|31;09|28;09|39;4;4;RapidTransit");  // Aulnay -> CDG
+    keys.push_back(";bled_paumé;bus_magique;8711388;2011|07|31;09|28;09|39;4;4;bus");  // Bled Paumé -> L'Abbaye
+    keys.push_back(";8711388;800:T4;8727141;2011|07|31;09|40;09|50;4;4;Tramway");      // L'abbaye -> Aulnay
+    keys.push_back(";8727141;RER B;8770870;2011|07|31;09|28;09|39;4;4;rapidtransit");  // Aulnay -> CDG
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 2);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -427,8 +427,8 @@ BOOST_FIXTURE_TEST_CASE(exclusive_line, fare_load_fixture) {
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 1150);  // Kof ! c'est cher la navette AF
 
     keys.clear();
-    keys.push_back(";bled_paumé;bus_magique;8711388;2011|07|31;09|28;09|39;4;4;Bus");  // Bled Paumé -> L'Abbaye
-    keys.push_back(";paris;098098001:1;areoport;2011|07|31;09|28;09|39;4;4;Bus");
+    keys.push_back(";bled_paumé;bus_magique;8711388;2011|07|31;09|28;09|39;4;4;bus");  // Bled Paumé -> L'Abbaye
+    keys.push_back(";paris;098098001:1;areoport;2011|07|31;09|28;09|39;4;4;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 2);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -438,9 +438,9 @@ BOOST_FIXTURE_TEST_CASE(exclusive_line, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(metro_rer_bus, fare_load_fixture) {
     // Metro-RER-Bus
     keys.clear();
-    keys.push_back("439;59465;100110008:8;8739303;2011|12|01;16|07;16|34;1;1;Metro");
-    keys.push_back("436;8739303;800:C;8739315;2011|12|01;16|41;17|12;1;4;RapidTransit");
-    keys.push_back("285;8739315;056356006:H;2:212;2011|12|01;17|17;17|19;4;4;Bus");
+    keys.push_back("439;59465;100110008:8;8739303;2011|12|01;16|07;16|34;1;1;metro");
+    keys.push_back("436;8739303;800:C;8739315;2011|12|01;16|41;17|12;1;4;rapidtransit");
+    keys.push_back("285;8739315;056356006:H;2:212;2011|12|01;17|17;17|19;4;4;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 2);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 320);
@@ -451,10 +451,10 @@ BOOST_FIXTURE_TEST_CASE(metro_rer_bus, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(stif_test_case_1, fare_load_fixture) {
     // Essais avec noctilien
     keys.clear();
-    keys.push_back("56;59557;100987785:N12;59452;2011|12|02;03|20;03|42;1;1;Bus");
-    keys.push_back("56;59452;100987762:N62;59:182428;2011|12|02;03|48;04|22;1;3;Bus");
-    keys.push_back("442;41:6487;100100195:195;59:153463;2011|12|02;05|14;05|20;3;3;Bus");
-    keys.push_back("442;59:153463;100100194:194;59:1055459;2011|12|02;05|28;05|31;3;3;Bus");
+    keys.push_back("56;59557;100987785:N12;59452;2011|12|02;03|20;03|42;1;1;bus");
+    keys.push_back("56;59452;100987762:N62;59:182428;2011|12|02;03|48;04|22;1;3;bus");
+    keys.push_back("442;41:6487;100100195:195;59:153463;2011|12|02;05|14;05|20;3;3;bus");
+    keys.push_back("442;59:153463;100100194:194;59:1055459;2011|12|02;05|28;05|31;3;3;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 3);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -465,11 +465,11 @@ BOOST_FIXTURE_TEST_CASE(stif_test_case_1, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(mode_than_90_after_billing, fare_load_fixture) {
     // Plus de 90min depuis le dernier compostage
     keys.clear();
-    keys.push_back("442;59362;100100068:68;59624;2011|12|05;10|52;11|08;1;2;Bus");
-    keys.push_back("442;59624;100100295:295;24:14919;2011|12|05;11|15;11|56;2;3;Bus");
-    keys.push_back("101;24:14919;039039307:307;24:14929;2011|12|05;12|01;12|15;3;4;Bus");
-    keys.push_back("285;8739300;056356102:BAK;8739315;2011|12|05;12|21;12|26;4;4;Bus");
-    keys.push_back("405;8739315;027027011:11;50:8168;2011|12|05;12|30;12|33;4;4;Bus");
+    keys.push_back("442;59362;100100068:68;59624;2011|12|05;10|52;11|08;1;2;bus");
+    keys.push_back("442;59624;100100295:295;24:14919;2011|12|05;11|15;11|56;2;3;bus");
+    keys.push_back("101;24:14919;039039307:307;24:14929;2011|12|05;12|01;12|15;3;4;bus");
+    keys.push_back("285;8739300;056356102:BAK;8739315;2011|12|05;12|21;12|26;4;4;bus");
+    keys.push_back("405;8739315;027027011:11;50:8168;2011|12|05;12|30;12|33;4;4;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 2);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -479,7 +479,7 @@ BOOST_FIXTURE_TEST_CASE(mode_than_90_after_billing, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(orlybus, fare_load_fixture) {
     // Orlybus
     keys.clear();
-    keys.push_back("442;8775863;100100283:ORLYBUS;59675;2011|12|05;05|35;05|56;1;4;Bus");
+    keys.push_back("442;8775863;100100283:ORLYBUS;59675;2011|12|05;05|35;05|56;1;4;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 690);
@@ -489,8 +489,8 @@ BOOST_FIXTURE_TEST_CASE(free_journey, fare_load_fixture) {
     // UN trajet qui coûtait 0 pour des raison obscures
     keys.clear();
     keys.push_back("440;59108;100112013:T3;59624;2011|12|05;11|43;11|45;1;1;Tramway");
-    keys.push_back("442;59624;100100028:28;59349;2011|12|05;11|56;12|09;1;1;Bus");
-    keys.push_back("442;59349;100100092:92;59:181763;2011|12|05;12|12;12|27;1;1;Bus");
+    keys.push_back("442;59624;100100028:28;59349;2011|12|05;11|56;12|09;1;1;bus");
+    keys.push_back("442;59349;100100092:92;59:181763;2011|12|05;12|12;12|27;1;1;bus");
     res = f.compute_fare(string_to_path(keys));
     BOOST_CHECK_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -500,8 +500,8 @@ BOOST_FIXTURE_TEST_CASE(mantis_sword_36393, fare_load_fixture) {
     // Ticket mantis sword 36393
     // Ressort deux ticket t+ au lieu d'un seul
     keys.clear();
-    keys.push_back("436;8768600;810:A;8775800;2011|12|13;09|49;09|57;1;1;RapidTransit");
-    keys.push_back("439;8775800;100110006:6;59455;2011|12|13;10|04;10|12;1;1;Metro");
+    keys.push_back("436;8768600;810:A;8775800;2011|12|13;09|49;09|57;1;1;rapidtransit");
+    keys.push_back("439;8775800;100110006:6;59455;2011|12|13;10|04;10|12;1;1;metro");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
@@ -510,24 +510,24 @@ BOOST_FIXTURE_TEST_CASE(mantis_sword_36393, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(stif_test_case_2, fare_load_fixture) {
     // Remonté par le stif, deux tickets au lieu d'un
     keys.clear();
-    keys.push_back("439;59500;100110009:9;59489;2011|12|13;10|17;10|23;1;1;Metro");
-    keys.push_back("437;8738400;800:J;8738107;2011|12|13;10|31;10|39;1;3;LocalTrain");
+    keys.push_back("439;59500;100110009:9;59489;2011|12|13;10|17;10|23;1;1;metro");
+    keys.push_back("437;8738400;800:J;8738107;2011|12|13;10|31;10|39;1;3;localtrain");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 245);
 
     keys.clear();
-    keys.push_back("437;8738287;800:L;8738221;2011|12|13;19|36;19|52;4;3;LocalTrain");
-    keys.push_back("439;59594;100110001:1;59250;2011|12|13;20|04;20|09;2;2;Metro");
+    keys.push_back("437;8738287;800:L;8738221;2011|12|13;19|36;19|52;4;3;localtrain");
+    keys.push_back("439;59594;100110001:1;59250;2011|12|13;20|04;20|09;2;2;metro");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 395);
 
     // Remonté par le stif, deux tickets au lieu d'un
     keys.clear();
-    keys.push_back("439;59591;100110001:1;59592;2012|01|03;11|13;11|17;1;1;Metro");
-    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;Metro");
-    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;LocalTrain");
+    keys.push_back("439;59591;100110001:1;59592;2012|01|03;11|13;11|17;1;1;metro");
+    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;metro");
+    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;localtrain");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 250);
@@ -542,7 +542,7 @@ BOOST_FIXTURE_TEST_CASE(mantis_sword_39517, fare_load_fixture) {
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 170);
 
     // on rajoute un bout de RER, on doit basculer vers un ticket OD
-    keys.push_back("436;8727141;810:B;8727148;2012|06|26;19|41;19|50;4;4;RapidTransit");
+    keys.push_back("436;8727141;810:B;8727148;2012|06|26;19|41;19|50;4;4;rapidtransit");
     res = f.compute_fare(string_to_path(keys));
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 1);
     BOOST_CHECK_EQUAL(res.tickets.at(0).value, 265);
@@ -562,9 +562,9 @@ BOOST_FIXTURE_TEST_CASE(mantis_sword_46044, fare_load_fixture) {
 BOOST_FIXTURE_TEST_CASE(journeys_with_unknown_section, fare_load_fixture) {
     // tests with unknown section in the middle
     keys.clear();
-    keys.push_back("439;59591;100110001:1;59592;2012|01|03;11|13;11|17;1;1;Metro");
-    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;Metro");
-    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;LocalTrain");
+    keys.push_back("439;59591;100110001:1;59592;2012|01|03;11|13;11|17;1;1;metro");
+    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;metro");
+    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;localtrain");
     keys.push_back("bob;morane;contre;tout;2011|07|01;02|06;02|10;1;1;chacal");  // unkown fare section
     res = f.compute_fare(string_to_path(keys));
     //    print_res(res);
@@ -575,8 +575,8 @@ BOOST_FIXTURE_TEST_CASE(journeys_with_unknown_section, fare_load_fixture) {
     keys.clear();
     keys.push_back("Filbleu;FILURSE-2;FILNav31;FILGATO-2;2011|07|01;02|06;02|10;1;1;metro");
     keys.push_back("bob;morane;contre;tout;2011|07|01;02|06;02|10;1;1;chacal");  // unkown fare section
-    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;Metro");
-    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;LocalTrain");
+    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;metro");
+    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;localtrain");
     res = f.compute_fare(string_to_path(keys));
     //    print_res(res);
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 3);
@@ -589,9 +589,9 @@ BOOST_FIXTURE_TEST_CASE(journeys_with_unknown_section, fare_load_fixture) {
     // tests with unknown section in the beginning
     keys.clear();
     keys.push_back("bob;morane;contre;tout;2011|07|01;02|06;02|10;1;1;chacal");  // unkown fare section
-    keys.push_back("439;59591;100110001:1;59592;2012|01|03;11|13;11|17;1;1;Metro");
-    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;Metro");
-    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;LocalTrain");
+    keys.push_back("439;59591;100110001:1;59592;2012|01|03;11|13;11|17;1;1;metro");
+    keys.push_back("439;59592;100110013:13;8739100;2012|01|03;11|23;11|30;1;1;metro");
+    keys.push_back("437;8739100;800:N;8739156;2012|01|03;11|35;11|42;1;2;localtrain");
     res = f.compute_fare(string_to_path(keys));
     //    print_res(res);
     BOOST_REQUIRE_EQUAL(res.tickets.size(), 2);

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -711,7 +711,13 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
     compute_most_serious_disruption(pb_journey, pb_creator);
 
     // fare computation, done at the end for the journey to be complete
+    auto before_fare = std::chrono::system_clock::now();
     auto fare = pb_creator.data->fare->compute_fare(path);
+    auto after_fare = std::chrono::system_clock::now();
+    LOG4CPLUS_DEBUG(
+        logger,
+        "Fare duration : " << std::chrono::duration_cast<std::chrono::milliseconds>(after_fare - before_fare).count());
+
     try {
         pb_creator.fill_fare_section(pb_journey, fare);
     } catch (const navitia::exception& e) {


### PR DESCRIPTION
Two updates to the fare engine :
- removed the lower casing of ids in fare transition (e.g. network=BlaBla is no longer equivalent to network=bLablA)
- accept "line=myLine" conditions for a fare transition

Needed to accept the conversion of fare v2 to fare v1 in https://github.com/CanalTP/transit_model/pull/509

https://jira.kisio.org/browse/NAVP-1465