### PR TITLE
Add end point terminus schedules

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -149,7 +149,8 @@ class add_computed_resources(object):
                 collection in ['stop_areas', 'stop_points', 'lines', 'routes', 'addresses']
                 and "region" in kwargs
             ):
-                for api in ['route_schedules', 'stop_schedules', 'arrivals', 'departures', "places_nearby"]:
+                for api in ['route_schedules', 'stop_schedules', 'arrivals', 'departures', "places_nearby",
+                            "terminus_schedules"]:
                     data['links'].append(
                         {"href": url_for("v1." + api, **kwargs), "rel": api, "type": api, "templated": templated}
                     )

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -149,8 +149,14 @@ class add_computed_resources(object):
                 collection in ['stop_areas', 'stop_points', 'lines', 'routes', 'addresses']
                 and "region" in kwargs
             ):
-                for api in ['route_schedules', 'stop_schedules', 'arrivals', 'departures', "places_nearby",
-                            "terminus_schedules"]:
+                for api in [
+                    'route_schedules',
+                    'stop_schedules',
+                    'arrivals',
+                    'departures',
+                    "places_nearby",
+                    "terminus_schedules",
+                ]:
                     data['links'].append(
                         {"href": url_for("v1." + api, **kwargs), "rel": api, "type": api, "templated": templated}
                     )

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -291,6 +291,13 @@ class StopSchedules(Schedules):
         )
 
 
+class TerminusSchedules(Schedules):
+    def __init__(self):
+        super(TerminusSchedules, self).__init__(
+            "terminus_schedules", output_type_serializer=api.TerminusSchedulesSerializer
+        )
+
+
 class add_passages_links:
     """
     delete disruption links and put the disruptions directly in the owner objets

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -186,7 +186,7 @@ class add_coverage_link(generate_links):
             "arrivals": "stop_areas/{stop_areas.id}",
             "stop_schedules": "stop_areas/{stop_areas.id}",
             "route_schedules": "lines/{lines.id}",
-            "terminus_schedules": "stop_areas/{stop_areas.id}"
+            "terminus_schedules": "stop_areas/{stop_areas.id}",
         }
 
     def __call__(self, f):

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -186,6 +186,7 @@ class add_coverage_link(generate_links):
             "arrivals": "stop_areas/{stop_areas.id}",
             "stop_schedules": "stop_areas/{stop_areas.id}",
             "route_schedules": "lines/{lines.id}",
+            "terminus_schedules": "stop_areas/{stop_areas.id}"
         }
 
     def __call__(self, f):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -342,6 +342,10 @@ class StopSchedulesSerializer(SchedulesSerializer):
     stop_schedules = schedule.StopScheduleSerializer(many=True, display_none=True)
 
 
+class TerminusSchedulesSerializer(SchedulesSerializer):
+    terminus_schedules = schedule.TerminusScheduleSerializer(many=True, display_none=True)
+
+
 class RouteSchedulesSerializer(SchedulesSerializer):
     route_schedules = schedule.RouteScheduleSerializer(many=True, display_none=True)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/schedule.py
@@ -100,6 +100,20 @@ class StopScheduleSerializer(PbNestedSerializer):
         return _get_links(obj)
 
 
+class TerminusScheduleSerializer(PbNestedSerializer):
+    stop_point = pt.StopPointSerializer()
+    route = pt.RouteSerializer()
+    additional_informations = EnumField(attr="response_status", display_none=True)
+    display_informations = pt.RouteDisplayInformationSerializer(attr='pt_display_informations')
+    date_times = DateTimeTypeSerializer(many=True, display_none=True)
+    links = jsonschema.MethodField(schema_type=LinkSchema(many=True))
+    first_datetime = DateTimeTypeSerializer(display_none=False)
+    last_datetime = DateTimeTypeSerializer(display_none=False)
+
+    def get_links(self, obj):
+        return _get_links(obj)
+
+
 class RowSerializer(PbNestedSerializer):
     stop_point = pt.StopPointSerializer()
     date_times = DateTimeTypeSerializer(many=True, display_none=True)

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -296,4 +296,12 @@ class V1Routing(AModule):
             endpoint="calendars",
         )
 
+        self.add_resource(
+            Schedules.TerminusSchedules,
+            region + '<uri:uri>/terminus_schedules',
+            coord + '<uri:uri>/terminus_schedules',
+            '/terminus_schedules',
+            endpoint='terminus_schedules',
+        )
+
         self.add_resource(JSONSchema.Schema, '/schema', endpoint="schema")

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -204,6 +204,9 @@ class Scenario(object):
     def departure_boards(self, request, instance):
         return instance.schedule.departure_boards(request)
 
+    def terminus_schedules(self, request, instance):
+        return instance.schedule.terminus_schedules(request)
+
     def places_nearby(self, request, instance):
         req = request_pb2.Request()
         req.requested_api = type_pb2.places_nearby

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -341,6 +341,9 @@ class MixedSchedule(object):
 
         return resp
 
+    def terminus_schedules(self, request):
+        return self.__stop_times(request, api=type_pb2.terminus_schedules, departure_filter=request["filter"])
+
     def departure_boards(self, request):
         resp = self.__stop_times(request, api=type_pb2.DEPARTURE_BOARDS, departure_filter=request["filter"])
 

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -150,7 +150,8 @@ def get_real_notes(obj, full_response):
 def is_valid_terminus_schedule(terminus_schedule, tester, only_time=False):
     is_valid_stop_point(get_not_null(terminus_schedule, "stop_point"), depth_check=2)
     is_valid_route(get_not_null(terminus_schedule, "route"), depth_check=2)
-
+    if len(terminus_schedule.get('date_times', [])) == 0:
+        return
     datetimes = get_not_null(terminus_schedule, "date_times")
     assert len(datetimes) != 0, "we have to have date_times"
     for dt_wrapper in datetimes:
@@ -406,6 +407,7 @@ class TestDepartureBoard(AbstractTestFixture):
         is_valid_notes(response["notes"])
         assert "terminus_schedules" in response
         assert len(response["terminus_schedules"]) == 1
+        is_valid_terminus_schedules(response["terminus_schedules"], self.tester, only_time=False)
         assert response["terminus_schedules"][0]["additional_informations"] == "no_departure_this_day"
         assert response["terminus_schedules"][0]["route"]["id"] == "A:1"
         assert len(response["terminus_schedules"][0]["date_times"]) == 0
@@ -424,10 +426,10 @@ class TestDepartureBoard(AbstractTestFixture):
 
     def test_terminus_schedules_on_terminus(self):
         """
-        No terminus_schedules on terminus
+        No terminus_schedules on terminus 'Tstop3' as there is no route/vj of return.
         """
         response = self.query_region("stop_areas/Tstop3/terminus_schedules?" "from_datetime=20120615T080000")
-
+        is_valid_terminus_schedules(response["terminus_schedules"], self.tester, only_time=False)
         is_valid_notes(response["notes"])
         assert "terminus_schedules" in response
         assert len(response["terminus_schedules"]) == 0
@@ -449,7 +451,7 @@ class TestDepartureBoard(AbstractTestFixture):
         same as stop_schedules
         """
         response = self.query_region("stop_areas/Tstop1/terminus_schedules?" "from_datetime=20120620T080000")
-
+        is_valid_terminus_schedules(response["terminus_schedules"], self.tester, only_time=False)
         is_valid_notes(response["notes"])
         assert "terminus_schedules" in response
         assert len(response["terminus_schedules"]) == 1
@@ -680,9 +682,7 @@ class TestDepartureBoard(AbstractTestFixture):
         is_valid_notes(response["notes"])
         assert "terminus_schedules" in response
         assert len(response["terminus_schedules"]) == 1
-
         is_valid_terminus_schedules(response["terminus_schedules"], self.tester, only_time=False)
-
         assert len(response["terminus_schedules"][0]["date_times"]) == 2
         assert response["terminus_schedules"][0]["stop_point"]["name"] == "ODTstop1"
         assert response["terminus_schedules"][0]["route"]["name"] == "B"

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -351,7 +351,6 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["stop_schedules"][0]["date_times"][0]["links"][0]["value"] == "vehicle_journey:vj2"
 
         # Stop_schedules in TStop2: Partial Terminus
-
         response = self.query_region(
             "stop_areas/Tstop1/stop_schedules?" "from_datetime=20120615T080000&calendar=cal_partial_terminus"
         )
@@ -398,6 +397,20 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["stop_schedules"][0]["date_times"][1]["date_time"] == "20120615T103000"
         assert response["stop_schedules"][0]["stop_point"]["id"] == "StopR2"
 
+        # terminus_schedules on partial_terminus with calendar
+        # There is neither terminus nor partial_terminus in terminus_schedules
+        response = self.query_region(
+            "stop_areas/Tstop2/terminus_schedules?" "from_datetime=20120615T080000&calendar=cal_partial_terminus"
+        )
+
+        is_valid_notes(response["notes"])
+        assert "terminus_schedules" in response
+        assert len(response["terminus_schedules"]) == 1
+        assert response["terminus_schedules"][0]["additional_informations"] == "no_departure_this_day"
+        assert response["terminus_schedules"][0]["route"]["id"] == "A:1"
+        assert len(response["terminus_schedules"][0]["date_times"]) == 0
+        assert response["terminus_schedules"][0]["stop_point"]["id"] == "Tstop2"
+
     def test_real_terminus(self):
         """
         Real Terminus
@@ -409,6 +422,16 @@ class TestDepartureBoard(AbstractTestFixture):
         assert len(response["stop_schedules"]) == 1
         assert response["stop_schedules"][0]["additional_informations"] == "terminus"
 
+    def test_terminus_schedules_on_terminus(self):
+        """
+        No terminus_schedules on terminus
+        """
+        response = self.query_region("stop_areas/Tstop3/terminus_schedules?" "from_datetime=20120615T080000")
+
+        is_valid_notes(response["notes"])
+        assert "terminus_schedules" in response
+        assert len(response["terminus_schedules"]) == 0
+
     def test_no_departure_this_day(self):
         """
         no departure for this day : 20120620T080000
@@ -419,6 +442,19 @@ class TestDepartureBoard(AbstractTestFixture):
         assert "stop_schedules" in response
         assert len(response["stop_schedules"]) == 1
         assert response["stop_schedules"][0]["additional_informations"] == "no_departure_this_day"
+
+    def test_terminus_schedules_on_no_departure_this_day(self):
+        """
+        no departure for this day : 20120620T080000
+        same as stop_schedules
+        """
+        response = self.query_region("stop_areas/Tstop1/terminus_schedules?" "from_datetime=20120620T080000")
+
+        is_valid_notes(response["notes"])
+        assert "terminus_schedules" in response
+        assert len(response["terminus_schedules"]) == 1
+        assert response["terminus_schedules"][0]["additional_informations"] == "no_departure_this_day"
+        assert len(response["terminus_schedules"][0]["date_times"]) == 0
 
     def test_routes_schedule(self):
         """

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -249,6 +249,7 @@ static bool get_geojson_state(const pbnavitia::Request& request) {
         case pbnavitia::NEXT_DEPARTURES:
         case pbnavitia::NEXT_ARRIVALS:
         case pbnavitia::DEPARTURE_BOARDS:
+        case pbnavitia::terminus_schedules:
             result = request.next_stop_times().disable_geojson();
             break;
         case pbnavitia::PTREFERENTIAL:
@@ -471,6 +472,14 @@ void Worker::next_stop_times(const pbnavitia::NextStopTimeRequest& request, pbna
                     forbidden_uri, from_datetime, request.duration(), request.items_per_schedule(), request.depth(),
                     request.count(), request.start_page(), rt_level);
                 break;
+             case pbnavitia::terminus_schedules:
+                timetables::terminus_schedules(
+                    this->pb_creator, request.departure_filter(),
+                    request.has_calendar() ? boost::optional<const std::string>(request.calendar())
+                                           : boost::optional<const std::string>(),
+                            forbidden_uri, from_datetime, request.duration(), request.depth(), request.count(),
+                            request.start_page(), request.items_per_schedule());
+                        break;
             default:
                 LOG4CPLUS_WARN(logger, "Unknown timetable query");
                 pb_creator.fill_pb_error(pbnavitia::Error::unknown_api, "Unknown time table api");
@@ -1056,6 +1065,7 @@ void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {
         case pbnavitia::NEXT_DEPARTURES:
         case pbnavitia::NEXT_ARRIVALS:
         case pbnavitia::DEPARTURE_BOARDS:
+        case pbnavitia::terminus_schedules:
             next_stop_times(request.next_stop_times(), request.requested_api());
             break;
         case pbnavitia::NMPLANNER:

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -472,14 +472,14 @@ void Worker::next_stop_times(const pbnavitia::NextStopTimeRequest& request, pbna
                     forbidden_uri, from_datetime, request.duration(), request.items_per_schedule(), request.depth(),
                     request.count(), request.start_page(), rt_level);
                 break;
-             case pbnavitia::terminus_schedules:
-                timetables::terminus_schedules(
-                    this->pb_creator, request.departure_filter(),
-                    request.has_calendar() ? boost::optional<const std::string>(request.calendar())
-                                           : boost::optional<const std::string>(),
-                            forbidden_uri, from_datetime, request.duration(), request.depth(), request.count(),
-                            request.start_page(), request.items_per_schedule());
-                        break;
+            case pbnavitia::terminus_schedules:
+                timetables::terminus_schedules(this->pb_creator, request.departure_filter(),
+                                               request.has_calendar()
+                                                   ? boost::optional<const std::string>(request.calendar())
+                                                   : boost::optional<const std::string>(),
+                                               forbidden_uri, from_datetime, request.duration(), request.depth(),
+                                               request.count(), request.start_page(), request.items_per_schedule());
+                break;
             default:
                 LOG4CPLUS_WARN(logger, "Unknown timetable query");
                 pb_creator.fill_pb_error(pbnavitia::Error::unknown_api, "Unknown time table api");

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -41,6 +41,7 @@ namespace type {
 struct StopPoint;
 struct StopTime;
 struct Route;
+struct Line;
 struct VehicleJourney;
 struct MetaVehicleJourney;
 struct PhysicalMode;
@@ -54,6 +55,7 @@ using JppIdx = Idx<JourneyPatternPoint>;
 using JpIdx = Idx<JourneyPattern>;
 using SpIdx = Idx<type::StopPoint>;
 using RouteIdx = Idx<type::Route>;
+using LineIdx = Idx<type::Line>;
 using VjIdx = Idx<type::VehicleJourney>;
 using MvjIdx = Idx<type::MetaVehicleJourney>;
 using PhyModeIdx = Idx<type::PhysicalMode>;

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -140,6 +140,90 @@ static void render(PbCreator& pb_creator,
     }
 }
 
+static void render(PbCreator& pb_creator,
+                   const std::map<routing::JppIdx, pbnavitia::ResponseStatus>& response_status,
+                   const std::map<routing::JppIdx, vector_dt_st>& map_route_stop_point,
+                   const std::map<routing::JppIdx, first_and_last_stop_time>& map_route_point_first_last_st,
+                   const DateTime datetime,
+                   const DateTime max_datetime,
+                   const boost::optional<const std::string> calendar_id,
+                   const uint32_t depth) {
+    pb_creator.action_period =
+        pt::time_period(to_posix_time(datetime, *pb_creator.data), to_posix_time(max_datetime, *pb_creator.data));
+
+    for (const auto& id_vec : map_route_stop_point) {
+        auto schedule = pb_creator.add_terminus_schedules();
+        // Each schedule has a stop_point and a route
+        const auto& jpp_dir = pb_creator.data->dataRaptor->jp_container.get(id_vec.first);
+        const auto& jp_dir = pb_creator.data->dataRaptor->jp_container.get(jpp_dir.jp_idx);
+        const type::Route* route = pb_creator.data->pt_data->routes[jp_dir.route_idx.val];
+        const type::StopPoint* stop_point = pb_creator.data->pt_data->stop_points[jpp_dir.sp_idx.val];
+        pb_creator.fill(stop_point, schedule->mutable_stop_point(), depth);
+
+        auto m_route = schedule->mutable_route();
+
+        pb_creator.fill(route, m_route, depth);
+        if (route->line != nullptr) {
+            auto m_line = m_route->mutable_line();
+            pb_creator.fill(route->line, m_line, 0);
+        }
+        auto pt_display_information = schedule->mutable_pt_display_informations();
+
+        pb_creator.fill(route, pt_display_information, 0);
+
+        // add informations for debug. TODO : clean that
+        const auto& jpc = pb_creator.data->dataRaptor->jp_container;
+        pt_display_information->set_direction(
+            pb_creator.data->pt_data->stop_points[jpc.get(jp_dir.jpps.back()).sp_idx.val]->stop_area->name);
+        pt_display_information->set_description(std::string("JP = ") + std::to_string(jpp_dir.jp_idx.val)
+                                                + " JPP = " + std::to_string(id_vec.first.val));
+
+        // Now we fill the date_times
+        for (auto dt_st : id_vec.second) {
+            const auto& st_calendar = navitia::StopTimeCalendar(dt_st.second, dt_st.first, calendar_id);
+            // terminus or partial terminus
+            if (is_last_stoptime(st_calendar.stop_time)) {
+                continue;
+            }
+            auto date_time = schedule->add_date_times();
+            pb_creator.fill(&st_calendar, date_time, 0);
+            if (dt_st.second != nullptr) {
+                auto vj = dt_st.second->vehicle_journey;
+                if (vj != nullptr) {
+                    for (const auto& comment : pb_creator.data->pt_data->comments.get(*vj)) {
+                        pb_creator.fill(&comment, date_time->mutable_properties()->add_notes(), 0);
+                    }
+                }
+            }
+        }
+
+        // add first and last datetime
+        const auto& first_last_it = map_route_point_first_last_st.find(id_vec.first);
+        if (first_last_it != map_route_point_first_last_st.end()) {
+            // first date time
+            if (first_last_it->second.first) {
+                auto first_stop_time = *(first_last_it->second.first);
+                const auto& st_calendar =
+                    navitia::StopTimeCalendar(first_stop_time.second, first_stop_time.first, calendar_id);
+                pb_creator.fill(&st_calendar, schedule->mutable_first_datetime(), 0);
+            }
+            // last date time
+            if (first_last_it->second.second) {
+                auto last_stop_time = *(first_last_it->second.second);
+                const auto& st_calendar =
+                    navitia::StopTimeCalendar(last_stop_time.second, last_stop_time.first, calendar_id);
+                pb_creator.fill(&st_calendar, schedule->mutable_last_datetime(), 0);
+            }
+        }
+
+        // response status
+        const auto& it = response_status.find(id_vec.first);
+        if (it != response_status.end()) {
+            schedule->set_response_status(it->second);
+        }
+    }
+}
+
 static time_duration to_navitia(const boost::posix_time::time_duration& dur) {
     return navitia::seconds(dur.total_seconds());
 }
@@ -192,6 +276,37 @@ static std::vector<routing::JppIdx> get_jpp_from_route_point(const RoutePointIdx
         routepoint_jpps.push_back(jpp_idx);
     }
     return routepoint_jpps;
+}
+
+// JppIdx represents here the final part of a Journey Pattern (from JPP to the end), blind from what's before JPP.
+struct JourneyPatternEndsByDirection {
+    JourneyPatternEndsByDirection(const routing::JppIdx& direction) : direction(direction), jp_ends() {}
+    // direction is the "richest" JP's final part (the one with the most JPP after given JPP)
+    routing::JppIdx direction;
+    // jp_ends groups JP omnibus and direct JP if they use the same succession of SP in the same order
+    std::vector<routing::JppIdx> jp_ends;
+};
+
+// For the JP of 'tested', check if all the JPP following 'tested' itself are included in the same order
+// in the JP 'direction', starting from  JPP 'direction' itself
+static bool is_jp_end_included_in_direction(const routing::JourneyPatternPoint& tested,
+                                            const routing::JourneyPatternPoint& direction,
+                                            const routing::JourneyPatternContainer& jpc) {
+    const auto& jp_tested = jpc.get(tested.jp_idx);
+    uint16_t tested_it = tested.order.val;
+
+    const auto& jp_direction = jpc.get(direction.jp_idx);
+    for (uint16_t direction_it = direction.order.val; direction_it < jp_direction.jpps.size(); ++direction_it) {
+        const auto& jpp_tested = jpc.get(jp_tested.jpps[tested_it]);
+        const auto& jpp_direction = jpc.get(jp_direction.jpps[direction_it]);
+        if (jpp_tested.sp_idx == jpp_direction.sp_idx) {
+            ++tested_it;
+            if (tested_it >= jp_tested.jpps.size()) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 void departure_board(PbCreator& pb_creator,
@@ -337,6 +452,211 @@ void departure_board(PbCreator& pb_creator,
 
     pb_creator.make_paginate(total_result, start_page, count,
                              std::max(pb_creator.departure_boards_size(), pb_creator.stop_schedules_size()));
+}
+
+void terminus_schedules(PbCreator& pb_creator,
+                        const std::string& request,
+                        const boost::optional<const std::string>& calendar_id,
+                        const std::vector<std::string>& forbidden_uris,
+                        const pt::ptime date,
+                        const uint32_t duration,
+                        const uint32_t depth,
+                        const int count,
+                        const int start_page,
+                        const size_t items_per_route_point) {
+    RequestHandle handler(pb_creator, date, duration, calendar_id);
+    handler.init_jpp(request, forbidden_uris);
+    log4cplus::Logger logger = log4cplus::Logger::getInstance("log");
+
+    if (pb_creator.has_error() || (handler.journey_pattern_points.size() == 0)) {
+        return;
+    }
+
+    if (calendar_id) {
+        // check whether that calendar exists, to raise an early error
+        if (pb_creator.data->pt_data->calendars_map.find(*calendar_id)
+            == pb_creator.data->pt_data->calendars_map.end()) {
+            pb_creator.fill_pb_error(pbnavitia::Error::bad_filter, "stop_schedules : calendar does not exist");
+            return;
+        }
+    }
+    //  <stop_point_route, status>
+    std::map<routing::JppIdx, pbnavitia::ResponseStatus> response_status;
+
+    std::map<routing::JppIdx, vector_dt_st> map_route_stop_point;
+    std::map<routing::JppIdx, first_and_last_stop_time> map_route_point_first_last_st;
+
+    using LinePointIdx = std::pair<routing::LineIdx, routing::SpIdx>;
+    // group JourneyPatternEndsByDirection by StopPoint and Line so that directions at different
+    // stop points or different lines stay separated
+    std::map<LinePointIdx, std::vector<JourneyPatternEndsByDirection>> jp_ends_by_directions_from_lp;
+    // Iterate over all JP final parts (from JPP to the end)
+    for (const auto& jpp_idx : handler.journey_pattern_points) {
+        const auto& jp_end = pb_creator.data->dataRaptor->jp_container.get(jpp_idx);
+        const auto& jp = pb_creator.data->dataRaptor->jp_container.get(jp_end.jp_idx);
+        if (jp_end.order.val == jp.jpps.size() - 1) {  // no use considering cases where JPP is the terminus for departures
+            continue;
+        }
+        const type::Route* route = pb_creator.data->pt_data->routes[jp.route_idx.val];
+        LinePointIdx key_lp = {routing::LineIdx(route->line->idx), jp_end.sp_idx};
+        auto jp_ends_by_directions_it = jp_ends_by_directions_from_lp.find(key_lp);
+        bool is_jp_end_associated_to_a_direction = false;
+        if (jp_ends_by_directions_it != jp_ends_by_directions_from_lp.end()) {
+            // StopPoint already has directions associated, exploring them to see if:
+            // 1. current JP's final part is included in one direction
+            // 2. or if JP's final part includes some already existing directions
+            std::vector<size_t> to_erase;
+            boost::optional<JourneyPatternEndsByDirection&> referent_direction_for = boost::none;
+            for (size_t jp_ends_by_dir_it = 0; jp_ends_by_dir_it < jp_ends_by_directions_it->second.size();
+                 ++jp_ends_by_dir_it) {
+                auto& jp_ends_by_direction = jp_ends_by_directions_it->second[jp_ends_by_dir_it];
+                const auto& direction = pb_creator.data->dataRaptor->jp_container.get(jp_ends_by_direction.direction);
+                // 1. jp_end is included in one direction :  associate that JP's final part to this direction
+                if (is_jp_end_included_in_direction(jp_end, direction, pb_creator.data->dataRaptor->jp_container)) {
+                    jp_ends_by_direction.jp_ends.push_back(jpp_idx);  // associate to direction
+                    is_jp_end_associated_to_a_direction = true;
+                    break;
+                }
+                // 2. If a jp_end includes a referent direction it becomes referent direction for that group of jp_ends.
+                // NB: A new jp_end can "reconciliate" multiple group of jp_ends that were separated
+                // (include their referent directions), in that case they are all merged.
+                if (is_jp_end_included_in_direction(direction, jp_end, pb_creator.data->dataRaptor->jp_container)) {
+                    if (!referent_direction_for) {
+                        referent_direction_for = jp_ends_by_direction;  // richest direction is the first one we found
+                        referent_direction_for->direction = jpp_idx;    // jp_end is now the referent direction
+                        referent_direction_for->jp_ends.push_back(jpp_idx);  // associate to direction
+                    } else {
+                        // merge into richest direction and list direction to be erased
+                        referent_direction_for->jp_ends.insert(referent_direction_for->jp_ends.end(),
+                                                               jp_ends_by_direction.jp_ends.begin(),
+                                                               jp_ends_by_direction.jp_ends.end());
+                        to_erase.push_back(jp_ends_by_dir_it);
+                    }
+                    is_jp_end_associated_to_a_direction = true;
+                }
+            }
+            while (to_erase.size()) {
+                // erase from the end to keep valid indexes to erase
+                jp_ends_by_directions_it->second.erase(jp_ends_by_directions_it->second.begin() + to_erase.back());
+                to_erase.pop_back();
+            }
+        }
+        if (!is_jp_end_associated_to_a_direction) {
+            // StopPoint has no direction associated yet, creating it and associate current direction
+            // (with only one JP final part: the direction itself)
+            jp_ends_by_directions_from_lp[key_lp].emplace_back(jpp_idx);
+            jp_ends_by_directions_from_lp[key_lp].back().jp_ends.push_back(jpp_idx);
+        }
+    }
+
+    std::vector<JourneyPatternEndsByDirection> jp_ends_by_directions;
+    for (auto vec_jp_ends_by_dirs : jp_ends_by_directions_from_lp) {
+        jp_ends_by_directions.insert(jp_ends_by_directions.end(), vec_jp_ends_by_dirs.second.begin(),
+                                     vec_jp_ends_by_dirs.second.end());
+    }
+
+    size_t total_result = jp_ends_by_directions.size();
+    jp_ends_by_directions = paginate(jp_ends_by_directions, count, start_page);
+    auto sort_predicate = [](routing::datetime_stop_time dt1, routing::datetime_stop_time dt2) {
+        return dt1.first < dt2.first;
+    };
+
+    for (const auto& jp_ends_one_dir : jp_ends_by_directions) {
+        const auto& jpp_dir = pb_creator.data->dataRaptor->jp_container.get(jp_ends_one_dir.direction);
+        const auto& jp_dir = pb_creator.data->dataRaptor->jp_container.get(jpp_dir.jp_idx);
+        const type::Route* route = pb_creator.data->pt_data->routes[jp_dir.route_idx.val];
+        const type::StopPoint* stop_point = pb_creator.data->pt_data->stop_points[jpp_dir.sp_idx.val];
+
+        const auto routepoint_jpps = jp_ends_one_dir.jp_ends;
+        const auto& route_point = jp_ends_one_dir.direction;
+
+        std::vector<routing::datetime_stop_time> stop_times;
+        int32_t utc_offset = 0;
+        if (!calendar_id) {
+            stop_times =
+                routing::get_stop_times(routing::StopEvent::pick_up, routepoint_jpps, handler.date_time,
+                                        handler.max_datetime, items_per_route_point, *pb_creator.data,
+                                        navitia::type::RTLevel::Base);
+            std::sort(stop_times.begin(), stop_times.end(), sort_predicate);
+
+            if (route->line->opening_time && !stop_times.empty()) {
+                // retrieve utc offset
+                utc_offset = stop_times[0].second->vehicle_journey->utc_to_local_offset();
+
+                // first and last Date time
+                map_route_point_first_last_st[route_point] = get_first_and_last_stop_time(
+                        stop_times[0], *route->line->opening_time, routepoint_jpps,
+                        handler.date_time + DateTimeUtils::SECONDS_PER_DAY, *pb_creator.data,
+                        navitia::type::RTLevel::Base, utc_offset);
+            }
+
+        } else {
+            stop_times = routing::get_calendar_stop_times(routepoint_jpps, DateTimeUtils::hour(handler.date_time),
+                                                          DateTimeUtils::hour(handler.max_datetime), *pb_creator.data,
+                                                          *calendar_id);
+            // for calendar we want the first stop time to start from handler.date_time
+            std::sort(stop_times.begin(), stop_times.end(), routing::CalendarScheduleSort(handler.date_time));
+            if (stop_times.size() > items_per_route_point) {
+                stop_times.resize(items_per_route_point);
+            }
+        }
+
+        // If we have a calendar_id we have stop_times at the terminus and can use them to check
+        // if the current stop is a terminus or a partial terminus
+        if (calendar_id) {
+            // If all stop_times are on the terminus of their vj
+            // (stop_time order is equal to the order of the last stop_time of the vj)
+            if (is_terminus_for_all_stop_times(stop_times)) {                
+                if (stop_point->stop_area == route->destination) {
+                    response_status[route_point] = pbnavitia::ResponseStatus::terminus;
+                    LOG4CPLUS_DEBUG(logger, " *** Terminus in calendar_id ***");
+                } else {
+                    // Otherwise it's a partial_terminus
+                    response_status[route_point] = pbnavitia::ResponseStatus::partial_terminus;
+                    LOG4CPLUS_DEBUG(logger, " *** Partial terminus in calendar_id ***");
+                }
+            }
+        }
+
+        // If there is no departure for a request with "RealTime", Test existence of any departure with "base_schedule"
+        // If departure with base_schedule is not empty, additional_information = active_disruption
+        // Else additional_information = no_departure_this_day
+        if (stop_times.empty() && (response_status.find(route_point) == response_status.end())) {
+            auto resp_status = pbnavitia::ResponseStatus::no_departure_this_day;
+            if (line_closed(navitia::seconds(duration), route, date)) {
+                resp_status = pbnavitia::ResponseStatus::no_active_circulation_this_day;
+            }
+
+            // If we have no calendar terminuses have no pick_up stop_time, we try to get drop_off time
+            // to see if it's just a terminus
+            if (!calendar_id) {
+                auto tmp_stop_times =
+                    routing::get_stop_times(routing::StopEvent::drop_off, routepoint_jpps, handler.date_time,
+                                            handler.max_datetime, items_per_route_point, *pb_creator.data,
+                                            navitia::type::RTLevel::Base);
+                // If there is stop_times and everyone of them is a terminus
+                if (!tmp_stop_times.empty() && is_terminus_for_all_stop_times(tmp_stop_times)) {
+                    // If we are on the main destination
+                    if (stop_point->stop_area == route->destination) {                        
+                        resp_status = pbnavitia::ResponseStatus::terminus;
+                        LOG4CPLUS_DEBUG(logger, " *** Terminus in !calendar_id ***");
+                    } else {
+                        // Otherwise it's a partial_terminus
+                        resp_status = pbnavitia::ResponseStatus::partial_terminus;
+                        LOG4CPLUS_DEBUG(logger, " *** Partial terminus in !calendar_id ***");
+                    }
+                }
+            }
+            response_status[route_point] = resp_status;
+        }
+
+        map_route_stop_point[route_point] = stop_times;
+    }
+
+    render(pb_creator, response_status, map_route_stop_point, map_route_point_first_last_st, handler.date_time,
+           handler.max_datetime, calendar_id, depth);
+
+    pb_creator.make_paginate(total_result, start_page, count, pb_creator.terminus_schedules_size());
 }
 
 std::pair<DateTime, DateTime> get_daily_opening_time_bounds(const routing::datetime_stop_time& next_stop_time,

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -494,7 +494,8 @@ void terminus_schedules(PbCreator& pb_creator,
     for (const auto& jpp_idx : handler.journey_pattern_points) {
         const auto& jp_end = pb_creator.data->dataRaptor->jp_container.get(jpp_idx);
         const auto& jp = pb_creator.data->dataRaptor->jp_container.get(jp_end.jp_idx);
-        if (jp_end.order.val == jp.jpps.size() - 1) {  // no use considering cases where JPP is the terminus for departures
+        if (jp_end.order.val
+            == jp.jpps.size() - 1) {  // no use considering cases where JPP is the terminus for departures
             continue;
         }
         const type::Route* route = pb_creator.data->pt_data->routes[jp.route_idx.val];
@@ -573,10 +574,9 @@ void terminus_schedules(PbCreator& pb_creator,
         std::vector<routing::datetime_stop_time> stop_times;
         int32_t utc_offset = 0;
         if (!calendar_id) {
-            stop_times =
-                routing::get_stop_times(routing::StopEvent::pick_up, routepoint_jpps, handler.date_time,
-                                        handler.max_datetime, items_per_route_point, *pb_creator.data,
-                                        navitia::type::RTLevel::Base);
+            stop_times = routing::get_stop_times(routing::StopEvent::pick_up, routepoint_jpps, handler.date_time,
+                                                 handler.max_datetime, items_per_route_point, *pb_creator.data,
+                                                 navitia::type::RTLevel::Base);
             std::sort(stop_times.begin(), stop_times.end(), sort_predicate);
 
             if (route->line->opening_time && !stop_times.empty()) {
@@ -584,10 +584,10 @@ void terminus_schedules(PbCreator& pb_creator,
                 utc_offset = stop_times[0].second->vehicle_journey->utc_to_local_offset();
 
                 // first and last Date time
-                map_route_point_first_last_st[route_point] = get_first_and_last_stop_time(
-                        stop_times[0], *route->line->opening_time, routepoint_jpps,
-                        handler.date_time + DateTimeUtils::SECONDS_PER_DAY, *pb_creator.data,
-                        navitia::type::RTLevel::Base, utc_offset);
+                map_route_point_first_last_st[route_point] =
+                    get_first_and_last_stop_time(stop_times[0], *route->line->opening_time, routepoint_jpps,
+                                                 handler.date_time + DateTimeUtils::SECONDS_PER_DAY, *pb_creator.data,
+                                                 navitia::type::RTLevel::Base, utc_offset);
             }
 
         } else {
@@ -606,7 +606,7 @@ void terminus_schedules(PbCreator& pb_creator,
         if (calendar_id) {
             // If all stop_times are on the terminus of their vj
             // (stop_time order is equal to the order of the last stop_time of the vj)
-            if (is_terminus_for_all_stop_times(stop_times)) {                
+            if (is_terminus_for_all_stop_times(stop_times)) {
                 if (stop_point->stop_area == route->destination) {
                     response_status[route_point] = pbnavitia::ResponseStatus::terminus;
                     LOG4CPLUS_DEBUG(logger, " *** Terminus in calendar_id ***");
@@ -630,14 +630,13 @@ void terminus_schedules(PbCreator& pb_creator,
             // If we have no calendar terminuses have no pick_up stop_time, we try to get drop_off time
             // to see if it's just a terminus
             if (!calendar_id) {
-                auto tmp_stop_times =
-                    routing::get_stop_times(routing::StopEvent::drop_off, routepoint_jpps, handler.date_time,
-                                            handler.max_datetime, items_per_route_point, *pb_creator.data,
-                                            navitia::type::RTLevel::Base);
+                auto tmp_stop_times = routing::get_stop_times(
+                    routing::StopEvent::drop_off, routepoint_jpps, handler.date_time, handler.max_datetime,
+                    items_per_route_point, *pb_creator.data, navitia::type::RTLevel::Base);
                 // If there is stop_times and everyone of them is a terminus
                 if (!tmp_stop_times.empty() && is_terminus_for_all_stop_times(tmp_stop_times)) {
                     // If we are on the main destination
-                    if (stop_point->stop_area == route->destination) {                        
+                    if (stop_point->stop_area == route->destination) {
                         resp_status = pbnavitia::ResponseStatus::terminus;
                         LOG4CPLUS_DEBUG(logger, " *** Terminus in !calendar_id ***");
                     } else {

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -144,8 +144,8 @@ static void render(PbCreator& pb_creator,
                    const std::map<routing::JppIdx, pbnavitia::ResponseStatus>& response_status,
                    const std::map<routing::JppIdx, vector_dt_st>& map_route_stop_point,
                    const std::map<routing::JppIdx, first_and_last_stop_time>& map_route_point_first_last_st,
-                   const DateTime datetime,
-                   const DateTime max_datetime,
+                   const DateTime& datetime,
+                   const DateTime& max_datetime,
                    const boost::optional<const std::string> calendar_id,
                    const uint32_t depth) {
     pb_creator.action_period =
@@ -461,8 +461,8 @@ void terminus_schedules(PbCreator& pb_creator,
                         const pt::ptime date,
                         const uint32_t duration,
                         const uint32_t depth,
-                        const int count,
-                        const int start_page,
+                        const uint32_t count,
+                        const uint32_t start_page,
                         const size_t items_per_route_point) {
     RequestHandle handler(pb_creator, date, duration, calendar_id);
     handler.init_jpp(request, forbidden_uris);

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -61,8 +61,8 @@ void terminus_schedules(PbCreator& pb_creator,
                         const pt::ptime date,
                         const uint32_t duration,
                         const uint32_t depth,
-                        const int count,
-                        const int start_page,
+                        const uint32_t count,
+                        const uint32_t start_page,
                         const size_t items_per_route_point);
 
 bool between_opening_and_closing(const time_duration& me, const time_duration& opening, const time_duration& closing);

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -54,6 +54,17 @@ void departure_board(PbCreator& pb_creator,
                      const type::RTLevel rt_level,
                      const size_t items_per_route_point);
 
+void terminus_schedules(PbCreator& pb_creator,
+                        const std::string& request,
+                        const boost::optional<const std::string>& calendar_id,
+                        const std::vector<std::string>& forbidden_uris,
+                        const pt::ptime date,
+                        const uint32_t duration,
+                        const uint32_t depth,
+                        const int count,
+                        const int start_page,
+                        const size_t items_per_route_point);
+
 bool between_opening_and_closing(const time_duration& me, const time_duration& opening, const time_duration& closing);
 
 time_duration length_of_time(const time_duration& duration_1, const time_duration& duration_2);

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -1792,6 +1792,33 @@ BOOST_AUTO_TEST_CASE(stop_schedule_on_terminus) {
     BOOST_CHECK_EQUAL(stop_schedule.response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 }
 
+//  Check that there is no terminus_schedules on terminuses.
+BOOST_AUTO_TEST_CASE(terminus_schedule_on_terminus) {
+    ed::builder b("20181101");
+
+    b.vj("A", "01").name("vj:0")("stop1", "8:00"_t, "8:00"_t)("stop2", "8:05"_t, "8:05"_t)("stop3", "8:10"_t, "8:10"_t);
+
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto* data_ptr = b.data.get();
+
+    navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"), 86400, 3, 10, 0,
+                       std::numeric_limits<size_t>::max());
+    auto resp = pb_creator_dep.get_response();
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+
+    // Even for a day without circulation, no terminus_schedule on terminus.
+    navitia::PbCreator pb_creator_no_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"), 86400, 3, 10, 0,
+                       std::numeric_limits<size_t>::max());
+    resp = pb_creator_no_dep.get_response();
+
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+}
+
 //  Check stop_schedules on partial terminuses.
 //  We check that no departure has priority over partial terminus
 BOOST_AUTO_TEST_CASE(stop_schedule_on_partial_terminus) {
@@ -1835,34 +1862,7 @@ BOOST_AUTO_TEST_CASE(stop_schedule_on_partial_terminus) {
     BOOST_CHECK_EQUAL(stop_schedule.response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
 }
 
-//  Check that there is no terminus_schedules on terminuses.
-BOOST_AUTO_TEST_CASE(terminus_schedule_on_terminus) {
-    ed::builder b("20181101");
-
-    b.vj("A", "01").name("vj:0")("stop1", "8:00"_t, "8:00"_t)("stop2", "8:05"_t, "8:05"_t)("stop3", "8:10"_t, "8:10"_t);
-
-    b.finish();
-    b.data->pt_data->sort_and_index();
-    b.data->build_raptor();
-    b.data->pt_data->build_uri();
-    auto* data_ptr = b.data.get();
-
-    navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"), 86400, 3, 10, 0,
-                       std::numeric_limits<size_t>::max());
-    auto resp = pb_creator_dep.get_response();
-    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
-
-    // Even for a day without circulation, no terminus_schedule on terminus.
-    navitia::PbCreator pb_creator_no_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"), 86400, 3, 10, 0,
-                       std::numeric_limits<size_t>::max());
-    resp = pb_creator_no_dep.get_response();
-
-    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
-}
-
-//  Check terminus_schedules on partial terminuses.
+//  Check that there is no terminus_schedules on partial terminuses.
 BOOST_AUTO_TEST_CASE(terminus_schedule_on_partial_terminus) {
     ed::builder b("20181101");
 

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -97,8 +97,8 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"),
-                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"), 43200, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
@@ -143,16 +143,18 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150619T094500"),
-                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150619T094500"), 43200, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).date_times_size(), 0);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).route().name(), "A");
-        BOOST_CHECK_EQUAL(resp.terminus_schedules(0).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(0).response_status(),
+                          pbnavitia::ResponseStatus::no_departure_this_day);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).route().name(), "B");
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).date_times_size(), 0);
-        BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(),
+                          pbnavitia::ResponseStatus::no_departure_this_day);
     }
 
     // no departure for route "B"
@@ -173,15 +175,16 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150621T094500"),
-                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150621T094500"), 43200, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).date_times_size(), 1);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).route().name(), "A");
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).route().name(), "B");
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).date_times_size(), 0);
-        BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(),
+                          pbnavitia::ResponseStatus::no_departure_this_day);
     }
 
     // Terminus for route "A"
@@ -202,8 +205,8 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop2", {}, {}, d("20150615T094500"),
-                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop2", {}, {}, d("20150615T094500"), 43200, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 1);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).route().name(), "B");
@@ -226,8 +229,8 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop3", {}, {}, d("20150615T094500"),
-                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop3", {}, {}, d("20150615T094500"), 43200, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
     }
@@ -245,8 +248,8 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
     }
@@ -696,8 +699,8 @@ BOOST_AUTO_TEST_CASE(terminus_schedules_on_terminus_multiple_route) {
     b.data->pt_data->build_uri();
     auto* data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"),
-                       86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                       std::numeric_limits<size_t>::max());
 
     pbnavitia::Response resp = pb_creator.get_response();
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 1);
@@ -1005,7 +1008,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
     b.data->build_uri();
     b.data->complete();
     b.data->build_raptor();
-    //Empty stop schedule without any date_time
+    // Empty stop schedule without any date_time
     {
         navitia::PbCreator pb_creator;
         pb_creator.init(b.data.get(), bt::second_clock::universal_time(), null_time_period);
@@ -1018,12 +1021,12 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
         pbnavitia::StopSchedule stop_schedule = resp.stop_schedules(0);
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 0);
     }
-    //Empty stop schedule without any date_time also for terminus schedule
+    // Empty stop schedule without any date_time also for terminus schedule
     {
         navitia::PbCreator pb_creator;
         pb_creator.init(b.data.get(), bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE(!resp.has_error());
@@ -1498,8 +1501,8 @@ BOOST_AUTO_TEST_CASE(departureboard_test_with_lines_closed) {
 
     // Same for terminus schedule
     navitia::PbCreator pb_creator1(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T063000"),
-                       600, 0, 10, 0, std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T063000"), 600, 0, 10, 0,
+                       std::numeric_limits<size_t>::max());
     resp = pb_creator.get_response();
     // Two elements as there are two lines (A, B)
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
@@ -1695,10 +1698,10 @@ BOOST_AUTO_TEST_CASE(stop_schedules_order_by_line_route_stop_point) {
     test(6, "route:13rl", "JennerRL");
     test(7, "route:13rl", "RubensRL");
 
-    //We compare terminus_schedume with stop_schedule:
+    // We compare terminus_schedume with stop_schedule:
     navitia::PbCreator pb_creator_1(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_1, "network.uri=base_network", {}, {}, d("20170103T070000"), 86400,
-                       3, 20, 0,std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator_1, "network.uri=base_network", {}, {}, d("20170103T070000"), 86400, 3, 20, 0,
+                       std::numeric_limits<size_t>::max());
     resp = pb_creator_1.get_response();
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 4);
 
@@ -1845,15 +1848,15 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_on_terminus) {
     auto* data_ptr = b.data.get();
 
     navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"),
-                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"), 86400, 3, 10, 0,
+                       std::numeric_limits<size_t>::max());
     auto resp = pb_creator_dep.get_response();
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
 
     // Even for a day without circulation, no terminus_schedule on terminus.
     navitia::PbCreator pb_creator_no_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"),
-                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"), 86400, 3, 10, 0,
+                       std::numeric_limits<size_t>::max());
     resp = pb_creator_no_dep.get_response();
 
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
@@ -1875,15 +1878,15 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_on_partial_terminus) {
     data_ptr->pt_data->routes[0]->destination = b.sas.find("real terminus")->second;
 
     navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"),
-                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"), 86400, 3, 10, 0,
+                       std::numeric_limits<size_t>::max());
     auto resp = pb_creator_dep.get_response();
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
 
     // Even for a day without circulation, no terminus_schedule on partial terminus.
     navitia::PbCreator pb_creator_no_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
-    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"),
-                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"), 86400, 3, 10, 0,
+                       std::numeric_limits<size_t>::max());
     resp = pb_creator_no_dep.get_response();
     BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
 }
@@ -1929,22 +1932,22 @@ BOOST_AUTO_TEST_CASE(schedules_on_Y_shaped_routes) {
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "C");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11,00,00));
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(1).time(), time_to_int(11,15,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11, 00, 00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(1).time(), time_to_int(11, 15, 00));
         // Direction B -> A
         stop_schedule = resp.stop_schedules(1);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "bobette");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12,00,00));
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(1).time(), time_to_int(12,55,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12, 00, 00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(1).time(), time_to_int(12, 55, 00));
     }
     // we should have three terminus_schedules: B -> C, B -> D and b -> A
     {
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 3);
@@ -1954,22 +1957,22 @@ BOOST_AUTO_TEST_CASE(schedules_on_Y_shaped_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "C");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11,00,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11, 00, 00));
         // Direction B -> D
         terminus_schedule = resp.terminus_schedules(1);
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "bob");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "D");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11,15,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11, 15, 00));
         // Direction B -> A
         terminus_schedule = resp.terminus_schedules(2);
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "bobette");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12,00,00));
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(12,55,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12, 00, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(12, 55, 00));
     }
 }
 
@@ -1984,10 +1987,14 @@ BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
      * Bobynette:  D -> C -> B -> A
      */
     ed::builder b("20160802");
-    b.vj("line:bob", "11111111", "", true, "vj1", "").route("route:bob")("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
-    b.vj("line:bob", "11111111", "", true, "vj2", "").route("route:boby")("A", "10:15"_t)("B", "11:15"_t)("C", "12:15"_t)("D", "13:15"_t);
-    b.vj("line:bob", "11111111", "", true, "vj3", "").route("route:bobette")("C", "11:00"_t)("B", "12:00"_t)("A", "13:00"_t);
-    b.vj("line:bob", "11111111", "", true, "vj4", "").route("route:bobynette")("D", "11:00"_t)("C", "12:00"_t)("B", "13:00"_t)("A", "14:00"_t);
+    b.vj("line:bob", "11111111", "", true, "vj1", "")
+        .route("route:bob")("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
+    b.vj("line:bob", "11111111", "", true, "vj2", "")
+        .route("route:boby")("A", "10:15"_t)("B", "11:15"_t)("C", "12:15"_t)("D", "13:15"_t);
+    b.vj("line:bob", "11111111", "", true, "vj3", "")
+        .route("route:bobette")("C", "11:00"_t)("B", "12:00"_t)("A", "13:00"_t);
+    b.vj("line:bob", "11111111", "", true, "vj4", "")
+        .route("route:bobynette")("D", "11:00"_t)("C", "12:00"_t)("B", "13:00"_t)("A", "14:00"_t);
 
     b.finish();
     b.data->pt_data->sort_and_index();
@@ -2011,34 +2018,34 @@ BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "C");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11,00,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11, 00, 00));
         // Direction B -> A
         stop_schedule = resp.stop_schedules(1);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bobette");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12,00,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12, 00, 00));
         // Directions B -> C -> D
         stop_schedule = resp.stop_schedules(2);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:boby");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "D");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11,15,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11, 15, 00));
         // Direction B -> A
         stop_schedule = resp.stop_schedules(3);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bobynette");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(13,00,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(13, 00, 00));
     }
     // we should have two terminus_schedules: B -> C -> D and b -> A
     {
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
@@ -2049,8 +2056,8 @@ BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12,00,00));
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(13,00,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12, 00, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(13, 00, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().vehicle_journey_id(), "vehicle_journey:vj3");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().vehicle_journey_id(), "vehicle_journey:vj4");
 
@@ -2061,8 +2068,8 @@ BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "D");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11,00,00));
-        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(11,15,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11, 00, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(11, 15, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().vehicle_journey_id(), "vehicle_journey:vj1");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().vehicle_journey_id(), "vehicle_journey:vj2");
     }

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -91,6 +91,24 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(), 1);
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(), 1);
     }
+
+    // comparing terminus_schedule with above stop_schedules
+    // same number of elements as terminus_schedules contains an element per destination but not route.
+    {
+        auto* data_ptr = b.data.get();
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T094500"),
+                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+
+        resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).date_times_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).date_times_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).stop_point().uri(), "stop1");
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).pt_display_informations().direction(), "stop2");
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).pt_display_informations().direction(), "stop3");
+    }
+
     // no departure for route "A"
     {
         auto* data_ptr = b.data.get();
@@ -120,6 +138,23 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(), 0);
         BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
     }
+
+    // no departure for all routes in terminus_schedules
+    {
+        auto* data_ptr = b.data.get();
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150619T094500"),
+                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).date_times_size(), 0);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).route().name(), "A");
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(0).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).route().name(), "B");
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).date_times_size(), 0);
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+    }
+
     // no departure for route "B"
     {
         auto* data_ptr = b.data.get();
@@ -133,6 +168,22 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).route().name(), "B");
         BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
     }
+
+    // no departure for route "B" for terminus_schedules
+    {
+        auto* data_ptr = b.data.get();
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150621T094500"),
+                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).date_times_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).route().name(), "A");
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).route().name(), "B");
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).date_times_size(), 0);
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+    }
+
     // Terminus for route "A"
     {
         auto* data_ptr = b.data.get();
@@ -146,6 +197,19 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).route().name(), "B");
         BOOST_CHECK_EQUAL(resp.stop_schedules(1).date_times_size(), 1);
     }
+
+    // No terminus_schedules on terminus for toute "A"
+    {
+        auto* data_ptr = b.data.get();
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop2", {}, {}, d("20150615T094500"),
+                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).route().name(), "B");
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(0).date_times_size(), 1);
+    }
+
     // Terminus for route "B"
     {
         auto* data_ptr = b.data.get();
@@ -157,11 +221,32 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).route().name(), "B");
         BOOST_CHECK_EQUAL(resp.stop_schedules(0).response_status(), pbnavitia::ResponseStatus::terminus);
     }
+
+    // No terminus_schedules for stop_point stop3 (terminus for route "B")
+    {
+        auto* data_ptr = b.data.get();
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop3", {}, {}, d("20150615T094500"),
+                           43200, 0, 10, 0, std::numeric_limits<size_t>::max());
+        resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+    }
+
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
         departure_board(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"), 86400, 0, 10, 0,
                         nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+        resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
+    }
+
+    // Date out of bounds in terminus_schedules
+    {
+        auto* data_ptr = b.data.get();
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop2", {}, {}, d("20120701T094500"),
+                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
         resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.error().id(), pbnavitia::Error::date_out_of_bounds);
     }
@@ -591,6 +676,34 @@ BOOST_AUTO_TEST_CASE(terminus_multiple_route) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(terminus_schedules_on_terminus_multiple_route) {
+    /*
+     * Check terminus_schedules on terminus
+     *
+     * 1 line, 2 route, bob and bobette (one forward, and one backward)
+     * Bob    :  A -> B -> C
+     * Bobette:  C -> B -> A
+     *
+     * for a terminus schedule on A, bobette will be excluded.
+     * */
+    ed::builder b("20160802");
+    b.vj("bob")("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
+    b.vj("bobette")("C", "10:00"_t)("B", "11:00"_t)("A", "12:00"_t);
+
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto* data_ptr = b.data.get();
+    navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"),
+                       86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+
+    pbnavitia::Response resp = pb_creator.get_response();
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 1);
+    BOOST_CHECK_EQUAL(resp.terminus_schedules(0).route().name(), "bob");
+}
+
 // Test that departure_board manage to output departures even if there is no service for multiple days
 BOOST_AUTO_TEST_CASE(departure_board_multiple_days) {
     ed::builder b("20180101");
@@ -892,6 +1005,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
     b.data->build_uri();
     b.data->complete();
     b.data->build_raptor();
+    //Empty stop schedule without any date_time
     {
         navitia::PbCreator pb_creator;
         pb_creator.init(b.data.get(), bt::second_clock::universal_time(), null_time_period);
@@ -904,6 +1018,19 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
         pbnavitia::StopSchedule stop_schedule = resp.stop_schedules(0);
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 0);
     }
+    //Empty stop schedule without any date_time also for terminus schedule
+    {
+        navitia::PbCreator pb_creator;
+        pb_creator.init(b.data.get(), bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=stop1", calendar_id, {}, d("20120615T080000"),
+                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE(!resp.has_error());
+        BOOST_CHECK_EQUAL(resp.terminus_schedules_size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).date_times_size(), 0);
+    }
+
     {
         navitia::PbCreator pb_creator;
         pb_creator.init(b.data.get(), bt::second_clock::universal_time(), null_time_period);
@@ -1368,6 +1495,16 @@ BOOST_AUTO_TEST_CASE(departureboard_test_with_lines_closed) {
     resp = pb_creator.get_response();
     BOOST_CHECK_EQUAL(resp.stop_schedules(0).response_status(), ResponseStatus::no_active_circulation_this_day);
     BOOST_CHECK_EQUAL(resp.stop_schedules(1).response_status(), ResponseStatus::no_active_circulation_this_day);
+
+    // Same for terminus schedule
+    navitia::PbCreator pb_creator1(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator, "stop_point.uri=stop1", {}, {}, d("20150615T063000"),
+                       600, 0, 10, 0, std::numeric_limits<size_t>::max());
+    resp = pb_creator.get_response();
+    // Two elements as there are two lines (A, B)
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
+    BOOST_CHECK_EQUAL(resp.terminus_schedules(0).response_status(), ResponseStatus::no_active_circulation_this_day);
+    BOOST_CHECK_EQUAL(resp.terminus_schedules(1).response_status(), ResponseStatus::no_active_circulation_this_day);
 }
 
 // Check with depth 3 than disable_geojson doesn't fill geojson in the response
@@ -1557,6 +1694,22 @@ BOOST_AUTO_TEST_CASE(stop_schedules_order_by_line_route_stop_point) {
     test(5, "route:13lr", "RubensLR");
     test(6, "route:13rl", "JennerRL");
     test(7, "route:13rl", "RubensRL");
+
+    //We compare terminus_schedume with stop_schedule:
+    navitia::PbCreator pb_creator_1(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_1, "network.uri=base_network", {}, {}, d("20170103T070000"), 86400,
+                       3, 20, 0,std::numeric_limits<size_t>::max());
+    resp = pb_creator_1.get_response();
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 4);
+
+    auto test_1 = [&](int terminus_schedule, const char* route, const char* stop_point) {
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(terminus_schedule).route().uri(), route);
+        BOOST_CHECK_EQUAL(resp.terminus_schedules(terminus_schedule).stop_point().uri(), stop_point);
+    };
+    test_1(0, "route:5lr", "RubensLR");
+    test_1(1, "route:5rl", "JennerRL");
+    test_1(2, "route:13lr", "RubensLR");
+    test_1(3, "route:13rl", "JennerRL");
 }
 
 //  Check stop_schedules on loop lines.
@@ -1677,4 +1830,240 @@ BOOST_AUTO_TEST_CASE(stop_schedule_on_partial_terminus) {
     BOOST_CHECK_EQUAL(stop_schedule.route().direction().uri(), "real terminus");
     BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 0);
     BOOST_CHECK_EQUAL(stop_schedule.response_status(), pbnavitia::ResponseStatus::no_departure_this_day);
+}
+
+//  Check that there is no terminus_schedules on terminuses.
+BOOST_AUTO_TEST_CASE(terminus_schedule_on_terminus) {
+    ed::builder b("20181101");
+
+    b.vj("A", "01").name("vj:0")("stop1", "8:00"_t, "8:00"_t)("stop2", "8:05"_t, "8:05"_t)("stop3", "8:10"_t, "8:10"_t);
+
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto* data_ptr = b.data.get();
+
+    navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"),
+                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    auto resp = pb_creator_dep.get_response();
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+
+    // Even for a day without circulation, no terminus_schedule on terminus.
+    navitia::PbCreator pb_creator_no_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"),
+                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    resp = pb_creator_no_dep.get_response();
+
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+}
+
+//  Check terminus_schedules on partial terminuses.
+BOOST_AUTO_TEST_CASE(terminus_schedule_on_partial_terminus) {
+    ed::builder b("20181101");
+
+    b.vj("A", "01").name("vj:0")("stop1", "8:00"_t, "8:00"_t)("stop2", "8:05"_t, "8:05"_t)("stop3", "8:10"_t, "8:10"_t);
+    b.sa("real terminus");
+
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto* data_ptr = b.data.get();
+    // Set a different terminus on the route to have partial terminuses
+    data_ptr->pt_data->routes[0]->destination = b.sas.find("real terminus")->second;
+
+    navitia::PbCreator pb_creator_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_dep, "stop_point.uri=stop3", {}, {}, d("20181101T075500"),
+                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    auto resp = pb_creator_dep.get_response();
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+
+    // Even for a day without circulation, no terminus_schedule on partial terminus.
+    navitia::PbCreator pb_creator_no_dep(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    terminus_schedules(pb_creator_no_dep, "stop_point.uri=stop3", {}, {}, d("20181102T075500"),
+                       86400, 3, 10, 0, std::numeric_limits<size_t>::max());
+    resp = pb_creator_no_dep.get_response();
+    BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(schedules_on_Y_shaped_routes) {
+    /*
+     * Check winning direction for Y-shaped route for terminus_schedules
+     *
+     * 1 line, 2 route, bob and bobette (one forward, and one backward)
+     * Bob    :  A -> B -> C / A -> B -> D
+     * Bobette:  C -> B -> A / D -> B -> A
+     *                           C
+     *                      -
+     * A -------------- B
+     *                      -
+     *                           D
+     */
+    ed::builder b("20160802");
+    b.vj("bob").route("bob")("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
+    b.vj("bob").route("bob")("A", "10:15"_t)("B", "11:15"_t)("D", "12:15"_t);
+    b.vj("bob").route("bobette")("C", "11:00"_t)("B", "12:00"_t)("A", "13:00"_t);
+    b.vj("bob").route("bobette")("D", "11:55"_t)("B", "12:55"_t)("A", "13:55"_t);
+
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto* data_ptr = b.data.get();
+
+    auto builder_date = navitia::to_posix_timestamp("20160802T000000"_dt);
+
+    // We will have only two stop_schedules.
+    {
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        departure_board(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                        nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 2);
+        // Directions B -> C and B -> D
+        auto stop_schedule = resp.stop_schedules(0);
+        BOOST_CHECK_EQUAL(stop_schedule.route().name(), "bob");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "C");
+        BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11,00,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(1).time(), time_to_int(11,15,00));
+        // Direction B -> A
+        stop_schedule = resp.stop_schedules(1);
+        BOOST_CHECK_EQUAL(stop_schedule.route().name(), "bobette");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
+        BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12,00,00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(1).time(), time_to_int(12,55,00));
+    }
+    // we should have three terminus_schedules: B -> C, B -> D and b -> A
+    {
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"),
+                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 3);
+        // Direction B -> C
+        auto terminus_schedule = resp.terminus_schedules(0);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "bob");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "C");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11,00,00));
+        // Direction B -> D
+        terminus_schedule = resp.terminus_schedules(1);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "bob");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "D");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11,15,00));
+        // Direction B -> A
+        terminus_schedule = resp.terminus_schedules(2);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "bobette");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12,00,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(12,55,00));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
+    /*
+     * Check loosing terminus routes for terminus_schedules
+     *
+     * 1 line, 4 routes, bob, boby ,bobette and bobynette (one forward, and one backward)
+     * Bob    :  A -> B -> C
+     * Boby   :  A -> B -> C -> D
+     * Bobette:         C -> B -> A
+     * Bobynette:  D -> C -> B -> A
+     */
+    ed::builder b("20160802");
+    b.vj("line:bob", "11111111", "", true, "vj1", "").route("route:bob")("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
+    b.vj("line:bob", "11111111", "", true, "vj2", "").route("route:boby")("A", "10:15"_t)("B", "11:15"_t)("C", "12:15"_t)("D", "13:15"_t);
+    b.vj("line:bob", "11111111", "", true, "vj3", "").route("route:bobette")("C", "11:00"_t)("B", "12:00"_t)("A", "13:00"_t);
+    b.vj("line:bob", "11111111", "", true, "vj4", "").route("route:bobynette")("D", "11:00"_t)("C", "12:00"_t)("B", "13:00"_t)("A", "14:00"_t);
+
+    b.finish();
+    b.data->pt_data->sort_and_index();
+    b.data->build_raptor();
+    b.data->pt_data->build_uri();
+    auto* data_ptr = b.data.get();
+
+    auto builder_date = navitia::to_posix_timestamp("20160802T000000"_dt);
+
+    // We will have 4 stop_schedules.
+    {
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        departure_board(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                        nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 4);
+        // Directions B -> C
+        auto stop_schedule = resp.stop_schedules(0);
+        BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bob");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "C");
+        BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11,00,00));
+        // Direction B -> A
+        stop_schedule = resp.stop_schedules(1);
+        BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bobette");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
+        BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12,00,00));
+        // Directions B -> C -> D
+        stop_schedule = resp.stop_schedules(2);
+        BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:boby");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "D");
+        BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11,15,00));
+        // Direction B -> A
+        stop_schedule = resp.stop_schedules(3);
+        BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bobynette");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
+        BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(13,00,00));
+    }
+    // we should have two terminus_schedules: B -> C -> D and b -> A
+    {
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"),
+                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
+        // Direction B -> A
+        auto terminus_schedule = resp.terminus_schedules(0);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "route:bobette");
+        BOOST_CHECK_EQUAL(terminus_schedule.route().line().name(), "line:bob");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12,00,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(13,00,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().vehicle_journey_id(), "vehicle_journey:vj3");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().vehicle_journey_id(), "vehicle_journey:vj4");
+
+        // Direction B -> D (direction B -> C is merged in B -> C -> D)
+        terminus_schedule = resp.terminus_schedules(1);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "route:boby");
+        BOOST_CHECK_EQUAL(terminus_schedule.route().line().name(), "line:bob");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "D");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11,00,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(11,15,00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().vehicle_journey_id(), "vehicle_journey:vj1");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().vehicle_journey_id(), "vehicle_journey:vj2");
+    }
 }

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(1).date_times_size(), 1);
     }
 
-    // comparing terminus_schedule with above stop_schedules
+    // comparing terminus_schedule with above stop_schedules (function "departure_board")
     // same number of elements as terminus_schedules contains an element per destination but not route.
     {
         auto* data_ptr = b.data.get();
@@ -106,6 +106,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).date_times_size(), 1);
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).stop_point().uri(), "stop1");
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(0).pt_display_informations().direction(), "stop2");
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).stop_point().uri(), "stop1");
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules(1).pt_display_informations().direction(), "stop3");
     }
 
@@ -201,7 +202,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         BOOST_CHECK_EQUAL(resp.stop_schedules(1).date_times_size(), 1);
     }
 
-    // No terminus_schedules on terminus for toute "A"
+    // No terminus_schedules on terminus for route "A"
     {
         auto* data_ptr = b.data.get();
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -2123,8 +2123,8 @@ BOOST_AUTO_TEST_CASE(schedules_on_terminus_with_return_vj) {
     // We will have 1 terminus_schedules as the route toward terminus is excluded.
     {
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=C", {}, {}, d("20160802T090000"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=C", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 1);
@@ -2153,9 +2153,11 @@ BOOST_AUTO_TEST_CASE(schedules_with_routes_with_different_intermediate_stops) {
      */
     ed::builder b("20160802");
     b.vj("line:bob", "11111111", "", true, "vj1", "")
-        .route("route:bob")("A", "10:00"_t)("B", "10:30"_t)("C", "11:00"_t)("C", "11:30"_t)("G", "12:00"_t)("H", "12:30"_t);
+        .route("route:bob")("A", "10:00"_t)("B", "10:30"_t)("C", "11:00"_t)("C", "11:30"_t)("G", "12:00"_t)("H",
+                                                                                                            "12:30"_t);
     b.vj("line:bob", "11111111", "", true, "vj2", "")
-        .route("route:boby")("A", "10:15"_t)("B", "10:45"_t)("E", "11:15"_t)("F", "11:45"_t)("G", "12:15"_t)("H", "12:45"_t);
+        .route("route:boby")("A", "10:15"_t)("B", "10:45"_t)("E", "11:15"_t)("F", "11:45"_t)("G", "12:15"_t)("H",
+                                                                                                             "12:45"_t);
     b.finish();
     b.data->pt_data->sort_and_index();
     b.data->build_raptor();
@@ -2192,8 +2194,8 @@ BOOST_AUTO_TEST_CASE(schedules_with_routes_with_different_intermediate_stops) {
     // serving all the stops served by two routes
     {
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
@@ -2320,7 +2322,7 @@ BOOST_AUTO_TEST_CASE(schedules_on_circular_routes) {
     b.vj("line:bob", "11111111", "", true, "vj1", "")
         .route("route:bob")("A", "10:00"_t)("B", "10:30"_t)("C", "11:00"_t);
     b.vj("line:bob", "11111111", "", true, "vj2", "")
-        .route("route:boby")("A", "10:15"_t)("B", "10:45"_t)("C", "11:15"_t) ("A", "11:45"_t);
+        .route("route:boby")("A", "10:15"_t)("B", "10:45"_t)("C", "11:15"_t)("A", "11:45"_t);
     b.finish();
     b.data->pt_data->sort_and_index();
     b.data->build_raptor();
@@ -2355,8 +2357,8 @@ BOOST_AUTO_TEST_CASE(schedules_on_circular_routes) {
     // We should have 1 terminus_schedules with 2 date_times as two routes are merged.
     {
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
-        terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"),
-                           86400, 0, 10, 0, std::numeric_limits<size_t>::max());
+        terminus_schedules(pb_creator, "stop_point.uri=A", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                           std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 1);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1860,6 +1860,10 @@ pbnavitia::StopSchedule* PbCreator::add_stop_schedules() {
     return response.add_stop_schedules();
 }
 
+pbnavitia::StopSchedule* PbCreator::add_terminus_schedules() {
+    return response.add_terminus_schedules();
+}
+
 int PbCreator::route_schedules_size() {
     return response.route_schedules_size();
 }
@@ -2192,6 +2196,10 @@ void PbCreator::make_paginate(const int total_result,
 
 int PbCreator::departure_boards_size() {
     return response.departure_boards_size();
+}
+
+int PbCreator::terminus_schedules_size() {
+    return response.terminus_schedules_size();
 }
 
 int PbCreator::stop_schedules_size() {

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -325,11 +325,13 @@ struct PbCreator {
     bool empty_journeys();
     pbnavitia::RouteSchedule* add_route_schedules();
     pbnavitia::StopSchedule* add_stop_schedules();
+    pbnavitia::StopSchedule* add_terminus_schedules();
     int route_schedules_size();
     pbnavitia::Passage* add_next_departures();
     pbnavitia::Passage* add_next_arrivals();
     void make_paginate(const int, const int, const int, const int);
     int departure_boards_size();
+    int terminus_schedules_size();
     int stop_schedules_size();
     int traffic_reports_size();
     int line_reports_size();


### PR DESCRIPTION
- New end point /terminus_schedules added
- Some unit tests added in kraken
- Some more integration tests to come
- Ticket : https://jira.kisio.org/browse/NAVP-1515

Note: please see https://jira.kisio.org/browse/NAVP-1515 for more information.
Based on POC #2979

Some benchmark figures (comparisons between stop_schedules and terminus_schedules with IDFM data):
1. gare du nord -> 3 times faster
2. gare du nor / rer B -> 5 times faster
3. St Michel Notre Dame / rer -> 5 times faster
 
