### PR TITLE
[Jormun] Sort administration region by level

### DIFF
--- a/source/georef/adminref.cpp
+++ b/source/georef/adminref.cpp
@@ -35,6 +35,23 @@ www.navitia.io
 
 namespace navitia {
 namespace georef {
+
+Admin::Admin(idx_t idx,
+             const std::string& uri,
+             const std::string& name,
+             int level,
+             const std::string& insee,
+             const std::string& label,
+             const nt::GeographicalCoord& coord,
+             const Postal_codes& postal_codes)
+    : Header(idx, uri),
+      Nameable(name),
+      level(level),
+      insee(insee),
+      label(label),
+      coord(coord),
+      postal_codes(postal_codes) {}
+
 std::string Admin::get_range_postal_codes() {
     std::string post_code;
     // the label is the range of the postcode

--- a/source/georef/adminref.h
+++ b/source/georef/adminref.h
@@ -50,6 +50,7 @@ typedef boost::geometry::model::box<navitia::type::GeographicalCoord> Box;
 
 struct Admin : nt::Header, nt::Nameable {
     const static type::Type_e type = type::Type_e::Admin;
+    using Postal_codes = std::vector<std::string>;
     /**
       http://wiki.openstreetmap.org/wiki/Key:admin_level#admin_level
       Level = 2  : Pays
@@ -75,10 +76,18 @@ struct Admin : nt::Header, nt::Nameable {
 
     // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1
     std::vector<const nt::StopPoint*> odt_stop_points;  // zone odt stop points for the admin
-    std::vector<std::string> postal_codes;
+    Postal_codes postal_codes;
 
     Admin() : level(-1) {}
     Admin(int lev) : level(lev) {}
+    Admin(idx_t idx,
+          const std::string& uri,
+          const std::string& name,
+          int level,
+          const std::string& insee,
+          const std::string& label,
+          const nt::GeographicalCoord& coord,
+          const Postal_codes& postal_codes);
     std::string get_range_postal_codes();
     std::string postal_codes_to_string() const;
     template <class Archive>

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -210,6 +210,26 @@ class PbGenericSerializer(PbNestedSerializer):
     name = jsonschema.Field(schema_type=str, display_none=True, description='Name of the object')
 
 
+class SortedGenericSerializer(object):
+    '''
+    Sorted generic serializer can be used to sort a iterable container according to a specific key.
+
+    The derived class needs to implement `sort_key(self, o)`, a function used to extract the comparison key (as the `key` argument from https://docs.python.org/3.3/library/functions.html#sorted)
+
+    Implementation is based on 'serpy.Serializer.to_value' - https://serpy.readthedocs.io/en/latest/_modules/serpy/serializer.html#Serializer.to_value
+    '''
+
+    def to_value(self, obj):
+        fields = self._compiled_fields
+        serialize = self._serialize
+
+        if self.many == False:
+            return serialize(obj, fields)
+
+        serialized_objs = (serialize(o, fields) for o in obj)
+        return sorted(serialized_objs, key=self.sort_key)
+
+
 class AmountSerializer(PbNestedSerializer):
     value = jsonschema.Field(schema_type=float)
     unit = jsonschema.Field(schema_type=str)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -32,6 +32,7 @@ from jormungandr.interfaces.v1.serializer import jsonschema
 import serpy
 import six
 import operator
+import abc
 from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field
 
 
@@ -210,7 +211,7 @@ class PbGenericSerializer(PbNestedSerializer):
     name = jsonschema.Field(schema_type=str, display_none=True, description='Name of the object')
 
 
-class SortedGenericSerializer(object):
+class SortedGenericSerializer(serpy.Serializer):
     '''
     Sorted generic serializer can be used to sort a iterable container according to a specific key.
 
@@ -218,6 +219,10 @@ class SortedGenericSerializer(object):
 
     Implementation is based on 'serpy.Serializer.to_value' - https://serpy.readthedocs.io/en/latest/_modules/serpy/serializer.html#Serializer.to_value
     '''
+
+    @abc.abstractmethod
+    def sort_key(self):
+        raise NotImplementedError
 
     def to_value(self, obj):
         fields = self._compiled_fields

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -30,7 +30,12 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 import serpy
 
-from jormungandr.interfaces.v1.serializer.base import PbGenericSerializer, EnumListField, LiteralField
+from jormungandr.interfaces.v1.serializer.base import (
+    PbGenericSerializer,
+    EnumListField,
+    LiteralField,
+    SortedGenericSerializer,
+)
 from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field, DateType
 from jormungandr.interfaces.v1.serializer.time import TimeField, PeriodSerializer, DateTimeField
 from jormungandr.interfaces.v1.serializer.fields import *
@@ -309,12 +314,15 @@ class CarParkSerializer(PbNestedSerializer):
     total_places = jsonschema.IntField()
 
 
-class AdminSerializer(PbGenericSerializer):
+class AdminSerializer(SortedGenericSerializer, PbGenericSerializer):
     level = jsonschema.Field(schema_type=int)
     zip_code = jsonschema.Field(schema_type=str, display_none=True)
     label = jsonschema.Field(schema_type=str)
     insee = jsonschema.Field(schema_type=str)
     coord = CoordSerializer(required=False)
+
+    def sort_key(self, obj):
+        return obj["level"]
 
 
 class AddressSerializer(PbGenericSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/test/serializer_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/serializer_tests.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2001-2020, Kisio and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from jormungandr.interfaces.v1.serializer.base import SortedGenericSerializer
+import pytest
+import serpy
+
+
+def test_sorted_generic_serializer():
+    class SortSerializer(SortedGenericSerializer, serpy.DictSerializer):
+        v = serpy.IntField()
+
+        def sort_key(self, obj):
+            return obj
+
+    objs = [{'v': '2'}, {'v': '4'}, {'v': '3'}, {'v': '1'}]
+    data = SortSerializer(objs, many=True).data
+    assert data[0]['v'] == 1
+    assert data[1]['v'] == 2
+    assert data[2]['v'] == 3
+    assert data[3]['v'] == 4

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -296,3 +296,16 @@ class TestPlaces(AbstractTestFixture):
         places = response['places']
         assert len(places) == 1
         assert 'distance' not in places[0]
+
+
+@dataset({"basic_routing_test": {}})
+class TestAdministrativesRegions(AbstractTestFixture):
+    def test_administrative_regions_are_ordered_by_level(self):
+        """
+        In kraken's data, administrative regions aren't sorted.
+        At serialization time, we should order them by level ascending
+        """
+        response = self.query_region("stop_areas/A")
+        admins = response['stop_areas'][0]['administrative_regions']
+        levels = [admin['level'] for admin in admins]
+        assert levels[0] < levels[1] < levels[2]

--- a/source/tests/mock-kraken/basic_routing_test.cpp
+++ b/source/tests/mock-kraken/basic_routing_test.cpp
@@ -150,29 +150,21 @@ int main(int argc, const char* const argv[]) {
     sp->is_zonal = true;
     b.data->pt_data->stop_points_by_area.insert(area_2, sp);
 
-    b.data->geo_ref->admins.push_back(new navitia::georef::Admin());
-    auto admin = b.data->geo_ref->admins.back();
-    admin->uri = "admin:93700";
-    admin->name = "Drancy";
-    admin->insee = "93700";
-    admin->level = 8;
-    admin->postal_codes.push_back("93700");
-    admin->coord = {12, 12};
-    admin->idx = 0;
+    auto drancy = new navitia::georef::Admin(0, "admin:93700", "Drancy", 8, "93700", "Drancy", {12, 12}, {"93700"});
+    auto paris = new navitia::georef::Admin(1, "admin:75000", "Paris", 8, "75000", "Paris", {22, 22}, {"75000"});
+    auto paris12 =
+        new navitia::georef::Admin(2, "admin:75012", "Paris 12em", 9, "75012", "Paris 12", {23, 23}, {"75012"});
+    auto aligre =
+        new navitia::georef::Admin(3, "admin:75012", "Aligre market", 10, "75012", "Aligre", {23, 23}, {"75012"});
 
-    b.data->geo_ref->admins.push_back(new navitia::georef::Admin());
-    admin = b.data->geo_ref->admins.back();
-    admin->uri = "admin:75000";
-    admin->name = "Paris";
-    admin->insee = "75000";
-    admin->level = 8;
-    admin->postal_codes.push_back("75012");
-    admin->coord = {22, 22};
-    admin->idx = 1;
-
+    b.data->geo_ref->admins.assign({drancy, paris, paris12, aligre});
     b.data->complete();
     b.manage_admin();
     b.make();
+
+    auto stop_area_A = b.data->pt_data->stop_areas[0];
+    // we willingly add cities in the wrong order of level to make sure they'll get sorted
+    stop_area_A->admin_list.assign({aligre, paris, paris12});
 
     mock_kraken kraken(b, argc, argv);
     return 0;

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -100,6 +100,9 @@ enum class OdtLevel_e { scheduled = 0, with_stops = 1, zonal = 2, all = 3 };
 struct Nameable {
     std::string name;
     bool visible = true;
+
+    Nameable() = default;
+    Nameable(const std::string name) : name(name) {}
 };
 
 struct PT_Data;
@@ -118,6 +121,9 @@ inline Indexes make_indexes(std::initializer_list<idx_t> l) {
 struct Header {
     idx_t idx = invalid_idx;  // Index of the object in the main structure
     std::string uri;          // unique indentifier of the object
+
+    Header() = default;
+    Header(idx_t idx, const std::string& uri) : idx(idx), uri(uri) {}
     Indexes get(Type_e, const PT_Data&) const { return Indexes{}; }
 };
 

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -102,7 +102,7 @@ struct Nameable {
     bool visible = true;
 
     Nameable() = default;
-    Nameable(const std::string name) : name(name) {}
+    Nameable(const std::string& name) : name(name) {}
 };
 
 struct PT_Data;


### PR DESCRIPTION
We have recently broken the interface by changing the order of which administration regions get returned, like in :
```
{
  "administrative_regions": [
    {  
      "id": "admin:osm:relation:1773820",
      "level": 10,
      "name": "Wazemmes",
      [...]
    },
    {
      "id": "admin:fr:59350",
      "level": 8,
      "name": "Lille (59000-59800)",
      [...]
    },
    {
      "id": "admin:fr:95354",
      "level": 9,
      "name": "Lille",
      [...]
    }
]
```

In order not to break the previous implementation, we need to sort the admin regions by `level`.
This is achieve by implementing the `SortedGenericSerializer` interface.

:warning:  I broke it down by commits to make it easier to read :)

todo:
 - [x] Run Artemis - https://ci.navitia.io/job/custom_Artemis/27/ :ok_hand: 