### PR TITLE
CI: trigger Jenkins for publishing packages on internal server

### DIFF
--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -33,3 +33,5 @@ jobs:
         path: "${{env.NAVITIA_DEBIAN_PACKAGES}}"
     - name: remove useless temporary files
       run: rm -rf ../navitia-*
+    - name: trigger navitia debian packages publishing on internal server
+      run: http -v -f POST https://${{secrets.jenkins_token}}@ci.navitia.io/job/publish_navitia_release_packages_from_github/build

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -33,5 +33,5 @@ jobs:
         path: "${{env.NAVITIA_DEBIAN_PACKAGES}}"
     - name: remove useless temporary files
       run: rm -rf ../navitia-*
-    - name: trigger navitia debian packages publishing on internal server
+    - name: trigger jenkins to publish Artifacts on internal server
       run: http -v -f POST https://${{secrets.jenkins_token}}@ci.navitia.io/job/publish_navitia_release_packages_from_github/build


### PR DESCRIPTION
trigger this Jenkins https://ci.navitia.io/job/publish_navitia_release_packages_from_github/
to retreive Artifacts and send them to internal FTP server for the DevOps