### PR TITLE
Revert "[Jormun] correction of datetime tranformation for current_datetime"

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Calendars.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Calendars.py
@@ -37,13 +37,12 @@ from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.serializer import api
 from jormungandr.interfaces.common import split_uri
-from jormungandr.resources_utils import ResourceUtc
 from navitiacommon.parser_args_type import DateTimeFormat, DepthArgument
 from datetime import datetime
 import six
 
 
-class Calendars(ResourceUri, ResourceUtc):
+class Calendars(ResourceUri):
     def __init__(self):
         ResourceUri.__init__(self, output_type_serializer=api.CalendarsSerializer)
         parser_get = self.parsers["get"]
@@ -84,7 +83,7 @@ class Calendars(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -111,9 +110,6 @@ class Calendars(ResourceUri, ResourceUtc):
             args["filter"] = self.get_filter(split_uri(uri), args)
         else:
             args["filter"] = ""
-
-        # change dt to utc
-        args['_current_datetime'] = self.convert_to_utc(args['_current_datetime'])
 
         self._register_interpreted_parameters(args)
         response = i_manager.dispatch(args, "calendars", instance_name=self.region)

--- a/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Disruptions.py
@@ -39,14 +39,13 @@ from jormungandr.interfaces.v1.errors import ManageError
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from jormungandr.interfaces.v1.serializer import api
 from jormungandr.interfaces.common import split_uri
-from jormungandr.resources_utils import ResourceUtc
 from navitiacommon.parser_args_type import BooleanType, DateTimeFormat, DepthArgument
 from flask.globals import g
 from datetime import datetime
 import six
 
 
-class TrafficReport(ResourceUri, ResourceUtc):
+class TrafficReport(ResourceUri):
     def __init__(self):
         ResourceUri.__init__(self, output_type_serializer=api.TrafficReportsSerializer)
         parser_get = self.parsers["get"]
@@ -60,7 +59,7 @@ class TrafficReport(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -111,8 +110,6 @@ class TrafficReport(ResourceUri, ResourceUtc):
         self.region = i_manager.get_region(region, lon, lat)
         timezone.set_request_timezone(self.region)
         args = self.parsers["get"].parse_args()
-        # change dt to utc
-        args['_current_datetime'] = self.convert_to_utc(args['_current_datetime'])
 
         if args['disable_geojson']:
             g.disable_geojson = True

--- a/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
@@ -63,7 +63,7 @@ class LineReports(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -106,9 +106,6 @@ class LineReports(ResourceUri, ResourceUtc):
             g.disable_geojson = True
 
         args["filter"] = self.get_filter(split_uri(uri), args)
-
-        # change dt to utc
-        args['_current_datetime'] = self.convert_to_utc(args['_current_datetime'])
 
         if args['since']:
             args['since'] = date_to_timestamp(self.convert_to_utc(args['since']))

--- a/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Ptobjects.py
@@ -37,7 +37,6 @@ from flask.globals import g
 from jormungandr import i_manager, timezone
 from jormungandr.interfaces.v1.decorators import get_obj_serializer
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
-from jormungandr.resources_utils import ResourceUtc
 from jormungandr.interfaces.v1.serializer import api
 from jormungandr.interfaces.parsers import default_count_arg_type
 from navitiacommon.parser_args_type import BooleanType, OptionValue, DateTimeFormat, DepthArgument
@@ -49,7 +48,7 @@ pt_object_type_values = ["network", "commercial_mode", "line", "line_group", "ro
 pt_object_type_default_values = ["network", "commercial_mode", "line", "line_group", "route", "stop_area"]
 
 
-class Ptobjects(ResourceUri, ResourceUtc):
+class Ptobjects(ResourceUri):
     def __init__(self, *args, **kwargs):
         ResourceUri.__init__(self, output_type_serializer=api.PtObjectsSerializer, *args, **kwargs)
         self.parsers["get"].add_argument("q", type=six.text_type, required=True, help="The data to search")
@@ -78,7 +77,7 @@ class Ptobjects(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -99,10 +98,6 @@ class Ptobjects(ResourceUri, ResourceUtc):
         self.region = i_manager.get_region(region, lon, lat)
         timezone.set_request_timezone(self.region)
         args = self.parsers["get"].parse_args()
-
-        # change dt to utc
-        args['_current_datetime'] = self.convert_to_utc(args['_current_datetime'])
-
         if args['disable_geojson']:
             g.disable_geojson = True
         self._register_interpreted_parameters(args)

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -141,7 +141,7 @@ class Schedules(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -247,7 +247,6 @@ class Schedules(ResourceUri, ResourceUtc):
 
         if not args["from_datetime"] and not args["until_datetime"]:
             # no datetime given, default is the current time, and we activate the realtime
-            args['_current_datetime'] = self.convert_to_utc(args['_current_datetime'])
             args['from_datetime'] = args['_current_datetime']
             if args["calendar"]:  # if we have a calendar, the dt is only used for sorting, so 00:00 is fine
                 args['from_datetime'] = args['from_datetime'].replace(hour=0, minute=0)

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -108,7 +108,7 @@ class Uri(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -189,7 +189,6 @@ class Uri(ResourceUri, ResourceUtc):
         set_request_timezone(self.region)
 
         # change dt to utc
-        args['_current_datetime'] = self.convert_to_utc(args['_current_datetime'])
         if args['since']:
             args['_original_since'] = args['since']
             args['since'] = date_to_timestamp(self.convert_to_utc(args['since']))

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -413,7 +413,7 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             type=DateTimeFormat(),
             schema_metadata={'default': 'now'},
             hidden=True,
-            default=datetime.now(),
+            default=datetime.utcnow(),
             help='The datetime considered as "now". Used for debug, default is '
             'the moment of the request. It will mainly change the output '
             'of the disruptions.',
@@ -502,6 +502,6 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         if args['datetime']:
             args['original_datetime'] = args['datetime']
         else:
-            args['original_datetime'] = args['_current_datetime']
+            args['original_datetime'] = pytz.UTC.localize(args['_current_datetime'])
 
         return args

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -145,20 +145,11 @@ def date_to_timestamp(date):
 
 
 def str_datetime_utc_to_local(dt, timezone):
-    local = pytz.timezone(timezone)
     if dt:
-        obj_dt = DateTimeFormat()(dt)
-        if obj_dt.tzinfo is not None:
-            localized_dt = obj_dt
-        else:
-            # if we don't have a timezone in the datetime, we consider it a local time from the coverage's tz
-            localized_dt = local.normalize(local.localize(obj_dt))
-        # convert to utc as datetime is in local
-        utc_dt = localized_dt.astimezone(pytz.utc)
+        utc_dt = DateTimeFormat()(dt)
     else:
         utc_dt = datetime.utcnow()
-
-    # Finally convert to local datetime
+    local = pytz.timezone(timezone)
     return dt_to_str(utc_dt.replace(tzinfo=pytz.UTC).astimezone(local))
 
 

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -220,13 +220,13 @@ class TestPtRef(AbstractTestFixture):
         stop_area:stop1 with _current_datetime
         """
 
-        # parameter _current_datetime accepts local datetime as well as datetime with timezone
-        # Possible values are 20140116T005959 or 20140115T235959Z or 20140116T005959+0100
-        # In Europe/Paris timezone, the diff between UTC and local time is 1 Hour
+        # In Europe/Paris timezone, the diff between UTC and
+        # local time is 2 Hours
+        utc_datetime = '20140115T235959'
         local_date_time = '20140116T005959'
         timezone = 'Europe/Paris'
 
-        response = self.query_region("stop_areas/stop_area:stop1?_current_datetime={}".format(local_date_time))
+        response = self.query_region("stop_areas/stop_area:stop1?_current_datetime={}".format(utc_datetime))
 
         disruptions = get_not_null(response, 'disruptions')
 
@@ -624,33 +624,6 @@ class TestPtRef(AbstractTestFixture):
         response = self.query_region(query, display=True)
 
         self.is_valid_journey_response(response, query)
-
-    def test_journey_with_current_datetime(self):
-        base_query = query = 'journeys?from={}&to={}'.format(
-            quote_plus(u'stop_with name bob \" , é'.encode('utf-8')),
-            quote_plus(u'stop_area:stop1'.encode('utf-8')),
-        )
-        # we use _current_datetime with local datetime value 2014-01-05T08:00:00
-        query = base_query + '&_current_datetime=20140105T080000'
-        response = self.query_region(query, display=True)
-        self.is_valid_journey_response(response, query)
-        assert response['context']['timezone'] == 'Europe/Paris'
-        assert response['context']['current_datetime'] == '20140105T080000'
-        assert response['journeys'][0]['departure_date_time'] == '20140105T090000'
-
-        # we use _current_datetime with local datetime value 2014-01-05T08:30:00
-        query = base_query + '&_current_datetime=20140105T083000'
-        response = self.query_region(query, display=True)
-        assert response['context']['timezone'] == 'Europe/Paris'
-        assert response['context']['current_datetime'] == '20140105T083000'
-        assert response['journeys'][0]['departure_date_time'] == '20140105T090000'
-
-        # we use _current_datetime with local datetime value 2014-01-05T09:10:00
-        query = base_query + '&_current_datetime=20140105T091000'
-        response = self.query_region(query, check=False, display=True)
-        assert response[0]['context']['timezone'] == 'Europe/Paris'
-        assert response[0]['context']['current_datetime'] == '20140105T091000'
-        assert response[0]['error']['id'] == 'no_solution'
 
     def test_vj_period_filter(self):
         """with just a since in the middle of the period, we find vj1"""


### PR DESCRIPTION
Reverts CanalTP/navitia#3241

After investigations, it seems to be bad to keep this PR for several reasons :

- The **_current_datetime** is now a local time. The problem is that we lost the _timezone information_ with this format. It is an issue for requests without coverages.
- Threre is a bug with disruptions for **journeys** API (https://jira.kisio.org/browse/NAVITIAII-3136)... We can fix it but we have to create an other : If we have a request without coverage, we need to fix an arbitrary timezone for multi-coverage.

The straightwforward choise is the revert