### PR TITLE
[Type] Bump data version to 7

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -72,7 +72,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 6;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 7;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),


### PR DESCRIPTION
Because of the changes introduced in https://github.com/CanalTP/navitia/pull/3271/commits/c1042e0210d6e8f1bc3e44123303efe1f3393de1
 - MultiPolygonMap<const StopPoint*> changed to std::unique_ptr<StopPointPolygonMap> in Pt_data.

Next release will require re-binarisation.


Kudos to @benoit-bst  for spotting it. 