### PR TITLE
[Tyr] Set `distributed` as default scenario for Navitia's instances

### DIFF
--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -310,7 +310,7 @@ class Instance(db.Model):  # type: ignore
     # params for jormungandr
     # ============================================================
     # the scenario used by jormungandr, by default we use the new default scenario (and not the default one...)
-    scenario = db.Column(db.Text, nullable=False, default='new_default')
+    scenario = db.Column(db.Text, nullable=False, default='distributed')
 
     # order of the journey, this order is for clockwise request, else it is reversed
     journey_order = db.Column(

--- a/source/tyr/tests/integration/instance_test.py
+++ b/source/tyr/tests/integration/instance_test.py
@@ -381,7 +381,7 @@ def test_update_instances_with_invalid_scenario(create_instance):
     assert status == 400
 
     resp = api_get('/v0/instances/')
-    assert resp[0]['scenario'] == 'new_default'
+    assert resp[0]['scenario'] == 'distributed'
 
 
 def test_update_max_nb_crowfly_by_mode(create_instance):


### PR DESCRIPTION
Update our model so that default scenario are set to `distributed` for new coverages