### PR TITLE
[Realtime] VJ name is Headsign with a new trip

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2464,7 +2464,7 @@ class TestKirinAddTripWithHeadSign(MockKirinDisruptionsFixture):
         new_vj = self.query_region('vehicle_journeys/vehicle_journey:additional-trip:modified:0:new_trip')
         assert len(new_vj['vehicle_journeys']) == 1
         # Name is empty but headsign assigned from the disruption
-        assert (new_vj['vehicle_journeys'][0]['name']) == ''
+        assert (new_vj['vehicle_journeys'][0]['name']) == 'trip_headsign'
         assert (new_vj['vehicle_journeys'][0]['headsign']) == 'trip_headsign'
 
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2463,7 +2463,6 @@ class TestKirinAddTripWithHeadSign(MockKirinDisruptionsFixture):
         # Check the vehicle_journey created by real-time
         new_vj = self.query_region('vehicle_journeys/vehicle_journey:additional-trip:modified:0:new_trip')
         assert len(new_vj['vehicle_journeys']) == 1
-        # Name is empty but headsign assigned from the disruption
         assert (new_vj['vehicle_journeys'][0]['name']) == 'trip_headsign'
         assert (new_vj['vehicle_journeys'][0]['headsign']) == 'trip_headsign'
 

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -330,6 +330,7 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 // Affect the headsign to vj if present in gtfs-rt
                 if (!impact->headsign.empty()) {
                     vj->headsign = impact->headsign;
+                    vj->name = impact->headsign;
                     pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, impact->headsign);
                 }
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2932,6 +2932,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->uri, "vehicle_journey:vj_new_trip:modified:0:feed-1");
     BOOST_CHECK_EQUAL(vj->idx, 1);
     BOOST_CHECK_EQUAL(vj->name, "");
+    BOOST_CHECK_EQUAL(vj->headsign, "");
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip");
     BOOST_CHECK_EQUAL(vj->stop_time_list.size(), 4);
     BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));
@@ -3081,6 +3082,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->uri, "vehicle_journey:vj_new_trip_2:modified:0:feed-2");
     BOOST_CHECK_EQUAL(vj->idx, 2);
     BOOST_CHECK_EQUAL(vj->name, "trip_headsign");
+    BOOST_CHECK_EQUAL(vj->headsign, "trip_headsign");
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip_2");
     BOOST_CHECK_EQUAL(vj->stop_time_list.size(), 4);
     BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2931,6 +2931,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->dataset->contributor->name, contributor_name);
     BOOST_CHECK_EQUAL(vj->uri, "vehicle_journey:vj_new_trip:modified:0:feed-1");
     BOOST_CHECK_EQUAL(vj->idx, 1);
+    BOOST_CHECK_EQUAL(vj->name, "");
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip");
     BOOST_CHECK_EQUAL(vj->stop_time_list.size(), 4);
     BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));
@@ -3079,6 +3080,7 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->dataset->contributor->name, contributor_name);
     BOOST_CHECK_EQUAL(vj->uri, "vehicle_journey:vj_new_trip_2:modified:0:feed-2");
     BOOST_CHECK_EQUAL(vj->idx, 2);
+    BOOST_CHECK_EQUAL(vj->name, "trip_headsign");
     BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip_2");
     BOOST_CHECK_EQUAL(vj->stop_time_list.size(), 4);
     BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));


### PR DESCRIPTION
### Issue
Nowaday, the name is empty when a new trip with headsign is added from realtime -> https://github.com/CanalTP/navitia/blob/dev/source/jormungandr/tests/kirin_realtime_tests.py#L2467
This PR aims to fix it. 
Thank you @pbougue  for the highlight, it was fast !

**JIRA** : https://jira.kisio.org/browse/NAVITIAII-3313