### PR TITLE
jormungandr: Update journey total duration at the end

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -359,6 +359,19 @@ def update_durations(pb_resp):
         j.duration = total_duration
 
 
+def update_total_co2_emission(pb_resp):
+    """
+    update journey.co2_emission.value
+    """
+    if not pb_resp.journeys:
+        return
+    for j in pb_resp.journeys:
+        total_co2_emission = 0
+        for s in j.sections:
+            total_co2_emission += s.co2_emission.value
+        j.co2_emission.value = total_co2_emission
+
+
 def _get_section_id(section):
     street_network_mode = None
     if section.type in SECTION_TYPES_TO_RETAIN:
@@ -1120,6 +1133,8 @@ class Scenario(simple.Scenario):
 
         # We have to update total duration as some sections could be updated in distributed.
         update_durations(pb_resp)
+        # We have to update total co2_emission as some sections could be updated in distributed.
+        update_total_co2_emission(pb_resp)
 
         # need to clean extra tickets after culling journeys
         journey_filter.remove_excess_tickets(pb_resp)

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -352,11 +352,8 @@ def update_durations(pb_resp):
     if not pb_resp.journeys:
         return
     for j in pb_resp.journeys:
-        total_duration = 0
-        for s in j.sections:
-            total_duration += s.duration
-        j.durations.total = total_duration
-        j.duration = total_duration
+        j.duration = sum(s.duration for s in j.sections)
+        j.durations.total = j.duration
 
 
 def update_total_co2_emission(pb_resp):
@@ -366,10 +363,7 @@ def update_total_co2_emission(pb_resp):
     if not pb_resp.journeys:
         return
     for j in pb_resp.journeys:
-        total_co2_emission = 0
-        for s in j.sections:
-            total_co2_emission += s.co2_emission.value
-        j.co2_emission.value = total_co2_emission
+        j.co2_emission.value = sum(s.co2_emission.value for s in j.sections)
 
 
 def _get_section_id(section):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -345,6 +345,20 @@ def tag_journeys(resp):
     tag_ecologic(resp)
 
 
+def update_durations(pb_resp):
+    """
+    update journey.duration and journey.durations.total
+    """
+    if not pb_resp.journeys:
+        return
+    for j in pb_resp.journeys:
+        total_duration = 0
+        for s in j.sections:
+            total_duration += s.duration
+        j.durations.total = total_duration
+        j.duration = total_duration
+
+
 def _get_section_id(section):
     street_network_mode = None
     if section.type in SECTION_TYPES_TO_RETAIN:
@@ -1103,6 +1117,10 @@ class Scenario(simple.Scenario):
         journey_filter.delete_journeys((pb_resp,), api_request)
         type_journeys(pb_resp, api_request)
         culling_journeys(pb_resp, api_request)
+
+        # We have to update total duration as some sections could be updated in distributed.
+        update_durations(pb_resp)
+
         # need to clean extra tickets after culling journeys
         journey_filter.remove_excess_tickets(pb_resp)
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -139,7 +139,7 @@ def str_to_dt(str):
 
 def date_to_timestamp(date):
     """
-    convert a datetime objet to a posix timestamp (number of seconds from 1070/1/1)
+    convert a datetime objet to a posix timestamp (number of seconds from 1970/1/1)
     """
     return int(calendar.timegm(date.utctimetuple()))
 


### PR DESCRIPTION
As fallback sections from origin and toward the destination are enriched only toward the end for selected journeys, we should also update total duration. All the other elements as listed below are correct.
* departure_date_time and arrival_date_time of the journey.
* departure_date_time, arrival_date_time and duration of all the sections are correct.
* The duration total per mode is correct.
* Update journey.duration and journey.durations.total

For details refer to: https://jira.kisio.org/browse/NAVITIAII-3155

Update co2_emission for journey adding co2_emission values of all section for each journey in the response.
For details refer to: https://jira.kisio.org/browse/NAVITIAII-3148
