### PR TITLE
[DOC] add new badges into the main readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 ## Overview on how-to contribute
 
-Dev branch: [![Last build](https://github.com/CanalTP/navitia/workflows/Build%20Navitia%20Packages%20For%20Dev/badge.svg)](https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)
+Dev branch: [![Last build](https://img.shields.io/github/workflow/status/CanalTP/navitia/Build%20Navitia%20Packages%20For%20Dev?logo=github&style=flat-square)](https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)
 
 Fork the github repo, create a new branch from dev, and submit your pull request!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 ## Overview on how-to contribute
 
-Dev branch: [![Last build](https://ci.navitia.io/job/navitia_dev/badge/icon)](https://ci.navitia.io/job/navitia_dev)
+Dev branch: [![Last build](https://github.com/CanalTP/navitia/workflows/Build%20Navitia%20Packages%20For%20Dev/badge.svg)](https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev%22)
 
 Fork the github repo, create a new branch from dev, and submit your pull request!
 

--- a/readme.rst
+++ b/readme.rst
@@ -7,17 +7,20 @@
 =========
 ``(pronounce [navi-sia])``
 
-.. class:: no-web no-pdf
+.. image:: https://img.shields.io/github/v/tag/CanalTp/navitia?style=flat-square
+    :target: https://github.com/CanalTP/navitia/releases
+    :alt: version
 
-    Release branch: |last_release_build|
-
-.. |last_release_build| image:: https://img.shields.io/github/workflow/status/CanalTP/navitia/Build%20Navitia%20Packages%20For%20Release?logo=github&style=flat-square
+.. image:: https://img.shields.io/github/workflow/status/CanalTP/navitia/Build%20Navitia%20Packages%20For%20Release?logo=github&style=flat-square
     :target: https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22
     :alt: Last build
 
 .. image:: https://img.shields.io/github/license/CanalTP/navitia?color=9873b9&style=flat-square
     :alt: license
-    :align: center
+
+.. image:: https://img.shields.io/matrix/navitia:matrix.org?style=flat-square
+    :target: https://riot.im/app/#/room/#navitia:matrix.org
+    :alt: chat
 
 Presentation
 ============

--- a/readme.rst
+++ b/readme.rst
@@ -11,10 +11,13 @@
 
     Release branch: |last_release_build|
 
-.. |last_release_build| image:: https://ci.navitia.io/job/navitia_release/badge/icon
-    :target: https://ci.navitia.io/job/navitia_release/
+.. |last_release_build| image:: https://github.com/CanalTP/navitia/workflows/Build%20Navitia%20Packages%20For%20Release/badge.svg
+    :target: https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22
     :alt: Last build
 
+.. image:: https://img.shields.io/github/license/CanalTP/navitia?color=9873b9&style=flat-square
+    :alt: license
+    :align: center
 
 Presentation
 ============

--- a/readme.rst
+++ b/readme.rst
@@ -10,17 +10,21 @@
 .. image:: https://img.shields.io/github/v/tag/CanalTp/navitia?style=flat-square
     :target: https://github.com/CanalTP/navitia/releases
     :alt: version
+    :align: center
 
 .. image:: https://img.shields.io/github/workflow/status/CanalTP/navitia/Build%20Navitia%20Packages%20For%20Release?logo=github&style=flat-square
     :target: https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22
     :alt: Last build
+    :align: center
 
 .. image:: https://img.shields.io/github/license/CanalTP/navitia?color=9873b9&style=flat-square
     :alt: license
+    :align: center
 
 .. image:: https://img.shields.io/matrix/navitia:matrix.org?style=flat-square
     :target: https://riot.im/app/#/room/#navitia:matrix.org
     :alt: chat
+    :align: center
 
 Presentation
 ============

--- a/readme.rst
+++ b/readme.rst
@@ -11,7 +11,7 @@
 
     Release branch: |last_release_build|
 
-.. |last_release_build| image:: https://github.com/CanalTP/navitia/workflows/Build%20Navitia%20Packages%20For%20Release/badge.svg
+.. |last_release_build| image:: https://img.shields.io/github/workflow/status/CanalTP/navitia/Build%20Navitia%20Packages%20For%20Release?logo=github&style=flat-square
     :target: https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22
     :alt: Last build
 

--- a/readme.rst
+++ b/readme.rst
@@ -7,21 +7,18 @@
 =========
 ``(pronounce [navi-sia])``
 
-.. image:: https://img.shields.io/github/v/tag/CanalTp/navitia?style=flat-square
+.. image:: https://img.shields.io/github/v/tag/CanalTp/navitia?logo=github&style=flat-square
     :target: https://github.com/CanalTP/navitia/releases
     :alt: version
     :align: center
-
 .. image:: https://img.shields.io/github/workflow/status/CanalTP/navitia/Build%20Navitia%20Packages%20For%20Release?logo=github&style=flat-square
     :target: https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22
     :alt: Last build
     :align: center
-
 .. image:: https://img.shields.io/github/license/CanalTP/navitia?color=9873b9&style=flat-square
     :alt: license
     :align: center
-
-.. image:: https://img.shields.io/matrix/navitia:matrix.org?style=flat-square
+.. image:: https://img.shields.io/matrix/navitia:matrix.org?logo=riot&style=flat-square
     :target: https://riot.im/app/#/room/#navitia:matrix.org
     :alt: chat
     :align: center


### PR DESCRIPTION
- Build **badges** are dead due to the change of CI flow

![badges](https://user-images.githubusercontent.com/32099204/87670063-6485a980-c76f-11ea-84b5-dd212ad20bfd.png)

Now, _github actions_ is the system for building packages

- Add new badges like riot chat link, license and version release

