### PR TITLE
[Kraken] Decide which type of next stoptime to use in runtime

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -745,7 +745,9 @@ void Worker::err_msg_isochron(navitia::PbCreator& pb_creator, const std::string&
     pb_creator.fill_pb_error(pbnavitia::Error::bad_format, pbnavitia::NO_SOLUTION, err_msg);
 }
 
-void Worker::journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API api) {
+void Worker::journeys(const pbnavitia::JourneysRequest& request,
+                      pbnavitia::API api,
+                      const boost::posix_time::ptime& current_datetime) {
     try {
         navitia::JourneysArg arg = fill_journeys(request);
 
@@ -772,7 +774,7 @@ void Worker::journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API 
                     request.night_bus_filter_max_factor(), request.night_bus_filter_base_factor(),
                     request.has_timeframe_duration() ? boost::make_optional<uint32_t>(request.timeframe_duration())
                                                      : boost::none,
-                    request.depth());
+                    request.depth(), current_datetime);
                 break;
             default:
                 routing::make_response(
@@ -785,7 +787,7 @@ void Worker::journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API 
                     request.night_bus_filter_max_factor(), request.night_bus_filter_base_factor(),
                     request.has_timeframe_duration() ? boost::make_optional<uint32_t>(request.timeframe_duration())
                                                      : boost::none,
-                    request.depth());
+                    request.depth(), current_datetime);
         }
     } catch (const navitia::coord_conversion_exception& e) {
         this->pb_creator.fill_pb_error(pbnavitia::Error::bad_format, e.what());
@@ -1085,7 +1087,7 @@ void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {
         case pbnavitia::NMPLANNER:
         case pbnavitia::pt_planner:
         case pbnavitia::PLANNER:
-            journeys(request.journeys(), request.requested_api());
+            journeys(request.journeys(), request.requested_api(), current_datetime);
             break;
         case pbnavitia::ISOCHRONE:
             isochrone(request.journeys());

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -112,7 +112,9 @@ private:
 
     JourneysArg fill_journeys(const pbnavitia::JourneysRequest& request);
     void err_msg_isochron(navitia::PbCreator& pb_creator, const std::string& err_msg);
-    void journeys(const pbnavitia::JourneysRequest& request, pbnavitia::API api);
+    void journeys(const pbnavitia::JourneysRequest& request,
+                  pbnavitia::API api,
+                  const boost::posix_time::ptime& current_datetime);
     void isochrone(const pbnavitia::JourneysRequest& request);
     void pt_ref(const pbnavitia::PTRefRequest& request);
     void traffic_reports(const pbnavitia::TrafficReportsRequest& request);

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -466,13 +466,13 @@ boost::iterator_range<CachedNextStopTime::vDtSt::const_iterator> CachedNextStopT
 }
 
 std::pair<const type::StopTime*, DateTime> CachedNextStopTime::next_stop_time(const StopEvent stop_event,
-        const JppIdx jpp_idx,
-        const DateTime dt,
-        const bool clockwise,
-        const type::RTLevel ,
-        const type::VehicleProperties& ,
-        const bool check_freq ,
-        const boost::optional<DateTime>&) const {
+                                                                              const JppIdx jpp_idx,
+                                                                              const DateTime dt,
+                                                                              const bool clockwise,
+                                                                              const type::RTLevel,
+                                                                              const type::VehicleProperties&,
+                                                                              const bool check_freq,
+                                                                              const boost::optional<DateTime>&) const {
     const auto& v = (stop_event == StopEvent::pick_up ? departure[jpp_idx] : arrival[jpp_idx]);
     const type::StopTime* null_st = nullptr;
     decltype(v.begin()) search;
@@ -640,7 +640,7 @@ DateTime get_previous_stop_time(const StopEvent stop_event,
     // overnight case and hour > midnight
     if (hour > upper_bound) {
         // case with hour in [upper_bound, lower_boud]
-        if (freq_vj.is_valid(date, rt_level)) {
+        if (freq_vj.is_valid(date - 1, rt_level)) {
             return DateTimeUtils::set(date, upper_bound);
         }
         return DateTimeUtils::not_valid;

--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -466,9 +466,13 @@ boost::iterator_range<CachedNextStopTime::vDtSt::const_iterator> CachedNextStopT
 }
 
 std::pair<const type::StopTime*, DateTime> CachedNextStopTime::next_stop_time(const StopEvent stop_event,
-                                                                              const JppIdx jpp_idx,
-                                                                              const DateTime dt,
-                                                                              const bool clockwise) const {
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const bool clockwise,
+        const type::RTLevel ,
+        const type::VehicleProperties& ,
+        const bool check_freq ,
+        const boost::optional<DateTime>&) const {
     const auto& v = (stop_event == StopEvent::pick_up ? departure[jpp_idx] : arrival[jpp_idx]);
     const type::StopTime* null_st = nullptr;
     decltype(v.begin()) search;

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -61,18 +61,17 @@ struct JourneyPatternContainer;
 struct dataRAPTOR;
 
 struct NextStopTimeInterface {
-	virtual std::pair<const type::StopTime*, DateTime>
-	next_stop_time(const StopEvent stop_event,
-				   const JppIdx jpp_idx,
-	                const DateTime dt,
-	        const bool clockwise,
-	        const type::RTLevel rt_level,
-	        const type::VehicleProperties& vehicle_props,
-	        const bool check_freq = true,
-	        const boost::optional<DateTime>& bound = boost::none) const = 0;
-	virtual ~NextStopTimeInterface() {};
+    virtual std::pair<const type::StopTime*, DateTime> next_stop_time(
+        const StopEvent stop_event,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const bool clockwise,
+        const type::RTLevel rt_level,
+        const type::VehicleProperties& vehicle_props,
+        const bool check_freq = true,
+        const boost::optional<DateTime>& bound = boost::none) const = 0;
+    virtual ~NextStopTimeInterface(){};
 };
-
 
 struct NextStopTimeData {
     typedef boost::iterator_range<std::vector<const type::StopTime*>::const_iterator> StopTimeIter;
@@ -161,7 +160,7 @@ private:
     IdxMap<JourneyPatternPoint, TimesStopTimes<Arrival>> arrival;
 };
 
-struct NextStopTime: public NextStopTimeInterface {
+struct NextStopTime : public NextStopTimeInterface {
     explicit NextStopTime(const type::Data& d) : data(d) {}
     virtual ~NextStopTime() = default;
     // Returns the next stop time at given journey pattern point
@@ -228,7 +227,7 @@ struct CachedNextStopTimeKey {
     bool operator<(const CachedNextStopTimeKey& other) const;
 };
 
-struct CachedNextStopTime: public NextStopTimeInterface {
+struct CachedNextStopTime : public NextStopTimeInterface {
     using DtSt = std::pair<DateTime, const type::StopTime*>;
     using vDtSt = std::vector<DtSt>;
     using vDtStByJpp = IdxMap<JourneyPatternPoint, vDtSt>;
@@ -237,16 +236,14 @@ struct CachedNextStopTime: public NextStopTimeInterface {
     // Returns the next stop time at given journey pattern point
     // either a vehicle that leaves or that arrives depending on
     // clockwise.
-    std::pair<const type::StopTime*, DateTime> next_stop_time(
-        const StopEvent stop_event,
-        const JppIdx jpp_idx,
-        const DateTime dt,
-        const bool clockwise,
-        const type::RTLevel ,
-        const type::VehicleProperties& ,
-        const bool check_freq ,
-        const boost::optional<DateTime>&) const override;
-
+    std::pair<const type::StopTime*, DateTime> next_stop_time(const StopEvent stop_event,
+                                                              const JppIdx jpp_idx,
+                                                              const DateTime dt,
+                                                              const bool clockwise,
+                                                              const type::RTLevel,
+                                                              const type::VehicleProperties&,
+                                                              const bool check_freq,
+                                                              const boost::optional<DateTime>&) const override;
 
 private:
     // This structure provide the same interface as a vDtStByJpp, but
@@ -296,6 +293,7 @@ struct CachedNextStopTimeManager {
                                                    const type::AccessibiliteParams& accessibilite_params);
 
     void warmup(const CachedNextStopTimeManager& other) { this->lru.warmup(other.lru); }
+    size_t get_max_size() const { return lru.get_max_size(); }
 
 private:
     struct CacheCreator {

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -60,6 +60,20 @@ namespace routing {
 struct JourneyPatternContainer;
 struct dataRAPTOR;
 
+struct NextStopTimeInterface {
+	virtual std::pair<const type::StopTime*, DateTime>
+	next_stop_time(const StopEvent stop_event,
+				   const JppIdx jpp_idx,
+	                const DateTime dt,
+	        const bool clockwise,
+	        const type::RTLevel rt_level,
+	        const type::VehicleProperties& vehicle_props,
+	        const bool check_freq = true,
+	        const boost::optional<DateTime>& bound = boost::none) const = 0;
+	virtual ~NextStopTimeInterface() {};
+};
+
+
 struct NextStopTimeData {
     typedef boost::iterator_range<std::vector<const type::StopTime*>::const_iterator> StopTimeIter;
     typedef boost::iterator_range<std::vector<const type::StopTime*>::const_reverse_iterator> StopTimeReverseIter;
@@ -147,16 +161,16 @@ private:
     IdxMap<JourneyPatternPoint, TimesStopTimes<Arrival>> arrival;
 };
 
-struct NextStopTime {
+struct NextStopTime: public NextStopTimeInterface {
     explicit NextStopTime(const type::Data& d) : data(d) {}
-
+    virtual ~NextStopTime() = default;
     // Returns the next stop time at given journey pattern point
     // either a vehicle that leaves or that arrives depending on
     // clockwise The last parametter, check_freq, allow to forget to
     // test frequency vehicle journey, a big improvement in speed if
     // you know your journey pattern don't have frequency vehicle
     // journeys.
-    inline std::pair<const type::StopTime*, DateTime> next_stop_time(
+    std::pair<const type::StopTime*, DateTime> next_stop_time(
         const StopEvent stop_event,
         const JppIdx jpp_idx,
         const DateTime dt,
@@ -164,7 +178,7 @@ struct NextStopTime {
         const type::RTLevel rt_level,
         const type::VehicleProperties& vehicle_props,
         const bool check_freq = true,
-        const boost::optional<DateTime>& bound = boost::none) const {
+        const boost::optional<DateTime>& bound = boost::none) const override {
         if (clockwise) {
             return earliest_stop_time(stop_event, jpp_idx, dt, rt_level, vehicle_props, check_freq, bound);
         } else {
@@ -214,7 +228,7 @@ struct CachedNextStopTimeKey {
     bool operator<(const CachedNextStopTimeKey& other) const;
 };
 
-struct CachedNextStopTime {
+struct CachedNextStopTime: public NextStopTimeInterface {
     using DtSt = std::pair<DateTime, const type::StopTime*>;
     using vDtSt = std::vector<DtSt>;
     using vDtStByJpp = IdxMap<JourneyPatternPoint, vDtSt>;
@@ -223,10 +237,16 @@ struct CachedNextStopTime {
     // Returns the next stop time at given journey pattern point
     // either a vehicle that leaves or that arrives depending on
     // clockwise.
-    std::pair<const type::StopTime*, DateTime> next_stop_time(const StopEvent stop_event,
-                                                              const JppIdx jpp_idx,
-                                                              const DateTime dt,
-                                                              const bool clockwise) const;
+    std::pair<const type::StopTime*, DateTime> next_stop_time(
+        const StopEvent stop_event,
+        const JppIdx jpp_idx,
+        const DateTime dt,
+        const bool clockwise,
+        const type::RTLevel ,
+        const type::VehicleProperties& ,
+        const bool check_freq ,
+        const boost::optional<DateTime>&) const override;
+
 
 private:
     // This structure provide the same interface as a vDtStByJpp, but

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -252,12 +252,12 @@ void RAPTOR::set_next_stop_time(const DateTime& departure_datetime,
 
     switch (next_st_type) {
         case RAPTOR::NEXT_STOPTIME_TYPE::CACHED:
-            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using cached next_stop_time");
+            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using cached next_stop_time -------------");
             next_st = data.dataRaptor->cached_next_st_manager->load(clockwise ? departure_datetime : bound, rt_level,
                                                                     accessibilite_params);
             break;
         case RAPTOR::NEXT_STOPTIME_TYPE::UNCACHED:
-            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using uncached next_stop_time");
+            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using uncached next_stop_time------------------");
             next_st = uncached_next_st;
             break;
         default:
@@ -982,7 +982,7 @@ std::vector<Path> RAPTOR::compute(const type::StopArea* departure,
 
     return compute_all(departures, destinations, DateTimeUtils::set(departure_day, departure_hour), rt_level,
                        transfer_penalty, borne, max_transfers, accessibilite_params, forbidden_uri, {}, clockwise,
-                       direct_path_dur);
+                       direct_path_dur, 0, current_datetime);
 }
 
 int RAPTOR::best_round(SpIdx sp_idx) {

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -225,6 +225,11 @@ void RAPTOR::init(const map_stop_point_duration& dep,
     }
 }
 
+std::shared_ptr<const NextStopTimeInterface> RAPTOR::choose_next_stop_time(const DateTime& departure_datetime) const {
+	return uncached_next_st;
+};
+
+
 void RAPTOR::first_raptor_loop(const map_stop_point_duration& departures,
                                const DateTime& departure_datetime,
                                const nt::RTLevel rt_level,
@@ -235,6 +240,9 @@ void RAPTOR::first_raptor_loop(const map_stop_point_duration& departures,
     const DateTime bound = limit_bound(clockwise, departure_datetime, bound_limit);
 
     assert(data.dataRaptor->cached_next_st_manager);
+
+    next_st = choose_next_stop_time(departure_datetime);
+
     // next_st = data.dataRaptor->cached_next_st_manager->load(clockwise ? departure_datetime : bound, rt_level,
     //                                                        accessibilite_params);
 
@@ -794,7 +802,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
                     /// the corresponding StopTime is
                     ///    tmp_st_dt.first
 
-                    const auto tmp_st_dt = uncached_next_st.next_stop_time(
+                    const auto tmp_st_dt = next_st->next_stop_time(
                         visitor.stop_event(), jpp.idx, previous_dt, visitor.clockwise(), rt_level,
                         accessibilite_params.vehicle_properties, jpp.has_freq);
                     // const auto tmp_st_dt =

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -231,7 +231,7 @@ RAPTOR::NEXT_STOPTIME_TYPE RAPTOR::choose_next_stop_time_type(
     const DateTime& departure_datetime,
     const boost::optional<boost::posix_time::ptime>& current_datetime) const {
     boost::posix_time::ptime now =
-        current_datetime ? *current_datetime : (boost::posix_time::second_clock::universal_time());
+        current_datetime ? *current_datetime : boost::posix_time::second_clock::universal_time();
     size_t now_days = static_cast<size_t>((now.date() - data.meta->production_date.begin()).days());
     size_t requested_days = static_cast<size_t>(departure_datetime / navitia::DateTimeUtils::SECONDS_PER_DAY);
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -230,7 +230,8 @@ void RAPTOR::init(const map_stop_point_duration& dep,
 RAPTOR::NEXT_STOPTIME_TYPE RAPTOR::choose_next_stop_time_type(
     const DateTime& departure_datetime,
     const boost::optional<boost::posix_time::ptime>& current_datetime) const {
-    boost::posix_time::ptime now = current_datetime.value_or(boost::posix_time::second_clock::universal_time());
+    boost::posix_time::ptime now =
+        current_datetime ? *current_datetime : (boost::posix_time::second_clock::universal_time());
     size_t now_days = static_cast<size_t>((now.date() - data.meta->production_date.begin()).days());
     size_t requested_days = static_cast<size_t>(departure_datetime / navitia::DateTimeUtils::SECONDS_PER_DAY);
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -252,12 +252,12 @@ void RAPTOR::set_next_stop_time(const DateTime& departure_datetime,
 
     switch (next_st_type) {
         case RAPTOR::NEXT_STOPTIME_TYPE::CACHED:
-            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using cached next_stop_time -------------");
+            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using cached next_stop_time");
             next_st = data.dataRaptor->cached_next_st_manager->load(clockwise ? departure_datetime : bound, rt_level,
                                                                     accessibilite_params);
             break;
         case RAPTOR::NEXT_STOPTIME_TYPE::UNCACHED:
-            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using uncached next_stop_time------------------");
+            LOG4CPLUS_INFO(raptor_logger, "Raptor: Using uncached next_stop_time");
             next_st = uncached_next_st;
             break;
         default:

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -74,7 +74,9 @@ struct RAPTOR {
 
     const navitia::type::Data& data;
 
-    std::shared_ptr<const CachedNextStopTime> next_st;
+    // std::shared_ptr<const CachedNextStopTime> next_st;
+
+    NextStopTime uncached_next_st;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers
@@ -99,6 +101,7 @@ struct RAPTOR {
 
     explicit RAPTOR(const navitia::type::Data& data)
         : data(data),
+          uncached_next_st(data),
           best_labels(data.pt_data->stop_points),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
@@ -199,7 +202,10 @@ struct RAPTOR {
                               const nt::RTLevel rt_level);
 
     /// Boucle principale, parcourt les journey_patterns,
-    void boucleRAPTOR(const bool clockwise, const nt::RTLevel rt_level, const uint32_t max_transfers);
+    void boucleRAPTOR(const type::AccessibiliteParams& accessibilite_params,
+                      const bool clockwise,
+                      const nt::RTLevel rt_level,
+                      const uint32_t max_transfers);
 
     /// Apply foot pathes to labels
     /// Return true if it improves at least one label, false otherwise
@@ -219,6 +225,7 @@ struct RAPTOR {
     /// Main loop
     template <typename Visitor>
     void raptor_loop(Visitor visitor,
+                     const type::AccessibiliteParams& accessibilite_params,
                      const nt::RTLevel rt_level,
                      uint32_t max_transfers = std::numeric_limits<uint32_t>::max());
 

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -70,6 +70,11 @@ struct StartingPointSndPhase {
 
 /** Worker Raptor : une instance par thread, les données sont modifiées par le calcul */
 struct RAPTOR {
+    enum class NEXT_STOPTIME_TYPE {
+        UNCACHED,
+        CACHED,
+    };
+
     typedef std::list<Journey> Journeys;
 
     const navitia::type::Data& data;
@@ -136,7 +141,8 @@ struct RAPTOR {
                               const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
                               uint32_t max_transfers = std::numeric_limits<uint32_t>::max(),
                               const std::vector<std::string>& forbidden_uri = {},
-                              const boost::optional<navitia::time_duration>& direct_path_dur = boost::none);
+                              const boost::optional<navitia::time_duration>& direct_path_dur = boost::none,
+                              const boost::optional<boost::posix_time::ptime>& current_datetime = boost::none);
 
     /** Calcul d'itinéraires multiples dans le sens horaire à partir de plusieurs
      * stop points de départs, vers plusieurs stoppoints d'arrivée,
@@ -154,7 +160,8 @@ struct RAPTOR {
                                   const std::vector<std::string>& allowed_ids = std::vector<std::string>(),
                                   bool clockwise = true,
                                   const boost::optional<navitia::time_duration>& direct_path_dur = boost::none,
-                                  const size_t max_extra_second_pass = 0);
+                                  const size_t max_extra_second_pass = 0,
+                                  const boost::optional<boost::posix_time::ptime>& current_datetime = boost::none);
 
     Journeys compute_all_journeys(const map_stop_point_duration& departures,
                                   const map_stop_point_duration& destinations,
@@ -166,7 +173,8 @@ struct RAPTOR {
                                   const type::AccessibiliteParams& accessibilite_params = type::AccessibiliteParams(),
                                   bool clockwise = true,
                                   const boost::optional<navitia::time_duration>& direct_path_dur = boost::none,
-                                  const size_t max_extra_second_pass = 0);
+                                  const size_t max_extra_second_pass = 0,
+                                  const boost::optional<boost::posix_time::ptime>& current_datetime = boost::none);
 
     template <class T>
     std::vector<Path> from_journeys_to_path(const T& journeys) const {
@@ -242,7 +250,8 @@ struct RAPTOR {
                            const DateTime& bound_limit,
                            const uint32_t max_transfers,
                            const type::AccessibiliteParams& accessibilite_params,
-                           const bool clockwise);
+                           const bool clockwise,
+                           const boost::optional<boost::posix_time::ptime>& current_datetime = boost::none);
 
     ~RAPTOR() = default;
 
@@ -250,11 +259,15 @@ struct RAPTOR {
     std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points);
 
 private:
-    enum class NEXT_STOPTIME_TYPE {
-        UNCACHED,
-        CACHED,
-    };
-    NEXT_STOPTIME_TYPE choose_next_stop_time(const DateTime& departure_datetime) const;
+    NEXT_STOPTIME_TYPE choose_next_stop_time_type(
+        const DateTime& departure_datetime,
+        const boost::optional<boost::posix_time::ptime>& current_datetime) const;
+    void set_next_stop_time(const DateTime& departure_datetime,
+                            const nt::RTLevel rt_level,
+                            const DateTime& bound_limit,
+                            const type::AccessibiliteParams& accessibilite_params,
+                            const bool clockwise,
+                            const NEXT_STOPTIME_TYPE next_st_type);
 };
 
 }  // namespace routing

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -74,9 +74,10 @@ struct RAPTOR {
 
     const navitia::type::Data& data;
 
-    // std::shared_ptr<const CachedNextStopTime> next_st;
+    std::shared_ptr<const CachedNextStopTime> cached_next_st;
+    std::shared_ptr<const NextStopTime> uncached_next_st;
 
-    NextStopTime uncached_next_st;
+    std::shared_ptr<const NextStopTimeInterface> next_st;
 
     /// Contains the different labels used by raptor.
     /// Each element of index i in this vector represents the labels with i transfers
@@ -101,7 +102,7 @@ struct RAPTOR {
 
     explicit RAPTOR(const navitia::type::Data& data)
         : data(data),
-          uncached_next_st(data),
+		  uncached_next_st(std::make_shared<const NextStopTime>(data)),
           best_labels(data.pt_data->stop_points),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
@@ -247,6 +248,8 @@ struct RAPTOR {
 
     std::string print_all_labels();
     std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points);
+private:
+    std::shared_ptr<const NextStopTimeInterface> choose_next_stop_time(const DateTime& departure_datetime) const;
 };
 
 }  // namespace routing

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -102,7 +102,7 @@ struct RAPTOR {
 
     explicit RAPTOR(const navitia::type::Data& data)
         : data(data),
-		  uncached_next_st(std::make_shared<const NextStopTime>(data)),
+          uncached_next_st(std::make_shared<const NextStopTime>(data)),
           best_labels(data.pt_data->stop_points),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
@@ -248,8 +248,13 @@ struct RAPTOR {
 
     std::string print_all_labels();
     std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points);
+
 private:
-    std::shared_ptr<const NextStopTimeInterface> choose_next_stop_time(const DateTime& departure_datetime) const;
+    enum class NEXT_STOPTIME_TYPE {
+        UNCACHED,
+        CACHED,
+    };
+    NEXT_STOPTIME_TYPE choose_next_stop_time(const DateTime& departure_datetime) const;
 };
 
 }  // namespace routing

--- a/source/routing/raptor_api.h
+++ b/source/routing/raptor_api.h
@@ -100,7 +100,8 @@ void make_response(navitia::PbCreator& pb_creator,
                    const double night_bus_filter_max_factor = NightBusFilter::default_max_factor,
                    const int32_t night_bus_filter_base_factor = NightBusFilter::default_base_factor,
                    const boost::optional<uint32_t>& timeframe_duration = boost::none,
-                   const uint32_t depth = 1);
+                   const uint32_t depth = 1,
+                   const boost::optional<boost::posix_time::ptime>& current_datetime = boost::none);
 
 void make_isochrone(navitia::PbCreator& pb_creator,
                     RAPTOR& raptor,
@@ -138,7 +139,8 @@ void make_pt_response(navitia::PbCreator& pb_creator,
                       const double night_bus_filter_max_factor = NightBusFilter::default_max_factor,
                       const int32_t night_bus_filter_base_factor = NightBusFilter::default_base_factor,
                       const boost::optional<uint32_t>& timeframe_duration = boost::none,
-                      const uint32_t depth = 1);
+                      const uint32_t depth = 1,
+                      const boost::optional<boost::posix_time::ptime>& current_datetime = boost::none);
 
 boost::optional<routing::map_stop_point_duration> get_stop_points(const type::EntryPoint& ep,
                                                                   const type::Data& data,

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -133,8 +133,8 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
         assert(conn != nullptr);
         // const auto new_st_dt = reader.raptor.next_st->next_stop_time(StopEvent::pick_up, cur_jpp_idx,
         //                                                             prev_s->get_out_dt + conn->duration, true);
-        const auto new_st_dt = reader.raptor.uncached_next_st.earliest_stop_time(
-            StopEvent::pick_up, cur_jpp_idx, prev_s->get_out_dt + conn->duration, reader.rt_level,
+        const auto new_st_dt = reader.raptor.next_st->next_stop_time(
+            StopEvent::pick_up, cur_jpp_idx, prev_s->get_out_dt + conn->duration, true, reader.rt_level,
             reader.accessibilite_params.vehicle_properties);
 
         if (new_st_dt.first && new_st_dt.second < cur_s.get_in_dt) {
@@ -547,7 +547,7 @@ struct RaptorSolutionReader {
             // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
             // v.clockwise());
             const auto begin_st_dt =
-                raptor.uncached_next_st.next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
+                raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
                                                        accessibilite_params.vehicle_properties, true, begin_limit);
             if (begin_st_dt.first == nullptr) {
                 continue;
@@ -584,7 +584,7 @@ struct RaptorSolutionReader {
             // trying to begin
             // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
             // v.clockwise());
-            const auto begin_st_dt = raptor.uncached_next_st.next_stop_time(
+            const auto begin_st_dt = raptor.next_st->next_stop_time(
                 v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level, accessibilite_params.vehicle_properties);
             if (begin_st_dt.first == nullptr) {
                 continue;

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -548,7 +548,7 @@ struct RaptorSolutionReader {
             // v.clockwise());
             const auto begin_st_dt =
                 raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
-                                                       accessibilite_params.vehicle_properties, true, begin_limit);
+                                               accessibilite_params.vehicle_properties, true, begin_limit);
             if (begin_st_dt.first == nullptr) {
                 continue;
             }
@@ -584,8 +584,8 @@ struct RaptorSolutionReader {
             // trying to begin
             // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
             // v.clockwise());
-            const auto begin_st_dt = raptor.next_st->next_stop_time(
-                v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level, accessibilite_params.vehicle_properties);
+            const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(),
+                                                                    rt_level, accessibilite_params.vehicle_properties);
             if (begin_st_dt.first == nullptr) {
                 continue;
             }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -131,8 +131,12 @@ void align_left(const RaptorSolutionReader<Visitor>& reader, Journey& j) {
         const auto* conn = reader.raptor.data.pt_data->get_stop_point_connection(*prev_s->get_out_st->stop_point,
                                                                                  *cur_s.get_in_st->stop_point);
         assert(conn != nullptr);
-        const auto new_st_dt = reader.raptor.next_st->next_stop_time(StopEvent::pick_up, cur_jpp_idx,
-                                                                     prev_s->get_out_dt + conn->duration, true);
+        // const auto new_st_dt = reader.raptor.next_st->next_stop_time(StopEvent::pick_up, cur_jpp_idx,
+        //                                                             prev_s->get_out_dt + conn->duration, true);
+        const auto new_st_dt = reader.raptor.uncached_next_st.earliest_stop_time(
+            StopEvent::pick_up, cur_jpp_idx, prev_s->get_out_dt + conn->duration, reader.rt_level,
+            reader.accessibilite_params.vehicle_properties);
+
         if (new_st_dt.first && new_st_dt.second < cur_s.get_in_dt) {
             const auto out_st_dt = get_out_st_dt(new_st_dt, jp_container.get_jpp(*cur_s.get_out_st), jp_container);
             if (out_st_dt.first) {
@@ -540,7 +544,11 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count][begin_sp_idx].dt_pt;
         for (const auto& jpp : raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise());
+            // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
+            // v.clockwise());
+            const auto begin_st_dt =
+                raptor.uncached_next_st.next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
+                                                       accessibilite_params.vehicle_properties, true, begin_limit);
             if (begin_st_dt.first == nullptr) {
                 continue;
             }
@@ -574,7 +582,10 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count][begin_sp_idx].dt_pt;
         for (const auto& jpp : raptor.jpps_from_sp[begin_sp_idx]) {
             // trying to begin
-            const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise());
+            // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
+            // v.clockwise());
+            const auto begin_st_dt = raptor.uncached_next_st.next_stop_time(
+                v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level, accessibilite_params.vehicle_properties);
             if (begin_st_dt.first == nullptr) {
                 continue;
             }


### PR DESCRIPTION
Reuse the uncached next_stop_time when the request's `datetime` is not contained in the time window( [Today,  Today + N]).
 
(no cache)         (cache)         ( no cache)
----------[Fixed Time Window ]------------

The performance drop-off in production MAY be due to the frequent invalidation of next_stop_time. In fact, this actually unveiled the shortcomings of the LRU cache, which is, when if the cache hit is frequently missed, instead of improving the performance, we lost much more time in rebuilding the cache in the place of reusing pre-computed data...

The solution is to fix a date window, let's say [N, N+5]. Any request whose datetime is out of the window, we'll use the uncached next_stop_time. Eventually, we will observe a performance dropoff, but only for a small portion of requests.  The advantage of the solution is that cache invalidation is largely reduced.     
