### PR TITLE
Purge instance after each bina

### DIFF
--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -169,6 +169,9 @@ def import_data(
             current_app.logger.info("skipping mimir import")
 
         actions.append(finish_job.si(job.id))
+
+        # We should delete old backup directories related to this instance
+        actions.append(purge_instance.si(instance.id, current_app.config['DATASET_MAX_BACKUPS_TO_KEEP']))
         if asynchronous:
             return chain(*actions).delay()
         else:


### PR DESCRIPTION
At the end of import_data, we should clean unnecessary backup data files. 
Note: 

- Not easy to test the function import_data
- Added task 'purge_instance' is already well tested and only deletes delete able files. 
- Tested in local with tyr environment.
Ticket: https://jira.kisio.org/browse/NAVP-1567