### PR TITLE
CI: split build navitia debian package for release and dev

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -1,10 +1,9 @@
-name: Build Navitia Packages
+name: Build Navitia Packages for dev
 
 on:
   push:
     branches:
       - dev
-      - release
 
 
 jobs:

--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -1,4 +1,4 @@
-name: Build Navitia Packages for dev
+name: Build Navitia Packages For Dev
 
 on:
   push:

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -1,0 +1,35 @@
+name: Build Navitia Packages for release
+
+on:
+  push:
+    branches:
+      - release
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    container:
+      image: navitia/debian8_dev
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: dkpg-buildpackage
+      run: |
+        sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
+        git submodule update --init --recursive
+        DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b
+    - name: install zip dependency
+      run: apt update && apt install -y zip httpie
+    - name: create navitia_debian_packages.zip
+      run: |
+        zip navitia_debian_packages.zip ../navitia-*
+        echo "::set-env name=NAVITIA_DEBIAN_PACKAGES::navitia_debian_packages.zip"
+    - name: upload debian packages
+      uses: actions/upload-artifact@v1
+      with:
+        name: navitia-debian-packages
+        path: "${{env.NAVITIA_DEBIAN_PACKAGES}}"
+    - name: remove useless temporary files
+      run: rm -rf ../navitia-*

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -1,4 +1,4 @@
-name: Build Navitia Packages for release
+name: Build Navitia Packages For Release
 
 on:
   push:


### PR DESCRIPTION
we need to split the _build navitia package workflow_ because of **artifacts**.
The last success artifacts have to be not the same for dev platform and release platform !
It is more confortable to retreive only the good concerned artifacts if we use 2 separated workflows.

For the moment, we don’t use release packages. It is for a near future