### PR TITLE
[Jormun] asynchronous ridesharing mode

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -24,9 +24,6 @@ SQLALCHEMY_DATABASE_URI = os.getenv(
 
 DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', False))
 
-# Active the asynchronous ridesharing mode
-ASYNCHRONOUS_RIDESHARING = boolean(os.getenv('JORMUNGANDR_ASYNCHRONOUS_RIDESHARING', False))
-
 # disable authentication
 PUBLIC = boolean(os.getenv('JORMUNGANDR_IS_PUBLIC', True))
 

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -24,6 +24,9 @@ SQLALCHEMY_DATABASE_URI = os.getenv(
 
 DISABLE_DATABASE = boolean(os.getenv('JORMUNGANDR_DISABLE_DATABASE', False))
 
+# Active the asynchronous ridesharing mode
+ASYNCHRONOUS_RIDESHARING = boolean(os.getenv('JORMUNGANDR_ASYNCHRONOUS_RIDESHARING', False))
+
 # disable authentication
 PUBLIC = boolean(os.getenv('JORMUNGANDR_IS_PUBLIC', True))
 

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -134,7 +134,6 @@ class Instance(object):
         self.georef = georef.Kraken(self)
         self.planner = planner.Kraken(self)
         self._streetnetwork_backend_manager = streetnetwork_backend_manager
-        self.asynchronous_ridesharing = False
 
         if app.config[str('DISABLE_DATABASE')]:
             self._streetnetwork_backend_manager.init_streetnetwork_backends_legacy(
@@ -172,12 +171,6 @@ class Instance(object):
                 app.config[str('EQUIPMENT_DETAILS_PROVIDERS')], self.get_providers_from_db
             )
 
-        # New ridesharing type
-        if app.config[str('DISABLE_DATABASE')]:
-            self.asynchronous_ridesharing = app.config[str('ASYNCHRONOUS_RIDESHARING')]
-        else:
-            self.asynchronous_ridesharing = self.get_asynchronous_ridesharing_from_db  # type: ignore
-
         # Init equipment providers from config
         self.equipment_provider_manager.init_providers(instance_equipment_providers)
 
@@ -186,11 +179,6 @@ class Instance(object):
         :return: a callable query of equipment providers associated to the current instance in db
         """
         return self._get_models().equipment_details_providers
-
-    def get_asynchronous_ridesharing_from_db(self):
-        # type: () -> bool
-        instance_db = self.get_models()
-        return get_value_or_default('asynchronous_ridesharing', instance_db, self.name)
 
     @property
     def autocomplete(self):
@@ -501,6 +489,12 @@ class Instance(object):
         # type: () -> int
         instance_db = self.get_models()
         return get_value_or_default('max_extra_second_pass', instance_db, self.name)
+
+    @property
+    def asynchronous_ridesharing(self):
+        # type: () -> bool
+        instance_db = self.get_models()
+        return get_value_or_default('asynchronous_ridesharing', instance_db, self.name)
 
     @property
     def max_nb_crowfly_by_mode(self):

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -134,6 +134,7 @@ class Instance(object):
         self.georef = georef.Kraken(self)
         self.planner = planner.Kraken(self)
         self._streetnetwork_backend_manager = streetnetwork_backend_manager
+        self.asynchronous_ridesharing = False
 
         if app.config[str('DISABLE_DATABASE')]:
             self._streetnetwork_backend_manager.init_streetnetwork_backends_legacy(
@@ -171,6 +172,12 @@ class Instance(object):
                 app.config[str('EQUIPMENT_DETAILS_PROVIDERS')], self.get_providers_from_db
             )
 
+        # New ridesharing type
+        if app.config[str('DISABLE_DATABASE')]:
+            self.asynchronous_ridesharing = app.config[str('ASYNCHRONOUS_RIDESHARING')]
+        else:
+            self.asynchronous_ridesharing = self.get_asynchronous_ridesharing_from_db  # type: ignore
+
         # Init equipment providers from config
         self.equipment_provider_manager.init_providers(instance_equipment_providers)
 
@@ -179,6 +186,11 @@ class Instance(object):
         :return: a callable query of equipment providers associated to the current instance in db
         """
         return self._get_models().equipment_details_providers
+
+    def get_asynchronous_ridesharing_from_db(self):
+        # type: () -> bool
+        instance_db = self.get_models()
+        return get_value_or_default('asynchronous_ridesharing', instance_db, self.name)
 
     @property
     def autocomplete(self):

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -458,9 +458,8 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "only_ridesharing",
             type=BooleanType(),
-            hidden=True,
             default=False,
-            help="active the asynchronous mode for the ridesharing services",
+            help="active ridesharing filter. We expose only ridesharing responses",
         )
         parser_get.add_argument(
             "_asynchronous_ridesharing",

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -30,7 +30,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, unicode_literals, division
-from jormungandr import i_manager, fallback_modes
+from jormungandr import i_manager, fallback_modes, partner_services
 from jormungandr.interfaces.v1.ResourceUri import ResourceUri
 from datetime import datetime
 from jormungandr.resources_utils import ResourceUtc
@@ -456,10 +456,11 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             help="define the duration to reach stop points by crow fly",
         )
         parser_get.add_argument(
-            "only_ridesharing",
-            type=BooleanType(),
-            default=False,
-            help="active ridesharing filter. We expose only ridesharing responses",
+            "partner_services[]",
+            type=OptionValue(partner_services.all_partner_services),
+            dest="partner_services",
+            action="append",
+            help='Expose only the partner type into the response.',
         )
         parser_get.add_argument(
             "_asynchronous_ridesharing",

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -455,6 +455,13 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             hidden=True,
             help="define the duration to reach stop points by crow fly",
         )
+        parser_get.add_argument(
+            "only_ridesharing",
+            type=BooleanType(),
+            hidden=True,
+            default=False,
+            help="active the asynchronous mode for the ridesharing services",
+        )
 
     def parse_args(self, region=None, uri=None):
         args = self.parsers['get'].parse_args()

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -462,6 +462,12 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             default=False,
             help="active the asynchronous mode for the ridesharing services",
         )
+        parser_get.add_argument(
+            "_asynchronous_ridesharing",
+            type=BooleanType(),
+            hidden=True,
+            help="active the asynchronous mode for the ridesharing services",
+        )
 
     def parse_args(self, region=None, uri=None):
         args = self.parsers['get'].parse_args()

--- a/source/jormungandr/jormungandr/partner_services.py
+++ b/source/jormungandr/jormungandr/partner_services.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2001-2020, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from enum import Enum
+
+
+# The different partner services
+class PartnerServices(Enum):
+    ridesharing = "ridesharing"
+
+    @classmethod
+    def modes_str(cls):
+        return {e.name for e in cls}
+
+    @classmethod
+    def modes_enum(cls):
+        return set(cls)
+
+
+all_partner_services = PartnerServices.modes_str()

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1189,14 +1189,14 @@ class Scenario(simple.Scenario):
             'ridesharing' in request['origin_mode'] or 'ridesharing' in request['destination_mode']
         ):
 
-            def active_asynchronous_ridesharing(request, instance):
+            def is_asynchronous_ridesharing(request, instance):
                 if request.get("_asynchronous_ridesharing", None) is None:
                     # when the param is not set in the request, use the instance config
                     return instance.asynchronous_ridesharing
                 else:
                     return request.get("_asynchronous_ridesharing")
 
-            if not active_asynchronous_ridesharing(request, instance) or request.get('only_ridesharing', False):
+            if not is_asynchronous_ridesharing(request, instance) or request.get('only_ridesharing', False):
                 logger.debug('trying to add ridesharing journeys')
                 try:
                     decorate_journeys_with_ridesharing_offers(pb_response, instance, request)

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1196,13 +1196,17 @@ class Scenario(simple.Scenario):
                 else:
                     return request.get("_asynchronous_ridesharing")
 
-            if not is_asynchronous_ridesharing(request, instance) or request.get('only_ridesharing', False):
+            def is_ridesharing_partner_service(request):
+                partner_services = request.get('partner_services', None)
+                return partner_services is not None and 'ridesharing' in partner_services
+
+            if not is_asynchronous_ridesharing(request, instance) or is_ridesharing_partner_service(request):
                 logger.debug('trying to add ridesharing journeys')
                 try:
                     decorate_journeys_with_ridesharing_offers(pb_response, instance, request)
                 except Exception:
                     logger.exception('Error while retrieving ridesharing ads')
-                if request.get('only_ridesharing', False):
+                if is_ridesharing_partner_service(request):
                     for j in pb_response.journeys:
                         if not 'ridesharing' in j.tags:
                             journey_filter.mark_as_dead(j, request.get('debug'), 'only_ridesharing_option')

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1097,19 +1097,8 @@ class Scenario(simple.Scenario):
         compute_car_co2_emission(pb_resp, api_request, instance, "{}_car_co2".format(request_id))
         tag_journeys(pb_resp)
 
-        if instance.ridesharing_services and (
-            'ridesharing' in ridesharing_req['origin_mode']
-            or 'ridesharing' in ridesharing_req['destination_mode']
-        ):
-            logger.debug('trying to add ridesharing journeys')
-            try:
-                decorate_journeys(pb_resp, instance, api_request)
-            except Exception:
-                logger.exception('Error while retrieving ridesharing ads')
-        else:
-            for j in pb_resp.journeys:
-                if 'ridesharing' in j.tags:
-                    journey_filter.mark_as_dead(j, api_request.get('debug'), 'no_matching_ridesharing_found')
+        # Handle ridesharing service
+        self.handle_ridesharing_services(logger, instance, ridesharing_req, pb_resp)
 
         journey_filter.delete_journeys((pb_resp,), api_request)
         type_journeys(pb_resp, api_request)
@@ -1193,6 +1182,31 @@ class Scenario(simple.Scenario):
                 del resp.journeys[request["max_nb_journeys"] :]
 
         return resp
+
+    def handle_ridesharing_services(self, logger, instance, request, pb_response):
+
+        if instance.ridesharing_services and (
+            'ridesharing' in request['origin_mode'] or 'ridesharing' in request['destination_mode']
+        ):
+            if not instance.asynchronous_ridesharing or request.get('only_ridesharing', False):
+                logger.debug('trying to add ridesharing journeys')
+                try:
+                    decorate_journeys(pb_response, instance, request)
+                except Exception:
+                    logger.exception('Error while retrieving ridesharing ads')
+                if request.get('only_ridesharing', False):
+                    for j in pb_response.journeys:
+                        if not 'ridesharing' in j.tags:
+                            journey_filter.mark_as_dead(j, request.get('debug'), 'only_ridesharing_option')
+            else:
+                for j in pb_response.journeys:
+                    if 'ridesharing' in j.tags:
+                        journey_filter.mark_as_dead(j, request.get('debug'), 'asynchrnous_ridesharing_mode')
+            self._add_ridesharing_link(pb_response, request)
+        else:
+            for j in pb_response.journeys:
+                if 'ridesharing' in j.tags:
+                    journey_filter.mark_as_dead(j, request.get('debug'), 'no_matching_ridesharing_found')
 
     def create_next_kraken_request(self, request, responses):
         """

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_helper.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_helper.py
@@ -49,7 +49,7 @@ def _make_pb_fp(fp):
     return pb_fp
 
 
-def decorate_journeys(response, instance, request):
+def decorate_journeys_with_ridesharing_offers(response, instance, request):
     # TODO: disable same journey schedule link for ridesharing journey?
     for journey in response.journeys:
         if 'ridesharing' not in journey.tags or to_be_deleted(journey):

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -326,7 +326,7 @@ class Scenario(object):
 
     def _add_ridesharing_link(self, resp, params):
         req = request.args.to_dict(flat=False)
-        req['only_ridesharing'] = 'True'
+        req['partner_services[]'] = 'ridesharing'
         req['datetime'] = dt_to_str(params.original_datetime)
         add_link(resp, rel='ridesharing_journeys', **req)
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -324,6 +324,12 @@ class Scenario(object):
     def isochrone(self, request, instance):
         raise NotImplementedError()
 
+    def _add_ridesharing_link(self, resp, params):
+        req = request.args.to_dict(flat=False)
+        req['only_ridesharing'] = 'True'
+        req['datetime'] = dt_to_str(params.original_datetime)
+        add_link(resp, rel='ridesharing_journeys', **req)
+
     def _add_prev_link(self, resp, params, clockwise):
         prev_dt = self.previous_journey_datetime(resp.journeys, clockwise)
         if prev_dt is not None:

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -2306,6 +2306,31 @@ class JourneysRidesharing:
             float(rs_section["to"]["address"]["coord"]["lat"])
         )
 
+    def test_asynchronous_ridesharing_mode(self):
+        query = (
+            "journeys?from=0.0000898312;0.0000898312&to=0.00188646;0.000449156&datetime=20120614T075500&"
+            "first_section_mode[]={first}&last_section_mode[]={last}&debug=true&_asynchronous_ridesharing=True".format(
+                first='ridesharing', last='walking'
+            )
+        )
+        response = self.query_region(query)
+        check_best(response)
+        assert len(response["journeys"]) == 1
+        assert response["journeys"][0]["type"] == "best"
+        rs_journey = response["journeys"][0]
+        assert "ridesharing" in rs_journey["tags"]
+        rs_section = rs_journey["sections"][0]
+        assert rs_section["mode"] == "ridesharing"
+        assert rs_section["type"] == "street_network"
+        # A link is added to call the new ridesharing API
+        links = response["links"]
+        link_is_present = False
+        for link in links:
+            if "ridesharing" in link["rel"]:
+                link_is_present = True
+                break
+        assert link_is_present
+
     def test_first_ridesharing_section_mode_forbidden(self):
         def exec_and_check(query):
             response, status = self.query_region(query, check=False)

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -172,6 +172,8 @@ here_max_matrix_points = 100
 
 stop_points_nearby_duration = 5 * 60  # In secs
 
+asynchronous_ridesharing = False
+
 
 def get_value_or_default(attr, instance, instance_name):
     if not instance or getattr(instance, attr, None) == None:

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -543,6 +543,9 @@ class Instance(db.Model):  # type: ignore
         server_default=str(default_values.stop_points_nearby_duration),
     )
 
+    # Active the asynchronous_ridesharing mode
+    asynchronous_ridesharing = db.Column(db.Boolean, default=False, nullable=False)
+
     def __init__(self, name=None, is_free=False, authorizations=None, jobs=None):
         self.name = name
         self.is_free = is_free

--- a/source/tyr/migrations/versions/5127fcffb248_add_asynchronous_ridesharing_mode.py
+++ b/source/tyr/migrations/versions/5127fcffb248_add_asynchronous_ridesharing_mode.py
@@ -1,4 +1,4 @@
-"""add synchronous ridesharing option
+"""add asynchronous ridesharing option
 
 Revision ID: 5127fcffb248
 Revises: b413ec1e3bbc

--- a/source/tyr/migrations/versions/5127fcffb248_add_asynchronous_ridesharing_mode.py
+++ b/source/tyr/migrations/versions/5127fcffb248_add_asynchronous_ridesharing_mode.py
@@ -1,0 +1,25 @@
+"""add synchronous ridesharing option
+
+Revision ID: 5127fcffb248
+Revises: b413ec1e3bbc
+Create Date: 2020-09-15 15:16:26.651648
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5127fcffb248'
+down_revision = 'b413ec1e3bbc'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column(
+        'instance',
+        sa.Column('asynchronous_ridesharing', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade():
+    op.drop_column('instance', 'asynchronous_ridesharing')

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -194,6 +194,7 @@ instance_fields = {
     'ridesharing_speed': fields.Raw,
     'max_ridesharing_duration_to_pt': fields.Raw,
     'traveler_profiles': fields.List(fields.Nested(traveler_profile)),
+    'asynchronous_ridesharing': fields.Boolean,
 }
 
 api_fields = {'id': fields.Raw, 'name': fields.Raw}

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -728,6 +728,13 @@ class Instance(flask_restful.Resource):
             location=('json', 'values'),
             default=instance.max_ridesharing_duration_to_pt,
         )
+        parser.add_argument(
+            'asynchronous_ridesharing',
+            type=inputs.boolean,
+            help='Active the asynchronous mode for ridesharing',
+            location=('json', 'values'),
+            default=instance.asynchronous_ridesharing,
+        )
 
         args = parser.parse_args()
 
@@ -800,6 +807,7 @@ class Instance(flask_restful.Resource):
                         'max_car_no_park_direct_path_duration',
                         'ridesharing_speed',
                         'max_ridesharing_duration_to_pt',
+                        'asynchronous_ridesharing',
                     ],
                 ),
                 maxlen=0,


### PR DESCRIPTION
## Final Objective

**Confluence**: https://confluence.kisio.org/display/NAV/Covoiturage+%3A+le+RideSharing+dans+Navitia
**JIRA**: https://jira.kisio.org/browse/NAVP-1660

### Current mode
We have added the new _ridesharing_journeys_ link

![old_ridesharing](https://user-images.githubusercontent.com/32099204/93336912-ad69e500-f828-11ea-9966-d3d947a3bd44.png)

### New mode

**first call** is the same response of the _current mode_ without ridesharing journeys (you have to click on the link)
![first_new_ridesharing](https://user-images.githubusercontent.com/32099204/93336928-b490f300-f828-11ea-9b08-43d36ae18bb4.png)

when you click on **ridesharing_jouneys link**, it calls the same request with a additional parameter **"partner_services=ridesharing"**.
It returns only the ridesharing journeys.
![second_new_ridesharing](https://user-images.githubusercontent.com/32099204/93336938-b8247a00-f828-11ea-9896-4be8237a37ff.png)

finally, the request time consumption is now during the second call (via the ridesharing_journeys link)

## new mode activation (for the migration)
By the Db field : asynchronous_ridesharing into instance table (navitia_configurator field :heart:)
By a API parameter : _asynchronous_ridesharing=True (for tests purpose)

## Notes

- whether old or new mode, a link is added (ridesharing_journeys) to call only ridesharing response
- Tyr is ready
- There is a debate around the parameter name : **"partner_services[]=ridesharing"**. It is open, feel free to propose a different name (@stifoon @wassimbenaissa and more)