### PR TITLE
[Mergify] configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,9 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
-      - status-success~=build
+      - status-success=build (navitia/debian8_dev)
+      - status-success=build (navitia/debian9_dev)
+      - status-success=build (navitia/debian10_dev)
       - status-success=check_submodules
       - status-success=precommit
       - status-success=check_artemis


### PR DESCRIPTION
We have noticed that Mergify wasn't working properly:
 * The validation of CI jobs was wrong.
 * Mergify was merging without waiting on CI to finish...

When looking at the documentation, there is a section that says : 
```
Do not use conditions such as:
 - status-success~=build while expecting this to wait for all status checks that have build in their name (see point 1. above).
```
https://doc.mergify.io/conditions.html#validating-all-status-check

And that's exactly what we were doing.............

So, let's update the configuration to validate each build configuration: debian8, 9, 10. 

---

This change has been made by @nonifier from https://mergify.io simulator.

---


<details>
<summary>Mergify commands and options</summary>
<br />
More conditions and actions can be found in the [documention](https://doc.mergify.io/).
<br />
<br />
You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.io/) you can:

- look at your merge queues
- generate the Mergify configuration with the simulator.

Finally, you can contact us on https://mergify.io/
</details>
