### PR TITLE
[raptor] count stay_in as a transfer in the pareto front

### DIFF
--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -53,14 +53,16 @@ bool Journey::is_pt() const {
 bool Journey::better_on_dt(const Journey& that,
                            bool request_clockwise,
                            const navitia::time_duration transfer_penalty) const {
-    // we consider that an extra transfer (hence a bigger sections.size() ) is worthwhile
+    const int nb_transfer = sections.size() + nb_vj_extentions;
+    const int that_nb_transfer = that.sections.size() + that.nb_vj_extentions;
+    // we consider that an extra transfer is worthwhile
     // only if it reduces the arrival time by at least transfer_penalty
-    DateTime penalized_arrival = arrival_dt + transfer_penalty * sections.size();
-    DateTime that_penalized_arrival = that.arrival_dt + transfer_penalty * that.sections.size();
+    const DateTime penalized_arrival = arrival_dt + transfer_penalty * nb_transfer;
+    const DateTime that_penalized_arrival = that.arrival_dt + transfer_penalty * that_nb_transfer;
     // Similary, we consider that an extra transfer (hence a bigger sections.size() ) is worthwhile
     // only if it increases the departure time by at least transfer_penalty
-    DateTime penalized_departure = departure_dt - transfer_penalty * sections.size();
-    DateTime that_penalized_departure = that.departure_dt - transfer_penalty * that.sections.size();
+    const DateTime penalized_departure = departure_dt - transfer_penalty * nb_transfer;
+    const DateTime that_penalized_departure = that.departure_dt - transfer_penalty * that_nb_transfer;
 
     if (request_clockwise) {
         // if the (non-penalized) arrival times are the same, we compare the penalized departure times
@@ -94,12 +96,14 @@ bool Journey::better_on_transfer(const Journey& that) const {
     return true;
 }
 bool Journey::better_on_sn(const Journey& that, const navitia::time_duration transfer_penalty) const {
+    const int nb_transfer = sections.size() + nb_vj_extentions;
+    const int that_nb_transfer = that.sections.size() + that.nb_vj_extentions;
     // we consider that the transfer duration as well as the street network duration are
     // walking duration
-    // we consider that an extra transfer (hence a bigger sections.size() ) is worthwhile
+    // we consider that an extra transfer  is worthwhile
     // only if it reduces the walking duration by at least transfer_penalty
-    return sn_dur + transfer_dur + transfer_penalty * sections.size()
-           <= that.sn_dur + that.transfer_dur + transfer_penalty * that.sections.size();
+    return sn_dur + transfer_dur + transfer_penalty * nb_transfer
+           <= that.sn_dur + that.transfer_dur + transfer_penalty * that_nb_transfer;
     ;
 }
 


### PR DESCRIPTION
A stay-in in a journey didn't count as a transfer in the comparison operator used in the Pareto front.
As a results, we obtained journeys that used a stay-in just to gain a few seconds of walking or arrive a few seconds earlier.

This PR count a stay-in as a transfer.

Artemis run https://ci.navitia.io/view/custom_artemis/job/custom_Artemis/47/

To be merged with https://github.com/CanalTP/artemis_references/pull/229

- [x] waiting for some QA before merge