### PR TITLE
ed: way of type tunnel can be visible

### DIFF
--- a/source/ed/connectors/osm_tags_reader.cpp
+++ b/source/ed/connectors/osm_tags_reader.cpp
@@ -329,8 +329,8 @@ std::bitset<8> parse_way_tags(const std::map<std::string, std::string>& tags) {
         std::transform(key.begin(), key.end(), key.begin(), ::tolower);
         std::transform(val.begin(), val.end(), val.begin(), ::tolower);
 
-        // We do not want to autocomplete on public transport objects and tunnels
-        if (key == "public_transport" || key == "tunnel") {
+        // We do not want to autocomplete on public transport objects
+        if (key == "public_transport") {
             set_visible_false();
         }
 


### PR DESCRIPTION
* This PR is the correction of the BUG on way of type tunnel after merging  https://github.com/CanalTP/navitia/pull/3120

* As we take the property (tunnel) of the only way among all the other way "cours lafayette", the final aggregated way "cours lafayette" is not visible in autocomplete kraken.

* The test on "tunnel" can be done in future if needed but with some tests.
  
* Ticket: https://jira.kisio.org/browse/NAVITIAII-3041