### PR TITLE
[Jormun] crowfly replaces street network section when the computation has failed

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
@@ -206,6 +206,13 @@ class FallbackDurations:
             or not len(sn_routing_matrix.rows[0].routing_response)
         ):
             logger.debug("no fallback durations found from %s by %s", self._requested_place_obj.uri, self._mode)
+            for sp in places_isochrone:
+                result[sp.uri] = DurationElement(
+                    self._get_manhattan_duration(sp.distance, self._speed_switcher.get(self._mode)),
+                    response_pb2.reached,
+                    None,
+                    0,
+                )
             return result
 
         for pos, r in enumerate(sn_routing_matrix.rows[0].routing_response):

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -216,6 +216,8 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][2]['duration'] == 2000
         assert not response['journeys'][2]['sections'][0].get('cycle_lane_length')
 
+        assert not response.get('feed_publishers')
+
 
 @dataset(
     {
@@ -238,6 +240,10 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert len(response['journeys']) == 1
 
         assert len(response['journeys'][0]['sections']) == 3
-        assert response['journeys'][0]['sections'][0]['type'] == 'crow_fly'  # replace the street network
+        assert (
+            response['journeys'][0]['sections'][0]['type'] == 'crow_fly'
+        ), "A crow fly should replace the street network"
         assert response['journeys'][0]['sections'][1]['type'] == 'public_transport'
-        assert response['journeys'][0]['sections'][2]['type'] == 'crow_fly'  # replace the street network
+        assert (
+            response['journeys'][0]['sections'][2]['type'] == 'crow_fly'
+        ), "A crow fly should replace the street network"

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -226,9 +226,9 @@ class TestAsgardDirectPath(AbstractTestFixture):
     }
 )
 class TestAsgardDirectPath(AbstractTestFixture):
-    def test_crowfly_replaces_section_if_streetwork_failed(self):
+    def test_crowfly_replaces_section_if_street_network_failed(self):
         """
-        Topic: This case arrives when the street network computation failed.
+        Topic: This case arrives when the street network computation has failed.
                In this case, we replace the lost street network section by a crowfly, like in New Default
         """
         response, status = self.query_region(journey_basic_query, check=False)

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -46,6 +46,19 @@ MOCKED_ASGARD_CONF = [
         },
     }
 ]
+MOCKED_ASGARD_CONF_WITH_BAD_RESPONSE = [
+    {
+        "modes": ['walking', 'car', 'bss', 'bike'],
+        "class": "tests.direct_path_asgard_integration_tests.MockAsgardWithBadResponse",
+        "args": {
+            "costing_options": {"bicycle": {"bicycle_type": "Hybrid"}},
+            "api_key": "",
+            "asgard_socket": "bob_socket",
+            "service_url": "http://bob.com",
+            "timeout": 10,
+        },
+    }
+]
 s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
 r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset
 
@@ -114,11 +127,15 @@ def route_response(mode):
     return response
 
 
-def response_valid(request):
+def valid_response(request):
     if request.requested_api == type_pb2.direct_path:
         return route_response(request.direct_path.streetnetwork_params.origin_mode)
     else:
         return response_pb2.Response()
+
+
+def bad_response(request):
+    return response_pb2.Response()
 
 
 def check_journeys(resp):
@@ -134,26 +151,43 @@ class MockAsgard(Asgard):
         )
 
     def _call_asgard(self, request):
-        return response_valid(request)
+        return valid_response(request)
+
+
+class MockAsgardWithBadResponse(Asgard):
+    def __init__(
+        self, instance, service_url, asgard_socket, modes=None, id=None, timeout=10, api_key=None, **kwargs
+    ):
+        Asgard.__init__(
+            self, instance, service_url, asgard_socket, modes or [], id or 'asgard', timeout, api_key, **kwargs
+        )
+
+    def _call_asgard(self, request):
+        return bad_response(request)
 
 
 @dataset(
     {'main_routing_test': {'scenario': 'distributed', 'instance_config': {'street_network': MOCKED_ASGARD_CONF}}}
 )
 class TestAsgardDirectPath(AbstractTestFixture):
-    def test_journey_with_bike_direct_path(self):
+    def test_journey_with_direct_path(self):
+        """
+        we only want direct path
+        """
         query = (
             journey_basic_query
             + "&first_section_mode[]=walking"
             + "&first_section_mode[]=bike"
             + "&first_section_mode[]=car"
-            + "&debug=true"
+            + "&forbidden_uris[]=stop_point:stopA"
+            + "&forbidden_uris[]=stop_point:stopB"
         )
         response = self.query_region(query)
         check_journeys(response)
+
         assert len(response['journeys']) == 3
 
-        # car from asgard
+        # car direct path from asgard
         assert 'car' in response['journeys'][0]['tags']
         assert len(response['journeys'][0]['sections']) == 1
         assert response['journeys'][0]['duration'] == 500
@@ -162,7 +196,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][0]['distances']['car'] == 50
         assert not response['journeys'][0]['sections'][0].get('cycle_lane_length')
 
-        # bike from asgard
+        # bike direct path from asgard
         assert 'bike' in response['journeys'][1]['tags']
         assert len(response['journeys'][1]['sections']) == 1
         assert response['journeys'][1]['duration'] == 1000
@@ -172,7 +206,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][1]['duration'] == 1000
         assert response['journeys'][1]['sections'][0]['cycle_lane_length'] == 30
 
-        # walking from asgard
+        # walking direct path from asgard
         assert 'walking' in response['journeys'][2]['tags']
         assert len(response['journeys'][2]['sections']) == 1
         assert response['journeys'][2]['duration'] == 2000
@@ -182,4 +216,28 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][2]['duration'] == 2000
         assert not response['journeys'][2]['sections'][0].get('cycle_lane_length')
 
-        assert not response.get('feed_publishers')
+
+@dataset(
+    {
+        'main_routing_test': {
+            'scenario': 'distributed',
+            'instance_config': {'street_network': MOCKED_ASGARD_CONF_WITH_BAD_RESPONSE},
+        }
+    }
+)
+class TestAsgardDirectPath(AbstractTestFixture):
+    def test_crowfly_replaces_section_if_streetwork_failed(self):
+        """
+        Topic: This case arrives when the street network computation failed.
+               In this case, we replace the lost street network section by a crowfly, like in New Default
+        """
+        response, status = self.query_region(journey_basic_query, check=False)
+        assert status == 200
+        check_journeys(response)
+
+        assert len(response['journeys']) == 1
+
+        assert len(response['journeys'][0]['sections']) == 3
+        assert response['journeys'][0]['sections'][0]['type'] == 'crow_fly'  # replace the street network
+        assert response['journeys'][0]['sections'][1]['type'] == 'public_transport'
+        assert response['journeys'][0]['sections'][2]['type'] == 'crow_fly'  # replace the street network

--- a/source/jormungandr/tests/direct_path_parking_with_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_parking_with_asgard_integration_tests.py
@@ -63,7 +63,7 @@ s_coord = "0.0000898312;0.0000898312"  # coordinate of S in the dataset
 r_coord = "0.00188646;0.00071865"  # coordinate of R in the dataset
 
 journey_basic_query = "journeys?from={from_coord}&to={to_coord}&datetime={datetime}".format(
-    from_coord=s_coord, to_coord=r_coord, datetime="20190125T080000"
+    from_coord=s_coord, to_coord=r_coord, datetime="20120614080000"
 )
 
 


### PR DESCRIPTION
### Topic

Nowaday, in **Distributed** scenario, if the street network computation return an empty response, an exception occurs, `no origin nor destination`
To be consistent with the **New Default** scenario, we have to create a crowfly section that replaces street network.

It will fix the **JIRA** https://jira.kisio.org/browse/NAVP-1571
