### PR TITLE
[Jormungandr] Remove keep_alive http session in geocodejson

### DIFF
--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -185,11 +185,7 @@ class GeocodeJson(AbstractAutocomplete):
             fail_max=app.config['CIRCUIT_BREAKER_MAX_BRAGI_FAIL'],
             reset_timeout=app.config['CIRCUIT_BREAKER_BRAGI_TIMEOUT_S'],
         )
-        # create a session to allow connection pooling via keep alive
-        if kwargs.get('disable_keepalive', False):
-            self.session = requests
-        else:
-            self.session = requests.Session()
+        self.session = requests
 
     def call_bragi(self, url, method, **kwargs):
         try:


### PR DESCRIPTION
https://jira.kisio.org/browse/ND-638

the keep_alive http session seems to emit some nonsense `FIN/ACK` to Bragi. These `FIN/ACK` are not attached to any session and are treated by Firewall as Non-Sync TCP which impact the performance...

We've tried deactivation of keep_alive on a jormungandr machine, it seems that it worked, non more random `FIN/ACK` is emitted by jormungandr