### PR TITLE
[CI] Update checkout version to v2

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -84,10 +84,9 @@ jobs:
       run: |
         apt update && apt install -y protobuf-compiler python python-pip python3  python3-pip clang-format-6.0 git 2to3
         pip install -r requirements_pre-commit.txt --upgrade
-    - name: install pre-commit
-      run: |
-        pip install pre-commit
-        pre-commit --version
+    - uses: pre-commit/action@v1.0.1
+    - name: print install pre-commit
+      run: pre-commit --version
     - name: Build Protobuf
       run: bash source/scripts/build_protobuf.sh
     - name: Pre-commit Run

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -76,24 +76,21 @@ jobs:
 
   precommit:
     runs-on: ubuntu-latest
+    container:
+      image: ubuntu:18.04
+      # we need python 3.6 and clang-format-6.0
+      # we should be able to use no container once https://github.com/actions/virtual-environments/issues/46 is
+      # resolved
     steps:
-    - uses: actions/checkout@v2
-      with:
-          submodules: true
+    - uses: actions/checkout@v1
     - name: install dependencies
       run: |
         apt update && apt install -y protobuf-compiler python python-pip python3  python3-pip clang-format-6.0 git 2to3
         pip install -r requirements_pre-commit.txt --upgrade
-    - uses: actions/setup-python@v1
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.0.1
-    - name: print install pre-commit
-      run: pre-commit --version
+    - name: get submodule
+      run: |
+        sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
+        git submodule update --init --recursive
     - name: Build Protobuf
       run: bash source/scripts/build_protobuf.sh
     - name: Pre-commit Run

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -41,11 +41,9 @@ jobs:
           - 5672:5672
 
     steps:
-    - uses: actions/checkout@v1
-    - name: get submodule
-      run: |
-        sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
-        git submodule update --init --recursive
+    - uses: actions/checkout@v2
+      with:
+          submodules: true
     - name: Install dependencies
       run: pip install -r source/jormungandr/requirements_dev.txt
     - name: configure
@@ -84,15 +82,13 @@ jobs:
       # we should be able to use no container once https://github.com/actions/virtual-environments/issues/46 is
       # resolved
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+      with:
+          submodules: true
     - name: install dependencies
       run: |
         apt update && apt install -y protobuf-compiler python python-pip python3  python3-pip clang-format-6.0 git 2to3
         pip install -r requirements_pre-commit.txt --upgrade
-    - name: get submodule
-      run: |
-        sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
-        git submodule update --init --recursive
     - name: Build Protobuf
       run: bash source/scripts/build_protobuf.sh
     - name: Pre-commit Run

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -84,6 +84,10 @@ jobs:
       run: |
         apt update && apt install -y protobuf-compiler python python-pip python3  python3-pip clang-format-6.0 git 2to3
         pip install -r requirements_pre-commit.txt --upgrade
+    - name: install pre-commit
+      run: |
+        pip install pre-commit
+        pre-commit --version
     - name: Build Protobuf
       run: bash source/scripts/build_protobuf.sh
     - name: Pre-commit Run

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -84,6 +84,11 @@ jobs:
       run: |
         apt update && apt install -y protobuf-compiler python python-pip python3  python3-pip clang-format-6.0 git 2to3
         pip install -r requirements_pre-commit.txt --upgrade
+    - uses: actions/setup-python@v1
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
     - uses: pre-commit/action@v1.0.1
     - name: print install pre-commit
       run: pre-commit --version

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -85,6 +85,8 @@ jobs:
         apt update && apt install -y protobuf-compiler python python-pip python3  python3-pip clang-format-6.0 git 2to3
         pip install -r requirements_pre-commit.txt --upgrade
     - uses: actions/setup-python@v1
+    - name: set PY
+      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
     - uses: actions/cache@v1
       with:
         path: ~/.cache/pre-commit

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,7 +29,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
+            docker_image: ['navitia/debian8_dev:dev', 'navitia/debian9_dev', 'navitia/debian10_dev']
 
     container:
         image: ${{matrix.docker_image}}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -76,11 +76,6 @@ jobs:
 
   precommit:
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:18.04
-      # we need python 3.6 and clang-format-6.0
-      # we should be able to use no container once https://github.com/actions/virtual-environments/issues/46 is
-      # resolved
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-          submodules: true
+          submodules: 'recursive'
     - name: Install dependencies
       run: pip install -r source/jormungandr/requirements_dev.txt
     - name: configure


### PR DESCRIPTION
What's new in v2:
 * Improved performance
 * Script authenticated git commands
 * Supports SSH
 * Creates a local branch, no longer detached HEAD when checking out a branch
 * Improved layout, the input path is always relative to $GITHUB_WORKSPACE