### PR TITLE
[CI] Fix unresolved dependency on protobuf-files for Thermometer

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,11 +24,10 @@ jobs:
 
 
   build:
+    runs-on: ubuntu-latest
+
     container:
       image: navitia/debian8_dev
-
-    # tests
-    runs-on: ubuntu-latest
 
     services:
       rabbitmq:
@@ -43,12 +42,11 @@ jobs:
         sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
         git submodule update --init --recursive
     - name: Install dependencies
-      run: |
-        pip install -r source/jormungandr/requirements_dev.txt
+      run: pip install -r source/jormungandr/requirements_dev.txt
     - name: configure
       run: cmake source
     - name: make
-      run:  make protobuf_files && make -j $(nproc)
+      run:  make -j $(nproc)
     - name: tests
       run: |
         export JORMUNGANDR_BROKER_URL='amqp://guest:guest@rabbitmq:5672//'

--- a/source/time_tables/thermometer.cpp
+++ b/source/time_tables/thermometer.cpp
@@ -30,9 +30,10 @@ www.navitia.io
 
 #include "thermometer.h"
 
-#include "ptreferential/ptreferential.h"
 #include "type/route.h"
 #include "type/stop_point.h"
+#include "type/stop_time.h"
+#include "type/vehicle_journey.h"
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/topological_sort.hpp>

--- a/source/time_tables/thermometer.h
+++ b/source/time_tables/thermometer.h
@@ -29,7 +29,8 @@ www.navitia.io
 */
 
 #pragma once
-#include "type/data.h"
+#include "type/fwd_type.h"
+#include "type/type_interfaces.h"
 
 #include <boost/functional/hash.hpp>
 namespace navitia {


### PR DESCRIPTION
Because `thermometer` target was relying on `type/data.h`, a missing
dependency on `protobuf_files` was failing the build if `make
protobuf_files` wasn't executed first (see. https://github.com/CanalTP/navitia/blob/dev/.github/workflows/workflow.yml#L51).

This change removes `type/data.h` along with the unresolved dependency
to simplify the build process.

`make` is now all you need.