### PR TITLE
[Jormun] adapt properly durations, distances and sections for ridesharing journeys

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1229,7 +1229,7 @@ class Scenario(simple.Scenario):
                 logger.debug('trying to add ridesharing journeys')
                 try:
                     instance.ridesharing_services_manager.decorate_journeys_with_ridesharing_offers(
-                        pb_response, request
+                        pb_response, request, instance
                     )
                 except Exception:
                     logger.exception('Error while retrieving ridesharing ads')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
@@ -175,6 +175,7 @@ class Blablalines(AbstractRidesharingService):
             res.available_seats = offer.get('available_seats')
             res.total_seats = None
 
+            # departure coord is absent in the offer and hence to be generated from the request
             res.departure_date_time = request_datetime
             res.pickup_date_time = res.departure_date_time + res.origin_pickup_duration
             res.dropoff_date_time = res.pickup_date_time + res.duration

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
@@ -150,19 +150,7 @@ class Blablalines(AbstractRidesharingService):
                 jormungandr.street_network.utils.crowfly_distance_between(dropoff_coord, arrival_coord)
             )
 
-            # shape is a list of type_pb2.GeographicalCoord()
-            res.shape = []
-            shape = decode_polyline(offer.get('journey_polyline'), precision=5)
-            if not shape or res.pickup_place.lon != shape[0][0] or res.pickup_place.lat != shape[0][1]:
-                res.shape.append(type_pb2.GeographicalCoord(lon=res.pickup_place.lon, lat=res.pickup_place.lat))
-
-            if shape:
-                res.shape.extend((type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in shape))
-
-            if not shape or res.dropoff_place.lon != shape[-1][0] or res.dropoff_place.lat != shape[-1][1]:
-                res.shape.append(
-                    type_pb2.GeographicalCoord(lon=res.dropoff_place.lon, lat=res.dropoff_place.lat)
-                )
+            res.shape = self._retreive_main_shape(offer, 'journey_polyline', res.pickup_place, res.dropoff_place)
 
             currency = offer.get('price', {}).get('currency')
             if currency == "EUR":

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
@@ -187,7 +187,7 @@ class Blablalines(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, limit=None):
+    def _request_journeys(self, from_coord, to_coord, period_extremity, instance, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
@@ -162,6 +162,7 @@ class InstantSystem(AbstractRidesharingService):
                 res.origin_pickup_distance = int(
                     jormungandr.street_network.utils.crowfly_distance_between(departure_coord, pickup_coord)
                 )
+                # we choose to calculate with speed=1.12 the average speed for a walker
                 res.origin_pickup_duration = jormungandr.street_network.utils.get_manhattan_duration(
                     res.origin_pickup_distance, 1.12
                 )
@@ -182,6 +183,7 @@ class InstantSystem(AbstractRidesharingService):
                 res.dropoff_dest_distance = int(
                     jormungandr.street_network.utils.crowfly_distance_between(dropoff_coord, arrival_coord)
                 )
+                # we choose to calculate with speed=1.12 the average speed for a walker
                 res.dropoff_dest_duration = jormungandr.street_network.utils.get_manhattan_duration(
                     res.dropoff_dest_distance, 1.12
                 )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
@@ -34,7 +34,7 @@ import logging
 import pybreaker
 import pytz
 
-from jormungandr import utils
+from jormungandr.utils import Coords, make_timestamp_from_str
 from jormungandr import app
 import jormungandr.scenarios.ridesharing.ridesharing_journey as rsj
 from jormungandr.scenarios.ridesharing.ridesharing_service import (
@@ -44,6 +44,7 @@ from jormungandr.scenarios.ridesharing.ridesharing_service import (
 )
 from jormungandr.utils import decode_polyline
 from navitiacommon import type_pb2
+import jormungandr.street_network.utils
 
 DEFAULT_INSTANT_SYSTEM_FEED_PUBLISHER = {
     'id': 'Instant System',
@@ -121,7 +122,7 @@ class InstantSystem(AbstractRidesharingService):
 
         return (j for j in raw_journeys if has_ridesharing_path(j))
 
-    def _make_response(self, raw_json):
+    def _make_response(self, raw_json, from_coord, to_coord):
         raw_journeys = raw_json.get('journeys')
 
         if not raw_journeys:
@@ -141,22 +142,50 @@ class InstantSystem(AbstractRidesharingService):
                 res.metadata = self.journey_metadata
 
                 res.distance = j.get('distance')
-                res.duration = None
 
                 res.ridesharing_ad = j.get('url')
 
                 ridesharing_ad = p['rideSharingAd']
+
+                # departure coord
+                lat, lon = from_coord.split(',')
+                departure_coord = Coords(lat=lat, lon=lon)
+
+                # pick up coord
                 from_data = p['from']
+                pickup_lat = from_data.get('lat')
+                pickup_lon = from_data.get('lon')
+                pickup_coord = Coords(lat=pickup_lat, lon=pickup_lon)
 
-                res.pickup_place = rsj.Place(
-                    addr=from_data.get('name'), lat=from_data.get('lat'), lon=from_data.get('lon')
+                res.pickup_place = rsj.Place(addr=from_data.get('name'), lat=pickup_lat, lon=pickup_lon)
+
+                res.origin_pickup_distance = int(
+                    jormungandr.street_network.utils.crowfly_distance_between(departure_coord, pickup_coord)
                 )
+                res.origin_pickup_duration = jormungandr.street_network.utils.get_manhattan_duration(
+                    res.origin_pickup_distance, 1.12
+                )
+                res.origin_pickup_shape = None  # Not specified
 
+                # drop off coord
                 to_data = p['to']
+                dropoff_lat = to_data.get('lat')
+                dropoff_lon = to_data.get('lon')
+                dropoff_coord = Coords(lat=dropoff_lat, lon=dropoff_lon)
 
-                res.dropoff_place = rsj.Place(
-                    addr=to_data.get('name'), lat=to_data.get('lat'), lon=to_data.get('lon')
+                res.dropoff_place = rsj.Place(addr=to_data.get('name'), lat=dropoff_lat, lon=dropoff_lon)
+
+                # arrival coord
+                lat, lon = to_coord.split(',')
+                arrival_coord = Coords(lat=lat, lon=lon)
+
+                res.dropoff_dest_distance = int(
+                    jormungandr.street_network.utils.crowfly_distance_between(dropoff_coord, arrival_coord)
                 )
+                res.dropoff_dest_duration = jormungandr.street_network.utils.get_manhattan_duration(
+                    res.dropoff_dest_distance, 1.12
+                )
+                res.dropoff_dest_shape = None  # Not specified
 
                 # shape is a list of type_pb2.GeographicalCoord()
                 res.shape = []
@@ -174,8 +203,11 @@ class InstantSystem(AbstractRidesharingService):
                         type_pb2.GeographicalCoord(lon=res.dropoff_place.lon, lat=res.dropoff_place.lat)
                     )
 
-                res.pickup_date_time = utils.make_timestamp_from_str(p['departureDate'])
-                res.dropoff_date_time = utils.make_timestamp_from_str(p['arrivalDate'])
+                res.pickup_date_time = make_timestamp_from_str(p['departureDate'])
+                res.departure_date_time = res.pickup_date_time - res.origin_pickup_duration
+                res.dropoff_date_time = make_timestamp_from_str(p['arrivalDate'])
+                res.arrival_date_time = res.dropoff_date_time + res.dropoff_dest_duration
+                res.duration = res.dropoff_date_time - res.pickup_date_time
 
                 user = ridesharing_ad['user']
 
@@ -249,7 +281,7 @@ class InstantSystem(AbstractRidesharingService):
             raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
 
         if resp:
-            r = self._make_response(resp.json())
+            r = self._make_response(resp.json(), from_coord, to_coord)
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
             logging.getLogger('stat.ridesharing.instant-system').info(
                 'Received ridesharing offers : %s',

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
@@ -190,21 +190,7 @@ class InstantSystem(AbstractRidesharingService):
                 )
                 res.dropoff_dest_shape = None  # Not specified
 
-                # shape is a list of type_pb2.GeographicalCoord()
-                res.shape = []
-                shape = decode_polyline(p.get('shape'), precision=5)
-                if not shape or res.pickup_place.lon != shape[0][0] or res.pickup_place.lat != shape[0][1]:
-                    res.shape.append(
-                        type_pb2.GeographicalCoord(lon=res.pickup_place.lon, lat=res.pickup_place.lat)
-                    )
-
-                if shape:
-                    res.shape.extend((type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in shape))
-
-                if not shape or res.dropoff_place.lon != shape[-1][0] or res.dropoff_place.lat != shape[-1][1]:
-                    res.shape.append(
-                        type_pb2.GeographicalCoord(lon=res.dropoff_place.lon, lat=res.dropoff_place.lat)
-                    )
+                res.shape = self._retreive_main_shape(p, 'shape', res.pickup_place, res.dropoff_place)
 
                 res.pickup_date_time = make_timestamp_from_str(p['departureDate'])
                 res.departure_date_time = res.pickup_date_time - res.origin_pickup_duration

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -111,7 +111,21 @@ class Karos(AbstractRidesharingService):
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
             res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
+            res.origin_pickup_distance = int(offer.get('departureToPickupWalkingDistance'))
+            res.origin_pickup_shape = []
+            origin_pickup_shape = decode_polyline(offer.get('departureToPickupWalkingPolyline'), precision=5)
+            if origin_pickup_shape:
+                res.origin_pickup_shape.extend(
+                    (type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in origin_pickup_shape)
+                )
             res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
+            res.dropoff_dest_distance = int(offer.get('dropoffToArrivalWalkingDistance'))
+            res.dropoff_dest_shape = []
+            dropoff_dest_shape = decode_polyline(offer.get('dropoffToArrivalWalkingPolyline'), precision=5)
+            if dropoff_dest_shape:
+                res.dropoff_dest_shape.extend(
+                    (type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in dropoff_dest_shape)
+                )
 
             res.pickup_place = rsj.Place(
                 addr='', lat=offer.get('driverDepartureLat'), lon=offer.get('driverDepartureLng')
@@ -141,8 +155,9 @@ class Karos(AbstractRidesharingService):
             res.total_seats = None
 
             res.pickup_date_time = offer.get('driverDepartureDate')
-            if res.pickup_date_time is not None:
-                res.dropoff_date_time = res.pickup_date_time + offer.get('duration')
+            res.departure_date_time = res.pickup_date_time - res.origin_pickup_duration
+            res.dropoff_date_time = res.pickup_date_time + offer.get('duration')
+            res.arrival_date_time = res.dropoff_date_time + res.dropoff_dest_duration
 
             gender_map = {'M': rsj.Gender.MALE, 'F': rsj.Gender.FEMALE}
             driver_gender = offer.get('driver', {}).get('gender')
@@ -200,14 +215,14 @@ class Karos(AbstractRidesharingService):
         if resp:
             r = self._make_response(resp.json())
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
-            logging.getLogger('stat.ridesharing.instant-system').info(
+            logging.getLogger('stat.ridesharing.karos').info(
                 'Received ridesharing offers : %s',
                 len(r),
                 extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': len(r)},
             )
             return r
         self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=0)
-        logging.getLogger('stat.ridesharing.instant-system').info(
+        logging.getLogger('stat.ridesharing.karos').info(
             'Received ridesharing offers : 0',
             extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': 0},
         )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -176,7 +176,7 @@ class Karos(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, limit=None):
+    def _request_journeys(self, from_coord, to_coord, period_extremity, instance, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -111,7 +111,7 @@ class Karos(AbstractRidesharingService):
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
             res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
-            res.origin_pickup_distance = int(offer.get('departureToPickupWalkingDistance'))
+            res.origin_pickup_distance = offer.get('departureToPickupWalkingDistance')
             res.origin_pickup_shape = []
             origin_pickup_shape = decode_polyline(offer.get('departureToPickupWalkingPolyline'), precision=5)
             if origin_pickup_shape:
@@ -119,7 +119,7 @@ class Karos(AbstractRidesharingService):
                     (type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in origin_pickup_shape)
                 )
             res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
-            res.dropoff_dest_distance = int(offer.get('dropoffToArrivalWalkingDistance'))
+            res.dropoff_dest_distance = offer.get('dropoffToArrivalWalkingDistance')
             res.dropoff_dest_shape = []
             dropoff_dest_shape = decode_polyline(offer.get('dropoffToArrivalWalkingPolyline'), precision=5)
             if dropoff_dest_shape:

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
@@ -111,7 +111,21 @@ class Klaxit(AbstractRidesharingService):
             res.ridesharing_ad = offer.get('webUrl')
             res.duration = offer.get('duration')
             res.origin_pickup_duration = offer.get('departureToPickupWalkingTime')
+            res.origin_pickup_distance = offer.get('departureToPickupWalkingDistance')
+            res.origin_pickup_shape = []
+            origin_pickup_shape = decode_polyline(offer.get('departureToPickupWalkingPolyline'), precision=5)
+            if origin_pickup_shape:
+                res.origin_pickup_shape.extend(
+                    (type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in origin_pickup_shape)
+                )
             res.dropoff_dest_duration = offer.get('dropoffToArrivalWalkingTime')
+            res.dropoff_dest_distance = offer.get('dropoffToArrivalWalkingDistance')
+            res.dropoff_dest_shape = []
+            dropoff_dest_shape = decode_polyline(offer.get('dropoffToArrivalWalkingPolyline'), precision=5)
+            if dropoff_dest_shape:
+                res.dropoff_dest_shape.extend(
+                    (type_pb2.GeographicalCoord(lon=c[0], lat=c[1]) for c in dropoff_dest_shape)
+                )
 
             res.pickup_place = rsj.Place(
                 addr='', lat=offer.get('driverDepartureLat'), lon=offer.get('driverDepartureLng')
@@ -142,8 +156,9 @@ class Klaxit(AbstractRidesharingService):
             res.total_seats = None
 
             res.pickup_date_time = offer.get('driverDepartureDate')
-            if res.pickup_date_time is not None:
-                res.dropoff_date_time = res.pickup_date_time + offer.get('duration')
+            res.departure_date_time = res.pickup_date_time - res.origin_pickup_duration
+            res.dropoff_date_time = res.pickup_date_time + offer.get('duration')
+            res.arrival_date_time = res.dropoff_date_time + res.dropoff_dest_duration
 
             driver_alias = offer.get('driver', {}).get('alias')
             driver_grade = offer.get('driver', {}).get('grade')
@@ -196,14 +211,14 @@ class Klaxit(AbstractRidesharingService):
         if resp:
             r = self._make_response(resp.json())
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
-            logging.getLogger('stat.ridesharing.instant-system').info(
+            logging.getLogger('stat.ridesharing.klaxit').info(
                 'Received ridesharing offers : %s',
                 len(r),
                 extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': len(r)},
             )
             return r
         self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=0)
-        logging.getLogger('stat.ridesharing.instant-system').info(
+        logging.getLogger('stat.ridesharing.klaxit').info(
             'Received ridesharing offers : 0',
             extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': 0},
         )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_journey.py
@@ -80,6 +80,8 @@ class RidesharingJourney(object):
         'ridesharing_ad',
         'pickup_place',
         'dropoff_place',
+        'departure_date_time',
+        'arrival_date_time',
         'pickup_date_time',
         'dropoff_date_time',
         # driver will be Individual
@@ -90,4 +92,8 @@ class RidesharingJourney(object):
         'available_seats',
         'origin_pickup_duration',
         'dropoff_dest_duration',
+        'origin_pickup_distance',
+        'dropoff_dest_distance',
+        'origin_pickup_shape',
+        'dropoff_dest_shape',
     )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
@@ -104,14 +104,14 @@ class AbstractRidesharingService(object):
             )
             raise RidesharingServiceError(str(e))
 
-    def request_journeys_with_feed_publisher(self, from_coord, to_coord, period_extremity, limit=None):
+    def request_journeys_with_feed_publisher(self, from_coord, to_coord, period_extremity, instance, limit=None):
         """
         This function shouldn't be overwritten!
 
         :return: a list(mandatory) contains solutions and a feed_publisher
         """
         try:
-            journeys = self._request_journeys(from_coord, to_coord, period_extremity, limit)
+            journeys = self._request_journeys(from_coord, to_coord, period_extremity, instance, limit)
             feed_publisher = self._get_feed_publisher()
 
             self.record_call('ok')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -288,13 +288,14 @@ class RidesharingServiceManager(object):
             start_teleport_section.origin.CopyFrom(from_pt_obj)
             start_teleport_section.destination.CopyFrom(pb_rsj_pickup)
             if rsj.origin_pickup_shape:
+                # If stree_network shape in the offer contains only two coords, we use default CROW_FLY section"
                 if len(rsj.origin_pickup_shape) == 2:
                     start_teleport_section.type = response_pb2.CROW_FLY
-                    start_teleport_section.length = rsj.origin_pickup_distance
+                    start_teleport_section.length = int(rsj.origin_pickup_distance)
                     start_teleport_section.shape.extend(rsj.origin_pickup_shape)
                 else:
                     start_teleport_section.type = response_pb2.STREET_NETWORK
-                    start_teleport_section.length = rsj.origin_pickup_distance
+                    start_teleport_section.length = int(rsj.origin_pickup_distance)
                     start_teleport_section.street_network.length = start_teleport_section.length
                     start_teleport_section.street_network.duration = start_teleport_section.duration
                     start_teleport_section.street_network.mode = response_pb2.Walking
@@ -309,7 +310,7 @@ class RidesharingServiceManager(object):
 
             # We take departure to pickup duration
             if rsj.origin_pickup_duration:
-                start_teleport_section.duration = rsj.origin_pickup_duration
+                start_teleport_section.duration = int(rsj.origin_pickup_duration)
                 pb_rsj.durations.walking += start_teleport_section.duration
                 pb_rsj.durations.total += start_teleport_section.duration
                 pb_rsj.duration = start_teleport_section.duration
@@ -366,7 +367,7 @@ class RidesharingServiceManager(object):
             if rsj.dropoff_date_time:
                 rs_section.end_date_time = rsj.dropoff_date_time
             if rsj.duration:
-                rs_section.duration = rsj.duration
+                rs_section.duration = int(rsj.duration)
             # report values to journey
             pb_rsj.distances.ridesharing += rs_section.length
             pb_rsj.durations.total += rs_section.duration
@@ -380,13 +381,14 @@ class RidesharingServiceManager(object):
             end_teleport_section.origin.CopyFrom(pb_rsj_dropoff)
             end_teleport_section.destination.CopyFrom(to_pt_obj)
             if rsj.dropoff_dest_shape:
+                # If stree_network shape in the offer contains only two coords, we use default CROW_FLY section"
                 if len(rsj.dropoff_dest_shape) == 2:
                     end_teleport_section.type = response_pb2.CROW_FLY
-                    end_teleport_section.length = rsj.dropoff_dest_distance
+                    end_teleport_section.length = int(rsj.dropoff_dest_distance)
                     end_teleport_section.shape.extend(rsj.dropoff_dest_shape)
                 else:
                     end_teleport_section.type = response_pb2.STREET_NETWORK
-                    end_teleport_section.length = rsj.dropoff_dest_distance
+                    end_teleport_section.length = int(rsj.dropoff_dest_distance)
                     end_teleport_section.street_network.length = end_teleport_section.length
                     end_teleport_section.street_network.duration = end_teleport_section.duration
                     end_teleport_section.street_network.mode = response_pb2.Walking
@@ -401,7 +403,7 @@ class RidesharingServiceManager(object):
 
             # We take dropoff to destination duration
             if rsj.dropoff_dest_duration:
-                end_teleport_section.duration = rsj.dropoff_dest_duration
+                end_teleport_section.duration = int(rsj.dropoff_dest_duration)
                 pb_rsj.durations.walking += end_teleport_section.duration
                 pb_rsj.durations.total += end_teleport_section.duration
                 pb_rsj.duration += end_teleport_section.duration

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -275,29 +275,47 @@ class RidesharingServiceManager(object):
             dropoff_coord = get_pt_object_coord(pb_rsj_dropoff)
 
             pb_rsj.requested_date_time = period_extremity.datetime
-            if rsj.pickup_date_time:
-                pb_rsj.departure_date_time = rsj.pickup_date_time
-            if rsj.dropoff_date_time:
-                pb_rsj.arrival_date_time = rsj.dropoff_date_time
+            if rsj.departure_date_time:
+                pb_rsj.departure_date_time = rsj.departure_date_time
+            if rsj.arrival_date_time:
+                pb_rsj.arrival_date_time = rsj.arrival_date_time
             pb_rsj.tags.append('ridesharing')
 
             # start teleport section
             start_teleport_section = pb_rsj.sections.add()
             start_teleport_section.id = "section_{}".format(six.text_type(generate_id()))
-            start_teleport_section.type = response_pb2.CROW_FLY
             start_teleport_section.street_network.mode = response_pb2.Walking
             start_teleport_section.origin.CopyFrom(from_pt_obj)
             start_teleport_section.destination.CopyFrom(pb_rsj_pickup)
-            start_teleport_section.length = int(crowfly_distance_between(from_coord, pickup_coord))
+            if rsj.origin_pickup_shape:
+                if len(rsj.origin_pickup_shape) == 2:
+                    start_teleport_section.type = response_pb2.CROW_FLY
+                    start_teleport_section.length = rsj.origin_pickup_distance
+                    start_teleport_section.shape.extend(rsj.origin_pickup_shape)
+                else:
+                    start_teleport_section.type = response_pb2.STREET_NETWORK
+                    start_teleport_section.length = rsj.origin_pickup_distance
+                    start_teleport_section.street_network.length = start_teleport_section.length
+                    start_teleport_section.street_network.duration = start_teleport_section.duration
+                    start_teleport_section.street_network.mode = response_pb2.Walking
+                    for sh in rsj.origin_pickup_shape:
+                        coord = start_teleport_section.street_network.coordinates.add()
+                        coord.lon = float(sh.lon)
+                        coord.lat = float(sh.lat)
+            else:
+                start_teleport_section.type = response_pb2.CROW_FLY
+                start_teleport_section.length = int(crowfly_distance_between(from_coord, pickup_coord))
+                start_teleport_section.shape.extend([from_coord, pickup_coord])
 
             # We take departure to pickup duration
-            start_teleport_section.duration = int(getattr(rsj, 'origin_pickup_duration', 0))
-            pb_rsj.durations.walking += start_teleport_section.duration
-            pb_rsj.durations.total += start_teleport_section.duration
-
-            start_teleport_section.shape.extend([from_coord, pickup_coord])
+            if rsj.origin_pickup_duration:
+                start_teleport_section.duration = rsj.origin_pickup_duration
+                pb_rsj.durations.walking += start_teleport_section.duration
+                pb_rsj.durations.total += start_teleport_section.duration
+                pb_rsj.duration = start_teleport_section.duration
+            if rsj.departure_date_time:
+                start_teleport_section.begin_date_time = rsj.departure_date_time
             if rsj.pickup_date_time:
-                start_teleport_section.begin_date_time = rsj.pickup_date_time
                 start_teleport_section.end_date_time = rsj.pickup_date_time
             # report value to journey
             pb_rsj.distances.walking += start_teleport_section.length
@@ -343,9 +361,9 @@ class RidesharingServiceManager(object):
 
             rs_section.shape.extend(rsj.shape)
 
-            if rsj.pickup_date_time and rsj.dropoff_date_time:
-                rs_section.duration = rsj.dropoff_date_time - rsj.pickup_date_time
+            if rsj.pickup_date_time:
                 rs_section.begin_date_time = rsj.pickup_date_time
+            if rsj.dropoff_date_time:
                 rs_section.end_date_time = rsj.dropoff_date_time
             if rsj.duration:
                 rs_section.duration = rsj.duration
@@ -353,26 +371,45 @@ class RidesharingServiceManager(object):
             pb_rsj.distances.ridesharing += rs_section.length
             pb_rsj.durations.total += rs_section.duration
             pb_rsj.durations.ridesharing += rs_section.duration
+            pb_rsj.duration += rs_section.duration
 
             # end teleport section
             end_teleport_section = pb_rsj.sections.add()
             end_teleport_section.id = "section_{}".format(six.text_type(generate_id()))
-            end_teleport_section.type = response_pb2.CROW_FLY
             end_teleport_section.street_network.mode = response_pb2.Walking
             end_teleport_section.origin.CopyFrom(pb_rsj_dropoff)
             end_teleport_section.destination.CopyFrom(to_pt_obj)
-            end_teleport_section.length = int(crowfly_distance_between(dropoff_coord, to_coord))
+            if rsj.dropoff_dest_shape:
+                if len(rsj.dropoff_dest_shape) == 2:
+                    end_teleport_section.type = response_pb2.CROW_FLY
+                    end_teleport_section.length = rsj.dropoff_dest_distance
+                    end_teleport_section.shape.extend(rsj.dropoff_dest_shape)
+                else:
+                    end_teleport_section.type = response_pb2.STREET_NETWORK
+                    end_teleport_section.length = rsj.dropoff_dest_distance
+                    end_teleport_section.street_network.length = end_teleport_section.length
+                    end_teleport_section.street_network.duration = end_teleport_section.duration
+                    end_teleport_section.street_network.mode = response_pb2.Walking
+                    for sh in rsj.dropoff_dest_shape:
+                        coord = end_teleport_section.street_network.coordinates.add()
+                        coord.lon = float(sh.lon)
+                        coord.lat = float(sh.lat)
+            else:
+                end_teleport_section.type = response_pb2.CROW_FLY
+                end_teleport_section.length = int(crowfly_distance_between(dropoff_coord, to_coord))
+                end_teleport_section.shape.extend([dropoff_coord, to_coord])
 
             # We take dropoff to destination duration
-            end_teleport_section.duration = int(getattr(rsj, 'dropoff_dest_duration', 0))
-            pb_rsj.durations.walking += end_teleport_section.duration
-            pb_rsj.durations.total += end_teleport_section.duration
-            pb_rsj.duration += pb_rsj.durations.total
+            if rsj.dropoff_dest_duration:
+                end_teleport_section.duration = rsj.dropoff_dest_duration
+                pb_rsj.durations.walking += end_teleport_section.duration
+                pb_rsj.durations.total += end_teleport_section.duration
+                pb_rsj.duration += end_teleport_section.duration
 
-            end_teleport_section.shape.extend([dropoff_coord, to_coord])
             if rsj.dropoff_date_time:
                 end_teleport_section.begin_date_time = rsj.dropoff_date_time
-                end_teleport_section.end_date_time = rsj.dropoff_date_time
+            if rsj.arrival_date_time:
+                end_teleport_section.end_date_time = rsj.arrival_date_time
             # report value to journey
             pb_rsj.distances.walking += end_teleport_section.length
 

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
@@ -150,7 +150,7 @@ def blablalines_test():
             datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
         )
         ridesharing_journeys, feed_publisher = blablalines.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity
+            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance=DummyInstance()
         )
 
         assert len(ridesharing_journeys) == 2
@@ -215,6 +215,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.PeriodExtremity(
                     datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
                 ),
+                DummyInstance(),
             )
 
         exception_params = e.value.get_params().values()

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
@@ -178,6 +178,7 @@ DUMMY_INSTANT_SYSTEM_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I d
 # A hack class
 class DummyInstance:
     name = ''
+    walking_speed = 1.12
 
 
 def get_ridesharing_service_test():
@@ -249,7 +250,7 @@ def instant_system_test():
             datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
         )
         ridesharing_journeys, feed_publisher = instant_system.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity
+            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance=DummyInstance()
         )
 
         assert len(ridesharing_journeys) == 2
@@ -343,6 +344,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.PeriodExtremity(
                     datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
                 ),
+                DummyInstance(),
             )
 
         exception_params = e.value.get_params().values()

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -253,7 +253,7 @@ def karos_service_test():
         )
 
         ridesharing_journeys, feed_publisher = karos.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity
+            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance=DummyInstance()
         )
 
         assert len(ridesharing_journeys) == 2
@@ -330,6 +330,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.PeriodExtremity(
                     datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
                 ),
+                DummyInstance(),
             )
 
         exception_params = e.value.get_params().values()

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
@@ -170,7 +170,7 @@ def klaxit_service_test():
         )
 
         ridesharing_journeys, feed_publisher = klaxit.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity
+            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance=DummyInstance()
         )
 
         assert len(ridesharing_journeys) == 2
@@ -241,6 +241,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.PeriodExtremity(
                     datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
                 ),
+                DummyInstance(),
             )
 
         exception_params = e.value.get_params().values()

--- a/source/jormungandr/jormungandr/street_network/utils.py
+++ b/source/jormungandr/jormungandr/street_network/utils.py
@@ -47,6 +47,10 @@ def crowfly_distance_between(start_coord, end_coord):
     return EARTH_RADIUS_IN_METERS * 2.0 * math.asin(math.sqrt(lat_h + tmp * lon_h))
 
 
+def get_manhattan_duration(distance, speed):
+    return int((distance * math.sqrt(2)) / speed)
+
+
 def make_speed_switcher(req):
     from jormungandr.fallback_modes import FallbackModes
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -70,6 +70,12 @@ def kilometers_to_meters(distance):
     return distance * 1000.0
 
 
+class Coords:
+    def __init__(self, lat, lon):
+        self.lat = float(lat)
+        self.lon = float(lon)
+
+
 def is_coord(uri):
     # for the moment we do a simple check
     return get_lon_lat(uri) != (None, None)

--- a/source/jormungandr/tests/blablalines_routing_tests.py
+++ b/source/jormungandr/tests/blablalines_routing_tests.py
@@ -147,8 +147,15 @@ class TestBlablalines(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[0].get('mode') == 'walking'
         # For start teleport section we take departure to pickup duration
         assert rsj_sections[0].get('duration') == 174
+        assert (
+            rsj_sections[0].get('departure_date_time') == '20120614T075500'
+        )  # for blablalines departure_date_time = request_date_time
+        assert rsj_sections[0].get('arrival_date_time') == '20120614T075754'
 
         assert rsj_sections[1].get('type') == 'ridesharing'
+        assert rsj_sections[1].get('duration') == 1301
+        assert rsj_sections[1].get('departure_date_time') == '20120614T075754'
+        assert rsj_sections[1].get('arrival_date_time') == '20120614T081935'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
         assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.78995, 47.28728]
         rsj_info = rsj_sections[1].get('ridesharing_informations')
@@ -171,8 +178,10 @@ class TestBlablalines(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[2].get('type') == 'crow_fly'
         assert rsj_sections[2].get('mode') == 'walking'
-        # For end teleport section we take dropoff to destination duration
         assert rsj_sections[2].get('duration') == 76
+        assert rsj_sections[2].get('departure_date_time') == '20120614T081935'
+        assert rsj_sections[2].get('arrival_date_time') == '20120614T082051'
+        # For end teleport section we take dropoff to destination duration
 
         fps = response['feed_publishers']
         assert len(fps) == 2

--- a/source/jormungandr/tests/blablalines_routing_tests.py
+++ b/source/jormungandr/tests/blablalines_routing_tests.py
@@ -145,7 +145,6 @@ class TestBlablalines(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[0].get('type') == 'crow_fly'
         assert rsj_sections[0].get('mode') == 'walking'
-        # For start teleport section we take departure to pickup duration
         assert rsj_sections[0].get('duration') == 174
         assert (
             rsj_sections[0].get('departure_date_time') == '20120614T075500'
@@ -181,7 +180,6 @@ class TestBlablalines(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[2].get('duration') == 76
         assert rsj_sections[2].get('departure_date_time') == '20120614T081935'
         assert rsj_sections[2].get('arrival_date_time') == '20120614T082051'
-        # For end teleport section we take dropoff to destination duration
 
         fps = response['feed_publishers']
         assert len(fps) == 2

--- a/source/jormungandr/tests/instant_system_new_default_routing_tests.py
+++ b/source/jormungandr/tests/instant_system_new_default_routing_tests.py
@@ -120,7 +120,7 @@ class TestInstantSystem(NewDefaultScenarioAbstractTestFixture):
         test ridesharing_jouneys details
         """
         q = (
-            "journeys?from=0.0000898312;0.0000898312&to=0.00188646;0.00071865&datetime=20120614T075500&"
+            "journeys?from=0.0000898312;0.0000698312&to=0.00188646;0.00071865&datetime=20120614T075500&"
             "first_section_mode[]={first}&last_section_mode[]={last}&forbidden_uris[]=PM".format(
                 first='ridesharing', last='walking'
             )
@@ -154,7 +154,7 @@ class TestInstantSystem(NewDefaultScenarioAbstractTestFixture):
         rs_journeys = sections[0].get('ridesharing_journeys')
         assert len(rs_journeys) == 1
         assert rs_journeys[0].get('distances').get('ridesharing') == 224
-        assert rs_journeys[0].get('durations').get('walking') == 0
+        assert rs_journeys[0].get('durations').get('walking') == 2
         assert rs_journeys[0].get('durations').get('ridesharing') == 1057
         assert 'ridesharing' in rs_journeys[0].get('tags')
         rsj_sections = rs_journeys[0].get('sections')
@@ -162,8 +162,14 @@ class TestInstantSystem(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[0].get('type') == 'crow_fly'
         assert rsj_sections[0].get('mode') == 'walking'
+        assert rsj_sections[0].get('duration') == 2
+        assert rsj_sections[0].get('departure_date_time') == '20171225T070757'
+        assert rsj_sections[0].get('arrival_date_time') == '20171225T070759'
 
         assert rsj_sections[1].get('type') == 'ridesharing'
+        assert rsj_sections[1].get('duration') == 1057
+        assert rsj_sections[1].get('departure_date_time') == '20171225T070759'
+        assert rsj_sections[1].get('arrival_date_time') == '20171225T072536'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
         assert rsj_sections[1].get('geojson').get('coordinates')[2] == [-1.68635, 48.1101]
         rsj_info = rsj_sections[1].get('ridesharing_informations')
@@ -191,6 +197,9 @@ class TestInstantSystem(NewDefaultScenarioAbstractTestFixture):
 
         assert rsj_sections[2].get('type') == 'crow_fly'
         assert rsj_sections[2].get('mode') == 'walking'
+        assert rsj_sections[2].get('duration') == 0
+        assert rsj_sections[2].get('departure_date_time') == '20171225T072536'
+        assert rsj_sections[2].get('arrival_date_time') == '20171225T072536'
 
         fps = response['feed_publishers']
         assert len(fps) == 2

--- a/source/jormungandr/tests/karos_routing_tests.py
+++ b/source/jormungandr/tests/karos_routing_tests.py
@@ -153,16 +153,20 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
         rsj_sections = rs_journeys[0].get('sections')
         assert len(rsj_sections) == 3
 
-        assert rsj_sections[0].get('type') == 'crow_fly'
+        assert rsj_sections[0].get('type') == 'street_network'
         assert rsj_sections[0].get('mode') == 'walking'
         # For start teleport section we take departure to pickup duration
         assert rsj_sections[0].get('duration') == 174
+        assert rsj_sections[0].get('departure_date_time') == '20201006T123935'
+        assert rsj_sections[0].get('arrival_date_time') == '20201006T124229'
 
         assert rsj_sections[1].get('type') == 'ridesharing'
+        assert rsj_sections[1].get('duration') == 1301
+        assert rsj_sections[1].get('departure_date_time') == '20201006T124229'
+        assert rsj_sections[1].get('arrival_date_time') == '20201006T130410'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
         assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.78995, 47.28728]
         # ridesharing duration comes from the offer
-        assert rsj_sections[1].get('duration') == 1301
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'
         assert rsj_info.get('operator') == 'karos'
@@ -178,10 +182,12 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
         assert ticket['links'][0]['id'] == rsj_sections[1]['id']
         assert rs_journeys[0].get('fare').get('total').get('value') == tickets[0].get('cost').get('value')
 
-        assert rsj_sections[2].get('type') == 'crow_fly'
+        assert rsj_sections[2].get('type') == 'street_network'
         assert rsj_sections[2].get('mode') == 'walking'
         # For end teleport section we take dropoff to destination duration
         assert rsj_sections[2].get('duration') == 76
+        assert rsj_sections[2].get('departure_date_time') == '20201006T130410'
+        assert rsj_sections[2].get('arrival_date_time') == '20201006T130526'
 
         fps = response['feed_publishers']
         assert len(fps) == 2

--- a/source/jormungandr/tests/klaxit_routing_tests.py
+++ b/source/jormungandr/tests/klaxit_routing_tests.py
@@ -146,16 +146,19 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
         rsj_sections = rs_journeys[0].get('sections')
         assert len(rsj_sections) == 3
 
-        assert rsj_sections[0].get('type') == 'crow_fly'
+        assert rsj_sections[0].get('type') == 'street_network'
         assert rsj_sections[0].get('mode') == 'walking'
-        # For start teleport section we take departure to pickup duration
         assert rsj_sections[0].get('duration') == 174
+        assert rsj_sections[0].get('departure_date_time') == '20201006T123935'
+        assert rsj_sections[0].get('arrival_date_time') == '20201006T124229'
 
         assert rsj_sections[1].get('type') == 'ridesharing'
+        assert rsj_sections[1].get('duration') == 1301
+        assert rsj_sections[1].get('departure_date_time') == '20201006T124229'
+        assert rsj_sections[1].get('arrival_date_time') == '20201006T130410'
         assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
         assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.78995, 47.28728]
         # ridesharing duration comes from the offer
-        assert rsj_sections[1].get('duration') == 1301
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'
         assert rsj_info.get('operator') == 'klaxit'
@@ -171,10 +174,11 @@ class TestKlaxit(NewDefaultScenarioAbstractTestFixture):
         assert ticket['links'][0]['id'] == rsj_sections[1]['id']
         assert rs_journeys[0].get('fare').get('total').get('value') == tickets[0].get('cost').get('value')
 
-        assert rsj_sections[2].get('type') == 'crow_fly'
+        assert rsj_sections[2].get('type') == 'street_network'
         assert rsj_sections[2].get('mode') == 'walking'
-        # For end teleport section we take dropoff to destination duration
         assert rsj_sections[2].get('duration') == 76
+        assert rsj_sections[2].get('departure_date_time') == '20201006T130410'
+        assert rsj_sections[2].get('arrival_date_time') == '20201006T130526'
 
         fps = response['feed_publishers']
         assert len(fps) == 2


### PR DESCRIPTION
There was several problems with ridesharing journeys. 
_Durations_, _distances_, _sections type_ was not exact and we didn't use _street network information_ when it exist.

List of the fixes:

- **Blablalines** : the departures date time is the request datetime (because we haven't the information)
- **Instant system**: add a crowfly section with manhattan distance
- **All**: if we have a shape for _first section or last section_ we create street network section with all informations. Otherwise, it is a crowfly section
- **All**: if we have a shape with 2 coords, this is not a street network but a crowfly (Karos case)
- **All**: for all connector we fill _departure_date_time_ and _arrival_date_time_
- **All**: the sequence of _date time_ in the ridesharing journeys sections is consistent
- **All**: durations and distances are correct

Sorry for the reviewer. It is not easy to understand all stuff, but I assure you I tested in real conditions :cat: and it works