### PR TITLE
[Jormun][Tyr] Update ujson

### DIFF
--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.5.3
 pytz==2013.9
 retrying==1.3.3
 aniso8601==0.82
-ujson==1.35
+ujson==2.0.3
 urllib3==1.24.2
 numpy==1.9.0
 pybreaker==0.2.3

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -23,7 +23,7 @@ python-dateutil==2.5.3
 pytz==2013.9
 retrying==1.3.3
 aniso8601==0.82
-ujson==2.0.3
+git+https://github.com/esnme/ultrajson.git@ac4637fbc4e72bd59f221d9bba19127820d21023
 urllib3==1.24.2
 numpy==1.9.0
 pybreaker==0.2.3

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -28,7 +28,7 @@ six==1.10.0
 validate-email==1.3
 wsgiref==0.1.2; python_version < '3.2'
 retrying==1.3.3
-ujson==1.35
+ujson==2.0.3
 jsonschema==2.6.0
 python-dateutil==2.5.3
 typing==3.7.4

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -28,7 +28,7 @@ six==1.10.0
 validate-email==1.3
 wsgiref==0.1.2; python_version < '3.2'
 retrying==1.3.3
-ujson==2.0.3
+git+https://github.com/esnme/ultrajson.git@ac4637fbc4e72bd59f221d9bba19127820d21023
 jsonschema==2.6.0
 python-dateutil==2.5.3
 typing==3.7.4


### PR DESCRIPTION
Fixes error:
`ImportError: /home/mehdi/Envs/jormun/lib/python2.7/site-packages/ujson.so: undefined symbol: Buffer_AppendShortHexUnchecked`

However, officials release (>2.0.0) removes a lot of functionalitites still needed in navitia:
![image](https://user-images.githubusercontent.com/35227890/80228250-1c168e00-864f-11ea-8d1d-2d645abe83bf.png)

So, ujson is installed with the commit before these breaking changes and after the fix for the error mentionned above.

Tested locally on ubuntu 18.04