### PR TITLE
[Kraken] Update assert that was not compiling with compiler's suggested alternative

### DIFF
--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -743,7 +743,7 @@ void RAPTOR::raptor_loop(Visitor visitor, const nt::RTLevel rt_level, uint32_t m
 
                             working_labels.mut_dt_pt(jpp.sp_idx) = workingDt;
                             working_labels.mut_walking_duration_pt(jpp.sp_idx) = working_walking_duration;
-                            BOOST_ASSERT(working_fallback_duration != DateTimeUtils::not_valid);
+                            BOOST_ASSERT(working_walking_duration != DateTimeUtils::not_valid);
                             best_labels_pts[jpp.sp_idx] = workingDt;
                             best_labels_pts_walking[jpp.sp_idx] = working_walking_duration;
                             continue_algorithm = true;


### PR DESCRIPTION
This is why I dislike assert. It hides code away from you when you CI doesn't compile in debug mode :) 
```sh
In file included from /usr/include/boost/assert.hpp:58,
                 from /usr/include/boost/range/algorithm_ext/push_back.hpp:19,
                 from /home/ogeorget/dev/kisio/source/navitia/source/routing/raptor.cpp:40:
/navitia/source/routing/raptor.cpp: In member function ‘void navitia::routing::RAPTOR::raptor_loop(Visitor, navitia::type::RTLevel, uint32_t)’:
/navitia/source/routing/raptor.cpp:746:42: error: ‘working_fallback_duration’ was not declared in this scope
                             BOOST_ASSERT(working_fallback_duration != DateTimeUtils::not_valid);
                                          ^~~~~~~~~~~~~~~~~~~~~~~~~
/navitia/source/routing/raptor.cpp:746:42: note: suggested alternative: ‘working_walking_duration’
```