### PR TITLE
erase terminus link to fix Artemis bibus tests

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -149,14 +149,7 @@ class add_computed_resources(object):
                 collection in ['stop_areas', 'stop_points', 'lines', 'routes', 'addresses']
                 and "region" in kwargs
             ):
-                for api in [
-                    'route_schedules',
-                    'stop_schedules',
-                    'arrivals',
-                    'departures',
-                    "places_nearby",
-                    "terminus_schedules",
-                ]:
+                for api in ['route_schedules', 'stop_schedules', 'arrivals', 'departures', "places_nearby"]:
                     data['links'].append(
                         {"href": url_for("v1." + api, **kwargs), "rel": api, "type": api, "templated": templated}
                     )


### PR DESCRIPTION
**Artemis** failed because of terminus_schedules links within **Bibus test**s
https://ci.navitia.io/job/Artemis/2478/console