### PR TITLE
fix debian compatibility to build sources

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: [navitia/debian8_dev, navitia/debian9_dev]
+            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
 
     container:
         image: ${{matrix.docker_image}}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -31,6 +31,9 @@ set(CMAKE_INSTALL_PREFIX "/usr")
 include(GetGitRevisionDescription)
 git_describe(GIT_REVISION)
 
+# Detect Os version
+include(DetectOsVersion)
+
 # Compilation flags (Debug and Release)
 include(CompilationFlags)
 

--- a/source/cmake_modules/DetectOsVersion.cmake
+++ b/source/cmake_modules/DetectOsVersion.cmake
@@ -1,0 +1,105 @@
+if(${CMAKE_VERSION} VERSION_GREATER "3.1.0")
+    cmake_policy(SET CMP0054 NEW)
+endif()
+
+# Returns a simple string describing the current architecture. Possible
+# return values currently include: amd64, x86_64, x86.
+# Returns a lowercased version of a given lsb_release field.
+MACRO (_LSB_RELEASE field retval)
+  EXECUTE_PROCESS (COMMAND lsb_release "--${field}"
+  OUTPUT_VARIABLE _output ERROR_VARIABLE _output RESULT_VARIABLE _result)
+  IF (_result)
+    MESSAGE (FATAL_ERROR "Cannot determine Linux revision! Output from "
+    "lsb_release --${field}: ${_output}")
+  ENDIF (_result)
+  STRING (REGEX REPLACE "^[^:]*:" "" _output "${_output}")
+  STRING (TOLOWER "${_output}" _output)
+  STRING (STRIP "${_output}" ${retval})
+ENDMACRO (_LSB_RELEASE)
+
+# Returns a lowercased version of a given /etc/os-release field.
+MACRO (_OS_RELEASE field retval)
+  FILE (STRINGS /etc/os-release vars)
+  SET (${_value} "${field}-NOTFOUND")
+  FOREACH (var ${vars})
+    IF (var MATCHES "^${field}=(.*)")
+      SET (_value "${CMAKE_MATCH_1}")
+      # Value may be quoted in single- or double-quotes; strip them
+      IF (_value MATCHES "^['\"](.*)['\"]\$")
+        SET (_value "${CMAKE_MATCH_1}")
+      ENDIF ()
+      BREAK ()
+    ENDIF ()
+  ENDFOREACH ()
+
+  SET (${retval} "${_value}")
+ENDMACRO (_OS_RELEASE)
+
+# Returns a simple string describing the current platform. Possible
+# return values currently include: windows_msvc2017; windows_msvc2015;
+# windows_msvc2013; windows_msvc2012; macosx; or any value from
+# _DETERMINE_LINUX_DISTRO.
+
+# Returns a simple string describing the current Linux distribution
+# compatibility. Possible return values currently include:
+# ubuntu14.04, ubuntu12.04, ubuntu10.04, centos5, centos6, debian7, debian8.
+MACRO (DETERMINE_LINUX_DISTRO)
+  IF (EXISTS "/etc/os-release")
+      _OS_RELEASE (ID OS_ID)
+      _OS_RELEASE (VERSION_ID OS_VERSION)
+  ENDIF ()
+  IF (NOT ( OS_ID AND OS_VERSION ) )
+    FIND_PROGRAM(LSB_RELEASE lsb_release)
+    IF (LSB_RELEASE)
+      _LSB_RELEASE (id OS_ID)
+      _LSB_RELEASE (release OS_VERSION)
+    ELSE (LSB_RELEASE)
+      MESSAGE (WARNING "Can't determine Linux platform without /etc/os-release or lsb_release")
+      SET (OS_ID "unknown")
+      SET (OS_VERSION "")
+    ENDIF (LSB_RELEASE)
+  ENDIF ()
+  IF (OS_ID STREQUAL "linuxmint")
+    # Linux Mint is an Ubuntu derivative; estimate nearest Ubuntu equivalent
+    SET (OS_ID "ubuntu")
+    IF (OS_VERSION VERSION_LESS 13)
+      SET (OS_VERSION 10.04)
+    ELSEIF (OS_VERSION VERSION_LESS 17)
+      SET (OS_VERSION 12.04)
+    ELSEIF (OS_VERSION VERSION_LESS 18)
+      SET (OS_VERSION 14.04)
+    ELSE ()
+      SET (OS_VERSION 16.04)
+    ENDIF ()
+  ELSEIF (OS_ID STREQUAL "debian" OR OS_ID STREQUAL "centos" OR OS_ID STREQUAL "rhel")
+    # Just use the major version from the CentOS/Debian/RHEL identifier;
+    # we don't need different builds for different minor versions.
+    STRING (REGEX MATCH "[0-9]+" OS_VERSION "${OS_VERSION}")
+  ELSEIF (OS_ID STREQUAL "fedora" AND OS_VERSION VERSION_LESS 26)
+    SET (OS_ID "centos")
+    SET (OS_VERSION "7")
+  ELSEIF (OS_ID MATCHES "opensuse.*" OR OS_ID MATCHES "suse.*" OR OS_ID MATCHES "sles.*")
+    SET(OS_ID "suse")
+    # Just use the major version from the SuSE identifier - we don't
+    # need different builds for different minor versions.
+    STRING (REGEX MATCH "[0-9]+" OS_VERSION "${OS_VERSION}")
+  ENDIF (OS_ID STREQUAL "linuxmint")
+  SET ("${OS_ID}${OS_VERSION}")
+ENDMACRO (DETERMINE_LINUX_DISTRO)
+
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    message( FATAL_ERROR "-- OS ${CMAKE_SYSTEM_NAME} not supported")
+endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+
+DETERMINE_LINUX_DISTRO()
+message("-- OS ${CMAKE_SYSTEM_NAME} ${OS_ID}-${OS_VERSION}")
+
+if(("${OS_ID}" STREQUAL "debian" AND "${OS_VERSION}" LESS 10) OR ("${OS_ID}" STREQUAL "ubuntu"))
+    message("-- need for backward compatibility for libpqxx")
+    set(PQXX_COMPATIBILITY ON)
+    if(PQXX_COMPATIBILITY)
+        add_definitions(-DPQXX_COMPATIBILITY)
+    endif()
+else(("${OS_ID}" STREQUAL "debian" AND "${OS_VERSION}" LESS 10) OR ("${OS_ID}" STREQUAL "ubuntu"))
+    message("-- no need for backward compatibility for libpqxx")
+endif(("${OS_ID}" STREQUAL "debian" AND "${OS_VERSION}" LESS 10) OR ("${OS_ID}" STREQUAL "ubuntu"))

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -57,6 +57,12 @@ namespace pt = boost::posix_time;
 namespace georef = navitia::georef;
 namespace ed {
 
+#if PQXX_COMPATIBILITY
+typedef pqxx::tuple pqxx_row;
+#else
+typedef pqxx::row pqxx_row;
+#endif
+
 // A functor that first asks to GeoRef the admins of coord, and, if
 // GeoRef found nothing, asks to the cities database.
 struct FindAdminWithCities {
@@ -190,11 +196,11 @@ struct FindAdminWithCities {
             )sql") % c.lon() % c.lat();
         pqxx::result db_result = work->exec(sql_req.str());
 
-        auto not_in_insee_admins_map = [&](const pqxx::tuple& row) {
+        auto not_in_insee_admins_map = [&](const pqxx_row& row) {
             return insee_admins_map.count(row["insee"].c_str()) == 0;
         };
-        auto not_already_added = [&](const pqxx::tuple& row) { return added_admins.count(row["uri"].c_str()) == 0; };
-        auto make_admin_from_row = [&](const pqxx::tuple& row) { return make_admin(row); };
+        auto not_already_added = [&](const pqxx_row& row) { return added_admins.count(row["uri"].c_str()) == 0; };
+        auto make_admin_from_row = [&](const pqxx_row& row) { return make_admin(row); };
 
         std::vector<georef::Admin*> new_admins;
         // clang-format off


### PR DESCRIPTION
Currently, we can't compile with the new last debian version (**debian 10 - buster**). The fact is, the **pqxx** libraries broke backward compatibility by changing the Major number.
So, we have a difference in the API with the new version (version 6). The new Pqxx library has changed with the debian 10 buster...

The last version: **libpqxx-dev 4.xx**
The new version: **libpqxx-dev 6.xx**

My first idea was to use _Apt Debian backport_, but it seemed there was not the Pqxx old version into the backport (https://packages.debian.org/search?keywords=libpqxx-dev).
I did not want to re-compile the librairie after a curl acces to the sources. Therefore, I decided to use the master weapon :gun: the **CMake OS detection**.
It consists to detect OS for applicating the good struct with a **#if** into the code

I tested that for:
- debian 8
- debian 9
- debian 10
- ubuntu 18.04

Now, we can compile with the last debian version.

- [x] debian 10 added to CI

**Note:** The detection script is generic, it can detect a lot of OS (mint, fedora, opensuse, debian, ubuntu). I only tested OS that we support