### PR TITLE
[Jorm] get_realtime_proxy on non-realtime object causing 'no handler found'

### DIFF
--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -60,7 +60,7 @@ def get_realtime_system_code(route_point):
         return None
 
     # for the moment we consider that there can be only one rt_system
-    return rt_system[0]
+    return six.text_type(rt_system[0])
 
 
 class RealTimePassage(object):
@@ -198,7 +198,7 @@ class MixedSchedule(object):
         if not route_point:
             return None
 
-        rt_system_code = six.text_type(get_realtime_system_code(route_point))
+        rt_system_code = get_realtime_system_code(route_point)
         if not rt_system_code:
             return None
 


### PR DESCRIPTION
We were casting a `None` object into a string (u"None") causing it to fail the
check condition.

This is raising a "no handle found" message to new-relic whereas no
realtime proxy is actually configured, hence generating a false-positive error.

fun fact: This is raising 10K `realtime_internal_failure` a minute on new relic. 

Kudos to @SGrenet for spotting it.  