### PR TITLE
Modification default value of system_id for ridesharing services

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/test/add_common_status_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/add_common_status_tests.py
@@ -69,7 +69,7 @@ expected_instant_system_ridesharing_status = [
         "circuit_breaker": {"current_state": "closed", "fail_counter": 0, "reset_timeout": 60},
         "class": "InstantSystem",
         "crowfly_radius": 500,
-        "id": "Instant System",
+        "id": "instant_system",
         "network": "Network 1",
         "rating_scale_max": 5,
         "rating_scale_min": 0,
@@ -101,7 +101,7 @@ expected_karos_ridesharing_status = [
     {
         "network": "Karos",
         "circuit_breaker": {"fail_counter": 0, "current_state": "closed", "reset_timeout": 60},
-        "id": "Karos",
+        "id": "karos",
         "class": "Karos",
         "departure_radius": 10,
         "arrival_radius": 10,

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/blablacar.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/blablacar.py
@@ -70,7 +70,7 @@ class Blablacar(AbstractRidesharingService):
         self.service_url = service_url
         self.api_key = api_key
         self.network = network
-        self.system_id = 'Blablacar'
+        self.system_id = 'blablacar'
         self.timeout = timeout
         self.timedelta = timedelta
         self.feed_publisher = None if feed_publisher is None else RsFeedPublisher(**feed_publisher)

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
@@ -71,7 +71,7 @@ class InstantSystem(AbstractRidesharingService):
         self.network = network
         self.rating_scale_min = rating_scale_min
         self.rating_scale_max = rating_scale_max
-        self.system_id = 'Instant System'
+        self.system_id = 'instant_system'
         self.timeout = timeout
         self.feed_publisher = None if feed_publisher is None else RsFeedPublisher(**feed_publisher)
         self.crowfly_radius = crowfly_radius

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -65,7 +65,7 @@ class Karos(AbstractRidesharingService):
         self.service_url = service_url
         self.api_key = api_key
         self.network = network
-        self.system_id = 'Karos'
+        self.system_id = 'karos'
         self.timeout = timeout
         self.timedelta = timedelta
         self.departure_radius = departure_radius

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
@@ -65,7 +65,7 @@ class Klaxit(AbstractRidesharingService):
         self.service_url = service_url
         self.api_key = api_key
         self.network = network
-        self.system_id = 'Klaxit VIA API'
+        self.system_id = 'klaxit'
         self.timeout = timeout
         self.timedelta = timedelta
         self.departure_radius = departure_radius

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablacar_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablacar_tests.py
@@ -124,13 +124,13 @@ def get_ridesharing_service_test():
     assert services[0].service_url == 'toto'
     assert services[0].api_key == 'toto key'
     assert services[0].network == 'N'
-    assert services[0].system_id == 'Blablacar'
+    assert services[0].system_id == 'blablacar'
     assert services[0]._get_feed_publisher() == RsFeedPublisher(**DUMMY_BLABLACAR_FEED_PUBLISHER)
 
     assert services[1].service_url == 'tata'
     assert services[1].api_key == 'tata key'
     assert services[1].network == 'M'
-    assert services[1].system_id == 'Blablacar'
+    assert services[1].system_id == 'blablacar'
     assert services[1]._get_feed_publisher() == RsFeedPublisher(**DEFAULT_BLABLACAR_FEED_PUBLISHER)
 
 
@@ -155,7 +155,7 @@ def blablacar_test():
 
         assert len(ridesharing_journeys) == 2
         assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[0].metadata.system_id == 'Blablacar'
+        assert ridesharing_journeys[0].metadata.system_id == 'blablacar'
         assert ridesharing_journeys[0].ridesharing_ad == 'https://blablalines.com'
 
         assert ridesharing_journeys[0].pickup_place.addr == ""  # address is not provided in mock
@@ -181,7 +181,7 @@ def blablacar_test():
         assert ridesharing_journeys[0].available_seats == 3
 
         assert ridesharing_journeys[1].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[1].metadata.system_id == 'Blablacar'
+        assert ridesharing_journeys[1].metadata.system_id == 'blablacar'
         assert ridesharing_journeys[1].shape
         assert ridesharing_journeys[1].ridesharing_ad == 'https://blablalines.com'
 

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
@@ -217,7 +217,7 @@ def get_ridesharing_service_test():
     assert services[0].service_url == 'toto'
     assert services[0].api_key == 'toto key'
     assert services[0].network == 'N'
-    assert services[0].system_id == 'Instant System'
+    assert services[0].system_id == 'instant_system'
     assert services[0].rating_scale_min == 0
     assert services[0].rating_scale_max == 10
     assert services[0]._get_feed_publisher() == RsFeedPublisher(**DUMMY_INSTANT_SYSTEM_FEED_PUBLISHER)
@@ -225,7 +225,7 @@ def get_ridesharing_service_test():
     assert services[1].service_url == 'tata'
     assert services[1].api_key == 'tata key'
     assert services[1].network == 'M'
-    assert services[1].system_id == 'Instant System'
+    assert services[1].system_id == 'instant_system'
     assert services[1].rating_scale_min == 1
     assert services[1].rating_scale_max == 5
     assert services[1]._get_feed_publisher() == RsFeedPublisher(**DEFAULT_INSTANT_SYSTEM_FEED_PUBLISHER)
@@ -254,7 +254,7 @@ def instant_system_test():
 
         assert len(ridesharing_journeys) == 2
         assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[0].metadata.system_id == 'Instant System'
+        assert ridesharing_journeys[0].metadata.system_id == 'instant_system'
         assert ridesharing_journeys[0].metadata.rating_scale_min == 0
         assert ridesharing_journeys[0].metadata.rating_scale_max == 10
         assert (
@@ -294,7 +294,7 @@ def instant_system_test():
         assert ridesharing_journeys[0].available_seats == 4
 
         assert ridesharing_journeys[1].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[1].metadata.system_id == 'Instant System'
+        assert ridesharing_journeys[1].metadata.system_id == 'instant_system'
         assert ridesharing_journeys[1].metadata.rating_scale_min == 0
         assert ridesharing_journeys[1].metadata.rating_scale_max == 10
         # the shape should not be none, but we don't test the whole string

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -206,7 +206,7 @@ def get_ridesharing_service_test():
     assert services[0].service_url == 'toto'
     assert services[0].api_key == 'toto key'
     assert services[0].network == 'N'
-    assert services[0].system_id == 'Karos'
+    assert services[0].system_id == 'karos'
     assert services[0].timeout == 10
     assert services[0].timedelta == 7000
     assert services[0].departure_radius == 15
@@ -216,7 +216,7 @@ def get_ridesharing_service_test():
     assert services[1].service_url == 'tata'
     assert services[1].api_key == 'tata key'
     assert services[1].network == 'M'
-    assert services[1].system_id == 'Karos'
+    assert services[1].system_id == 'karos'
     # Default values
     assert services[1].timeout == 2
     assert services[1].timedelta == 3600
@@ -238,7 +238,7 @@ def karos_service_test():
 
         # Check status information
         status = karos.status()
-        assert status['id'] == 'Karos'
+        assert status['id'] == 'karos'
         assert status['class'] == 'Karos'
         assert status['network'] == 'dummyNetwork'
         assert status['circuit_breaker']['fail_counter'] == 0
@@ -258,7 +258,7 @@ def karos_service_test():
 
         assert len(ridesharing_journeys) == 2
         assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[0].metadata.system_id == 'Karos'
+        assert ridesharing_journeys[0].metadata.system_id == 'karos'
         assert (
             ridesharing_journeys[0].ridesharing_ad
             == 'https://www.karos.fr/vianavigo?data=eyJmaXJzdE5hbWUiOiAiQW50b25lbGxvIiwgImlkIjogImY3MmZlNWNkLWQyODctNDViMy1iMzViLTdkMmFmNTZmOWE2NiIsICJncmFkZSI6IDUsICJhZ2UiOiAyMCwgImxhc3ROYW1lIjogIk0iLCAiZHVyYXRpb25fc2luY2VfbGFzdF9sb2dpbiI6IDk0LCAiZGVwYXJ0dXJlVG9QaWNrdXBXYWxraW5nUG9seWxpbmUiOiAiaWp6aEhpZ19NYVl0YEAiLCAicGljdHVyZSI6ICJodHRwczovL3N0b3JhZ2UtZG93bmxvYWQuZ29vZ2xlYXBpcy5jb20va2Fyb3MtZGUuYXBwc3BvdC5jb20vcC8yMDYwOTg3Ny0yOWRiLTRjZTUtYmIwMy03Njg0MGM0ODY4ZmEuanBnIiwgImRyb3BvZmZUb0Fycml2YWxXYWxraW5nVGltZSI6IDU3NTIsICJwaG9uZV92ZXJpZmllZCI6IHRydWUsICJkdXJhdGlvbiI6IDY5NiwgInByaWNlIjogeyJhbW91bnQiOiAyLjAsICJkaXNjb3VudCI6IDAuMH0sICJnZW5kZXIiOiAiTSIsICJyZXNwb25zZV9yYXRlIjogMC44NDg0ODQ4NDg0ODQ4NDg1LCAiZHJvcG9mZlRvQXJyaXZhbFdhbGtpbmdQb2x5bGluZSI6ICJjd3ZoSGdxZ0x+ZkJieFIiLCAiZGVwYXJ0dXJlX3RpbWUiOiAxNjAyMDY4NTM5LCAibmJfY2FycG9vbCI6IDQzLCAiZGVwYXJ0dXJlVG9QaWNrdXBXYWxraW5nVGltZSI6IDQ1NywgImpvdXJuZXlQb2x5bGluZSI6ICJrZHtoSHNlfkxSZkBSZkBiQn5DakhqTWpDbkZ6QG5BYkJyRD9SUmZAUj9SU3pFekpSZkB6QG5BakNiR3pAYkJSUnpAYkJ+SHpPfkNqSFJSbkF2QmZAYkJ2QmJCekBuQT9mQFJ2QnJEckk/ZkB+Q2ZKUlJuQWJHbkFyRFJmQG5BckRmQHZCekBqQz9SUmZAZkBiQmZAdkJiQnpFfkNmSlJ6QD9SfkNuS1JmQHpAdkJmQGpDekBqQ1JmQFJmQFJmQFJuQVJmQG5BfkNmQGJCP2ZAUmZAdkJ2Rz9SekB2QmZAdkJ6QGpDUm5BekBqQ1JSUnpAYkJuRj9SYkJuRmJCekU/ZkByRGJMbkFyRFJmQD9mQD9SbkFyRFJuQW5BckR2QmpIPz8/ZkBmQFI/Um5GalJ6QHZCUm5BP1I/ZkBSYkJmQD9Se0BTe0BnQHtAP1NnQHtAa0hjVj8/UmdAU1NTU1NSP2ZAZkBSP1JuRmpSekB2QlJuQT9SP2ZAUmJCP3pAUz8/YkdTZkpvQXJdZ0B+V29Bel53THZgRWdAZkpvQWpXZ0BiR3NEckQifQ=='
@@ -291,7 +291,7 @@ def karos_service_test():
         assert ridesharing_journeys[0].total_seats is None
         assert ridesharing_journeys[0].available_seats == 3
         assert ridesharing_journeys[1].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[1].metadata.system_id == 'Karos'
+        assert ridesharing_journeys[1].metadata.system_id == 'karos'
         assert ridesharing_journeys[1].shape
         assert (
             ridesharing_journeys[1].ridesharing_ad

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
@@ -143,13 +143,13 @@ def klaxit_service_config_test():
     assert services[0].service_url == 'toto'
     assert services[0].api_key == 'toto key'
     assert services[0].network == 'N'
-    assert services[0].system_id == 'Klaxit VIA API'
+    assert services[0].system_id == 'klaxit'
     assert services[0]._get_feed_publisher() == RsFeedPublisher(**DUMMY_KLAXIT_FEED_PUBLISHER)
 
     assert services[1].service_url == 'tata'
     assert services[1].api_key == 'tata key'
     assert services[1].network == 'M'
-    assert services[1].system_id == 'Klaxit VIA API'
+    assert services[1].system_id == 'klaxit'
     assert services[1]._get_feed_publisher() == RsFeedPublisher(**DEFAULT_KLAXIT_FEED_PUBLISHER)
 
 
@@ -175,7 +175,7 @@ def klaxit_service_test():
 
         assert len(ridesharing_journeys) == 2
         assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[0].metadata.system_id == 'Klaxit VIA API'
+        assert ridesharing_journeys[0].metadata.system_id == 'klaxit'
         assert ridesharing_journeys[0].ridesharing_ad == 'https://klaxit.app.link'
 
         assert ridesharing_journeys[0].pickup_place.addr == ""  # address is not provided in mock
@@ -202,7 +202,7 @@ def klaxit_service_test():
         assert ridesharing_journeys[0].available_seats is None
 
         assert ridesharing_journeys[1].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[1].metadata.system_id == 'Klaxit VIA API'
+        assert ridesharing_journeys[1].metadata.system_id == 'klaxit'
         assert ridesharing_journeys[1].shape
         assert ridesharing_journeys[1].ridesharing_ad == 'https://klaxit.app.link'
 

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
@@ -132,7 +132,7 @@ def two_ridesharing_service_manager_config_from_file_and_db_test():
     ridesharing_manager.update_config()
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 1
-    assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "Instant System"
+    assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"
     assert ridesharing_manager._rs_services_getter
     assert ridesharing_manager._update_interval == 60
     assert len(ridesharing_manager._ridesharing_services_legacy) == 1
@@ -155,7 +155,7 @@ def two_same_ridesharing_service_manager_config_from_file_and_db_test():
     ridesharing_manager.update_config()
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 1
-    assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "Instant System"
+    assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"
     assert ridesharing_manager._rs_services_getter
     assert ridesharing_manager._update_interval == 60
     assert ridesharing_manager._update_interval == 60
@@ -178,8 +178,8 @@ def ridesharing_service_manager_config_from_file_and_db_test():
     ridesharing_manager.update_config()
     assert len(ridesharing_manager.ridesharing_services_configuration) == 0
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 2
-    assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "Instant System"
-    assert ridesharing_manager._ridesharing_services["Blablacar"].system_id == "Blablacar"
+    assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"
+    assert ridesharing_manager._ridesharing_services["Blablacar"].system_id == "blablacar"
     assert ridesharing_manager._rs_services_getter
     assert ridesharing_manager._update_interval == 60
     assert ridesharing_manager._update_interval == 60
@@ -193,7 +193,7 @@ def blablacar_init_class_test():
     ridesharing_manager = RidesharingServiceManager(instance, [])
     service = ridesharing_manager._init_class(config_blablacar["class"], config_blablacar["args"])
     assert isinstance(service, Blablacar)
-    assert service.system_id == "Blablacar"
+    assert service.system_id == "blablacar"
 
 
 def instant_system_init_class_test():
@@ -201,4 +201,4 @@ def instant_system_init_class_test():
     ridesharing_manager = RidesharingServiceManager(instance, [])
     service = ridesharing_manager._init_class(config_instant_system["class"], config_instant_system["args"])
     assert isinstance(service, InstantSystem)
-    assert service.system_id == 'Instant System'
+    assert service.system_id == 'instant_system'

--- a/source/jormungandr/tests/blablacar_routing_tests.py
+++ b/source/jormungandr/tests/blablacar_routing_tests.py
@@ -149,7 +149,7 @@ class TestBlablacar(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.78995, 47.28728]
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'
-        assert rsj_info.get('operator') == 'Blablacar'
+        assert rsj_info.get('operator') == 'blablacar'
         assert rsj_info.get('seats').get('available') == 3
 
         assert 'total' not in rsj_info.get('seats')

--- a/source/jormungandr/tests/instant_system_new_default_routing_tests.py
+++ b/source/jormungandr/tests/instant_system_new_default_routing_tests.py
@@ -173,7 +173,7 @@ class TestInstantSystem(NewDefaultScenarioAbstractTestFixture):
         assert rsj_info.get('driver').get('rating').get('scale_min') == 0.0
         assert rsj_info.get('driver').get('rating').get('scale_max') == 5.0
         assert rsj_info.get('network') == 'Super Covoit'
-        assert rsj_info.get('operator') == 'Instant System'
+        assert rsj_info.get('operator') == 'instant_system'
         assert rsj_info.get('seats').get('available') == 4
 
         assert 'total' not in rsj_info.get('seats')

--- a/source/jormungandr/tests/karos_routing_tests.py
+++ b/source/jormungandr/tests/karos_routing_tests.py
@@ -165,7 +165,7 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[1].get('duration') == 1301
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'
-        assert rsj_info.get('operator') == 'Karos'
+        assert rsj_info.get('operator') == 'karos'
 
         rsj_links = rsj_sections[1].get('links')
         assert len(rsj_links) == 2

--- a/source/jormungandr/tests/klaxit_routing_tests.py
+++ b/source/jormungandr/tests/klaxit_routing_tests.py
@@ -158,7 +158,7 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[1].get('duration') == 1301
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'
-        assert rsj_info.get('operator') == 'Klaxit VIA API'
+        assert rsj_info.get('operator') == 'klaxit'
 
         rsj_links = rsj_sections[1].get('links')
         assert len(rsj_links) == 2


### PR DESCRIPTION
Modification default system_id:
- Instant System >> instant_system
- Klaxit VIA API >> klaxit
- Blablacar >> blablacar
- Karos >> karos

. This is so as not to have a string of characters in the object identifier and to do: 
`http://xxx/v0/ridesharing_services/Klaxit VIA API `
. To be able to compare two objects, the first from the database and the other from the configuration file [here](https://github.com/CanalTP/navitia/blob/dev/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py#L173)
