### PR TITLE
Ci: Create Github release

### DIFF
--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -51,10 +51,14 @@ jobs:
           echo '{"text":":information_source: Navitia Github Actions: build_navitia_packages_for_release succeded -' $version_number 'navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
           echo '{"text":":octopus: Navitia Release: The version' $version_number 'is available. changelog: https://github.com/CanalTP/navitia/releases/tag/v'$version_number'"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}
 
-    - name: Github Release
-      uses: softprops/action-gh-release@v1
-      if: success() && matrix.distribution == 'debian10' && startsWith(github.ref, 'refs/tags/')
-      with:
-        files: navitia_debian10_packages.zip
+    - name: github Release
+      id: create_release
+      uses: actions/create-release@v1
+      if: success() && matrix.distribution == 'debian8'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false


### PR DESCRIPTION
### Issue
During the last release `softprops/action-gh-release@v1` didn't work properly.
I prefer to use the classic `actions/create-release@v1` that I already use here https://github.com/CanalTP/core_team_ci_tools