### PR TITLE
[CI] Remove Artemis checks

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -135,16 +135,6 @@ jobs:
         pre-commit run --all --show-diff-on-failure
 
 
-  check_artemis:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: check artemis
-      run: ./source/scripts/checkJenkinsJob.sh Artemis
-    - name: check artemis IDFM
-      run: ./source/scripts/checkJenkinsJob.sh Artemis_idfm
-
-
   release_script_tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This really makes me sad :sob: 

But because of the new security enforcement, we have to remove Artemis checks while waiting for an alternate method to validate Artemis' state. 