### PR TITLE
[ED] Fix prolongation trip that goes back in time

### DIFF
--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -590,22 +590,54 @@ void Data::pick_up_drop_of_on_borders() {
             continue;
         }
 
-        auto* first_st = vj->stop_time_list.front();
-        auto* last_st = vj->stop_time_list.back();
-
         /*
          * The first arrival and last departure of a vehicle don't make sense as they can't be used.
          * So let's forbid them
          *
-         * This is true unless the vehicle has a stay-on on different stop points.
+         * This is true unless the vehicle has a stay-in on different stop points as described below
          */
+
+        auto* first_st = vj->stop_time_list.front();
+        auto* last_st = vj->stop_time_list.back();
+
         first_st->drop_off_allowed = false;
         last_st->pick_up_allowed = false;
 
+        /*
+         * In the example below we assuming that VJ:1 and VJ:2 are sharing the same block_id.
+         *
+         * The stay-in section is allowed with 2 configurations:
+         *  - when two VJ share the same stop point with similar stop times (example 1)
+         *  - when two VJ are joined on 2 different stop points with consecutive stop times (example 2)
+         *
+         *   Example 1:
+         *   ----------
+         *         out          in   out         in
+         *          X    SP1    |    ▲    SP2    X
+         *          X           ▼    |           X
+         *    VJ:1   08:00-09:00      10:00-11:00
+         *    VJ:2                    10:00-11:00      14:00-15:00
+         *                           X           ▲    |           X
+         *                           X           |    ▼   SP3     X
+         *                           out         in   out         in
+         *                           |- Stay-In -|
+         *
+         *   Example 2:
+         *   ----------
+         *                                       (1)  (2)
+         *         out          in   out         in   out         in   out         in
+         *          X    SP1    |    ▲    SP2    |    ▲    SP3    |    ▲   SP4     X
+         *          X           ▼    |           ▼    |           |    |           X
+         *    VJ:1   08:00-09:00      10:00-11:00     |           ▼    |           X
+         *    VJ:2                                     12:00-13:00      14:00-15:00
+         *                           |---------- Stay In ---------|
+         *
+         *  Example 2 is the only case were we allow specific pick-up and drop-off
+         */
         if (vj->prev_vj) {
             if (vj->joins_on_different_stop_points(*vj->prev_vj)) {
-                first_st->drop_off_allowed = true;
-                vj->prev_vj->stop_time_list.back()->pick_up_allowed = true;
+                vj->prev_vj->stop_time_list.back()->pick_up_allowed = true;  // (1) in example 2
+                first_st->drop_off_allowed = true;                           // (2) in example 2
             }
         }
     }

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -591,10 +591,10 @@ void Data::pick_up_drop_of_on_borders() {
         }
 
         /*
-         * The first arrival and last departure of a vehicle don't make sense as they can't be used.
+         * The first arrival and last departure of a vehicle-journey don't make sense as they can't be used.
          * So let's forbid them
          *
-         * This is true unless the vehicle has a stay-in on different stop points as described below
+         * This is true unless the vehicle-journey has a stay-in on different stop points as described below
          */
 
         auto* first_st = vj->stop_time_list.front();

--- a/source/ed/data.cpp
+++ b/source/ed/data.cpp
@@ -604,7 +604,7 @@ void Data::pick_up_drop_of_on_borders() {
         last_st->pick_up_allowed = false;
 
         /*
-         * In the example below we assuming that VJ:1 and VJ:2 are sharing the same block_id.
+         * In the example below we are assuming that VJ:1 and VJ:2 are sharing the same block_id.
          *
          * The stay-in section is allowed with 2 configurations:
          *  - when two VJ share the same stop point with similar stop times (example 1)

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -113,6 +113,13 @@ bool StopPoint::operator<(const StopPoint& other) const {
     return *(this->stop_area) < *(other.stop_area);
 }
 
+bool StopPoint::operator!=(const StopPoint& sp) const {
+    /*
+     * We assume that URI are all unique accross stop points
+     */
+    return uri != sp.uri;
+}
+
 int VehicleJourney::earliest_time() const {
     const auto& st = std::min_element(stop_time_list.begin(), stop_time_list.end(), [](StopTime* st1, StopTime* st2) {
         return std::min(st1->boarding_time, st1->arrival_time) < std::min(st2->boarding_time, st2->arrival_time);
@@ -124,13 +131,11 @@ bool VehicleJourney::operator<(const VehicleJourney& other) const {
     return this->uri < other.uri;
 }
 
-bool VehicleJourney::has_prev_vj_prolongation_on_same_stop_point() const {
-    if (prev_vj) {
-        const auto* vj_first_st = stop_time_list.front();
-        const auto* prev_vj_last_st = prev_vj->stop_time_list.back();
-        return vj_first_st->stop_point->idx == prev_vj_last_st->stop_point->idx;
-    }
-    return false;
+bool VehicleJourney::joins_on_different_stop_points(const ed::types::VehicleJourney& prev_vj) const {
+    const auto* vj_first_st = stop_time_list.front();
+    const auto* prev_vj_last_st = prev_vj.stop_time_list.back();
+
+    return *vj_first_st->stop_point != *prev_vj_last_st->stop_point;
 }
 
 bool StopPointConnection::operator<(const StopPointConnection& other) const {

--- a/source/ed/types.cpp
+++ b/source/ed/types.cpp
@@ -124,6 +124,15 @@ bool VehicleJourney::operator<(const VehicleJourney& other) const {
     return this->uri < other.uri;
 }
 
+bool VehicleJourney::has_prev_vj_prolongation_on_same_stop_point() const {
+    if (prev_vj) {
+        const auto* vj_first_st = stop_time_list.front();
+        const auto* prev_vj_last_st = prev_vj->stop_time_list.back();
+        return vj_first_st->stop_point->idx == prev_vj_last_st->stop_point->idx;
+    }
+    return false;
+}
+
 bool StopPointConnection::operator<(const StopPointConnection& other) const {
     if (this->departure == other.departure) {
         if (this->destination == other.destination) {

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -291,8 +291,7 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     int earliest_time() const;
 
     bool operator<(const VehicleJourney& other) const;
-
-    bool has_prev_vj_prolongation_on_same_stop_point() const;
+    bool joins_on_different_stop_points(const ed::types::VehicleJourney& prev_vj) const;
 };
 
 struct StopPoint : public Header, Nameable, hasProperties {
@@ -310,6 +309,7 @@ struct StopPoint : public Header, Nameable, hasProperties {
     StopPoint() : fare_zone(), stop_area(nullptr), network(nullptr) {}
 
     bool operator<(const StopPoint& other) const;
+    bool operator!=(const StopPoint& sp) const;
 };
 
 struct Shape {

--- a/source/ed/types.h
+++ b/source/ed/types.h
@@ -282,8 +282,8 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     ValidityPattern* adapted_validity_pattern = nullptr;
     std::vector<VehicleJourney*> adapted_vehicle_journey_list;
     VehicleJourney* theoric_vehicle_journey = nullptr;
-    VehicleJourney* prev_vj = nullptr;
-    VehicleJourney* next_vj = nullptr;
+    VehicleJourney* prev_vj = nullptr;  // previous vj with the same block_id
+    VehicleJourney* next_vj = nullptr;  // next vj with the same block_id
 
     navitia::type::RTLevel realtime_level = navitia::type::RTLevel::Base;
 
@@ -291,6 +291,8 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     int earliest_time() const;
 
     bool operator<(const VehicleJourney& other) const;
+
+    bool has_prev_vj_prolongation_on_same_stop_point() const;
 };
 
 struct StopPoint : public Header, Nameable, hasProperties {


### PR DESCRIPTION
Because of allowing pick-up and drop-off at the extremity of a vehicle journeys with a
prolongation, we were able to go back in time.

This PR allows pick-up at the first
stop time and drop-off at the last stop time only for vehicle journeys
that has a prolongation with another one at a different stop point.

This solves https://github.com/CanalTP/artemis/pull/378

- [x] needs https://github.com/CanalTP/artemis_references/pull/221