### PR TITLE
[Jormun] update the way to choose between two similar journeys

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -514,6 +514,22 @@ def fallback_duration(journey):
     return duration
 
 
+def end_fallback_duration(journey):
+    for section in reversed(journey.sections):
+        if section.type in (response_pb2.STREET_NETWORK, response_pb2.CROW_FLY):
+            return section.duration
+
+    return 0
+
+
+def start_fallback_duration(journey):
+    for section in journey.sections:
+        if section.type in (response_pb2.STREET_NETWORK, response_pb2.CROW_FLY):
+            return section.duration
+
+    return 0
+
+
 def _debug_journey(journey):
     """
     For debug purpose print the journey
@@ -651,32 +667,35 @@ def _get_worst_similar(j1, j2, request):
             (and traveler presumes he can do it walking too, as the practical case is 0s fallback)
     """
     if request.get('clockwise', True):
-        if j1.arrival_date_time != j2.arrival_date_time:
-            # we dont want to arrive a few seconds earlier if it means walking more
-            # so we consider that arriving 1s earlier is better if we walk at most 1s more
-            # hence we compare arrival_time + walking_time instead of just arrival time
-            j1_penalized_arrival = j1.arrival_date_time + fallback_duration(j1)
-            j2_penalized_arrival = j2.arrival_date_time + fallback_duration(j2)
+
+        # we dont want to arrive a few seconds earlier if it means walking more
+        # so we consider that arriving 1s earlier is better if we walk at most 1s more
+        # hence we compare arrival_time + walking_time instead of just arrival time
+        j1_penalized_arrival = j1.arrival_date_time + end_fallback_duration(j1)
+        j2_penalized_arrival = j2.arrival_date_time + end_fallback_duration(j2)
+        if j1_penalized_arrival != j2_penalized_arrival:
             return j1 if j1_penalized_arrival > j2_penalized_arrival else j2
 
         # arrival times are the same, let's look at departure times
-        if j1.departure_date_time != j2.departure_date_time:
-            # we dont want to depart a few seconds later if it means walking more
-            # so we consider that departing 1s later is better if we walk at most 1s more
-            # hence we compare departure_time - walking_time instead of just departure time
-            j1_penalized_departure = j1.departure_date_time - fallback_duration(j1)
-            j2_penalized_departure = j2.departure_date_time - fallback_duration(j2)
+
+        # we dont want to depart a few seconds later if it means walking more
+        # so we consider that departing 1s later is better if we walk at most 1s more
+        # hence we compare departure_time - walking_time instead of just departure time
+        j1_penalized_departure = j1.departure_date_time - start_fallback_duration(j1)
+        j2_penalized_departure = j2.departure_date_time - start_fallback_duration(j2)
+        if j1_penalized_departure != j2_penalized_departure:
             return j1 if j1_penalized_departure < j2_penalized_departure else j2
     else:
-        if j1.departure_date_time != j2.departure_date_time:
-            j1_penalized_departure = j1.departure_date_time - fallback_duration(j1)
-            j2_penalized_departure = j2.departure_date_time - fallback_duration(j2)
+
+        j1_penalized_departure = j1.departure_date_time - start_fallback_duration(j1)
+        j2_penalized_departure = j2.departure_date_time - start_fallback_duration(j2)
+        if j1_penalized_departure != j2_penalized_departure:
             return j1 if j1_penalized_departure < j2_penalized_departure else j2
 
         # departure times are the same, let's look at arrival times
-        if j1.arrival_date_time != j2.arrival_date_time:
-            j1_penalized_arrival = j1.arrival_date_time + fallback_duration(j1)
-            j2_penalized_arrival = j2.arrival_date_time + fallback_duration(j2)
+        j1_penalized_arrival = j1.arrival_date_time + end_fallback_duration(j1)
+        j2_penalized_arrival = j2.arrival_date_time + end_fallback_duration(j2)
+        if j1_penalized_arrival != j2_penalized_arrival:
             return j1 if j1_penalized_arrival > j2_penalized_arrival else j2
 
     if j1.duration != j2.duration:


### PR DESCRIPTION
With the previous version of the filter, the order in which the journeys were compared changed the output.
For example, given the list of journeys [A,B,C] it would select A, and given the list [B, C, A] it would select C.
Now it should be independent of the order.
