### PR TITLE
[Kraken] Fix boost optional warnings

### DIFF
--- a/source/ed/connectors/speed_parser.cpp
+++ b/source/ed/connectors/speed_parser.cpp
@@ -133,7 +133,7 @@ SpeedsParser SpeedsParser::defaults() {
 
 boost::optional<float> SpeedsParser::get_speed(const std::string& highway,
                                                const boost::optional<std::string>& max_speed) const {
-    boost::optional<float> speed;
+    auto speed = boost::make_optional(false, float{});
 
     if (max_speeds_by_type.empty() && speed_factor_by_type.empty()) {
         return boost::none;

--- a/source/georef/path_finder.cpp
+++ b/source/georef/path_finder.cpp
@@ -416,7 +416,7 @@ Path create_path(const GeoRef& geo_ref,
 
     // On reparcourt tout dans le bon ordre
     nt::idx_t last_way = type::invalid_idx;
-    boost::optional<PathItem::TransportCaracteristic> last_transport_carac{};
+    auto last_transport_carac = boost::make_optional(false, PathItem::TransportCaracteristic{});
     PathItem path_item;
     path_item.coordinates.push_back(geo_ref.graph[reverse_path.back()].coord);
 

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_command(OUTPUT ${PROTO_HDRS} ${PROTO_SRCS}
 add_custom_command (OUTPUT ${NAVITIACOMMON_PROTO_PY}
     COMMAND protoc ARGS "--python_out=${NAVITIACOMMON_DIR}"
     type.proto response.proto request.proto task.proto stat.proto
-    COMMAND 2to3 -w ${NAVITIACOMMON_PROTO_PY}
+    COMMAND 2to3 --no-diffs -w ${NAVITIACOMMON_PROTO_PY}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/navitia-proto" VERBATIM
     DEPENDS ${PROTO_FILES})
 
@@ -67,7 +67,7 @@ add_custom_command (OUTPUT ${NAVITIACOMMON_PROTO_PY}
 add_custom_command (OUTPUT ${MONITOR_KRAKEN_PROTO_PY}
     COMMAND protoc ARGS "--python_out=${MONITOR_KRAKEN_DIR}"
     type.proto response.proto request.proto
-    COMMAND 2to3 -w ${MONITOR_KRAKEN_PROTO_PY}
+    COMMAND 2to3 --no-diffs -w ${MONITOR_KRAKEN_PROTO_PY}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/navitia-proto" VERBATIM
     DEPENDS ${PROTO_FILES})
 
@@ -75,7 +75,7 @@ add_custom_command (OUTPUT ${MONITOR_KRAKEN_PROTO_PY}
 add_custom_command (OUTPUT ${JORMUNGANDR_TEST_PY}
     COMMAND protoc ARGS "--python_out=${JORMUNGANDR_TEST_DIR}"
     chaos.proto gtfs-realtime.proto kirin.proto
-    COMMAND 2to3 -w ${JORMUNGANDR_TEST_PY}
+    COMMAND 2to3 --no-diffs -w ${JORMUNGANDR_TEST_PY}
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/chaos-proto" VERBATIM
     DEPENDS ${PROTO_FILES})
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1796,8 +1796,7 @@ void PbCreator::fill_street_sections(const type::EntryPoint& ori_dest,
     }
 
     auto session_departure = departure;
-
-    boost::optional<georef::PathItem::TransportCaracteristic> last_transportation_carac = {};
+    auto last_transportation_carac = boost::make_optional(false, georef::PathItem::TransportCaracteristic{});
     auto section = create_section(pb_journey, path.path_items.front(), depth);
     georef::PathItem last_item;
 

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -295,7 +295,7 @@ std::set<RankStopTime> VehicleJourney::get_sections_ranks(const StopArea* start_
      *  - s1/s2/s5 from the 11th to the 15th
      * */
     std::set<RankStopTime> res;
-    boost::optional<RankStopTime> section_start_rank;
+    auto section_start_rank = boost::make_optional(false, RankStopTime{});
     bool section_starting = false, section_ending = false;
     const auto* base_vj = this->get_corresponding_base();
     const auto* vj = base_vj ? base_vj : this;


### PR DESCRIPTION
Fix warning raised by the compiler about potentially uninitialized value. 

This is a bug in the GCC < 5.1. 

https://www.boost.org/doc/libs/1_65_1/libs/optional/doc/html/boost_optional/tutorial/gotchas/false_positive_with__wmaybe_uninitialized.html