### PR TITLE
fix link to get pip for pyhton 2.7

### DIFF
--- a/scripts/ubuntu_bionic_disco_dev_env_install.sh
+++ b/scripts/ubuntu_bionic_disco_dev_env_install.sh
@@ -39,7 +39,7 @@ OS_VERSION="$(lsb_release -rs| cut -d '.' -f 1)"
 echo "-- OS found: $(lsb_release -ds)"
 if [ ${OS_VERSION} -eq 20 ]; then
     sudo apt-get install -y python2-dev
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
     sudo python2 get-pip.py
     rm get-pip.py
 else


### PR DESCRIPTION
Update link to get pip for python2.7 changed (for Ubuntu > 20.04)