### PR TITLE
[kraken + ed] remove clang warnings

### DIFF
--- a/source/ed/connectors/conv_coord.h
+++ b/source/ed/connectors/conv_coord.h
@@ -29,6 +29,7 @@ www.navitia.io
 */
 
 #pragma once
+#define ACCEPT_USE_OF_DEPRECATED_PROJ_API_H
 #include <proj_api.h>
 #include "type/geographical_coord.h"
 

--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -41,7 +41,7 @@ namespace ed {
 namespace connectors {
 
 constexpr float kmh_to_ms(long double val) {
-    return val / 3.6;
+    return val / 3.6L;
 }
 
 constexpr float operator"" _kmh(long double val) {
@@ -148,7 +148,7 @@ boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
             try {
                 // todo handle value not in km/h.
                 // if there is no unit the value is in km/h else cast will fail
-                speed = kmh_to_ms(boost::lexical_cast<float>(s));
+                speed = kmh_to_ms(boost::lexical_cast<long double>(s));
             } catch (const std::exception&) {
                 std::cerr << "impossible to convert \"" << max_speed << "\" in speed" << std::endl;
             }

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -255,7 +255,7 @@ struct FindAdminWithCities {
     }
 };
 
-bool rename_file(const std::string& source_name, const std::string& dest_name) {
+static bool rename_file(const std::string& source_name, const std::string& dest_name) {
     auto logger = log4cplus::Logger::getInstance("ed2nav::rename_file");
     LOG4CPLUS_INFO(logger, "Trying to rename " << source_name << " to " << dest_name);
     if (boost::filesystem::exists(source_name)) {
@@ -268,7 +268,7 @@ bool rename_file(const std::string& source_name, const std::string& dest_name) {
     return true;
 }
 
-bool remove_file(const std::string& filename) {
+static bool remove_file(const std::string& filename) {
     if(!boost::filesystem::exists(filename))
         return true;
 

--- a/source/ed/ed2nav.h
+++ b/source/ed/ed2nav.h
@@ -38,7 +38,7 @@ www.navitia.io
 
 namespace navitia {
 namespace type {
-struct Data;
+class Data;
 }  // namespace type
 }  // namespace navitia
 

--- a/source/ed/tests/speed_parser_test.cpp
+++ b/source/ed/tests/speed_parser_test.cpp
@@ -35,7 +35,7 @@ www.navitia.io
 #include <boost/test/unit_test.hpp>
 #include "ed/connectors/speed_parser.h"
 #include "tests/utils_test.h"
-#include <boost/optional/optional_io.hpp>`
+#include <boost/optional/optional_io.hpp>
 struct logger_initialized {
     logger_initialized() { navitia::init_logger(); }
 };

--- a/source/georef/dijkstra_path_finder.cpp
+++ b/source/georef/dijkstra_path_finder.cpp
@@ -185,7 +185,7 @@ struct ProjectionGetterOnCoords {
         try {
             const auto& projection = georef.projected_coords.at(coord);
             return projection[mode];
-        } catch (std::out_of_range& e) {
+        } catch (std::out_of_range&) {
             return georef::ProjectionData{coord, georef, mode};
         }
     }

--- a/source/georef/georef_types.h
+++ b/source/georef/georef_types.h
@@ -7,9 +7,9 @@
 namespace navitia {
 namespace georef {
 
-class Vertex;
+struct Vertex;
 
-// Plein de typedefs pour nous simpfilier un peu la vie
+// Plein de typedefs pour nous simplifier un peu la vie
 
 /** Définit le type de graph que l'on va utiliser
  *

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -114,7 +114,6 @@ struct apply_impacts_visitor : public boost::static_visitor<> {
 
     virtual ~apply_impacts_visitor() = default;
     apply_impacts_visitor(const apply_impacts_visitor&) = default;
-    apply_impacts_visitor(apply_impacts_visitor&&) = default;
     apply_impacts_visitor& operator=(const apply_impacts_visitor& other) = delete;
     apply_impacts_visitor& operator=(apply_impacts_visitor&& other) noexcept = delete;
 

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -162,7 +162,7 @@ void MaintenanceWorker::handle_task_in_batch(const std::vector<AmqpClient::Envel
     }
 }
 
-bool autocomplete_rebuilding_needed(const transit_realtime::FeedEntity& entity) {
+static bool autocomplete_rebuilding_needed(const transit_realtime::FeedEntity& entity) {
     return ((entity.trip_update().GetExtension(kirin::effect)
              == transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE)
             || (entity.trip_update().GetExtension(kirin::effect) == transit_realtime::Alert_Effect::Alert_Effect_DETOUR)

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -67,7 +67,6 @@ struct coord_conversion_exception : public recoverable_exception {
     coord_conversion_exception& operator=(const coord_conversion_exception&) = default;
 
     coord_conversion_exception(coord_conversion_exception&&) = default;
-    coord_conversion_exception& operator=(coord_conversion_exception&&) = default;
 
     ~coord_conversion_exception() noexcept override = default;
 };

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -115,7 +115,7 @@ void find(navitia::PbCreator& pb_creator,
                 auto nb_w = pb_creator.data->geo_ref->nearest_addr(coord);
                 // we'll regenerate the good number in make_pb
                 result.emplace_back(nb_w.second->idx, std::move(coord), 0, type,
-                                    std::move(std::vector<std::tuple<nt::idx_t, float>>()));
+                                    std::vector<std::tuple<nt::idx_t, float>>());
                 ++total_result;
             } catch (const proximitylist::NotFound&) {
             }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -52,7 +52,6 @@ struct PathElt {
                      const DateTime e_dt,
                      const PathElt* p = nullptr)
         : begin_st(b), begin_dt(b_dt), end_st(e), end_dt(e_dt), prev(p) {}
-    ~PathElt() = default;
     PathElt(const PathElt&) = delete;
     PathElt& operator=(const PathElt&) = delete;
     PathElt(const PathElt&&) = delete;


### PR DESCRIPTION
After compiling in clang (been a while :smile:) some warnings appeared.

* easy warnings
* allow deprecated `proj` API (as my lib is newer): I still have `conv_coord_test` test breaking on that (56m distance between what's tested and the conversion using the newer version of PROJ). This PR does not fix the test (I don't know if we should accept any of the 2 values, only one, a range or something else).
* :warning: last commit is more debatable I think (I miss context on those lines and their adds): please review carefully

:mag: please review by commit (read comment first).