### PR TITLE
[Jormun+Tyr] Asynchronous ridesharing

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -24,6 +24,9 @@ SQLALCHEMY_DATABASE_URI = os.getenv(
 
 DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', False))
 
+# Active the asynchronous ridesharing mode
+ASYNCHRONOUS_RIDESHARING = boolean(os.getenv('JORMUNGANDR_ASYNCHRONOUS_RIDESHARING', False))
+
 # disable authentication
 PUBLIC = boolean(os.getenv('JORMUNGANDR_IS_PUBLIC', True))
 

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -134,6 +134,7 @@ class Instance(object):
         self.georef = georef.Kraken(self)
         self.planner = planner.Kraken(self)
         self._streetnetwork_backend_manager = streetnetwork_backend_manager
+        self.asynchronous_ridesharing = False
 
         if app.config[str('DISABLE_DATABASE')]:
             self._streetnetwork_backend_manager.init_streetnetwork_backends_legacy(
@@ -171,6 +172,12 @@ class Instance(object):
                 app.config[str('EQUIPMENT_DETAILS_PROVIDERS')], self.get_providers_from_db
             )
 
+        # New ridesharing type
+        if app.config[str('DISABLE_DATABASE')]:
+            self.asynchronous_ridesharing = app.config[str('ASYNCHRONOUS_RIDESHARING')]
+        else:
+            self.asynchronous_ridesharing = self.get_asynchronous_ridesharing_from_db
+
         # Init equipment providers from config
         self.equipment_provider_manager.init_providers(instance_equipment_providers)
 
@@ -179,6 +186,10 @@ class Instance(object):
         :return: a callable query of equipment providers associated to the current instance in db
         """
         return self._get_models().equipment_details_providers
+
+    def get_asynchronous_ridesharing_from_db(self):
+        instance_db = self.get_models()
+        return get_value_or_default('asynchronous_ridesharing', instance_db, self.name)
 
     @property
     def autocomplete(self):

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -176,7 +176,7 @@ class Instance(object):
         if app.config[str('DISABLE_DATABASE')]:
             self.asynchronous_ridesharing = app.config[str('ASYNCHRONOUS_RIDESHARING')]
         else:
-            self.asynchronous_ridesharing = self.get_asynchronous_ridesharing_from_db
+            self.asynchronous_ridesharing = self.get_asynchronous_ridesharing_from_db  # type: ignore
 
         # Init equipment providers from config
         self.equipment_provider_manager.init_providers(instance_equipment_providers)
@@ -187,7 +187,6 @@ class Instance(object):
         """
         return self._get_models().equipment_details_providers
 
-    @property
     def get_asynchronous_ridesharing_from_db(self):
         # type: () -> bool
         instance_db = self.get_models()

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -187,7 +187,9 @@ class Instance(object):
         """
         return self._get_models().equipment_details_providers
 
+    @property
     def get_asynchronous_ridesharing_from_db(self):
+        # type: () -> bool
         instance_db = self.get_models()
         return get_value_or_default('asynchronous_ridesharing', instance_db, self.name)
 

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -455,6 +455,13 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             hidden=True,
             help="define the duration to reach stop points by crow fly",
         )
+        parser_get.add_argument(
+            "_asynchronous_ridesharing",
+            type=BooleanType(),
+            hidden=True,
+            default=False,
+            help="active the asynchronous mode for the ridesharing services",
+        )
 
     def parse_args(self, region=None, uri=None):
         args = self.parsers['get'].parse_args()

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1184,7 +1184,6 @@ class Scenario(simple.Scenario):
         return resp
 
     def handle_ridesharing_services(self, logger, instance, request, pb_response):
-
         def active_asynchronous_ridesharing(request, instance):
             if request.get("_asynchronous_ridesharing", False):
                 return True
@@ -1194,8 +1193,7 @@ class Scenario(simple.Scenario):
 
         if not active_asynchronous_ridesharing(request, instance):
             if instance.ridesharing_services and (
-                'ridesharing' in request['origin_mode']
-                or 'ridesharing' in request['destination_mode']
+                'ridesharing' in request['origin_mode'] or 'ridesharing' in request['destination_mode']
             ):
                 logger.debug('trying to add ridesharing journeys')
                 try:

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1097,19 +1097,8 @@ class Scenario(simple.Scenario):
         compute_car_co2_emission(pb_resp, api_request, instance, "{}_car_co2".format(request_id))
         tag_journeys(pb_resp)
 
-        if instance.ridesharing_services and (
-            'ridesharing' in ridesharing_req['origin_mode']
-            or 'ridesharing' in ridesharing_req['destination_mode']
-        ):
-            logger.debug('trying to add ridesharing journeys')
-            try:
-                decorate_journeys(pb_resp, instance, api_request)
-            except Exception:
-                logger.exception('Error while retrieving ridesharing ads')
-        else:
-            for j in pb_resp.journeys:
-                if 'ridesharing' in j.tags:
-                    journey_filter.mark_as_dead(j, api_request.get('debug'), 'no_matching_ridesharing_found')
+        # Handle ridesharing service
+        self.handle_ridesharing_services(logger, instance, ridesharing_req, pb_resp)
 
         journey_filter.delete_journeys((pb_resp,), api_request)
         type_journeys(pb_resp, api_request)
@@ -1193,6 +1182,32 @@ class Scenario(simple.Scenario):
                 del resp.journeys[request["max_nb_journeys"] :]
 
         return resp
+
+    def handle_ridesharing_services(self, logger, instance, request, pb_response):
+
+        def active_asynchronous_ridesharing(request, instance):
+            if request.get("_asynchronous_ridesharing", False):
+                return True
+            if instance.asynchronous_ridesharing:
+                return True
+            return False
+
+        if not active_asynchronous_ridesharing(request, instance):
+            if instance.ridesharing_services and (
+                'ridesharing' in request['origin_mode']
+                or 'ridesharing' in request['destination_mode']
+            ):
+                logger.debug('trying to add ridesharing journeys')
+                try:
+                    decorate_journeys(pb_response, instance, request)
+                except Exception:
+                    logger.exception('Error while retrieving ridesharing ads')
+            else:
+                for j in pb_response.journeys:
+                    if 'ridesharing' in j.tags:
+                        journey_filter.mark_as_dead(j, request.get('debug'), 'no_matching_ridesharing_found')
+        else:
+            self._add_ridesharing_link(pb_response, request)
 
     def create_next_kraken_request(self, request, responses):
         """

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1185,11 +1185,11 @@ class Scenario(simple.Scenario):
 
     def handle_ridesharing_services(self, logger, instance, request, pb_response):
         def active_asynchronous_ridesharing(request, instance):
-            if request.get("_asynchronous_ridesharing", False):
-                return True
-            if instance.asynchronous_ridesharing:
-                return True
-            return False
+            if request.get("_asynchronous_ridesharing", None) is None:
+                # when the param is not set in the request, use the instance config
+                return instance.asynchronous_ridesharing
+            else:
+                return request.get("_asynchronous_ridesharing")
 
         if not active_asynchronous_ridesharing(request, instance):
             if instance.ridesharing_services and (

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -325,8 +325,20 @@ class Scenario(object):
         raise NotImplementedError()
 
     def _add_ridesharing_link(self, resp, params):
-        params['_asynchronous_ridesharing'] = 'False'
-        add_link(resp, rel='ridesharing', **params)
+        # TODO : Add a link to call ridesharing API
+        # For the moment, the endpoint API doesn't exit.
+        # This is a fake link that have to be replaced/completed.
+        # ressource_name = ridesharing, after the ridesharing API integration
+        link = resp.links.add(rel='ridesharing', is_templated=False, description='call ridesharing services', ressource_name='journeys')
+        # from
+        args = link.kwargs.add(key='from')
+        args.values.extend(['2.23719;48.89499'])
+        # to
+        args = link.kwargs.add(key='to')
+        args.values.extend(['2.38693;48.85066'])
+        # datetime
+        args = link.kwargs.add(key='datetime')
+        args.values.extend(['20200904T000605'])
 
     def _add_prev_link(self, resp, params, clockwise):
         prev_dt = self.previous_journey_datetime(resp.journeys, clockwise)

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -324,6 +324,10 @@ class Scenario(object):
     def isochrone(self, request, instance):
         raise NotImplementedError()
 
+    def _add_ridesharing_link(self, resp, params):
+        params['_asynchronous_ridesharing'] = 'False'
+        add_link(resp, rel='ridesharing', **params)
+
     def _add_prev_link(self, resp, params, clockwise):
         prev_dt = self.previous_journey_datetime(resp.journeys, clockwise)
         if prev_dt is not None:

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -329,7 +329,12 @@ class Scenario(object):
         # For the moment, the endpoint API doesn't exit.
         # This is a fake link that have to be replaced/completed.
         # ressource_name = ridesharing, after the ridesharing API integration
-        link = resp.links.add(rel='ridesharing', is_templated=False, description='call ridesharing services', ressource_name='journeys')
+        link = resp.links.add(
+            rel='ridesharing',
+            is_templated=False,
+            description='call ridesharing services',
+            ressource_name='journeys',
+        )
         # from
         args = link.kwargs.add(key='from')
         args.values.extend(['2.23719;48.89499'])

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -2306,6 +2306,31 @@ class JourneysRidesharing:
             float(rs_section["to"]["address"]["coord"]["lat"])
         )
 
+    def test_asynchronous_ridesharing_mode(self):
+        query = (
+            "journeys?from=0.0000898312;0.0000898312&to=0.00188646;0.000449156&datetime=20120614T075500&"
+            "first_section_mode[]={first}&last_section_mode[]={last}&debug=true&_asynchronous_ridesharing=True".format(
+                first='ridesharing', last='walking'
+            )
+        )
+        response = self.query_region(query)
+        check_best(response)
+        assert len(response["journeys"]) == 1
+        assert response["journeys"][0]["type"] == "best"
+        rs_journey = response["journeys"][0]
+        assert "ridesharing" in rs_journey["tags"]
+        rs_section = rs_journey["sections"][0]
+        assert rs_section["mode"] == "ridesharing"
+        assert rs_section["type"] == "street_network"
+        # A link is added to call the new ridesharing API
+        links = response["links"]
+        link_is_present = False
+        for link in links:
+            if "ridesharing" in link["rel"]:
+                link_is_present = True
+                break
+        assert link_is_present
+
     def test_first_ridesharing_section_mode_forbidden(self):
         def exec_and_check(query):
             response, status = self.query_region(query, check=False)

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -172,6 +172,7 @@ here_max_matrix_points = 100
 
 stop_points_nearby_duration = 5 * 60  # In secs
 
+asynchronous_ridesharing = False
 
 def get_value_or_default(attr, instance, instance_name):
     if not instance or getattr(instance, attr, None) == None:

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -174,6 +174,7 @@ stop_points_nearby_duration = 5 * 60  # In secs
 
 asynchronous_ridesharing = False
 
+
 def get_value_or_default(attr, instance, instance_name):
     if not instance or getattr(instance, attr, None) == None:
         value = getattr(sys.modules[__name__], attr)

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -543,6 +543,9 @@ class Instance(db.Model):  # type: ignore
         server_default=str(default_values.stop_points_nearby_duration),
     )
 
+    # Active the asynchronous_ridesharing mode
+    asynchronous_ridesharing = db.Column(db.Boolean, default=False, nullable=False)
+
     def __init__(self, name=None, is_free=False, authorizations=None, jobs=None):
         self.name = name
         self.is_free = is_free

--- a/source/tyr/migrations/versions/0ccb5413baa9_add_asynchronous_ridesharing_mode.py
+++ b/source/tyr/migrations/versions/0ccb5413baa9_add_asynchronous_ridesharing_mode.py
@@ -1,0 +1,22 @@
+"""add asynchronous ridesharing
+
+Revision ID: 0ccb5413baa9
+Revises: b413ec1e3bbc
+Create Date: 2020-09-04 11:23:13.637259
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '0ccb5413baa9'
+down_revision = 'b413ec1e3bbc'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('instance', sa.Column('asynchronous_ridesharing', sa.Boolean(), nullable=False, server_default=sa.false()))
+
+
+def downgrade():
+    op.drop_column('instance', 'asynchronous_ridesharing')

--- a/source/tyr/migrations/versions/0ccb5413baa9_add_asynchronous_ridesharing_mode.py
+++ b/source/tyr/migrations/versions/0ccb5413baa9_add_asynchronous_ridesharing_mode.py
@@ -15,7 +15,10 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column('instance', sa.Column('asynchronous_ridesharing', sa.Boolean(), nullable=False, server_default=sa.false()))
+    op.add_column(
+        'instance',
+        sa.Column('asynchronous_ridesharing', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
 
 
 def downgrade():

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -193,11 +193,8 @@ instance_fields = {
     'max_car_no_park_direct_path_duration': fields.Raw,
     'ridesharing_speed': fields.Raw,
     'max_ridesharing_duration_to_pt': fields.Raw,
-<<<<<<< Updated upstream
     'traveler_profiles': fields.List(fields.Nested(traveler_profile)),
-=======
     'asynchronous_ridesharing': fields.Boolean,
->>>>>>> Stashed changes
 }
 
 api_fields = {'id': fields.Raw, 'name': fields.Raw}

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -193,7 +193,11 @@ instance_fields = {
     'max_car_no_park_direct_path_duration': fields.Raw,
     'ridesharing_speed': fields.Raw,
     'max_ridesharing_duration_to_pt': fields.Raw,
+<<<<<<< Updated upstream
     'traveler_profiles': fields.List(fields.Nested(traveler_profile)),
+=======
+    'asynchronous_ridesharing': fields.Boolean,
+>>>>>>> Stashed changes
 }
 
 api_fields = {'id': fields.Raw, 'name': fields.Raw}

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -728,6 +728,13 @@ class Instance(flask_restful.Resource):
             location=('json', 'values'),
             default=instance.max_ridesharing_duration_to_pt,
         )
+        parser.add_argument(
+            'asynchronous_ridesharing',
+            type=inputs.boolean,
+            help='Active the asynchronous mode for ridesharing',
+            location=('json', 'values'),
+            default=instance.asynchronous_ridesharing,
+        )
 
         args = parser.parse_args()
 
@@ -800,6 +807,7 @@ class Instance(flask_restful.Resource):
                         'max_car_no_park_direct_path_duration',
                         'ridesharing_speed',
                         'max_ridesharing_duration_to_pt',
+                        'asynchronous_ridesharing',
                     ],
                 ),
                 maxlen=0,


### PR DESCRIPTION
### Objective

Make **Ridesharing** calls asynchronous. 
For that, we create an option that active the new mode. This mode is simple :

- We call a journeys with ridesharing option (_first_section_mode[] or last_section_mode[] =ridesharing_). 
- The response is a car response without ridesharing, but a link is added into the response to call the _new ridesharing API_ (Work in progress).

**JIRA**: https://jira.kisio.org/browse/NAVP-1646

### Activation

- By var env : **JORMUNGANDR_ASYNCHRONOUS_RIDESHARING**
- By a parameter, within the settings file : **ASYNCHRONOUS_RIDESHARING=True**
- By the Db field : **asynchronous_ridesharing** into instance table
- By a API parameter : **_asynchronous_ridesharing=True**

### Notes

- For the moment, the _**link is fake**_ because the ridesharing API doesn't exist
- Tyr is ready
