### PR TITLE
[ridesharing] Karaos - fix main shape without useless coords

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -120,21 +120,20 @@ class Karos(AbstractRidesharingService):
             res.dropoff_dest_shape = self._retreive_shape(offer, 'dropoffToArrivalWalkingPolyline')
 
             shape = self._retreive_shape(offer, 'journeyPolyline')
-            # This is a particular case for Karos. We don't need extrapolation for the rest of the ride.
-            # It change the pickup and dropoff place
-            if len(shape) > 2:
+            # This is a particular case for Karos.
+            # we don't use the :
+            # driverArrivalLat   - driverArrivalLng
+            # driverDepartureLat - driverDepartureLng
+            # Because that doesn't represent the start and the end of our ride. It represents extra
+            # informations about the complete driver ride.
+            # We fill the pickup and dropoff place with the shape
+            if len(shape) >= 2:
                 res.pickup_place = rsj.Place(
                     addr='', lat=shape[0].lat, lon=shape[0].lon
                 )
                 res.dropoff_place = rsj.Place(
                     addr='', lat=shape[-1].lat, lon=shape[-1].lon
                 )
-
-                shape = shape[1:-1]
-                if not shape or res.pickup_place.lon != shape[0].lon or res.pickup_place.lat != shape[0].lat:
-                    shape.insert(0, type_pb2.GeographicalCoord(lon=res.pickup_place.lon, lat=res.pickup_place.lat))
-                if not shape or res.dropoff_place.lon != shape[-1].lon or res.dropoff_place.lat != shape[-1].lat:
-                    shape.append(type_pb2.GeographicalCoord(lon=res.dropoff_place.lon, lat=res.dropoff_place.lat))
             else:
                 res.pickup_place = rsj.Place(
                     addr='', lat=offer.get('driverDepartureLat'), lon=offer.get('driverDepartureLng')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -128,12 +128,8 @@ class Karos(AbstractRidesharingService):
             # informations about the complete driver ride.
             # We fill the pickup and dropoff place with the shape
             if len(shape) >= 2:
-                res.pickup_place = rsj.Place(
-                    addr='', lat=shape[0].lat, lon=shape[0].lon
-                )
-                res.dropoff_place = rsj.Place(
-                    addr='', lat=shape[-1].lat, lon=shape[-1].lon
-                )
+                res.pickup_place = rsj.Place(addr='', lat=shape[0].lat, lon=shape[0].lon)
+                res.dropoff_place = rsj.Place(addr='', lat=shape[-1].lat, lon=shape[-1].lon)
             else:
                 res.pickup_place = rsj.Place(
                     addr='', lat=offer.get('driverDepartureLat'), lon=offer.get('driverDepartureLng')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -268,18 +268,18 @@ def karos_service_test():
         )
 
         assert ridesharing_journeys[0].pickup_place.addr == ""  # address is not provided in mock
-        assert ridesharing_journeys[0].pickup_place.lat == 48.8181
-        assert ridesharing_journeys[0].pickup_place.lon == 2.398
+        assert ridesharing_journeys[0].pickup_place.lat == 48.8047
+        assert ridesharing_journeys[0].pickup_place.lon == 2.2897
 
         assert ridesharing_journeys[0].dropoff_place.addr == ""  # address is not provided in mock
-        assert ridesharing_journeys[0].dropoff_place.lat == 48.7849
-        assert ridesharing_journeys[0].dropoff_place.lon == 2.1832
+        assert ridesharing_journeys[0].dropoff_place.lat == 48.7821
+        assert ridesharing_journeys[0].dropoff_place.lon == 2.1738
 
         assert ridesharing_journeys[0].shape
         assert ridesharing_journeys[0].shape[0].lat == ridesharing_journeys[0].pickup_place.lat
         assert ridesharing_journeys[0].shape[0].lon == ridesharing_journeys[0].pickup_place.lon
-        assert ridesharing_journeys[0].shape[1].lat == 48.8047  # test that we really load a shape
-        assert ridesharing_journeys[0].shape[1].lon == 2.2897
+        assert ridesharing_journeys[0].shape[1].lat == 48.8046  # test that we really load a shape
+        assert ridesharing_journeys[0].shape[1].lon == 2.2895
         assert ridesharing_journeys[0].shape[-1].lat == ridesharing_journeys[0].dropoff_place.lat
         assert ridesharing_journeys[0].shape[-1].lon == ridesharing_journeys[0].dropoff_place.lon
 

--- a/source/jormungandr/tests/karos_routing_tests.py
+++ b/source/jormungandr/tests/karos_routing_tests.py
@@ -164,8 +164,8 @@ class TestKaros(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[1].get('duration') == 1301
         assert rsj_sections[1].get('departure_date_time') == '20201006T124229'
         assert rsj_sections[1].get('arrival_date_time') == '20201006T130410'
-        assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.0000898312, 0.0000898312]
-        assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.78995, 47.28728]
+        assert rsj_sections[1].get('geojson').get('coordinates')[0] == [0.78975, 47.28698]
+        assert rsj_sections[1].get('geojson').get('coordinates')[2] == [0.79009, 47.28742]
         # ridesharing duration comes from the offer
         rsj_info = rsj_sections[1].get('ridesharing_informations')
         assert rsj_info.get('network') == 'Super Covoit'


### PR DESCRIPTION
### issue

**Karos** sends 2 fields`driverArrival` and `driverDeparture`, that we don't want to use. 
Because it doesn't represent the start and the arrival of the offer. Just the start and the arrival of the **driver**. 
We directly use shape to catch arrival and departure

UTest coords was false. Now it is fix

**Real examples** :

**1. Ride**

before
![ridesharing_karos_1](https://user-images.githubusercontent.com/32099204/105359906-473b0780-5bf8-11eb-89c9-10a7b1c31a24.png)
after
![ridesharing_karos_avec_correctif_1](https://user-images.githubusercontent.com/32099204/105359961-56ba5080-5bf8-11eb-8797-75d3778d4bcb.png)

**2. Ride**

before
![ridesharing_karos_2](https://user-images.githubusercontent.com/32099204/105359993-6174e580-5bf8-11eb-820f-48fb92c3aa29.png)
after
![ridesharing_karos_avec_correctif_2](https://user-images.githubusercontent.com/32099204/105360026-6c2f7a80-5bf8-11eb-9fdc-9924bfffe494.png)


