### PR TITLE
[Jormun] Add Here street network connector

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -383,6 +383,24 @@ class Journeys(JourneyCommon):
             help="how long it takes to park the car, " "used especially in distributed scenario",
         )
         parser_get.add_argument(
+            "_here_realtime_traffic",
+            type=six.text_type,
+            hidden=True,
+            help="Here, Active or not the realtime traffic information (enabled/disabled)",
+        )
+        parser_get.add_argument(
+            "_here_matrix_type",
+            type=six.text_type,
+            hidden=True,
+            help="Here, street network matrix type (simple_matrix/multi_direct_path)",
+        )
+        parser_get.add_argument(
+            "_here_max_matrix_points",
+            type=six.text_type,
+            hidden=True,
+            help="Here, Max number of matrix points for the street network computation (limited to 100)",
+        )
+        parser_get.add_argument(
             "equipment_details",
             default=True,
             type=BooleanType(),

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -384,9 +384,10 @@ class Journeys(JourneyCommon):
         )
         parser_get.add_argument(
             "_here_realtime_traffic",
-            type=six.text_type,
+            type=BooleanType(),
+            default=True,
             hidden=True,
-            help="Here, Active or not the realtime traffic information (enabled/disabled)",
+            help="Here, Active or not the realtime traffic information (True/False)",
         )
         parser_get.add_argument(
             "_here_matrix_type",
@@ -396,7 +397,8 @@ class Journeys(JourneyCommon):
         )
         parser_get.add_argument(
             "_here_max_matrix_points",
-            type=six.text_type,
+            type=int,
+            default=default_values.here_max_matrix_points,
             hidden=True,
             help="Here, Max number of matrix points for the street network computation (limited to 100)",
         )

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
@@ -127,12 +127,24 @@ class StreetNetworkSerializer(OutsideServiceCommon):
     modes = StringListField(display_none=True)
     timeout = MethodField(schema_type=float, display_none=False)
     backend_class = MethodField(schema_type=str, display_none=False)
+    matrix_type = MethodField(schema_type=str, display_none=False)
+    max_matrix_points = MethodField(schema_type=int, display_none=False)
+    realtime_traffic = MethodField(schema_type=str, display_none=False)
 
     def get_timeout(self, obj):
         return obj.get('timeout', None)
 
     def get_backend_class(self, obj):
         return obj.get('backend_class', None)
+
+    def get_matrix_type(self, obj):
+        return obj.get('matrix_type', None)
+
+    def get_max_matrix_points(self, obj):
+        return obj.get('max_matrix_points', None)
+
+    def get_realtime_traffic(self, obj):
+        return obj.get('realtime_traffic', None)
 
 
 class RidesharingServicesSerializer(OutsideServiceCommon):

--- a/source/jormungandr/jormungandr/street_network/street_networks.md
+++ b/source/jormungandr/jormungandr/street_network/street_networks.md
@@ -1,0 +1,48 @@
+# Street Networks Services
+
+## Here
+
+Provide a external API that delivers street network solution with realtime traffic informations.<br>
+Navitia uses it to perform car sections.<br>
+Here documentation : https://developer.here.com/
+
+### How to connect Here with Navitia.
+
+Insert into **Jormun** configuration:
+
+```
+ "street_network": [
+    {
+        "class": "jormungandr.street_network.here.Here",
+        "modes": ["car", "car_no_park"],
+        "args": {
+            "service_base_url": "route.ls.hereapi.com/routing/7.2",
+            "apiKey": "Token",
+            "timeout": 20,                      # optional,
+            "realtime_traffic": "enabled",      # optional
+            "matrix_type": "simple_matrix",     # optional
+            "max_matrix_points": 100,           # optional
+        }
+    }
+ ]
+```
+
+Available optional parameters list:
+* timeout: circuit breaker timeout. By default 10 secs
+* realtime_traffic: activation of realtime traffic informations - enable/disabled. By default, enabled
+* matrix_type: the matrix method - simple_matrix/multi_direct_path. By default simple_matrix
+* max_matrix_points: the max number of allowed matrix points. By default 100 (the maximum)
+
+### How to debug
+
+You can easily override parameters for tests inside requests.<br>
+List of available API parameters:
+* _here_realtime_traffic: enabled/disabled
+* _here_matrix_type: simple_matrix/multi_direct_path
+* _here_max_matrix_points: int value [1-100]
+
+Example:
+
+```
+http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=disabled&_here_max_matrix_points=50
+```

--- a/source/jormungandr/jormungandr/street_network/street_networks.md
+++ b/source/jormungandr/jormungandr/street_network/street_networks.md
@@ -18,8 +18,8 @@ Insert into **Jormun** configuration:
         "args": {
             "service_base_url": "route.ls.hereapi.com/routing/7.2",
             "apiKey": "Token",
-            "timeout": 20,                      # optional,
-            "realtime_traffic": "enabled",      # optional
+            "timeout": 20,                      # optional
+            "realtime_traffic": true,           # optional
             "matrix_type": "simple_matrix",     # optional
             "max_matrix_points": 100,           # optional
         }
@@ -29,7 +29,7 @@ Insert into **Jormun** configuration:
 
 Available optional parameters list:
 * timeout: circuit breaker timeout. By default 10 secs
-* realtime_traffic: activation of realtime traffic informations - enable/disabled. By default, enabled
+* realtime_traffic: activation of realtime traffic informations - true/false. By default, true
 * matrix_type: the matrix method - simple_matrix/multi_direct_path. By default simple_matrix
 * max_matrix_points: the max number of allowed matrix points. By default 100 (the maximum)
 
@@ -37,12 +37,12 @@ Available optional parameters list:
 
 You can easily override parameters for tests inside requests.<br>
 List of available API parameters:
-* _here_realtime_traffic: enabled/disabled
+* _here_realtime_traffic: true/false
 * _here_matrix_type: simple_matrix/multi_direct_path
 * _here_max_matrix_points: int value [1-100]
 
 Example:
 
 ```
-http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=disabled&_here_max_matrix_points=50
+http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50
 ```

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -116,7 +116,7 @@ def valid_here_routing_response():
 def test_matrix(valid_here_matrix):
     instance = MagicMock()
     instance.walking_speed = 1.12
-    here = Here(instance=instance, service_base_url='bob.com', app_id='toto', app_code='tata')
+    here = Here(instance=instance, service_base_url='bob.com', apiKey='toto')
     origin = make_pt_object(type_pb2.ADDRESS, 2.439938, 48.572841)
     destination = make_pt_object(type_pb2.ADDRESS, 2.440548, 48.57307)
     with requests_mock.Mocker() as req:
@@ -141,7 +141,7 @@ def test_matrix(valid_here_matrix):
 def test_matrix_timeout():
     instance = MagicMock()
     instance.walking_speed = 1.12
-    here = Here(instance=instance, service_base_url='bob.com', app_id='toto', app_code='tata')
+    here = Here(instance=instance, service_base_url='bob.com', apiKey='toto')
     origin = make_pt_object(type_pb2.ADDRESS, 2.439938, 48.572841)
     destination = make_pt_object(type_pb2.ADDRESS, 2.440548, 48.57307)
     with requests_mock.Mocker() as req:
@@ -195,12 +195,14 @@ def status_test():
         timeout=89,
     )
     status = here.status()
-    assert len(status) == 6
+    assert len(status) == 8
     assert status['id'] == u'tata-é$~#@"*!\'`§èû'
     assert status['class'] == "Here"
     assert status['modes'] == ["walking", "bike", "car"]
     assert status['timeout'] == 89
-    assert status['max_points'] == 100
+    assert status['matrix_type'] == "simple_matrix"
+    assert status['max_matrix_points'] == 100
+    assert status['realtime_traffic'] == "enabled"
     assert len(status['circuit_breaker']) == 3
     assert status['circuit_breaker']['current_state'] == 'closed'
     assert status['circuit_breaker']['fail_counter'] == 0

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -55,6 +55,9 @@ class MockResponse(object):
     def json(self):
         return self.data
 
+    def raise_for_status(self):
+        return self.status_code
+
     @property
     def text(self):
         return self.data

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -39,8 +39,7 @@ MOCKED_INSTANCE_CONF = {
         'street_network': [
             {
                 "args": {
-                    "api_id": "bob_id",
-                    "api_code": "bob_code",
+                    "apiKey": "bob_id",
                     "service_base_url": "route.bob.here.com/routing/7.2/",
                     "timeout": 20,
                 },

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -167,6 +167,9 @@ street_network_bss = "kraken"
 street_network_ridesharing = "ridesharingKraken"
 street_network_taxi = "taxiKraken"
 
+# Here - https://developer.here.com/
+here_max_matrix_points = 100
+
 
 def get_value_or_default(attr, instance, instance_name):
     if not instance or getattr(instance, attr, None) == None:


### PR DESCRIPTION
# Integrate Here street network within Navitia

Now, **Here** works with navitia. It allows car sections with **realtime traffic** information.
The integration follows the **Here** developer documentation : https://developer.here.com/documentation/routing/dev_guide/topics/routing-mode-parameter-combinations.html

A bit of documentation was done : https://github.com/benoit-bst/navitia/blob/ef0302e32e5475bf1dd42042f2182ff8af105bb8/source/jormungandr/jormungandr/street_network/street_networks.md
The **configuration** is exposed, and the **debug method** too

For the moment, we can only activate the feature on the entire coverage with the **jormun configuration file** or the **DB**.

## Tests

An important difference with Kraken street network has to be highlighted. 
**Here** is capable of compute 100 matrix points (The max value). It is a huge difference with Kraken, because it allows thousands of matrix points !! (so thousands of potential available SP in _car_no_park_ mode). These possibilities to **Car+TC journeys** are better. 
You can test the difference with a request + `first_section_mode=car_no_park`. Sometimes **Kraken** offers an solution and **here** not...

Even if kraken has more **Car+TC solutions**, the results have a poor quality (street network are too rough). 
On the other hand, with **Here SN**, the car section is very appreciable (Realtime traffic is a gift :gift:)

## performance

I roughly tested with few requests and it shows that:

### for a simple direct path
```
Request : 
http://localhost:5000/v1/coverage/transilien/journeys?from=2.20794%3B48.89901&to=2.39166%3B48.84661&_override_scenario=distributed&first_section_mode%5B%5D=car_no_park&_min_car=0&_min_car_no_park=0&direct_path=only&
```
Kraken : 250 ms
Here : 600 ms
**Ratio** : +60% for Here

### for a Car+TC
```
Request : 
http://localhost:5000/v1/coverage/transilien/journeys?from=2.14408%3B48.89812&to=2.33443%3B48.84189&_override_scenario=distributed&first_section_mode%5B%5D=car_no_park&_min_car=0&_min_car_no_park=0
```
Kraken : 450 ms
Here : 1200 ms
**Ratio** : +62% for Here

Considering the results, we need to find bottlenecks to improve the speed if it is possible.

