### PR TITLE
[Tyr] Traveller profile

### DIFF
--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -290,6 +290,8 @@ class Instance(db.Model):  # type: ignore
         cascade='save-update, merge, delete, delete-orphan',
     )
 
+    traveler_profiles = db.relationship('TravelerProfile', backref='instance')
+
     import_stops_in_mimir = db.Column(db.Boolean, default=False, nullable=False)
 
     import_ntfs_in_mimir = db.Column(db.Boolean, default=False, nullable=False)

--- a/source/tyr/tests/integration/instance_test.py
+++ b/source/tyr/tests/integration/instance_test.py
@@ -90,6 +90,13 @@ def test_get_instance(create_instance):
     assert resp[0]['id'] == create_instance
 
 
+def test_get_instance_with_traveler_profile(create_instance):
+    resp = api_get('/v0/instances/fr')
+    assert len(resp) == 1
+    assert 'traveler_profiles' in resp[0]
+    assert len(resp[0]['traveler_profiles']) == 0, "By default, traveler profiles are empty"
+
+
 def test_update_instances(create_instance):
     params = {
         "journey_order": "arrival_time",
@@ -265,6 +272,19 @@ def test_get_non_existant_profile(create_instance):
     assert status == 404
 
 
+def test_create_default_instance(create_instance):
+    _, status = api_post('/v0/instances/new_instance', check=False)
+    assert status == 201, "New instance should be created"
+
+    _, status = api_get('/v0/instances/new_instance', check=False)
+    assert status == 200, "New instance should now be available"
+
+
+def test_create_instance_already_existing_should_fail(create_instance):
+    _, status = api_post('/v0/instances/fr', check=False)
+    assert status >= 400, "Instance 'fr' already exists and cannot be created again"
+
+
 def test_create_empty_traveler_profile(create_instance):
     """
     we have created a profile with all default value, totally useless...
@@ -295,6 +315,8 @@ def test_update_traveler_profile(create_instance, traveler_profile_params):
         content_type='application/json',
     )
     check_traveler_profile(resp, traveler_profile_params)
+
+    api_get('/v0/instances/fr/traveler_profiles')
 
     resp = api_get('/v0/instances/fr/traveler_profiles/standard')
     check_traveler_profile(resp[0], traveler_profile_params)

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -104,6 +104,23 @@ class FieldUrlStreetNetworkBackend(fields.Raw):
         return url_for('streetnetwork_backends', backend_id=value, _external=True)
 
 
+traveler_profile = {
+    'traveler_type': fields.String,
+    'walking_speed': fields.Raw,
+    'bike_speed': fields.Raw,
+    'bss_speed': fields.Raw,
+    'car_speed': fields.Raw,
+    'wheelchair': fields.Boolean,
+    'max_walking_duration_to_pt': fields.Raw,
+    'max_bike_duration_to_pt': fields.Raw,
+    'max_bss_duration_to_pt': fields.Raw,
+    'max_car_duration_to_pt': fields.Raw,
+    'first_section_mode': fields.List(fields.String),
+    'last_section_mode': fields.List(fields.String),
+    'error': fields.String,
+}
+
+
 instance_fields = {
     'id': fields.Raw,
     'name': fields.Raw,
@@ -176,6 +193,7 @@ instance_fields = {
     'max_car_no_park_direct_path_duration': fields.Raw,
     'ridesharing_speed': fields.Raw,
     'max_ridesharing_duration_to_pt': fields.Raw,
+    'traveler_profiles': fields.List(fields.Nested(traveler_profile)),
 }
 
 api_fields = {'id': fields.Raw, 'name': fields.Raw}
@@ -243,22 +261,6 @@ jobs_fields = {'jobs': fields.List(fields.Nested(job_fields))}
 one_job_fields = {'job': fields.Nested(job_fields)}
 
 poi_types_fields = {'poi_types': fields.List(fields.Nested({'uri': fields.Raw, 'name': fields.Raw}))}
-
-traveler_profile = {
-    'traveler_type': fields.String,
-    'walking_speed': fields.Raw,
-    'bike_speed': fields.Raw,
-    'bss_speed': fields.Raw,
-    'car_speed': fields.Raw,
-    'wheelchair': fields.Boolean,
-    'max_walking_duration_to_pt': fields.Raw,
-    'max_bike_duration_to_pt': fields.Raw,
-    'max_bss_duration_to_pt': fields.Raw,
-    'max_car_duration_to_pt': fields.Raw,
-    'first_section_mode': fields.List(fields.String),
-    'last_section_mode': fields.List(fields.String),
-    'error': fields.String,
-}
 
 autocomplete_parameter_fields = {
     'id': fields.Raw,

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1441,7 +1441,7 @@ class TravelerProfile(flask_restful.Resource):
         @wraps(f)
         def wrapper(*args, **kwds):
             tp = kwds.get('traveler_type')
-            if tp in acceptable_traveler_types:
+            if tp in acceptable_traveler_types or tp is None:
                 return f(*args, **kwds)
             return (
                 {'error': 'traveler profile: {0} is not one of in {1}'.format(tp, acceptable_traveler_types)},

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -335,6 +335,22 @@ class Instance(flask_restful.Resource):
 
         return marshal(instance, instance_fields)
 
+    def post(self, name, version=0):
+        '''
+        Create a default instance with a specific name.
+        '''
+        query = models.Instance.query_all().filter(models.Instance.name == name)
+        if query.count() > 0:
+            return {'instance': name, 'created': 'failed', 'error': 'already created'}, 400
+
+        try:
+            new_instance = models.Instance(name=name)
+            db.session.add(new_instance)
+            db.session.commit()
+            return {'instance': name, 'created': 'ok'}, 201
+        except Exception as e:
+            return {'instance': name, 'created': 'failed', 'error': e.message()}, 500
+
     def put(self, version=0, id=None, name=None):
         instance = models.Instance.get_from_id_or_name(id, name)
 


### PR DESCRIPTION
This PR does 3 things:
 - It fixes Tyr's endpoint `Tyr/<version>/instances/<coverage>/traveler_profiles` to display all traveller profiles.
 - It adds to a coverage all its `traveler_profiles` when querying `Tyr/<version>/instances/<coverage>`
 - it adds a new endpoint to Tyr's instance. To create a default coverage in DB using a **POST** on `Tyr/<version>/instances/<coverage>`