### PR TITLE
[GeoRef] Add projection cache to `get_duration_with_dijkstra`

### DIFF
--- a/source/georef/dijkstra_path_finder.cpp
+++ b/source/georef/dijkstra_path_finder.cpp
@@ -177,10 +177,10 @@ routing::map_stop_point_duration DijkstraPathFinder::find_nearest_stop_points(
     return result;
 }
 
-struct ProjectionGetterOnFly {
+struct ProjectionGetterOnCoords {
     const GeoRef::ProjectedCoords& projected_coords;
     const type::Mode_e mode = type::Mode_e::Walking;
-    ProjectionGetterOnFly(const GeoRef::ProjectedCoords& projected_coords, const type::Mode_e mode)
+    ProjectionGetterOnCoords(const GeoRef::ProjectedCoords& projected_coords, const type::Mode_e mode)
         : projected_coords(projected_coords), mode(mode) {}
     const georef::ProjectionData& operator()(const type::GeographicalCoord& coord) const {
         const auto& projection = projected_coords.at(coord);
@@ -195,10 +195,10 @@ DijkstraPathFinder::get_duration_with_dijkstra(const navitia::time_duration& rad
         return {};
     }
 
-    ProjectionGetterOnFly projection_getter(geo_ref.projected_coords,
-                                            mode == type::Mode_e::Car ? nt::Mode_e::Walking : mode);
+    ProjectionGetterOnCoords projection_getter(geo_ref.projected_coords,
+                                               mode == type::Mode_e::Car ? nt::Mode_e::Walking : mode);
     return start_dijkstra_and_fill_duration_map<DijkstraPathFinder::coord_uri, type::GeographicalCoord,
-                                                ProjectionGetterOnFly>(radius, dest_coords, projection_getter);
+                                                ProjectionGetterOnCoords>(radius, dest_coords, projection_getter);
 }
 
 template <class Visitor>

--- a/source/georef/edge.h
+++ b/source/georef/edge.h
@@ -1,0 +1,56 @@
+/* Copyright © 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include "type/type_interfaces.h"
+#include "type/time_duration.h"
+
+namespace nt = navitia::type;
+
+namespace navitia {
+namespace georef {
+
+/** Edge properties (used to be "segment")*/
+
+struct Edge {
+    nt::idx_t way_idx = nt::invalid_idx;   //< indexing street name
+    nt::idx_t geom_idx = nt::invalid_idx;  // geometry index
+    navitia::time_duration duration = {};  // duration of the edge
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar& way_idx& geom_idx& duration;
+    }
+    Edge(nt::idx_t wid, navitia::time_duration dur) : way_idx(wid), duration(dur) {}
+    Edge() {}
+};
+
+}  // namespace georef
+}  // namespace navitia

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -566,10 +566,24 @@ void GeoRef::project_stop_points(const std::vector<type::StopPoint*>& stop_point
     this->projected_stop_points.clear();
     this->projected_stop_points.reserve(stop_points.size());
 
+    this->projected_coords.clear();
+    this->projected_coords.reserve(stop_points.size());
+
     for (const type::StopPoint* stop_point : stop_points) {
         std::pair<GeoRef::ProjectionByMode, bool> pair = project_stop_point(stop_point);
 
+        /*
+         * We build 2 different caches :
+         *  1. projected_stop_points : based on the stop_point id for NewDefault
+         *  2. projected_coords : based on GeographicalCoord for distributed.
+         *
+         *  TODO: remove projected_stop_points and replace it with the other one.
+         *  This could save us spave, but the Dijkstra related interface for Georef
+         *  needs a lot of rework.
+         */
         this->projected_stop_points.push_back(pair.first);
+        this->projected_coords[stop_point->coord] = pair.first;
+
         if (pair.second) {
             messages[error::matched] += 1;
         } else {

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -205,6 +205,9 @@ struct GeoRef {
     typedef flat_enum_map<nt::Mode_e, ProjectionData> ProjectionByMode;
     std::vector<ProjectionByMode> projected_stop_points = {};
 
+    typedef std::unordered_map<nt::GeographicalCoord, ProjectionByMode> ProjectedCoords;
+    ProjectedCoords projected_coords;
+
     /// Graphe pour effectuer le calcul d'itinéraire
     Graph graph;
 

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -36,8 +36,9 @@ www.navitia.io
 #include "utils/flat_enum_map.h"
 #include "utils/serialization_vector.h"
 #include "type/time_duration.h"
+#include "georef/georef_types.h"
+#include "georef/projection_data.h"
 
-#include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/adj_list_serialize.hpp>
 #include <boost/serialization/serialization.hpp>
 #include <boost/serialization/utility.hpp>
@@ -80,40 +81,6 @@ struct Vertex {
         ar& coord;
     }
 };
-
-/** Edge properties (used to be "segment")*/
-
-struct Edge {
-    nt::idx_t way_idx = nt::invalid_idx;   //< indexing street name
-    nt::idx_t geom_idx = nt::invalid_idx;  // geometry index
-    navitia::time_duration duration = {};  // duration of the edge
-
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int) {
-        ar& way_idx& geom_idx& duration;
-    }
-    Edge(nt::idx_t wid, navitia::time_duration dur) : way_idx(wid), duration(dur) {}
-    Edge() {}
-};
-
-// Plein de typedefs pour nous simpfilier un peu la vie
-
-/** Définit le type de graph que l'on va utiliser
- *
- * Les arcs sortants et la liste des nœuds sont représentés par des vecteurs
- * les arcs sont orientés
- * les propriétés des nœuds et arcs sont les classes définies précédemment
- */
-typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, Vertex, Edge> Graph;
-
-/// Représentation d'un nœud dans le g,raphe
-typedef boost::graph_traits<Graph>::vertex_descriptor vertex_t;
-
-/// Représentation d'un arc dans le graphe
-typedef boost::graph_traits<Graph>::edge_descriptor edge_t;
-
-/// Pour parcourir les segements du graphe
-typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
 
 /** le numéro de la maison :
     il représente un point dans la rue, voie */
@@ -347,60 +314,6 @@ private:
     edge_t nearest_edge(const type::GeographicalCoord& coordinates,
                         const proximitylist::ProximityList<vertex_t>& prox,
                         double horizon = 500) const;
-};
-
-/** When given a coordinate, we have to associate it with the street network.
- *
- * This structure handle this.
- *
- * It contains
- *   - 2 possible nodes (each end of the edge where the coordinate has been projected)
- *   - the coordinate of the projection
- *   - the 2 distances between the projected point and the ends (NOTE, this is not the distance between the coordinate
- * and the ends)
- *
- */
-struct ProjectionData {
-    // enum used to acces the nodes and the distances
-    enum class Direction { Source = 0, Target, size };
-    // 2 possible nodes (each end of the edge where the coordinate has been projected)
-    flat_enum_map<Direction, vertex_t> vertices;
-
-    // The edge we projected on. Needed since we can't be sure to get the right edge with only the source and the target
-    // because of parallel edges.
-    Edge edge;
-
-    // has the projection been successful?
-    bool found = false;
-
-    // The coordinate projected on the edge
-    type::GeographicalCoord projected;
-
-    // the original coordinate before projection
-    type::GeographicalCoord real_coord;
-
-    // Distance between the projected point and the ends
-    flat_enum_map<Direction, double> distances{{{-1, -1}}};
-
-    ProjectionData() {}
-    // Project the coordinate on the graph corresponding to the transportation mode of the offset
-    ProjectionData(const type::GeographicalCoord& coord, const GeoRef& sn, type::Mode_e mode = type::Mode_e::Walking);
-
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int) {
-        ar& vertices& projected& distances& found& real_coord& edge;
-    }
-
-    void init(const type::GeographicalCoord& coord, const GeoRef& sn, const edge_t& nearest_edge);
-
-    // syntaxic sugar
-    vertex_t operator[](Direction d) const {
-        if (!found) {
-            throw proximitylist::NotFound();
-        }
-
-        return vertices[d];
-    }
 };
 
 /** Nommage d'un POI (point of interest). **/

--- a/source/georef/georef_types.h
+++ b/source/georef/georef_types.h
@@ -1,0 +1,32 @@
+
+#pragma once
+
+#include "georef/edge.h"
+#include <boost/graph/adjacency_list.hpp>
+
+namespace navitia {
+namespace georef {
+
+class Vertex;
+
+// Plein de typedefs pour nous simpfilier un peu la vie
+
+/** Définit le type de graph que l'on va utiliser
+ *
+ * Les arcs sortants et la liste des nœuds sont représentés par des vecteurs
+ * les arcs sont orientés
+ * les propriétés des nœuds et arcs sont les classes définies précédemment
+ */
+typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::directedS, Vertex, Edge> Graph;
+
+/// Représentation d'un nœud dans le g,raphe
+typedef boost::graph_traits<Graph>::vertex_descriptor vertex_t;
+
+/// Représentation d'un arc dans le graphe
+typedef boost::graph_traits<Graph>::edge_descriptor edge_t;
+
+/// Pour parcourir les segements du graphe
+typedef boost::graph_traits<Graph>::edge_iterator edge_iterator;
+
+}  // namespace georef
+}  // namespace navitia

--- a/source/georef/projection_data.h
+++ b/source/georef/projection_data.h
@@ -1,0 +1,93 @@
+/* Copyright © 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include "georef/georef_types.h"
+#include "georef/edge.h"
+
+namespace navitia {
+namespace georef {
+
+/** When given a coordinate, we have to associate it with the street network.
+ *
+ * This structure handle this.
+ *
+ * It contains
+ *   - 2 possible nodes (each end of the edge where the coordinate has been projected)
+ *   - the coordinate of the projection
+ *   - the 2 distances between the projected point and the ends (NOTE, this is not the distance between the coordinate
+ * and the ends)
+ *
+ */
+struct ProjectionData {
+    // enum used to acces the nodes and the distances
+    enum class Direction { Source = 0, Target, size };
+    // 2 possible nodes (each end of the edge where the coordinate has been projected)
+    flat_enum_map<Direction, vertex_t> vertices;
+
+    // The edge we projected on. Needed since we can't be sure to get the right edge with only the source and the target
+    // because of parallel edges.
+    Edge edge;
+
+    // has the projection been successful?
+    bool found = false;
+
+    // The coordinate projected on the edge
+    type::GeographicalCoord projected;
+
+    // the original coordinate before projection
+    type::GeographicalCoord real_coord;
+
+    // Distance between the projected point and the ends
+    flat_enum_map<Direction, double> distances{{{-1, -1}}};
+
+    ProjectionData() {}
+    // Project the coordinate on the graph corresponding to the transportation mode of the offset
+    ProjectionData(const type::GeographicalCoord& coord, const GeoRef& sn, type::Mode_e mode = type::Mode_e::Walking);
+
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int) {
+        ar& vertices& projected& distances& found& real_coord& edge;
+    }
+
+    void init(const type::GeographicalCoord& coord, const GeoRef& sn, const edge_t& nearest_edge);
+
+    // syntaxic sugar
+    vertex_t operator[](Direction d) const {
+        if (!found) {
+            throw proximitylist::NotFound();
+        }
+
+        return vertices[d];
+    }
+};
+
+}  // namespace georef
+}  // namespace navitia

--- a/source/type/geographical_coord.h
+++ b/source/type/geographical_coord.h
@@ -41,6 +41,7 @@ www.navitia.io
 #include <boost/geometry/multi/geometries/multi_linestring.hpp>
 #include <boost/geometry/multi/geometries/register/multi_linestring.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/functional/hash.hpp>
 
 namespace navitia {
 namespace type {
@@ -181,6 +182,19 @@ typedef boost::geometry::model::polygon<GeographicalCoord> Polygon;
 typedef boost::geometry::model::multi_polygon<Polygon> MultiPolygon;
 }  // namespace type
 }  // namespace navitia
+
+namespace std {
+template <>
+struct hash<navitia::type::GeographicalCoord> {
+    std::size_t operator()(const navitia::type::GeographicalCoord& coord) const {
+        std::size_t seed = 0;
+        boost::hash_combine(seed, coord.lon());
+        boost::hash_combine(seed, coord.lat());
+        return seed;
+    }
+};
+}  // namespace std
+
 namespace boost {
 namespace serialization {
 template <class Archive>


### PR DESCRIPTION
Street Network Matrix can be computed 2 different ways with Kraken using `DijkstraPathFinder`:
 1. via `find_nearest_stop_points()` with a proximity that holds stop points ids (New Default scenario).
 2.  via `get_duration_with_dijsktra()` with a list of coordinates (Distributed scenario).

In the second case, we want to avoid projecting the coordinate for every single object. We could use this exact same caching mechanism at the one done for 1. (in `ProjectionGetterByCache`). 

This PR adds a cache that maps each stop points coordinate to its projected data on the street network. 

Read by commit to avoid all the header moves... 