### PR TITLE
[CI] Add clang-tidy as part of our CI's workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,6 @@
+Checks:          '-*, clang-analyzer-*'
+HeaderFilterRegex: '*'
+AnalyzeTemporaryDtors: false
+FormatStyle:     file
+User:            Navitia
+CheckOptions:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,15 @@ on:
 
 
 jobs:
-  check_submodules:
+  info:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Dump GitHub context
+      env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+
+  checks:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -23,9 +31,32 @@ jobs:
     - name: check submodules
       run: ./source/scripts/check_submodules.sh
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+          ref: ${{ github.head_ref }}
+          submodules: 'recursive'
+    - name : Install dependencies
+      run: sudo apt install -y liblog4cplus-dev libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libssl-dev libosmpbf-dev libpqxx-dev libproj-dev libzmq3-dev python-yaml clang-tools clang-tidy libboost-all-dev 2to3
+    - name: Cmake
+      run: cmake source
+    - name: Clang Tidy
+      run: make tidy_fix
+    - name: Commit and push changes
+      uses: stefanzweifel/git-auto-commit-action@v4.1.6
+      with:
+        commit_message: "Applying automatic clang-tidy changes"
+        commit_user_name: "Github-action"
+        commit_user_email: "github-action@kisio.com"
+        branch: ${{ github.head_ref }}
+        repository: source
+
 
   build:
     runs-on: ubuntu-latest
+    needs: lint
 
     strategy:
         matrix:
@@ -41,11 +72,9 @@ jobs:
           - 5672:5672
 
     steps:
-    - uses: actions/checkout@v1
-    - name: get submodule
-      run: |
-        sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules
-        git submodule update --init --recursive
+    - uses: actions/checkout@v2
+      with:
+          submodules: 'recursive'
     - name: Install dependencies for python2
       run: pip install -r source/jormungandr/requirements_dev.txt
     - name: configure

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -51,6 +51,9 @@ include(ThirdParty)
 # Tests environment
 include(TestsEnv)
 
+# Clang-tidy
+include(EnableClangTidy)
+
 # Add current compilation dir to include path to handle config.h
 include_directories(SYSTEM "${CMAKE_CURRENT_BINARY_DIR}")
 include_directories("${CMAKE_SOURCE_DIR}")

--- a/source/cmake_modules/EnableClangTidy.cmake
+++ b/source/cmake_modules/EnableClangTidy.cmake
@@ -1,0 +1,44 @@
+
+message("-- Enable clang-tidy")
+
+# Generates a compile_commands.json file containing the exact compiler calls for all translation units
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+set(CLANG_TIDY_BINARY_NAME
+    NAMES clang-tidy clang-tidy-6.0)
+find_program(CLANG_TIDY_BIN ${CLANG_TIDY_BINARY_NAME})
+
+set(RUN_CLANG_TIDY_BINARY_NAME
+    NAMES run-clang-tidy.py run-clang-tidy-6.0.py)
+find_program(RUN_CLANG_TIDY_BIN ${RUN_CLANG_TIDY_BINARY_NAME})
+
+if(CLANG_TIDY_BIN STREQUAL "CLANG_TIDY_BIN-NOTFOUND")
+    message(FATAL_ERROR "unable to locate ${CLANG_TIDY_BINARY_NAME}")
+endif()
+
+if(RUN_CLANG_TIDY_BIN STREQUAL "RUN_CLANG_TIDY_BIN-NOTFOUND")
+    message(FATAL_ERROR "unable to locate ${RUN_CLANG_TIDY_BINARY_NAME}")
+endif()
+
+# Get all .cpp files in navitia/source/ and remove everything
+# From utils and /third_party
+file(GLOB_RECURSE FILES_TO_SCAN "${CMAKE_SOURCE_DIR}/*.cpp")
+list(FILTER FILES_TO_SCAN EXCLUDE REGEX "(third_party|utils)")
+list(APPEND RUN_CLANG_TIDY_BIN_ARGS -clang-tidy-binary ${CLANG_TIDY_BIN} "${FILES_TO_SCAN}")
+
+add_custom_target(
+    tidy
+    COMMAND ${RUN_CLANG_TIDY_BIN} ${RUN_CLANG_TIDY_BIN_ARGS}
+    COMMENT "running clang tidy -- ${CMAKE_SOURCE_DIR}"
+    DEPENDS protobuf_files
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
+add_custom_target(
+    tidy_fix
+    COMMAND ${RUN_CLANG_TIDY_BIN} -fix ${RUN_CLANG_TIDY_BIN_ARGS}
+    COMMENT "running clang tidy -fix -- ${CMAKE_SOURCE_DIR}"
+    DEPENDS protobuf_files
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+


### PR DESCRIPTION
BEFORE builds are being performed, we run clang-tidy on the c++ source
code and apply all changes onto the current branch.

This way, we keep the code tidy and formated before it's being built and
tested.

## Clang-Tidy as introduced changes that break my code....
> If this happens, run clang-tidy localy using:
```
make tidy_fix
```
> Fix the code and push it all to you local branch !

## Hang on a minute ! Why aren't we using pre-commit ?
> Clang tidy uses LLVM frontend to parse and understand the code which
 makes clang-tidy really slow... But it's what makes clang-tidy so powerful
 aas well.
> Not to bloat pre-commit with a unbearable waiting time, the process is
done in the CI side.

## What are we checking against ?
> So far, we only check `clang-analyzwe` to validate the workflow.
> If we are fine with it, we could alway add more interesting checks
like : `mordernize-*, cppcoreguidelines-*, readability-*` etc...
> I wanted this to be an iterative process not to introduce to many
changes in one time.