### PR TITLE
CI: Several actions to increase the CI quality

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: [navitia/debian8_dev]
+            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
 
     container:
         image: ${{matrix.docker_image}}
@@ -101,7 +101,7 @@ jobs:
   check_artemis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: check artemis
       run: ./source/scripts/checkJenkinsJob.sh Artemis
     - name: check artemis IDFM

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,8 +14,9 @@ jobs:
   check_submodules:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: get submodule
+    - uses: actions/checkout@v2
+    - name: checkout submodules
+      shell: bash
       run: |
         sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
         git submodule update --init --recursive
@@ -28,7 +29,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
+            docker_image: [navitia/debian8_dev, navitia/debian9_dev]
 
     container:
         image: ${{matrix.docker_image}}
@@ -65,6 +66,11 @@ jobs:
       run: |
         pip install -r source/tyr/requirements_dev.txt
         pip install -r source/sql/requirements.txt
+    - name: docker_test
+      run: |
+        export NAVITIA_CHAOS_DUMP_PATH=$(echo $GITHUB_WORKSPACE/source/tests/chaos/chaos_loading.sql.gz | sed -e 's#__w#home/runner/work#')
+        echo $NAVITIA_CHAOS_DUMP_PATH
+        make docker_test
       env:
         NAVITIA_DOCKER_NETWORK: ${{ job.container.network }}
         TYR_CELERY_BROKER_URL: 'amqp://guest:guest@rabbitmq:5672//'

--- a/source/scripts/check_submodules.sh
+++ b/source/scripts/check_submodules.sh
@@ -33,14 +33,9 @@ for submod in $submodules; do
 	head=`cat .git/modules/$module_path/refs/remotes/origin/HEAD` # eg. "ref: refs/remotes/origin/master"
 	remote_ref=`echo $head | sed "s%ref: refs/remotes/%%"` # eg. origin/master
 
-    echo "---------------------------"
-    echo $module_path
-    echo $head
-    echo $remote_ref
 	pushd $module_path > /dev/null
 		# Check whether the current commit contained in the remote HEAD
 		contained=`git branch --all --contains HEAD --no-color | grep $remote_ref`
-        echo "contained $contained"
 		if [ -z "$contained" ]; then
 			_add_error "Submodule $module_path points to a commit not merged to its head ! "
 			_add_error " > submodule: $module_path"

--- a/source/scripts/check_submodules.sh
+++ b/source/scripts/check_submodules.sh
@@ -33,11 +33,15 @@ for submod in $submodules; do
 	head=`cat .git/modules/$module_path/refs/remotes/origin/HEAD` # eg. "ref: refs/remotes/origin/master"
 	remote_ref=`echo $head | sed "s%ref: refs/remotes/%%"` # eg. origin/master
 
+    echo "---------------------------"
+    echo $module_path
+    echo $head
+    echo $remote_ref
 	pushd $module_path > /dev/null
-		# Check whether the current commit is merged or contained in the remote HEAD
-		is_merged=`git branch --all --merged HEAD --no-color | grep $remote_ref`
+		# Check whether the current commit contained in the remote HEAD
 		contained=`git branch --all --contains HEAD --no-color | grep $remote_ref`
-		if [ -z "$is_merged" -a -z "$contained" ]; then
+        echo "contained $contained"
+		if [ -z "$contained" ]; then
 			_add_error "Submodule $module_path points to a commit not merged to its head ! "
 			_add_error " > submodule: $module_path"
 			_add_error " > commit: $sha1"


### PR DESCRIPTION
Several actions to increase the CI quality

- Pass **checkout in V2 mode**. The actions/checkout@v2 is less buggy. We can re-build jobs easlily without problems (https://github.com/actions/checkout/issues/23). Re-triggering a workflow finally works.
However, checkout V2 use a really new version of Git (Setup Git 2.18 or higher). So, this is not available for ubuntu 18 or debian 8/9...
- **Re-sync submodules** (SimpleAmqClient) and check only if submodules HEAD is contained inside origin/HEAD with **check_submodules** script
- Resurrect **Docker tests**
- Resurrect **debian 9 container** for build/tests