### PR TITLE
Ed: Parse postal_code in osm

### DIFF
--- a/source/ed/connectors/osm_tags_reader.cpp
+++ b/source/ed/connectors/osm_tags_reader.cpp
@@ -324,5 +324,17 @@ const RuleOsmTag2PoiType* PoiTypeParams::get_applicable_poi_rule(const CanalTP::
     return nullptr;
 }
 
+const std::string get_postal_code_from_tags(const CanalTP::Tags& tags) {
+    if (tags.find("addr:postcode") != tags.end()) {
+        return tags.at("addr:postcode");
+    }
+
+    if (tags.find("postal_code") != tags.end()) {
+        return tags.at("postal_code");
+    }
+
+    return std::string();
+}
+
 }  // namespace connectors
 }  // namespace ed

--- a/source/ed/connectors/osm_tags_reader.h
+++ b/source/ed/connectors/osm_tags_reader.h
@@ -72,5 +72,7 @@ struct PoiTypeParams {
     const RuleOsmTag2PoiType* get_applicable_poi_rule(const CanalTP::Tags& tags) const;
 };
 
+const std::string get_postal_code_from_tags(const CanalTP::Tags& tags);
+
 }  // namespace connectors
 }  // namespace ed

--- a/source/ed/osm2ed.cpp
+++ b/source/ed/osm2ed.cpp
@@ -69,7 +69,7 @@ void ReadRelationsVisitor::relation_callback(uint64_t osm_id,
     const auto tmp_admin_level = tags.find("admin_level");
     const auto boundary = tags.find("boundary");
 
-    std::string insee, postal_code, name;
+    std::string insee, name;
     if (!use_cities && tmp_admin_level != tags.end() && boundary != tags.end()
         && boundary->second == "administrative") {
         // we consider only admin boundaries with level 8, 9 or 10
@@ -115,9 +115,7 @@ void ReadRelationsVisitor::relation_callback(uint64_t osm_id,
         if (tags.find("name") != tags.end()) {
             name = tags.at("name");
         }
-        if (tags.find("addr:postcode") != tags.end()) {
-            postal_code = tags.at("addr:postcode");
-        }
+        const auto postal_code = get_postal_code_from_tags(tags);
 
         std::string uri;
         if (insee.empty()) {

--- a/source/ed/tests/osm_tags_reader_test.cpp
+++ b/source/ed/tests/osm_tags_reader_test.cpp
@@ -274,3 +274,16 @@ BOOST_AUTO_TEST_CASE(highway_cycleway_visible) {
     std::bitset<8> res = ed::connectors::parse_way_tags({{"highway", "cycleway"}});
     BOOST_CHECK_EQUAL(res[ed::connectors::VISIBLE], true);
 }
+
+BOOST_AUTO_TEST_CASE(get_postal_code_from_tags_test) {
+    BOOST_CHECK_EQUAL(ed::connectors::get_postal_code_from_tags({{"tag1", "plop"}, {"tag2", "plopi"}}), std::string());
+
+    BOOST_CHECK_EQUAL(ed::connectors::get_postal_code_from_tags({{"tag1", "plop"}, {"addr:postcode", "42"}}),
+                      std::string("42"));
+
+    BOOST_CHECK_EQUAL(ed::connectors::get_postal_code_from_tags({{"tag1", "plop"}, {"postal_code", "67"}}),
+                      std::string("67"));
+
+    BOOST_CHECK_EQUAL(ed::connectors::get_postal_code_from_tags({{"addr:postcode", "23"}, {"postal_code", "168"}}),
+                      std::string("23"));
+}


### PR DESCRIPTION
https://jira.kisio.org/browse/NAVITIAII-3033

In osm, for postal codes we have two codes : `addr:postcode` and `postal_code`.

We only parsed `addr:postcode` but now, if `addr:postcode` does not exist and `postal_code` exists, we use it.