### PR TITLE
kraken: Select when autocomplete needs rebuild during realtime process

### DIFF
--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -163,14 +163,11 @@ void MaintenanceWorker::handle_task_in_batch(const std::vector<AmqpClient::Envel
 }
 
 bool autocomplete_rebuilding_needed(const transit_realtime::FeedEntity& entity) {
-    if ((entity.trip_update().GetExtension(kirin::effect)
-         == transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE)
-        || (entity.trip_update().GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_DETOUR)
-        || (entity.trip_update().GetExtension(kirin::effect)
-            == transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE)) {
-        return true;
-    }
-    return false;
+    return ((entity.trip_update().GetExtension(kirin::effect)
+             == transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE)
+            || (entity.trip_update().GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_DETOUR)
+            || (entity.trip_update().GetExtension(kirin::effect)
+                == transit_realtime::Alert_Effect::Alert_Effect_MODIFIED_SERVICE));
 }
 
 void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelope::ptr_t>& envelopes) {


### PR DESCRIPTION
**Aim:** There is no need to rebuild Autocomplete in all case

The case list when it is needed with a realtime flow is :

- ADDITIONAL_SERVICE
- MODIFIED_SERVICE
- DETOUR

it represents about 10% of the overall CPUs load

**Artemis** is green with this change