### PR TITLE
[docker compose] waiting artifacts to run GA job

### DIFF
--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -5,12 +5,6 @@ on:
     workflows: ["Build Navitia Packages For Dev Multi Distributions"]
     types:
       - completed
-      - requested
-  pull_request:
-  push:
-    branches:
-      - dev
-      - release
 
 jobs:
   build:

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -3,9 +3,9 @@ name: Publish Docker Compose Images
 on:
   workflow_run:
     workflows: ["Build Navitia Packages For Dev Multi Distributions"]
-    branches: [dev]
     types:
       - completed
+      - requested
   pull_request:
   push:
     branches:

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -1,6 +1,12 @@
 name: Publish Docker Compose Images
 
 on:
+  workflow_run:
+    workflows: ["Build Navitia Packages For Dev Multi Distributions"]
+    branches: [dev]
+    types:
+      - completed
+  pull_request:
   push:
     branches:
       - dev
@@ -21,8 +27,4 @@ jobs:
     - name: build, create and publish images for branch [ ${{ env.BRANCH_NAME }} ]
       working-directory: builder_from_package
       run: ./build.sh -e push -o ${{secrets.access_token_github}} -t navitia_builder -b ${{ env.BRANCH_NAME }} -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
-    - name: slack notification (the job has failed)
-      if: failure()
-      run: |
-          echo '{"text":":warning: Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
 

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -22,4 +22,8 @@ jobs:
     - name: build, create and publish images for branch [ ${{ env.BRANCH_NAME }} ]
       working-directory: builder_from_package
       run: ./build.sh -e push -o ${{secrets.access_token_github}} -t navitia_builder -b ${{ env.BRANCH_NAME }} -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+    - name: slack notification (the job has failed)
+      if: failure()
+      run: |
+          echo '{"text":":warning: Github Actions: publish_docker_compose_images failed ! (https://github.com/CanalTP/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
 

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -6,6 +6,7 @@ on:
     branches: [publish_docker_compose_job_is_waiting]
     types:
       - completed
+      - requested
 
 jobs:
   build:

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -3,7 +3,7 @@ name: Publish Docker Compose Images
 on:
   workflow_run:
     workflows: ["Build Navitia Packages For Dev Multi Distributions"]
-    branches: [dev]
+    branches: [publish_docker_compose_job_is_waiting]
     types:
       - completed
 

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -3,10 +3,9 @@ name: Publish Docker Compose Images
 on:
   workflow_run:
     workflows: ["Build Navitia Packages For Dev Multi Distributions"]
-    branches: [publish_docker_compose_job_is_waiting]
+    branches: [dev]
     types:
       - completed
-      - requested
 
 jobs:
   build:

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -3,6 +3,7 @@ name: Publish Docker Compose Images
 on:
   workflow_run:
     workflows: ["Build Navitia Packages For Dev Multi Distributions"]
+    branches: [dev]
     types:
       - completed
 


### PR DESCRIPTION
We want to chain jobs like:
```
build packages -> publish docker compse
```
Because docker compose needs debian packages...
@pbench found a way with https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
Dunno if it works. **Merge** it and **revert** If it does not work :duck: 