### PR TITLE
add addess node into stop_points for any depth

### DIFF
--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -618,9 +618,7 @@ void PbCreator::Filler::fill_pb_object(const nt::StopPoint* sp, pbnavitia::StopP
         fill(sp->admin_list, stop_point->mutable_administrative_regions());
     }
 
-    if (depth > 2) {
-        fill(&sp->coord, stop_point);
-    }
+    fill(&sp->coord, stop_point);
 
     if (depth > 0) {
         fill(sp->stop_area, stop_point);


### PR DESCRIPTION
Address node are always added into stop_points
Test incoming ...

Related to JIRA ticket : : https://jira.kisio.org/browse/NAVITIAII-3377