### PR TITLE
[release] fix script_release

### DIFF
--- a/release/script_release.py
+++ b/release/script_release.py
@@ -121,18 +121,13 @@ class ReleaseManager:
             exit(1)
 
     def get_new_version_number(self):
-        latest_version = None
         last_tag = self.git.describe('--tags', abbrev=0)
 
-        version = re.search('.*(\d+\.\d+\.\d+).*', last_tag)
-        if version:
-            latest_version = version.group(1)
-
-        if not latest_version:
+        if not last_tag:
             print("no latest version found")
             exit(1)
 
-        version_n = latest_version.split('.')
+        version_n = last_tag[1:].split('.')
         print("latest version is {}".format(version_n))
 
         self.version = [int(i) for i in version_n]


### PR DESCRIPTION
### Issue
The script doesn't work with a version number > 9. So, for **v10.0.0** it see the version **0.0.0** :duck: 
It is the first time because of the 10...

Because navitia version always start with a v (https://github.com/CanalTP/navitia/tags), a simple `last_tag[1:].split('.')` retrieve the real version number