### PR TITLE
[Jormun] Here SN, language instruction is now configurable

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -426,7 +426,6 @@ class Journeys(JourneyCommon):
                 ]
             ),
             hidden=True,
-            # hidden=True,
             help='Here, select a specific language for guidance instruction.\n'
             'list available:\n'
             '- afrikaans = af\n'

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -420,6 +420,7 @@ class Journeys(JourneyCommon):
                     'hindi',
                     'italian',
                     'japanese',
+                    'nepali',
                     'portuguese',
                     'russian',
                     'spanish',
@@ -439,6 +440,7 @@ class Journeys(JourneyCommon):
             '- hindi = hi\n'
             '- italian = it-it\n'
             '- japanese = ja-jp\n'
+            '- nepali = ne-np\n'
             '- portuguese = pt-pt\n'
             '- russian = ru-ru\n'
             '- spanish = es-es\n',

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -406,6 +406,44 @@ class Journeys(JourneyCommon):
             help="Here, Active or not the realtime traffic information (True/False)",
         )
         parser_get.add_argument(
+            "_here_language",
+            type=OptionValue(
+                [
+                    'afrikaans',
+                    'arabic',
+                    'chinese',
+                    'dutch',
+                    'english',
+                    'french',
+                    'german',
+                    'hebrew',
+                    'hindi',
+                    'italian',
+                    'japanese',
+                    'portuguese',
+                    'russian',
+                    'spanish',
+                ]
+            ),
+            # hidden=True,
+            help='Here, select a specific language for guidance instruction.\n'
+            'list available:\n'
+            '- afrikaans = af\n'
+            '- arabic = ar-sa\n'
+            '- chinese = zh-cn\n'
+            '- dutch = nl-nl\n'
+            '- english = en-gb\n'
+            '- french = fr-fr\n'
+            '- german = de-de\n'
+            '- hebrew = he\n'
+            '- hindi = hi\n'
+            '- italian = it-it\n'
+            '- japanese = ja-jp\n'
+            '- portuguese = pt-pt\n'
+            '- russian = ru-ru\n'
+            '- spanish = es-es\n',
+        )
+        parser_get.add_argument(
             "_here_matrix_type",
             type=six.text_type,
             hidden=True,

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -425,6 +425,7 @@ class Journeys(JourneyCommon):
                     'spanish',
                 ]
             ),
+            hidden=True,
             # hidden=True,
             help='Here, select a specific language for guidance instruction.\n'
             'list available:\n'

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
@@ -130,6 +130,7 @@ class StreetNetworkSerializer(OutsideServiceCommon):
     matrix_type = MethodField(schema_type=str, display_none=False)
     max_matrix_points = MethodField(schema_type=int, display_none=False)
     realtime_traffic = MethodField(schema_type=str, display_none=False)
+    language = MethodField(schema_type=str, display_none=False)
 
     def get_timeout(self, obj):
         return obj.get('timeout', None)
@@ -145,6 +146,9 @@ class StreetNetworkSerializer(OutsideServiceCommon):
 
     def get_realtime_traffic(self, obj):
         return obj.get('realtime_traffic', None)
+
+    def get_language(self, obj):
+        return obj.get('language', None)
 
 
 class RidesharingServicesSerializer(OutsideServiceCommon):

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -59,6 +59,7 @@ class Languages(Enum):
     hindi = "hi"
     italian = "it-it"
     japanese = "ja-jp"
+    nepali = "ne-np"
     portuguese = "pt-pt"
     russian = "ru-ru"
     spanish = "es-es"
@@ -77,6 +78,7 @@ def _convert_here_language(language):
         "hindi": Languages.hindi,
         "italian": Languages.italian,
         "japanese": Languages.japanese,
+        "nepali": Languages.nepali,
         "portuguese": Languages.portuguese,
         "russian": Languages.russian,
         "spanish": Languages.spanish,

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -44,6 +44,49 @@ from six import text_type
 from enum import Enum
 import itertools
 
+# Possible values implemented. Full languages within the doc:
+# https://developer.here.com/documentation/routing/dev_guide/topics/resource-param-type-languages.html#languages
+# Be careful, the syntax has to be exact
+class Languages(Enum):
+    afrikaans = "af"
+    arabic = "ar-sa"
+    chinese = "zh-cn"
+    dutch = "nl-nl"
+    english = "en-gb"
+    french = "fr-fr"
+    german = "de-de"
+    hebrew = "he"
+    hindi = "hi"
+    italian = "it-it"
+    japanese = "ja-jp"
+    portuguese = "pt-pt"
+    russian = "ru-ru"
+    spanish = "es-es"
+
+
+def _convert_here_language(language):
+    map_language = {
+        "afrikaans": Languages.afrikaans,
+        "arabic": Languages.arabic,
+        "chinese": Languages.chinese,
+        "dutch": Languages.dutch,
+        "english": Languages.english,
+        "french": Languages.french,
+        "german": Languages.german,
+        "hebrew": Languages.hebrew,
+        "hindi": Languages.hindi,
+        "italian": Languages.italian,
+        "japanese": Languages.japanese,
+        "portuguese": Languages.portuguese,
+        "russian": Languages.russian,
+        "spanish": Languages.spanish,
+    }
+    try:
+        return map_language[language]
+    except KeyError:
+        raise TechnicalError('HERE does not handle the language {}'.format(language))
+
+
 # Possible values to active/deactivate realtime traffic
 class RealTimeTraffic(Enum):
     enabled = "enabled"
@@ -123,6 +166,7 @@ class Here(AbstractStreetNetworkService):
         matrix_type=MatrixType.simple_matrix.value,
         max_matrix_points=default_values.here_max_matrix_points,
         realtime_traffic=True,
+        language="english",
         feed_publisher=DEFAULT_HERE_FEED_PUBLISHER,
         **kwargs
     ):
@@ -142,14 +186,15 @@ class Here(AbstractStreetNetworkService):
         self.matrix_type = self._get_matrix_type(matrix_type)
         self.max_matrix_points = self._get_max_matrix_points(max_matrix_points)
         self.realtime_traffic = self._get_realtime_traffic(realtime_traffic)
+        self.language = self._get_language(language.lower())
         self.breaker = pybreaker.CircuitBreaker(
             fail_max=app.config['CIRCUIT_BREAKER_MAX_HERE_FAIL'],
             reset_timeout=app.config['CIRCUIT_BREAKER_HERE_TIMEOUT_S'],
         )
 
         self.log.debug(
-            'Here, load confifguration max_matrix_points={} - matrix_type={} - realtime_traffic={}'.format(
-                self.max_matrix_points, self.matrix_type.value, self.realtime_traffic.value
+            'Here, load confifguration max_matrix_points={} - matrix_type={} - realtime_traffic={} - language={}'.format(
+                self.max_matrix_points, self.matrix_type.value, self.realtime_traffic.value, self.language.value
             )
         )
         self._feed_publisher = FeedPublisher(**feed_publisher) if feed_publisher else None
@@ -163,6 +208,7 @@ class Here(AbstractStreetNetworkService):
             'matrix_type': self.matrix_type.value,
             'max_matrix_points': self.max_matrix_points,
             'realtime_traffic': self.realtime_traffic.value,
+            'language': self.language.value,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,
                 'fail_counter': self.breaker.fail_counter,
@@ -282,6 +328,20 @@ class Here(AbstractStreetNetworkService):
 
         return resp
 
+    def _get_language(self, language):
+        _language = _convert_here_language(language)
+        if _language not in Languages:
+            self.log.error('Here parameters language={} not exist - force to english'.format(language))
+            return Languages.english
+        return _language
+
+    def get_language_parameter(self, request):
+        _language = request.get('_here_language', None)
+        if _language == None:
+            return self.language
+        else:
+            return self._get_language(_language.lower())
+
     def _get_realtime_traffic(self, rt_traffic):
         realtime_traffic = _convert_realtime_traffic(rt_traffic)
         if realtime_traffic == RealTimeTraffic.unknown:
@@ -335,7 +395,7 @@ class Here(AbstractStreetNetworkService):
             matrix_type = self._get_matrix_type(_matrix_type)
         return max_matrix_points, matrix_type
 
-    def get_direct_path_params(self, origin, destination, mode, fallback_extremity, realtime_traffic):
+    def get_direct_path_params(self, origin, destination, mode, fallback_extremity, realtime_traffic, language):
         datetime, clockwise = fallback_extremity
         params = {
             'apiKey': self.apiKey,
@@ -347,6 +407,7 @@ class Here(AbstractStreetNetworkService):
             'summaryAttributes': 'traveltime',
             'legAttributes': 'bt,tt,mn',
             'maneuverAttributes': 'di,rn,le,tt,po',
+            'language': '{language}'.format(language=language.value),
             # street network mode + realtime activation
             'mode': 'fastest;{mode};traffic:{realtime_traffic}'.format(
                 mode=get_here_mode(mode), realtime_traffic=realtime_traffic.value
@@ -369,9 +430,10 @@ class Here(AbstractStreetNetworkService):
         request_id,
     ):
         realtime_traffic = self.get_realtime_traffic_parameter(request)
+        language = self.get_language_parameter(request)
 
         params = self.get_direct_path_params(
-            pt_object_origin, pt_object_destination, mode, fallback_extremity, realtime_traffic
+            pt_object_origin, pt_object_destination, mode, fallback_extremity, realtime_traffic, language
         )
         r = self._call_here(self.routing_service_url, params=params)
         if r.status_code != 200:

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -65,30 +65,6 @@ class Languages(Enum):
     spanish = "es-es"
 
 
-def _convert_here_language(language):
-    map_language = {
-        "afrikaans": Languages.afrikaans,
-        "arabic": Languages.arabic,
-        "chinese": Languages.chinese,
-        "dutch": Languages.dutch,
-        "english": Languages.english,
-        "french": Languages.french,
-        "german": Languages.german,
-        "hebrew": Languages.hebrew,
-        "hindi": Languages.hindi,
-        "italian": Languages.italian,
-        "japanese": Languages.japanese,
-        "nepali": Languages.nepali,
-        "portuguese": Languages.portuguese,
-        "russian": Languages.russian,
-        "spanish": Languages.spanish,
-    }
-    try:
-        return map_language[language]
-    except KeyError:
-        raise TechnicalError('HERE does not handle the language {}'.format(language))
-
-
 # Possible values to active/deactivate realtime traffic
 class RealTimeTraffic(Enum):
     enabled = "enabled"
@@ -331,11 +307,11 @@ class Here(AbstractStreetNetworkService):
         return resp
 
     def _get_language(self, language):
-        _language = _convert_here_language(language)
-        if _language not in Languages:
+        try:
+            return Languages[language]
+        except KeyError:
             self.log.error('Here parameters language={} not exist - force to english'.format(language))
             return Languages.english
-        return _language
 
     def get_language_parameter(self, request):
         _language = request.get('_here_language', None)

--- a/source/jormungandr/jormungandr/street_network/street_networks.md
+++ b/source/jormungandr/jormungandr/street_network/street_networks.md
@@ -20,6 +20,7 @@ Insert into **Jormun** configuration:
             "apiKey": "Token",
             "timeout": 20,                      # optional
             "realtime_traffic": true,           # optional
+            "language": 'english',              # optional
             "matrix_type": "simple_matrix",     # optional
             "max_matrix_points": 100,           # optional
         }
@@ -30,6 +31,21 @@ Insert into **Jormun** configuration:
 Available optional parameters list:
 * timeout: circuit breaker timeout. By default 10 secs
 * realtime_traffic: activation of realtime traffic informations - true/false. By default, true
+* language: the selected language for guidance instruction - list available bellow. By default, english
+    * afrikaans
+    * arabic
+    * chinese
+    * dutch
+    * english
+    * french
+    * german
+    * hebrew
+    * hindi
+    * italian
+    * japanese
+    * portuguese
+    * russian
+    * spanish
 * matrix_type: the matrix method - simple_matrix/multi_direct_path. By default simple_matrix
 * max_matrix_points: the max number of allowed matrix points. By default 100 (the maximum)
 
@@ -38,11 +54,12 @@ Available optional parameters list:
 You can easily override parameters for tests inside requests.<br>
 List of available API parameters:
 * _here_realtime_traffic: true/false
+* _here_language: "english" or "french" or "dutch" ...
 * _here_matrix_type: simple_matrix/multi_direct_path
 * _here_max_matrix_points: int value [1-100]
 
 Example:
 
 ```
-http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50
+http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50&_here_language=french
 ```

--- a/source/jormungandr/jormungandr/street_network/street_networks.md
+++ b/source/jormungandr/jormungandr/street_network/street_networks.md
@@ -43,6 +43,7 @@ Available optional parameters list:
     * hindi
     * italian
     * japanese
+    * nepali
     * portuguese
     * russian
     * spanish

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -195,7 +195,7 @@ def status_test():
         timeout=89,
     )
     status = here.status()
-    assert len(status) == 8
+    assert len(status) == 9
     assert status['id'] == u'tata-é$~#@"*!\'`§èû'
     assert status['class'] == "Here"
     assert status['modes'] == ["walking", "bike", "car"]
@@ -203,6 +203,7 @@ def status_test():
     assert status['matrix_type'] == "simple_matrix"
     assert status['max_matrix_points'] == 100
     assert status['realtime_traffic'] == "enabled"
+    assert status['language'] == "en-gb"
     assert len(status['circuit_breaker']) == 3
     assert status['circuit_breaker']['current_state'] == 'closed'
     assert status['circuit_breaker']['fail_counter'] == 0

--- a/source/jormungandr/tests/here_distributed_routing_tests.py
+++ b/source/jormungandr/tests/here_distributed_routing_tests.py
@@ -41,6 +41,7 @@ MOCKED_INSTANCE_CONF = {
                 "args": {
                     "apiKey": "bob_id",
                     "service_base_url": "route.bob.here.com/routing/7.2/",
+                    "language": "french",
                     "timeout": 20,
                 },
                 "modes": ["car", "car_no_park"],


### PR DESCRIPTION
## Summary
Offer a configurable **language instruction** parameter. In **jormun configuration** and with **hidden parameter** for tests/debug purpose.

### configure jormun

```
"street_network": [                                                                                                                                                                                                                                                         
        {                                                                                                                                                                                                                                                                        
            "class": "jormungandr.street_network.here.Here",                                                                                                                                                                                                                     
            "modes": ["car", "car_no_park"],                                                                                                                                                                                                                                     
            "args": {                                                                                                                                                                                                                                                            
                "service_base_url": "route.ls.hereapi.com/routing/7.2",                                                                                                                                                                                                          
                "apiKey": "mkI6PtD_IsGNO1wkGXDYB7Q_2-TC28SjmcUH1iJrGb8",                                                                                                                                                                                                         
                "timeout": 20,                                                                                                                                                                                                                                                   
                "realtime_traffic": true,                                                                                                                                                                                                                                        
                "language": "french",                <--------------------------                                                                                                                                                                                                                                                                                                                                                                                                                                      
            }                                                                                                                                                                                                                                                                    
        }                                                                                                                                                                                                                                                                        
     ]
```
### With a parameter

```
http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_language=french
```


- [x] updated status
- [x] updated doc

### Result for dutch language
![language](https://user-images.githubusercontent.com/32099204/87046538-a061c180-c1f9-11ea-8498-aa769c5ac68f.png)
