### PR TITLE
[CI] Test debian 8 dev docker built by our CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: ['navitia/debian8_dev:dev', 'navitia/debian9_dev', 'navitia/debian10_dev']
+            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
 
     container:
         image: ${{matrix.docker_image}}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
+            docker_image: ['navitia/debian8_dev:dev', 'navitia/debian9_dev', 'navitia/debian10_dev']
 
     container:
         image: ${{matrix.docker_image}}

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -1,3 +1,5 @@
+configparser==4.0.2 ; python_version == "2.7"
+setuptools==44.1.0 ; python_version == "2.7"
 Flask==1.1.1
 flask_restful==0.3.7
 Flask-SQLAlchemy==2.4


### PR DESCRIPTION
Build Navitia against our freshly backed docker image `navitia/debian8_dev`

Jenkins now has 2 new jobs:
 * https://ci.navitia.io/view/navitia/job/navitia_docker_images
 * https://ci.navitia.io/view/navitia/job/navitia_docker_images_pull_request

The 1st one build the docker8_dev image and pushes it to docker hub using tag `latest`
The 2nd one build the docker8_dev image from pull request and pushes it to docker hub using tag `dev` 

https://hub.docker.com/r/navitia/debian8_dev/tags

