### PR TITLE
[VER] Bump major data version because of changes in Ed for stay in.

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -72,7 +72,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 5;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 6;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),


### PR DESCRIPTION
Because of changes done in https://github.com/CanalTP/navitia/pull/3254, we need a new binarization, and a new major version number !