### PR TITLE
CI: build navitia packages on github actions

### DIFF
--- a/.github/workflows/build_navitia_packages.yml
+++ b/.github/workflows/build_navitia_packages.yml
@@ -1,0 +1,36 @@
+name: Build Navitia Packages
+
+on:
+  push:
+    branches:
+      - dev
+      - release
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: navitia/debian8_dev
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: dkpg-buildpackage
+      run: |
+        sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
+        git submodule update --init --recursive
+        DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b
+    - name: install zip dependency
+      run: apt update && apt install -y zip
+    - name: create navitia_debian_packages.zip
+      run: |
+        zip navitia_debian_packages.zip ../navitia-*
+        echo "::set-env name=NAVITIA_DEBIAN_PACKAGES::navitia_debian_packages.zip"
+    - name: upload debian packages
+      uses: actions/upload-artifact@v1
+      with:
+        name: navitia-debian-packages
+        path: "${{env.NAVITIA_DEBIAN_PACKAGES}}"
+    - name: remove useless temporary files
+      run: rm -rf ../navitia-*


### PR DESCRIPTION
Actions :
- Build **navitia**
- Create debian packages **.deb** and compress them inside a unique ### **.zip**
- Allow downloading
- Side quest : try to resurrect **mergify**

**Note**:
Setting up var env with an `echo` is an hack inside the **official doc** :
https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-environment-variable-set-env

**Todo**: 
- [X] Set up the artifact