### PR TITLE
[Jormun] Fix - Timeo should raise on HTTP error

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/timeo_test.py
@@ -213,8 +213,7 @@ def get_passages_test():
         )
 
 
-@requests_mock.Mocker()
-def get_next_passage_for_route_point_with_requests_response_model_test(requests_mock):
+def get_next_passage_for_route_point_with_requests_response_model_test():
     '''
         We test a call on Timeo based on a real requests' response model object.
 
@@ -226,12 +225,13 @@ def get_next_passage_for_route_point_with_requests_response_model_test(requests_
     '''
     timeo_test_url = 'http://bob.com/tata'
 
-    requests_mock.get(timeo_test_url, status_code=404)
+    with requests_mock.Mocker() as mocker:
+        mocker.get(timeo_test_url, status_code=404)
 
-    timeo = Timeo('tata', timeo_test_url, {}, 'UTC')
-    timeo._make_url = mock.MagicMock(return_value=timeo_test_url)
-    with raises(RealtimeProxyError):
-        timeo._get_next_passage_for_route_point(mock.MagicMock())
+        timeo = Timeo('tata', timeo_test_url, {}, 'UTC')
+        timeo._make_url = mock.MagicMock(return_value=timeo_test_url)
+        with raises(RealtimeProxyError):
+            timeo._get_next_passage_for_route_point(mock.MagicMock())
 
 
 def get_passages_no_passages_test():

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -183,19 +183,10 @@ class Timeo(RealtimeProxy):
             extra={'rt_system_id': six.text_type(self.rt_system_id)},
         )
         r = self._call_timeo(url)
-        if not r:
-            return None
-
         return self._get_passages(r, current_dt, route_point.fetch_line_uri())
 
     def _get_passages(self, response, current_dt, line_uri=None):
         status_code = response.status_code
-        timeo_resp = response.json()
-
-        logging.getLogger(__name__).debug(
-            'timeo response: {}'.format(timeo_resp), extra={'rt_system_id': six.text_type(self.rt_system_id)}
-        )
-
         # Handling http error
         if status_code != 200:
             logging.getLogger(__name__).error(
@@ -203,6 +194,11 @@ class Timeo(RealtimeProxy):
                 extra={'rt_system_id': six.text_type(self.rt_system_id), 'status_code': status_code},
             )
             raise RealtimeProxyError('non 200 response')
+
+        timeo_resp = response.json()
+        logging.getLogger(__name__).debug(
+            'timeo response: {}'.format(timeo_resp), extra={'rt_system_id': six.text_type(self.rt_system_id)}
+        )
 
         # internal timeo error handling
         message_responses = timeo_resp.get('MessageResponse')


### PR DESCRIPTION
When a call to Timeo fail with a HTTP status code of 400 and above, we were silently ignoring the call.

This PR changes the behaviour to make sure an exception is raised when an error occurred so we can monitor in New Relic failing calls. 