### PR TITLE
[Mergify] We already have a rule that says we are good to go after 2 approvals.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,6 @@ pull_request_rules:
   - name: automatic merge when CI passes and 2 reviews
     conditions:
       - "#approved-reviews-by>=2"
-      - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
       - "#commented-reviews-by=0"
       - status-success~=build


### PR DESCRIPTION
This rules will not merge if there is still a pending review, even though you already have 2 approvals.
This is a impediment to our flow, let's remove it !