### PR TITLE
Kraken: fix headsign in route_schedules API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     -   id: check-ast
     -   id: check-merge-conflict
     -   id: check-yaml
+        args: [--allow-multiple-documents]
     -   id: flake8
         language_version: python2.7
 -   repo: https://github.com/CanalTP/navitia-pre-commit

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -1153,7 +1153,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         assert len(route_schedules) == 1
         assert len(route_schedules[0]['table']['headers']) == 1
         display_info = route_schedules[0]['table']['headers'][0]['display_informations']
-        assert display_info['headsign'] == "vjA"
+        assert display_info['headsign'] == "A00"
         assert {"A00", "vjA_hs"} == set(display_info['headsigns'])
 
     def test_trip_id_vj(self):

--- a/source/time_tables/route_schedules.cpp
+++ b/source/time_tables/route_schedules.cpp
@@ -427,10 +427,6 @@ void route_schedule(PbCreator& pb_creator,
                     auto sts = std::vector<const nt::StopTime*>{dt_stop_time.second};
                     const auto& vj_st = navitia::VjStopTimes(vj, sts);
                     pb_creator.fill(&vj_st, vj_display_information, 0);
-                    // as we only issue headsign for vj in route_schedules:
-                    // - need to override headsign with trip headsign (i.e. vj.name)
-                    // - issue all headsigns of the vj in headsigns
-                    vj_display_information->set_headsign(vj->name);
                     for (const auto& headsign : pb_creator.data->pt_data->headsign_handler.get_all_headsigns(vj)) {
                         vj_display_information->add_headsigns(headsign);
                     }


### PR DESCRIPTION
ISO headsign route_schedules and journeys API in display_informations

Jira: [NAVITIAII-3320](https://jira.kisio.org/browse/NAVITIAII-3320)

> in /journeys:
![image](https://user-images.githubusercontent.com/4006603/108734882-34399100-7530-11eb-9611-f0be50a4da54.png)

**Before** correction in route_schedules API:
headsign = vj.name
![image](https://user-images.githubusercontent.com/4006603/108735384-c8a3f380-7530-11eb-8262-6d56c62fef53.png)


**After** correction in route_schedules API:

![image](https://user-images.githubusercontent.com/4006603/108735065-63500280-7530-11eb-8906-c26826277944.png)
