### PR TITLE
[Kraken] optim proximitylist_api

### DIFF
--- a/source/proximity_list/proximity_list.cpp
+++ b/source/proximity_list/proximity_list.cpp
@@ -148,8 +148,8 @@ static int radius_search(const std::shared_ptr<index_t>& NN_index,
 
 template <class T>
 auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
-                                        double radius,
-                                        int size,
+                                        const double radius,
+                                        const int size,
                                         IndexCoord /*unused*/) const
     -> std::vector<typename ReturnTypeTrait<T, IndexCoord>::ValueType> {
     // Containers are auto-sized by NN_index, Flann will return all objects inside of the given radius
@@ -166,10 +166,10 @@ auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
     return res;
 }
 
-template <class T>
+template <typename T>
 auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
-                                        double radius,
-                                        int size,
+                                        const double radius,
+                                        const int size,
                                         IndexCoordDistance /*unused*/) const
     -> std::vector<typename ReturnTypeTrait<T, IndexCoordDistance>::ValueType> {
     // Containers are auto-sized by NN_index, Flann will return all objects inside of the given radius
@@ -188,8 +188,8 @@ auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
 
 template <class T>
 auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
-                                        double radius,
-                                        int size,
+                                        const double radius,
+                                        const int size,
                                         IndexOnly /*unused*/) const
     -> std::vector<typename ReturnTypeTrait<T, IndexOnly>::ValueType> {
     // Using small sized std::array will avoid heap allocation and limit the research
@@ -203,7 +203,6 @@ auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
     std::vector<typename ReturnTypeTrait<T, IndexOnly>::ValueType> res;
     auto op = [](const Item& item, float /*unused*/) { return item.element; };
     make_result<T>(coord, items, indices_data, distances_data, nb_found, res, op);
-    ;
 
     return res;
 }

--- a/source/proximity_list/proximity_list.cpp
+++ b/source/proximity_list/proximity_list.cpp
@@ -93,12 +93,20 @@ void ProximityList<T>::build() {
 }
 
 template <typename T, typename Item>
-static auto extract(const Item& item, IndexCoord /*unused*/) -> typename ReturnTypeTrait<T, IndexCoord>::ValueType {
+static auto extract(const Item& item, float /*unused*/, IndexCoord /*unused*/) ->
+    typename ReturnTypeTrait<T, IndexCoord>::ValueType {
     return std::make_pair(item.element, item.coord);
 }
 
 template <typename T, typename Item>
-static auto extract(const Item& item, IndexOnly /*unused*/) -> typename ReturnTypeTrait<T, IndexOnly>::ValueType {
+static auto extract(const Item& item, float distance, IndexCoordDistance /*unused*/) ->
+    typename ReturnTypeTrait<T, IndexCoordDistance>::ValueType {
+    return std::make_tuple(item.element, item.coord, distance);
+}
+
+template <typename T, typename Item>
+static auto extract(const Item& item, float /*unused*/, IndexOnly /*unused*/) ->
+    typename ReturnTypeTrait<T, IndexOnly>::ValueType {
     return item.element;
 }
 
@@ -126,7 +134,7 @@ static auto make_result(const type::GeographicalCoord& coord,
             log4cplus::Logger::getInstance("log"),
             "Distance(squared) from the coord: " << coord.lon() << " " << coord.lat() << " is " << distances.at(i));
 
-        res.push_back(extract<T>(items[res_ind], Tag{}));
+        res.push_back(extract<T>(items[res_ind], distances.at(i), Tag{}));
     }
     return res;
 }
@@ -170,6 +178,21 @@ auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
     assert(indices.size() == 1);
     assert(distances.size() == 1);
     return make_result<T>(coord, items, indices[0], distances[0], nb_found, IndexCoord{});
+}
+
+template <class T>
+auto ProximityList<T>::find_within_impl(const GeographicalCoord& coord,
+                                        double radius,
+                                        int size,
+                                        IndexCoordDistance /*unused*/) const
+    -> std::vector<typename ReturnTypeTrait<T, IndexCoordDistance>::ValueType> {
+    // Containers are auto-sized by NN_index, Flann will return all objects inside of the given radius
+    std::vector<std::vector<int>> indices;
+    std::vector<std::vector<index_t::DistanceType>> distances;
+    int nb_found = radius_search(NN_index, coord, radius, size, indices, distances);
+    assert(indices.size() == 1);
+    assert(distances.size() == 1);
+    return make_result<T>(coord, items, indices[0], distances[0], nb_found, IndexCoordDistance{});
 }
 
 template <class T>

--- a/source/proximity_list/proximity_list.h
+++ b/source/proximity_list/proximity_list.h
@@ -62,6 +62,7 @@ struct NotFound : public recoverable_exception {
 // find_within Dispatch Tag
 struct IndexOnly {};
 struct IndexCoord {};
+struct IndexCoordDistance {};
 
 template <typename T, typename Tag>
 struct ReturnTypeTrait;
@@ -76,6 +77,10 @@ struct ReturnTypeTrait<T, IndexCoord> {
     typedef std::pair<T, GeographicalCoord> ValueType;
 };
 
+template <typename T>
+struct ReturnTypeTrait<T, IndexCoordDistance> {
+    typedef std::tuple<T, GeographicalCoord, float> ValueType;
+};
 /* A structure allows to find K Nearest Neighbours with a given radius.
  *
  * The Item contains T(in practice, the Idx of the wanted object) and the coord of the object.
@@ -162,6 +167,9 @@ private:
      * */
     auto find_within_impl(const GeographicalCoord& coord, double radius, int size, IndexCoord) const
         -> std::vector<typename ReturnTypeTrait<T, IndexCoord>::ValueType>;
+
+    auto find_within_impl(const GeographicalCoord& coord, double radius, int size, IndexCoordDistance) const
+        -> std::vector<typename ReturnTypeTrait<T, IndexCoordDistance>::ValueType>;
 
     /*
      * This implementation is used for edge projection

--- a/source/proximity_list/proximity_list.h
+++ b/source/proximity_list/proximity_list.h
@@ -120,10 +120,12 @@ struct ProximityList {
     void build();
 
     /*
-     * This method can return two types of result
+     * This method can return three types of result
      *
      * When Tag is IndexCorrd, the method returns a vector of Index and Coord, which is useful for searching
      * features nearby a wanted place.
+
+     * When Tag is IndexCorrdDistance, the method returns a vector of Index, Coord and the Distance.
      *
      * If Tag is IndexOnly, the method returns a vector of Index, which is useful for coord projections.
      *
@@ -165,10 +167,10 @@ private:
      *
      * Note that this implementation returns the indices AND the coords of all the nearest elements
      * */
-    auto find_within_impl(const GeographicalCoord& coord, double radius, int size, IndexCoord) const
+    auto find_within_impl(const GeographicalCoord& coord, const double radius, const int size, IndexCoord) const
         -> std::vector<typename ReturnTypeTrait<T, IndexCoord>::ValueType>;
 
-    auto find_within_impl(const GeographicalCoord& coord, double radius, int size, IndexCoordDistance) const
+    auto find_within_impl(const GeographicalCoord& coord, const double radius, const int size, IndexCoordDistance) const
         -> std::vector<typename ReturnTypeTrait<T, IndexCoordDistance>::ValueType>;
 
     /*
@@ -179,7 +181,7 @@ private:
      * .
      * Note that this implementation returns ONLY indices of nearest elements
      * */
-    auto find_within_impl(const GeographicalCoord& coord, double radius, int size, IndexOnly) const
+    auto find_within_impl(const GeographicalCoord& coord, const double radius, const int size, IndexOnly) const
         -> std::vector<typename ReturnTypeTrait<T, IndexOnly>::ValueType>;
 };
 

--- a/source/proximity_list/proximitylist_api.h
+++ b/source/proximity_list/proximitylist_api.h
@@ -47,7 +47,6 @@ typedef uint32_t idx_t;
 
 namespace proximitylist {
 
-typedef std::vector<std::pair<type::idx_t, type::GeographicalCoord>> vector_idx_coord;
 void find(navitia::PbCreator& pb_creator,
           const type::GeographicalCoord& coord,
           const double distance,


### PR DESCRIPTION
https://jira.kisio.org/browse/TRR-103

a new interface is added to `find_within()`  in `proximity_list.cpp` which allows returning the crow fly distance.

two things are optimized in` proximitylist_api.cpp`:

1 no more 'sort', because the 'list' returned by flann are already sorted regarding the distance
2 no more computation of distance, the distances are now returned by `find_within()` 

The gain is about 10% ~ 40% for the call of proximity list, since the elapsed time (1ms ~ 10ms) in this function is quite small, the global gain for '/journeys' is small too...

