### PR TITLE
[ALL] Manage trip shortname and headsign

### DIFF
--- a/fixtures/ed/ntfs/trips.txt
+++ b/fixtures/ed/ntfs/trips.txt
@@ -1,6 +1,6 @@
-route_id,service_id,trip_id,trip_headsign,block_id,company_id,odt_condition_id,physical_mode_id,trip_property_id,contributor_id,geometry_id,dataset_id
-route_1,1,trip_1,"vehiclejourney1",,,0_test1,BUS,1,C1,,dataset_id1
-route_2,1,trip_2,"vehiclejourney2",,,0_test1,BUS,0,C1,,dataset_id2
-route_3,1,trip_3,"vehiclejourney3",,,0_test1,BUS,0,C1,,dataset_id3
-route_3,1,trip_4,"NULL",,,0_test1,,0,C1,,dataset_id4
-route_4,1,trip_5,,,,,BUS,,,,dataset_id5
+route_id,service_id,trip_id,trip_headsign,block_id,company_id,odt_condition_id,physical_mode_id,trip_property_id,contributor_id,geometry_id,dataset_id,trip_short_name
+route_1,1,trip_1,"vehiclejourney1",,,0_test1,BUS,1,C1,,dataset_id1,trip_1_short_name
+route_2,1,trip_2,"vehiclejourney2",,,0_test1,BUS,0,C1,,dataset_id2,trip_2_short_name
+route_3,1,trip_3,"vehiclejourney3",,,0_test1,BUS,0,C1,,dataset_id3,
+route_3,1,trip_4,"NULL",,,0_test1,,0,C1,,dataset_id4,
+route_4,1,trip_5,,,,,BUS,,,,dataset_id5,trip_5_short_name

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -197,19 +197,7 @@ nt::VehicleJourney* VJ::make() {
     }
     vj->physical_mode->vehicle_journey_list.push_back(vj);
 
-    /*
-    std::cout << "*** Before ****" << std::endl;
-    std::cout << "vj.uri: " << vj->uri << std::endl;
-    std::cout << "vj.name: " << vj->name << std::endl;
-    std::cout << "vj.headsign: " << vj->headsign << std::endl;
-    */
     pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, vj_headsign);
-    /*
-    std::cout << "*** After ****" << std::endl;
-    std::cout << "vj.uri: " << vj->uri << std::endl;
-    std::cout << "vj.name: " << vj->name << std::endl;
-    std::cout << "vj.headsign: " << vj->headsign << std::endl << std::endl;
-    */
 
     if (!_block_id.empty()) {
         b.block_vjs.insert(std::make_pair(_block_id, vj));

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -78,6 +78,7 @@ struct VJ {
     const bool is_frequency;
     const bool wheelchair_boarding;
     std::string _name;
+    std::string _headsign;
     std::string _meta_vj_name;
     std::string _physical_mode;
     const uint32_t start_time;
@@ -98,6 +99,7 @@ struct VJ {
        const bool is_frequency,
        const bool wheelchair_boarding = true,
        std::string name = "",
+       std::string headsign = "",
        std::string meta_vj_name = "",
        std::string physical_mode = "",
        const uint32_t start_time = 0,
@@ -152,6 +154,10 @@ struct VJ {
 
     VJ& name(const std::string& u) {
         _name = u;
+        return *this;
+    }
+    VJ& headsign(const std::string& u) {
+        _headsign = u;
         return *this;
     }
     VJ& valid_all_days() {
@@ -297,6 +303,7 @@ struct builder {
           const std::string& block_id = "",
           const bool wheelchair_boarding = true,
           const std::string& name = "",
+          const std::string& headsign = "",
           const std::string& meta_vj = "",
           const std::string& physical_mode = "",
           const nt::RTLevel vj_type = nt::RTLevel::Base);
@@ -307,6 +314,7 @@ struct builder {
                        const std::string& block_id = "",
                        const bool wheelchair_boarding = true,
                        const std::string& name = "",
+                       const std::string& headsign = "",
                        const std::string& meta_vj = "",
                        const std::string& physical_mode = "",
                        const bool is_frequency = false,
@@ -324,6 +332,7 @@ struct builder {
                     const std::string& block_id = "",
                     const bool wheelchair_boarding = true,
                     const std::string& name = "",
+                    const std::string& headsign = "",
                     const std::string& meta_vj = "");
 
     // Create a new stop area

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -435,8 +435,8 @@ void StopTimeFusioHandler::init(Data& data) {
         date_time_estimated_c = csv.get_pos_col("date_time_estimated");
     }
     id_c = csv.get_pos_col("stop_time_id");
-    headsign_c = csv.get_pos_col("stop_headsign");
-    short_name_c = csv.get_pos_col("trip_short_name_at_stop");
+    stop_headsign_c = csv.get_pos_col("stop_headsign");
+    trip_short_name_at_stop_c = csv.get_pos_col("trip_short_name_at_stop");
     boarding_duration_c = csv.get_pos_col("boarding_duration");
     alighting_duration_c = csv.get_pos_col("alighting_duration");
 }
@@ -478,10 +478,10 @@ void StopTimeFusioHandler::handle_line(Data& data, const csv_row& row, bool is_f
         }
 
         // stop_headsign value has priority over trip_short_name_at_stop
-        if (is_valid(headsign_c, row)) {
-            stop_time->headsign = row[headsign_c];
-        } else if (is_valid(short_name_c, row)) {
-            stop_time->headsign = row[short_name_c];
+        if (is_valid(stop_headsign_c, row)) {
+            stop_time->headsign = row[stop_headsign_c];
+        } else if (is_valid(trip_short_name_at_stop_c, row)) {
+            stop_time->headsign = row[trip_short_name_at_stop_c];
         }
 
         if (is_valid(boarding_duration_c, row)) {
@@ -555,7 +555,7 @@ void TripsFusioHandler::init(Data& d) {
     route_id_c = csv.get_pos_col("route_id");
     service_c = csv.get_pos_col("service_id");
     trip_c = csv.get_pos_col("trip_id");
-    headsign_c = csv.get_pos_col("trip_headsign");
+    trip_headsign_c = csv.get_pos_col("trip_headsign");
     block_id_c = csv.get_pos_col("block_id");
     comment_id_c = csv.get_pos_col("comment_id");
     trip_propertie_id_c = csv.get_pos_col("trip_property_id");
@@ -628,16 +628,16 @@ std::vector<ed::types::VehicleJourney*> TripsFusioHandler::get_split_vj(Data& da
         }
         vj->uri = vj_uri;
 
-        if (is_valid(headsign_c, row)) {
-            vj->headsign = row[headsign_c];
+        if (is_valid(trip_headsign_c, row)) {
+            vj->headsign = row[trip_headsign_c];
         } else {
             vj->headsign = vj->uri;
         }
 
         if (is_valid(trip_short_name_c, row)) {
             vj->name = row[trip_short_name_c];
-        } else if (is_valid(headsign_c, row)) {
-            vj->name = row[headsign_c];
+        } else if (is_valid(trip_headsign_c, row)) {
+            vj->name = row[trip_headsign_c];
         } else {
             vj->name = vj->uri;
         }

--- a/source/ed/connectors/fusio_parser.cpp
+++ b/source/ed/connectors/fusio_parser.cpp
@@ -436,6 +436,7 @@ void StopTimeFusioHandler::init(Data& data) {
     }
     id_c = csv.get_pos_col("stop_time_id");
     headsign_c = csv.get_pos_col("stop_headsign");
+    short_name_c = csv.get_pos_col("trip_short_name_at_stop");
     boarding_duration_c = csv.get_pos_col("boarding_duration");
     alighting_duration_c = csv.get_pos_col("alighting_duration");
 }
@@ -476,8 +477,11 @@ void StopTimeFusioHandler::handle_line(Data& data, const csv_row& row, bool is_f
             }
         }
 
+        // stop_headsign value has priority over trip_short_name_at_stop
         if (is_valid(headsign_c, row)) {
             stop_time->headsign = row[headsign_c];
+        } else if (is_valid(short_name_c, row)) {
+            stop_time->headsign = row[short_name_c];
         }
 
         if (is_valid(boarding_duration_c, row)) {
@@ -567,6 +571,7 @@ void TripsFusioHandler::init(Data& d) {
     if (dataset_id_c == -1) {
         dataset_id_c = csv.get_pos_col("frame_id");
     }
+    trip_short_name_c = csv.get_pos_col("trip_short_name");
 }
 
 std::vector<ed::types::VehicleJourney*> TripsFusioHandler::get_split_vj(Data& data, const csv_row& row, bool) {
@@ -623,10 +628,19 @@ std::vector<ed::types::VehicleJourney*> TripsFusioHandler::get_split_vj(Data& da
         }
         vj->uri = vj_uri;
 
-        if (is_valid(headsign_c, row))
+        if (is_valid(headsign_c, row)) {
+            vj->headsign = row[headsign_c];
+        } else {
+            vj->headsign = vj->uri;
+        }
+
+        if (is_valid(trip_short_name_c, row)) {
+            vj->name = row[trip_short_name_c];
+        } else if (is_valid(headsign_c, row)) {
             vj->name = row[headsign_c];
-        else
+        } else {
             vj->name = vj->uri;
+        }
 
         vj->validity_pattern = vp_xx;
         vj->adapted_validity_pattern = vp_xx;

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -109,7 +109,8 @@ struct GeometriesFusioHandler : public GenericHandler {
 struct TripsFusioHandler : public GenericHandler {
     TripsFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
     int route_id_c, service_c, trip_c, headsign_c, block_id_c, comment_id_c, trip_propertie_id_c, odt_type_c,
-        company_id_c, odt_condition_id_c, physical_mode_c, ext_code_c, geometry_id_c, contributor_id_c, dataset_id_c;
+        company_id_c, odt_condition_id_c, physical_mode_c, ext_code_c, geometry_id_c, contributor_id_c, dataset_id_c,
+        trip_short_name_c;
 
     int ignored = 0;
     int ignored_vj = 0;
@@ -125,7 +126,7 @@ struct TripsFusioHandler : public GenericHandler {
 struct StopTimeFusioHandler : public StopTimeGtfsHandler {
     StopTimeFusioHandler(GtfsData& gdata, CsvReader& reader)
         : StopTimeGtfsHandler(gdata, reader), is_stop_time_precision(true) {}
-    int desc_c, itl_c, date_time_estimated_c, id_c, headsign_c, boarding_duration_c, alighting_duration_c;
+    int desc_c, itl_c, date_time_estimated_c, id_c, headsign_c, boarding_duration_c, alighting_duration_c, short_name_c;
     bool is_stop_time_precision;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);

--- a/source/ed/connectors/fusio_parser.h
+++ b/source/ed/connectors/fusio_parser.h
@@ -108,7 +108,7 @@ struct GeometriesFusioHandler : public GenericHandler {
 
 struct TripsFusioHandler : public GenericHandler {
     TripsFusioHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int route_id_c, service_c, trip_c, headsign_c, block_id_c, comment_id_c, trip_propertie_id_c, odt_type_c,
+    int route_id_c, service_c, trip_c, trip_headsign_c, block_id_c, comment_id_c, trip_propertie_id_c, odt_type_c,
         company_id_c, odt_condition_id_c, physical_mode_c, ext_code_c, geometry_id_c, contributor_id_c, dataset_id_c,
         trip_short_name_c;
 
@@ -126,7 +126,8 @@ struct TripsFusioHandler : public GenericHandler {
 struct StopTimeFusioHandler : public StopTimeGtfsHandler {
     StopTimeFusioHandler(GtfsData& gdata, CsvReader& reader)
         : StopTimeGtfsHandler(gdata, reader), is_stop_time_precision(true) {}
-    int desc_c, itl_c, date_time_estimated_c, id_c, headsign_c, boarding_duration_c, alighting_duration_c, short_name_c;
+    int desc_c, itl_c, date_time_estimated_c, id_c, stop_headsign_c, boarding_duration_c, alighting_duration_c,
+        trip_short_name_at_stop_c;
     bool is_stop_time_precision;
     void init(Data&);
     void handle_line(Data& data, const csv_row& line, bool is_first_line);

--- a/source/ed/connectors/gtfs_parser.cpp
+++ b/source/ed/connectors/gtfs_parser.cpp
@@ -859,7 +859,7 @@ void TripsGtfsHandler::init(Data& data) {
     id_c = csv.get_pos_col("route_id");
     service_c = csv.get_pos_col("service_id");
     trip_c = csv.get_pos_col("trip_id");
-    headsign_c = csv.get_pos_col("trip_headsign");
+    trip_headsign_c = csv.get_pos_col("trip_headsign");
     block_id_c = csv.get_pos_col("block_id");
     wheelchair_c = csv.get_pos_col("wheelchair_accessible");
     bikes_c = csv.get_pos_col("bikes_allowed");
@@ -950,8 +950,8 @@ void TripsGtfsHandler::handle_line(Data& data, const csv_row& row, bool) {
         }
 
         vj->uri = vj_uri;
-        if (has_col(headsign_c, row))
-            vj->name = row[headsign_c];
+        if (has_col(trip_headsign_c, row))
+            vj->name = row[trip_headsign_c];
         else
             vj->name = vj->uri;
 

--- a/source/ed/connectors/gtfs_parser.h
+++ b/source/ed/connectors/gtfs_parser.h
@@ -310,7 +310,7 @@ struct ShapesGtfsHandler : public GenericHandler {
 
 struct TripsGtfsHandler : public GenericHandler {
     TripsGtfsHandler(GtfsData& gdata, CsvReader& reader) : GenericHandler(gdata, reader) {}
-    int id_c, service_c, trip_c, headsign_c, block_id_c, wheelchair_c, bikes_c, shape_id_c, direction_id_c;
+    int id_c, service_c, trip_c, trip_headsign_c, block_id_c, wheelchair_c, bikes_c, shape_id_c, direction_id_c;
 
     int ignored = 0;
     int ignored_vj = 0;

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -225,7 +225,6 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     BOOST_REQUIRE_EQUAL(vj_from_headsign_4.size(), 1);
     BOOST_REQUIRE_EQUAL(vj_from_headsign_4[0]->headsign, "trip_5_dst_2");
     BOOST_REQUIRE_EQUAL(vj_from_headsign_4[0]->name, "trip_5_short_name");
-
 }
 
 BOOST_FIXTURE_TEST_CASE(gtfs_test, ArgsFixture) {

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -203,6 +203,29 @@ BOOST_FIXTURE_TEST_CASE(fusio_test, ArgsFixture) {
     BOOST_REQUIRE_EQUAL(data.pt_data->contributors.size(), 1);
     BOOST_REQUIRE_EQUAL(data.pt_data->contributors[0]->license, "LICENSE");
     BOOST_REQUIRE_EQUAL(data.pt_data->contributors[0]->website, "http://www.canaltp.fr");
+
+    // Here we check trip_short_name as well as headsign of some vjs
+    const nt::HeadsignHandler& headsigns = data.pt_data->headsign_handler;
+    // vjs with headsign="vehiclejourney1" and trip_short_name="trip_1_short_name"
+    const auto vj_from_headsign_1 = headsigns.get_vj_from_headsign("vehiclejourney1");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_1.size(), 2);
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_1[0]->headsign, "vehiclejourney1");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_1[0]->name, "trip_1_short_name");
+    // vjs with headsign="vehiclejourney3" but without trip_short_name
+    const auto vj_from_headsign_2 = headsigns.get_vj_from_headsign("vehiclejourney3");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_2.size(), 2);
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_2[0]->headsign, "vehiclejourney3");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_2[0]->name, "vehiclejourney3");
+    // vjs without headsign but with trip_short_name="trip_5_short_name"
+    const auto vj_from_headsign_3 = headsigns.get_vj_from_headsign("trip_5_dst_1");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_3.size(), 1);
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_3[0]->headsign, "trip_5_dst_1");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_3[0]->name, "trip_5_short_name");
+    const auto vj_from_headsign_4 = headsigns.get_vj_from_headsign("trip_5_dst_2");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_4.size(), 1);
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_4[0]->headsign, "trip_5_dst_2");
+    BOOST_REQUIRE_EQUAL(vj_from_headsign_4[0]->name, "trip_5_short_name");
+
 }
 
 BOOST_FIXTURE_TEST_CASE(gtfs_test, ArgsFixture) {

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -994,11 +994,26 @@ void EdPersistor::insert_vehicle_properties(const std::vector<types::VehicleJour
 }
 
 void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourney*>& vehicle_journeys) {
-    this->lotus.prepare_bulk_insert(
-        "navitia.vehicle_journey",
-        {"id", "uri", "name", "validity_pattern_id", "dataset_id", "start_time", "end_time", "headway_sec",
-         "adapted_validity_pattern_id", "company_id", "route_id", "physical_mode_id", "theoric_vehicle_journey_id",
-         "vehicle_properties_id", "odt_type_id", "odt_message", "is_frequency", "meta_vj_name", "vj_class"});
+    this->lotus.prepare_bulk_insert("navitia.vehicle_journey", {"id",
+                                                                "uri",
+                                                                "name",
+                                                                "validity_pattern_id",
+                                                                "dataset_id",
+                                                                "start_time",
+                                                                "end_time",
+                                                                "headway_sec",
+                                                                "adapted_validity_pattern_id",
+                                                                "company_id",
+                                                                "route_id",
+                                                                "physical_mode_id",
+                                                                "theoric_vehicle_journey_id",
+                                                                "vehicle_properties_id",
+                                                                "odt_type_id",
+                                                                "odt_message",
+                                                                "is_frequency",
+                                                                "meta_vj_name",
+                                                                "vj_class",
+                                                                "headsign"});
 
     for (types::VehicleJourney* vj : vehicle_journeys) {
         std::vector<std::string> values;

--- a/source/ed/ed_persistor.cpp
+++ b/source/ed/ed_persistor.cpp
@@ -1065,6 +1065,8 @@ void EdPersistor::insert_vehicle_journeys(const std::vector<types::VehicleJourne
         values.push_back(vj->meta_vj_name);
         // vj_class
         values.push_back(navitia::type::get_string_from_rt_level(vj->realtime_level));
+        // headsign
+        values.push_back(vj->headsign);
 
         this->lotus.insert(values);
     }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -851,16 +851,14 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work) {
         if (mvj_name.empty()) {
             mvj_name = vj_name;
         }
-        std::string headsign = const_it["headsign"].as<std::string>();
-        if (!headsign.empty()) {
-            vj->headsign = headsign;
-        }
 
         auto mvj = data.pt_data->meta_vjs.get_or_create(mvj_name);
         auto rt_level = navitia::type::get_rt_level_from_string(const_it["vj_class"].as<std::string>());
         const auto& vp = *validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
         const auto uri = const_it["uri"].as<std::string>();
         const auto name = const_it["name"].as<std::string>();
+        const auto headsign = const_it["headsign"].as<std::string>();
+
         const auto vj_id = const_it["id"].as<idx_t>();
         if (const_it["is_frequency"].as<bool>()) {
             auto f_vj = mvj->create_frequency_vj(uri, name, headsign, rt_level, vp, route,

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -827,6 +827,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work) {
         "vj.meta_vj_name as meta_vj_name, "
         "vj.vj_class as vj_class, "
         "vj.dataset_id as dataset_id, "
+        "vj.headsign as headsign, "
         "vp.wheelchair_accessible as wheelchair_accessible,"
         "vp.bike_accepted as bike_accepted,"
         "vp.air_conditioned as air_conditioned,"
@@ -850,6 +851,11 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work) {
         if (mvj_name.empty()) {
             mvj_name = vj_name;
         }
+        std::string headsign = const_it["headsign"].as<std::string>();
+        if (!headsign.empty()) {
+            vj->headsign = headsign;
+        }
+
         auto mvj = data.pt_data->meta_vjs.get_or_create(mvj_name);
         auto rt_level = navitia::type::get_rt_level_from_string(const_it["vj_class"].as<std::string>());
         const auto& vp = *validity_pattern_map[const_it["validity_pattern_id"].as<idx_t>()];
@@ -857,14 +863,15 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work) {
         const auto name = const_it["name"].as<std::string>();
         const auto vj_id = const_it["id"].as<idx_t>();
         if (const_it["is_frequency"].as<bool>()) {
-            auto f_vj =
-                mvj->create_frequency_vj(uri, name, rt_level, vp, route, std::move(sts_from_vj[vj_id]), *data.pt_data);
+            auto f_vj = mvj->create_frequency_vj(uri, name, headsign, rt_level, vp, route,
+                                                 std::move(sts_from_vj[vj_id]), *data.pt_data);
             const_it["start_time"].to(f_vj->start_time);
             const_it["end_time"].to(f_vj->end_time);
             const_it["headway_sec"].to(f_vj->headway_secs);
             vj = f_vj;
         } else {
-            vj = mvj->create_discrete_vj(uri, name, rt_level, vp, route, std::move(sts_from_vj[vj_id]), *data.pt_data);
+            vj = mvj->create_discrete_vj(uri, name, headsign, rt_level, vp, route, std::move(sts_from_vj[vj_id]),
+                                         *data.pt_data);
         }
         const_it["odt_message"].to(vj->odt_message);
         // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1
@@ -915,7 +922,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work) {
             next_vjs.insert(std::make_pair(const_it["next_vj_id"].as<idx_t>(), vj));
         }
 
-        data.pt_data->headsign_handler.change_name_and_register_as_headsign(*vj, vj->name);
+        data.pt_data->headsign_handler.change_name_and_register_as_headsign(*vj, vj->headsign);
         vehicle_journey_map[vj_id] = vj;
 
         // we check if we have some comments

--- a/source/ed/tests/fusioparser_test.cpp
+++ b/source/ed/tests/fusioparser_test.cpp
@@ -186,8 +186,10 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list[3]->headsign, "N2");
     BOOST_REQUIRE_EQUAL(vj->stop_time_list[4]->headsign, "N2");
 
-    // vj_headsign
-    BOOST_REQUIRE_EQUAL(vj->name, "vehiclejourney1");
+    // vj_headsign feed from trip_headsign if not empty
+    BOOST_REQUIRE_EQUAL(vj->headsign, "vehiclejourney1");
+    // vj_name feed from trip_short_name if empty from vj_headsign
+    BOOST_REQUIRE_EQUAL(vj->name, "trip_1_short_name");
 
     navitia::type::hasVehicleProperties has_vehicle_properties;
     has_vehicle_properties.set_vehicle(navitia::type::hasVehicleProperties::BIKE_ACCEPTED);
@@ -249,8 +251,10 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     // stop_headsign
     const types::VehicleJourney* vj1 = data.vehicle_journeys.at(6);
 
-    // headsign of vj and stop_times
+    // vj_name feed from trip_short_name if empty from vj_headsign
     BOOST_REQUIRE_EQUAL(vj1->name.substr(0, 6), "NULL");
+    // headsign of vj and stop_times
+    BOOST_REQUIRE_EQUAL(vj1->headsign.substr(0, 6), "NULL");
 
     BOOST_REQUIRE_EQUAL(vj1->stop_time_list[0]->headsign, "HS");
     BOOST_REQUIRE_EQUAL(vj1->stop_time_list[1]->headsign, "HS");
@@ -268,6 +272,11 @@ BOOST_AUTO_TEST_CASE(parse_small_ntfs_dataset) {
     BOOST_REQUIRE_EQUAL(vj1->start_time, "04:55:00"_t);
     BOOST_REQUIRE_EQUAL(vj1->end_time, "26:55:00"_t);
     BOOST_REQUIRE_EQUAL(vj1->headway_secs, "01:00:00"_t);
+
+    // vehicle_journey without trip_headsign takes trip_id value
+    BOOST_REQUIRE_EQUAL(vj1->headsign, "trip_5_dst_1");
+    // vj_name feed from trip_short_name if empty from vj_headsign
+    BOOST_REQUIRE_EQUAL(vj1->name, "trip_5_short_name");
 
     BOOST_REQUIRE_EQUAL(vj1->stop_time_list.size(), 4);
     BOOST_REQUIRE_EQUAL(vj1->stop_time_list.at(0)->departure_time, 300);

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -271,6 +271,7 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     std::string odt_message;
     std::string meta_vj_name;  // link to it's meta vj
     std::string shape_id;
+    std::string headsign;
 
     int start_time = std::numeric_limits<int>::max();    /// First departure of vehicle
     int end_time = std::numeric_limits<int>::max();      /// Last departure of vehicle journey

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -556,6 +556,7 @@ class VehicleJourneySerializer(PbGenericSerializer):
     start_time = TimeField(display_none=False)
     end_time = TimeField(display_none=False)
     headway_secs = jsonschema.MethodField(schema_type=int, display_none=False)
+    headsign = jsonschema.Field(schema_type=str, display_none=False)
 
     def get_headway_secs(self, obj):
         if obj.HasField(str('headway_secs')):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -635,6 +635,7 @@ class VJDisplayInformationSerializer(RouteDisplayInformationSerializer):
     equipments = Equipments(attr='has_equipments', display_none=True)
     headsign = jsonschema.Field(schema_type=str, display_none=True)
     headsigns = StringListField(display_none=False)
+    trip_short_name = jsonschema.Field(schema_type=str, display_none=False)
 
 
 def make_properties_links(properties):

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -1121,7 +1121,17 @@ class JourneyCommon(object):
         r = self.query('/v1/coverage/main_routing_test/journeys?to=stopA&from=stopB&datetime=20120614T080100&')
         assert r['journeys'][0]['type'] == 'best'
         assert r['journeys'][0]['sections'][1]['type'] == 'public_transport'
+        # Here the heassign is modified by the headsign at stop.
+        assert r['journeys'][0]['sections'][1]['display_informations']['trip_short_name'] == 'vjA'
+        assert r['journeys'][0]['sections'][1]['display_informations']['headsign'] == 'A00'
         first_journey_pt = r['journeys'][0]['sections'][1]['display_informations']['name']
+
+        # we can also verify the properties of the vehicle_journey in the section
+        vj = self.query(
+            '/v1/coverage/main_routing_test/vehicle_journeys/vehicle_journey:vjA?datetime=20120614T080100'
+        )
+        assert vj['vehicle_journeys'][0]['name'] == 'vjA'
+        assert vj['vehicle_journeys'][0]['headsign'] == 'vjA_hs'
 
         # Query same journey schedules
         # A new journey vjM is available
@@ -1133,6 +1143,9 @@ class JourneyCommon(object):
         assert len(r['journeys']) > 1
         next_journey_pt = r['journeys'][1]['sections'][1]['display_informations']['name']
         assert next_journey_pt != first_journey_pt
+        # here we have the same headsign as well as trip_short_name
+        assert r['journeys'][1]['sections'][1]['display_informations']['trip_short_name'] == 'vjM'
+        assert r['journeys'][1]['sections'][1]['display_informations']['headsign'] == 'vjM'
 
         # Activate 'no_shared_section' parameter and query the same journey schedules
         # The parameter 'no_shared_section' shouldn't be taken into account

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2112,6 +2112,9 @@ class TestPtRefOnAddedTrip(MockKirinDisruptionsFixture):
         assert resp["routes"][0]["id"] == "route:stopC_stopB"
         resp = self.query_region("lines/line:stopC_stopB/vehicle_journeys")
         assert resp["vehicle_journeys"][0]["id"] == "vehicle_journey:additional-trip:modified:0:new_trip"
+        # Name and headsign are empty
+        assert resp["vehicle_journeys"][0]["name"] == ""
+        assert resp["vehicle_journeys"][0]["headsign"] == ""
 
         # We should be able to get the line from vehicle_journey recently added
         resp = self.query_region("vehicle_journeys/vehicle_journey:additional-trip:modified:0:new_trip/lines")
@@ -2454,6 +2457,7 @@ class TestKirinAddTripWithHeadSign(MockKirinDisruptionsFixture):
         # Check the vehicle_journey created by real-time
         new_vj = self.query_region('vehicle_journeys/vehicle_journey:additional-trip:modified:0:new_trip')
         assert len(new_vj['vehicle_journeys']) == 1
+        # Name is empty but headsign assigned from the disruption
         assert (new_vj['vehicle_journeys'][0]['name']) == ''
         assert (new_vj['vehicle_journeys'][0]['headsign']) == 'trip_headsign'
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1774,7 +1774,7 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
         assert status == 404
         assert len(stop_schedules['stop_schedules']) == 0
 
-        # New disruption, a new trip with 2 stop_times in realtime
+        # New disruption, a new trip without headsign with 2 stop_times in realtime
         self.send_mock(
             "additional-trip",
             "20120614",
@@ -1845,6 +1845,9 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
         response = self.query_region(vj_query)
         assert has_the_disruption(response, 'new_trip')
         assert len(response['vehicle_journeys']) == 1
+        # Check that name and headsign are empty
+        assert response['vehicle_journeys'][0]['name'] == ''
+        assert response['vehicle_journeys'][0]['headsign'] == ''
         assert response['vehicle_journeys'][0]['disruptions'][0]['id'] == 'new_trip'
         assert len(response['vehicle_journeys'][0]['stop_times']) == 2
         assert response['vehicle_journeys'][0]['stop_times'][0]['drop_off_allowed'] is True
@@ -2447,6 +2450,12 @@ class TestKirinAddTripWithHeadSign(MockKirinDisruptionsFixture):
         assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
         assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
         assert pt_journey['sections'][0]['display_informations']['headsign'] == 'trip_headsign'
+
+        # Check the vehicle_journey created by real-time
+        new_vj = self.query_region('vehicle_journeys/vehicle_journey:additional-trip:modified:0:new_trip')
+        assert len(new_vj['vehicle_journeys']) == 1
+        assert (new_vj['vehicle_journeys'][0]['name']) == ''
+        assert (new_vj['vehicle_journeys'][0]['headsign']) == 'trip_headsign'
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING_NO_ADD)

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -84,6 +84,8 @@ class TestPtRef(AbstractTestFixture):
         assert len(vjs) == 4
         vj = vjs[0]
         assert vj['id'] == 'vehicle_journey:vj1'
+        assert vj['name'] == 'vj1'
+        assert vj['headsign'] == 'vj1'
 
         assert len(vj['stop_times']) == 2
 
@@ -1052,6 +1054,8 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         assert len(vjs) == 1
+        assert vjs[0]['name'] == 'vjA'
+        assert vjs[0]['headsign'] == 'vjA'
 
     def test_headsign_with_resource_uri(self):
         """test usage of headsign with resource uri"""
@@ -1108,6 +1112,8 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         assert len(vjs) == 1
+        assert vjs[0]['name'] == "vjA"
+        assert vjs[0]['headsign'] == "vjA"
         assert len(vjs[0]['stop_times']) == 2
         assert vjs[0]['stop_times'][0]['headsign'] == "A00"
         assert vjs[0]['stop_times'][1]['headsign'] == "vjA"
@@ -1157,7 +1163,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         vjs = get_not_null(response, 'vehicle_journeys')
         for vj in vjs:
             is_valid_vehicle_journey(vj, depth_check=1)
-        assert any(vj['name'] == "vjB" and vj['trip']['id'] == "vjB" for vj in vjs)
+        assert any(vj['name'] == "vjB" and vj['headsign'] == "vjB" and vj['trip']['id'] == "vjB" for vj in vjs)
 
     def test_disruptions(self):
         """test the /disruptions api"""

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -1050,16 +1050,16 @@ class TestPtRefRoutingCov(AbstractTestFixture):
 
     def test_headsign(self):
         """test basic usage of headsign"""
-        response = self.query_region('vehicle_journeys?headsign=vjA')
+        response = self.query_region('vehicle_journeys?headsign=vjA_hs')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         assert len(vjs) == 1
         assert vjs[0]['name'] == 'vjA'
-        assert vjs[0]['headsign'] == 'vjA'
+        assert vjs[0]['headsign'] == 'vjA_hs'
 
     def test_headsign_with_resource_uri(self):
         """test usage of headsign with resource uri"""
-        response = self.query_region('physical_modes/physical_mode:0x0/vehicle_journeys' '?headsign=vjA')
+        response = self.query_region('physical_modes/physical_mode:0x0/vehicle_journeys' '?headsign=vjA_hs')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         assert len(vjs) == 1
@@ -1067,7 +1067,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
     def test_headsign_with_code_filter_and_resource_uri(self):
         """test usage of headsign with code filter and resource uri"""
         response = self.query_region(
-            'physical_modes/physical_mode:0x0/vehicle_journeys' '?headsign=vjA&filter=line.code=1A'
+            'physical_modes/physical_mode:0x0/vehicle_journeys' '?headsign=vjA_hs&filter=line.code=1A'
         )
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
@@ -1113,10 +1113,10 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         vjs = get_not_null(response, 'vehicle_journeys')
         assert len(vjs) == 1
         assert vjs[0]['name'] == "vjA"
-        assert vjs[0]['headsign'] == "vjA"
+        assert vjs[0]['headsign'] == "vjA_hs"
         assert len(vjs[0]['stop_times']) == 2
         assert vjs[0]['stop_times'][0]['headsign'] == "A00"
-        assert vjs[0]['stop_times'][1]['headsign'] == "vjA"
+        assert vjs[0]['stop_times'][1]['headsign'] == "vjA_hs"
 
     def test_headsign_display_info_journeys(self):
         """test basic print of headsign in section for journeys"""
@@ -1154,7 +1154,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         assert len(route_schedules[0]['table']['headers']) == 1
         display_info = route_schedules[0]['table']['headers'][0]['display_informations']
         assert display_info['headsign'] == "vjA"
-        assert {"A00", "vjA"} == set(display_info['headsigns'])
+        assert {"A00", "vjA_hs"} == set(display_info['headsigns'])
 
     def test_trip_id_vj(self):
         """test basic print of trip and its id in vehicle_journeys"""

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -70,8 +70,8 @@ nt::VehicleJourney* create_vj_from_old_vj(nt::MetaVehicleJourney* mvj,
     auto odt_message = vj->odt_message;
     auto vehicle_properties = vj->_vehicle_properties;
 
-    auto* new_vj =
-        mvj->create_discrete_vj(new_vj_uri, vj->name, rt_level, new_vp, vj->route, std::move(new_stop_times), pt_data);
+    auto* new_vj = mvj->create_discrete_vj(new_vj_uri, vj->name, vj->headsign, rt_level, new_vp, vj->route,
+                                           std::move(new_stop_times), pt_data);
     vj = nullptr;  // after create_discrete_vj, the vj can have been deleted
 
     new_vj->company = company;
@@ -82,6 +82,7 @@ nt::VehicleJourney* create_vj_from_old_vj(nt::MetaVehicleJourney* mvj,
     if (!mvj->get_base_vj().empty()) {
         new_vj->physical_mode = mvj->get_base_vj().at(0)->physical_mode;
         new_vj->name = mvj->get_base_vj().at(0)->name;
+        new_vj->headsign = mvj->get_base_vj().at(0)->headsign;
     } else {
         // If we set nothing for physical_mode, it'll crash when building raptor
         new_vj->physical_mode = pt_data.physical_modes[0];
@@ -248,7 +249,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             }
 
             // Create new VJ (default name/headsign is empty)
-            auto* vj = mvj->create_discrete_vj(new_vj_uri, "", type::RTLevel::RealTime, canceled_vp, r,
+            auto* vj = mvj->create_discrete_vj(new_vj_uri, "", "", type::RTLevel::RealTime, canceled_vp, r,
                                                std::move(stoptimes), pt_data);
             LOG4CPLUS_TRACE(log, "New vj has been created " << vj->uri);
 
@@ -321,11 +322,12 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             // name and dataset
             if (!mvj->get_base_vj().empty()) {
                 vj->name = mvj->get_base_vj().at(0)->name;
+                vj->headsign = mvj->get_base_vj().at(0)->headsign;
                 vj->dataset = mvj->get_base_vj().at(0)->dataset;
             } else {
                 // Affect the headsign to vj if present in gtfs-rt
                 if (!impact->headsign.empty()) {
-                    vj->name = impact->headsign;
+                    vj->headsign = impact->headsign;
                     pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, impact->headsign);
                 }
 

--- a/source/ptreferential/tests/ptref_odt_level_test.cpp
+++ b/source/ptreferential/tests/ptref_odt_level_test.cpp
@@ -83,10 +83,11 @@ public:
     void add_vj(const std::string& vj_name) {
         auto mvj = data.pt_data->meta_vjs.get_or_create(vj_name);
         std::vector<nt::StopTime> sts;
+        std::string headsign = vj_name + "_hs";
         sts.emplace_back();
         sts.back().stop_point = data.pt_data->stop_points.at(0);
-        mvj->create_discrete_vj("vehicle_journey:" + vj_name, vj_name, nt::RTLevel::Base, nt::ValidityPattern(),
-                                current_rt, std::move(sts), *data.pt_data);
+        mvj->create_discrete_vj("vehicle_journey:" + vj_name, vj_name, headsign, nt::RTLevel::Base,
+                                nt::ValidityPattern(), current_rt, std::move(sts), *data.pt_data);
     }
     void set_estimated(const std::string& vj_name) {
         data.pt_data->vehicle_journeys_map.at(vj_name)->stop_time_list.front().set_date_time_estimated(true);

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -95,10 +95,10 @@ BOOST_AUTO_TEST_CASE(physical_modes) {
     ed::builder b("201303011T1739");
     b.generate_dummy_basis();
     // Physical_mode = Car
-    b.vj("A", "11110000", "", true, "", "", "physical_mode:Car")("stop1", 8000, 8050)("stop2", 8200, 8250);
+    b.vj("A", "11110000", "", true, "", "", "", "physical_mode:Car")("stop1", 8000, 8050)("stop2", 8200, 8250);
     // Physical_mode = Metro
-    b.vj("A", "00001111", "", true, "", "", "physical_mode:0x1")("stop1", 8000, 8050)("stop2", 8200, 8250)("stop3",
-                                                                                                           8500, 8500);
+    b.vj("A", "00001111", "", true, "", "", "", "physical_mode:0x1")("stop1", 8000, 8050)("stop2", 8200, 8250)(
+        "stop3", 8500, 8500);
     // Physical_mode = Tram
     auto* vj_c = b.vj("C")("stop3", 9000, 9050)("stop4", 9200, 9250).make();
     b.connection("stop2", "stop3", 10 * 60);

--- a/source/ptreferential/tests/vehicle_journey_test.cpp
+++ b/source/ptreferential/tests/vehicle_journey_test.cpp
@@ -130,6 +130,8 @@ BOOST_AUTO_TEST_CASE(stop_points_in_vehicle_journeys_test) {
     const auto resp_sp2 = pb_creator_sp2.get_response();
     BOOST_REQUIRE_EQUAL(resp_sp2.vehicle_journeys().size(), 1);
     BOOST_CHECK_EQUAL(resp_sp2.vehicle_journeys(0).uri(), "vehicle_journey:vj1");
+    BOOST_CHECK_EQUAL(resp_sp2.vehicle_journeys(0).name(), "vj1");
+    BOOST_CHECK_EQUAL(resp_sp2.vehicle_journeys(0).headsign(), "vj1");
 
     // Check that both vj0 and vj1 are linked to sp0
     navitia::PbCreator pb_creator_sp0(data, bt::second_clock::universal_time(), null_time_period);
@@ -139,5 +141,7 @@ BOOST_AUTO_TEST_CASE(stop_points_in_vehicle_journeys_test) {
     const auto resp_sp0 = pb_creator_sp0.get_response();
     BOOST_REQUIRE_EQUAL(resp_sp0.vehicle_journeys().size(), 2);
     BOOST_CHECK_EQUAL(resp_sp0.vehicle_journeys(0).uri(), "vehicle_journey:vj0");
+    BOOST_CHECK_EQUAL(resp_sp0.vehicle_journeys(0).name(), "vj0");
+    BOOST_CHECK_EQUAL(resp_sp0.vehicle_journeys(0).headsign(), "vj0");
     BOOST_CHECK_EQUAL(resp_sp0.vehicle_journeys(1).uri(), "vehicle_journey:vj1");
 }

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -445,7 +445,8 @@ struct routing_api_data {
         b.sa("stopB", B.lon(), B.lat());
         if (activate_pt) {
             // we add a very fast bus (2 seconds) to be faster than walking and biking
-            b.vj("A", "111111", "", false, "vjA")("stop_point:stopB", "08:01"_t)("stop_point:stopA", "08:01:02"_t)
+            b.vj("A", "111111", "", false, "vjA", "vjA_hs")("stop_point:stopB", "08:01"_t)("stop_point:stopA",
+                                                                                           "08:01:02"_t)
                 .st_shape({B, I, A});
             b.lines["A"]->code = "1A";
             b.lines["A"]->color = "289728";

--- a/source/sql/alembic/versions/1faee1d2551a_add_headsign_in_vehiclejourney.py
+++ b/source/sql/alembic/versions/1faee1d2551a_add_headsign_in_vehiclejourney.py
@@ -1,0 +1,23 @@
+"""Add_headsign_in_vehiclejourney
+
+Revision ID: 1faee1d2551a
+Revises: 844a9fa86ad2
+Create Date: 2020-05-12 16:43:03.076464
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '1faee1d2551a'
+down_revision = '844a9fa86ad2'
+
+from alembic import op
+import sqlalchemy as sa
+import geoalchemy2 as ga
+
+
+def upgrade():
+    op.add_column('vehicle_journey', sa.Column('headsign', sa.TEXT(), nullable=True), schema='navitia')
+
+
+def downgrade():
+    op.drop_column('vehicle_journey', 'headsign', schema='navitia')

--- a/source/tests/mock-kraken/main_ptref_test.cpp
+++ b/source/tests/mock-kraken/main_ptref_test.cpp
@@ -77,7 +77,7 @@ struct data_set {
         // add lines
         b.sa("stop_area:stop1", 9, 9, false, true)("stop_area:stop1", 9, 9);
         b.sa("stop_area:stop2", 10, 10, false, true)("stop_area:stop2", 10, 10);
-        b.vj_with_network("network:A", "line:A", "", "", true, "vj1", "", "physical_mode:Car")(
+        b.vj_with_network("network:A", "line:A", "", "", true, "vj1", "", "", "physical_mode:Car")(
             "stop_area:stop1", 10 * 3600 + 15 * 60, 10 * 3600 + 15 * 60)("stop_area:stop2", 11 * 3600 + 10 * 60,
                                                                          11 * 3600 + 10 * 60);
         b.lines["line:A"]->calendar_list.push_back(wednesday_cal);

--- a/source/tests/mock-kraken/main_stif_test.cpp
+++ b/source/tests/mock-kraken/main_stif_test.cpp
@@ -48,19 +48,20 @@ int main(int argc, const char* const argv[]) {
     b.vj("C")("stopC", "10:30"_t)("stopB", "11:00"_t);
     b.connection("stopC", "stopC", 0);
 
-    b.vj("P", "11111111", "", true, "", "", "physical_mode:Bus")("stopP", "15:00"_t)("stopQ", "16:00"_t);
-    b.vj("Q", "11111111", "", true, "", "", "physical_mode:Bus")("stopQ", "16:00"_t)("stopR", "17:00"_t);
-    b.vj("R", "11111111", "", true, "", "", "physical_mode:Bus")("stopR", "17:00"_t)("stopS", "18:00"_t);
-    b.vj("S", "11111111", "", true, "", "", "physical_mode:Bus")("stopS", "18:00"_t)("stopT", "19:00"_t);
-    b.vj("T", "11111111", "", true, "", "", "physical_mode:Bus")("stopP", "15:00"_t)("stopT", "20:00"_t);
+    b.vj("P", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopP", "15:00"_t)("stopQ", "16:00"_t);
+    b.vj("Q", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopQ", "16:00"_t)("stopR", "17:00"_t);
+    b.vj("R", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopR", "17:00"_t)("stopS", "18:00"_t);
+    b.vj("S", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopS", "18:00"_t)("stopT", "19:00"_t);
+    b.vj("T", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopP", "15:00"_t)("stopT", "20:00"_t);
     b.connection("stopQ", "stopQ", 0);
     b.connection("stopR", "stopR", 0);
     b.connection("stopS", "stopS", 0);
 
     b.connection("stopT", "stopT", 0);
-    b.vj("U", "11111111", "", true, "", "", "physical_mode:Tramway")("stopT", "19:00"_t)("stopU", "19:30"_t);  // Tram
-    b.vj("V", "11111111", "", true, "", "", "physical_mode:Bus")("stopU", "19:30"_t)("stopV", "20:00"_t);      // Bus
-    b.vj("W", "11111111", "", true, "", "", "physical_mode:Bus")("stopV", "20:00"_t)("stopW", "20:30"_t);      // Bus
+    b.vj("U", "11111111", "", true, "", "", "", "physical_mode:Tramway")("stopT", "19:00"_t)("stopU",
+                                                                                             "19:30"_t);       // Tram
+    b.vj("V", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopU", "19:30"_t)("stopV", "20:00"_t);  // Bus
+    b.vj("W", "11111111", "", true, "", "", "", "physical_mode:Bus")("stopV", "20:00"_t)("stopW", "20:30"_t);  // Bus
 
     b.connection("stopU", "stopU", 0);
     b.connection("stopV", "stopV", 0);

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -103,10 +103,10 @@ struct route_schedule_fixture {
 
     route_schedule_fixture() {
         const std::string a_name = "stopA", b_name = "stopB", c_name = "stopC", d_name = "stopD";
-        b.vj("A", "1111111", "", true, "1", "1")(c_name, 8 * 3600 + 5 * 60)(d_name, 9 * 3600 + 30 * 60);
-        b.vj("A", "1111111", "", true, "2", "2")(a_name, 8 * 3600)(b_name, 8 * 3600 + 10 * 60);
-        b.vj("A", "1111111", "", true, "3", "3")(a_name, 8 * 3600 + 5 * 60)(b_name, 8 * 3600 + 20 * 60);
-        b.vj("A", "1111111", "", true, "4", "4")(b_name, 8 * 3600 + 25 * 60)(d_name, 9 * 3600 + 35 * 60);
+        b.vj("A", "1111111", "", true, "1", "hs_1", "1")(c_name, 8 * 3600 + 5 * 60)(d_name, 9 * 3600 + 30 * 60);
+        b.vj("A", "1111111", "", true, "2", "hs_2", "2")(a_name, 8 * 3600)(b_name, 8 * 3600 + 10 * 60);
+        b.vj("A", "1111111", "", true, "3", "hs_3", "3")(a_name, 8 * 3600 + 5 * 60)(b_name, 8 * 3600 + 20 * 60);
+        b.vj("A", "1111111", "", true, "4", "hs_4", "4")(b_name, 8 * 3600 + 25 * 60)(d_name, 9 * 3600 + 35 * 60);
         b.finish();
         b.data->pt_data->sort_and_index();
         b.data->build_raptor();
@@ -176,11 +176,14 @@ struct route_schedule_calendar_fixture {
         boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20120613");
         boost::gregorian::date end = boost::gregorian::date_from_iso_string("20120630");
 
-        vj5 = b.vj("B", "1111111", "", true, "VJ5", "MVJ5")(S1_name, "10:00"_t)(S2_name, "10:30"_t)(S3_name, "11:00"_t)
+        vj5 = b.vj("B", "1111111", "", true, "VJ5", "hs_VJ5", "MVJ5")(S1_name, "10:00"_t)(S2_name, "10:30"_t)(S3_name,
+                                                                                                              "11:00"_t)
                   .make();
-        vj6 = b.vj("B", "1111111", "", true, "VJ6", "MVJ6")(S1_name, "11:00"_t)(S2_name, "11:30"_t)(S3_name, "12:00"_t)
+        vj6 = b.vj("B", "1111111", "", true, "VJ6", "hs_VJ6", "MVJ6")(S1_name, "11:00"_t)(S2_name, "11:30"_t)(S3_name,
+                                                                                                              "12:00"_t)
                   .make();
-        vj7 = b.vj("B", "1111111", "", true, "VJ7", "MVJ7")(S1_name, "13:00"_t)(S2_name, "13:37"_t)(S3_name, "14:00"_t)
+        vj7 = b.vj("B", "1111111", "", true, "VJ7", "hs_VJ7", "MVJ7")(S1_name, "13:00"_t)(S2_name, "13:37"_t)(S3_name,
+                                                                                                              "14:00"_t)
                   .make();
 
         auto save_cal = [&](navitia::type::Calendar* cal) {
@@ -444,9 +447,9 @@ BOOST_AUTO_TEST_CASE(test_route_schedule_with_different_vp_over_midnight) {
     boost::gregorian::date begin = boost::gregorian::date_from_iso_string("20150101");
     boost::gregorian::date end = boost::gregorian::date_from_iso_string("20160101");
 
-    b.vj("L", "111111", "", true, "A", "A")("st1", "23:30"_t)("st2", "23:40"_t)("st3", "23:50"_t);
-    b.vj("L", "111111", "", true, "B", "B")("st1", "23:50"_t)("st2", "24:00"_t)("st3", "24:10"_t);
-    b.vj("L", "111110", "", true, "C", "C")("st1", "24:10"_t)("st2", "24:20"_t)("st3", "24:30"_t);
+    b.vj("L", "111111", "", true, "A", "hs_A", "A")("st1", "23:30"_t)("st2", "23:40"_t)("st3", "23:50"_t);
+    b.vj("L", "111111", "", true, "B", "hs_B", "B")("st1", "23:50"_t)("st2", "24:00"_t)("st3", "24:10"_t);
+    b.vj("L", "111110", "", true, "C", "hs_C", "C")("st1", "24:10"_t)("st2", "24:20"_t)("st3", "24:30"_t);
 
     auto save_cal = [&](navitia::type::Calendar* cal) {
         b.data->pt_data->calendars.push_back(cal);
@@ -495,10 +498,11 @@ BOOST_AUTO_TEST_CASE(test_route_schedule_with_different_vp_over_midnight) {
 // st6 5 7 8
 BOOST_AUTO_TEST_CASE(complicated_order_1) {
     ed::builder b = {"20120614"};
-    b.vj("L", "1111111", "", true, "A", "A")("st4", "5:00"_t)("st5", "6:00"_t)("st6", "7:00"_t);
-    b.vj("L", "1111111", "", true, "B", "B")("st1", "1:00"_t)("st2", "3:00"_t)("st3", "5:00"_t)("st4", "6:00"_t)(
-        "st5", "7:00"_t)("st6", "8:00"_t);
-    b.vj("L", "1111111", "", true, "C", "C")("st1", "2:00"_t)("st4", "3:00"_t)("st5", "4:00"_t)("st6", "5:00"_t);
+    b.vj("L", "1111111", "", true, "A", "hs_A", "A")("st4", "5:00"_t)("st5", "6:00"_t)("st6", "7:00"_t);
+    b.vj("L", "1111111", "", true, "B", "hs_B", "B")("st1", "1:00"_t)("st2", "3:00"_t)("st3", "5:00"_t)(
+        "st4", "6:00"_t)("st5", "7:00"_t)("st6", "8:00"_t);
+    b.vj("L", "1111111", "", true, "C", "hs_C", "C")("st1", "2:00"_t)("st4", "3:00"_t)("st5", "4:00"_t)("st6",
+                                                                                                        "5:00"_t);
 
     b.finish();
     b.data->pt_data->sort_and_index();
@@ -533,10 +537,11 @@ BOOST_AUTO_TEST_CASE(complicated_order_1) {
 // st8 10 11
 BOOST_AUTO_TEST_CASE(complicated_order_2) {
     ed::builder b = {"20120614"};
-    b.vj("L", "1111111", "", true, "A", "A")("st1", "1:00"_t)("st2", "2:00"_t)("st3", "3:00"_t)("st4", "5:00"_t)(
-        "st5", "7:00"_t)("st6", "9:00"_t)("st7", "10:00"_t)("st8", "11:00"_t);
-    b.vj("L", "1111111", "", true, "B", "B")("st1", "2:00"_t)("st2", "3:00"_t)("st3", "4:00"_t)("st6", "7:00"_t);
-    b.vj("L", "1111111", "", true, "C", "C")("st6", "8:00"_t)("st7", "9:00"_t)("st8", "10:00"_t);
+    b.vj("L", "1111111", "", true, "A", "hs_A", "A")("st1", "1:00"_t)("st2", "2:00"_t)("st3", "3:00"_t)(
+        "st4", "5:00"_t)("st5", "7:00"_t)("st6", "9:00"_t)("st7", "10:00"_t)("st8", "11:00"_t);
+    b.vj("L", "1111111", "", true, "B", "hs_B", "B")("st1", "2:00"_t)("st2", "3:00"_t)("st3", "4:00"_t)("st6",
+                                                                                                        "7:00"_t);
+    b.vj("L", "1111111", "", true, "C", "hs_C", "C")("st6", "8:00"_t)("st7", "9:00"_t)("st8", "10:00"_t);
 
     b.finish();
     b.data->pt_data->sort_and_index();
@@ -567,11 +572,12 @@ BOOST_AUTO_TEST_CASE(complicated_order_2) {
 // st4 7 8
 BOOST_AUTO_TEST_CASE(complicated_order_3) {
     ed::builder b = {"20120614"};
-    b.vj("L", "1111111", "", true, "A", "A")("st3", "6:00"_t)("st4", "7:00"_t);
-    b.vj("L", "1111111", "", true, "B", "B")("st1", "1:00"_t)("st2", "2:00"_t)("st3", "7:00"_t)("st4", "8:00"_t);
-    b.vj("L", "1111111", "", true, "C", "C")("st1", "2:00"_t)("st2", "3:00"_t);
-    b.vj("L", "1111111", "", true, "D", "D")("st1", "3:00"_t)("st2", "4:00"_t);
-    b.vj("L", "1111111", "", true, "E", "E")("st1", "4:00"_t)("st2", "5:00"_t);
+    b.vj("L", "1111111", "", true, "A", "hs_A", "A")("st3", "6:00"_t)("st4", "7:00"_t);
+    b.vj("L", "1111111", "", true, "B", "hs_B", "B")("st1", "1:00"_t)("st2", "2:00"_t)("st3", "7:00"_t)("st4",
+                                                                                                        "8:00"_t);
+    b.vj("L", "1111111", "", true, "C", "hs_C", "C")("st1", "2:00"_t)("st2", "3:00"_t);
+    b.vj("L", "1111111", "", true, "D", "hs_D", "D")("st1", "3:00"_t)("st2", "4:00"_t);
+    b.vj("L", "1111111", "", true, "E", "hs_E", "E")("st1", "4:00"_t)("st2", "5:00"_t);
 
     b.finish();
     b.data->pt_data->sort_and_index();
@@ -638,11 +644,12 @@ BOOST_AUTO_TEST_CASE(complicated_order_3) {
 
 BOOST_AUTO_TEST_CASE(complicated_order_with_impacts) {
     ed::builder b = {"20120614"};
-    b.vj("L", "1111111", "", true, "A", "A")("st3", "6:00"_t)("st4", "7:00"_t);
-    b.vj("L", "1111111", "", true, "B", "B")("st1", "1:00"_t)("st2", "2:00"_t)("st3", "7:00"_t)("st4", "8:00"_t);
-    b.vj("L", "1111111", "", true, "C", "C")("st1", "2:00"_t)("st2", "3:00"_t);
-    b.vj("L", "1111111", "", true, "D", "D")("st1", "3:00"_t)("st2", "4:00"_t);
-    b.vj("L", "1111111", "", true, "E", "E")("st1", "4:00"_t)("st2", "5:00"_t);
+    b.vj("L", "1111111", "", true, "A", "hs_A", "A")("st3", "6:00"_t)("st4", "7:00"_t);
+    b.vj("L", "1111111", "", true, "B", "hs_B", "B")("st1", "1:00"_t)("st2", "2:00"_t)("st3", "7:00"_t)("st4",
+                                                                                                        "8:00"_t);
+    b.vj("L", "1111111", "", true, "C", "hs_C", "C")("st1", "2:00"_t)("st2", "3:00"_t);
+    b.vj("L", "1111111", "", true, "D", "hs_D", "D")("st1", "3:00"_t)("st2", "4:00"_t);
+    b.vj("L", "1111111", "", true, "E", "hs_E", "E")("st1", "4:00"_t)("st2", "5:00"_t);
 
     b.finish();
     b.data->pt_data->sort_and_index();

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -72,7 +72,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 4;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 5;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/headsign_handler.cpp
+++ b/source/type/headsign_handler.cpp
@@ -48,10 +48,10 @@ void HeadsignHandler::serialize(Archive& ar, const unsigned int /*unused*/) {
 SERIALIZABLE(HeadsignHandler)
 
 void HeadsignHandler::change_name_and_register_as_headsign(VehicleJourney& vj, const std::string& new_name) {
-    std::string prev_name = vj.name;
-    vj.name = new_name;
-    headsign_mvj[vj.name].insert(vj.meta_vj);
-    if (prev_name != vj.name) {
+    std::string prev_name = vj.headsign;
+    vj.headsign = new_name;
+    headsign_mvj[vj.headsign].insert(vj.meta_vj);
+    if (prev_name != vj.headsign) {
         update_headsign_mvj_after_remove(vj, prev_name);
     }
 }
@@ -81,7 +81,7 @@ void HeadsignHandler::update_headsign_mvj_after_remove(const VehicleJourney& vj,
 const std::string& HeadsignHandler::get_headsign(const StopTime& stop_time) const {
     // if no headsign map for vj: return name
     if (!navitia::contains(headsign_changes, stop_time.vehicle_journey)) {
-        return stop_time.vehicle_journey->name;
+        return stop_time.vehicle_journey->headsign;
     }
 
     // otherwise use headsign change map
@@ -90,14 +90,14 @@ const std::string& HeadsignHandler::get_headsign(const StopTime& stop_time) cons
 
     // if no headsign change stored: return name
     if (map_stop_time_headsign_change.empty()) {
-        return stop_time.vehicle_journey->name;
+        return stop_time.vehicle_journey->headsign;
     }
 
     // get next change
     auto it_headsign = map_stop_time_headsign_change.upper_bound(order_stop_time);
     // if next change is the first: return name
     if (it_headsign == map_stop_time_headsign_change.begin()) {
-        return stop_time.vehicle_journey->name;
+        return stop_time.vehicle_journey->headsign;
     }
 
     // get previous change and return headsign
@@ -123,7 +123,7 @@ std::set<std::string> HeadsignHandler::get_all_headsigns(const VehicleJourney* v
 }
 
 bool HeadsignHandler::has_headsign_or_name(const VehicleJourney& vj, const std::string& headsign) const {
-    if (vj.name == headsign) {
+    if (vj.headsign == headsign) {
         return true;
     }
 
@@ -157,7 +157,7 @@ std::vector<const VehicleJourney*> HeadsignHandler::get_vj_from_headsign(const s
 
 void HeadsignHandler::affect_headsign_to_stop_time(const StopTime& stop_time, const std::string& headsign) {
     const VehicleJourney* vj = stop_time.vehicle_journey;
-    assert(find_or_default(vj->name, headsign_mvj).count(vj->meta_vj));
+    assert(find_or_default(vj->headsign, headsign_mvj).count(vj->meta_vj));
     std::string prev_headsign_for_stop_time = get_headsign(stop_time);
     if (headsign == prev_headsign_for_stop_time) {
         return;

--- a/source/type/meta_vehicle_journey.cpp
+++ b/source/type/meta_vehicle_journey.cpp
@@ -147,6 +147,7 @@ void MetaVehicleJourney::clean_up_useless_vjs(nt::PT_Data& pt_data) {
 template <typename VJ>
 VJ* MetaVehicleJourney::impl_create_vj(const std::string& uri,
                                        const std::string& name,
+                                       const std::string& headsign,
                                        const RTLevel level,
                                        const ValidityPattern& canceled_vp,
                                        Route* route,
@@ -159,6 +160,7 @@ VJ* MetaVehicleJourney::impl_create_vj(const std::string& uri,
     vj_ptr->meta_vj = this;
     vj_ptr->uri = uri;
     vj_ptr->name = name;
+    vj_ptr->headsign = headsign;
     vj_ptr->realtime_level = level;
     vj_ptr->shift = 0;
     if (!sts.empty()) {
@@ -237,22 +239,26 @@ VJ* MetaVehicleJourney::impl_create_vj(const std::string& uri,
 
 FrequencyVehicleJourney* MetaVehicleJourney::create_frequency_vj(const std::string& uri,
                                                                  const std::string& name,
+                                                                 const std::string& headsign,
                                                                  const RTLevel level,
                                                                  const ValidityPattern& canceled_vp,
                                                                  Route* route,
                                                                  std::vector<StopTime> sts,
                                                                  nt::PT_Data& pt_data) {
-    return impl_create_vj<FrequencyVehicleJourney>(uri, name, level, canceled_vp, route, std::move(sts), pt_data);
+    return impl_create_vj<FrequencyVehicleJourney>(uri, name, headsign, level, canceled_vp, route, std::move(sts),
+                                                   pt_data);
 }
 
 DiscreteVehicleJourney* MetaVehicleJourney::create_discrete_vj(const std::string& uri,
                                                                const std::string& name,
+                                                               const std::string& headsign,
                                                                const RTLevel level,
                                                                const ValidityPattern& canceled_vp,
                                                                Route* route,
                                                                std::vector<StopTime> sts,
                                                                nt::PT_Data& pt_data) {
-    return impl_create_vj<DiscreteVehicleJourney>(uri, name, level, canceled_vp, route, std::move(sts), pt_data);
+    return impl_create_vj<DiscreteVehicleJourney>(uri, name, headsign, level, canceled_vp, route, std::move(sts),
+                                                  pt_data);
 }
 
 void MetaVehicleJourney::cancel_vj(RTLevel level,

--- a/source/type/meta_vehicle_journey.h
+++ b/source/type/meta_vehicle_journey.h
@@ -73,6 +73,7 @@ struct MetaVehicleJourney : public Header, HasMessages {
 
     FrequencyVehicleJourney* create_frequency_vj(const std::string& uri,
                                                  const std::string& name,
+                                                 const std::string& headsign,
                                                  const RTLevel,
                                                  const ValidityPattern& canceled_vp,
                                                  Route*,
@@ -80,6 +81,7 @@ struct MetaVehicleJourney : public Header, HasMessages {
                                                  PT_Data&);
     DiscreteVehicleJourney* create_discrete_vj(const std::string& uri,
                                                const std::string& name,
+                                               const std::string& headsign,
                                                const RTLevel,
                                                const ValidityPattern& canceled_vp,
                                                Route*,
@@ -129,6 +131,7 @@ private:
     template <typename VJ>
     VJ* impl_create_vj(const std::string& uri,
                        const std::string& name,
+                       const std::string& headsign,
                        const RTLevel,
                        const ValidityPattern& canceled_vp,
                        Route*,

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -833,6 +833,7 @@ void PbCreator::Filler::fill_pb_object(const nt::ValidityPattern* vp, pbnavitia:
 void PbCreator::Filler::fill_pb_object(const nt::VehicleJourney* vj, pbnavitia::VehicleJourney* vehicle_journey) {
     vehicle_journey->set_name(vj->name);
     vehicle_journey->set_uri(vj->uri);
+    vehicle_journey->set_headsign(vj->headsign);
     add_contributor(vj);
     fill_comments(vj, vehicle_journey);
     vehicle_journey->set_odt_message(vj->odt_message);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1447,6 +1447,7 @@ void PbCreator::Filler::fill_pb_object(const VjStopTimes* vj_stoptimes, pbnaviti
         fill_with_creator(vj_stoptimes->vj, [&]() { return has_equipments; });
     }
     fill(pb_creator.data->pt_data->comments.get(vj_stoptimes->vj), pt_display_info->mutable_notes());
+    pt_display_info->set_trip_short_name(vj_stoptimes->vj->name);
 }
 
 void PbCreator::Filler::fill_pb_object(const nt::VehicleJourney* vj, pbnavitia::hasEquipments* has_equipments) {

--- a/source/type/tests/fill_pb_object_tests.cpp
+++ b/source/type/tests/fill_pb_object_tests.cpp
@@ -104,13 +104,13 @@ BOOST_AUTO_TEST_CASE(physical_and_commercial_modes_stop_area) {
     ed::builder b("201303011T1739");
     b.generate_dummy_basis();
     // Physical_mode = Tram
-    b.vj_with_network("Network1", "A", "11110000", "", true, "", "", "physical_mode:0x0")("stop1", 8000, 8050)(
+    b.vj_with_network("Network1", "A", "11110000", "", true, "", "", "", "physical_mode:0x0")("stop1", 8000, 8050)(
         "stop2", 8200, 8250);
     // Physical_mode = Metro
-    b.vj("A", "11110000", "", true, "", "", "physical_mode:0x1")("stop1", 8000, 8050)("stop2", 8200, 8250)("stop3",
-                                                                                                           8500, 8500);
+    b.vj("A", "11110000", "", true, "", "", "", "physical_mode:0x1")("stop1", 8000, 8050)("stop2", 8200, 8250)(
+        "stop3", 8500, 8500);
     // Physical_mode = Car
-    b.vj_with_network("Network2", "B", "00001111", "", true, "", "", "physical_mode:Car")("stop4", 8000, 8050)(
+    b.vj_with_network("Network2", "B", "00001111", "", true, "", "", "", "physical_mode:Car")("stop4", 8000, 8050)(
         "stop5", 8200, 8250)("stop6", 8500, 8500);
 
     nt::Line* ln = b.lines.find("A")->second;

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -67,45 +67,50 @@ BOOST_FIXTURE_TEST_CASE(headsign_handler_functionnal_test, HeadsignFixture) {
     nt::HeadsignHandler& headsign_handler = b.data->pt_data->headsign_handler;
     const auto& vj_vec = b.data->pt_data->vehicle_journeys;
 
+    // check the initial name and headsign
+    BOOST_CHECK_EQUAL(vj_vec[0]->name, "A1");
+    BOOST_CHECK_EQUAL(vj_vec[0]->headsign, "A1");
     headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(0), "A00");
-    headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(1), vj_vec[1]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(1), vj_vec[1]->headsign);
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[0]->stop_time_list.at(0)), "A00");
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[0]->stop_time_list.at(1)), vj_vec[1]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[0]->stop_time_list.at(1)), vj_vec[1]->headsign);
 
-    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(0), vj_vec[1]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(0), vj_vec[1]->headsign);
     headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(1), "B11");
     headsign_handler.affect_headsign_to_stop_time(vj_vec[1]->stop_time_list.at(2), "B11");
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(0)), vj_vec[1]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(0)), vj_vec[1]->headsign);
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(1)), "B11");
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[1]->stop_time_list.at(2)), "B11");
 
     headsign_handler.affect_headsign_to_stop_time(vj_vec[2]->stop_time_list.at(1), "C21");
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(0)), vj_vec[2]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(0)), vj_vec[2]->headsign);
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(1)), "C21");
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(2)), vj_vec[2]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[2]->stop_time_list.at(2)), vj_vec[2]->headsign);
 
     headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), "D31");
-    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), vj_vec[3]->name);
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[3]->stop_time_list.at(0)), vj_vec[3]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), vj_vec[3]->headsign);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[3]->stop_time_list.at(0)), vj_vec[3]->headsign);
 
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[4]->stop_time_list.at(0)), vj_vec[4]->name);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign(vj_vec[4]->stop_time_list.at(0)), vj_vec[4]->headsign);
 
     // check that we can retrieve every vj from matching headsign
-    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("metaVJA").size(), 2);
-    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("metaVJA"), vj_vec[0]));
-    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("metaVJA"), vj_vec[1]));
+    // As meta_vj name is not assigned to headsign no vjs for "metaVJA"
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("metaVJA").size(), 0);
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("metaVJA").size(), 0);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("A1"), vj_vec[0]));
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("A2"), vj_vec[1]));
     BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("A00").size(), 1);
     BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("A00"), vj_vec[0]));
     BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("B11").size(), 1);
     BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("B11"), vj_vec[1]));
-    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[2]->name).size(), 1);
-    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[2]->name), vj_vec[2]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[2]->headsign).size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[2]->headsign), vj_vec[2]));
     BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign("C21").size(), 1);
     BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign("C21"), vj_vec[2]));
-    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[3]->name).size(), 1);
-    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[3]->name), vj_vec[3]));
-    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[4]->name).size(), 1);
-    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[4]->name), vj_vec[4]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[3]->headsign).size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[3]->headsign), vj_vec[3]));
+    BOOST_CHECK_EQUAL(headsign_handler.get_vj_from_headsign(vj_vec[4]->headsign).size(), 1);
+    BOOST_CHECK(navitia::contains(headsign_handler.get_vj_from_headsign(vj_vec[4]->headsign), vj_vec[4]));
 }
 
 struct HeadsignHandlerTest : nt::HeadsignHandler {
@@ -123,7 +128,7 @@ BOOST_FIXTURE_TEST_CASE(headsign_handler_internal_test, HeadsignFixture) {
     auto& vj_vec = b.data->pt_data->vehicle_journeys;
     // done for the "actual" handler in build helper but not on test handler
     for (const auto& vj : vj_vec) {
-        headsign_handler.change_name_and_register_as_headsign(*vj, vj->name);
+        headsign_handler.change_name_and_register_as_headsign(*vj, vj->headsign);
     }
 
     headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(0), "A00");
@@ -135,21 +140,25 @@ BOOST_FIXTURE_TEST_CASE(headsign_handler_internal_test, HeadsignFixture) {
     headsign_handler.affect_headsign_to_stop_time(vj_vec[2]->stop_time_list.at(1), "metaVJA");
 
     headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), "D31");
-    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), vj_vec[3]->name);
+    headsign_handler.affect_headsign_to_stop_time(vj_vec[3]->stop_time_list.at(0), vj_vec[3]->headsign);
 
     // check that we only store changes, no more
     BOOST_REQUIRE_EQUAL(headsign_handler.get_headsign_changes().size(), 3);
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_changes().at(vj_vec[0]).size(), 2);
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_changes().at(vj_vec[1]).size(), 2);
+    // Three headsign changes instead of 2 for vj_vec[0]: "A1", "A00" and "metaVJA"
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_changes().at(vj_vec[0]).size(), 3);
+    // Three headsign changes instead of 2 for vj_vec[1]: "A2", "metaVJA" and "B11"
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_changes().at(vj_vec[1]).size(), 3);
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign_changes().at(vj_vec[2]).size(), 2);
 
     // check that we store all matches, no more
-    BOOST_REQUIRE_EQUAL(headsign_handler.get_headsign_mvj().size(), 6);
+    // 8 changes instead of 6: "A1", "A2", "vj 2", "vj 3", "vj 4", "A00", "metaVJA", "B11"
+    BOOST_REQUIRE_EQUAL(headsign_handler.get_headsign_mvj().size(), 8);
+
     // check that only 2 meta-vj are stored for metaVJA (but 3 vj are behind)
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at("metaVJA").size(), 2);
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at("A00").size(), 1);
     BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at("B11").size(), 1);
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at(vj_vec[2]->name).size(), 1);
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at(vj_vec[3]->name).size(), 1);
-    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at(vj_vec[4]->name).size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at(vj_vec[2]->headsign).size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at(vj_vec[3]->headsign).size(), 1);
+    BOOST_CHECK_EQUAL(headsign_handler.get_headsign_mvj().at(vj_vec[4]->headsign).size(), 1);
 }

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -49,12 +49,12 @@ namespace type {
 template <class Archive>
 void VehicleJourney::save(Archive& ar, const unsigned int /*unused*/) const {
     ar& name& uri& route& physical_mode& company& validity_patterns& idx& stop_time_list& realtime_level&
-        vehicle_journey_type& odt_message& _vehicle_properties& next_vj& prev_vj& meta_vj& shift& dataset;
+        vehicle_journey_type& odt_message& _vehicle_properties& next_vj& prev_vj& meta_vj& shift& dataset& headsign;
 }
 template <class Archive>
 void VehicleJourney::load(Archive& ar, const unsigned int /*unused*/) {
     ar& name& uri& route& physical_mode& company& validity_patterns& idx& stop_time_list& realtime_level&
-        vehicle_journey_type& odt_message& _vehicle_properties& next_vj& prev_vj& meta_vj& shift& dataset;
+        vehicle_journey_type& odt_message& _vehicle_properties& next_vj& prev_vj& meta_vj& shift& dataset& headsign;
 
     // due to circular references we can't load the vjs in the dataset using only boost::serialize
     // so we need to save the vj in it's dataset

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -78,6 +78,7 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     MetaVehicleJourney* meta_vj = nullptr;
     std::string odt_message;  // TODO It seems a VJ can have either a comment or an odt_message but never both, so we
                               // could use only the 'comment' to store the odt_message
+    std::string headsign;
 
     // TODO ODT NTFSv0.3: remove that when we stop to support NTFSv0.1
     VehicleJourneyType vehicle_journey_type = VehicleJourneyType::regular;


### PR DESCRIPTION
How it works before modification:
- Feed vehicle_journey.name from the attribute 'headsign' (trip_id if absent) in ntfs source file trips.txt
- Use this value to manage headsign to be displayed in display_informations.headsign in some end points like journeys, departures, arrivals, stop_schedules ...
- 'headsgn_handler' manages the value of display_informations.headsign depending on headsign of each trip(vehicle_journey) and it's stops (stop_headsign in stops.txt).
- vehicle_journey doesn't have attribute 'headsign'.

How it should work after:
- Add an attribute 'headsign' in vehicle_journey (kraken as well as response json) ,feed vehicle_journey.headsign(trip_id if absent) from 'headsign' trips.txt as above.
- Feed vehicle_journey.name from the attribute 'trip_short_name'(if absent headsign or trip_id) in trips.txt.
- 'headsign_handler' should manage the headsign as before using attribute vehicle_journey.headsign instead of vehicle_journey.name. Feed stop_headsign from stop_headsign if present else trip_short_name_at_stop from stops.txt (stop_headsign has priority over trip_short_name_at_stop).
- Add an attribute 'trip_short_name' in display_informations and affect the value of vehicle_journey.name.

Tests:
- Existing tests should work perhaps with little adaptation.
- As we don't have enough tests on headsign, tests on endpoints as journeys, departures, arrivals, stop_schedules, stop_schedules, route_schedules.. should be added verifying all the possible transformation of headsign as well as short_name from source date to the response json. 

For more details see ticket : https://jira.kisio.org/browse/NAVP-942