### PR TITLE
[Jormungandr] Add lines in StopArea and StopPoint when depth = 3 in the query

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -398,6 +398,7 @@ class StopPointSerializer(PbGenericSerializer):
     address = AddressSerializer(display_none=False)
     fare_zone = jsonschema.MethodField(schema_type=lambda: FareZoneSerializer(), display_none=False)
     equipment_details = EquipmentDetailsSerializer(many=True)
+    lines = jsonschema.MethodField(schema_type=lambda: LineSerializer(many=True), display_none=False)
 
     def get_fare_zone(self, obj):
         if obj.HasField(str('fare_zone')):
@@ -410,6 +411,9 @@ class StopPointSerializer(PbGenericSerializer):
             return StopAreaSerializer(obj.stop_area, display_none=False).data
         else:
             return None
+
+    def get_lines(self, obj):
+        return LineSerializer(obj.lines, many=True, display_none=False).data
 
 
 class StopAreaSerializer(PbGenericSerializer):
@@ -430,6 +434,10 @@ class StopAreaSerializer(PbGenericSerializer):
     stop_points = StopPointSerializer(
         many=True, display_none=False, description='Stop points contained in this stop area'
     )
+    lines = jsonschema.MethodField(schema_type=lambda: LineSerializer(many=True), display_none=False)
+
+    def get_lines(self, obj):
+        return LineSerializer(obj.lines, many=True, display_none=False).data
 
 
 class PlaceSerializer(PbGenericSerializer):
@@ -458,9 +466,6 @@ class PlaceNearbySerializer(PlaceSerializer):
 class NetworkSerializer(PbGenericSerializer):
     links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
     codes = CodeSerializer(many=True, display_none=False)
-
-    def get_lines(self, obj):
-        return LineSerializer(obj.lines, many=True, display_none=False).data
 
 
 class RouteSerializer(PbGenericSerializer):

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -758,6 +758,10 @@ def is_valid_line(line, depth_check=1):
     get_not_null(line, "name")
     get_not_null(line, "id")
 
+    for physical_mode in line.get("physical_modes", []):
+        is_valid_physical_mode(physical_mode)
+    is_valid_commercial_mode(get_not_null(line, "commercial_mode"))
+
     for c in line.get('comments', []):
         is_valid_comment(c)
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -533,6 +533,11 @@ void PbCreator::Filler::fill_pb_object(const nt::StopArea* sa, pbnavitia::StopAr
 
     fill_messages(sa, stop_area);
     fill_codes(sa, stop_area);
+
+    if (depth > 2) {
+        std::vector<nt::Line*> lines = ptref_indexes<nt::Line>(sa);
+        copy(0, dump_message_options).fill(lines, stop_area->mutable_lines());
+    }
 }
 
 void PbCreator::Filler::fill_pb_object(const ng::Admin* adm, pbnavitia::AdministrativeRegion* admin) {
@@ -636,6 +641,11 @@ void PbCreator::Filler::fill_pb_object(const nt::StopPoint* sp, pbnavitia::StopP
 
     fill_messages(sp, stop_point);
     fill_codes(sp, stop_point);
+
+    if (depth > 2) {
+        std::vector<nt::Line*> lines = ptref_indexes<nt::Line>(sp);
+        copy(0, dump_message_options).fill(lines, stop_point->mutable_lines());
+    }
 }
 
 void PbCreator::Filler::fill_pb_object(const nt::Company* c, pbnavitia::Company* company) {
@@ -688,6 +698,8 @@ void PbCreator::Filler::fill_pb_object(const nt::Line* l, pbnavitia::Line* line)
     if (l->closing_time) {
         line->set_closing_time((*l->closing_time).total_seconds());
     }
+    fill(l->physical_mode_list, line->mutable_physical_modes());
+    fill(l->commercial_mode, line);
 
     if (depth > 0) {
         if (!this->pb_creator.disable_geojson) {
@@ -695,9 +707,6 @@ void PbCreator::Filler::fill_pb_object(const nt::Line* l, pbnavitia::Line* line)
         }
 
         fill(l->route_list, line->mutable_routes());
-        fill(l->physical_mode_list, line->mutable_physical_modes());
-
-        fill(l->commercial_mode, line);
         fill(l->network, line);
 
         fill(l->line_group_list, line->mutable_line_groups());

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -326,6 +326,10 @@ template <>
 inline Type_e get_type_e<StopPoint>() {
     return Type_e::StopPoint;
 }
+template <>
+inline Type_e get_type_e<Line>() {
+    return Type_e::Line;
+}
 
 }  // namespace type
 // trait to access the number of elements in the Mode_e enum


### PR DESCRIPTION
Some modifications:
- Display commercial_mode and physical_modes in Line even without parameter depth(depth = 0) as basic attributes.
- with the parameter depth = 3 display lines in
-- StopArea (Line with basic attributes).
-- StopPoint (Line with basic attributes).

For details see : https://jira.kisio.org/browse/NAVP-1630