### PR TITLE
CI: Erase the infamous plugin for GA release

### DIFF
--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -51,14 +51,3 @@ jobs:
           echo '{"text":":information_source: Navitia Github Actions: build_navitia_packages_for_release succeded -' $version_number 'navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
           echo '{"text":":octopus: Navitia Release: The version' $version_number 'is available. changelog: https://github.com/CanalTP/navitia/releases/tag/v'$version_number'"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}
 
-    - name: github Release
-      id: create_release
-      uses: actions/create-release@v1
-      if: success() && matrix.distribution == 'debian8'
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false


### PR DESCRIPTION
It is the second time that we have a nitpicking fail during the release. I say stop :stop_button: 
Historic: https://github.com/CanalTP/navitia/pull/3398

It is possible the error comes from our model _dev/release branch_ (A very old way and not conventional)
So, the first step is to change the model _dev/release_ into _master/release_ :hear_no_evil: 