### PR TITLE
[terminus_schedules] Add endpoint in the documentation and set data_fressness default value to 'base_schedule'

### DIFF
--- a/documentation/rfc/ptref_grammar.md
+++ b/documentation/rfc/ptref_grammar.md
@@ -12,7 +12,7 @@ The `line_reports` endpoint builds its response on the `lines` collection.
 
 The `route_schedules` endpoint builds its response on the `routes` collections.
 
-The `arrivals`, `departures` and `stop_schedules` endpoint builds their responses on the `journey_pattern_points` collection.
+The `arrivals`, `departures`, `stop_schedules` and `terminus_schedules` endpoint builds their responses on the `journey_pattern_points` collection.
 
 ## Predicates
 

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1603,7 +1603,7 @@ nop      | direction_type     | enum                            | Allow to filte
 $ curl 'https://api.navitia.io/v1/coverage/sandbox/lines/line:RAT:M1/terminus_schedules' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
 
 #response
-Same as stop_schedule but objects embedded in terminus_schedules instead of stop_schedules
+Same as stop_schedule but objects are embedded in the `terminus_schedules` section instead
 
 HTTP/1.1 200 OK
 {
@@ -1620,7 +1620,7 @@ HTTP/1.1 200 OK
 Also known as `/terminus_schedules` service.
 
 This endpoint gives you access to time tables going through a stop point.
-Departures are groupped observing all the stations being served after considered stop point. This can also be same as:<br>
+Departures are grouped observing all served stations after considered stop point. This can also be same as:<br>
 ![terminus_schedules](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg/640px-Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg)
 
 The response is made of an array of [terminus_schedule](#terminus-schedule), and another one of [note](#note).<br>[Context](#context) object provides the `current_datetime`, useful to compute waiting time when requesting Navitia without a `from_datetime`.<br>Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/terminus_schedules>
@@ -1629,8 +1629,8 @@ The response is made of an array of [terminus_schedule](#terminus-schedule), and
 
 | url | Result |
 |--------------------------------------------------------|-----------------------------------------------------------------------------------|
-| `/coverage/{region_id}/{resource_path}/terminus_schedules` | List of the schedules grouped by observing all the stations being served after considered stop_point for a given resource   |
-| `/coverage/{lon;lat}/coords/{lon;lat}/terminus_schedules`  | List of the schedules grouped by observing all the stations being served after considered stop_point for coordinates, navitia guesses the region from coordinates |
+| `/coverage/{region_id}/{resource_path}/terminus_schedules` | List of the schedules grouped by observing all served stations after considered stop_point for a given resource   |
+| `/coverage/{lon;lat}/coords/{lon;lat}/terminus_schedules`  | List of the schedules grouped by observing all served stations after considered stop_point for coordinates, navitia guesses the region from coordinates |
 
 ### Parameters
 Same as stop_schedule parametres

--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -1592,6 +1592,53 @@ nop      | direction_type     | enum                            | Allow to filte
 |additional_informations|[additional_informations](#additional-informations)|Other informations, when no departures<br> enum values:<ul><li>date_out_of_bounds</li><li>terminus</li><li>partial_terminus</li><li>active_disruption</li><li>no_departures_known</li></ul>|
 
 
+<a name="terminus-schedules"></a>Terminus Schedules
+---------------------------------------------------
+
+>[Try it on Navitia playground (click on "EXT" buttons to see times)](http://canaltp.github.io/navitia-playground/play.html?request=https%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fsandbox%2Fstop_areas%2Fstop_area%253ARAT%253ASA%253AGDLYO%2Fterminus_schedules%3Fitems_per_schedule%3D2%26&token=3b036afe-0110-4202-b9ed-99718476c2e0``` shell
+
+
+``` shell
+#request
+$ curl 'https://api.navitia.io/v1/coverage/sandbox/lines/line:RAT:M1/terminus_schedules' -H 'Authorization: 3b036afe-0110-4202-b9ed-99718476c2e0'
+
+#response
+Same as stop_schedule but objects embedded in terminus_schedules instead of stop_schedules
+
+HTTP/1.1 200 OK
+{
+    "terminus_schedules": [],
+    "pagination": {...},
+    "links": [...],
+    "disruptions": [],
+    "notes": [],
+    "feed_publishers": [...],
+    "exceptions": []
+}
+```
+
+Also known as `/terminus_schedules` service.
+
+This endpoint gives you access to time tables going through a stop point.
+Departures are groupped observing all the stations being served after considered stop point. This can also be same as:<br>
+![terminus_schedules](https://upload.wikimedia.org/wikipedia/commons/thumb/7/7d/Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg/640px-Panneau_SIEL_couleurs_Paris-Op%C3%A9ra.jpg)
+
+The response is made of an array of [terminus_schedule](#terminus-schedule), and another one of [note](#note).<br>[Context](#context) object provides the `current_datetime`, useful to compute waiting time when requesting Navitia without a `from_datetime`.<br>Can be accessed via: <https://api.navitia.io/v1/{a_path_to_a_resource}/terminus_schedules>
+
+### Accesses
+
+| url | Result |
+|--------------------------------------------------------|-----------------------------------------------------------------------------------|
+| `/coverage/{region_id}/{resource_path}/terminus_schedules` | List of the schedules grouped by observing all the stations being served after considered stop_point for a given resource   |
+| `/coverage/{lon;lat}/coords/{lon;lat}/terminus_schedules`  | List of the schedules grouped by observing all the stations being served after considered stop_point for coordinates, navitia guesses the region from coordinates |
+
+### Parameters
+Same as stop_schedule parametres
+
+### <a name="terminus-schedule"></a>Terminus_schedule object
+Same as stop_schedule object
+
+
 <a name="departures"></a>Departures
 -----------------------------------
 

--- a/documentation/slate/source/includes/departures.md
+++ b/documentation/slate/source/includes/departures.md
@@ -4,6 +4,10 @@
 The "Next Departures" feature provides the next scheduled departures or arrivals
 for a specific mode of public transport (bus, tram, metro, train) at your selected stop, near coordinates, etc.
 
+>[Try it on Navitia playground (click on "EXT" buttons to see times)](http://canaltp.github.io/navitia-playground/play.html?request=https%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fsandbox%2Fstop_areas%2Fstop_area%253ARAT%253ASA%253AGDLYO%2Fterminus_schedules%3Fitems_per_schedule%3D2%26&token=3b036afe-0110-4202-b9ed-99718476c2e0)
+
+* use `terminus_schedules` if you want to display departures grouped by terminus (2 next departures for each terminus for example)
+
 >[Try it on Navitia playground (click on "EXT" buttons to see times)](http://canaltp.github.io/navitia-playground/play.html?request=https%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Fsandbox%2Fstop_areas%2Fstop_area%253ARAT%253ASA%253AGDLYO%2Fstop_schedules%3Fitems_per_schedule%3D2%26&token=3b036afe-0110-4202-b9ed-99718476c2e0)
 
 * use `stop_schedules` if you want to display departures grouped by route (2 next departures for each route for example)

--- a/documentation/slate/source/includes/examples.md
+++ b/documentation/slate/source/includes/examples.md
@@ -166,6 +166,7 @@ We could push the exploration further and:
     - <https://api.navitia.io/v1/coverage/fr-idf/coords/2.377310;48.847002/places_nearby>
     - or <https://api.navitia.io/v1/coverage/fr-idf/coords/2.377310;48.847002/lines>
     - or <https://api.navitia.io/v1/coverage/fr-idf/coords/2.377310;48.847002/stop_schedules>
+    - or <https://api.navitia.io/v1/coverage/fr-idf/coords/2.377310;48.847002/terminus_schedules>
     - or ...
 
 Seek and search

--- a/documentation/slate/source/includes/interface.md
+++ b/documentation/slate/source/includes/interface.md
@@ -137,6 +137,7 @@ Examples of sorted objects tables:
 * journeys in a `/journeys` response
 * `/departures` and `/arrivals`
 * `/stop_schedules`
+* `/terminus_schedules`
 * stop_points in `/routes/{route_id}?depth=3`
 * `/places_nearby`
 * `/places`

--- a/documentation/slate/source/includes/realtime.md
+++ b/documentation/slate/source/includes/realtime.md
@@ -618,3 +618,20 @@ http://api.navitia.io/v1/coverage/<coverage>/physical_modes/<physical_mode>/line
 In the list of "date_times" available in the response, the field "data_freshness" is "realtime" and the field "date_time" is equal to the field "base_date_time".
 
 No disruption is present at the root level of the response and so, in the sections "date_times" and "display_informations", there's no link to any disruption.
+
+<div></div>
+### Terminus Schedules
+
+``` shell
+# Request example for /terminus_schedules (data_freshness=base_schedule by default)
+http://api.navitia.io/v1/coverage/<coverage>/physical_modes/<physical_mode>/lines/<line>/stop_areas/<stop_area>/terminus_schedules?from_datetime=<from_date>&data_freshness=realtime
+```
+
+``` shell
+# Extract of an impacted terminus_schedules object from the response /terminus_schedules
+Same elements as in stop_scedule object.
+```
+
+In the list of "date_times" available in the response, the field "data_freshness" is "realtime" and the field "date_time" is equal to the field "base_date_time".
+
+No disruption is present at the root level of the response and so, in the sections "date_times" and "display_informations", there's no link to any disruption.

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -202,7 +202,7 @@ class Schedules(ResourceUri, ResourceUtc):
     def _get_default_freshness(self):
         # The data freshness depends on the endpoint
         # for route_schedule, by default we want the base schedule
-        if self.endpoint == 'route_schedules':
+        if self.endpoint in ['route_schedules', 'terminus_schedules']:
             return 'base_schedule'
         # for stop_schedule and previous/next departure/arrival, we want the freshest data by default
         else:

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -401,8 +401,10 @@ class TestDepartureBoard(AbstractTestFixture):
         # terminus_schedules on partial_terminus with calendar
         # There is neither terminus nor partial_terminus in terminus_schedules
         # Here the disruption could be injected by chaos or kirin
+
         response = self.query_region(
-            "stop_areas/Tstop2/terminus_schedules?" "from_datetime=20120615T080000&calendar=cal_partial_terminus"
+            "stop_areas/Tstop2/terminus_schedules?"
+            "from_datetime=20120615T080000&calendar=cal_partial_terminus&data_freshness=realtime"
         )
 
         is_valid_notes(response["notes"])

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -160,8 +160,11 @@ class TestDepartures(AbstractTestFixture):
     def test_terminus_schedules_realtime(self):
         """
         Here we have two realtime date_times from a realtime proxy
+        data_freshness default value is base_schedule for terminus_schedules
         """
-        query = self.query_template_ter.format(sp='C:S0', dt='20160102T1100', data_freshness='')
+        query = self.query_template_ter.format(
+            sp='C:S0', dt='20160102T1100', data_freshness='&data_freshness=realtime'
+        )
         response = self.query_region(query)
         date_times = response['terminus_schedules'][0]['date_times']
         next_passage_dts = [dt["date_time"] for dt in date_times]

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -296,9 +296,10 @@ class TestDepartures(AbstractTestFixture):
     def test_terminus_schedule_with_realtime(self):
         """
         Here we have realtime stop_times from proxy_realtime_timeo
+        data_freshness default value is base_schedule for terminus_schedules
         """
         query = self.query_template_ter.format(
-            sp='S42', dt='20160102T0900', data_freshness='', c_dt='20160102T0900'
+            sp='S42', dt='20160102T0900', data_freshness='&data_freshness=realtime', c_dt='20160102T0900'
         )
 
         response = self.query_region(query)
@@ -324,7 +325,7 @@ class TestDepartures(AbstractTestFixture):
         Here we have theoretical stop_times only as C:S0 is absent in proxy_realtime_timeo
         """
         query = self.query_template_ter.format(
-            sp='C:S0', dt='20160102T0900', data_freshness='', c_dt='20160102T0900'
+            sp='C:S0', dt='20160102T0900', data_freshness='&data_freshness=realtime', c_dt='20160102T0900'
         )
         response = self.query_region(query)
         is_valid_notes(response["notes"])


### PR DESCRIPTION
1. Documentation on the endpoint terminus_schedules.
2. data_freshness default value set to base_schedule.

Ticket: https://jira.kisio.org/browse/NAVP-1553