### PR TITLE
[Jormun] Set distributed scenario on call to kraken.

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -405,12 +405,12 @@ class Scenario(new_default.Scenario):
     def __init__(self):
         super(Scenario, self).__init__()
         self._scenario = Distributed()
-        record_custom_parameter('scenario', 'distributed')
 
     def get_context(self):
         return PartialResponseContext()
 
     def call_kraken(self, request_type, request, instance, krakens_call, request_id, context):
+        record_custom_parameter('scenario', 'distributed')
         logger = logging.getLogger(__name__)
         logger.warning("using experimental scenario!!")
         """


### PR DESCRIPTION
This will ensure reporting is correctly handled when an instance has its
scenario configured from the database. Otherwise, this would only be set
when overriding the parameter using `_override_scenario`