### PR TITLE
CI: add notifications to slack

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -35,3 +35,7 @@ jobs:
       run: rm -rf ../navitia-*
     - name: trigger deploy on artemis
       run: http -v -f POST https://${{secrets.jenkins_token}}@ci.navitia.io/job/deploy_navitia_on_artemis_from_github/build
+    - name: slack notification (the job has failed)
+      if: failure()
+      run: |
+          echo '{"text":"Github Actions: build_navitia_packages_for_dev failed (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -38,4 +38,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Github Actions: build_navitia_packages_for_dev failed (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: build_navitia_packages_for_dev failed (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}

--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -38,4 +38,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":"Github Actions: build_navitia_packages_for_dev failed (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: build_navitia_packages_for_dev failed (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -46,5 +46,5 @@ jobs:
     - name: slack notification (the job has successed)
       if: success()
       run: |
-          echo '{"text":"Github Actions: build_navitia_packages_for_release succeded - ${{env.VERSION_NUMBER}} navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
-          echo '{"text":"Navitia Release: The version ${{env.VERSION_NUMBER}} is available. changelog: https://github.com/CanalTP/navitia/releases/tag/v${{env.VERSION_NUMBER}}"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}
+          echo '{"text":":information_source: Github Actions: build_navitia_packages_for_release succeded - ${{env.VERSION_NUMBER}} navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":octopus: Navitia Release: The version ${{env.VERSION_NUMBER}} is available. changelog: https://github.com/CanalTP/navitia/releases/tag/v${{env.VERSION_NUMBER}}"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: retreive version number
+      run: |
+          version_number=$(head -n 1 debian/changelog | cut -d'(' -f 2 | cut -d')' -f 1)
+          echo "::set-env name=VERSION_NUMBER::$version_number"
     - name: dkpg-buildpackage
       run: |
         sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
@@ -38,8 +42,9 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Github Actions: build_navitia_packages_for_release failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: build_navitia_packages_for_release failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
     - name: slack notification (the job has successed)
       if: success()
       run: |
-          echo '{"text":":tada: Github Actions: build_navitia_packages_for_release succeded - navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":"Github Actions: build_navitia_packages_for_release succeded - navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":"Navitia Release: The version ${{env.VERSION_NUMBER}} is available. changelog: https://github.com/CanalTP/navitia/releases/tag/v${{env.VERSION_NUMBER}}"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -46,5 +46,5 @@ jobs:
     - name: slack notification (the job has successed)
       if: success()
       run: |
-          echo '{"text":"Github Actions: build_navitia_packages_for_release succeded - navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":"Github Actions: build_navitia_packages_for_release succeded - ${{env.VERSION_NUMBER}} navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
           echo '{"text":"Navitia Release: The version ${{env.VERSION_NUMBER}} is available. changelog: https://github.com/CanalTP/navitia/releases/tag/v${{env.VERSION_NUMBER}}"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -35,3 +35,11 @@ jobs:
       run: rm -rf ../navitia-*
     - name: trigger jenkins to publish Artifacts on internal server
       run: http -v -f POST https://${{secrets.jenkins_token}}@ci.navitia.io/job/publish_navitia_release_packages_from_github/build
+    - name: slack notification (the job has failed)
+      if: failure()
+      run: |
+          echo '{"text":"Github Actions: build_navitia_packages_for_release failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_URL}}
+    - name: slack notification (the job has successed)
+      if: success()
+      run: |
+          echo '{"text":"Github Actions: build_navitia_packages_for_release succeded - navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -38,8 +38,8 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":"Github Actions: build_navitia_packages_for_release failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: build_navitia_packages_for_release failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_URL}}
     - name: slack notification (the job has successed)
       if: success()
       run: |
-          echo '{"text":"Github Actions: build_navitia_packages_for_release succeded - navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":tada: Github Actions: build_navitia_packages_for_release succeded - navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: CanalTP/navitia-docker-compose
+    - name: install httpie dependency
+      run: apt update && apt install -y httpie
     - name: build navitia_builder docker image
       working-directory: builder
       run: docker build --pull --no-cache=true -t navitia_builder .
@@ -23,3 +25,7 @@ jobs:
     - if: github.ref == 'refs/heads/release'
       name: create and publish RELEASE images
       run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock navitia_builder -b release -l -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+    - name: slack notification (the job has failed)
+      if: failure()
+      run: |
+          echo '{"text":"Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         repository: CanalTP/navitia-docker-compose
     - name: install httpie dependency
-      run: apt update && apt install -y httpie
+      run: sudo apt update && sudo apt install -y httpie
     - name: build navitia_builder docker image
       working-directory: builder
       run: docker build --pull --no-cache=true -t navitia_builder .

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -28,4 +28,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -28,4 +28,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":"Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -51,4 +51,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Github Actions: publish_navitia_documentation failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: publish_navitia_documentation failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -17,7 +17,7 @@ jobs:
     - name: install bundle
       run: sudo apt update && sudo apt install -y bundler
     - name: install httpie dependency
-      run: apt update && apt install -y httpie
+      run: sudo apt update && sudo apt install -y httpie
     - name: git checkout on dev
       run: git checkout dev
     - name: generate documentation on dev

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -1,7 +1,6 @@
 name: Publish Navitia Documentation
 
 on:
-  pull_request:
   push:
     branches:
       - dev
@@ -53,7 +52,3 @@ jobs:
       if: failure()
       run: |
           echo '{"text":"Github Actions: publish_navitia_documentation failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}
-    - name: slack notification test
-      if: success()
-      run: |
-          echo '{"text":"Github Actions: this is a test ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -16,7 +16,7 @@ jobs:
     - name: install bundle
       run: sudo apt update && sudo apt install -y bundler
     - name: install httpie dependency
-      run: sudo apt update && sudo apt install -y httpie
+      run: sudo apt install -y httpie
     - name: git checkout on dev
       run: git checkout dev
     - name: generate documentation on dev

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -51,4 +51,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":"Github Actions: publish_navitia_documentation failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+          echo '{"text":":warning: Github Actions: publish_navitia_documentation failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -1,6 +1,7 @@
 name: Publish Navitia Documentation
 
 on:
+  pull_request:
   push:
     branches:
       - dev
@@ -15,6 +16,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: install bundle
       run: sudo apt update && sudo apt install -y bundler
+    - name: install httpie dependency
+      run: apt update && apt install -y httpie
     - name: git checkout on dev
       run: git checkout dev
     - name: generate documentation on dev
@@ -46,3 +49,11 @@ jobs:
       with:
         github_token: ${{secrets.GITHUB_TOKEN}}
         branch: 'gh-pages'
+    - name: slack notification (the job has failed)
+      if: failure()
+      run: |
+          echo '{"text":"Github Actions: publish_navitia_documentation failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}
+    - name: slack notification test
+      if: success()
+      run: |
+          echo '{"text":"Github Actions: this is a test ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_URL}}


### PR DESCRIPTION
We want to avoid **silent crash** within CI after a merge.
All github Actions are now protected. A **notification** is sended for each failure on **navitia_core_team** slack channel to alert the team.
list of jobs

- build navitia packages for dev
- build navitia packages for release (Very important
- publish docker compose images
- publish navitia documentation

in extra, a message is sended when build navitia packages for release is in success

It looks like that with the good sentence
![example_slack](https://user-images.githubusercontent.com/32099204/78024388-8e4dc880-7358-11ea-81a1-717a898bdac6.png)

Added the release message automaticly on #navitia channel too