### PR TITLE
[Jormun] take SN maneuvers into account with Here

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -38,7 +38,12 @@ from jormungandr.interfaces.v1.serializer.pt import (
     StringListField,
 )
 from jormungandr.interfaces.v1.serializer.time import DateTimeField
-from jormungandr.interfaces.v1.serializer.fields import LinkSchema, RoundedField, SectionGeoJsonField
+from jormungandr.interfaces.v1.serializer.fields import (
+    LinkSchema,
+    RoundedField,
+    SectionGeoJsonField,
+    CoordSerializer,
+)
 from jormungandr.interfaces.v1.serializer.base import (
     AmountSerializer,
     PbNestedSerializer,
@@ -167,10 +172,31 @@ class JourneyDebugSerializer(PbNestedSerializer):
 
 
 class PathSerializer(PbNestedSerializer):
+    id = jsonschema.MethodField(schema_type=int, display_none=False)
     length = RoundedField(display_none=True)
     name = jsonschema.Field(schema_type=str, display_none=True)
     duration = RoundedField(display_none=True)
     direction = jsonschema.Field(schema_type=int, display_none=True)
+    instruction = jsonschema.MethodField(schema_type=int, display_none=False)
+    coordinate = jsonschema.MethodField(schema_type=lambda: CoordSerializer())
+
+    def get_id(self, obj):
+        if obj.HasField(str('id')):
+            return obj.id
+        else:
+            return None
+
+    def get_instruction(self, obj):
+        if obj.HasField(str('instruction')):
+            return obj.instruction
+        else:
+            return None
+
+    def get_coordinate(self, obj):
+        if obj.HasField(str('coordinate')):
+            return CoordSerializer(obj.coordinate, display_none=False).data
+        else:
+            return None
 
 
 class SectionTypeEnum(EnumField):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -177,7 +177,7 @@ class PathSerializer(PbNestedSerializer):
     name = jsonschema.Field(schema_type=str, display_none=True)
     duration = RoundedField(display_none=True)
     direction = jsonschema.Field(schema_type=int, display_none=True)
-    instruction = jsonschema.MethodField(schema_type=int, display_none=False)
+    instruction = jsonschema.MethodField(schema_type=str, display_none=False)
     coordinate = jsonschema.MethodField(schema_type=lambda: CoordSerializer())
 
     def get_id(self, obj):

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -78,7 +78,23 @@ HERE_ROUTING_RESPONSE_BEGINNING_FALLBACK_PATH = {
     "response": {
         "route": [
             {
-                "leg": [{"length": 10, "maneuver": [{"length": 10, "travelTime": 15}], "travelTime": 15}],
+                "leg": [
+                    {
+                        "length": 10,
+                        "maneuver": [
+                            {
+                                "id": "M1",
+                                "length": 10,
+                                "travelTime": 15,
+                                "direction": "left",
+                                "position": {"latitude": 48.9995432, "longitude": 2.3498600},
+                                "roadName": "street 1",
+                                "instruction": "blabla turn left 1",
+                            }
+                        ],
+                        "travelTime": 15,
+                    }
+                ],
                 "shape": ["52.4999825,13.3999652", "52.4987912,13.4510744"],
                 "summary": {
                     "_type": "RouteSummaryType",
@@ -100,7 +116,26 @@ HERE_ROUTING_RESPONSE_END_FALLBACK_PATH = {
                 "leg": [
                     {
                         "length": 100,
-                        "maneuver": [{"length": 10, "travelTime": 10}, {"length": 90, "travelTime": 50}],
+                        "maneuver": [
+                            {
+                                "id": "M1",
+                                "length": 10,
+                                "travelTime": 10,
+                                "direction": "left",
+                                "position": {"latitude": 48.8765432, "longitude": 2.2798654},
+                                "roadName": "street 2",
+                                "instruction": "blabla turn left 2",
+                            },
+                            {
+                                "id": "M2",
+                                "length": 90,
+                                "travelTime": 50,
+                                "direction": "forward",
+                                "position": {"latitude": 60.8765432, "longitude": 3.2798654},
+                                "roadName": "street 3",
+                                "instruction": "blabla continue on 3",
+                            },
+                        ],
                         "travelTime": 60,
                         'BaseTime': 60,
                     }
@@ -126,7 +161,26 @@ HERE_ROUTING_RESPONSE_DIRECT_PATH = {
                 "leg": [
                     {
                         "length": 100,
-                        "maneuver": [{"length": 20, "travelTime": 100}, {"length": 80, "travelTime": 200}],
+                        "maneuver": [
+                            {
+                                "id": "M1",
+                                "length": 20,
+                                "travelTime": 100,
+                                "direction": "left",
+                                "position": {"latitude": 48.8756444, "longitude": 2.0944333},
+                                "roadName": "street 4",
+                                "instruction": "blabla turn left 4",
+                            },
+                            {
+                                "id": "M2",
+                                "length": 80,
+                                "travelTime": 200,
+                                "direction": "right",
+                                "position": {"latitude": 50.0061111, "longitude": 2.2468054},
+                                "roadName": "street 5",
+                                "instruction": "blabla turn right 5",
+                            },
+                        ],
                         "travelTime": 300,
                         'BaseTime': 200,
                     }
@@ -250,6 +304,24 @@ class TestHere(NewDefaultScenarioAbstractTestFixture):
         assert sections[0].get('arrival_date_time') == '20120614T070500'
         assert sections[0].get('duration') == 300
         assert sections[0].get('type') == 'street_network'
+        # check path
+        path = sections[0].get('path')
+        assert path[0].get('id') == 1
+        assert path[0].get('name') == "street 4"
+        assert path[0].get('length') == 20
+        assert path[0].get('duration') == 100
+        assert path[0].get('direction') == -90
+        assert path[0].get('instruction') == "blabla turn left 4"
+        assert path[0].get('coordinate').get('lat') == "48.8756444"
+        assert path[0].get('coordinate').get('lon') == "2.0944333"
+        assert path[1].get('id') == 2
+        assert path[1].get('name') == "street 5"
+        assert path[1].get('length') == 80
+        assert path[1].get('duration') == 200
+        assert path[1].get('direction') == 90
+        assert path[1].get('instruction') == "blabla turn right 5"
+        assert path[1].get('coordinate').get('lat') == "50.0061111"
+        assert path[1].get('coordinate').get('lon') == "2.2468054"
 
         car_fallback = journeys[1]
 
@@ -259,9 +331,20 @@ class TestHere(NewDefaultScenarioAbstractTestFixture):
         sections = car_fallback.get('sections')
         assert len(sections) == 3
         assert sections[0].get('mode') == 'car'
+        assert sections[0].get('type') == 'street_network'
         assert sections[0].get('departure_date_time') == '20120614T080045'
         assert sections[0].get('arrival_date_time') == '20120614T080100'
         assert sections[0].get('duration') == 15
+        # check path
+        path = sections[0].get('path')
+        assert path[0].get('id') == 1
+        assert path[0].get('name') == "street 1"
+        assert path[0].get('length') == 10
+        assert path[0].get('duration') == 15
+        assert path[0].get('direction') == -90
+        assert path[0].get('instruction') == "blabla turn left 1"
+        assert path[0].get('coordinate').get('lat') == "48.9995432"
+        assert path[0].get('coordinate').get('lon') == "2.34986"
 
         assert sections[1].get('departure_date_time') == '20120614T080100'
         assert sections[1].get('arrival_date_time') == '20120614T080102'
@@ -273,6 +356,24 @@ class TestHere(NewDefaultScenarioAbstractTestFixture):
         assert sections[2].get('duration') == 60
         assert sections[2].get('type') == 'street_network'
         assert sections[2].get('mode') == 'car'
+        # check path
+        path = sections[2].get('path')
+        assert path[0].get('id') == 1
+        assert path[0].get('name') == "street 2"
+        assert path[0].get('length') == 10
+        assert path[0].get('duration') == 10
+        assert path[0].get('direction') == -90
+        assert path[0].get('instruction') == "blabla turn left 2"
+        assert path[0].get('coordinate').get('lat') == "48.8765432"
+        assert path[0].get('coordinate').get('lon') == "2.2798654"
+        assert path[1].get('id') == 2
+        assert path[1].get('name') == "street 3"
+        assert path[1].get('length') == 90
+        assert path[1].get('duration') == 50
+        assert path[1].get('direction') == 0
+        assert path[1].get('instruction') == "blabla continue on 3"
+        assert path[1].get('coordinate').get('lat') == "60.8765432"
+        assert path[1].get('coordinate').get('lon') == "3.2798654"
 
         feeds = get_not_null(response, 'feed_publishers')
         assert len(feeds) == 2


### PR DESCRIPTION
**Objective** : Adding **Here** Maneuvers and keep backward compatibilty.
We use the same **Path** struct with new optionnal fields to extend it
**JIRA** : https://jira.kisio.org/browse/NAVP-1612

The output **API** is like that:

![here_maneuvers](https://user-images.githubusercontent.com/32099204/86359555-6c265800-bc71-11ea-869d-edbf0eb47303.png)

A full **instruction** in html format is available with several parameters : length, duration, direction, ...

For the moment Maneuvers are only in **english**. A next PR will allow to configure language with this list of possibilities :
https://developer.here.com/documentation/routing/dev_guide/topics/resource-param-type-languages.html#languages

TODO : 
- [x] Merge https://github.com/CanalTP/navitia-proto/pull/143 and change submodule to master

At the end, It will be presented like this in the playground :

![playground_with_guidance](https://user-images.githubusercontent.com/32099204/86445072-0c33be00-bd12-11ea-94f5-5ddf8ef10e1d.png)

The Playground PR link https://github.com/CanalTP/navitia-playground/pull/326