### PR TITLE
[Raptor] ignore the max_extra_second_pass parameter and set it to zero

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -751,14 +751,14 @@ void Worker::journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API 
                                            "no origin point nor destination point given");
             return;
         }
-
+        uint32_t max_extra_second_pass = 0;  // request.max_extra_second_pass()
         switch (api) {
             case pbnavitia::pt_planner:
                 routing::make_pt_response(
                     this->pb_creator, *planner, arg.origins, arg.destinations, arg.datetimes[0], request.clockwise(),
                     arg.accessibilite_params, arg.forbidden, arg.allowed, arg.rt_level,
                     seconds{request.walking_transfer_penalty()}, request.max_duration(), request.max_transfers(),
-                    request.max_extra_second_pass(),
+                    max_extra_second_pass,
                     request.has_direct_path_duration()
                         ? boost::optional<time_duration>(seconds{request.direct_path_duration()})
                         : boost::optional<time_duration>(),
@@ -774,7 +774,7 @@ void Worker::journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API 
                     this->pb_creator, *planner, arg.origins[0], arg.destinations[0], arg.datetimes, request.clockwise(),
                     arg.accessibilite_params, arg.forbidden, arg.allowed, *street_network_worker, arg.rt_level,
                     seconds{request.walking_transfer_penalty()}, request.max_duration(), request.max_transfers(),
-                    request.max_extra_second_pass(), request.free_radius_from(), request.free_radius_to(),
+                    max_extra_second_pass, request.free_radius_from(), request.free_radius_to(),
                     request.has_min_nb_journeys() ? boost::make_optional<uint32_t>(request.min_nb_journeys())
                                                   : boost::none,
                     request.night_bus_filter_max_factor(), request.night_bus_filter_base_factor(),


### PR DESCRIPTION
To be merged with https://github.com/CanalTP/artemis_references/pull/226