### PR TITLE
Ridesharing: Rename Blablacar to Blablalines, price in centime, crofly durations calculated 

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -168,8 +168,8 @@ CIRCUIT_BREAKER_CYKLEO_TIMEOUT_S = 60  # the circuit breaker retries after this 
 CIRCUIT_BREAKER_MAX_INSTANT_SYSTEM_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_INSTANT_SYSTEM_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 
-CIRCUIT_BREAKER_MAX_BLABLACAR_FAIL = 4  # max instance call failures before stopping attempt
-CIRCUIT_BREAKER_BLABLACAR_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
+CIRCUIT_BREAKER_MAX_BLABLALINES_FAIL = 4  # max instance call failures before stopping attempt
+CIRCUIT_BREAKER_BLABLALINES_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 
 CIRCUIT_BREAKER_MAX_KAROS_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_KAROS_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -110,6 +110,10 @@ class Karos(AbstractRidesharingService):
             res.distance = offer.get('distance')
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
+            res.origin_pickup_distance = offer.get('departureToPickupWalkingDistance')
+            res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
+            res.dropoff_dest_distance = offer.get('dropoffToArrivalWalkingDistance')
+            res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
 
             res.pickup_place = rsj.Place(
                 addr='', lat=offer.get('driverDepartureLat'), lon=offer.get('driverDepartureLng')
@@ -132,7 +136,7 @@ class Karos(AbstractRidesharingService):
                     type_pb2.GeographicalCoord(lon=res.dropoff_place.lon, lat=res.dropoff_place.lat)
                 )
 
-            res.price = offer.get('price', {}).get('amount')
+            res.price = offer.get('price', {}).get('amount') * 100.0
             res.currency = "centime"
 
             res.available_seats = offer.get('availableSeats')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -110,9 +110,7 @@ class Karos(AbstractRidesharingService):
             res.distance = offer.get('distance')
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
-            res.origin_pickup_distance = offer.get('departureToPickupWalkingDistance')
             res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
-            res.dropoff_dest_distance = offer.get('dropoffToArrivalWalkingDistance')
             res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
 
             res.pickup_place = rsj.Place(

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
@@ -110,6 +110,10 @@ class Klaxit(AbstractRidesharingService):
             res.distance = offer.get('distance')
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
+            res.origin_pickup_distance = offer.get('departureToPickupWalkingDistance')
+            res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
+            res.dropoff_dest_distance = offer.get('dropoffToArrivalWalkingDistance')
+            res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
 
             res.pickup_place = rsj.Place(
                 addr='', lat=offer.get('driverDepartureLat'), lon=offer.get('driverDepartureLng')
@@ -132,7 +136,8 @@ class Klaxit(AbstractRidesharingService):
                     type_pb2.GeographicalCoord(lon=res.dropoff_place.lon, lat=res.dropoff_place.lat)
                 )
 
-            res.price = offer.get('price', {}).get('amount')
+            # For Klaxit the price is in euro
+            res.price = offer.get('price', {}).get('amount') * 100.0
             res.currency = "centime"
 
             res.available_seats = offer.get('available_seats')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
@@ -110,9 +110,7 @@ class Klaxit(AbstractRidesharingService):
             res.distance = offer.get('distance')
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
-            res.origin_pickup_distance = offer.get('departureToPickupWalkingDistance')
             res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
-            res.dropoff_dest_distance = offer.get('dropoffToArrivalWalkingDistance')
             res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
 
             res.pickup_place = rsj.Place(

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing.md
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing.md
@@ -1,19 +1,19 @@
 # Ridesharing Services
 
-## Blablacar
+## Blablalines
 
 Provides an external API that delivers ridesharing offers.<br>
 Navitia exposes the offers inside **ridesharing_journeys** json output field.<br>
-Blablacar documentation : https://www.blablalines.com/public-api-v2#search-get
+Blablalines documentation : https://www.blablalines.com/public-api-v2#search-get
 
-### How to connect Blablacar with Navitia.
+### How to connect Blablalines with Navitia.
 
 Insert into **Jormun** configuration:
 
 ```
  "ridesharing": [
     {
-        "class": "jormungandr.scenarios.ridesharing.blablacar.Blablacar",
+        "class": "jormungandr.scenarios.ridesharing.blablalines.Blablalines",
         "args": {
             "service_url": "https://api.blablalines.com/2/third_party/public/search",
             "api_key": "Token",

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
@@ -88,8 +88,6 @@ class RidesharingJourney(object):
         'currency',  # "centime" (EURO cents) is the preferred currency (price is filled accordingly)
         'total_seats',
         'available_seats',
-        'origin_pickup_distance',
         'origin_pickup_duration',
-        'dropoff_dest_distance',
         'dropoff_dest_duration',
     )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
@@ -88,4 +88,8 @@ class RidesharingJourney(object):
         'currency',  # "centime" (EURO cents) is the preferred currency (price is filled accordingly)
         'total_seats',
         'available_seats',
+        'origin_pickup_distance',
+        'origin_pickup_duration',
+        'dropoff_dest_distance',
+        'dropoff_dest_duration',
     )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -240,11 +240,7 @@ class RidesharingServiceManager(object):
             start_teleport_section.length = int(crowfly_distance_between(from_coord, pickup_coord))
 
             # We take departure to pickup duration
-            start_teleport_section.duration = (
-                int(rsj.origin_pickup_duration)
-                if getattr(rsj, 'origin_pickup_duration', None) is not None
-                else 0
-            )
+            start_teleport_section.duration = int(getattr(rsj, 'origin_pickup_duration', 0))
             pb_rsj.durations.walking += start_teleport_section.duration
             pb_rsj.durations.total += start_teleport_section.duration
 
@@ -317,9 +313,7 @@ class RidesharingServiceManager(object):
             end_teleport_section.length = int(crowfly_distance_between(dropoff_coord, to_coord))
 
             # We take dropoff to destination duration
-            end_teleport_section.duration = (
-                int(rsj.dropoff_dest_duration) if getattr(rsj, 'dropoff_dest_duration', None) is not None else 0
-            )
+            end_teleport_section.duration = int(getattr(rsj, 'dropoff_dest_duration', 0))
             pb_rsj.durations.walking += end_teleport_section.duration
             pb_rsj.durations.total += end_teleport_section.duration
             pb_rsj.duration += pb_rsj.durations.total

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
@@ -31,7 +31,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 
-from jormungandr.scenarios.ridesharing.blablacar import Blablacar, DEFAULT_BLABLACAR_FEED_PUBLISHER
+from jormungandr.scenarios.ridesharing.blablalines import Blablalines, DEFAULT_BLABLALINES_FEED_PUBLISHER
 from jormungandr.scenarios.ridesharing.ridesharing_service_manager import RidesharingServiceManager
 from jormungandr.scenarios.ridesharing.ridesharing_service import RsFeedPublisher, RidesharingServiceError
 
@@ -91,7 +91,7 @@ fixed = regex.sub(r"\\\\", fake_response)
 
 mock_get = mock.MagicMock(return_value=utils_test.MockResponse(json.loads(fixed), 200, '{}'))
 
-DUMMY_BLABLACAR_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 'url': 'http://w.tf'}
+DUMMY_BLABLALINES_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 'url': 'http://w.tf'}
 
 # A hack class
 class DummyInstance:
@@ -101,16 +101,16 @@ class DummyInstance:
 def get_ridesharing_service_test():
     configs = [
         {
-            "class": "jormungandr.scenarios.ridesharing.blablacar.Blablacar",
+            "class": "jormungandr.scenarios.ridesharing.blablalines.Blablalines",
             "args": {
                 "service_url": "toto",
                 "api_key": "toto key",
                 "network": "N",
-                "feed_publisher": DUMMY_BLABLACAR_FEED_PUBLISHER,
+                "feed_publisher": DUMMY_BLABLALINES_FEED_PUBLISHER,
             },
         },
         {
-            "class": "jormungandr.scenarios.ridesharing.blablacar.Blablacar",
+            "class": "jormungandr.scenarios.ridesharing.blablalines.Blablalines",
             "args": {"service_url": "tata", "api_key": "tata key", "network": "M"},
         },
     ]
@@ -124,24 +124,24 @@ def get_ridesharing_service_test():
     assert services[0].service_url == 'toto'
     assert services[0].api_key == 'toto key'
     assert services[0].network == 'N'
-    assert services[0].system_id == 'blablacar'
-    assert services[0]._get_feed_publisher() == RsFeedPublisher(**DUMMY_BLABLACAR_FEED_PUBLISHER)
+    assert services[0].system_id == 'blablalines'
+    assert services[0]._get_feed_publisher() == RsFeedPublisher(**DUMMY_BLABLALINES_FEED_PUBLISHER)
 
     assert services[1].service_url == 'tata'
     assert services[1].api_key == 'tata key'
     assert services[1].network == 'M'
-    assert services[1].system_id == 'blablacar'
-    assert services[1]._get_feed_publisher() == RsFeedPublisher(**DEFAULT_BLABLACAR_FEED_PUBLISHER)
+    assert services[1].system_id == 'blablalines'
+    assert services[1]._get_feed_publisher() == RsFeedPublisher(**DEFAULT_BLABLALINES_FEED_PUBLISHER)
 
 
-def blablacar_test():
+def blablalines_test():
     with mock.patch('requests.get', mock_get):
 
-        blablacar = Blablacar(
+        blablalines = Blablalines(
             service_url='dummyUrl',
             api_key='dummyApiKey',
             network='dummyNetwork',
-            feed_publisher=DUMMY_BLABLACAR_FEED_PUBLISHER,
+            feed_publisher=DUMMY_BLABLALINES_FEED_PUBLISHER,
         )
         from_coord = '47.28696,0.78981'
         to_coord = '47.38642,0.69039'
@@ -149,13 +149,13 @@ def blablacar_test():
         period_extremity = utils.PeriodExtremity(
             datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
         )
-        ridesharing_journeys, feed_publisher = blablacar.request_journeys_with_feed_publisher(
+        ridesharing_journeys, feed_publisher = blablalines.request_journeys_with_feed_publisher(
             from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity
         )
 
         assert len(ridesharing_journeys) == 2
         assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[0].metadata.system_id == 'blablacar'
+        assert ridesharing_journeys[0].metadata.system_id == 'blablalines'
         assert ridesharing_journeys[0].ridesharing_ad == 'https://blablalines.com'
 
         assert ridesharing_journeys[0].pickup_place.addr == ""  # address is not provided in mock
@@ -174,14 +174,14 @@ def blablacar_test():
         assert ridesharing_journeys[0].shape[-1].lat == ridesharing_journeys[0].dropoff_place.lat
         assert ridesharing_journeys[0].shape[-1].lon == ridesharing_journeys[0].dropoff_place.lon
 
-        assert ridesharing_journeys[0].price == 1
+        assert ridesharing_journeys[0].price == 100.0
         assert ridesharing_journeys[0].currency == 'centime'
 
         assert ridesharing_journeys[0].total_seats is None
         assert ridesharing_journeys[0].available_seats == 3
 
         assert ridesharing_journeys[1].metadata.network == 'dummyNetwork'
-        assert ridesharing_journeys[1].metadata.system_id == 'blablacar'
+        assert ridesharing_journeys[1].metadata.system_id == 'blablalines'
         assert ridesharing_journeys[1].shape
         assert ridesharing_journeys[1].ridesharing_ad == 'https://blablalines.com'
 
@@ -193,23 +193,23 @@ def blablacar_test():
         assert ridesharing_journeys[1].dropoff_place.lat == 47.38399
         assert ridesharing_journeys[1].dropoff_place.lon == 0.69192
 
-        assert ridesharing_journeys[1].price == 3
+        assert ridesharing_journeys[1].price == 300.0
         assert ridesharing_journeys[1].currency == 'centime'
 
         assert ridesharing_journeys[1].total_seats is None
         assert ridesharing_journeys[1].available_seats == 2
 
-        assert feed_publisher == RsFeedPublisher(**DUMMY_BLABLACAR_FEED_PUBLISHER)
+        assert feed_publisher == RsFeedPublisher(**DUMMY_BLABLALINES_FEED_PUBLISHER)
 
 
 def test_request_journeys_should_raise_on_non_200():
     with requests_mock.Mocker() as mock:
-        blablacar = Blablacar(service_url='http://blablacar', api_key='ApiKey', network='Network')
+        blablalines = Blablalines(service_url='http://blablalines', api_key='ApiKey', network='Network')
 
-        mock.get('http://blablacar', status_code=401, text='{this is the http response}')
+        mock.get('http://blablalines', status_code=401, text='{this is the http response}')
 
         with pytest.raises(RidesharingServiceError) as e:
-            blablacar._request_journeys(
+            blablalines._request_journeys(
                 '1.2,3.4',
                 '5.6,7.8',
                 utils.PeriodExtremity(

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -286,7 +286,7 @@ def karos_service_test():
         assert ridesharing_journeys[0].driver.rate == 5
         assert ridesharing_journeys[0].driver.rate_count is None
 
-        assert ridesharing_journeys[0].price == 2
+        assert ridesharing_journeys[0].price == 200.0
         assert ridesharing_journeys[0].currency == 'centime'
         assert ridesharing_journeys[0].total_seats is None
         assert ridesharing_journeys[0].available_seats == 3
@@ -306,7 +306,7 @@ def karos_service_test():
         assert ridesharing_journeys[1].dropoff_place.lat == 48.7028
         assert ridesharing_journeys[1].dropoff_place.lon == 2.1029
 
-        assert ridesharing_journeys[1].price == 2
+        assert ridesharing_journeys[1].price == 200.0
         assert ridesharing_journeys[1].currency == 'centime'
         assert ridesharing_journeys[1].total_seats is None
         assert ridesharing_journeys[1].available_seats == 3

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
@@ -194,7 +194,7 @@ def klaxit_service_test():
         assert ridesharing_journeys[0].shape[-1].lat == ridesharing_journeys[0].dropoff_place.lat
         assert ridesharing_journeys[0].shape[-1].lon == ridesharing_journeys[0].dropoff_place.lon
 
-        assert ridesharing_journeys[0].price == 0.51
+        assert ridesharing_journeys[0].price == 51.0
         assert ridesharing_journeys[0].currency == 'centime'
 
         # Klaxit doesn't have any information on seats
@@ -214,7 +214,7 @@ def klaxit_service_test():
         assert ridesharing_journeys[1].dropoff_place.lat == 48.8559454289402
         assert ridesharing_journeys[1].dropoff_place.lon == 2.37563525508835
 
-        assert ridesharing_journeys[1].price == 0.56
+        assert ridesharing_journeys[1].price == pytest.approx(56.0, abs=0.01)
         assert ridesharing_journeys[1].currency == 'centime'
 
         # Klaxit doesn't have any information on seats

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
@@ -29,7 +29,7 @@
 # www.navitia.io
 
 from jormungandr.scenarios.ridesharing.ridesharing_service_manager import RidesharingServiceManager
-from jormungandr.scenarios.ridesharing.blablacar import Blablacar
+from jormungandr.scenarios.ridesharing.blablalines import Blablalines
 from jormungandr.scenarios.ridesharing.instant_system import InstantSystem
 from navitiacommon.models.ridesharing_service import RidesharingService
 
@@ -51,8 +51,8 @@ config_instant_system = {
         "timeframe_duration": 1800,
     },
 }
-config_blablacar = {
-    "class": "jormungandr.scenarios.ridesharing.blablacar.Blablacar",
+config_blablalines = {
+    "class": "jormungandr.scenarios.ridesharing.blablalines.Blablalines",
     "args": {"service_url": "tata", "api_key": "tata key", "network": "MM"},
 }
 
@@ -73,13 +73,13 @@ def instant_system_ridesharing_service_manager_config_from_file_test():
     assert len(ridesharing_manager._ridesharing_services_legacy) == 1
 
 
-def blablacar_ridesharing_service_manager_config_from_file_test():
+def blablalines_ridesharing_service_manager_config_from_file_test():
     """
-    creation of a ridesharing service from the configuration file: Blablacar
-    Result: We must find the service Blablacar
+    creation of a ridesharing service from the configuration file: Blablalines
+    Result: We must find the service Blablalines
     """
     instance = MockInstance()
-    ridesharing_services_config = [config_blablacar]
+    ridesharing_services_config = [config_blablalines]
     ridesharing_manager = RidesharingServiceManager(instance, ridesharing_services_config)
     ridesharing_manager.init_ridesharing_services()
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
@@ -91,11 +91,11 @@ def blablacar_ridesharing_service_manager_config_from_file_test():
 
 def two_ridesharing_service_manager_config_from_file_test():
     """
-    creation of a ride sharing services from the configuration file: Blablacar and InstantSystym
-    Result: We have to find both services Blablacar and InstantSystem
+    creation of a ride sharing services from the configuration file: Blablalines and InstantSystym
+    Result: We have to find both services Blablalines and InstantSystem
     """
     instance = MockInstance()
-    ridesharing_services_config = [config_blablacar, config_instant_system]
+    ridesharing_services_config = [config_blablalines, config_instant_system]
     ridesharing_manager = RidesharingServiceManager(instance, ridesharing_services_config)
     ridesharing_manager.init_ridesharing_services()
     assert len(ridesharing_manager.ridesharing_services_configuration) == 2
@@ -111,20 +111,20 @@ def mock_get_attr_instant_system():
     return [service]
 
 
-def mock_get_attr_instant_system_and_blablacar():
-    json = {"klass": config_blablacar["class"], "args": config_blablacar["args"]}
-    Blablacar = RidesharingService(id="Blablacar", json=json)
-    return [Blablacar] + mock_get_attr_instant_system()
+def mock_get_attr_instant_system_and_blablalines():
+    json = {"klass": config_blablalines["class"], "args": config_blablalines["args"]}
+    Blablalines = RidesharingService(id="Blablalines", json=json)
+    return [Blablalines] + mock_get_attr_instant_system()
 
 
 def two_ridesharing_service_manager_config_from_file_and_db_test():
     """
-    creation of a ridesharing service from the configuration file: Blablacar
+    creation of a ridesharing service from the configuration file: Blablalines
     creation of a ridesharing service from database : InstantSystem
-    Result: We have to find both services Blablacar and InstantSystem
+    Result: We have to find both services Blablalines and InstantSystem
     """
     instance = MockInstance()
-    ridesharing_services_config = [config_blablacar]
+    ridesharing_services_config = [config_blablalines]
     ridesharing_manager = RidesharingServiceManager(
         instance, ridesharing_services_config, rs_services_getter=mock_get_attr_instant_system
     )
@@ -167,19 +167,19 @@ def two_same_ridesharing_service_manager_config_from_file_and_db_test():
 def ridesharing_service_manager_config_from_file_and_db_test():
     """
     creation of a ridesharing service from database: InstantSystem
-    creation of a ridesharing service from database : Blablacar
-    Result: We have to find both services Blablacar and InstantSystem
+    creation of a ridesharing service from database : Blablalines
+    Result: We have to find both services Blablalines and InstantSystem
     """
     instance = MockInstance()
     ridesharing_manager = RidesharingServiceManager(
-        instance, [], rs_services_getter=mock_get_attr_instant_system_and_blablacar
+        instance, [], rs_services_getter=mock_get_attr_instant_system_and_blablalines
     )
     ridesharing_manager.init_ridesharing_services()
     ridesharing_manager.update_config()
     assert len(ridesharing_manager.ridesharing_services_configuration) == 0
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 2
     assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"
-    assert ridesharing_manager._ridesharing_services["Blablacar"].system_id == "blablacar"
+    assert ridesharing_manager._ridesharing_services["Blablalines"].system_id == "blablalines"
     assert ridesharing_manager._rs_services_getter
     assert ridesharing_manager._update_interval == 60
     assert ridesharing_manager._update_interval == 60
@@ -188,12 +188,12 @@ def ridesharing_service_manager_config_from_file_and_db_test():
     assert len(services) == 2
 
 
-def blablacar_init_class_test():
+def blablalines_init_class_test():
     instance = MockInstance()
     ridesharing_manager = RidesharingServiceManager(instance, [])
-    service = ridesharing_manager._init_class(config_blablacar["class"], config_blablacar["args"])
-    assert isinstance(service, Blablacar)
-    assert service.system_id == "blablacar"
+    service = ridesharing_manager._init_class(config_blablalines["class"], config_blablalines["args"])
+    assert isinstance(service, Blablalines)
+    assert service.system_id == "blablalines"
 
 
 def instant_system_init_class_test():

--- a/source/jormungandr/tests/blablalines_routing_tests.py
+++ b/source/jormungandr/tests/blablalines_routing_tests.py
@@ -34,7 +34,7 @@ from jormungandr.tests.utils_test import MockResponse
 from tests.check_utils import get_not_null, get_links_dict
 from tests.tests_mechanism import dataset, NewDefaultScenarioAbstractTestFixture
 
-DUMMY_BLABLACAR_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 'url': 'http://w.tf'}
+DUMMY_BLABLALINES_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 'url': 'http://w.tf'}
 
 MOCKED_INSTANCE_CONF = {
     'scenario': 'new_default',
@@ -46,16 +46,16 @@ MOCKED_INSTANCE_CONF = {
                     "api_key": "key",
                     "network": "Super Covoit",
                     "timedelta": 3600,
-                    "feed_publisher": DUMMY_BLABLACAR_FEED_PUBLISHER,
+                    "feed_publisher": DUMMY_BLABLALINES_FEED_PUBLISHER,
                 },
-                "class": "jormungandr.scenarios.ridesharing.blablacar.Blablacar",
+                "class": "jormungandr.scenarios.ridesharing.blablalines.Blablalines",
             }
         ]
     },
 }
 
 
-BLABLACAR_RESPONSE = [
+BLABLALINES_RESPONSE = [
     {
         "id": "53e0ac4f-e693-4e29-8f69-eb1142d5b99e_2020-09-28",
         "journey_polyline": "svr_H}fyC{@g@[[o@u@Qc@[sBMm@Qe@[g@e@k@aBuAIKOI?AACCEEAIDAN@DMf@GZ@d@QbBOzAy@xFAJ]r@IPOQm@a@wDoB?C?ECIGAGD?@m@c@uCiCcCgBEKsB}AK?IGs@i@m@y@Wm@oAoDaB_EYk@y@kAyDmG_A}Ao@}AQeAIcAOiBUw@Yc@WWUKiAe@USSQKOACAIEQMOOGO@MHKPGd@CZK^INq@`A}@lAmEhGcIdLcPlUqGdJ[XE?K@KFK\AH?DQl@aFjH{IlMoCdEgBrCkG~JqDtFcLpPyb@pn@aHdKoHjKcAtAQLSLC?G@KFMZAVI`@eCvDoAnBs@rAe@~@{@pBg@tAk@fBcEpO{FpTeL~a@wBfIoAjEy@fBK?KDOPIXCd@F`@UxAY`AQn@o@zCwAxFiAbEMd@cCdJ_BxF[t@GAE?KDILAP@RHLBB]`Bw@fDYbAQn@gBrGqAnFq@rCyIj\qH|XMNe@vAq@dCcFpRaF|QuFbT}CdL{CbLgE`PiCjJcApDYWoB{@gBw@_EiBiAi@[KwBmAiF}CuAm@Q@}A{@sFeDkDqBsIwEkYmOyJ_FgEmBiEeB_EuAkCw@aCm@{AWaCa@aCYcF[yCG_D@iEPaDXeANmBZsCl@wDdA_DhAcEfBiHjDoLzF}h@fWoKbFcAh@]E_Cl@s@L_AJqA?}@IkAOcAUaA[y@e@{@i@SISA_@Fa@T]XYd@Gn@R|@X~@p@dAn@|@h@z@?B?D@HJNB?@?|@~ArE`IPl@t@tAt@hBdAvCzBxFj@tHn@|Iz@zL~@nMf@hGLb@F`@TzCJpB^@VERSN]@a@Ae@|By@bA[dCw@NKpDiAxAc@|@U",
@@ -74,19 +74,21 @@ BLABLACAR_RESPONSE = [
 ]
 
 
-def mock_blablacar(_, params):
-    return MockResponse(BLABLACAR_RESPONSE, 200)
+def mock_blablalines(_, params):
+    return MockResponse(BLABLALINES_RESPONSE, 200)
 
 
 @pytest.fixture(scope="function", autouse=True)
-def mock_http_blablacar(monkeypatch):
-    monkeypatch.setattr('jormungandr.scenarios.ridesharing.blablacar.Blablacar._call_service', mock_blablacar)
+def mock_http_blablalines(monkeypatch):
+    monkeypatch.setattr(
+        'jormungandr.scenarios.ridesharing.blablalines.Blablalines._call_service', mock_blablalines
+    )
 
 
 @dataset({'main_routing_test': MOCKED_INSTANCE_CONF})
-class TestBlablacar(NewDefaultScenarioAbstractTestFixture):
+class TestBlablalines(NewDefaultScenarioAbstractTestFixture):
     """
-    Integration test with Blablacar
+    Integration test with Blablalines
     Note: '&forbidden_uris[]=PM' used to avoid line 'PM' and it's vj=vjPB in /journeys
     """
 
@@ -114,7 +116,7 @@ class TestBlablacar(NewDefaultScenarioAbstractTestFixture):
         tickets = response.get('tickets')
         assert len(tickets) == 1
         assert tickets[0].get('cost').get('currency') == 'centime'
-        assert tickets[0].get('cost').get('value') == '1.0'
+        assert tickets[0].get('cost').get('value') == '100.0'
         ticket = tickets[0]
 
         ridesharing_kraken = journeys[0]
@@ -135,7 +137,7 @@ class TestBlablacar(NewDefaultScenarioAbstractTestFixture):
         rs_journeys = sections[0].get('ridesharing_journeys')
         assert len(rs_journeys) == 1
         assert rs_journeys[0].get('distances').get('ridesharing') == 18869
-        assert rs_journeys[0].get('durations').get('walking') == 0  # two crow_fly sections have 0 duration
+        assert rs_journeys[0].get('durations').get('walking') == 250
         assert rs_journeys[0].get('durations').get('ridesharing') == 1301
         assert 'ridesharing' in rs_journeys[0].get('tags')
         rsj_sections = rs_journeys[0].get('sections')
@@ -143,13 +145,15 @@ class TestBlablacar(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[0].get('type') == 'crow_fly'
         assert rsj_sections[0].get('mode') == 'walking'
+        # For start teleport section we take departure to pickup duration
+        assert rsj_sections[0].get('duration') == 174
 
         assert rsj_sections[1].get('type') == 'ridesharing'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
         assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.78995, 47.28728]
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'
-        assert rsj_info.get('operator') == 'blablacar'
+        assert rsj_info.get('operator') == 'blablalines'
         assert rsj_info.get('seats').get('available') == 3
 
         assert 'total' not in rsj_info.get('seats')
@@ -167,11 +171,13 @@ class TestBlablacar(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[2].get('type') == 'crow_fly'
         assert rsj_sections[2].get('mode') == 'walking'
+        # For end teleport section we take dropoff to destination duration
+        assert rsj_sections[2].get('duration') == 76
 
         fps = response['feed_publishers']
         assert len(fps) == 2
 
         def equals_to_dummy_fp(fp):
-            return fp == DUMMY_BLABLACAR_FEED_PUBLISHER
+            return fp == DUMMY_BLABLALINES_FEED_PUBLISHER
 
         assert any(equals_to_dummy_fp(fp) for fp in fps)

--- a/source/jormungandr/tests/instant_system_new_default_routing_tests.py
+++ b/source/jormungandr/tests/instant_system_new_default_routing_tests.py
@@ -154,7 +154,7 @@ class TestInstantSystem(NewDefaultScenarioAbstractTestFixture):
         rs_journeys = sections[0].get('ridesharing_journeys')
         assert len(rs_journeys) == 1
         assert rs_journeys[0].get('distances').get('ridesharing') == 224
-        assert rs_journeys[0].get('durations').get('walking') == 0  # two crow_fly sections have 0 duration
+        assert rs_journeys[0].get('durations').get('walking') == 0
         assert rs_journeys[0].get('durations').get('ridesharing') == 1057
         assert 'ridesharing' in rs_journeys[0].get('tags')
         rsj_sections = rs_journeys[0].get('sections')

--- a/source/jormungandr/tests/karos_routing_tests.py
+++ b/source/jormungandr/tests/karos_routing_tests.py
@@ -126,7 +126,7 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
         tickets = response.get('tickets')
         assert len(tickets) == 1
         assert tickets[0].get('cost').get('currency') == 'centime'
-        assert tickets[0].get('cost').get('value') == '1.0'
+        assert tickets[0].get('cost').get('value') == '100.0'
         ticket = tickets[0]
 
         ridesharing_kraken = journeys[0]
@@ -147,7 +147,7 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
         rs_journeys = sections[0].get('ridesharing_journeys')
         assert len(rs_journeys) == 1
         assert rs_journeys[0].get('distances').get('ridesharing') == 18869
-        assert rs_journeys[0].get('durations').get('walking') == 0  # two crow_fly sections have 0 duration
+        assert rs_journeys[0].get('durations').get('walking') == 250
         assert rs_journeys[0].get('durations').get('ridesharing') == 1301
         assert 'ridesharing' in rs_journeys[0].get('tags')
         rsj_sections = rs_journeys[0].get('sections')
@@ -155,8 +155,8 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[0].get('type') == 'crow_fly'
         assert rsj_sections[0].get('mode') == 'walking'
-        # crowfly duration in ridesharing is always 0
-        assert rsj_sections[0].get('duration') == 0
+        # For start teleport section we take departure to pickup duration
+        assert rsj_sections[0].get('duration') == 174
 
         assert rsj_sections[1].get('type') == 'ridesharing'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
@@ -180,8 +180,8 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[2].get('type') == 'crow_fly'
         assert rsj_sections[2].get('mode') == 'walking'
-        # crowfly duration in ridesharing is always 0
-        assert rsj_sections[2].get('duration') == 0
+        # For end teleport section we take dropoff to destination duration
+        assert rsj_sections[2].get('duration') == 76
 
         fps = response['feed_publishers']
         assert len(fps) == 2

--- a/source/jormungandr/tests/klaxit_routing_tests.py
+++ b/source/jormungandr/tests/klaxit_routing_tests.py
@@ -119,7 +119,7 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
         tickets = response.get('tickets')
         assert len(tickets) == 1
         assert tickets[0].get('cost').get('currency') == 'centime'
-        assert tickets[0].get('cost').get('value') == '1.0'
+        assert tickets[0].get('cost').get('value') == '100.0'
         ticket = tickets[0]
 
         ridesharing_kraken = journeys[0]
@@ -140,7 +140,7 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
         rs_journeys = sections[0].get('ridesharing_journeys')
         assert len(rs_journeys) == 1
         assert rs_journeys[0].get('distances').get('ridesharing') == 18869
-        assert rs_journeys[0].get('durations').get('walking') == 0  # two crow_fly sections have 0 duration
+        assert rs_journeys[0].get('durations').get('walking') == 250
         assert rs_journeys[0].get('durations').get('ridesharing') == 1301
         assert 'ridesharing' in rs_journeys[0].get('tags')
         rsj_sections = rs_journeys[0].get('sections')
@@ -148,8 +148,8 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[0].get('type') == 'crow_fly'
         assert rsj_sections[0].get('mode') == 'walking'
-        # crowfly duration in ridesharing is always 0
-        assert rsj_sections[0].get('duration') == 0
+        # For start teleport section we take departure to pickup duration
+        assert rsj_sections[0].get('duration') == 174
 
         assert rsj_sections[1].get('type') == 'ridesharing'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
@@ -173,8 +173,8 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[2].get('type') == 'crow_fly'
         assert rsj_sections[2].get('mode') == 'walking'
-        # crowfly duration in ridesharing is always 0
-        assert rsj_sections[2].get('duration') == 0
+        # For end teleport section we take dropoff to destination duration
+        assert rsj_sections[2].get('duration') == 76
 
         fps = response['feed_publishers']
         assert len(fps) == 2


### PR DESCRIPTION
Modifications are the followings:

- Blablacar renamed to Blablalines
- Convertir le prix en centime: Blablacar, klaxit, karos
- Error: ridesharing_journeys absent in Blablalines
- ridesharing_journey[].duration, ridesharing_journey[].durations.walking and ridesharing_journey[].durations.total recalculated.

Concerned tickets: 
- https://jira.kisio.org/browse/NAVITIAII-3212
- https://jira.kisio.org/browse/NAVITIAII-3216
- https://jira.kisio.org/browse/NAVITIAII-3217
