### PR TITLE
[Kraken] Add stop_points_nearby option within places_nearby

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -502,8 +502,13 @@ void Worker::proximity_list(const pbnavitia::PlacesNearbyRequest& request) {
         this->pb_creator.fill_pb_error(pbnavitia::Error::bad_format, e.what());
         return;
     }
+    bool active_stop_points_nearby_options = false;
+    if (request.has_find_stop_points_nearby() && request.find_stop_points_nearby() == true) {
+        active_stop_points_nearby_options = true;
+    }
     proximitylist::find(this->pb_creator, coord, request.distance(), vector_of_pb_types(request), request.filter(),
-                        request.depth(), request.count(), request.start_page(), *data);
+                        request.depth(), request.count(), request.start_page(), *data,
+                        active_stop_points_nearby_options);
 }
 
 static type::StreetNetworkParams streetnetwork_params_of_entry_point(const pbnavitia::StreetNetworkParams& request,

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -502,10 +502,7 @@ void Worker::proximity_list(const pbnavitia::PlacesNearbyRequest& request) {
         this->pb_creator.fill_pb_error(pbnavitia::Error::bad_format, e.what());
         return;
     }
-    bool active_stop_points_nearby_options = false;
-    if (request.has_find_stop_points_nearby() && request.find_stop_points_nearby() == true) {
-        active_stop_points_nearby_options = true;
-    }
+    bool active_stop_points_nearby_options = request.has_find_stop_points_nearby() && request.find_stop_points_nearby();
     proximitylist::find(this->pb_creator, coord, request.distance(), vector_of_pb_types(request), request.filter(),
                         request.depth(), request.count(), request.start_page(), *data,
                         active_stop_points_nearby_options);

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -80,12 +80,10 @@ static void make_pb(navitia::PbCreator& pb_creator,
                 break;
         }
         // add stop points nearby into response
-        if (!stop_points_nearby_idx_distance.empty()) {
-            for (const auto& sp_idx_distance : stop_points_nearby_idx_distance) {
-                pbnavitia::PtObject* pt_obj = place->add_stop_points_nearby();
-                pb_creator.fill(data.pt_data->stop_points[std::get<0>(sp_idx_distance)], pt_obj, depth);
-                pt_obj->set_distance(std::get<1>(sp_idx_distance));
-            }
+        for (const auto& sp_idx_distance : stop_points_nearby_idx_distance) {
+            pbnavitia::PtObject* pt_obj = place->add_stop_points_nearby();
+            pb_creator.fill(data.pt_data->stop_points[std::get<0>(sp_idx_distance)], pt_obj, depth);
+            pt_obj->set_distance(std::get<1>(sp_idx_distance));
         }
     }
 }

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -79,7 +79,7 @@ static void make_pb(navitia::PbCreator& pb_creator,
             default:
                 break;
         }
-        // add stop points nearby into response
+        // add stop points nearby (PtObject) into response
         for (const auto& sp_idx_distance : stop_points_nearby_idx_distance) {
             pbnavitia::PtObject* pt_obj = place->add_stop_points_nearby();
             pb_creator.fill(data.pt_data->stop_points[std::get<0>(sp_idx_distance)], pt_obj, depth);

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -39,9 +39,9 @@ namespace proximitylist {
  * se charge de remplir l'objet protocolbuffer autocomplete passé en paramètre
  *
  */
-using t_result = std::tuple<nt::idx_t, nt::GeographicalCoord, float, nt::Type_e>;
+using t_result = std::tuple<nt::idx_t, nt::GeographicalCoord, float, nt::Type_e, std::vector<nt::idx_t>>;
 using idx_coord_distance = std::tuple<nt::idx_t, nt::GeographicalCoord, float>;
-using vector_idx_coord_distance = std::vector<idx_coord_distance>;
+using Vector_idx_coord_distance = std::vector<idx_coord_distance>;
 
 static void make_pb(navitia::PbCreator& pb_creator,
                     const std::vector<t_result>& result,
@@ -54,6 +54,7 @@ static void make_pb(navitia::PbCreator& pb_creator,
         auto coord_item = std::get<1>(result_item);
         auto distance = sqrt(std::get<2>(result_item));
         auto type = std::get<3>(result_item);
+        auto stop_points_nearby_idx = std::get<4>(result_item);
         switch (type) {
             case nt::Type_e::StopArea:
                 pb_creator.fill(data.pt_data->stop_areas[idx], place, depth);
@@ -77,12 +78,19 @@ static void make_pb(navitia::PbCreator& pb_creator,
             default:
                 break;
         }
+        // add stop points nearby into response
+        if (!stop_points_nearby_idx.empty()) {
+            for (const auto& sp_idx : stop_points_nearby_idx) {
+                pbnavitia::StopPoint* sp = place->add_stop_points_nearby();
+                pb_creator.fill(data.pt_data->stop_points[sp_idx], sp, depth);
+            }
+        }
     }
 }
 
-static void cut(vector_idx_coord_distance& list, const size_t end_pagination, const nt::GeographicalCoord& coord) {
-    const auto nb_sort = std::min(list.size(), end_pagination);
-    list.resize(nb_sort);
+static void cut(Vector_idx_coord_distance& idx_coord_distance, const size_t end_pagination) {
+    const auto nb_sort = std::min(idx_coord_distance.size(), end_pagination);
+    idx_coord_distance.resize(nb_sort);
 }
 
 void find(navitia::PbCreator& pb_creator,
@@ -93,7 +101,8 @@ void find(navitia::PbCreator& pb_creator,
           const uint32_t depth,
           const uint32_t count,
           const uint32_t start_page,
-          const type::Data& data) {
+          const type::Data& data,
+          const bool find_stop_points_nearby) {
     int total_result = 0;
     std::vector<t_result> result;
     auto end_pagination = (start_page + 1) * count;
@@ -103,14 +112,14 @@ void find(navitia::PbCreator& pb_creator,
             try {
                 auto nb_w = pb_creator.data->geo_ref->nearest_addr(coord);
                 // we'll regenerate the good number in make_pb
-                result.emplace_back(nb_w.second->idx, coord, 0, type);
+                result.emplace_back(nb_w.second->idx, std::move(coord), 0, type, std::move(std::vector<nt::idx_t>()));
                 ++total_result;
             } catch (const proximitylist::NotFound&) {
             }
             continue;
         }
 
-        vector_idx_coord_distance list;
+        Vector_idx_coord_distance vector_idx_coord_distance;
         type::Indexes indexes;
         if (!filter.empty()) {
             try {
@@ -128,44 +137,60 @@ void find(navitia::PbCreator& pb_creator,
         int search_count = -1;
         switch (type) {
             case nt::Type_e::StopArea:
-                list = pb_creator.data->pt_data->stop_area_proximity_list.find_within<IndexCoordDistance>(
-                    coord, distance, search_count);
+                vector_idx_coord_distance =
+                    pb_creator.data->pt_data->stop_area_proximity_list.find_within<IndexCoordDistance>(coord, distance,
+                                                                                                       search_count);
                 break;
             case nt::Type_e::StopPoint:
-                list = pb_creator.data->pt_data->stop_point_proximity_list.find_within<IndexCoordDistance>(
-                    coord, distance, search_count);
+                vector_idx_coord_distance =
+                    pb_creator.data->pt_data->stop_point_proximity_list.find_within<IndexCoordDistance>(coord, distance,
+                                                                                                        search_count);
                 break;
             case nt::Type_e::POI:
-                list = pb_creator.data->geo_ref->poi_proximity_list.find_within<IndexCoordDistance>(coord, distance,
-                                                                                                    search_count);
+                vector_idx_coord_distance =
+                    pb_creator.data->geo_ref->poi_proximity_list.find_within<IndexCoordDistance>(coord, distance,
+                                                                                                 search_count);
                 break;
             default:
                 break;
         }
 
-        vector_idx_coord_distance final_list;
+        Vector_idx_coord_distance final_vector_idx_coord_distance;
         if (filter.empty()) {
-            final_list = list;
+            final_vector_idx_coord_distance = vector_idx_coord_distance;
         } else {
-            for (const auto& element : list) {
+            for (const auto& element : vector_idx_coord_distance) {
                 auto idx = std::get<0>(element);
                 if (indexes.find(idx) != indexes.cend()) {
-                    final_list.push_back(element);
+                    final_vector_idx_coord_distance.push_back(element);
                 }
             }
         }
-        total_result += final_list.size();
-        cut(final_list, end_pagination, coord);
-        for (const auto& e : final_list) {
-            auto idx = std::get<0>(e);
-            auto coord = std::get<1>(e);
-            auto distance = std::get<2>(e);
-            result.emplace_back(idx, std::move(coord), distance, type);
+
+        total_result += final_vector_idx_coord_distance.size();
+        cut(final_vector_idx_coord_distance, end_pagination);
+        for (const auto& elem : final_vector_idx_coord_distance) {
+            auto idx = std::get<0>(elem);
+            auto coord = std::get<1>(elem);
+            auto distance = std::get<2>(elem);
+            std::vector<nt::idx_t> stop_points_nearby_idx;
+            // for each result found, we perform a new proximity research for stop point type.
+            if (find_stop_points_nearby) {
+                auto stop_points_nearby_idx_coord_distance =
+                    pb_creator.data->pt_data->stop_point_proximity_list.find_within<IndexCoordDistance>(
+                        std::get<1>(elem), distance, search_count);
+                stop_points_nearby_idx.reserve(stop_points_nearby_idx_coord_distance.size());
+                for (const auto& sp_idx : stop_points_nearby_idx_coord_distance) {
+                    stop_points_nearby_idx.emplace_back(std::get<0>(sp_idx));
+                }
+            }
+            result.emplace_back(idx, std::move(coord), distance, type, std::move(stop_points_nearby_idx));
         }
     }
     result = paginate(result, count, start_page);
     make_pb(pb_creator, result, depth, data, coord);
     pb_creator.make_paginate(total_result, start_page, count, result.size());
 }
+
 }  // namespace proximitylist
 }  // namespace navitia

--- a/source/proximity_list/proximitylist_api.h
+++ b/source/proximity_list/proximitylist_api.h
@@ -55,6 +55,7 @@ void find(navitia::PbCreator& pb_creator,
           const uint32_t depth,
           const uint32_t count,
           const uint32_t start_page,
-          const type::Data& data);
+          const type::Data& data,
+          const bool find_stop_points_nearby = false);
 }  // namespace proximitylist
 }  // namespace navitia

--- a/source/proximity_list/tests/test.cpp
+++ b/source/proximity_list/tests/test.cpp
@@ -368,3 +368,88 @@ BOOST_AUTO_TEST_CASE(test_poi_filter) {
     BOOST_CHECK(poi_names.find("bob") != poi_names.end());
     BOOST_CHECK(poi_names.find("bobette") != poi_names.end());
 }
+
+BOOST_AUTO_TEST_CASE(test_find_stop_points_nearby_options) {
+    navitia::type::Data data;
+
+    // origin
+    navitia::type::GeographicalCoord c;
+    c.set_lon(-1.554514);
+    c.set_lat(47.218515);
+
+    // POIs
+    {
+        auto poitype = new navitia::georef::POIType();
+        poitype->uri = "poi_type_1";
+        poitype->idx = 0;
+        data.geo_ref->poitypes.push_back(poitype);
+        auto poi = new navitia::georef::POI();
+        poi->uri = "poi_1";
+        poi->poitype_idx = 0;
+        poi->idx = 0;
+        poi->coord.set_lon(-1.557000);
+        poi->coord.set_lat(47.218515);
+        data.geo_ref->pois.push_back(poi);
+    }
+    {
+        auto poitype = new navitia::georef::POIType();
+        poitype->uri = "poi_type_2";
+        poitype->idx = 1;
+        data.geo_ref->poitypes.push_back(poitype);
+        auto poi_2 = new navitia::georef::POI();
+        poi_2->uri = "poi_2";
+        poi_2->idx = 1;
+        poi_2->poitype_idx = 1;
+        poi_2->coord.set_lon(-1.552000);
+        poi_2->coord.set_lat(47.218516);
+        data.geo_ref->pois.push_back(poi_2);
+        // This POI is too far
+        auto poi_3 = new navitia::georef::POI();
+        poi_3->uri = "poi_3";
+        poi_3->idx = 2;
+        poi_3->poitype_idx = 1;
+        poi_3->coord.set_lon(-1.551000);
+        poi_3->coord.set_lat(47.218516);
+        data.geo_ref->pois.push_back(poi_3);
+    }
+    // Stop Points
+    {
+        auto sp = new navitia::type::StopPoint();
+        sp->uri = "sp_1";
+        sp->idx = 0;
+        sp->coord.set_lon(-1.554514);
+        sp->coord.set_lat(47.214516);
+        data.pt_data->stop_points.push_back(sp);
+    }
+    {
+        auto sp = new navitia::type::StopPoint();
+        sp->uri = "sp_2";
+        sp->idx = 1;
+        sp->coord.set_lon(-1.554514);
+        sp->coord.set_lat(47.215515);
+        data.pt_data->stop_points.push_back(sp);
+    }
+    data.geo_ref->init();
+    data.build_proximity_list();
+    data.build_uri();
+    navitia::PbCreator pb_creator(&data, boost::gregorian::not_a_date_time, null_time_period);
+    find(pb_creator, c, 200, {navitia::type::Type_e::POI}, "poi_type.uri=poi_type_2", 1, 10, 0, data, true);
+    auto result = pb_creator.get_response();
+
+    // Only poi_2 is available (poi_type_2)
+    BOOST_REQUIRE_EQUAL(result.places_nearby().size(), 1);
+    BOOST_CHECK(result.places_nearby(0).uri() == "poi_2");
+    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby().size(), 2);
+    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(0).uri(), "sp_2");
+    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(1).uri(), "sp_1");
+
+    // Same request without stop_points_nearby option
+    navitia::PbCreator pb_creator2(&data, boost::gregorian::not_a_date_time, null_time_period);
+    find(pb_creator2, c, 200, {navitia::type::Type_e::POI}, "poi_type.uri=poi_type_2", 1, 10, 0, data, false);
+    result = pb_creator2.get_response();
+
+    // Only poi_2 is available (poi_type_2)
+    BOOST_REQUIRE_EQUAL(result.places_nearby().size(), 1);
+    BOOST_CHECK(result.places_nearby(0).uri() == "poi_2");
+    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby().size(), 0);
+}


### PR DESCRIPTION
**Subject** : In order to optimize performance for a car distributed request, we need to update places_nearby (This is the first part P+R quest)

Currently, we need to call a places_nearby to find **all P+R Pois** next to the origin. After that, a bunch of request have to find, for each P+R, the nearby StopPoints. 
So, at the end we do 1 places_nearby call + n places_nearby call for each P+R found.
This work optimize it in 1 call that send directly all informations (A list of P+R with the StopPoint list attached)
The **backward compatibility is keeped** because it is coded like an option.

**Nota**: For the moment this option is not activated. It will be integrated in a future PR

Todo:

- [x] navitia-proto : ~change local branch to master after~ https://github.com/CanalTP/navitia-proto/pull/140 ~is merged. This is the reason why **CI check_submodules** is~ :red_circle: 

**Jira**: https://jira.kisio.org/browse/TRR-101