### PR TITLE
[Kraken] Limit stop points nearby for place_nearby by radius option

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -502,10 +502,12 @@ void Worker::proximity_list(const pbnavitia::PlacesNearbyRequest& request) {
         this->pb_creator.fill_pb_error(pbnavitia::Error::bad_format, e.what());
         return;
     }
-    bool active_stop_points_nearby_options = request.has_find_stop_points_nearby() && request.find_stop_points_nearby();
+    double stop_points_nearby_radius = 0;
+    if (request.has_stop_points_nearby_radius() && request.stop_points_nearby_radius() > 0) {
+        stop_points_nearby_radius = request.stop_points_nearby_radius();
+    }
     proximitylist::find(this->pb_creator, coord, request.distance(), vector_of_pb_types(request), request.filter(),
-                        request.depth(), request.count(), request.start_page(), *data,
-                        active_stop_points_nearby_options);
+                        request.depth(), request.count(), request.start_page(), *data, stop_points_nearby_radius);
 }
 
 static type::StreetNetworkParams streetnetwork_params_of_entry_point(const pbnavitia::StreetNetworkParams& request,

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -83,7 +83,7 @@ static void make_pb(navitia::PbCreator& pb_creator,
         for (const auto& sp_idx_distance : stop_points_nearby_idx_distance) {
             pbnavitia::PtObject* pt_obj = place->add_stop_points_nearby();
             pb_creator.fill(data.pt_data->stop_points[std::get<0>(sp_idx_distance)], pt_obj, depth);
-            pt_obj->set_distance(std::get<1>(sp_idx_distance));
+            pt_obj->set_distance(sqrt(std::get<1>(sp_idx_distance)));
         }
     }
 }

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -102,7 +102,7 @@ void find(navitia::PbCreator& pb_creator,
           const uint32_t count,
           const uint32_t start_page,
           const type::Data& data,
-          const bool find_stop_points_nearby) {
+          const double stop_points_nearby_radius) {
     int total_result = 0;
     std::vector<t_result> result;
     auto end_pagination = (start_page + 1) * count;
@@ -176,10 +176,10 @@ void find(navitia::PbCreator& pb_creator,
             auto distance = std::get<2>(elem);
             std::vector<std::tuple<nt::idx_t, float>> stop_points_nearby_idx_distance;
             // for each result found, we perform a new proximity research for stop point type.
-            if (find_stop_points_nearby) {
+            if (stop_points_nearby_radius > 0) {
                 auto stop_points_nearby_idx_coord_distance =
                     pb_creator.data->pt_data->stop_point_proximity_list.find_within<IndexCoordDistance>(
-                        std::get<1>(elem), limit, search_count);
+                        std::get<1>(elem), stop_points_nearby_radius, search_count);
                 stop_points_nearby_idx_distance.reserve(stop_points_nearby_idx_coord_distance.size());
                 for (const auto& sp_idx : stop_points_nearby_idx_coord_distance) {
                     stop_points_nearby_idx_distance.emplace_back(std::get<0>(sp_idx), std::get<2>(sp_idx));

--- a/source/proximity_list/proximitylist_api.h
+++ b/source/proximity_list/proximitylist_api.h
@@ -56,6 +56,6 @@ void find(navitia::PbCreator& pb_creator,
           const uint32_t count,
           const uint32_t start_page,
           const type::Data& data,
-          const bool find_stop_points_nearby = false);
+          const double stop_points_nearby_radius = 0);
 }  // namespace proximitylist
 }  // namespace navitia

--- a/source/proximity_list/tests/test.cpp
+++ b/source/proximity_list/tests/test.cpp
@@ -436,9 +436,9 @@ BOOST_AUTO_TEST_CASE(test_find_stop_points_nearby_options) {
     BOOST_CHECK(result.places_nearby(0).uri() == "poi_2");
     BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby().size(), 2);
     BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(0).uri(), "sp_1");
-    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(0).distance(), 2);
+    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(0).distance(), 1);
     BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(1).uri(), "sp_2");
-    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(1).distance(), 5);
+    BOOST_REQUIRE_EQUAL(result.places_nearby(0).stop_points_nearby(1).distance(), 2);
 
     // Same request without stop_points_nearby option
     navitia::PbCreator pb_creator2(&data, boost::gregorian::not_a_date_time, null_time_period);

--- a/source/proximity_list/tests/test.cpp
+++ b/source/proximity_list/tests/test.cpp
@@ -428,7 +428,7 @@ BOOST_AUTO_TEST_CASE(test_find_stop_points_nearby_options) {
     data.build_proximity_list();
     data.build_uri();
     navitia::PbCreator pb_creator(&data, boost::gregorian::not_a_date_time, null_time_period);
-    find(pb_creator, c, 15, {navitia::type::Type_e::POI}, "poi_type.uri=poi_type_2", 1, 10, 0, data, true);
+    find(pb_creator, c, 15, {navitia::type::Type_e::POI}, "poi_type.uri=poi_type_2", 1, 10, 0, data, 15);
     auto result = pb_creator.get_response();
 
     // Only poi_2 is available (poi_type_2)
@@ -442,7 +442,7 @@ BOOST_AUTO_TEST_CASE(test_find_stop_points_nearby_options) {
 
     // Same request without stop_points_nearby option
     navitia::PbCreator pb_creator2(&data, boost::gregorian::not_a_date_time, null_time_period);
-    find(pb_creator2, c, 15, {navitia::type::Type_e::POI}, "poi_type.uri=poi_type_2", 1, 10, 0, data, false);
+    find(pb_creator2, c, 15, {navitia::type::Type_e::POI}, "poi_type.uri=poi_type_2", 1, 10, 0, data);
     result = pb_creator2.get_response();
 
     // Only poi_2 is available (poi_type_2)


### PR DESCRIPTION
It seems to be important in term of performance to select an other size of radius for **stop_points_nearby**. 
In the **Jormungandr** part, this radius will set to a distance of **5 min duration by walking**. It will allow to limit the searching field.

In extra, fix the distance **from Poi to stop_point**. I forgot the square root :speak_no_evil: 