### PR TITLE
[Places_nearby] filter with 'or' having atleast one matching criteria should work 

### DIFF
--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -218,6 +218,17 @@ class TestPlaces(AbstractTestFixture):
         assert places_nearby[0]['embedded_type'] == "stop_point"
         assert places_nearby[1]['embedded_type'] == "stop_point"
 
+        # Invalid filter of type unable_to_parse is managed
+        query = (
+            "/v1/coords/0.000001;0.000898311281954/places_nearby?type[]=stop_point&type[]=poi&filter=toto=tata"
+        )
+        response = self.query(query)
+        assert 'error' in response
+        assert 'unable_to_parse' in response['error']['id']
+        assert (
+            response["error"]["message"] == "Problem while parsing the query:Filter: unable to parse toto=tata"
+        )
+
     def test_places_nearby_with_coords_current_datetime(self):
         """places_nearby with _current_datetime"""
 

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -176,6 +176,48 @@ class TestPlaces(AbstractTestFixture):
         assert places_nearby[0]["embedded_type"] == "stop_point"
         assert places_nearby[0]["id"] == "stop_point:stopC"
 
+    def test_places_nearby_with_filter_and_multi_type(self):
+        """
+        Check api /places_nearby with combination of multi parameter &type[] and &filter
+        """
+        # places_nearby with /coords and type[]=poi gives 4 pois
+        query = "/v1/coords/0.000001;0.000898311281954/places_nearby?type[]=poi"
+        response = self.query(query)
+        assert len(response.get('places_nearby', [])) == 4
+        assert response.get('places_nearby', [])[0]['embedded_type'] == "poi"
+
+        # places_nearby with /coords and type[]=stop_point gives 4 stop_points
+        query = "/v1/coords/0.000001;0.000898311281954/places_nearby?type[]=stop_point"
+        response = self.query(query)
+        assert len(response.get('places_nearby', [])) == 4
+        assert response.get('places_nearby', [])[0]['embedded_type'] == "stop_point"
+
+        # places_nearby with /coords and type[]=poi, filter=line.uri=D gives 0 poi (empty response)
+        query = "coords/0.000001;0.000898311281954/places_nearby?type[]=poi&filter=line.uri=D"
+        response, status = self.query_region(query, check=False)
+        assert status == 200
+        assert len(response.get('places_nearby', [])) == 0
+
+        # places_nearby with /coords and type[]=stop_point, filter=line.uri=D gives 2 stop_points
+        query = "/v1/coords/0.000001;0.000898311281954/places_nearby?type[]=stop_point&filter=line.uri=D"
+        response = self.query(query)
+        places_nearby = response['places_nearby']
+        assert len(places_nearby) == 2
+        is_valid_places(places_nearby)
+        assert places_nearby[0]['embedded_type'] == "stop_point"
+        assert places_nearby[1]['embedded_type'] == "stop_point"
+
+        # places_nearby with /coords and type[]=stop_point&type[]=poi, filter=line.uri=D gives 2 stop_points
+        query = (
+            "/v1/coords/0.000001;0.000898311281954/places_nearby?type[]=stop_point&type[]=poi&filter=line.uri=D"
+        )
+        response = self.query(query)
+        places_nearby = response['places_nearby']
+        assert len(places_nearby) == 2
+        is_valid_places(places_nearby)
+        assert places_nearby[0]['embedded_type'] == "stop_point"
+        assert places_nearby[1]['embedded_type'] == "stop_point"
+
     def test_places_nearby_with_coords_current_datetime(self):
         """places_nearby with _current_datetime"""
 

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -127,6 +127,10 @@ void find(navitia::PbCreator& pb_creator,
         if (!filter.empty()) {
             try {
                 indexes = ptref::make_query(type, filter, forbidden_uris, *pb_creator.data);
+            } catch (const ptref::parsing_error& parse_error) {
+                pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse,
+                                         "Problem while parsing the query:" + parse_error.more);
+                return;
             } catch (const std::exception&) {
             }
         }

--- a/source/proximity_list/proximitylist_api.cpp
+++ b/source/proximity_list/proximitylist_api.cpp
@@ -127,13 +127,7 @@ void find(navitia::PbCreator& pb_creator,
         if (!filter.empty()) {
             try {
                 indexes = ptref::make_query(type, filter, forbidden_uris, *pb_creator.data);
-            } catch (const ptref::parsing_error& parse_error) {
-                pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse,
-                                         "Problem while parsing the query:" + parse_error.more);
-                return;
-            } catch (const ptref::ptref_error& pt_error) {
-                pb_creator.fill_pb_error(pbnavitia::Error::bad_filter, "ptref : " + pt_error.more);
-                return;
+            } catch (const std::exception&) {
             }
         }
         // We have to find all objects within distance, then apply the filter

--- a/source/proximity_list/tests/test.cpp
+++ b/source/proximity_list/tests/test.cpp
@@ -282,12 +282,12 @@ BOOST_AUTO_TEST_CASE(test_filter) {
     result = pb_creator.get_response();
     BOOST_CHECK_EQUAL(result.places_nearby().size(), 0);
 
-    // Bad request
+    // To be able to manage filter with more than one type of pt_objects we don't manage filter error
     pb_creator.init(&data, boost::gregorian::not_a_date_time, null_time_period);
     find(pb_creator, c, 200, {navitia::type::Type_e::StopArea}, {}, "stop_area.name=paspouet bachibouzouk", 1, 10, 0,
          data);
     result = pb_creator.get_response();
-    BOOST_CHECK_EQUAL(result.error().id(), pbnavitia::Error::unable_to_parse);
+    BOOST_CHECK_EQUAL(result.places_nearby().size(), 0);
 }
 
 BOOST_AUTO_TEST_CASE(test_poi_filter) {

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -736,6 +736,7 @@ BOOST_AUTO_TEST_CASE(test_ptref_complete_pathes) {
     const auto PhysicalMode = Type_e::PhysicalMode;
     const auto MetaVehicleJourney = Type_e::MetaVehicleJourney;
     const auto Impact = Type_e::Impact;
+    const auto LineGroup = Type_e::LineGroup;
     using p = std::vector<Type_e>;  // A path in the graph is a vector of PTRef types (only "source" is missing)
 
     BOOST_CHECK_EQUAL_RANGE(get_path(CommercialMode, StopArea), p({Line, Route, StopArea}));
@@ -783,19 +784,14 @@ BOOST_AUTO_TEST_CASE(test_ptref_complete_pathes) {
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, Network), p({VehicleJourney, Route, Line, Network}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, PhysicalMode), p({VehicleJourney, PhysicalMode}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, Route), p({VehicleJourney, Route}));
-    // BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, StopArea), p({VehicleJourney, Route, StopArea}));  // indirect shortcut
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, StopArea),
                             p({VehicleJourney, JourneyPattern, JourneyPatternPoint, StopPoint, StopArea}));
-    // BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, StopPoint), p({VehicleJourney, Route, StopPoint}));	// indirect
-    // shortcut
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, StopPoint),
                             p({VehicleJourney, JourneyPattern, JourneyPatternPoint, StopPoint}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, ValidityPattern), p({VehicleJourney, ValidityPattern}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Dataset, VehicleJourney), p({VehicleJourney}));
 
     BOOST_CHECK_EQUAL_RANGE(get_path(Impact, Company), p({Line, Company}));
-    // BOOST_CHECK_EQUAL_RANGE(get_path(Impact, Dataset), p({Route, Dataset}));  // indirect shortcut  // 2 paths with
-    // Route, VehicleJourney, Dataset
     BOOST_CHECK_EQUAL_RANGE(get_path(Impact, JourneyPattern), p({Route, JourneyPattern}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Impact, JourneyPatternPoint), p({StopPoint, JourneyPatternPoint}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Impact, Line), p({Line}));
@@ -857,6 +853,10 @@ BOOST_AUTO_TEST_CASE(test_ptref_complete_pathes) {
     BOOST_CHECK_EQUAL_RANGE(get_path(Line, StopPoint), p({Route, StopPoint}));  // indirect shortcut
     BOOST_CHECK_EQUAL_RANGE(get_path(Line, ValidityPattern), p({Route, VehicleJourney, ValidityPattern}));
     BOOST_CHECK_EQUAL_RANGE(get_path(Line, VehicleJourney), p({Route, VehicleJourney}));
+    BOOST_CHECK_EQUAL_RANGE(get_path(Line, LineGroup), p({LineGroup}));
+    BOOST_CHECK_EQUAL_RANGE(get_path(LineGroup, Line), p({Line}));
+    BOOST_CHECK_EQUAL_RANGE(get_path(Line, CommercialMode), p({CommercialMode}));
+    BOOST_CHECK_EQUAL_RANGE(get_path(CommercialMode, Line), p({Line}));
 
     BOOST_CHECK_EQUAL_RANGE(get_path(MetaVehicleJourney, Company), p({VehicleJourney, Company}));
     BOOST_CHECK_EQUAL_RANGE(get_path(MetaVehicleJourney, Dataset), p({VehicleJourney, Dataset}));
@@ -932,7 +932,6 @@ BOOST_AUTO_TEST_CASE(test_ptref_complete_pathes) {
     BOOST_CHECK_EQUAL_RANGE(get_path(StopArea, Line), p({Route, Line}));  // indirect shortcut
     BOOST_CHECK_EQUAL_RANGE(get_path(StopArea, MetaVehicleJourney),
                             p({StopPoint, JourneyPatternPoint, JourneyPattern, VehicleJourney, MetaVehicleJourney}));
-    // BOOST_CHECK_EQUAL_RANGE(get_path(StopArea, Network), p({StopPoint, Route, Line, Network}));  // indirect shortcut
     BOOST_CHECK_EQUAL_RANGE(get_path(StopArea, Network), p({Route, Line, Network}));
     BOOST_CHECK_EQUAL_RANGE(get_path(StopArea, PhysicalMode),
                             p({StopPoint, JourneyPatternPoint, JourneyPattern, PhysicalMode}));


### PR DESCRIPTION
Do not catch the exception on filter where there are more than one object types in places_nearby.
Ticket : https://jira.kisio.org/browse/NAVITIAII-3227