### PR TITLE
Doc: adapt markdown for double blank space

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,12 +54,9 @@ At the root of the repository, several directories can be found:
 The data_version stored into [source/type/data.cpp](source/type/data.cpp) is used to know if a given `nav` file
 is readable using a given kraken (both contain their version).
 
-So this number **must** be incremented when data serialization changes.
-In case multiple changes occur between 2 releases, only one increment is enough.
+So this number **must** be incremented when data serialization changes.<br>In case multiple changes occur between 2 releases, only one increment is enough.
 
-This number is also used to tag major versions of Navitia.
-Major version is tracked externally to know if nav-files must be regenerated.
-So please update this `data_version` to indicate a need for re-binarization.
+This number is also used to tag major versions of Navitia.<br>Major version is tracked externally to know if nav-files must be regenerated.<br>So please update this `data_version` to indicate a need for re-binarization.
 
 
 ## Tools
@@ -92,8 +89,7 @@ pre-commit init-templatedir ~/.git-template
 
 Python source code in this project is formatted using [Black](https://black.readthedocs.io/en/stable/)
 You should enable the pre-commit git hook to make sure it's being run before commiting your changes, it's
-also the easiest way to run Black.
-Otherwise, to only update the files that you've changed, simply run:
+also the easiest way to run Black.<br>Otherwise, to only update the files that you've changed, simply run:
 ```
 pre-commit run black
 ```

--- a/documentation/rfc/autocomplete.md
+++ b/documentation/rfc/autocomplete.md
@@ -45,9 +45,7 @@ The results are sorted by type, with the following order:
   - other (stop_points by example)
 
 
-For each type, we have the following order:
-In firsts positions, we have the results with a 100 quality (exact match). After them, the order is based
-on the *global score*, then by the length of the longest, then by the position of this substring,
+For each type, we have the following order:<br>In firsts positions, we have the results with a 100 quality (exact match). After them, the order is based on the *global score*, then by the length of the longest, then by the position of this substring,
 and finally by the quality.
 
 

--- a/documentation/rfc/disruptions_periods.md
+++ b/documentation/rfc/disruptions_periods.md
@@ -5,14 +5,12 @@ There are several periods in the disruptions model and they can be tricky to und
 ## Periods
 
 ### production period
-The production period is global to a navitia coverage and is the validity period of the coverage's data.
-This production period cannot exceed one year.
+The production period is global to a navitia coverage and is the validity period of the coverage's data.<br>This production period cannot exceed one year.
 
 ### publication period
 The publication period of a disruption is the period on which we want to display the disruption in navitia.
 
-The creator of the disruption might not want the traveller to know of a disruption before a certain date (because it's too uncertain, secret, ...).
-The publication period is the way to control this.
+The creator of the disruption might not want the traveller to know of a disruption before a certain date (because it's too uncertain, secret, ...).<br>The publication period is the way to control this.
 
 Please note that this period can be out of production period, but shouldn't affect impact's  management.
 
@@ -42,8 +40,7 @@ In this example 'now' is 01/01 at 10:00, 'action period' is, for each section of
 
 ### filter period
 
-On some ptref endpoints, one can provide a 'since' and 'until' parameter to filter disruptions or vehicle_journeys.
-Please refer to official navitia's API doc for use.
+On some ptref endpoints, one can provide a 'since' and 'until' parameter to filter disruptions or vehicle_journeys.<br>Please refer to official navitia's API doc for use.
 
 
 # Summary

--- a/documentation/rfc/doc-routing-algorithm.md
+++ b/documentation/rfc/doc-routing-algorithm.md
@@ -153,21 +153,15 @@ Advantages:
 * Flexibility
 
 Drawbacks:
-* Not exact walking objective:
-  The first pass does not optimize walking. This can lead to situations where the first pass removes options that would be valid in term of walking optimization.
-  The second pass is also bound by the `max_extra_second_pass` parameter (default to `0`) which can lead to sub-optimal journeys for the walking part.
+* Not exact walking objective:<br>The first pass does not optimize walking. This can lead to situations where the first pass removes options that would be valid in term of walking optimization.<br>The second pass is also bound by the `max_extra_second_pass` parameter (default to `0`) which can lead to sub-optimal journeys for the walking part.
 * Difficulty to add objectives
 * RAPTOR variants are quite complex and not really combinable
 
 #### Troubleshooting
 
-**Walking issue impacting the _start_ of the journey**
-By default, second passes only take walking into consideration at the arrival.
-It is possible to improve that by increasing the `_max_extra_second_pass` parameter (passing it to `10` is an acceptable value).
+**Walking issue impacting the _start_ of the journey**<br> By default, second passes only take walking into consideration at the arrival.<br>It is possible to improve that by increasing the `_max_extra_second_pass` parameter (passing it to `10` is an acceptable value).
 
-**Journey with trade-off using unexpected stop_points in terms of walking**
-This can be related to the first pass removing options that would be valid for the walking minimization.
-It is possible to check:
+**Journey with trade-off using unexpected stop_points in terms of walking**<br>This can be related to the first pass removing options that would be valid for the walking minimization.<br>It is possible to check:
 * if another journey arrives at the desired stop-point before (or at the same time with less connections) the desired journey
 * if forbidding the other journeys (be creative!) helps obtaining the desired journey
 

--- a/documentation/rfc/ridesharing.md
+++ b/documentation/rfc/ridesharing.md
@@ -85,13 +85,11 @@ Simplified output:
 }
 ```
 
-The main principle is to show a `crowfly` section with `ridesharing` as mode in the journey.
-This allows Navitia to have a succession of sections that:
+The main principle is to show a `crowfly` section with `ridesharing` as mode in the journey.<br>This allows Navitia to have a succession of sections that:
 * is consistent in both time and space _(A @7:00 -> B @9:00 -> C @10:00)_
 * respects constraints provided in parameters _(journey starting after 7:00)_
 
-Inside that ridesharing-crowfly section we find the `ridesharing_journeys`.
-They are showing multiple possible journeys using ridesharing and covering that crowfly section.
+Inside that ridesharing-crowfly section we find the `ridesharing_journeys`.<br>They are showing multiple possible journeys using ridesharing and covering that crowfly section.
 * Each journey will have a starting and ending crowfly to manage succession of sections in space (even with top-level sections).
 * Time-consistency is respected in that sub-journey _(A @6:30 -> A1 @6:30 -> A2 @9:30 -> B @9:30)_,
 * However time-consistency is not respected if an integrator chooses to substitute those sub-journey's sections to the top ridesharing-crowfly section

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -270,10 +270,7 @@ paginate results.
 
 #### <a name="depth"></a>depth
 
-You are looking for something, but Navitia doesn't output it in your favorite endpoint?
-You want to request more from navitia feed?
-You are receiving feeds that are too important and too slow with low bandwidth?
-You would like Navitia to serve GraphQL but it is still not planned?
+You are looking for something, but Navitia doesn't output it in your favorite endpoint?<br>You want to request more from navitia feed?<br>You are receiving feeds that are too important and too slow with low bandwidth?<br>You would like Navitia to serve GraphQL but it is still not planned?
 
 Feeds from endpoint might miss informations, but this tiny `depth=` parameter can
 expand Navitia power by making it more wordy. Or lighter if you want it.
@@ -1312,15 +1309,13 @@ Please remember that isochrones use crowfly at the end so they are less precise 
 
 #### Isochrones without public transport
 
-The main goal of Navitia is to handle public transport, so it's not recommended to avoid them.
-However if your are willing to do that, you can use a little trick and
+The main goal of Navitia is to handle public transport, so it's not recommended to avoid them.<br>However if your are willing to do that, you can use a little trick and
 pass the parameters `&allowed_id=physical_mode:Bus&forbidden_id=physical_mode:Bus`.
 You will only get circles.
 
 #### Car isochrones
 
-Using car in Navitia isochrones is not recommended.
-It is only handled for compatibility with `/journeys` but tends to squash every other result.
+Using car in Navitia isochrones is not recommended.<br>It is only handled for compatibility with `/journeys` but tends to squash every other result.
 
 
 <a name="route-schedules"></a>Route Schedules
@@ -1560,9 +1555,7 @@ This endpoint gives you access to time tables going through a stop
 point as:
 ![stop_schedules](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg/640px-Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg)
 
-The response is made of an array of [stop_schedule](#stop-schedule), and another one of [note](#note).
-[Context](#context) object provides the `current_datetime`, useful to compute waiting time when requesting Navitia without a `from_datetime`.
-Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/stop_schedules>
+The response is made of an array of [stop_schedule](#stop-schedule), and another one of [note](#note).<br>[Context](#context) object provides the `current_datetime`, useful to compute waiting time when requesting Navitia without a `from_datetime`.<br>Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/stop_schedules>
 
 See how disruptions affect stop schedules in the [real time](#realtime) section.
 
@@ -1790,9 +1783,7 @@ HTTP/1.1 200 OK
 
 ```
 
-This service provides the state of public transport traffic, grouped by lines and all their stops.
-It can be called for an overall coverage or for a specific object.
-Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/line_reports>
+This service provides the state of public transport traffic, grouped by lines and all their stops.<br>It can be called for an overall coverage or for a specific object.<br>Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/line_reports>
 
 <img src="./images/traffic_reports.png" alt="Traffic reports" width="300"/>
 
@@ -1923,8 +1914,7 @@ Details for disruption objects : [disruptions](#disruptions)
 #### What a line_report object **contains**
 
 -   1 line which is the grouping object
-    -   it can contain links to its disruptions.
-    These disruptions are globals and might not be applied on stop_areas and stop_points.
+    -   it can contain links to its disruptions.<br>These disruptions are globals and might not be applied on stop_areas and stop_points.
 -   1..n pt_objects
     -   each one contains at least a link to its disruptions.
 
@@ -1959,9 +1949,7 @@ HTTP/1.1 200 OK
 
 Also known as `/traffic_reports` service. We recommand to use line_reports in place of traffic_reports.
 
-This service provides the state of public transport traffic, grouped by network.
-It can be called for an overall coverage or for a specific object.
-Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/traffic_reports>
+This service provides the state of public transport traffic, grouped by network.<br>It can be called for an overall coverage or for a specific object.<br>Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/traffic_reports>
 
 ### Parameters
 
@@ -2148,13 +2136,11 @@ Details for disruption objects : [disruptions](#disruptions)
 #### What a traffic_report object **contains**
 
 -   1 network which is the grouping object
-    -   it can contain links to its disruptions.
-    These disruptions are globals and might not be applied on lines or stop_areas.
+    -   it can contain links to its disruptions.<br>These disruptions are globals and might not be applied on lines or stop_areas.
 -   0..n lines
     -   each line contains at least a link to its disruptions
 -   0..n stop_areas
-    -   each stop_area contains at least a link to its disruptions
-    If a stop_area is used by multiple networks, it will appear each time.
+    -   each stop_area contains at least a link to its disruptions<br>If a stop_area is used by multiple networks, it will appear each time.
 
 
 Equipment_Reports
@@ -2207,11 +2193,7 @@ HTTP/1.1 200 OK
 
 Also known as the `"/equipment_reports"` service.
 
-This service provides the state of equipments such as lifts or elevators that are giving you better accessibility to public transport facilities.
-The endpoint will report accessible equipment per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered per line.
-Some of the fields (cause, effect, periods etc...) are only displayed if a realtime equipment provider is setup with available data. Otherwise, only information provided by the NTFS will be reported.
-For more information, refer to [Equipment reports](#equipment-reports) API description.
-Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/equipment_reports>
+This service provides the state of equipments such as lifts or elevators that are giving you better accessibility to public transport facilities.<br>The endpoint will report accessible equipment per stop area and per line. Which means that an equipment detail is reported at the stop area level, with all stop areas gathered per line.<br>Some of the fields (cause, effect, periods etc...) are only displayed if a realtime equipment provider is setup with available data. Otherwise, only information provided by the NTFS will be reported.<br>For more information, refer to [Equipment reports](#equipment-reports) API description.<br>Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/equipment_reports>
 
 <aside class="warning">
     This feature requires a specific configuration from a equipment service provider.

--- a/documentation/slate/source/includes/examples.md
+++ b/documentation/slate/source/includes/examples.md
@@ -15,17 +15,13 @@ Basics on the API request
 $ curl 'https://api.navitia.io/v1/coverage/sandbox/stop_areas/stop_area%3ARAT%3ASA%3ABASTI/lines/line%3ARAT%3AM5/departures?count=4&depth=2&' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
 ```
 
-A query to Navitia's API is divided in 4 parts, as highlighted by colors in a [Navitia Playground example](http://canaltp.github.io/navitia-playground/play.html?request=https%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fsandbox%2Fstop_areas%2Fstop_area%253ARAT%253ASA%253ABASTI%2Flines%2Fline%253ARAT%253AM5%2Fdepartures%3Fcount%3D4%26depth%3D2%26&token=3b036afe-0110-4202-b9ed-99718476c2e0):
-![Navitia basic request](/images/navitia_basic.png)
+A query to Navitia's API is divided in 4 parts, as highlighted by colors in a [Navitia Playground example](http://canaltp.github.io/navitia-playground/play.html?request=https%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fsandbox%2Fstop_areas%2Fstop_area%253ARAT%253ASA%253ABASTI%2Flines%2Fline%253ARAT%253AM5%2Fdepartures%3Fcount%3D4%26depth%3D2%26&token=3b036afe-0110-4202-b9ed-99718476c2e0):<br>![Navitia basic request](/images/navitia_basic.png)
 
-1. **Root url** of the API, the address of the server.
-Here `https://api.navitia.io/v1/`
-2. **Path**, used to filter the request and precise what is affected by the query. This filter is an intersection of multiple `key/value` (logical _AND_).
-Here `/coverage/sandbox/stop_areas/stop_area:RAT:SA:BASTI/lines/line:RAT:M5/` means we are looking for information on everything that is in the region _"sandbox"_ and that is stricly related to both station _"Bastille"_ and line _"metro 5"_.
+1. **Root url** of the API, the address of the server.<br>Here `https://api.navitia.io/v1/`
+2. **Path**, used to filter the request and precise what is affected by the query. This filter is an intersection of multiple `key/value` (logical _AND_).<br>Here `/coverage/sandbox/stop_areas/stop_area:RAT:SA:BASTI/lines/line:RAT:M5/` means we are looking for information on everything that is in the region _"sandbox"_ and that is stricly related to both station _"Bastille"_ and line _"metro 5"_.
 3. **Endpoint**, specifies what type of information is requested, so the _feature_. It can be a service, like _journeys_, _isochrones_, _places_ or a collection of objects, like _lines_, _stop\_areas_, etc.
 Here `/departures?` means we are requesting _"next departures"_.
-4. **Parameters**, used to specify any additional detail linked to the endpoint requested.
-Here `?count=4&depth=2&` means we are requesting the next **_4_** departures and we want the response to be detailed to a depth of **_2_**.
+4. **Parameters**, used to specify any additional detail linked to the endpoint requested.<br>Here `?count=4&depth=2&` means we are requesting the next **_4_** departures and we want the response to be detailed to a depth of **_2_**.
 
 <aside class="success">
     Tadaaa!

--- a/documentation/slate/source/includes/interface.md
+++ b/documentation/slate/source/includes/interface.md
@@ -130,8 +130,7 @@ That means :
 Objects order
 -------------
 
-Unless specified, objects lists are not sorted and stability of objects' order is not guaranteed.
-This is also true for the ordering of the attributes of objects.
+Unless specified, objects lists are not sorted and stability of objects' order is not guaranteed.<br>This is also true for the ordering of the attributes of objects.
 
 Examples of sorted objects tables:
 
@@ -152,8 +151,7 @@ Examples of unsorted responses:
 Objects attributes
 ------------------
 
-Like almost any API, objects are subject to adaptations.
-Please be warned that we allow Navitia to add new attributes to objects, and it will never be considered a breaking change.
+Like almost any API, objects are subject to adaptations.<br>Please be warned that we allow Navitia to add new attributes to objects, and it will never be considered a breaking change.
 
 We also allow Navitia to add values to enum, so be prepared to that. For example [section's](#section) type of journeys are regularly evolving.
 

--- a/documentation/slate/source/includes/objects.md
+++ b/documentation/slate/source/includes/objects.md
@@ -752,9 +752,7 @@ context object is a complex object provided in any endpoint's response.
 It serves several goals:
 
 -   `timezone` provides timezone of any datetime in the response.
--   `current_datetime` provides the time the call was made.
-    It is precious to compute the waiting time until next passages (journeys, departures, etc.),
-    as when no datetime is provided at call, Navitia uses that "current_datetime" as reference time.
+-   `current_datetime` provides the time the call was made.<br>It is precious to compute the waiting time until next passages (journeys, departures, etc.), as when no datetime is provided at call, Navitia uses that "current_datetime" as reference time.
 -   `car_direct_path` can also be provided in journeys to help compare ecological footprint of transport.
 
 ### pt-date-time

--- a/documentation/slate/source/includes/realtime.md
+++ b/documentation/slate/source/includes/realtime.md
@@ -27,19 +27,15 @@ A disruption is present in the response of the endpoints described if the reques
 
 ## <a name="PT_object_collections_data_freshness"></a>Public transport object collections
 
-Several public transport objects have separate collections for `base_schedule` and `realtime`.
-So the data_freshness parameter may affect the number of objects returned depending on the request.
+Several public transport objects have separate collections for `base_schedule` and `realtime`.<br>So the data_freshness parameter may affect the number of objects returned depending on the request.
 
-For example when looking for a specific circulation with the collection vehicle_journey using the request:
-`http://api.navitia.io/v1/coverage/<toto>/vehicle_journeys?since=20191008T100000&until=20191008T200000&data_freshness=base_schedule`.
+For example when looking for a specific circulation with the collection vehicle_journey using the request:<br>`http://api.navitia.io/v1/coverage/<toto>/vehicle_journeys?since=20191008T100000&until=20191008T200000&data_freshness=base_schedule`.
 
 A vehicle_journey circulating between since and until that is **fully deleted** (NO_SERVICE) by a disruption will
-of course be **visible** if `data_freshness=base_schedule`.
-But it **will not appear** with the parameter `data_freshness=realtime` as it does not exist in that collection.
+of course be **visible** if `data_freshness=base_schedule`.<br>But it **will not appear** with the parameter `data_freshness=realtime` as it does not exist in that collection.
 
 On the other hand, a vehicle_journey that is **created** by a realtime feed will only be **visible** if
-`data_freshness=realtime` on that same request.
-And it will **not appear** if `data_freshness=base_schedule`.
+`data_freshness=realtime` on that same request.<br>And it will **not appear** if `data_freshness=base_schedule`.
 
 
 ## <a name="SIGNIFICANT_DELAYS"></a>Trip delayed
@@ -145,11 +141,9 @@ In a public transport section of the response:
 * "base_arrival_date_time"/"base_departure_date_time" represent the scheduled arrival/departure time without taking into account the delay
 * whereas "arrival_date_time"/"departure_date_time" are the actual arrival/departure time, after the delay is applied
 
-The delay can also be observed for every stop point of the journey with the same parameters in "stop_date_times".
-If the parameter "data_freshness" is set to "base_schedule", then "base_arrival_date_time"/"base_departure_date_time" = "arrival_date_time"/"departure_date_time".
+The delay can also be observed for every stop point of the journey with the same parameters in "stop_date_times".<br>If the parameter "data_freshness" is set to "base_schedule", then "base_arrival_date_time"/"base_departure_date_time" = "arrival_date_time"/"departure_date_time".
 
-A list of the disruptions impacting the journey is also present at the root level of the response.
-A link to the concerned disruption can be found in the section "display_informations".
+A list of the disruptions impacting the journey is also present at the root level of the response.<br>A link to the concerned disruption can be found in the section "display_informations".
 
 <div></div>
 ### Departures
@@ -203,8 +197,7 @@ http://api.navitia.io/v1/coverage/<coverage>/physical_modes/<physical_mode>/stop
 
 In the "stop_date_time" section of the response, the parameter "stop_date_time" is "realtime" and the fields "arrival_date_time"/"departure_date_time" take the delay into account, whereas "base_arrival_date_time"/"base_departure_date_time" show the base-schedule departure/arrival datetime.
 
-A list of the disruptions impacting the departures is also present at the root level of the response.
-A link to the concerned disruption can be found in the section "display_informations".
+A list of the disruptions impacting the departures is also present at the root level of the response.<br>A link to the concerned disruption can be found in the section "display_informations".
 
 <div></div>
 ### Stop Schedules
@@ -250,8 +243,7 @@ http://api.navitia.io/v1/coverage/<coverage>/physical_modes/<physical_mode>/line
 
 In the list of "date_times" available in the response, the parameter "data_freshness" is "realtime" and the field "date_time" takes the delay into account, whereas "base_date_time" shows the base-schedule departure datetime.
 
-A list of the disruptions impacting the stop schedules is also present at the root level of the response.
-A link to the concerned disruption can be found in the in the "date_times" object itself.
+A list of the disruptions impacting the stop schedules is also present at the root level of the response.<br>A link to the concerned disruption can be found in the in the "date_times" object itself.
 
 ## <a name="REDUCED_SERVICE"></a>Reduced service
 
@@ -269,22 +261,18 @@ A link to the concerned disruption can be found in the in the "date_times" objec
 ```
 The effect of the disruption is `REDUCED_SERVICE`. It means that the train won't be serving one or more stations in its journey.
 
-In the disruption, the deleted stations can be found in the list of "impacted_stops" with the departure/arrival status set to "deleted".
-See the [disruption](#disruption) objects section for its full content and description.
+In the disruption, the deleted stations can be found in the list of "impacted_stops" with the departure/arrival status set to "deleted".<br>See the [disruption](#disruption) objects section for its full content and description.
 
 <div></div>
 ### Journeys
 
-If the stop deleted is the origin/destination of a section of the journey, Navitia will compute a different itinerary to the requested station.
-If not (deleting intermediate stop), the journey won't be affected.
-Either way, a link to this disruption can be found in the section "display_informations" like for other disruptions.
+If the stop deleted is the origin/destination of a section of the journey, Navitia will compute a different itinerary to the requested station.<br>If not (deleting intermediate stop), the journey won't be affected.<br>Either way, a link to this disruption can be found in the section "display_informations" like for other disruptions.
 
 ### Departures & Stop Schedules
 
 At the deleted stop area, the departure time of the train with a reduced service simply won't be displayed in the list of departures/stop_schedules if "data_freshness" is set to "realtime".
 
-If "data_freshness" is "base_schedule", then the depature time is displayed.
-In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
+If "data_freshness" is "base_schedule", then the depature time is displayed.<br>In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
 
 ## <a name="NO_SERVICE"></a>No service
 
@@ -318,22 +306,19 @@ In that case, a link to this disruption can be found in the section "display_inf
 The effect of the disruption is `NO_SERVICE`. It means that the train won't be circulating at all.
 
 In the disruption, the deleted trip can be found in the "impacted_objects" list with the
-"application_periods" describing the period(s) of unavailability for the trip.
-See the [disruption](#disruption) objects section for its full content and description.
+"application_periods" describing the period(s) of unavailability for the trip.<br>See the [disruption](#disruption) objects section for its full content and description.
 
 <div></div>
 ### Journeys
 
 If the deleted trip is used by a section of the `base_schedule` journey, Navitia will compute a different
-itinerary to the requested station in `realtime`, or a later one (without using that trip).
-A link to this disruption can be found in the section "display_informations" like for other disruptions, on a `base_schedule` journey.
+itinerary to the requested station in `realtime`, or a later one (without using that trip).<br>A link to this disruption can be found in the section "display_informations" like for other disruptions, on a `base_schedule` journey.
 
 ### Departures & Stop Schedules
 
 At the deleted stop area, the departure time of the cancelled train simply won't be displayed in the list of departures/stop_schedules if "data_freshness" is set to "realtime".
 
-If "data_freshness" is "base_schedule", then the depature time is displayed.
-In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
+If "data_freshness" is "base_schedule", then the depature time is displayed.<br>In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
 
 ## <a name="MODIFIED_SERVICE"></a>Modified service
 
@@ -353,8 +338,7 @@ In that case, a link to this disruption can be found in the section "display_inf
 ```
 The effect of the disruption is `MODIFIED_SERVICE`. It means that there is one or several stop points added into the trip. This can be at any position in the trip (origin and destination included).
 
-In the disruption, new stop points can be found in the list of "impacted_stops" with the departure/arrival status set to "added". The scheduled arrival/departure at the new stop point can be found in "amended_arrival_time"/"amended_departure_time".
-See the [disruption](#disruption) objects section for its full content and description.
+In the disruption, new stop points can be found in the list of "impacted_stops" with the departure/arrival status set to "added". The scheduled arrival/departure at the new stop point can be found in "amended_arrival_time"/"amended_departure_time".<br>See the [disruption](#disruption) objects section for its full content and description.
 
 <div></div>
 ### Journeys
@@ -422,14 +406,12 @@ http://api.navitia.io/v1/coverage/<coverage>/journeys?from=<origin>&to=<destinat
 
 The status of the journey is `MODIFIED_SERVICE`. In a public transport section of the response, "arrival_date_time"/"departure_date_time" are the arrival/departure times of an added stop point. New stop points are only used when the "data_freshness" parameter is set to "realtime".
 
-A list of the disruptions impacting the journey is also present at the root level of the response.
-A link to the concerned disruption can be found in the section "display_informations".
+A list of the disruptions impacting the journey is also present at the root level of the response.<br>A link to the concerned disruption can be found in the section "display_informations".
 
 <div></div>
 ### Departures & Stop Schedules
 
-At the added stop area, the departure time of the train with a modified service is displayed if "data_freshness" is set to "realtime".
-In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
+At the added stop area, the departure time of the train with a modified service is displayed if "data_freshness" is set to "realtime".<br>In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
 
 The departure time of the train with a modified service simply won't be displayed in the list of departures/stop_schedules if "data_freshness" is set to "base_schedule".
 
@@ -453,8 +435,7 @@ The departure time of the train with a modified service simply won't be displaye
 ```
 The effect of the disruption is `ADDITIONAL_SERVICE`. It means that a new trip has been scheduled.
 
-In the disruption, every stops served by the new train can be found in the list of "impacted_stops" with the departure/arrival status set to "added". The scheduled arrival/departure at the new stop point can be found in "amended_arrival_time"/"amended_departure_time".
-See the [disruption](#disruption) objects section for its full content and description.
+In the disruption, every stops served by the new train can be found in the list of "impacted_stops" with the departure/arrival status set to "added". The scheduled arrival/departure at the new stop point can be found in "amended_arrival_time"/"amended_departure_time".<br>See the [disruption](#disruption) objects section for its full content and description.
 
 
 <div></div>
@@ -523,14 +504,11 @@ http://api.navitia.io/v1/coverage/<coverage>/journeys?from=<origin>&to=<destinat
     ]
 ```
 
-The status of the journey is `ADDITIONAL_SERVICE`. This new journey can only be displayed if "data_freshness" is set to "realtime".
-A list of disruptions impacting the journey is also present at the root level of the response.
-A link to the concerned disruption can be found in the section "display_informations".
+The status of the journey is `ADDITIONAL_SERVICE`. This new journey can only be displayed if "data_freshness" is set to "realtime".<br>A list of disruptions impacting the journey is also present at the root level of the response.<br>A link to the concerned disruption can be found in the section "display_informations".
 
 <div></div>
 ### Departures & Stop Schedules
-At one of the added stop area from the additional trip, the departure time of the added train is displayed if "data_freshness" is set to "realtime".
-In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
+At one of the added stop area from the additional trip, the departure time of the added train is displayed if "data_freshness" is set to "realtime".<br>In that case, a link to this disruption can be found in the section "display_informations" for departures, in the "date_times" object itself for stop_schedules.
 
 The departure time of the train with an additional service simply won't be displayed in the list of departures/stop_schedules if "data_freshness" is set to "base_schedule".
 
@@ -552,15 +530,12 @@ The departure time of the train with an additional service simply won't be displ
     "stop_time_effect": "unchanged",
 },
 ```
-The effect of the disruption is `UNKNOWN_EFFECT`. It means that the disruption affecting the journey is no longer effective, and the trip is back to its theoritical schedule.
-In the list of "impacted_stops" in the disruption, the "arrival_status"/"departure_status" is set to "unchanged".
-See the [disruption](#disruption) objects section for its full content and description.
+The effect of the disruption is `UNKNOWN_EFFECT`. It means that the disruption affecting the journey is no longer effective, and the trip is back to its theoritical schedule.<br>In the list of "impacted_stops" in the disruption, the "arrival_status"/"departure_status" is set to "unchanged".<br>See the [disruption](#disruption) objects section for its full content and description.
 
 <div></div>
 ### Journeys
 
-When requesting a journey that was previously disrupted and is now back to normal, the journey response will be the same with the parameter "data_freshness" set to "realtime" or to "base_schedule".
-In this case, no disruption is present in the response.
+When requesting a journey that was previously disrupted and is now back to normal, the journey response will be the same with the parameter "data_freshness" set to "realtime" or to "base_schedule".<br>In this case, no disruption is present in the response.
 
 <div></div>
 ### Departures

--- a/documentation/slate/source/includes/welcome.md
+++ b/documentation/slate/source/includes/welcome.md
@@ -20,18 +20,14 @@ Have a look at the examples below to learn what services we provide and how to u
 
 ### Approach
 
-Navitia is an open-source web API, **initially** built to provide traveler information on urban transportation networks.
-Its main purpose is to provide day-to-day informations to travelers.
-Over time, Navitia has been able to do way more, _sometimes_ for technical and debuging purpose _or_ because other functional needs fit quite well in what Navitia can do _or_ just because it was quite easy and super cool.
+Navitia is an open-source web API, **initially** built to provide traveler information on urban transportation networks.<br>Its main purpose is to provide day-to-day informations to travelers.<br>Over time, Navitia has been able to do way more, _sometimes_ for technical and debuging purpose _or_ because other functional needs fit quite well in what Navitia can do _or_ just because it was quite easy and super cool.
 
 Technically, Navitia is a [HATEOAS](http://en.wikipedia.org/wiki/HATEOAS) API that returns JSON formated results.
 
 
 ### Who's who
 
-Navitia is instanciated and exposed publicly through [api.navitia.io](http://api.navitia.io).
-Developments on Navitia are lead by Kisio Digital (previously CanalTP).
-Kisio Digital is a subsidiary of Keolis (itself a subsidiary of SNCF, French national railway company).
+Navitia is instanciated and exposed publicly through [api.navitia.io](http://api.navitia.io).<br>Developments on Navitia are lead by Kisio Digital (previously CanalTP).<br>Kisio Digital is a subsidiary of Keolis (itself a subsidiary of SNCF, French national railway company).
 
 
 <aside class="notice">

--- a/source/ed/readme.md
+++ b/source/ed/readme.md
@@ -57,8 +57,7 @@ Component that loads a GTFS data set into `ed`.
 
 The directory containing all gtfs text files is given with the `-i` option
 
-Warning: This component will soon be deprecated and replaced by our gtfs2ntfs converter.
-You can check it in [navitia_model](https://github.com/CanalTP/navitia_model).
+Warning: This component will soon be deprecated and replaced by our gtfs2ntfs converter.<br>You can check it in [navitia_model](https://github.com/CanalTP/navitia_model).
 The output NTFS will then be provided to fusio2ed.
 
 ## fusio2ed

--- a/source/kraken/readme.md
+++ b/source/kraken/readme.md
@@ -1,8 +1,7 @@
 # Kraken
 Kraken is a public transport trip planner and much more, it provides schedules, timetables and expose public
 transport data via
-[PTReferential](https://github.com/CanalTP/navitia/blob/dev/documentation/rfc/ptref_grammar.md).
-It also provides:
+[PTReferential](https://github.com/CanalTP/navitia/blob/dev/documentation/rfc/ptref_grammar.md).<br>It also provides:
   - (bad) street network routing that will be replaced by [asgard](https://github.com/CanalTP/asgard)
   - autocomplete that will be replaced by [mimir](https://github.com/CanalTP/mimirsbrunn)
 

--- a/source/log_analyzer/readme.md
+++ b/source/log_analyzer/readme.md
@@ -1,13 +1,11 @@
 # Log Analyzer
 
-The log analyzer produces a Gantt chart of the different computations performed during a "journey" call to Navitia.
-It does so by parsing the logs of Jormungandr and Kraken.
+The log analyzer produces a Gantt chart of the different computations performed during a "journey" call to Navitia.<br>It does so by parsing the logs of Jormungandr and Kraken.
 
 
 # How to use
 
-- Configure Jormungandr and Kraken logs to record the `info` level (on by default)
-The logs are on by default for Jormungandr. For Kraken, you can add these lines to the `kraken.ini` configuration file :
+- Configure Jormungandr and Kraken logs to record the `info` level (on by default)<br>The logs are on by default for Jormungandr. For Kraken, you can add these lines to the `kraken.ini` configuration file :
 
 ```
 [LOG]
@@ -19,8 +17,7 @@ log4cplus.appender.ALL_MSGS.layout.ConversionPattern=[%D{%y-%m-%d %H:%M:%S,%q}] 
 
 ```
 
-- prepare the needed python environment with `virtualenvwrapper` (see https://virtualenvwrapper.readthedocs.io/en/latest/ for installation instructions).
-  You can also install the python librairies listed in `requirements.txt` in your own environment
+- prepare the needed python environment with `virtualenvwrapper` (see https://virtualenvwrapper.readthedocs.io/en/latest/ for installation instructions).<br>You can also install the python librairies listed in `requirements.txt` in your own environment
 
 ```
 cd log_analyzer/

--- a/source/tyr/api_v1.md
+++ b/source/tyr/api_v1.md
@@ -45,8 +45,7 @@ If lots of elements expected in the response:
 }
 ```
 
-- POST /v1/<endpoints>:
-Used to create a new element of the endpoint. Returned status code should be **201**.
+- POST /v1/<endpoints>:<br>Used to create a new element of the endpoint. Returned status code should be **201**.
 ```
 {
     "endpoint": [
@@ -57,8 +56,7 @@ Used to create a new element of the endpoint. Returned status code should be **2
 }
 ```
 
-- PUT /v1/<endpoints>:
-Used to update a new element of the endpoint. Returned status code should be **200**.
+- PUT /v1/<endpoints>:<br>Used to update a new element of the endpoint. Returned status code should be **200**.
 Note: If the POST method isn't available for an endpoint, PUT can be used to create a new element. In this case, the returned status code should be **201**
 ```
 {


### PR DESCRIPTION
The choice is to uniform the _line break_ by using the
```html
html tag -> <br>
```
it avoids the misleading aspect of **double blank space** at the end of the line
The **br tag** is only useful for raw-line (not title, list, and so on...)

if you want to check the rightness of the work, please refer you to this commit https://github.com/CanalTP/navitia/commit/1383cac128ea8638a163a6e3a4fe8cf8c8fd5b7c

note this technique is already used here https://raw.githubusercontent.com/CanalTP/navitia/dev/scripts/README.md

this work also allows you to let your automatic blank-line suppression into your code editor, or inside precommit :fireworks: 