### PR TITLE
[CI] trigger new Artemis after a merge

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -36,9 +36,9 @@ jobs:
         path: "navitia_${{matrix.distribution}}_packages.zip"
     - name: remove useless temporary files
       run: rm -rf ../navitia-*
-    - name: run artemis NG on https://jenkins-core.canaltp.fr/job/artemis
+    - name: run artemis NG on https://jenkins-core.canaltp.fr/job/artemis_ng
       if: ${{matrix.distribution}} == 'debian8'
-      run: http -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/artemis/build
+      run: http -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/artemis_ng/build
     - name: slack notification (the job has failed)
       if: failure()
       run: |

--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -36,9 +36,9 @@ jobs:
         path: "navitia_${{matrix.distribution}}_packages.zip"
     - name: remove useless temporary files
       run: rm -rf ../navitia-*
-    - name: trigger deploy on artemis
+    - name: run artemis NG on https://jenkins-core.canaltp.fr/job/artemis
       if: ${{matrix.distribution}} == 'debian8'
-      run: echo "Trigger Artemis later"
+      run: http -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/artemis/build
     - name: slack notification (the job has failed)
       if: failure()
       run: |


### PR DESCRIPTION
With this PR we are be able to run the new **Artemis** (news CI) after a merge on **Dev branch**
- It runs the job https://github.com/CanalTP/jenkins_conf/pull/87#pullrequestreview-555343423 (@pbench)
- It is in parallel of the old artemis (which is always launched for the moment) to do a slow transition (old trig -> https://github.com/CanalTP/navitia/blob/dev/.github/workflows/build_navitia_packages_for_dev.yml#L36)

Feel free to merge @pbench when you are ready !