### PR TITLE
[Bug] prevent use-after-free caused by a disruption

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -95,7 +95,7 @@ void disrupt(ed::builder& b,
                            .tag_if_not_empty(pertub_tag)
                            .impact()
                            .severity(effect)
-                           .on(pt_obj_type, pt_obj_name)
+                           .on(pt_obj_type, pt_obj_name, *b.data->pt_data)
                            .application_periods(period)
                            .publish(period)
                            .get_disruption();
@@ -145,21 +145,21 @@ public:
             .publish(btp("20131219T123200"_dt, "20131221T123201"_dt))
             .application_periods(btp("20131220T123200"_dt, "20131221T123201"_dt))
             .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-            .on(nt::Type_e::Line, "line:A");
+            .on(nt::Type_e::Line, "line:A", *b.data->pt_data);
 
         b.impact(nt::RTLevel::Adapted)
             .uri("mess0")
             .publish(btp("20131221T083200"_dt, "20131221T123201"_dt))
             .application_periods(btp("20131221T083200"_dt, "20131221T123201"_dt))
             .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-            .on(nt::Type_e::Line, "line:S");
+            .on(nt::Type_e::Line, "line:S", *b.data->pt_data);
 
         b.impact(nt::RTLevel::Adapted)
             .uri("mess2")
             .application_periods(btp("20131223T123200"_dt, "20131225T123201"_dt))
             .publish(btp("20131224T123200"_dt, "20131226T123201"_dt))
             .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-            .on(nt::Type_e::Network, "network:K");
+            .on(nt::Type_e::Network, "network:K", *b.data->pt_data);
     }
 };
 
@@ -333,7 +333,7 @@ struct DisruptedNetwork {
                                       .severity(nt::disruption::Effect::NO_SERVICE)
                                       .application_periods(period)
                                       .publish(period)
-                                      .on_line_section("line_3", "sp3_2", "sp3_3", {"route_3"})
+                                      .on_line_section("line_3", "sp3_2", "sp3_3", {"route_3"}, *b.data->pt_data)
                                       .get_disruption(),
                                   *b.data->pt_data, *b.data->meta);
 

--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -484,16 +484,17 @@ Impacter& Impacter::severity(const std::string& uri) {
     return *this;
 }
 
-Impacter& Impacter::on(nt::Type_e type, const std::string& uri) {
+Impacter& Impacter::on(nt::Type_e type, const std::string& uri, nt::PT_Data& pt_data) {
     dis::Impact::link_informed_entity(dis::make_pt_obj(type, uri, *b.data->pt_data), impact,
-                                      b.data->meta->production_date, get_disruption().rt_level);
+                                      b.data->meta->production_date, get_disruption().rt_level, pt_data);
     return *this;
 }
 
 Impacter& Impacter::on_line_section(const std::string& line_uri,
                                     const std::string& start_stop_uri,
                                     const std::string& end_stop_uri,
-                                    const std::vector<std::string>& route_uris) {
+                                    const std::vector<std::string>& route_uris,
+                                    nt::PT_Data& pt_data) {
     // Note: don't forget to set the application period before calling this method for the correct
     // vehicle_journeys to be impacted
 
@@ -509,7 +510,7 @@ Impacter& Impacter::on_line_section(const std::string& line_uri,
     }
 
     dis::Impact::link_informed_entity(std::move(line_section), impact, b.data->meta->production_date,
-                                      get_disruption().rt_level);
+                                      get_disruption().rt_level, pt_data);
     return *this;
 }
 

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -232,12 +232,13 @@ struct Impacter {
                        const std::string& color = "#FFFF00",
                        int priority = 0);
 
-    Impacter& severity(const std::string& uri);             // link to existing severity
-    Impacter& on(nt::Type_e type, const std::string& uri);  // add elt in informed_entities
+    Impacter& severity(const std::string& uri);                                   // link to existing severity
+    Impacter& on(nt::Type_e type, const std::string& uri, nt::PT_Data& pt_data);  // add elt in informed_entities
     Impacter& on_line_section(const std::string& line_uri,
                               const std::string& start_stop_uri,
                               const std::string& end_stop_uri,
-                              const std::vector<std::string>& route_uris);  // add section in informed_entities
+                              const std::vector<std::string>& route_uris,
+                              nt::PT_Data& pt_data);  // add section in informed_entities
     Impacter& msg(nt::disruption::Message);
     Impacter& msg(const std::string& text, nt::disruption::ChannelType = nt::disruption::ChannelType::email);
     Impacter& publish(const boost::posix_time::time_period& p);

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -370,7 +370,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
         // Loop on each affected vj
         for (auto& impacted_vj : impacted_vjs) {
             std::vector<nt::StopTime> new_stop_times;
-            std::string& vj_uri = impacted_vj.vj_uri;
+            const std::string& vj_uri = impacted_vj.vj_uri;
             LOG4CPLUS_TRACE(log, "Impacted vj : " << vj_uri);
             auto vj_iterator = pt_data.vehicle_journeys_map.find(vj_uri);
             if (vj_iterator == pt_data.vehicle_journeys_map.end()) {

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -370,10 +370,16 @@ struct add_impacts_visitor : public apply_impacts_visitor {
         // Loop on each affected vj
         for (auto& impacted_vj : impacted_vjs) {
             std::vector<nt::StopTime> new_stop_times;
-            const auto* vj = impacted_vj.vj;
+            std::string& vj_uri = impacted_vj.vj_uri;
+            LOG4CPLUS_TRACE(log, "Impacted vj : " << vj_uri);
+            auto vj_iterator = pt_data.vehicle_journeys_map.find(vj_uri);
+            if (vj_iterator == pt_data.vehicle_journeys_map.end()) {
+                LOG4CPLUS_TRACE(log, "impacted vj : " << vj_uri << " not found in data. I ignore it.");
+                continue;
+            }
+            nt::VehicleJourney* vj = vj_iterator->second;
             auto& new_vp = impacted_vj.new_vp;
 
-            LOG4CPLUS_TRACE(log, "Impacted vj : " << vj->uri);
             for (const auto& st : vj->stop_time_list) {
                 // We need to get the associated base stop_time to compare its rank
                 const auto base_st = st.get_base_stop_time();

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -373,6 +373,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             const auto* vj = impacted_vj.vj;
             auto& new_vp = impacted_vj.new_vp;
 
+            LOG4CPLUS_TRACE(log, "Impacted vj : " << vj->uri);
             for (const auto& st : vj->stop_time_list) {
                 // We need to get the associated base stop_time to compare its rank
                 const auto base_st = st.get_base_stop_time();
@@ -405,6 +406,8 @@ struct add_impacts_visitor : public apply_impacts_visitor {
 
             new_vp.days = new_vp.days & (vj->validity_patterns[rt_level]->days >> vj->shift);
 
+            LOG4CPLUS_TRACE(log, "meta_vj : " << mvj->uri << " \n  old_vj: " << vj->uri
+                                              << " to be deleted \n new_vj_uri " << new_vj_uri);
             auto* new_vj =
                 create_vj_from_old_vj(mvj, vj, new_vj_uri, rt_level, new_vp, std::move(new_stop_times), pt_data);
             vj = nullptr;  // after the call to create_vj, vj may have been deleted :(

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -302,7 +302,7 @@ static boost::shared_ptr<nt::disruption::Impact> make_impact(const chaos::Impact
 
     for (auto& ptobj : make_pt_objects(chaos_impact.informed_entities(), pt_data)) {
         nt::disruption::Impact::link_informed_entity(std::move(ptobj), impact, meta.production_date,
-                                                     nt::RTLevel::Adapted);
+                                                     nt::RTLevel::Adapted, pt_data);
     }
     for (const auto& chaos_message : chaos_impact.messages()) {
         const auto& channel = chaos_message.channel();

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -595,7 +595,7 @@ static const type::disruption::Disruption* create_disruption(const std::string& 
         impact->severity = make_severity(id, std::move(wording), trip_effect, timestamp, holder);
         nd::Impact::link_informed_entity(
             nd::make_pt_obj(nt::Type_e::MetaVehicleJourney, trip_update.trip().trip_id(), *data.pt_data), impact,
-            data.meta->production_date, nt::RTLevel::RealTime);
+            data.meta->production_date, nt::RTLevel::RealTime, *data.pt_data);
         // messages
         disruption.add_impact(impact, holder);
     }

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -80,7 +80,7 @@ static void test_vjs_indexes(const std::vector<navitia::type::VehicleJourney*>& 
 BOOST_FIXTURE_TEST_CASE(simple_train_cancellation, SimpleDataset) {
     const auto& disrup = b.impact(nt::RTLevel::RealTime)
                              .severity(nt::disruption::Effect::NO_SERVICE)
-                             .on(nt::Type_e::MetaVehicleJourney, "vj:A-1")
+                             .on(nt::Type_e::MetaVehicleJourney, "vj:A-1", *b.data->pt_data)
                              .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                              .get_disruption();
 
@@ -224,7 +224,7 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_stops_different_hours) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "S2_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "S2")
+                                  .on(nt::Type_e::StopPoint, "S2", *b.data->pt_data)
                                   .application_periods(btp("20160101T100000"_dt, "20160101T1120001"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_stops_different_hours) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "S3_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "S3")
+                                  .on(nt::Type_e::StopPoint, "S3", *b.data->pt_data)
                                   .application_periods(btp("20160101T110000"_dt, "20160101T1400001"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE(add_impact_on_stop_area) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_area:stop1_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopArea, "stop_area:stop1")
+                                  .on(nt::Type_e::StopArea, "stop_area:stop1", *b.data->pt_data)
                                   .application_periods(btp("20120614T173200"_dt, "20120618T123200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(add_impact_on_stop_area_with_several_stop_point) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_area_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopArea, "stop_area")
+                                  .on(nt::Type_e::StopArea, "stop_area", *b.data->pt_data)
                                   .application_periods(btp("20120614T173200"_dt, "20120618T123200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_CASE(add_stop_area_impact_on_vj_pass_midnight) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_area_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopArea, "stop_area")
+                                  .on(nt::Type_e::StopArea, "stop_area", *b.data->pt_data)
                                   .application_periods(btp("20120615T000000"_dt, "20120618T000000"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -472,7 +472,7 @@ BOOST_AUTO_TEST_CASE(add_stop_point_impact_check_vp_filtering_last_day) {
     // Close stop_point:20 from the 4h at 9am to the 6h at 8:59am
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_point:20_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop_point:20")
+                                  .on(nt::Type_e::StopPoint, "stop_point:20", *b.data->pt_data)
                                   .application_periods(btp("20160404T090000"_dt, "20160406T085900"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(add_impact_with_sevral_application_period) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop3_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop3")
+                                  .on(nt::Type_e::StopPoint, "stop3", *b.data->pt_data)
                                   // 2012/6/14 7h -> 2012/6/17 6h
                                   .application_periods(btp("20120614T070000"_dt, "20120617T060000"_dt))
                                   // 2012/6/17 23h -> 2012/6/18 6h
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(remove_stop_point_impact) {
 
     const auto& disruption = b.impact(nt::RTLevel::Adapted, "stop3_closed")
                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                 .on(nt::Type_e::StopPoint, "stop3")
+                                 .on(nt::Type_e::StopPoint, "stop3", *b.data->pt_data)
                                  // 2012/6/14 7h -> 2012/6/17 6h
                                  .application_periods(btp("20120614T070000"_dt, "20120617T060000"_dt))
                                  // 2012/6/17 23h -> 2012/6/18 6h
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(remove_all_stop_point) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop1_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop1")
+                                  .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
                                   // 2012/6/14 8h00 -> 2012/6/19 8h05
                                   .application_periods(btp("20120614T080000"_dt, "20120619T080500"_dt))
                                   .get_disruption(),
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(remove_all_stop_point) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop2_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop2")
+                                  .on(nt::Type_e::StopPoint, "stop2", *b.data->pt_data)
                                   // 2012/6/14 8h15 -> 2012/6/19 8h17
                                   .application_periods(btp("20120614T081500"_dt, "20120619T081700"_dt))
                                   .get_disruption(),
@@ -641,7 +641,7 @@ BOOST_AUTO_TEST_CASE(remove_all_stop_point) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop3_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop3")
+                                  .on(nt::Type_e::StopPoint, "stop3", *b.data->pt_data)
                                   // 2012/6/14 8h45 -> 2012/6/19 8h47
                                   .application_periods(btp("20120614T084500"_dt, "20120619T084700"_dt))
                                   .get_disruption(),
@@ -703,7 +703,7 @@ BOOST_AUTO_TEST_CASE(stop_point_no_service_with_shift) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "stop2_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop2")
+                                  .on(nt::Type_e::StopPoint, "stop2", *b.data->pt_data)
                                   .application_periods(btp("20120617T000000"_dt, "20120617T080500"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -779,7 +779,7 @@ BOOST_AUTO_TEST_CASE(test_shift_of_a_disrupted_delayed_train) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "stop1_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop1")
+                                  .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
                                   .application_periods(btp("20120617T2200"_dt, "20120618T0000"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -863,7 +863,7 @@ BOOST_AUTO_TEST_CASE(disrupted_stop_point_then_delayed) {
     // Stop1 is closed between 2012/06/16 22:00 and 2012/06/16 23:30
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "stop1_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop1")
+                                  .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
                                   .application_periods(btp("20120616T2200"_dt, "20120616T2330"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -958,7 +958,7 @@ BOOST_AUTO_TEST_CASE(same_stop_point_on_vj) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop1_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop1")
+                                  .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
                                   .application_periods(btp("20120615T100000"_dt, "20120617T100000"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -1030,35 +1030,35 @@ BOOST_AUTO_TEST_CASE(stop_point_deletion_test) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_point_B2_closed_3")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "B2")
+                                  .on(nt::Type_e::StopPoint, "B2", *b.data->pt_data)
                                   .application_periods(btp("20120616T080000"_dt, "20120616T203200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_point_B3_closed_3")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "B3")
+                                  .on(nt::Type_e::StopPoint, "B3", *b.data->pt_data)
                                   .application_periods(btp("20120616T080000"_dt, "20120616T203200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_area_closed_1")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopArea, "stop_area")
+                                  .on(nt::Type_e::StopArea, "stop_area", *b.data->pt_data)
                                   .application_periods(btp("20120618T080000"_dt, "20120618T173200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_area_closed_2")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopArea, "stop_area")
+                                  .on(nt::Type_e::StopArea, "stop_area", *b.data->pt_data)
                                   .application_periods(btp("20120615T080000"_dt, "20120615T173200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "stop_area_closed_3")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopArea, "stop_area")
+                                  .on(nt::Type_e::StopArea, "stop_area", *b.data->pt_data)
                                   .application_periods(btp("20120614T080000"_dt, "20120614T173200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -1109,12 +1109,13 @@ BOOST_AUTO_TEST_CASE(add_simple_impact_on_line_section) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2016, 4, 4), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20160404T120000"_dt, "20160406T090000"_dt))
-                                  .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20160404T120000"_dt, "20160406T090000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1216,7 +1217,7 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
                                   .severity(nt::disruption::Effect::NO_SERVICE)
                                   .application_periods(btp("20160404T080000"_dt, "20160406T230000"_dt))
                                   .publish(btp("20160404T080000"_dt, "20160406T090000"_dt))
-                                  .on_line_section("line:1", "B", "C", {"line:1:0"})
+                                  .on_line_section("line:1", "B", "C", {"line:1:0"}, *b.data->pt_data)
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
@@ -1258,7 +1259,7 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
                                   .severity(nt::disruption::Effect::NO_SERVICE)
                                   .application_periods(btp("20160404T080000"_dt, "20160406T230000"_dt))
                                   .publish(btp("20160404T080000"_dt, "20160406T090000"_dt))
-                                  .on_line_section("line:1", "E", "F", {"line:1:0"})
+                                  .on_line_section("line:1", "E", "F", {"line:1:0"}, *b.data->pt_data)
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
@@ -1298,7 +1299,7 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
                                   .severity(nt::disruption::Effect::NO_SERVICE)
                                   .application_periods(btp("20160404T080000"_dt, "20160406T230000"_dt))
                                   .publish(btp("20160404T080000"_dt, "20160406T090000"_dt))
-                                  .on_line_section("line:1", "B", "G", {"line:1:0"})
+                                  .on_line_section("line:1", "B", "G", {"line:1:0"}, *b.data->pt_data)
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
@@ -1347,12 +1348,13 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_with_vj_pass_midnight) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2016, 4, 4), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20160405T003000"_dt, "20160406T090000"_dt))
-                                  .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20160405T003000"_dt, "20160406T090000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1405,12 +1407,13 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_cancelling_vj) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2016, 4, 4), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on_line_section("line:A", "stop_area:1", "stop_area:4", {"line:A:0"})
-                                  .application_periods(btp("20160404T000000"_dt, "20160406T230000"_dt))
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .on_line_section("line:A", "stop_area:1", "stop_area:4", {"line:A:0"}, *b.data->pt_data)
+            .application_periods(btp("20160404T000000"_dt, "20160406T230000"_dt))
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1504,13 +1507,13 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2016, 4, 4), bg::days(7));
 
-    navitia::apply_disruption(
-        b.impact(nt::RTLevel::Adapted, "line_section_sa1_sa5_routesA1-2-3")
-            .severity(nt::disruption::Effect::NO_SERVICE)
-            .application_periods(btp("20160404T000000"_dt, "20160409T240000"_dt))
-            .on_line_section("line:A", "stop_area:2", "stop_area:5", {"route:A1", "route:A2", "route:A3"})
-            .get_disruption(),
-        *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_sa1_sa5_routesA1-2-3")
+                                  .severity(nt::disruption::Effect::NO_SERVICE)
+                                  .application_periods(btp("20160404T000000"_dt, "20160409T240000"_dt))
+                                  .on_line_section("line:A", "stop_area:2", "stop_area:5",
+                                                   {"route:A1", "route:A2", "route:A3"}, *b.data->pt_data)
+                                  .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 4);
     // Only 6 vj, vj:3 shouldn't be affected by the section, vj:4 shouldn't be affected since the route isn't
@@ -1696,24 +1699,26 @@ BOOST_AUTO_TEST_CASE(add_multiple_impact_on_line_section) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2016, 4, 4), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_stop:area4-5")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on_line_section("line:A", "stop_area:4", "stop_area:5", {"line:A:0"})
-                                  .application_periods(btp("20160404T000000"_dt, "20160406T103500"_dt))
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_stop:area4-5")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .on_line_section("line:A", "stop_area:4", "stop_area:5", {"line:A:0"}, *b.data->pt_data)
+            .application_periods(btp("20160404T000000"_dt, "20160406T103500"_dt))
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
     // Only the first 2 vj should be impacted since vj:3 starts on the 6th but pass at stop_area:4 at 10:40am
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 5);
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_stop:area3-4")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on_line_section("line:A", "stop_area:3", "stop_area:4", {"line:A:0"})
-                                  .application_periods(btp("20160405T090000"_dt, "20160407T083500"_dt))
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_stop:area3-4")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .on_line_section("line:A", "stop_area:3", "stop_area:4", {"line:A:0"}, *b.data->pt_data)
+            .application_periods(btp("20160405T090000"_dt, "20160407T083500"_dt))
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 8);
 
@@ -1789,7 +1794,7 @@ BOOST_AUTO_TEST_CASE(update_impact) {
     const auto& disruption_1 = b.impact(nt::RTLevel::Adapted, "stop3_closed")
                                    .severity(nt::disruption::Effect::NO_SERVICE)
                                    .msg(disruption_message_1)
-                                   .on(nt::Type_e::StopPoint, "stop3")
+                                   .on(nt::Type_e::StopPoint, "stop3", *b.data->pt_data)
                                    // 2012/6/14 7h -> 2012/6/17 6h
                                    .application_periods(btp("20120614T070000"_dt, "20120617T060000"_dt))
                                    // 2012/6/17 23h -> 2012/6/18 6h
@@ -1800,7 +1805,7 @@ BOOST_AUTO_TEST_CASE(update_impact) {
 
     const auto& disruption_2 = b.impact(nt::RTLevel::Adapted, "stop2_closed")
                                    .severity(nt::disruption::Effect::NO_SERVICE)
-                                   .on(nt::Type_e::StopPoint, "stop2")
+                                   .on(nt::Type_e::StopPoint, "stop2", *b.data->pt_data)
                                    // 2012/6/14 7h -> 2012/6/17 6h
                                    .application_periods(btp("20120614T070000"_dt, "20120617T060000"_dt))
                                    // 2012/6/17 23h -> 2012/6/18 6h
@@ -1847,12 +1852,13 @@ BOOST_AUTO_TEST_CASE(impact_with_boarding_alighting_times) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
-                                  .application_periods(btp("20170101T120000"_dt, "20170131T000000"_dt))
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .application_periods(btp("20170101T120000"_dt, "20170131T000000"_dt))
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1905,12 +1911,13 @@ BOOST_AUTO_TEST_CASE(impact_lollipop_with_boarding_alighting_times) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on_line_section("line:A", "stop_area:3", "stop_area:3", {"line:A:0"})
-                                  .application_periods(btp("20170101T120000"_dt, "20170131T000000"_dt))
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .on_line_section("line:A", "stop_area:3", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .application_periods(btp("20170101T120000"_dt, "20170131T000000"_dt))
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -1965,7 +1972,7 @@ BOOST_AUTO_TEST_CASE(test_delay_on_line_does_nothing) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "lineA_delayed")
                                   .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                                  .on(nt::Type_e::Line, "A")
+                                  .on(nt::Type_e::Line, "A", *b.data->pt_data)
                                   .application_periods(btp("20120617T2200"_dt, "20120618T0000"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -2003,7 +2010,7 @@ BOOST_AUTO_TEST_CASE(test_indexes_after_applying_disruption) {
     // Only appliable on vj:2
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption_C")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "C")
+                                  .on(nt::Type_e::StopPoint, "C", *b.data->pt_data)
                                   .application_periods(btp("20170101T100000"_dt, "20170101T110000"_dt))
                                   .publish(btp("20170101T100000"_dt, "20170101T110000"_dt))
                                   .msg("Disruption on stop_point C")
@@ -2015,7 +2022,7 @@ BOOST_AUTO_TEST_CASE(test_indexes_after_applying_disruption) {
     // Only appliable on vj:3
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption_C1")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "C")
+                                  .on(nt::Type_e::StopPoint, "C", *b.data->pt_data)
                                   .application_periods(btp("20170101T110000"_dt, "20170101T235900"_dt))
                                   .publish(btp("20170101T110000"_dt, "20170101T235900"_dt))
                                   .msg("Disruption on stop_point C")
@@ -2027,7 +2034,7 @@ BOOST_AUTO_TEST_CASE(test_indexes_after_applying_disruption) {
     // Only appliable on vj:2, and will trigger the cleaning up of vj and the re-indexing of vj
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption_D")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "D")
+                                  .on(nt::Type_e::StopPoint, "D", *b.data->pt_data)
                                   .application_periods(btp("20170101T100000"_dt, "20170101T110000"_dt))
                                   .publish(btp("20170101T100000"_dt, "20170101T110000"_dt))
                                   .msg("Disruption on stop_point D")
@@ -2063,7 +2070,7 @@ BOOST_AUTO_TEST_CASE(significant_delay_on_stop_point_dont_remove_it) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "B_delayed")
                                   .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-                                  .on(nt::Type_e::StopPoint, "B")
+                                  .on(nt::Type_e::StopPoint, "B", *b.data->pt_data)
                                   .application_periods(btp("20170101T000000"_dt, "20170120T1120000"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -2091,14 +2098,14 @@ BOOST_AUTO_TEST_CASE(test_realtime_disruption_on_line_then_stop_point) {
      */
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Line A : penguins on the line")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::Line, "A")
+                                  .on(nt::Type_e::Line, "A", *b.data->pt_data)
                                   .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Fire at Montparnasse")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stopA2")
+                                  .on(nt::Type_e::StopPoint, "stopA2", *b.data->pt_data)
                                   .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -2115,8 +2122,8 @@ BOOST_AUTO_TEST_CASE(test_realtime_disruption_on_line_then_stop_point) {
      */
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "Penguins on fire at Montparnasse")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::Line, "B")
-                                  .on(nt::Type_e::StopPoint, "stopB2")
+                                  .on(nt::Type_e::Line, "B", *b.data->pt_data)
+                                  .on(nt::Type_e::StopPoint, "stopB2", *b.data->pt_data)
                                   .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -2134,7 +2141,7 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Penguins on fire at Montparnasse")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stopA2")
+                                  .on(nt::Type_e::StopPoint, "stopA2", *b.data->pt_data)
                                   .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -2158,7 +2165,7 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "coffee spilled on the line")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::Line, "A")
+                                  .on(nt::Type_e::Line, "A", *b.data->pt_data)
                                   .application_periods(btp("20120617T1000"_dt, "20120617T1200"_dt))
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
@@ -2195,12 +2202,12 @@ BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_same_vj) {
     dis_builder.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:2", "stop_area:2", {"line:A:0"});
+        .on_line_section("line:A", "stop_area:2", "stop_area:2", {"line:A:0"}, *b.data->pt_data);
 
     dis_builder.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:4", "stop_area:4", {"line:A:0"});
+        .on_line_section("line:A", "stop_area:4", "stop_area:4", {"line:A:0"}, *b.data->pt_data);
 
     navitia::apply_disruption(dis_builder.disruption, *b.data->pt_data, *b.data->meta);
 
@@ -2226,12 +2233,12 @@ BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_same_vj) {
     dis_builder_update.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:2", "stop_area:2", {"line:A:0"});
+        .on_line_section("line:A", "stop_area:2", "stop_area:2", {"line:A:0"}, *b.data->pt_data);
 
     dis_builder_update.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:4", "stop_area:4", {"line:A:0"});
+        .on_line_section("line:A", "stop_area:4", "stop_area:4", {"line:A:0"}, *b.data->pt_data);
 
     navitia::apply_disruption(dis_builder_update.disruption, *b.data->pt_data, *b.data->meta);
 
@@ -2279,12 +2286,12 @@ BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_different_vj) {
     dis_builder.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:2", "stop_area:4", {"line:A:0"});
+        .on_line_section("line:A", "stop_area:2", "stop_area:4", {"line:A:0"}, *b.data->pt_data);
 
     dis_builder.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:4", "stop_area:2", {"line:A:1"});
+        .on_line_section("line:A", "stop_area:4", "stop_area:2", {"line:A:1"}, *b.data->pt_data);
 
     navitia::apply_disruption(dis_builder.disruption, *b.data->pt_data, *b.data->meta);
 
@@ -2308,12 +2315,12 @@ BOOST_AUTO_TEST_CASE(update_disruption_with_multiple_impact_on_different_vj) {
     dis_builder_update.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:2", "stop_area:4", {"line:A:0"});
+        .on_line_section("line:A", "stop_area:2", "stop_area:4", {"line:A:0"}, *b.data->pt_data);
 
     dis_builder_update.impact()
         .severity(nt::disruption::Effect::NO_SERVICE)
         .application_periods(btp("20190301T000000"_dt, "20190305T000000"_dt))
-        .on_line_section("line:A", "stop_area:4", "stop_area:2", {"line:A:1"});
+        .on_line_section("line:A", "stop_area:4", "stop_area:2", {"line:A:1"}, *b.data->pt_data);
 
     navitia::apply_disruption(dis_builder_update.disruption, *b.data->pt_data, *b.data->meta);
 
@@ -2362,12 +2369,13 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_with_successive_stop_in_same_are
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2019, 9, 1), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20190901T120000"_dt, "20190910T090000"_dt))
-                                  .on_line_section("line:A", "stop_area:3", "stop_area:5", {"line:A:0"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190901T120000"_dt, "20190910T090000"_dt))
+            .on_line_section("line:A", "stop_area:3", "stop_area:5", {"line:A:0"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -2422,12 +2430,13 @@ BOOST_AUTO_TEST_CASE(add_impact_lollipop_vj_impact_stop_only_once) {
     b.make();
     b.data->meta->production_date = bg::date_period(bg::date(2019, 9, 1), bg::days(7));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20190901T120000"_dt, "20190910T090000"_dt))
-                                  .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190901T120000"_dt, "20190910T090000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -2475,12 +2484,13 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     b.data->meta->production_date = bg::date_period(bg::date(2019, 9, 1), bg::days(7));
 
     // Impact from 2 to 3 once
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20190901T120000"_dt, "20190910T090000"_dt))
-                                  .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190901T120000"_dt, "20190910T090000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);
@@ -2506,12 +2516,13 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 
     // And a second time on a slightly different calendar
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted_twice")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20190901T000000"_dt, "20190910T090000"_dt))
-                                  .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line:A_diverted_twice")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20190901T000000"_dt, "20190910T090000"_dt))
+            .on_line_section("line:A", "stop_area:2", "stop_area:3", {"line:A:0"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     BOOST_REQUIRE_EQUAL(b.data->pt_data->lines.size(), 1);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->routes.size(), 1);

--- a/source/kraken/tests/disruption_periods_test.cpp
+++ b/source/kraken/tests/disruption_periods_test.cpp
@@ -74,7 +74,7 @@ struct disruption_periods_fixture {
                                       .severity(nt::disruption::Effect::UNKNOWN_EFFECT)  // just an information
                                       .application_periods(btp("20170301T100000"_dt, "20170401T100000"_dt))
                                       .publish(btp("20170201T100000"_dt, "20170601T100000"_dt))
-                                      .on(nt::Type_e::Line, "1")
+                                      .on(nt::Type_e::Line, "1", *b.data->pt_data)
                                       .get_disruption(),
                                   *b.data->pt_data, *b.data->meta);
     }

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(add_blocking_disruption_and_delay_disruption) {
     using btp = boost::posix_time::time_period;
     const auto& disrup = b.impact(nt::RTLevel::RealTime)
                              .severity(nt::disruption::Effect::NO_SERVICE)
-                             .on(nt::Type_e::MetaVehicleJourney, "vj:1")
+                             .on(nt::Type_e::MetaVehicleJourney, "vj:1", *b.data->pt_data)
                              .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                              .get_disruption();
 

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line) {
     using btp = boost::posix_time::time_period;
     const auto& disrup_1 = b.impact(nt::RTLevel::RealTime, "Disruption 1")
                                .severity(nt::disruption::Effect::NO_SERVICE)
-                               .on(nt::Type_e::Line, "A")
+                               .on(nt::Type_e::Line, "A", *b.data->pt_data)
                                .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                                .get_disruption();
 
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line) {
 
     const auto& disrup_2 = b.impact(nt::RTLevel::RealTime, "Disruption 2")
                                .severity(nt::disruption::Effect::NO_SERVICE)
-                               .on(nt::Type_e::Line, "A")
+                               .on(nt::Type_e::Line, "A", *b.data->pt_data)
                                .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                                .get_disruption();
 
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(get_impact_indexes_of_line) {
 
     const auto& disrup_3 = b.impact(nt::RTLevel::RealTime, "Disruption 3")
                                .severity(nt::disruption::Effect::NO_SERVICE)
-                               .on(nt::Type_e::Line, "A")
+                               .on(nt::Type_e::Line, "A", *b.data->pt_data)
                                .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                                .get_disruption();
 
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(get_impact_indexes_of_stop_point) {
     using btp = boost::posix_time::time_period;
     const auto& disrup_1 = b.impact(nt::RTLevel::RealTime, "Disruption 1")
                                .severity(nt::disruption::Effect::NO_SERVICE)
-                               .on(nt::Type_e::StopPoint, "stop1")
+                               .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
                                .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                                .get_disruption();
 
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(ptref_on_vj_impacted) {
     using btp = boost::posix_time::time_period;
     const auto& disrup_1 = b.impact(nt::RTLevel::RealTime, "Disruption 1")
                                .severity(nt::disruption::Effect::OTHER_EFFECT)
-                               .on(nt::Type_e::MetaVehicleJourney, "vj:A-1")
+                               .on(nt::Type_e::MetaVehicleJourney, "vj:A-1", *b.data->pt_data)
                                .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                                .get_disruption();
     navitia::apply_disruption(disrup_1, *b.data->pt_data, *b.data->meta);
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(ptref_on_vj_impacted) {
     // disruption with Effect NO_SERVICE on vj:A-2
     const auto& disrup_2 = b.impact(nt::RTLevel::RealTime, "Disruption 2")
                                .severity(nt::disruption::Effect::NO_SERVICE)
-                               .on(nt::Type_e::MetaVehicleJourney, "vj:A-2")
+                               .on(nt::Type_e::MetaVehicleJourney, "vj:A-2", *b.data->pt_data)
                                .application_periods(btp("20150928T000000"_dt, "20150928T240000"_dt))
                                .get_disruption();
     navitia::apply_disruption(disrup_2, *b.data->pt_data, *b.data->meta);

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -2016,7 +2016,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
         .publish(default_period)
         .application_periods(default_period)
         .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-        .on(nt::Type_e::StopArea, "A")
+        .on(nt::Type_e::StopArea, "A", *b.data->pt_data)
         .msg("no luck");
 
     b.impact(nt::RTLevel::Adapted)
@@ -2024,7 +2024,7 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
         .publish(default_period)
         .application_periods(default_period)
         .severity(nt::disruption::Effect::DETOUR)
-        .on(nt::Type_e::Line, "l")
+        .on(nt::Type_e::Line, "l", *b.data->pt_data)
         .msg("no luck");
 
     nr::RAPTOR raptor(*b.data);
@@ -2071,7 +2071,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
         .publish(default_period)
         .application_periods(default_period)
         .severity(nt::disruption::Effect::SIGNIFICANT_DELAYS)
-        .on(nt::Type_e::StopArea, "A")
+        .on(nt::Type_e::StopArea, "A", *b.data->pt_data)
         .msg("no luck");
 
     b.impact(nt::RTLevel::Adapted)
@@ -2079,7 +2079,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
         .publish(default_period)
         .application_periods(default_period)
         .severity(nt::disruption::Effect::DETOUR)
-        .on(nt::Type_e::Network, "base_network");
+        .on(nt::Type_e::Network, "base_network", *b.data->pt_data);
 
     nr::RAPTOR raptor(*b.data);
 

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -658,7 +658,7 @@ struct routing_api_data {
             .uri("too_bad")
             .application_periods(default_period)
             .severity("info")
-            .on(nt::Type_e::StopArea, "stopA")
+            .on(nt::Type_e::StopArea, "stopA", *b.data->pt_data)
             .msg("no luck", nt::disruption::ChannelType::sms)
             .msg("try again", nt::disruption::ChannelType::sms)
             .publish(default_period);
@@ -671,8 +671,8 @@ struct routing_api_data {
             .uri("too_bad_again")
             .application_periods(default_period)
             .severity("disruption")
-            .on(nt::Type_e::Line, "A")
-            .on(nt::Type_e::Network, "base_network")
+            .on(nt::Type_e::Line, "A", *b.data->pt_data)
+            .on(nt::Type_e::Network, "base_network", *b.data->pt_data)
             .msg("sad message", nt::disruption::ChannelType::sms)
             .msg("too sad message", nt::disruption::ChannelType::sms);
 
@@ -685,8 +685,8 @@ struct routing_api_data {
             .application_periods(btp("20121001T000000"_dt, "20121015T120000"_dt))
             .application_periods(btp("20121201T000000"_dt, "20121215T120000"_dt))
             .severity("info")
-            .on(nt::Type_e::Line, "A")
-            .on(nt::Type_e::Network, "base_network")
+            .on(nt::Type_e::Line, "A", *b.data->pt_data)
+            .on(nt::Type_e::Network, "base_network", *b.data->pt_data)
             .msg("sad message", nt::disruption::ChannelType::sms)
             .msg("too sad message", nt::disruption::ChannelType::sms);
 
@@ -698,9 +698,9 @@ struct routing_api_data {
             .uri("impact_published_later")
             .application_periods(default_period)
             .severity("info")
-            .on(nt::Type_e::Line, "A")
+            .on(nt::Type_e::Line, "A", *b.data->pt_data)
             // add another pt impacted object just to test with several
-            .on(nt::Type_e::Network, "base_network")
+            .on(nt::Type_e::Network, "base_network", *b.data->pt_data)
             .msg("sad message", nt::disruption::ChannelType::sms)
             .msg("too sad message", nt::disruption::ChannelType::sms);
 
@@ -711,9 +711,9 @@ struct routing_api_data {
             .uri("too_bad_all_lines")
             .application_periods(dis_proper_period)
             .severity("info")
-            .on(nt::Type_e::Line, "A")
-            .on(nt::Type_e::Line, "B")
-            .on(nt::Type_e::Line, "C")
+            .on(nt::Type_e::Line, "A", *b.data->pt_data)
+            .on(nt::Type_e::Line, "B", *b.data->pt_data)
+            .on(nt::Type_e::Line, "C", *b.data->pt_data)
             .msg("no luck", nt::disruption::ChannelType::sms)
             .msg("try again", nt::disruption::ChannelType::sms);
 
@@ -725,7 +725,7 @@ struct routing_api_data {
             .uri("too_bad_route_A:0")
             .application_periods(route_period)
             .severity("info")
-            .on(nt::Type_e::Route, "A:0")
+            .on(nt::Type_e::Route, "A:0", *b.data->pt_data)
             .msg({"no luck",
                   "sms",
                   "sms",
@@ -750,8 +750,8 @@ struct routing_api_data {
             .uri("too_bad_route_A:0_and_line")
             .application_periods(dis_maker_period)
             .severity("info")
-            .on(nt::Type_e::Route, "A:0")
-            .on(nt::Type_e::Line, "A")
+            .on(nt::Type_e::Route, "A:0", *b.data->pt_data)
+            .on(nt::Type_e::Line, "A", *b.data->pt_data)
             .msg("no luck", nt::disruption::ChannelType::sms)
             .msg("try again", nt::disruption::ChannelType::sms)
             .msg({"beacon in channel",
@@ -766,21 +766,21 @@ struct routing_api_data {
             .uri("too_bad_line_B")
             .application_periods(dis_maker_period)
             .severity("disruption")
-            .on(nt::Type_e::Line, "B")
+            .on(nt::Type_e::Line, "B", *b.data->pt_data)
             .msg("try again", nt::disruption::ChannelType::sms);
 
         disruption_maker.impact()
             .uri("too_bad_line_C")
             .application_periods(dis_maker_period)
             .severity("foo")
-            .on(nt::Type_e::Line, "C")
+            .on(nt::Type_e::Line, "C", *b.data->pt_data)
             .msg("try again", nt::disruption::ChannelType::sms);
 
         disruption_maker.impact()
             .uri("too_bad_line_section_B_stop_B_route_B3")
             .application_periods(boost::posix_time::time_period("20120826T060000"_dt, "20120830T120000"_dt))
             .severity("disruption")
-            .on_line_section("B", "stopB", "stopB", {"B:3"})
+            .on_line_section("B", "stopB", "stopB", {"B:3"}, *b.data->pt_data)
             .msg("try again", nt::disruption::ChannelType::sms);
 
         // We create one disruption on stop 'stop_point:uselessA' with application period which doesn't intersect
@@ -797,7 +797,7 @@ struct routing_api_data {
             .uri("too_bad_future")
             .application_periods(future_application_period)
             .severity("info")
-            .on(nt::Type_e::StopArea, "stopA")
+            .on(nt::Type_e::StopArea, "stopA", *b.data->pt_data)
             .msg("no luck", nt::disruption::ChannelType::sms)
             .msg("try again", nt::disruption::ChannelType::sms)
             .publish(large_publication_period);

--- a/source/tests/mock-kraken/line_sections_test.cpp
+++ b/source/tests/mock-kraken/line_sections_test.cpp
@@ -86,28 +86,30 @@ int main(int argc, const char* const argv[]) {
     b.build_autocomplete();
     b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(30));
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
-                                  .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
-                                  .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
-                                  .on_line_section("line:1", "C", "E", {"route:line:1:1", "route:line:1:3"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line_1")
+            .severity(nt::disruption::Effect::NO_SERVICE)
+            .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+            .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+            .on_line_section("line:1", "C", "E", {"route:line:1:1", "route:line:1:3"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
-    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_1_other_effect")
-                                  .severity(nt::disruption::Effect::OTHER_EFFECT)
-                                  .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
-                                  .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
-                                  .on_line_section("line:1", "E", "F", {"route:line:1:1", "route:line:1:3"})
-                                  .on_line_section("line:1", "F", "E", {"route:line:1:1", "route:line:1:3"})
-                                  .get_disruption(),
-                              *b.data->pt_data, *b.data->meta);
+    navitia::apply_disruption(
+        b.impact(nt::RTLevel::Adapted, "line_section_on_line_1_other_effect")
+            .severity(nt::disruption::Effect::OTHER_EFFECT)
+            .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+            .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+            .on_line_section("line:1", "E", "F", {"route:line:1:1", "route:line:1:3"}, *b.data->pt_data)
+            .on_line_section("line:1", "F", "E", {"route:line:1:1", "route:line:1:3"}, *b.data->pt_data)
+            .get_disruption(),
+        *b.data->pt_data, *b.data->meta);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "line_section_on_line_2")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
                                   .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
                                   .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
-                                  .on_line_section("line:2", "B", "F", {"route:line:2:1"})
+                                  .on_line_section("line:2", "B", "F", {"route:line:2:1"}, *b.data->pt_data)
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 

--- a/source/tests/mock-kraken/main_ptref_test.cpp
+++ b/source/tests/mock-kraken/main_ptref_test.cpp
@@ -166,7 +166,7 @@ struct data_set {
         b.impact(nt::RTLevel::RealTime, "Disruption 1")
             .severity(nt::disruption::Effect::UNKNOWN_EFFECT)
             .msg("Disruption on StopArea stop_area:stop1", nt::disruption::ChannelType::email)
-            .on(nt::Type_e::StopArea, "stop_area:stop1")
+            .on(nt::Type_e::StopArea, "stop_area:stop1", *b.data->pt_data)
             .application_periods(btp("20140101T000000"_dt, "20140120T235959"_dt))
             .publish(btp("20140101T000000"_dt, "20140120T235959"_dt));
         // LineGroup added
@@ -182,7 +182,7 @@ struct data_set {
         b.impact(nt::RTLevel::RealTime, "Disruption On line:A")
             .severity(nt::disruption::Effect::UNKNOWN_EFFECT)
             .msg("Disruption on Line line:A", nt::disruption::ChannelType::email)
-            .on(nt::Type_e::Line, "line:A")
+            .on(nt::Type_e::Line, "line:A", *b.data->pt_data)
             .application_periods(btp("20140101T000000"_dt, "20140120T235959"_dt))
             .publish(btp("20140101T000000"_dt, "20140120T235959"_dt));
 

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test1) {
         using btp = boost::posix_time::time_period;
         b.impact(nt::RTLevel::Adapted, "Disruption 1")
             .severity(nt::disruption::Effect::UNKNOWN_EFFECT)
-            .on(nt::Type_e::StopPoint, "stop1")
+            .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
             .application_periods(btp("20150615T010000"_dt, "20150625T235900"_dt))
             .publish(btp("20150615T010000"_dt, "20150625T235900"_dt))
             .msg("Disruption on stop_point stop1");
@@ -538,7 +538,7 @@ BOOST_AUTO_TEST_CASE(departureboard_test_with_impacts) {
 
         navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption 1")
                                       .severity(nt::disruption::Effect::NO_SERVICE)
-                                      .on(nt::Type_e::StopPoint, "stop1")
+                                      .on(nt::Type_e::StopPoint, "stop1", *b.data->pt_data)
                                       .application_periods(btp("20150615T010000"_dt, "20150625T235900"_dt))
                                       .publish(btp("20150615T010000"_dt, "20150625T235900"_dt))
                                       .msg("Disruption on stop_point stop1")
@@ -998,7 +998,7 @@ BOOST_FIXTURE_TEST_CASE(test_not_associated_cal, calendar_fixture) {
     using btp = boost::posix_time::time_period;
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption StopR1")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "StopR1")
+                                  .on(nt::Type_e::StopPoint, "StopR1", *b.data->pt_data)
                                   .application_periods(btp("20120612T010000"_dt, "20120625T235900"_dt))
                                   .publish(btp("20120612T010000"_dt, "20120625T235900"_dt))
                                   .msg("Disruption on stop_point StopR1")
@@ -1135,7 +1135,7 @@ BOOST_FIXTURE_TEST_CASE(test_calendar_with_impact, calendar_fixture) {
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption stop2")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::StopPoint, "stop2")
+                                  .on(nt::Type_e::StopPoint, "stop2", *b.data->pt_data)
                                   .application_periods(btp("20120612T010000"_dt, "20120625T235900"_dt))
                                   .publish(btp("20120612T010000"_dt, "20120625T235900"_dt))
                                   .msg("Disruption on stop_point stop2")

--- a/source/time_tables/tests/route_schedules_test.cpp
+++ b/source/time_tables/tests/route_schedules_test.cpp
@@ -587,7 +587,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_3) {
     using btp = boost::posix_time::time_period;
     b.impact(nt::RTLevel::Adapted, "Disruption 1")
         .severity(nt::disruption::Effect::UNKNOWN_EFFECT)
-        .on(nt::Type_e::StopPoint, "st1")
+        .on(nt::Type_e::StopPoint, "st1", *b.data->pt_data)
         .application_periods(btp("20120614T010000"_dt, "20150625T235900"_dt))
         .publish(btp("20120614T010000"_dt, "20150625T235900"_dt))
         .msg("Disruption on stop_point st1");
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE(complicated_order_with_impacts) {
     using btp = boost::posix_time::time_period;
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption 1")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
-                                  .on(nt::Type_e::Line, "L")
+                                  .on(nt::Type_e::Line, "L", *b.data->pt_data)
                                   .application_periods(btp("20120614T010000"_dt, "20150625T235900"_dt))
                                   .publish(btp("20120614T010000"_dt, "20150625T235900"_dt))
                                   .msg("Disruption on line")

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -154,7 +154,6 @@ std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const LineSection& ls,
             // it's not passing by both stops and should not be impacted
             if (!section.empty()) {
                 // Once we know the line section is part of the vj we compute the vp for the adapted_vj
-                // LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
                 nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
                 for (const auto& period : impact.application_periods) {
                     // get the vp of the section

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -202,7 +202,7 @@ struct InformedEntitiesLinker : public boost::static_visitor<> {
                                                        << " does not impact any vj, it will not be linked to anything");
         }
         for (auto& impacted_vj : impacted_vjs) {
-            std::string& vj_uri = impacted_vj.vj_uri;
+            const std::string& vj_uri = impacted_vj.vj_uri;
             LOG4CPLUS_TRACE(log, "Impacted vj : " << vj_uri);
             auto vj_iterator = pt_data.vehicle_journeys_map.find(vj_uri);
             if (vj_iterator == pt_data.vehicle_journeys_map.end()) {

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -154,7 +154,7 @@ std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const LineSection& ls,
             // it's not passing by both stops and should not be impacted
             if (!section.empty()) {
                 // Once we know the line section is part of the vj we compute the vp for the adapted_vj
-                LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
+                // LOG4CPLUS_TRACE(log, "vj " << vj.uri << " pass by both stops, might be affected.");
                 nt::ValidityPattern new_vp{vj.validity_patterns[rt_level]->beginning_date};
                 for (const auto& period : impact.application_periods) {
                     // get the vp of the section

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -411,7 +411,7 @@ struct ImpactedVJ {
     std::string vj_uri;  // uri of the impacted vj
     ValidityPattern new_vp;
     std::set<RankStopTime> impacted_ranks;
-    ImpactedVJ(std::string vj_uri, ValidityPattern vp, std::set<RankStopTime> r)
+    ImpactedVJ(const std::string& vj_uri, ValidityPattern vp, std::set<RankStopTime> r)
         : vj_uri(vj_uri), new_vp(vp), impacted_ranks(std::move(r)) {}
 };
 /*

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -302,7 +302,8 @@ struct Impact {
     static void link_informed_entity(PtObj ptobj,
                                      SharedImpact& impact,
                                      const boost::gregorian::date_period&,
-                                     type::RTLevel);
+                                     type::RTLevel,
+                                     type::PT_Data& pt_data);
 
     bool is_valid(const boost::posix_time::ptime& publication_date,
                   const boost::posix_time::time_period& active_period) const;
@@ -407,11 +408,11 @@ public:
 };
 
 struct ImpactedVJ {
-    const VehicleJourney* vj;  // vj before impact
+    std::string vj_uri;  // uri of the impacted vj
     ValidityPattern new_vp;
     std::set<RankStopTime> impacted_ranks;
-    ImpactedVJ(const VehicleJourney* vj, ValidityPattern vp, std::set<RankStopTime> r)
-        : vj(vj), new_vp(vp), impacted_ranks(std::move(r)) {}
+    ImpactedVJ(std::string vj_uri, ValidityPattern vp, std::set<RankStopTime> r)
+        : vj_uri(vj_uri), new_vp(vp), impacted_ranks(std::move(r)) {}
 };
 /*
  * return the list of vehicle journey that are impacted by the linesection


### PR DESCRIPTION
**Problem**
In https://github.com/CanalTP/navitia/blob/1668db5e5fc03fd441a6e0d5492270563df45144/source/kraken/apply_disruption.cpp#L355

We first construct a `impacted_vjs` vector that contains raw pointers to `VehicleJourney`s.
Then we iterate over `impacted_vjs` and call `create_vj_from_old_vj` on each `VehicleJourney` pointer.
https://github.com/CanalTP/navitia/blob/1668db5e5fc03fd441a6e0d5492270563df45144/source/kraken/apply_disruption.cpp#L409

Each call to `create_vj_from_old_vj` will desallocate some `VehicleJourney` object in `clean_up_useless_vjs` :
https://github.com/CanalTP/navitia/blob/09b29a4b0498d0c7bd3b9785b28231c038914a98/source/type/meta_vehicle_journey.cpp#L227

However, it may desallocate a `VehicleJourney` which is present in `impacted_vjs` throught a pointer and not yet processed.
When we try to dereference that pointer, strange things happen.

**Fix**
In order to prevent the above scenario to happen, this PR made the following changes :

- the `impacted_vjs` store the `uri` of the `VehicleJourney`s rather than pointers
- when we process an impacted_vj, we check if a `VehicleJourney` with the given uri is still present in the data. If not, the impacted_vj is ignored (it has already been deleted after all).
