### PR TITLE
[jormun] Here, add exclusion areas option

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -459,16 +459,16 @@ class Journeys(JourneyCommon):
             help="Here, Max number of matrix points for the street network computation (limited to 100)",
         )
         parser_get.add_argument(
-            '_sn_exclusion_area[]',
+            '_here_exclusion_area[]',
             type=six.text_type,
             case_sensitive=False,
             hidden=True,
             action='append',
-            dest='_sn_exclusion_areas',
+            dest='_here_exclusion_area[]',
             help='Give 2 coords for an exclusion box. The format is like that:\n'
             'Coord_1!Coord_2 with Coord=lat;lon\n'
-            ' - exemple : _sn_exclusion_area[]=2.40553;48.84866!2.41453;48.85677\n'
-            ' - This is a list, you can add to the maximun 20 _sn_exclusion_area[]\n',
+            ' - exemple : _here_exclusion_area[]=2.40553;48.84866!2.41453;48.85677\n'
+            ' - This is a list, you can add to the maximun 20 _here_exclusion_area[]\n',
         )
         parser_get.add_argument(
             "equipment_details",

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -459,6 +459,18 @@ class Journeys(JourneyCommon):
             help="Here, Max number of matrix points for the street network computation (limited to 100)",
         )
         parser_get.add_argument(
+            '_sn_exclusion_area[]',
+            type=six.text_type,
+            case_sensitive=False,
+            hidden=True,
+            action='append',
+            dest='_sn_exclusion_areas',
+            help='Give 2 coords for an exclusion box. The format is like that:\n'
+            'Coord_1!Coord_2 with Coord=lat;lon\n'
+            ' - exemple : _sn_exclusion_area[]=2.40553;48.84866!2.41453;48.85677\n'
+            ' - This is a list, you can add to the maximun 20 _sn_exclusion_area[]\n',
+        )
+        parser_get.add_argument(
             "equipment_details",
             default=True,
             type=BooleanType(),

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -40,6 +40,7 @@ from jormungandr.utils import get_pt_object_coord, PeriodExtremity
 from jormungandr.street_network.street_network import AbstractStreetNetworkService, StreetNetworkPathKey
 from jormungandr.ptref import FeedPublisher
 from jormungandr.fallback_modes import FallbackModes as fm
+from jormungandr.utils import is_coord, get_lon_lat
 from six import text_type
 from enum import Enum
 import itertools
@@ -171,7 +172,7 @@ class Here(AbstractStreetNetworkService):
         )
 
         self.log.debug(
-            'Here, load confifguration max_matrix_points={} - matrix_type={} - realtime_traffic={} - language={}'.format(
+            'Here, load configuration max_matrix_points={} - matrix_type={} - realtime_traffic={} - language={}'.format(
                 self.max_matrix_points, self.matrix_type.value, self.realtime_traffic.value, self.language.value
             )
         )
@@ -306,6 +307,45 @@ class Here(AbstractStreetNetworkService):
 
         return resp
 
+    def get_exclusion_areas(self, request):
+        """
+        Retreive and adapt exclusion parameters for Here API.
+        See the Here doc for avoidAreas option
+        https://developer.here.com/documentation/routing/dev_guide/topics/resource-calculate-matrix.html
+        """
+        _exclusion_areas = request.get('_sn_exclusion_areas', None)
+        if _exclusion_areas == None:
+            return None
+        else:
+            boxes = ""
+            for idx, exclusion_area in enumerate(_exclusion_areas):
+                if exclusion_area.count('!') == 1:
+                    coord_1, coord_2 = exclusion_area.split('!')
+                    if is_coord(coord_1) and is_coord(coord_2):
+                        lon_1, lat_1 = get_lon_lat(coord_1)
+                        lon_2, lat_2 = get_lon_lat(coord_2)
+                        # The superior latitude has to be the first coord for Here API
+                        # https://developer.here.com/documentation/routing/dev_guide/topics/resource-param-type-bounding-box.html
+                        if lat_1 > lat_2:
+                            boxes += "{},{};{},{}".format(lat_1, lon_1, lat_2, lon_2)
+                        else:
+                            boxes += "{},{};{},{}".format(lat_2, lon_2, lat_1, lon_1)
+                        if idx < (len(_exclusion_areas) - 1):
+                            boxes += "!"
+                    else:
+                        self.log.error(
+                            'Here parameters _sn_exclusion_area[]={} is badly formated. Exclusion box is skipped'.format(
+                                exclusion_area
+                            )
+                        )
+                else:
+                    self.log.error(
+                        'Here parameters _sn_exclusion_area[]={} is badly formated. Exclusion box is skipped'.format(
+                            exclusion_area
+                        )
+                    )
+            return {"avoidAreas": boxes}
+
     def _get_language(self, language):
         try:
             return Languages[language]
@@ -373,7 +413,9 @@ class Here(AbstractStreetNetworkService):
             matrix_type = self._get_matrix_type(_matrix_type)
         return max_matrix_points, matrix_type
 
-    def get_direct_path_params(self, origin, destination, mode, fallback_extremity, realtime_traffic, language):
+    def get_direct_path_params(
+        self, origin, destination, mode, fallback_extremity, request, realtime_traffic, language
+    ):
         datetime, clockwise = fallback_extremity
         params = {
             'apiKey': self.apiKey,
@@ -393,6 +435,9 @@ class Here(AbstractStreetNetworkService):
             # With HERE, it's only possible to constraint the departure
             'departure': _str_to_dt(datetime),
         }
+        exclusion_areas = self.get_exclusion_areas(request)
+        if exclusion_areas != None:
+            params.update(exclusion_areas)
 
         return params
 
@@ -411,7 +456,13 @@ class Here(AbstractStreetNetworkService):
         language = self.get_language_parameter(request)
 
         params = self.get_direct_path_params(
-            pt_object_origin, pt_object_destination, mode, fallback_extremity, realtime_traffic, language
+            pt_object_origin,
+            pt_object_destination,
+            mode,
+            fallback_extremity,
+            request,
+            realtime_traffic,
+            language,
         )
         r = self._call_here(self.routing_service_url, params=params)
         if r.status_code != 200:
@@ -485,6 +536,9 @@ class Here(AbstractStreetNetworkService):
                 mode=get_here_mode(mode), realtime_traffic=realtime_traffic.value
             ),
         }
+        exclusion_areas = self.get_exclusion_areas(request)
+        if exclusion_areas != None:
+            params.update(exclusion_areas)
 
         # for the ending fallback matrix (or the beginning of non clockwise query), we do not know the
         # precise departure/arrival (as it depend on the public transport taken)
@@ -526,6 +580,7 @@ class Here(AbstractStreetNetworkService):
                     destination,
                     mode,
                     PeriodExtremity(datetime=request['datetime'], represents_start=request['clockwise']),
+                    request,
                     realtime_traffic,
                 )
                 r = self._call_here(self.routing_service_url, params=params)


### PR DESCRIPTION
### Topic
**Here** is capable to work with a list of **exclusion areas**. In fact this is exclusion box, created with 2 coords (the **avoidAreas** parameter: https://developer.here.com/documentation/routing/dev_guide/topics/resource-calculate-route.html).
In navitia, a parameter is added `_here_exclusion_area[]`. The format is as follows:
`coord_1!coord_2` -> example `_here_exclusion_area[]=2.36753;48.89632!2.32119;48.90422`

### Example

I wrote a request without exclusion areas :
`http://localhost:5000/v1/coverage/default/journeysfrom=2.26867%3B48.88134&to=2.40553%3B48.84866&first_section_mode%5B%5D=car_no_park&_override_scenario=distributed&direct_path=only`
the response gives me a trip with the _"périphérique intérieur"_ (at this point, more fast than _"périphérique extérieur"_)

![p_int](https://user-images.githubusercontent.com/32099204/88392615-94aaf900-cdbc-11ea-8f2b-e06c365aeac6.png)

I wrote the same request with an exclusion area that cross the "périphérique" (in the north). it forced, the journey to the south way

![p_ext](https://user-images.githubusercontent.com/32099204/88392860-0125f800-cdbd-11ea-9fac-574d9abebdf4.png)

This option is usefull to prevent journeys in a city with forbidden areas (market place the sunday, yellow jacket, national day, and so on) :smile_cat: 