### PR TITLE
Mergify: configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,6 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
       - status-success~=build
       - status-success=check_submodules
       - status-success=precommit


### PR DESCRIPTION
In practice, commenting a pull request should NOT prevent the PR from been merged. 

The removed rule suggested that no comment were left on the PR to enable auto-merge.

If you want to block the merging process, we should used the `changes-requested` feature.
 
---
This change has been made by @nonifier from https://mergify.io simulator.
---


<details>
<summary>Mergify commands and options</summary>
<br />
More conditions and actions can be found in the [documention](https://doc.mergify.io/).
<br />
<br />
You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR
- `@Mergifyio backports <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
