### PR TITLE
Reduce max duration value by 1 second

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -83,7 +83,7 @@ class Schedules(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "duration",
             type=int,
-            default=3600 * 24,
+            default=3600 * 24 - 1,
             help="Maximum duration between datetime and the retrieved stop time",
         )
         parser_get.add_argument("depth", type=DepthArgument(), default=2, help="The depth of your object")

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -2062,3 +2062,34 @@ class TestFirstLastDatetimeWithPositiveTimezone(AbstractTestFixture):
         assert len(stop_schedules[1]['date_times']) == 0
         assert 'first_datetime' not in stop_schedules[1]
         assert 'last_datetime' not in stop_schedules[1]
+
+    def test_duration_default_value(self):
+        # Query with duration=86400
+        # Here we have 4 date_times with the last one at 20170102T235000 + 86400 (24 hours)
+        from_datetime = "20170102T235000"
+        response = self.query_region(
+            "stop_points/X_S3/stop_schedules?from_datetime={}"
+            "&data_freshness=base_schedule&duration=86400".format(from_datetime)
+        )
+
+        stop_schedules = response['stop_schedules']
+        assert len(stop_schedules) == 2
+        assert len(stop_schedules[0]['date_times']) == 4
+        assert stop_schedules[0]['date_times'][0]['date_time'] == "20170102T235000"
+        assert stop_schedules[0]['date_times'][1]['date_time'] == "20170103T000000"
+        assert stop_schedules[0]['date_times'][2]['date_time'] == "20170103T001000"
+        assert stop_schedules[0]['date_times'][3]['date_time'] == "20170103T235000"
+
+        # Query without parameter duration (default value = 86399)
+        # Here we have exclude the last date_time at 20170102T235000 + 86400 (24 hours)
+        response = self.query_region(
+            "stop_points/X_S3/stop_schedules?from_datetime={}"
+            "&data_freshness=base_schedule".format(from_datetime)
+        )
+
+        stop_schedules = response['stop_schedules']
+        assert len(stop_schedules) == 2
+        assert len(stop_schedules[0]['date_times']) == 3
+        assert stop_schedules[0]['date_times'][0]['date_time'] == "20170102T235000"
+        assert stop_schedules[0]['date_times'][1]['date_time'] == "20170103T000000"
+        assert stop_schedules[0]['date_times'][2]['date_time'] == "20170103T001000"


### PR DESCRIPTION
If parameter duration is absent 86400 (24 hours) is used as default value in apis like stop_schedules, route_schedules, departures, arrivals ..

As explained in the ticket, we should use the value 24 hours - 1 second to exclure departure date_times at last second.
   
https://jira.kisio.org/browse/NAVITIAII-3385

This solution is with minimum risk instead of modifying filter with duration (exclusive).
