### PR TITLE
[Raptor] JPP based Raptor's Labels

### DIFF
--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -92,8 +92,8 @@ void dataRAPTOR::JppsFromJp::load(const JourneyPatternContainer& jp_container) {
 
 void dataRAPTOR::load(const type::PT_Data& pt_data, size_t cache_size) {
     jp_container.load(pt_data);
-    labels_const.init_inf(pt_data.stop_points);
-    labels_const_reverse.init_min(pt_data.stop_points);
+    labels_const.init_inf(jp_container.get_jpps_values());
+    labels_const_reverse.init_min(jp_container.get_jpps_values());
 
     connections.load(pt_data);
     jpps_from_sp.load(pt_data, jp_container);

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -267,16 +267,18 @@ std::vector<navitia::time_duration> init_distance(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            const auto& projections = worker.projected_stop_points[sp->idx];
-            const auto& proj = projections[mode];
-            if (proj.found) {
-                const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
-                distances[proj[source_e]] = std::min(
-                    distances[proj[source_e]], time_duration(seconds(duration + proj.distances[source_e] / speed)));
-                distances[proj[target_e]] = std::min(
-                    distances[proj[target_e]], time_duration(seconds(duration + proj.distances[target_e] / speed)));
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto& best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                const auto& projections = worker.projected_stop_points[sp->idx];
+                const auto& proj = projections[mode];
+                if (proj.found) {
+                    const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
+                    distances[proj[source_e]] = std::min(
+                        distances[proj[source_e]], time_duration(seconds(duration + proj.distances[source_e] / speed)));
+                    distances[proj[target_e]] = std::min(
+                        distances[proj[target_e]], time_duration(seconds(duration + proj.distances[target_e] / speed)));
+                }
             }
         }
     }
@@ -298,13 +300,15 @@ static std::vector<georef::vertex_t> init_vertex(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            const auto& projections = worker.projected_stop_points[sp->idx];
-            const auto& proj = projections[mode];
-            if (proj.found) {
-                initialized_points.push_back(proj[source_e]);
-                initialized_points.push_back(proj[target_e]);
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto& best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                const auto& projections = worker.projected_stop_points[sp->idx];
+                const auto& proj = projections[mode];
+                if (proj.found) {
+                    initialized_points.push_back(proj[source_e]);
+                    initialized_points.push_back(proj[target_e]);
+                }
             }
         }
     }
@@ -329,13 +333,15 @@ static BoundBox find_boundary_box(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            const auto& projections = worker.projected_stop_points[sp->idx];
-            const auto& proj = projections[mode];
-            if (proj.found) {
-                const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
-                box.set_box(sp->coord, walking_distance(max_duration, duration, speed) + distance_500m);
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto& best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                const auto& projections = worker.projected_stop_points[sp->idx];
+                const auto& proj = projections[mode];
+                if (proj.found) {
+                    const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
+                    box.set_box(sp->coord, walking_distance(max_duration, duration, speed) + distance_500m);
+                }
             }
         }
     }

--- a/source/routing/isochrone.cpp
+++ b/source/routing/isochrone.cpp
@@ -210,14 +210,16 @@ type::MultiPolygon build_single_isochrone(RAPTOR& raptor,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            uint duration_left = abs(int(best_lbl) - int(bound));
-            if (duration_left * speed < MIN_RADIUS) {
-                continue;
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                uint duration_left = abs(int(best_lbl) - int(bound));
+                if (duration_left * speed < MIN_RADIUS) {
+                    continue;
+                }
+                const auto& center = sp->coord;
+                circles_classed.emplace_back(center, duration_left);
             }
-            const auto& center = sp->coord;
-            circles_classed.emplace_back(center, duration_left);
         }
     }
     std::vector<InfoCircle> circles_check = delete_useless_circle(std::move(circles_classed), speed);

--- a/source/routing/labels.cpp
+++ b/source/routing/labels.cpp
@@ -29,13 +29,14 @@ www.navitia.io
 */
 
 #include "routing/labels.h"
+#include "routing/journey_pattern_container.h"
 #include "utils/boost_patched/range/combine.hpp"
 
 namespace navitia {
 namespace routing {
 
 Labels::Labels() {}
-Labels::Labels(const std::vector<type::StopPoint*> stop_points) : labels(stop_points) {}
+Labels::Labels(const std::vector<JourneyPatternPoint> jpps) : labels(jpps) {}
 
 Labels::Labels(const Map& dt_pts, const Map& dt_transfers, const Map& walkings, const Map& walking_transfers) {
     const auto& zip = boost::combine(dt_pts, dt_transfers.values(), walkings.values(), walking_transfers.values());
@@ -70,9 +71,9 @@ void Labels::fill_values(DateTime pts, DateTime transfert, DateTime walking, Dat
     boost::fill(labels.values(), default_label);
 }
 
-void Labels::init(const std::vector<type::StopPoint*>& stops, DateTime val) {
+void Labels::init(const std::vector<JourneyPatternPoint>& jpps, DateTime val) {
     Label init_label{val, val, DateTimeUtils::not_valid, DateTimeUtils::not_valid};
-    labels.assign(stops, init_label);
+    labels.assign(jpps, init_label);
 }
 
 }  // namespace routing

--- a/source/routing/labels.h
+++ b/source/routing/labels.h
@@ -64,19 +64,19 @@ struct Label {
 };
 
 struct Labels {
-    using Map = IdxMap<type::StopPoint, DateTime>;
-    using LabelsMap = IdxMap<type::StopPoint, Label>;
+    using Map = IdxMap<JourneyPatternPoint, DateTime>;
+    using LabelsMap = IdxMap<JourneyPatternPoint, Label>;
 
     Labels();
-    Labels(const std::vector<type::StopPoint*> stop_points);
+    Labels(const std::vector<JourneyPatternPoint> jpps);
     Labels(const Map& dt_pts, const Map& dt_transfers, const Map& walkings, const Map& walking_transfers);
 
     // initialize the structure according to the number of jpp
-    void init_inf(const std::vector<type::StopPoint*>& stops) { init(stops, DateTimeUtils::inf); }
-    void init_min(const std::vector<type::StopPoint*>& stops) { init(stops, DateTimeUtils::min); }
+    void init_inf(const std::vector<JourneyPatternPoint>& jpps) { init(jpps, DateTimeUtils::inf); }
+    void init_min(const std::vector<JourneyPatternPoint>& jpps) { init(jpps, DateTimeUtils::min); }
 
-    const Label& operator[](SpIdx sp_idx) const { return labels[sp_idx]; }
-    Label& operator[](SpIdx sp_idx) { return labels[sp_idx]; }
+    const Label& operator[](JppIdx jpp_idx) const { return labels[jpp_idx]; }
+    Label& operator[](JppIdx jpp_idx) { return labels[jpp_idx]; }
 
     LabelsMap::range values() { return labels.values(); }
 
@@ -91,10 +91,7 @@ struct Labels {
     void fill_values(DateTime pts, DateTime transfert, DateTime walking, DateTime walking_transfert);
 
 private:
-    void init(const std::vector<type::StopPoint*>& stops, DateTime val);
-
-    const DateTime& dt_pt(SpIdx sp_idx) const { return labels[sp_idx].dt_pt; }
-    DateTime& mut_dt_pt(SpIdx sp_idx) { return labels[sp_idx].dt_pt; }
+    void init(const std::vector<JourneyPatternPoint>& jpps, DateTime val);
 
     LabelsMap labels;
 };

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -61,7 +61,7 @@ namespace routing {
 DateTime limit_bound(const bool clockwise, const DateTime departure_datetime, const DateTime bound);
 
 struct StartingPointSndPhase {
-    SpIdx sp_idx;
+    JppIdx jpp_idx;
     unsigned count;
     DateTime end_dt;
     unsigned walking_dur;
@@ -99,7 +99,7 @@ struct RAPTOR {
 
     explicit RAPTOR(const navitia::type::Data& data)
         : data(data),
-          best_labels(data.pt_data->stop_points),
+          best_labels(data.dataRaptor->jp_container.get_jpps_values()),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
           Q(data.dataRaptor->jp_container.get_jps_values()),
@@ -112,13 +112,14 @@ struct RAPTOR {
     void clear(const bool clockwise, const DateTime bound);
 
     /// Initialize starting points
-    void init(const map_stop_point_duration& dep,
+    void init(const map_jpp_duration& dep,
               const DateTime bound,
               const bool clockwise,
               const type::Properties& properties);
 
     // pt_data object getters by typed idx
     const type::StopPoint* get_sp(SpIdx idx) const { return data.pt_data->stop_points[idx.val]; }
+    const JourneyPatternPoint& get_jpp(JppIdx idx) const { return data.dataRaptor->jp_container.get(idx); }
 
     /// Lance un calcul d'itinéraire entre deux stop areas avec aussi une borne
     std::vector<Path> compute(const type::StopArea* departure,
@@ -228,7 +229,7 @@ struct RAPTOR {
 
     /// First raptor loop
     /// externalized for testing purposes
-    void first_raptor_loop(const map_stop_point_duration& departures,
+    void first_raptor_loop(const map_jpp_duration& departures,
                            const DateTime& departure_datetime,
                            const nt::RTLevel rt_level,
                            const DateTime& bound_limit,

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -259,7 +259,7 @@ static void fill_shape(pbnavitia::Section* pb_section, const std::vector<const t
         // As every stop times may not be present (because they can be
         // filtered because of estimated datetime), we can only print
         // the shape if the 2 stop times are consecutive
-        if (prev_order + 1 == cur_order) {
+        if (prev_order + (uint16_t)1 == cur_order) {
             // If the shapes exist, we use them to generate the geometry
             if (st->shape_from_prev != nullptr) {
                 for (const auto& cur_coord : *st->shape_from_prev) {
@@ -957,48 +957,51 @@ static void add_isochrone_response(RAPTOR& raptor,
     pb_creator.fill(&origin, &pb_origin, 0);
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if ((clockwise && best_lbl < bound) || (!clockwise && best_lbl > bound)) {
-            int round = raptor.best_round(sp_idx);
-            const auto& best_round_label = raptor.labels[round][sp_idx];
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if ((clockwise && best_lbl < bound) || (!clockwise && best_lbl > bound)) {
+                int round = raptor.best_round(sp_idx);
+                const auto& best_round_label = raptor.labels[round][jpp.idx];
 
-            if (round == -1 || !is_dt_initialized(best_round_label.dt_pt)) {
-                continue;
-            }
+                if (round == -1 || !is_dt_initialized(best_round_label.dt_pt)) {
+                    continue;
+                }
 
-            // get absolute value
-            int duration = best_lbl > init_dt ? best_lbl - init_dt : init_dt - best_lbl;
+                // get absolute value
+                int duration = best_lbl > init_dt ? best_lbl - init_dt : init_dt - best_lbl;
 
-            if (duration > max_duration) {
-                continue;
-            }
-            auto pb_journey = pb_creator.add_journeys();
+                if (duration > max_duration) {
+                    continue;
+                }
+                auto pb_journey = pb_creator.add_journeys();
 
-            uint64_t departure;
-            uint64_t arrival;
-            // Note: since there is no 2nd pass for the isochrone, the departure dt
-            // is the requested dt (or the arrival dt for non clockwise)
-            if (clockwise) {
-                departure = to_posix_timestamp(init_dt, raptor.data);
-                arrival = to_posix_timestamp(best_lbl, raptor.data);
-            } else {
-                departure = to_posix_timestamp(best_lbl, raptor.data);
-                arrival = to_posix_timestamp(init_dt, raptor.data);
-            }
-            const auto str_requested = to_posix_timestamp(init_dt, raptor.data);
-            pb_journey->set_arrival_date_time(arrival);
-            pb_journey->set_departure_date_time(departure);
-            pb_journey->set_requested_date_time(str_requested);
-            pb_journey->set_duration(duration);
-            pb_journey->set_nb_transfers(round - 1);
-            pb_creator.action_period = bt::time_period(navitia::to_posix_time(best_lbl - duration, raptor.data),
-                                                       navitia::to_posix_time(best_lbl, raptor.data) + bt::seconds(1));
-            if (clockwise) {
-                *pb_journey->mutable_origin() = pb_origin;
-                pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
-            } else {
-                pb_creator.fill(sp, pb_journey->mutable_origin(), 0);
-                *pb_journey->mutable_destination() = pb_origin;
+                uint64_t departure;
+                uint64_t arrival;
+                // Note: since there is no 2nd pass for the isochrone, the departure dt
+                // is the requested dt (or the arrival dt for non clockwise)
+                if (clockwise) {
+                    departure = to_posix_timestamp(init_dt, raptor.data);
+                    arrival = to_posix_timestamp(best_lbl, raptor.data);
+                } else {
+                    departure = to_posix_timestamp(best_lbl, raptor.data);
+                    arrival = to_posix_timestamp(init_dt, raptor.data);
+                }
+                const auto str_requested = to_posix_timestamp(init_dt, raptor.data);
+                pb_journey->set_arrival_date_time(arrival);
+                pb_journey->set_departure_date_time(departure);
+                pb_journey->set_requested_date_time(str_requested);
+                pb_journey->set_duration(duration);
+                pb_journey->set_nb_transfers(round - 1);
+                pb_creator.action_period =
+                    bt::time_period(navitia::to_posix_time(best_lbl - duration, raptor.data),
+                                    navitia::to_posix_time(best_lbl, raptor.data) + bt::seconds(1));
+                if (clockwise) {
+                    *pb_journey->mutable_origin() = pb_origin;
+                    pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
+                } else {
+                    pb_creator.fill(sp, pb_journey->mutable_origin(), 0);
+                    *pb_journey->mutable_destination() = pb_origin;
+                }
             }
         }
     }

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -50,6 +50,7 @@ using MvjIdx = Idx<type::MetaVehicleJourney>;
 using PhyModeIdx = Idx<type::PhysicalMode>;
 
 using map_stop_point_duration = boost::container::flat_map<SpIdx, navitia::time_duration>;
+using map_jpp_duration = boost::container::flat_map<JppIdx, navitia::time_duration>;
 
 inline bool is_dt_initialized(const DateTime dt) {
     return dt != DateTimeUtils::inf && dt != DateTimeUtils::min;


### PR DESCRIPTION
⚠️ This is a work in progress ⚠️  

## What is this about ? 
We are still working on implementing a version of Raptor, where Labels would be computed not just per stop points, but also by taking into account the multiple routes that might pass by that stop point. 

NAVP-1686

## The Route Points Implementation
The first idea was to leverage the use of a `Route-Point` object that would define the association of a Route at a specific Stop point.
[After reviewing this implementation ](https://github.com/CanalTP/navitia/pull/3401), the idea of leveraging the `Journey Pattern Point` instead of the Route Point was raised and seemed to better fit the Raptor's design.

A `JPP` is to a `Journey Pattern` what a `Route Point` is to a `route`. 
This means that we are going to find the best label, for every journey pattern at all stop points. 

Because a `Route` only hold a few `Journey Patterns`, the use of `Jpp` instead of `Route Point` should not dramatically blow up in memory.  

## The JPP implementation
This PR is only a start of the implementation.  It is not finished an still needs some work, It doesn't even compile 👎🏼 . I've only done `raptor.cpp` and `dataRaptor.cpp` to put you on the track.

If you want to continue the work, let the compiler guide you :D 

As a reference, you can have a look at the work done for the `Route Point` [implementation](https://github.com/CanalTP/navitia/compare/dev...nonifier:raptor-route-points-2). It should give you a hint on the different places that need to be updated (but with less changes).

Keep on the good work and as always : 
![Good luck](https://media3.giphy.com/media/3ornk7TgUdhjhTYgta/giphy.gif?cid=ecf05e47klgoucd8l5mfsx1gh8ufqso8av6yrwto34bn2ruw&rid=giphy.gif)



