### PR TITLE
[Tyr] update virtualenv requirements

### DIFF
--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 -r ../../requirements_pre-commit.txt
+-r ../eitri/requirements.txt
 
 docker==3.4.1
 pytest==4.6.5


### PR DESCRIPTION
Tyr virtualenv requirements now includes eitri requirements (otherwise a package was missing when running docker_test)