### PR TITLE
Impact: Fix application period end value

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(network_filter1, Params) {
 
     BOOST_REQUIRE_EQUAL(impact->application_periods_size(), 1);
     BOOST_CHECK_EQUAL(impact->application_periods(0).begin(), navitia::test::to_posix_timestamp("20131220T123200"));
-    BOOST_CHECK_EQUAL(impact->application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123200"));
+    BOOST_CHECK_EQUAL(impact->application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123201"));
 }
 
 BOOST_FIXTURE_TEST_CASE(network_filter2, Params) {
@@ -213,7 +213,7 @@ BOOST_FIXTURE_TEST_CASE(network_filter2, Params) {
     BOOST_CHECK_EQUAL(impact->status(), pbnavitia::ActiveStatus::active);
     BOOST_REQUIRE_EQUAL(impact->application_periods_size(), 1);
     BOOST_CHECK_EQUAL(impact->application_periods(0).begin(), navitia::test::to_posix_timestamp("20131223T123200"));
-    BOOST_CHECK_EQUAL(impact->application_periods(0).end(), navitia::test::to_posix_timestamp("20131225T123200"));
+    BOOST_CHECK_EQUAL(impact->application_periods(0).end(), navitia::test::to_posix_timestamp("20131225T123201"));
 }
 
 BOOST_FIXTURE_TEST_CASE(line_filter, Params) {
@@ -241,7 +241,7 @@ BOOST_FIXTURE_TEST_CASE(line_filter, Params) {
 
     BOOST_REQUIRE_EQUAL(impact->application_periods_size(), 1);
     BOOST_CHECK_EQUAL(impact->application_periods(0).begin(), navitia::test::to_posix_timestamp("20131221T083200"));
-    BOOST_CHECK_EQUAL(impact->application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123200"));
+    BOOST_CHECK_EQUAL(impact->application_periods(0).end(), navitia::test::to_posix_timestamp("20131221T123201"));
 }
 
 BOOST_FIXTURE_TEST_CASE(Test1, Params) {

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -537,7 +537,7 @@ class TestChaosDisruptionsBlocking(ChaosDisruptionsFixture):
 
     def run_check(self, object_id, type_):
         links = []
-        journey_query_2_to_format = "journeys?from={from_coord}&to={to_coord}&disruption_active=true".format(
+        journey_query_2_to_format = "journeys?from={from_coord}&to={to_coord}&data_freshness=realtime".format(
             from_coord=s_coord, to_coord=r_coord
         )
         journey_query_2_to_format += "&datetime={datetime}"
@@ -640,17 +640,130 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
         We delete the network disruption and test if there's a journey using
         the line B.
         """
-        response = self.query_region(journey_basic_query)
 
+        def contains_pt_journey(resp):
+            return any(
+                [
+                    len([s for s in j["sections"] if s["type"] == "public_transport"]) == 1
+                    for j in resp["journeys"]
+                ]
+            )
+
+        def get_pt_sections(resp):
+            return [s for j in response['journeys'] for s in j['sections'] if s['type'] == 'public_transport']
+
+        response = self.query_region(journey_basic_query)
         assert "journeys" in response
         disruptions = self.get_disruptions(response)
         # no disruptions on the journey for the moment
         assert not disruptions
 
-        # some disruption are loaded on the dataset though
+        # Check which line is used in PT journey
+        pt_sections = get_pt_sections(response)
+        assert len(pt_sections) == 1
+        assert pt_sections[0]['departure_date_time'] == '20120614T080100'
+        assert pt_sections[0]['arrival_date_time'] == u'20120614T080102'
+        line_id = next(o['id'] for o in pt_sections[0]['links'] if o['type'] == 'line')
+        assert line_id == 'A'
+
+        # some disruptions are loaded on the dataset though
         nb_pre_loaded_disruption = len(get_not_null(self.query_region('disruptions'), 'disruptions'))
         assert nb_pre_loaded_disruption == 11
 
+        # Step 1 : Send an impact on a line with end date before PT departure datetime
+        # Information on PT section: departure = 20120614T080100 / arrival = 20120614T080102
+        # Proposed application period = (20120614T080000, 20120614T080100)
+        self.send_mock(
+            "blocking_line_disruption_ending_before_pt_departure",
+            "A",
+            "line",
+            blocking=True,
+            start_period="20120614T080000",
+            end_period="20120614T080100",
+        )
+
+        # Check disruptions
+        response = self.query_region('disruptions')
+        disruptions = get_not_null(response, 'disruptions')
+        assert len(disruptions) - nb_pre_loaded_disruption == 1
+        for d in disruptions:
+            is_valid_disruption(d)
+        assert "blocking_line_disruption_ending_before_pt_departure" in [
+            d['disruption_uri'] for d in disruptions
+        ]
+        nb_pre_loaded_disruption = len(disruptions)
+
+        # Check that the journey with PT exists and line 'A' is used in PT
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime")
+        assert contains_pt_journey(response) is True
+        pt_sections = get_pt_sections(response)
+        assert len(pt_sections) == 1
+        assert pt_sections[0]['departure_date_time'] == '20120614T080100'
+        assert pt_sections[0]['arrival_date_time'] == u'20120614T080102'
+        line_id = next(o['id'] for o in pt_sections[0]['links'] if o['type'] == 'line')
+        assert line_id == 'A'
+
+        # Step 2 : Send an impact on a line with start date same as PT arrival datetime
+        # Proposed application period = (20120614T080102, 20120614T090000)
+        self.send_mock(
+            "blocking_line_disruption_starting_from_pt_arrival",
+            "A",
+            "line",
+            blocking=True,
+            start_period="20120614T080102",
+            end_period="20120614T090000",
+        )
+        # Check disruptions
+        response = self.query_region('disruptions')
+        disruptions = get_not_null(response, 'disruptions')
+        assert len(disruptions) - nb_pre_loaded_disruption == 1
+        for d in disruptions:
+            is_valid_disruption(d)
+        assert "blocking_line_disruption_starting_from_pt_arrival" in [d['disruption_uri'] for d in disruptions]
+        nb_pre_loaded_disruption = len(disruptions)
+
+        # Check that the journey with PT exists and line 'A' is used in PT
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime")
+        assert contains_pt_journey(response) is True
+        pt_sections = get_pt_sections(response)
+        assert len(pt_sections) == 1
+        assert pt_sections[0]['departure_date_time'] == '20120614T080100'
+        assert pt_sections[0]['arrival_date_time'] == u'20120614T080102'
+        line_id = next(o['id'] for o in pt_sections[0]['links'] if o['type'] == 'line')
+        assert line_id == 'A'
+
+        # Step 3 : Send an impact on a line with start date 1 second before PT arrival datetime
+        # Proposed application period = (20120614T080101, 20120614T090000)
+        self.send_mock(
+            "blocking_line_disruption_starting_1s_before_pt_arrival",
+            "A",
+            "line",
+            blocking=True,
+            start_period="20120614T080101",
+            end_period="20120614T090000",
+        )
+        # Check disruptions
+        response = self.query_region('disruptions')
+        disruptions = get_not_null(response, 'disruptions')
+        assert len(disruptions) - nb_pre_loaded_disruption == 1
+        for d in disruptions:
+            is_valid_disruption(d)
+        assert "blocking_line_disruption_starting_1s_before_pt_arrival" in [
+            d['disruption_uri'] for d in disruptions
+        ]
+        nb_pre_loaded_disruption = len(disruptions)
+
+        # Check that the journey with PT exists but line 'M' is used in PT as 'A' is impacted
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime")
+        assert contains_pt_journey(response) is True
+        pt_sections = get_pt_sections(response)
+        assert len(pt_sections) == 1
+        assert pt_sections[0]['departure_date_time'] == '20120614T080101'
+        assert pt_sections[0]['arrival_date_time'] == u'20120614T080103'
+        line_id = next(o['id'] for o in pt_sections[0]['links'] if o['type'] == 'line')
+        assert line_id == 'M'
+
+        # Send blocking impacts on line A and base_network with very wide application period
         self.send_mock("blocking_line_disruption", "A", "line", blocking=True)
         self.send_mock("blocking_network_disruption", "base_network", "network", blocking=True)
 
@@ -663,15 +776,9 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
         assert {"blocking_line_disruption", "blocking_network_disruption"}.issubset(
             set([d['disruption_uri'] for d in disruptions])
         )
-
-        response = self.query_region(journey_basic_query + "&disruption_active=true")
-
-        assert all(
-            [
-                len([s for s in j["sections"] if s["type"] == "public_transport"]) == 0
-                for j in response["journeys"]
-            ]
-        )
+        # Check that there is no more PT journey in the response
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime")
+        assert contains_pt_journey(response) is False
 
         # we should then not have disruptions (since we don't get any journey)
         disruptions = self.get_disruptions(response)
@@ -679,7 +786,7 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
 
         # we then query for the same journey but without disruptions,
         # so we'll have a journey (but the disruptions will be displayed
-        response = self.query_region(journey_basic_query + "&disruption_active=false")
+        response = self.query_region(journey_basic_query + "&data_freshness=base_schedule")
         disruptions = self.get_disruptions(response)
         assert disruptions
         assert len(disruptions) == 2
@@ -687,7 +794,7 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
         assert 'blocking_network_disruption' in disruptions
 
         self.send_mock("blocking_network_disruption", "base_network", "network", blocking=True, is_deleted=True)
-        response = self.query_region(journey_basic_query + "&disruption_active=true")
+        response = self.query_region(journey_basic_query + "&data_freshness=realtime")
         links = []
 
         def get_line_id(k, v):
@@ -699,7 +806,7 @@ class TestChaosDisruptionsBlockingOverlapping(ChaosDisruptionsFixture):
         assert all([id_ != "A" for id_ in links])
 
         # we also query without disruption and obviously we should not have the network disruptions
-        response = self.query_region(journey_basic_query + "&disruption_active=false")
+        response = self.query_region(journey_basic_query + "&data_freshness=base_schedule")
         assert 'journeys' in response
         disruptions = self.get_disruptions(response)
         assert disruptions

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1819,7 +1819,7 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
             ]
         )
         assert new_trip_disrupt['application_periods'][0]['begin'] == '20120614T080100'
-        assert new_trip_disrupt['application_periods'][0]['end'] == '20120614T080101'  # last second is excluded
+        assert new_trip_disrupt['application_periods'][0]['end'] == '20120614T080102'
 
         # Check that a PT journey now exists
         response = self.query_region(C_B_query)
@@ -1832,6 +1832,12 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
         assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
         assert pt_journey['sections'][0]['display_informations']['commercial_mode'] == 'additional service'
         assert pt_journey['sections'][0]['display_informations']['physical_mode'] == 'Bus'
+
+        # Check date_times
+        assert pt_journey['sections'][0]['departure_date_time'] == '20120614T080100'
+        assert pt_journey['sections'][0]['arrival_date_time'] == '20120614T080102'
+        assert pt_journey['sections'][0]['stop_date_times'][0]['arrival_date_time'] == '20120614T080100'
+        assert pt_journey['sections'][0]['stop_date_times'][-1]['arrival_date_time'] == '20120614T080102'
 
         # Check /pt_objects after: new objects created
         response = self.query_region(ptobj_query)

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1151,7 +1151,7 @@ void PbCreator::Filler::fill_pb_object(const nd::Impact* impact, pbnavitia::Impa
     for (const auto& app_period : impact->application_periods) {
         auto p = pb_impact->add_application_periods();
         p->set_begin(navitia::to_posix_timestamp(app_period.begin()));
-        p->set_end(navitia::to_posix_timestamp(app_period.last()));
+        p->set_end(navitia::to_posix_timestamp(app_period.end()));
     }
 
     // TODO: updated at must be computed with the max of all computed values (from disruption, impact, ...)


### PR DESCRIPTION
* In the module pb_converter, period.last() is used while setting protobuf application_period.end() value in the response.
* This value is smaller (-1) than the real application.end() value used while crated in chaos.
Concerned ticket: https://jira.kisio.org/browse/NAVITIAII-3265

Before:
```javascript
"application_periods": ⊖[
       ⊖{
            "begin": "20201201T154000",
            "end": "20210228T223959"
        }
    ]
```

After:
```javascript
"application_periods": ⊖[
       ⊖{
            "begin": "20201201T154000",
            "end": "20210228T224000"
        }
    ]
```

