### PR TITLE
[Version] change data version for new version

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -72,7 +72,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 3;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 4;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),


### PR DESCRIPTION
Change **data_version 3 -> 4** because we need binarization since https://github.com/CanalTP/navitia/pull/3190
Is it an omission to do the release correctly