### PR TITLE
[Raptor] Compute Route Points add associate then to StopPoint/JPP

### DIFF
--- a/source/routing/journey_pattern_container.h
+++ b/source/routing/journey_pattern_container.h
@@ -58,6 +58,7 @@ const type::StopTime& get_corresponding_stop_time(const type::VehicleJourney& vj
 struct JourneyPatternPoint {
     JpIdx jp_idx;
     SpIdx sp_idx;
+    RoutePointIdx rp_idx;
     RankJourneyPatternPoint order;
     bool operator==(const JourneyPatternPoint& other) const { return sp_idx == other.sp_idx && order == other.order; }
 };
@@ -199,11 +200,11 @@ private:
     IdxMap<type::PhysicalMode, std::vector<JppIdx>> jpps_from_phy_mode;
 
     template <typename VJ>
-    void add_vj(const VJ&);
+    void add_vj(const VJ&, const type::PT_Data& pt_data);
     template <typename VJ>
     static JpKey make_key(const VJ&);
-    JpIdx make_jp(const JpKey&);
-    JppIdx make_jpp(const JpIdx&, const SpIdx&, const RankJourneyPatternPoint& order);
+    JpIdx make_jp(const JpKey&, const type::PT_Data& pt_data);
+    JppIdx make_jpp(const JpIdx&, const SpIdx&, const RoutePointIdx&, const RankJourneyPatternPoint& order);
     JourneyPattern& get_mut(const JpIdx&);
 };
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -120,6 +120,10 @@ struct RAPTOR {
     // pt_data object getters by typed idx
     const type::StopPoint* get_sp(SpIdx idx) const { return data.pt_data->stop_points[idx.val]; }
 
+    inline const type::RoutePoint& get_route_point(RoutePointIdx idx) const {
+        return data.pt_data->route_points[idx.val];
+    }
+
     /// Lance un calcul d'itinéraire entre deux stop areas avec aussi une borne
     std::vector<Path> compute(const type::StopArea* departure,
                               const type::StopArea* destination,

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -44,12 +44,14 @@ using JppIdx = Idx<JourneyPatternPoint>;
 using JpIdx = Idx<JourneyPattern>;
 using SpIdx = Idx<type::StopPoint>;
 using RouteIdx = Idx<type::Route>;
+using RoutePointIdx = Idx<type::RoutePoint>;
 using LineIdx = Idx<type::Line>;
 using VjIdx = Idx<type::VehicleJourney>;
 using MvjIdx = Idx<type::MetaVehicleJourney>;
 using PhyModeIdx = Idx<type::PhysicalMode>;
 
 using map_stop_point_duration = boost::container::flat_map<SpIdx, navitia::time_duration>;
+using map_route_point_duration = boost::container::flat_map<RoutePointIdx, navitia::time_duration>;
 
 inline bool is_dt_initialized(const DateTime dt) {
     return dt != DateTimeUtils::inf && dt != DateTimeUtils::min;

--- a/source/type/CMakeLists.txt
+++ b/source/type/CMakeLists.txt
@@ -100,11 +100,36 @@ target_link_libraries(pb_lib ${PROTOBUF_LIBRARY})
 add_library(pb_converter pb_converter.cpp)
 target_link_libraries(pb_converter thermometer vptranslator pthread pb_lib)
 
-add_library(types message.cpp datetime.cpp geographical_coord.cpp timezone_manager.cpp
-    validity_pattern.cpp type_utils.cpp stop_point.cpp connection.cpp calendar.cpp stop_area.cpp network.cpp
-    contributor.cpp dataset.cpp company.cpp commercial_mode.cpp physical_mode.cpp line.cpp route.cpp
-    vehicle_journey.cpp meta_vehicle_journey.cpp stop_time.cpp type_interfaces.cpp comment_container.cpp
-    odt_properties.cpp comment.cpp static_data.cpp entry_point.cpp)
+add_library(types
+    calendar.cpp
+    comment.cpp
+    comment_container.cpp
+    commercial_mode.cpp
+    company.cpp
+    connection.cpp
+    contributor.cpp
+    dataset.cpp
+    datetime.cpp
+    entry_point.cpp
+    geographical_coord.cpp
+    line.cpp
+    message.cpp
+    meta_vehicle_journey.cpp
+    network.cpp
+    odt_properties.cpp
+    physical_mode.cpp
+    route.cpp
+    route_point.cpp
+    static_data.cpp
+    stop_area.cpp
+    stop_point.cpp
+    stop_time.cpp
+    timezone_manager.cpp
+    type_interfaces.cpp
+    type_utils.cpp
+    validity_pattern.cpp
+    vehicle_journey.cpp
+)
 target_link_libraries(types ptreferential utils pb_lib protobuf)
 add_dependencies(types protobuf_files)
 

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -47,6 +47,7 @@ www.navitia.io
 #include "type/meta_vehicle_journey.h"
 #include "type/physical_mode.h"
 #include "type/commercial_mode.h"
+#include "type/route_point.h"
 #include "utils/functions.h"
 #include "utils/serialization_atomic.h"
 #include "utils/serialization_unique_ptr.h"
@@ -448,6 +449,16 @@ void Data::build_relations() {
         build_companies(vj);
         if (!navitia::contains(vj->route->line->physical_mode_list, vj->physical_mode)) {
             vj->route->line->physical_mode_list.push_back(vj->physical_mode);
+        }
+    }
+
+    auto& route_points = pt_data->route_points;
+    for (auto* sp : pt_data->stop_points) {
+        for (auto* route : sp->route_list) {
+            // Add new Route Point to PT_data
+            route_points.push_back({idx_t(route_points.size()), sp, route});
+            // set back-reference with the stop_point
+            sp->route_point_list.emplace(route, route_points.back());
         }
     }
 }

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -73,6 +73,7 @@ struct MetaVehicleJourney;
 struct Network;
 struct PhysicalMode;
 struct Route;
+struct RoutePoint;
 struct StopArea;
 struct StopPoint;
 struct StopPointConnection;

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -44,6 +44,7 @@ www.navitia.io
 #include "type/multi_polygon_map.h"
 #include "type/commercial_mode.h"
 #include "type/physical_mode.h"
+#include "type/route_point.h"
 #include "utils/functions.h"
 
 #include <boost/range/algorithm/find_if.hpp>

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -33,6 +33,7 @@ www.navitia.io
 #include "georef/fwd_georef.h"
 #include "type/message.h"
 #include "type/request.pb.h"
+#include "type/route_point.h"
 #include "autocomplete/autocomplete.h"
 #include "proximity_list/proximity_list.h"
 #include "utils/flat_enum_map.h"
@@ -72,6 +73,8 @@ public:
 #undef COLLECTION_AND_MAP
 
     std::vector<StopPointConnection*> stop_point_connections;
+    std::vector<RoutePoint> route_points;
+
     // meta vj factory
     navitia::ObjFactory<MetaVehicleJourney> meta_vjs;
 

--- a/source/type/route.h
+++ b/source/type/route.h
@@ -41,9 +41,6 @@ www.navitia.io
 namespace navitia {
 namespace type {
 
-struct StopPoint;
-struct StopArea;
-
 struct Route : public Header, Nameable, HasMessages {
     const static Type_e type = Type_e::Route;
     Line* line = nullptr;

--- a/source/type/route_point.h
+++ b/source/type/route_point.h
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2021, Canal TP and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -30,43 +30,26 @@ www.navitia.io
 
 #pragma once
 
-#include "type/type_interfaces.h"
-#include "type/geographical_coord.h"
 #include "type/fwd_type.h"
+#include "utils/idx_map.h"
 
-#include <boost/container/flat_set.hpp>
-#include <boost/container/flat_map.hpp>
+#include <boost/range/any_range.hpp>
 
-#include <vector>
-#include <set>
+#include <utility>
 
 namespace navitia {
 namespace type {
 
-struct StopPoint : public Header, Nameable, hasProperties, HasMessages {
-    const static Type_e type = Type_e::StopPoint;
-    GeographicalCoord coord;
-    std::string fare_zone;
-    bool is_zonal = false;
-    std::string platform_code;
-    std::string label;
-
-    StopArea* stop_area;
-    std::vector<navitia::georef::Admin*> admin_list;
-    Network* network;
-    std::vector<StopPointConnection*> stop_point_connection_list;
-    std::set<Dataset*> dataset_list;
-    boost::container::flat_set<Route*> route_list;
-    boost::container::flat_map<Route*, std::reference_wrapper<RoutePoint>> route_point_list;
-
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int);
-
-    StopPoint() : fare_zone(), stop_area(nullptr), network(nullptr) {}
-
-    Indexes get(Type_e type, const PT_Data& data) const;
-    bool operator<(const StopPoint& other) const;
+struct RoutePoint {
+    idx_t idx;
+    StopPoint* stop_point;
+    Route* route;
 };
+
+using RoutePointRefs = std::vector<std::reference_wrapper<type::RoutePoint>>;
+using StopPointRange = boost::any_range<StopPoint, boost::forward_traversal_tag, StopPoint&, std::ptrdiff_t>;
+
+RoutePointRefs route_points_from(const StopPointRange& sps);
 
 }  // namespace type
 }  // namespace navitia


### PR DESCRIPTION
This is the first real change that will introduce the unfamous `ROUTE POINT` : 
* A very simple data-structure which does the connection between a `Route` and (wait for it....) a `Stop Point` ! : 
```cpp
struct RoutePoint {
    idx_t idx;
    StopPoint* stop_point;
    Route* route;
};
```

The list of `RoutePoint` belongs to `PT_Data` like most the PT objects : 
```
class PT_Data : { 
    ...
    std::vector<RoutePoint> route_points;
}
```

And unlike the rest of the `PT_Data`, the objects are "referenced" not with a raw pointer (I know we all got tired of the raw pointer forest) but with proper c++ reference semantic through [std::reference_wrapper](https://en.cppreference.com/w/cpp/utility/functional/reference_wrapper) 🎉 
```cpp
struct StopPoint :
    [...] 
    boost::container::flat_map<Route*, std::reference_wrapper<RoutePoint>> route_point_list;
```

No call to `new` or `delete` has been harm during the development....