### PR TITLE
Cmake: add cmake options for stripping binaries and bypassing tests compilation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DH_VERBOSE = 1
 	dh $@  --with python2 --sourcedirectory=source --builddirectory=build_package --parallel --max-parallel=4
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release
+	dh_auto_configure -- -DCMAKE_BUILD_TYPE=Release -DSKIP_TESTS=ON
 
 override_dh_auto_build:
 	dh_auto_build -- -j4

--- a/install.rst
+++ b/install.rst
@@ -58,6 +58,11 @@ We hope you got the source code from git.
    Note: it will build in release mode. If you want to compile it with debug symbols run
    ``cmake -DCMAKE_BUILD_TYPE=Debug ../source``
 
+   list of options
+
+   * SKIP_TESTS=ON : Compile without the test parts
+   * STRIP_SYMBOLS=ON : Strip symbols within all code (Active -s option)
+
 #. Compile
 
    ``make -j4``

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -70,11 +70,15 @@ add_subdirectory(tyr)
 add_subdirectory(sql)
 add_subdirectory(disruption)
 add_subdirectory(calendar)
-add_subdirectory(tests)
 add_subdirectory(scripts)
 add_subdirectory(cities)
 add_subdirectory(tools)
 add_subdirectory(equipment)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)
 
 include(CheckIncludeFiles)
 include(CheckIncludeFileCXX)

--- a/source/autocomplete/CMakeLists.txt
+++ b/source/autocomplete/CMakeLists.txt
@@ -3,6 +3,9 @@ add_library(autocomplete autocomplete.cpp autocomplete_api.cpp utils.cpp)
 target_link_libraries(autocomplete pb_lib)
 add_dependencies(autocomplete protobuf_files)
 
-add_executable(autocomplete_test tests/test.cpp tests/test_utils.cpp)
-target_link_libraries(autocomplete_test autocomplete ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_REGEX_LIBRARY})
-ADD_BOOST_TEST(autocomplete_test)
+# Add tests
+if(NOT SKIP_TESTS)
+    add_executable(autocomplete_test tests/test.cpp tests/test_utils.cpp)
+    target_link_libraries(autocomplete_test autocomplete ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_REGEX_LIBRARY})
+    ADD_BOOST_TEST(autocomplete_test)
+endif(NOT SKIP_TESTS)

--- a/source/calendar/CMakeLists.txt
+++ b/source/calendar/CMakeLists.txt
@@ -3,4 +3,8 @@ SET(CALENDAR_SRC
     calendar.cpp
 )
 add_library(calendar_api ${CALENDAR_SRC})
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/cmake_modules/CompilationFlags.cmake
+++ b/source/cmake_modules/CompilationFlags.cmake
@@ -6,10 +6,20 @@ else("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(x86_|amd)64$")
 endif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "^(x86_|amd)64$")
 
 # Release by default
-IF(NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
     #https://cmake.org/pipermail/cmake/2009-June/030311.html
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel." FORCE)
-ENDIF(NOT CMAKE_BUILD_TYPE)
+    message("-- By default, Build type is Release")
+else(NOT CMAKE_BUILD_TYPE)
+    message("-- Build type : ${CMAKE_BUILD_TYPE}")
+endif(NOT CMAKE_BUILD_TYPE)
+
+# compile tests flag
+if(NOT SKIP_TESTS)
+    message("-- Tests compilation actived")
+else(NOT SKIP_TESTS)
+    message("-- Tests compilation deactived")
+endif(NOT SKIP_TESTS)
 
 # Gcc Release flags
 if(CMAKE_COMPILER_IS_GNUCXX)
@@ -51,6 +61,13 @@ endif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 # Debug flags
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG=1")
+
+# Strip symbols
+if(STRIP_SYMBOLS)
+    message("-- Strip symbols actived")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+endif(STRIP_SYMBOLS)
 
 set(NAVITIA_ALLOCATOR "tcmalloc")
 

--- a/source/disruption/CMakeLists.txt
+++ b/source/disruption/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(disruption_api traffic_reports_api.cpp line_reports_api.cpp)
 target_link_libraries(disruption_api pb_lib)
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/ed/CMakeLists.txt
+++ b/source/ed/CMakeLists.txt
@@ -38,9 +38,6 @@ target_link_libraries(ed2nav_lib connectors types)
 add_executable(ed2nav ed2nav_main.cpp)
 target_link_libraries(ed2nav ed2nav_lib ${ED_LINK_LIBS})
 
-add_subdirectory(tests)
-add_subdirectory(connectors)
-
 add_executable(geopal2ed geopal2ed.cpp)
 target_link_libraries(geopal2ed transportation_data_import ${ED_LINK_LIBS})
 
@@ -52,6 +49,11 @@ target_link_libraries(synonym2ed transportation_data_import ${ED_LINK_LIBS})
 
 set(ED_TARGETS_TO_INSTALL gtfs2ed osm2ed ed2nav fusio2ed fare2ed geopal2ed poi2ed synonym2ed)
 install(TARGETS ${ED_TARGETS_TO_INSTALL} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)
+add_subdirectory(connectors)
 
 add_custom_target(ed_executables DEPENDS ${ED_TARGETS_TO_INSTALL})
 

--- a/source/equipment/CMakeLists.txt
+++ b/source/equipment/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_library(equipment_api equipment_api.cpp)
 target_link_libraries(equipment_api pb_lib)
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/fare/CMakeLists.txt
+++ b/source/fare/CMakeLists.txt
@@ -5,4 +5,8 @@ SET(FARE_SRC
 
 add_library(fare ${FARE_SRC})
 target_link_libraries(fare routing pb_lib)
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/georef/CMakeLists.txt
+++ b/source/georef/CMakeLists.txt
@@ -15,4 +15,8 @@ SET(GEOREF_SRC
 
 add_library(georef ${GEOREF_SRC})
 target_link_libraries(georef proximitylist )
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -35,4 +35,8 @@ target_link_libraries(kraken workers ${NAVITIA_ALLOCATOR} ${Boost_THREAD_LIBRARY
 add_dependencies(kraken protobuf_files)
 
 install(TARGETS kraken DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/lz4_filter/CMakeLists.txt
+++ b/source/lz4_filter/CMakeLists.txt
@@ -1,1 +1,4 @@
-add_subdirectory(tests)
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/proximity_list/CMakeLists.txt
+++ b/source/proximity_list/CMakeLists.txt
@@ -7,4 +7,8 @@ add_library(proximitylist
 )
 add_dependencies(proximitylist protobuf_files)
 target_link_libraries(proximitylist types utils)
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/ptreferential/CMakeLists.txt
+++ b/source/ptreferential/CMakeLists.txt
@@ -6,4 +6,8 @@ SET(PTREF_SRC
   ptref_graph.cpp)
 add_library(ptreferential ${PTREF_SRC})
 target_link_libraries(ptreferential pb_converter data)
-add_subdirectory(tests)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/routing/CMakeLists.txt
+++ b/source/routing/CMakeLists.txt
@@ -17,4 +17,7 @@ target_link_libraries(benchmark_raptor_cache boost_program_options data profiler
 add_executable(benchmark_full benchmark_full.cpp)
 target_link_libraries(benchmark_full boost_program_options data)
 
-add_subdirectory(tests)
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/time_tables/CMakeLists.txt
+++ b/source/time_tables/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(thermometer thermometer.cpp)
 SET(TIME_TABLES_SRC passages.cpp route_schedules.cpp departure_boards.cpp request_handle.cpp)
 add_library(time_tables ${TIME_TABLES_SRC})
 target_link_libraries(time_tables routing thermometer)
-add_subdirectory(tests)
 
-
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -127,62 +127,7 @@ target_link_libraries(data
     ${Boost_SYSTEM_LIBRARY}
 )
 
-# >>>>> Tests <<<<<
-set(TYPES_TEST_LINK_LIBS
-    ed
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-)
-
-add_executable(fill_pb_placemark_test tests/fill_pb_placemark_test.cpp)
-target_link_libraries(fill_pb_placemark_test
-    data
-    routing
-    thermometer
-    pb_converter
-    ${TYPES_TEST_LINK_LIBS}
-)
-ADD_BOOST_TEST(fill_pb_placemark_test)
-
-add_executable(type_test tests/test.cpp)
-target_link_libraries(type_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(type_test)
-
-add_executable(datetime_test tests/datetime.cpp)
-target_link_libraries(datetime_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(datetime_test)
-
-add_executable(accessible_test tests/accessible.cpp)
-target_link_libraries(accessible_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(accessible_test)
-
-add_executable(multi_polygon_map_test tests/multi_polygon_map_test.cpp)
-target_link_libraries(multi_polygon_map_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(multi_polygon_map_test)
-
-add_executable(fill_pb_object_tests tests/fill_pb_object_tests.cpp)
-target_link_libraries(fill_pb_object_tests pb_converter ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(fill_pb_object_tests)
-
-add_executable(aggregation_odt_test tests/aggregation_odt_test.cpp)
-target_link_libraries(aggregation_odt_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(aggregation_odt_test)
-
-add_executable(comments_test tests/comments_test.cpp)
-target_link_libraries(comments_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(comments_test)
-
-add_executable(data_test tests/data_test.cpp)
-target_link_libraries(data_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(data_test)
-
-add_executable(code_container_test tests/code_container_test.cpp)
-target_link_libraries(code_container_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(code_container_test)
-
-add_executable(headsign_test tests/headsign_test.cpp)
-target_link_libraries(headsign_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(headsign_test)
-
-add_executable(create_vj_test tests/create_vj_test.cpp)
-target_link_libraries(create_vj_test ${TYPES_TEST_LINK_LIBS})
-ADD_BOOST_TEST(create_vj_test)
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/type/tests/CMakeLists.txt
+++ b/source/type/tests/CMakeLists.txt
@@ -1,0 +1,58 @@
+set(TYPES_TEST_LINK_LIBS
+    ed
+    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
+)
+
+add_executable(fill_pb_placemark_test fill_pb_placemark_test.cpp)
+target_link_libraries(fill_pb_placemark_test
+    data
+    routing
+    thermometer
+    pb_converter
+    ${TYPES_TEST_LINK_LIBS}
+)
+ADD_BOOST_TEST(fill_pb_placemark_test)
+
+add_executable(type_test test.cpp)
+target_link_libraries(type_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(type_test)
+
+add_executable(datetime_test datetime.cpp)
+target_link_libraries(datetime_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(datetime_test)
+
+add_executable(accessible_test accessible.cpp)
+target_link_libraries(accessible_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(accessible_test)
+
+add_executable(multi_polygon_map_test multi_polygon_map_test.cpp)
+target_link_libraries(multi_polygon_map_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(multi_polygon_map_test)
+
+add_executable(fill_pb_object_tests fill_pb_object_tests.cpp)
+target_link_libraries(fill_pb_object_tests pb_converter ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(fill_pb_object_tests)
+
+add_executable(aggregation_odt_test aggregation_odt_test.cpp)
+target_link_libraries(aggregation_odt_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(aggregation_odt_test)
+
+add_executable(comments_test comments_test.cpp)
+target_link_libraries(comments_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(comments_test)
+
+add_executable(data_test data_test.cpp)
+target_link_libraries(data_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(data_test)
+
+add_executable(code_container_test code_container_test.cpp)
+target_link_libraries(code_container_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(code_container_test)
+
+add_executable(headsign_test headsign_test.cpp)
+target_link_libraries(headsign_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(headsign_test)
+
+add_executable(create_vj_test create_vj_test.cpp)
+target_link_libraries(create_vj_test ${TYPES_TEST_LINK_LIBS})
+ADD_BOOST_TEST(create_vj_test)

--- a/source/vptranslator/CMakeLists.txt
+++ b/source/vptranslator/CMakeLists.txt
@@ -4,7 +4,9 @@ SET(vptranslator_src
 add_library(vptranslator ${vptranslator_src})
 target_link_libraries(vptranslator types)
 
-add_executable (vptranslator_test test.cpp)
-target_link_libraries(vptranslator_test types ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
-ADD_BOOST_TEST(vptranslator_test)
-
+# Add tests
+if(NOT SKIP_TESTS)
+    add_executable (vptranslator_test test.cpp)
+    target_link_libraries(vptranslator_test types ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+    ADD_BOOST_TEST(vptranslator_test)
+endif(NOT SKIP_TESTS)


### PR DESCRIPTION
For a **CI** goal
- **Bypass tests** : We need it to create build package with a low space disk fingerprint. Currently, the creation of the package takes about **20Go**. Without tests, wich are useless, we go down to 
**3.8Go**. 
**This is activate by default in the debian rules**
- **Stripping**: Potentialy usefull for the build_and_tests workflow. If the space is not enough, we can strip symbols to save space. without striping binaries + tests take 20Go. With the strip action, the size is about **4Go**

**Options** :
```
# Skipping tests
cmake -DSKIP_TESTS=ON sources

# Stripping symbols
cmake -DSTRIP_SYMBOLS=ON sources

```
Options are cumulative