### PR TITLE
[Github Actions] remove setenv in github actions

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -1,8 +1,6 @@
 name: Build Navitia Packages For Dev
 
 on:
-  # for test, TO BE REMOVED BEFORE MERGE
-  pull_request:
   push:
     branches:
       - dev

--- a/.github/workflows/build_navitia_packages_for_dev.yml
+++ b/.github/workflows/build_navitia_packages_for_dev.yml
@@ -1,6 +1,8 @@
 name: Build Navitia Packages For Dev
 
 on:
+  # for test, TO BE REMOVED BEFORE MERGE
+  pull_request:
   push:
     branches:
       - dev
@@ -25,12 +27,11 @@ jobs:
     - name: create navitia_debian_packages.zip
       run: |
         zip navitia_debian_packages.zip ../navitia-*
-        echo "::set-env name=NAVITIA_DEBIAN_PACKAGES::navitia_debian_packages.zip"
     - name: upload debian packages
       uses: actions/upload-artifact@v1
       with:
         name: navitia-debian-packages
-        path: "${{env.NAVITIA_DEBIAN_PACKAGES}}"
+        path: "navitia_debian_packages.zip"
     - name: remove useless temporary files
       run: rm -rf ../navitia-*
     - name: trigger deploy on artemis

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -1,8 +1,6 @@
 name: Build Navitia Packages For Release
 
 on:
-  # for test, TO BE REMOVED BEFORE MERGE
-  pull_request:
   push:
     branches:
       - release

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -1,6 +1,8 @@
 name: Build Navitia Packages For Release
 
 on:
+  # for test, TO BE REMOVED BEFORE MERGE
+  pull_request:
   push:
     branches:
       - release
@@ -29,12 +31,11 @@ jobs:
     - name: create navitia_debian_packages.zip
       run: |
         zip navitia_debian_packages.zip ../navitia-*
-        echo "::set-env name=NAVITIA_DEBIAN_PACKAGES::navitia_debian_packages.zip"
     - name: upload debian packages
       uses: actions/upload-artifact@v1
       with:
         name: navitia-debian-packages
-        path: "${{env.NAVITIA_DEBIAN_PACKAGES}}"
+        path: "navitia_debian_packages.zip"
     - name: remove useless temporary files
       run: rm -rf ../navitia-*
     - name: trigger jenkins to publish Artifacts on internal server


### PR DESCRIPTION
```
The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

I removed the "set-env" because it'll be removed from github-actions soon