### PR TITLE
[Kraken] Improve build time by moving multi-polygon-map out of pt-data

### DIFF
--- a/source/autocomplete/autocomplete.cpp
+++ b/source/autocomplete/autocomplete.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 #include "type/pt_data.h"
 #include "type/stop_area.h"
 #include "type/stop_point.h"
+#include "georef/georef.h"
 
 namespace navitia {
 namespace autocomplete {

--- a/source/autocomplete/autocomplete_api.cpp
+++ b/source/autocomplete/autocomplete_api.cpp
@@ -34,6 +34,7 @@ www.navitia.io
 #include "autocomplete/utils.h"
 #include "type/pb_converter.h"
 #include "utils/functions.h"
+#include "georef/georef.h"
 
 #include <algorithm>
 #include <utility>

--- a/source/disruption/traffic_reports_api.cpp
+++ b/source/disruption/traffic_reports_api.cpp
@@ -32,6 +32,7 @@ www.navitia.io
 
 #include "ptreferential/ptreferential.h"
 #include "type/pb_converter.h"
+#include "type/message.h"
 #include "utils/logger.h"
 #include "utils/paginate.h"
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -395,6 +395,26 @@ Impacter::Impacter(builder& bu, dis::Disruption& disrup) : b(bu) {
     disrup.add_impact(impact, b.data->pt_data->disruption_holder);
 }
 
+const dis::Disruption& Impacter::get_disruption() const {
+    return *impact->disruption;
+}
+
+Impacter& Impacter::uri(const std::string& u) {
+    impact->uri = u;
+    return *this;
+}
+
+Impacter& Impacter::application_periods(const boost::posix_time::time_period& p) {
+    impact->application_periods.push_back(p);
+    return *this;
+}
+
+Impacter& Impacter::publish(const boost::posix_time::time_period& p) {
+    // to ease use without a DisruptionCreator
+    impact->disruption->publication_period = p;
+    return *this;
+}
+
 DisruptionCreator& DisruptionCreator::tag(const std::string& t) {
     auto tag = boost::make_shared<dis::Tag>();
     tag->uri = t;

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -223,15 +223,9 @@ struct Impacter {
     Impacter(builder&, nt::disruption::Disruption&);
     builder& b;
     boost::shared_ptr<nt::disruption::Impact> impact;
-    const nt::disruption::Disruption& get_disruption() const { return *impact->disruption; }
-    Impacter& uri(const std::string& u) {
-        impact->uri = u;
-        return *this;
-    }
-    Impacter& application_periods(const boost::posix_time::time_period& p) {
-        impact->application_periods.push_back(p);
-        return *this;
-    }
+    const nt::disruption::Disruption& get_disruption() const;
+    Impacter& uri(const std::string& u);
+    Impacter& application_periods(const boost::posix_time::time_period& p);
     Impacter& severity(nt::disruption::Effect,
                        std::string uri = "",
                        const std::string& wording = "",
@@ -246,11 +240,7 @@ struct Impacter {
                               const std::vector<std::string>& route_uris);  // add section in informed_entities
     Impacter& msg(nt::disruption::Message);
     Impacter& msg(const std::string& text, nt::disruption::ChannelType = nt::disruption::ChannelType::email);
-    Impacter& publish(const boost::posix_time::time_period& p) {
-        // to ease use without a DisruptionCreator
-        impact->disruption->publication_period = p;
-        return *this;
-    }
+    Impacter& publish(const boost::posix_time::time_period& p);
 };
 
 struct DisruptionCreator {

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -47,6 +47,7 @@ www.navitia.io
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/adaptor/filtered.hpp>
+#include <boost/geometry.hpp>
 #include <pqxx/pqxx>
 
 #include <fstream>

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -612,7 +612,7 @@ void EdReader::fill_stop_points(nt::Data& data, pqxx::work& work) {
         if (!const_it["area"].is_null() && sp->is_zonal) {
             nt::MultiPolygon area;
             boost::geometry::read_wkt(const_it["area"].as<std::string>(), area);
-            data.pt_data->stop_points_by_area.insert(area, sp);
+            data.pt_data->add_stop_point_area(area, sp);
         }
 
         data.pt_data->stop_points.push_back(sp);

--- a/source/georef/fwd_georef.h
+++ b/source/georef/fwd_georef.h
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2014, Canal TP and/or its affiliates. All rights reserved.
+/* Copyright © Canal TP and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -27,35 +27,21 @@ channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
+
 #pragma once
 
-#include "type/pt_data.h"
-#include "type/message.h"
-#include "type/chaos.pb.h"
-#include "type/meta_data.h"
-
-#include <memory>
-
 namespace navitia {
+namespace georef {
 
-/*
- * Create a disruption from the chaos protobuf
- *
- * The disruption is registered in pt_data
- */
-const type::disruption::Disruption& make_disruption(const chaos::Disruption& chaos_disruption, type::PT_Data& pt_data);
+struct GeoRef;
+struct HouseNumber;
+struct POI;
+struct POIType;
+struct Path;
+struct PathItem;
+struct ProjectionData;
+struct Vertex;
+struct Way;
 
-/*
- * Create a disruption from the chaos protobuf and apply it on the pt_data
- */
-void make_and_apply_disruption(const chaos::Disruption& chaos_disruption,
-                               type::PT_Data& pt_data,
-                               const type::MetaData& meta);
-
-boost::optional<type::disruption::LineSection> make_line_section(const chaos::PtObject& chaos_section,
-                                                                 type::PT_Data& pt_data);
-
-bool is_publishable(const transit_realtime::TimeRange& publication_period,
-                    boost::posix_time::time_period production_period);
-
+}  // namespace georef
 }  // namespace navitia

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -36,6 +36,7 @@ www.navitia.io
 #include "utils/flat_enum_map.h"
 #include "utils/serialization_vector.h"
 #include "type/time_duration.h"
+#include "georef/fwd_georef.h"
 #include "georef/georef_types.h"
 #include "georef/projection_data.h"
 
@@ -159,11 +160,6 @@ struct Path {
     navitia::time_duration duration = {};  //< Total length of the path
     std::deque<PathItem> path_items = {};  //< List of street used
 };
-
-struct ProjectionData;
-
-struct POI;
-struct POIType;
 
 std::vector<Admin*> search_admins(const type::GeographicalCoord& coord, AdminRtree& admins_tree);
 

--- a/source/georef/street_network.h
+++ b/source/georef/street_network.h
@@ -29,7 +29,7 @@ www.navitia.io
 */
 
 #pragma once
-#include "georef.h"
+#include "georef/fwd_georef.h"
 #include "dijkstra_path_finder.h"
 #include "astar_path_finder.h"
 #include "routing/raptor_utils.h"

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -34,7 +34,10 @@ www.navitia.io
 #include "type/base_pt_objects.h"
 #include "type/network.h"
 #include "type/physical_mode.h"
+#include "type/message.h"
+#include "type/meta_data.h"
 #include "type/meta_vehicle_journey.h"
+#include "type/pt_data.h"
 #include "utils/logger.h"
 #include "utils/map_find.h"
 

--- a/source/kraken/apply_disruption.h
+++ b/source/kraken/apply_disruption.h
@@ -30,17 +30,14 @@ www.navitia.io
 
 #pragma once
 
-#include "type/pt_data.h"
-#include "type/message.h"
-#include "type/chaos.pb.h"
-#include "type/gtfs-realtime.pb.h"
-#include "type/meta_data.h"
+#include "type/fwd_type.h"
 
-#include <memory>
+#include <boost/date_time/gregorian/gregorian_types.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
 
 namespace navitia {
 
-boost::posix_time::time_period execution_period(const boost::gregorian::date& date, const nt::VehicleJourney& vj);
+boost::posix_time::time_period execution_period(const boost::gregorian::date& date, const type::VehicleJourney& vj);
 
 /**
  * WARNING: this method can add, remove or transform PT-Ref objects in PT_Data
@@ -48,7 +45,7 @@ boost::posix_time::time_period execution_period(const boost::gregorian::date& da
  * - RAPTOR (probably through Data.build_raptor)
  * - AUTOCOMPLETE on PT-Ref (probably through PT_Data.build_autocomplete)
  */
-void apply_disruption(const type::disruption::Disruption&, navitia::type::PT_Data&, const navitia::type::MetaData&);
+void apply_disruption(const type::disruption::Disruption&, navitia::type::PT_Data&, const type::MetaData&);
 
-void delete_disruption(const std::string& disruption_id, nt::PT_Data& pt_data, const nt::MetaData& meta);
+void delete_disruption(const std::string& disruption_id, type::PT_Data& pt_data, const type::MetaData& meta);
 }  // namespace navitia

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include <boost/make_shared.hpp>
 
 namespace bt = boost::posix_time;
+namespace nt = navitia::type;
 
 namespace navitia {
 

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -48,6 +48,7 @@ www.navitia.io
 namespace navitia {
 
 namespace nd = type::disruption;
+namespace nt = navitia::type;
 
 static bool base_vj_exists_the_same_day(const type::Data& data, const transit_realtime::TripUpdate& trip_update) {
     const auto& mvj = *data.pt_data->get_or_create_meta_vehicle_journey(trip_update.trip().trip_id(),

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -1177,7 +1177,7 @@ void Worker::odt_stop_points(const pbnavitia::GeographicalCoord& request) {
     coord.set_lon(request.lon());
     coord.set_lat(request.lat());
     const auto* data = this->pb_creator.data;
-    const auto& zonal_sps = data->pt_data->stop_points_by_area.find(coord);
+    const auto& zonal_sps = data->pt_data->get_stop_points_by_area(coord);
     this->pb_creator.pb_fill(zonal_sps, 0);
 }
 

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -41,6 +41,7 @@ struct RAPTOR;
 #include "type/type.pb.h"
 #include "type/response.pb.h"
 #include "type/request.pb.h"
+#include "type/accessibility_params.h"
 #include "kraken/data_manager.h"
 #include "utils/logger.h"
 #include "kraken/configuration.h"

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -31,6 +31,7 @@ www.navitia.io
 #include "proximitylist_api.h"
 
 #include "type/pb_converter.h"
+#include "georef/georef.h"
 #include "utils/paginate.h"
 
 namespace navitia {

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -28,6 +28,7 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
+#include "georef/georef.h"
 #include "ptreferential_utils.h"
 #include "ptref_graph.h"
 #include "ptreferential.h"
@@ -48,6 +49,7 @@ using navitia::type::make_indexes;
 using navitia::type::Type_e;
 
 namespace bt = boost::posix_time;
+namespace nt = navitia::type;
 
 namespace navitia {
 namespace ptref {

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "type/message.h"
 #include "type/meta_data.h"
 #include "type/pt_data.h"
+#include "type/static_data.h"
 
 #include <boost/range/algorithm/find.hpp>
 

--- a/source/routing/journey_pattern_container.h
+++ b/source/routing/journey_pattern_container.h
@@ -38,7 +38,7 @@ www.navitia.io
 namespace navitia {
 namespace type {
 
-struct PT_Data;
+class PT_Data;
 struct DiscreteVehicleJourney;
 struct FrequencyVehicleJourney;
 struct StopTime;

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -35,10 +35,13 @@ www.navitia.io
 #include "type/meta_data.h"
 #include "type/pt_data.h"
 #include "type/type_utils.h"
+#include "type/vehicle_journey.h"
 #include "utils/logger.h"
 
 #include <boost/range/algorithm/sort.hpp>
 #include <boost/range/algorithm_ext/push_back.hpp>
+
+namespace nt = navitia::type;
 
 namespace navitia {
 namespace routing {

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -48,7 +48,7 @@ www.navitia.io
 namespace navitia {
 
 namespace type {
-struct PT_Data;
+class PT_Data;
 class Data;
 struct FrequencyVehicleJourney;
 typedef std::bitset<8> VehicleProperties;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1112,7 +1112,7 @@ boost::optional<routing::map_stop_point_duration> get_stop_points(const type::En
     }
 
     // checking for zonal stop points
-    const auto& zonal_sps = data.pt_data->stop_points_by_area.find(ep.coordinates);
+    const auto& zonal_sps = data.pt_data->get_stop_points_by_area(ep.coordinates);
     for (const auto* stop_point : zonal_sps) {
         add_free_stop_point(stop_point, concerned_path_finder, result);
     }

--- a/source/tests/mock-kraken/basic_routing_test.cpp
+++ b/source/tests/mock-kraken/basic_routing_test.cpp
@@ -28,6 +28,7 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
+#include <boost/geometry.hpp>
 #include "utils/init.h"
 #include "routing/tests/routing_api_test_data.h"
 #include "mock_kraken.h"
@@ -145,10 +146,10 @@ int main(int argc, const char* const argv[]) {
 
     auto* sp = b.sps.at("P");
     sp->is_zonal = true;
-    b.data->pt_data->stop_points_by_area.insert(area_1, sp);
+    b.data->pt_data->add_stop_point_area(area_1, sp);
     sp = b.sps.at("Q");
     sp->is_zonal = true;
-    b.data->pt_data->stop_points_by_area.insert(area_2, sp);
+    b.data->pt_data->add_stop_point_area(area_2, sp);
 
     auto drancy = new navitia::georef::Admin(0, "admin:93700", "Drancy", 8, "93700", "Drancy", {12, 12}, {"93700"});
     auto paris = new navitia::georef::Admin(1, "admin:75000", "Paris", 8, "75000", "Paris", {22, 22}, {"75000"});

--- a/source/time_tables/passages.h
+++ b/source/time_tables/passages.h
@@ -29,7 +29,10 @@ www.navitia.io
 */
 
 #pragma once
+
+#include "type/fwd_type.h"
 #include "type/pb_converter.h"
+
 namespace navitia {
 namespace timetables {
 

--- a/source/tools/dumpsn.cpp
+++ b/source/tools/dumpsn.cpp
@@ -27,6 +27,8 @@ channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
+
+#include "georef/georef.h"
 #include "type/data.h"
 #include "type/pb_converter.h"
 #include "utils/init.h"  // init_app()

--- a/source/type/connection.h
+++ b/source/type/connection.h
@@ -38,7 +38,6 @@ namespace navitia {
 namespace type {
 
 struct StopPoint;
-struct PT_Data;
 
 enum class ConnectionType { StopPoint = 0, StopArea, Walking, VJ, Default, stay_in, undefined };
 

--- a/source/type/contributor.cpp
+++ b/source/type/contributor.cpp
@@ -29,11 +29,12 @@ www.navitia.io
 */
 
 #include "type/contributor.h"
-
 #include "type/dataset.h"
 #include "type/indexes.h"
 #include "type/pt_data.h"
 #include "type/serialization.h"
+
+#include <boost/serialization/set.hpp>
 
 namespace navitia {
 namespace type {

--- a/source/type/contributor.h
+++ b/source/type/contributor.h
@@ -29,8 +29,8 @@ www.navitia.io
 */
 
 #pragma once
-#include "type/type_interfaces.h"
 #include "type/fwd_type.h"
+#include "type/type_interfaces.h"
 
 #include <set>
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -34,7 +34,6 @@ www.navitia.io
 #include "utils/obj_factory.h"
 #include "utils/ptime.h"
 #include "type/fwd_type.h"
-#include "fare/fare.h"
 
 #include <boost/serialization/split_member.hpp>
 #include <boost/utility.hpp>

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -36,6 +36,7 @@ class RTree;
 namespace navitia {
 template <typename T>
 struct Rank;
+
 namespace georef {
 struct GeoRef;
 struct POI;
@@ -52,33 +53,34 @@ struct JourneyPattern;
 struct JourneyPatternPoint;
 }  // namespace routing
 namespace type {
-struct MetaData;
-
+class PT_Data;
+struct AssociatedCalendar;
+struct Calendar;
+struct CommercialMode;
+struct Company;
+struct Contributor;
+struct Dataset;
+struct DiscreteVehicleJourney;
+struct EntryPoint;
+struct ExceptionDate;
+struct FrequencyVehicleJourney;
 struct GeographicalCoord;
 struct Line;
-struct StopArea;
-struct Network;
-struct StopPointConnection;
-struct ValidityPattern;
-struct Route;
-struct VehicleJourney;
-struct StopTime;
-using RankStopTime = Rank<StopTime>;
-struct Dataset;
-struct StopPoint;
-struct ExceptionDate;
-struct Contributor;
-struct Company;
-struct CommercialMode;
-struct PhysicalMode;
 struct LineGroup;
+struct MetaData;
 struct MetaVehicleJourney;
-struct DiscreteVehicleJourney;
-struct FrequencyVehicleJourney;
-struct Calendar;
-struct AssociatedCalendar;
-struct PT_Data;
-struct EntryPoint;
+struct Network;
+struct PhysicalMode;
+struct Route;
+struct StopArea;
+struct StopPoint;
+struct StopPointConnection;
+struct StopTime;
+struct ValidityPattern;
+struct VehicleJourney;
+using RankStopTime = Rank<StopTime>;
+template <class T>
+struct MultiPolygonMap;
 namespace disruption {
 struct Impact;
 struct Message;

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -83,6 +83,7 @@ using RankStopTime = Rank<StopTime>;
 template <class T>
 struct MultiPolygonMap;
 namespace disruption {
+struct Disruption;
 struct Impact;
 struct Message;
 }  // namespace disruption

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -55,6 +55,7 @@ struct JourneyPatternPoint;
 namespace type {
 class PT_Data;
 struct AssociatedCalendar;
+struct AccessibiliteParams;
 struct Calendar;
 struct CommercialMode;
 struct Company;

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -44,6 +44,9 @@ www.navitia.io
 #include <boost/date_time/posix_time/time_serialize.hpp>
 #include <boost/format.hpp>
 #include <boost/serialization/variant.hpp>
+#include <boost/serialization/set.hpp>
+
+namespace nt = navitia::type;
 
 namespace navitia {
 namespace type {

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -211,8 +211,6 @@ typedef boost::variant<UnknownPtObj, Network*, StopArea*, StopPoint*, LineSectio
 
 PtObj make_pt_obj(Type_e type, const std::string& uri, PT_Data& pt_data);
 
-struct Disruption;
-
 struct Message {
     std::string text;
     std::string channel_id;

--- a/source/type/network.cpp
+++ b/source/type/network.cpp
@@ -28,12 +28,14 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
-#include "type/network.h"
 #include "type/dataset.h"
+#include "type/network.h"
 #include "type/indexes.h"
 #include "type/line.h"
 #include "type/pt_data.h"
 #include "type/serialization.h"
+
+#include <boost/serialization/set.hpp>
 
 namespace navitia {
 namespace type {

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -38,6 +38,7 @@ www.navitia.io
 #include "type/dataset.h"
 #include "type/physical_mode.h"
 #include "type/pt_data.h"
+#include "type/static_data.h"
 #include "vptranslator/vptranslator.h"
 #include "ptreferential/ptreferential.h"
 #include "utils/logger.h"

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -39,6 +39,7 @@ www.navitia.io
 #include "type/network.h"
 #include "type/base_pt_objects.h"
 #include "type/meta_vehicle_journey.h"
+#include "type/multi_polygon_map.h"
 #include "type/commercial_mode.h"
 #include "type/physical_mode.h"
 #include "utils/functions.h"
@@ -410,6 +411,16 @@ const StopPointConnection* PT_Data::get_stop_point_connection(const StopPoint& f
     }
     return *search;
 }
+
+std::vector<const StopPoint*> PT_Data::get_stop_points_by_area(const GeographicalCoord& coord) {
+    return stop_points_by_area->find(coord);
+}
+
+void PT_Data::add_stop_point_area(const MultiPolygon& area, StopPoint* sp) {
+    stop_points_by_area->insert(area, sp);
+}
+
+PT_Data::PT_Data() : stop_points_by_area(std::make_unique<StopPointPolygonMap>()) {}
 
 PT_Data::~PT_Data() {
     // big uggly hack :(

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -30,6 +30,8 @@ www.navitia.io
 
 #include "pt_data.h"
 
+#include "georef/adminref.h"
+#include "georef/georef.h"
 #include "type/serialization.h"
 #include "type/connection.h"
 #include "type/calendar.h"
@@ -45,6 +47,8 @@ www.navitia.io
 #include "utils/functions.h"
 
 #include <boost/range/algorithm/find_if.hpp>
+
+namespace nt = navitia::type;
 
 namespace navitia {
 namespace type {

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -30,7 +30,7 @@ www.navitia.io
 
 #pragma once
 #include "type/fwd_type.h"
-#include "georef/georef.h"
+#include "georef/fwd_georef.h"
 #include "type/message.h"
 #include "type/request.pb.h"
 #include "autocomplete/autocomplete.h"

--- a/source/type/route.cpp
+++ b/source/type/route.cpp
@@ -28,9 +28,8 @@ https://groups.google.com/d/forum/navitia
 www.navitia.io
 */
 
-#include "type/route.h"
-
 #include "type/dataset.h"
+#include "type/route.h"
 #include "type/indexes.h"
 #include "type/line.h"
 #include "type/pt_data.h"
@@ -38,6 +37,8 @@ www.navitia.io
 #include "type/stop_area.h"
 #include "type/stop_point.h"
 #include "type/vehicle_journey.h"
+
+#include <boost/serialization/set.hpp>
 
 namespace navitia {
 namespace type {

--- a/source/type/stop_point.cpp
+++ b/source/type/stop_point.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "type/route.h"
 #include "type/serialization.h"
 #include "type/stop_area.h"
+#include "georef/georef.h"
 
 #include <boost/serialization/weak_ptr.hpp>
 

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -105,7 +105,7 @@ struct Nameable {
     Nameable(const std::string& name) : name(name) {}
 };
 
-struct PT_Data;
+class PT_Data;
 
 using Indexes = boost::container::flat_set<idx_t>;
 

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -42,6 +42,9 @@ www.navitia.io
 #include "type/stop_point.h"
 #include "type/physical_mode.h"
 #include "type/meta_vehicle_journey.h"
+#include "georef/adminref.h"
+
+namespace nt = navitia::type;
 
 namespace navitia {
 namespace type {


### PR DESCRIPTION
## What
`pt_data.h` is where we most consume time by the compiler frontend (avg. 3.2 seconds, ~180sec total). Most of this time is used by the inclusion of `multi_polygon_map.h` (1.6 sec average, ~90sec total).

This PR removes that inclusion and replace it with the pimpl idioms.

This PR also removes `georef.h` from pt_data.h and street_network.h.

## How
Using clang's `-ftime-trace` compiler option - https://www.snsystems.com/technology/tech-blog/clang-time-trace-feature

## Why 
Because speed ! :zap: 

## How Much
On `dev` branch
```sh
$ time make -j5
real	14m35,851s
user	62m9,830s
sys	4m4,427s
```
On this branch
```sh
$ time make -j5
real	6m17,414s
user	26m10,663s
sys	2m42,221s
```
