### PR TITLE
[Raptor] Simplify Label's API exposure

### DIFF
--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -267,7 +267,7 @@ std::vector<navitia::time_duration> init_distance(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels.dt_pt(sp_idx);
+        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
         if (in_bound(best_lbl, bound, clockwise)) {
             const auto& projections = worker.projected_stop_points[sp->idx];
             const auto& proj = projections[mode];
@@ -298,7 +298,7 @@ static std::vector<georef::vertex_t> init_vertex(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels.dt_pt(sp_idx);
+        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
         if (in_bound(best_lbl, bound, clockwise)) {
             const auto& projections = worker.projected_stop_points[sp->idx];
             const auto& proj = projections[mode];
@@ -329,7 +329,7 @@ static BoundBox find_boundary_box(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels.dt_pt(sp_idx);
+        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
         if (in_bound(best_lbl, bound, clockwise)) {
             const auto& projections = worker.projected_stop_points[sp->idx];
             const auto& proj = projections[mode];

--- a/source/routing/isochrone.cpp
+++ b/source/routing/isochrone.cpp
@@ -210,7 +210,7 @@ type::MultiPolygon build_single_isochrone(RAPTOR& raptor,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels.dt_pt(sp_idx);
+        const auto best_lbl = raptor.best_labels[sp_idx].dt_pt;
         if (in_bound(best_lbl, bound, clockwise)) {
             uint duration_left = abs(int(best_lbl) - int(bound));
             if (duration_left * speed < MIN_RADIUS) {

--- a/source/routing/labels.cpp
+++ b/source/routing/labels.cpp
@@ -56,10 +56,10 @@ std::array<Labels::Map, 4> Labels::inrow_labels() {
         const auto& sp_idx = l.first;
         const auto& label = l.second;
 
-        row_labels[0][sp_idx] = label.dt_pts;
-        row_labels[1][sp_idx] = label.dt_transfers;
-        row_labels[2][sp_idx] = label.walking_duration_pts;
-        row_labels[3][sp_idx] = label.walking_duration_transfers;
+        row_labels[0][sp_idx] = label.dt_pt;
+        row_labels[1][sp_idx] = label.dt_transfer;
+        row_labels[2][sp_idx] = label.walking_duration_pt;
+        row_labels[3][sp_idx] = label.walking_duration_transfer;
     }
 
     return row_labels;

--- a/source/routing/labels.h
+++ b/source/routing/labels.h
@@ -41,29 +41,29 @@ www.navitia.io
 namespace navitia {
 namespace routing {
 
+struct Label {
+    // All these vectors are indexed by sp_idx
+    //
+    // dt_pt stores the earliest arrival time to stop_point.
+    // More precisely, at time dt_pt, we just alighted from
+    // a vehicle going through stop_point, but we need to do a transfer
+    // before being able to board a new vehicle.
+    DateTime dt_pt;
+
+    // dt_transfers[stop_point] stores the earliest time at which we are able
+    // to board a vehicle leaving from stop_point (i.e. a transfer to stop_point has been done).
+    DateTime dt_transfer;
+
+    // walking_duration_pts[stop_point] stores the total walking duration (fallback + transfers)  of a
+    // journey that alight to stop_point at DateTime dt_pt
+    DateTime walking_duration_pt;
+
+    // waling_duration_transfers[stop_point] stores the total walking duration (fallback + transfers) of a
+    // journey that allows to board a vehicle at stop_point at DateTime transfers_pts[stop_point]
+    DateTime walking_duration_transfer;
+};
+
 struct Labels {
-    struct Label {
-        // All these vectors are indexed by sp_idx
-        //
-        // dt_pts[stop_point] stores the earliest arrival time to stop_point.
-        // More precisely, at time dt_pts[stop_point], we just alighted from
-        // a vehicle going through stop_point, but we need to do a transfer
-        // before being able to board a new vehicle.
-        DateTime dt_pts;
-
-        // dt_transfers[stop_point] stores the earliest time at which we are able
-        // to board a vehicle leaving from stop_point (i.e. a transfer to stop_point has been done).
-        DateTime dt_transfers;
-
-        // walking_duration_pts[stop_point] stores the total walking duration (fallback + transfers)  of a
-        // journey that alight to stop_point at DateTime dt_pts[stop_point]
-        DateTime walking_duration_pts;
-
-        // waling_duration_transfers[stop_point] stores the total walking duration (fallback + transfers) of a
-        // journey that allows to board a vehicle at stop_point at DateTime transfers_pts[stop_point]
-        DateTime walking_duration_transfers;
-    };
-
     using Map = IdxMap<type::StopPoint, DateTime>;
     using LabelsMap = IdxMap<type::StopPoint, Label>;
 
@@ -73,25 +73,12 @@ struct Labels {
 
     // initialize the structure according to the number of jpp
     void init_inf(const std::vector<type::StopPoint*>& stops) { init(stops, DateTimeUtils::inf); }
-    // initialize the structure according to the number of jpp
     void init_min(const std::vector<type::StopPoint*>& stops) { init(stops, DateTimeUtils::min); }
 
-    // copy without touching the boarding_jpp fields
-    const DateTime& dt_transfer(SpIdx sp_idx) const { return labels[sp_idx].dt_transfers; }
-    const DateTime& dt_pt(SpIdx sp_idx) const { return labels[sp_idx].dt_pts; }
-    DateTime& mut_dt_transfer(SpIdx sp_idx) { return labels[sp_idx].dt_transfers; }
-    DateTime& mut_dt_pt(SpIdx sp_idx) { return labels[sp_idx].dt_pts; }
+    const Label& operator[](SpIdx sp_idx) const { return labels[sp_idx]; }
+    Label& operator[](SpIdx sp_idx) { return labels[sp_idx]; }
 
-    const DateTime& walking_duration_pt(SpIdx sp_idx) const { return labels[sp_idx].walking_duration_pts; }
-    const DateTime& walking_duration_transfer(SpIdx sp_idx) const { return labels[sp_idx].walking_duration_transfers; }
-    DateTime& mut_walking_duration_pt(SpIdx sp_idx) { return labels[sp_idx].walking_duration_pts; }
-    DateTime& mut_walking_duration_transfer(SpIdx sp_idx) { return labels[sp_idx].walking_duration_transfers; }
-
-    bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
-    bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }
-
-    const LabelsMap& get_labels_map() const { return labels; }
-    LabelsMap& get_labels_map() { return labels; }
+    LabelsMap::range values() { return labels.values(); }
 
     /* Split each label's field in a specific vector, and return them individually in an array of :
      *  1. stop point arrival datetime
@@ -105,6 +92,9 @@ struct Labels {
 
 private:
     void init(const std::vector<type::StopPoint*>& stops, DateTime val);
+
+    const DateTime& dt_pt(SpIdx sp_idx) const { return labels[sp_idx].dt_pt; }
+    DateTime& mut_dt_pt(SpIdx sp_idx) { return labels[sp_idx].dt_pt; }
 
     LabelsMap labels;
 };

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -957,11 +957,12 @@ static void add_isochrone_response(RAPTOR& raptor,
     pb_creator.fill(&origin, &pb_origin, 0);
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels.dt_pt(sp_idx);
+        const auto best_lbl = raptor.best_labels[sp_idx].dt_pt;
         if ((clockwise && best_lbl < bound) || (!clockwise && best_lbl > bound)) {
             int round = raptor.best_round(sp_idx);
+            const auto& best_round_label = raptor.labels[round][sp_idx];
 
-            if (round == -1 || !raptor.labels[round].pt_is_initialized(sp_idx)) {
+            if (round == -1 || !is_dt_initialized(best_round_label.dt_pt)) {
                 continue;
             }
 


### PR DESCRIPTION
The idea is to reduce to a fewer API calls the labels' access for a specific Stop point.
Because, they will be changed to Route Points later.

For a `Label`, we used to have the following API: 
```cpp
    const DateTime& dt_transfer(SpIdx sp_idx) const { return labels[sp_idx].dt_transfers; }
    const DateTime& dt_pt(SpIdx sp_idx) const { return labels[sp_idx].dt_pts; }
    DateTime& mut_dt_transfer(SpIdx sp_idx) { return labels[sp_idx].dt_transfers; }
    DateTime& mut_dt_pt(SpIdx sp_idx) { return labels[sp_idx].dt_pts; }

    const DateTime& walking_duration_pt(SpIdx sp_idx) const { return labels[sp_idx].walking_duration_pts; }
    const DateTime& walking_duration_transfer(SpIdx sp_idx) const { return labels[sp_idx].walking_duration_transfers; }
    DateTime& mut_walking_duration_pt(SpIdx sp_idx) { return labels[sp_idx].walking_duration_pts; }
    DateTime& mut_walking_duration_transfer(SpIdx sp_idx) { return labels[sp_idx].walking_duration_transfers; }

    bool pt_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_pt(sp_idx)); }
    bool transfer_is_initialized(SpIdx sp_idx) const { return is_dt_initialized(dt_transfer(sp_idx)); }

    const LabelsMap& get_labels_map() const { return labels; }
    LabelsMap& get_labels_map() { return labels; }
```
This PR reduce the calls to :
```cpp
    const Label& operator[](SpIdx sp_idx) const { return labels[sp_idx]; }
    Label& operator[](SpIdx sp_idx) { return labels[sp_idx]; }

    LabelsMap::range values() { return labels.values(); }
```


The idea is to be able to change those last 2 functions from a `SpIdx` (Stop point index) to `RoutePointIdx` a Route Point Index. I hope you guys see where this is going ! 


