### PR TITLE
Route points again, with 4mn walking penalty

### DIFF
--- a/source/jormungandr/tests/isochrone_tests.py
+++ b/source/jormungandr/tests/isochrone_tests.py
@@ -123,7 +123,7 @@ class TestIsochrone(AbstractTestFixture):
         )
         normal_response = self.query(q, display=True)
         is_valid_isochrone_response(normal_response, self.tester, q)
-        assert len(normal_response["journeys"]) == 2
+        assert len(normal_response["journeys"]) == 5
 
     def test_reverse_isochrone_coord_clockwise(self):
         q = "v1/coverage/basic_routing_test/journeys?datetime=20120614T080000&to=A"

--- a/source/routing/dataraptor.cpp
+++ b/source/routing/dataraptor.cpp
@@ -92,8 +92,8 @@ void dataRAPTOR::JppsFromJp::load(const JourneyPatternContainer& jp_container) {
 
 void dataRAPTOR::load(const type::PT_Data& pt_data, size_t cache_size) {
     jp_container.load(pt_data);
-    labels_const.init_inf(pt_data.stop_points);
-    labels_const_reverse.init_min(pt_data.stop_points);
+    labels_const.init_inf(jp_container.get_jpps_values());
+    labels_const_reverse.init_min(jp_container.get_jpps_values());
 
     connections.load(pt_data);
     jpps_from_sp.load(pt_data, jp_container);

--- a/source/routing/heat_map.cpp
+++ b/source/routing/heat_map.cpp
@@ -267,16 +267,18 @@ std::vector<navitia::time_duration> init_distance(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            const auto& projections = worker.projected_stop_points[sp->idx];
-            const auto& proj = projections[mode];
-            if (proj.found) {
-                const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
-                distances[proj[source_e]] = std::min(
-                    distances[proj[source_e]], time_duration(seconds(duration + proj.distances[source_e] / speed)));
-                distances[proj[target_e]] = std::min(
-                    distances[proj[target_e]], time_duration(seconds(duration + proj.distances[target_e] / speed)));
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto& best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                const auto& projections = worker.projected_stop_points[sp->idx];
+                const auto& proj = projections[mode];
+                if (proj.found) {
+                    const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
+                    distances[proj[source_e]] = std::min(
+                        distances[proj[source_e]], time_duration(seconds(duration + proj.distances[source_e] / speed)));
+                    distances[proj[target_e]] = std::min(
+                        distances[proj[target_e]], time_duration(seconds(duration + proj.distances[target_e] / speed)));
+                }
             }
         }
     }
@@ -298,13 +300,15 @@ static std::vector<georef::vertex_t> init_vertex(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            const auto& projections = worker.projected_stop_points[sp->idx];
-            const auto& proj = projections[mode];
-            if (proj.found) {
-                initialized_points.push_back(proj[source_e]);
-                initialized_points.push_back(proj[target_e]);
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto& best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                const auto& projections = worker.projected_stop_points[sp->idx];
+                const auto& proj = projections[mode];
+                if (proj.found) {
+                    initialized_points.push_back(proj[source_e]);
+                    initialized_points.push_back(proj[target_e]);
+                }
             }
         }
     }
@@ -329,13 +333,15 @@ static BoundBox find_boundary_box(const georef::GeoRef& worker,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto& best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            const auto& projections = worker.projected_stop_points[sp->idx];
-            const auto& proj = projections[mode];
-            if (proj.found) {
-                const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
-                box.set_box(sp->coord, walking_distance(max_duration, duration, speed) + distance_500m);
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto& best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                const auto& projections = worker.projected_stop_points[sp->idx];
+                const auto& proj = projections[mode];
+                if (proj.found) {
+                    const double duration = clockwise ? best_lbl - init_dt : init_dt - best_lbl;
+                    box.set_box(sp->coord, walking_distance(max_duration, duration, speed) + distance_500m);
+                }
             }
         }
     }

--- a/source/routing/isochrone.cpp
+++ b/source/routing/isochrone.cpp
@@ -210,14 +210,16 @@ type::MultiPolygon build_single_isochrone(RAPTOR& raptor,
     }
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if (in_bound(best_lbl, bound, clockwise)) {
-            uint duration_left = abs(int(best_lbl) - int(bound));
-            if (duration_left * speed < MIN_RADIUS) {
-                continue;
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if (in_bound(best_lbl, bound, clockwise)) {
+                uint duration_left = abs(int(best_lbl) - int(bound));
+                if (duration_left * speed < MIN_RADIUS) {
+                    continue;
+                }
+                const auto& center = sp->coord;
+                circles_classed.emplace_back(center, duration_left);
             }
-            const auto& center = sp->coord;
-            circles_classed.emplace_back(center, duration_left);
         }
     }
     std::vector<InfoCircle> circles_check = delete_useless_circle(std::move(circles_classed), speed);

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -102,8 +102,9 @@ bool Journey::better_on_sn(const Journey& that, const navitia::time_duration wal
     // walking duration
     // we consider that an extra transfer  is worthwhile
     // only if it reduces the walking duration by at least transfer_penalty
-    return sn_dur + transfer_dur + walking_transfer_penalty * std::max(2 * nb_transfer - 1, 0)
-           <= that.sn_dur + that.transfer_dur + walking_transfer_penalty * std::max(2 * that_nb_transfer - 1, 0);
+
+    return (sn_dur + transfer_dur) * 2 + total_waiting_dur
+           <= (that.sn_dur + that.transfer_dur) * 2 + that.total_waiting_dur;
     ;
 }
 

--- a/source/routing/journey.cpp
+++ b/source/routing/journey.cpp
@@ -101,9 +101,9 @@ bool Journey::better_on_sn(const Journey& that, const navitia::time_duration wal
     // we consider that the transfer duration as well as the street network duration are
     // walking duration
     // we consider that an extra transfer  is worthwhile
-    // only if it reduces the walking duration by at least arrival_transfer_penalty
-    return sn_dur + transfer_dur + walking_transfer_penalty * nb_transfer
-           <= that.sn_dur + that.transfer_dur + walking_transfer_penalty * that_nb_transfer;
+    // only if it reduces the walking duration by at least transfer_penalty
+    return sn_dur + transfer_dur + walking_transfer_penalty * std::max(2 * nb_transfer - 1, 0)
+           <= that.sn_dur + that.transfer_dur + walking_transfer_penalty * std::max(2 * that_nb_transfer - 1, 0);
     ;
 }
 

--- a/source/routing/labels.cpp
+++ b/source/routing/labels.cpp
@@ -29,50 +29,23 @@ www.navitia.io
 */
 
 #include "routing/labels.h"
+#include "routing/journey_pattern_container.h"
 #include "utils/boost_patched/range/combine.hpp"
 
 namespace navitia {
 namespace routing {
 
 Labels::Labels() {}
-Labels::Labels(const std::vector<type::StopPoint*> stop_points) : labels(stop_points) {}
-
-Labels::Labels(const Map& dt_pts, const Map& dt_transfers, const Map& walkings, const Map& walking_transfers) {
-    const auto& zip = boost::combine(dt_pts, dt_transfers.values(), walkings.values(), walking_transfers.values());
-    labels.resize(zip.size());
-    for (const auto& z : zip) {
-        const auto sp_idx = z.get<0>().first;
-        labels[sp_idx] = Label{z.get<0>().second, z.get<1>(), z.get<2>(), z.get<3>()};
-    }
-}
-
-std::array<Labels::Map, 4> Labels::inrow_labels() {
-    std::array<Map, 4> row_labels;
-
-    for (auto& row_label : row_labels)
-        row_label.resize(labels.size());
-
-    for (const auto& l : labels) {
-        const auto& sp_idx = l.first;
-        const auto& label = l.second;
-
-        row_labels[0][sp_idx] = label.dt_pt;
-        row_labels[1][sp_idx] = label.dt_transfer;
-        row_labels[2][sp_idx] = label.walking_duration_pt;
-        row_labels[3][sp_idx] = label.walking_duration_transfer;
-    }
-
-    return row_labels;
-}
+Labels::Labels(const std::vector<JourneyPatternPoint> jpps) : labels(jpps) {}
 
 void Labels::fill_values(DateTime pts, DateTime transfert, DateTime walking, DateTime walking_transfert) {
     Label default_label{pts, transfert, walking, walking_transfert};
     boost::fill(labels.values(), default_label);
 }
 
-void Labels::init(const std::vector<type::StopPoint*>& stops, DateTime val) {
+void Labels::init(const std::vector<JourneyPatternPoint>& jpps, DateTime val) {
     Label init_label{val, val, DateTimeUtils::not_valid, DateTimeUtils::not_valid};
-    labels.assign(stops, init_label);
+    labels.assign(jpps, init_label);
 }
 
 }  // namespace routing

--- a/source/routing/labels.h
+++ b/source/routing/labels.h
@@ -64,38 +64,25 @@ struct Label {
 };
 
 struct Labels {
-    using Map = IdxMap<type::StopPoint, DateTime>;
-    using LabelsMap = IdxMap<type::StopPoint, Label>;
+    using LabelsMap = IdxMap<JourneyPatternPoint, Label>;
 
     Labels();
-    Labels(const std::vector<type::StopPoint*> stop_points);
-    Labels(const Map& dt_pts, const Map& dt_transfers, const Map& walkings, const Map& walking_transfers);
+    Labels(const std::vector<JourneyPatternPoint> jpps);
 
     // initialize the structure according to the number of jpp
-    void init_inf(const std::vector<type::StopPoint*>& stops) { init(stops, DateTimeUtils::inf); }
-    void init_min(const std::vector<type::StopPoint*>& stops) { init(stops, DateTimeUtils::min); }
+    void init_inf(const std::vector<JourneyPatternPoint>& jpps) { init(jpps, DateTimeUtils::inf); }
+    void init_min(const std::vector<JourneyPatternPoint>& jpps) { init(jpps, DateTimeUtils::min); }
 
-    const Label& operator[](SpIdx sp_idx) const { return labels[sp_idx]; }
-    Label& operator[](SpIdx sp_idx) { return labels[sp_idx]; }
+    const Label& operator[](JppIdx jpp_idx) const { return labels[jpp_idx]; }
+    Label& operator[](JppIdx jpp_idx) { return labels[jpp_idx]; }
 
     LabelsMap::range values() { return labels.values(); }
 
-    /* Split each label's field in a specific vector, and return them individually in an array of :
-     *  1. stop point arrival datetime
-     *  2. stop point transfer datime
-     *  3. stop point waling duration
-     *  4. stop point walking transfer duration
-     */
-    std::array<Labels::Map, 4> inrow_labels();
-
     void fill_values(DateTime pts, DateTime transfert, DateTime walking, DateTime walking_transfert);
 
+    void init(const std::vector<JourneyPatternPoint>& jpps, DateTime val);
+
 private:
-    void init(const std::vector<type::StopPoint*>& stops, DateTime val);
-
-    const DateTime& dt_pt(SpIdx sp_idx) const { return labels[sp_idx].dt_pt; }
-    DateTime& mut_dt_pt(SpIdx sp_idx) { return labels[sp_idx].dt_pt; }
-
     LabelsMap labels;
 };
 

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -33,6 +33,7 @@ www.navitia.io
 #include "raptor_visitors.h"
 #include "type/meta_data.h"
 
+#include "routing/raptor_utils.h"
 #include "utils/logger.h"
 
 #include <boost/functional/hash.hpp>
@@ -94,8 +95,9 @@ bool RAPTOR::apply_vj_extension(const Visitor& v,
                 continue;
             }
 
-            Label& best_label = best_labels[sp_idx];
-            Label& working_label = working_labels[sp_idx];
+            const auto& jpp_idx = data.dataRaptor->jp_container.get_jpp(st);
+            Label& best_label = best_labels[jpp_idx];
+            Label& working_label = working_labels[jpp_idx];
 
             if (v.comp(workingDt, best_label.dt_pt)
                 || (workingDt == best_label.dt_pt && working_walking_duration < best_label.walking_duration_pt)) {
@@ -126,56 +128,58 @@ bool RAPTOR::foot_path(const Visitor& v) {
     const auto& cnx_list = v.clockwise() ? data.dataRaptor->connections.forward_connections
                                          : data.dataRaptor->connections.backward_connections;
 
-    for (const auto sp_cnx : cnx_list) {
+    for (const auto& sp_cnx : cnx_list) {
         // for all stop point, we check if we can improve the stop points they are in connection with
         const auto& sp_idx = sp_cnx.first;
-        const Label& working_label = working_labels[sp_idx];
+        for (const auto& jpp : jpps_from_sp[sp_idx]) {
+            const Label& working_label = working_labels[jpp.idx];
 
-        if (!is_dt_initialized(working_label.dt_pt)) {
-            continue;
-        }
+            if (!is_dt_initialized(working_label.dt_pt)) {
+                continue;
+            }
 
-        const DateTime start_connection_date = working_label.dt_pt;
+            const DateTime start_connection_date = working_label.dt_pt;
 
-        for (const auto& conn : sp_cnx.second) {
-            const SpIdx destination_sp_idx = conn.sp_idx;
-            const DateTime end_connection_date = v.combine(start_connection_date, conn.duration);
-            const DateTime candidate_walking_duration = working_label.walking_duration_pt + conn.walking_duration;
+            for (const auto& conn : sp_cnx.second) {
+                const SpIdx destination_sp_idx = conn.sp_idx;
+                for (const auto& destination_jpp : jpps_from_sp[destination_sp_idx]) {
+                    const DateTime end_connection_date = v.combine(start_connection_date, conn.duration);
+                    const DateTime candidate_walking_duration =
+                        working_label.walking_duration_pt + conn.walking_duration;
 
-            Label& destination_working_label = working_labels[destination_sp_idx];
-            Label& destination_best_label = best_labels[destination_sp_idx];
+                    Label& destination_working_label = working_labels[destination_jpp.idx];
+                    Label& destination_best_label = best_labels[destination_jpp.idx];
 
-            if (v.comp(end_connection_date, destination_best_label.dt_transfer)
-                || (end_connection_date == destination_best_label.dt_transfer
-                    && candidate_walking_duration < destination_best_label.walking_duration_transfer)) {
-                LOG4CPLUS_TRACE(raptor_logger,
-                                "Updating label transfer count : "
-                                    << count << " sp " << data.pt_data->stop_points[destination_sp_idx.val]->uri
-                                    << " from " << iso_string(destination_working_label.dt_transfer, data) << " to "
-                                    << iso_string(end_connection_date, data)
-                                    << " throught connection : " << data.pt_data->stop_points[sp_idx.val]->uri
-                                    << " walking : " << navitia::str(candidate_walking_duration)
-                                    << " previous best : " << iso_string(destination_best_label.dt_transfer, data));
+                    if (v.comp(end_connection_date, destination_best_label.dt_transfer)
+                        || (end_connection_date == destination_best_label.dt_transfer
+                            && candidate_walking_duration < destination_best_label.walking_duration_transfer)) {
+                        LOG4CPLUS_TRACE(
+                            raptor_logger,
+                            "Updating label transfer count : "
+                                << count << " sp " << data.pt_data->stop_points[destination_sp_idx.val]->uri << " from "
+                                << iso_string(destination_working_label.dt_transfer, data) << " to "
+                                << iso_string(end_connection_date, data)
+                                << " throught connection : " << data.pt_data->stop_points[sp_idx.val]->uri
+                                << " walking : " << navitia::str(candidate_walking_duration)
+                                << " previous best : " << iso_string(destination_best_label.dt_transfer, data));
 
-                // if we can improve the best label, we mark it
-                destination_working_label.dt_transfer = end_connection_date;
-                destination_working_label.walking_duration_transfer = candidate_walking_duration;
-                destination_best_label.dt_transfer = end_connection_date;
-                destination_best_label.walking_duration_transfer = candidate_walking_duration;
-                result = true;
+                        // if we can improve the best label, we mark it
+                        destination_working_label.dt_transfer = end_connection_date;
+                        destination_working_label.walking_duration_transfer = candidate_walking_duration;
+                        destination_best_label.dt_transfer = end_connection_date;
+                        destination_best_label.walking_duration_transfer = candidate_walking_duration;
+                        result = true;
+                    }
+                }
             }
         }
     }
 
     for (const auto sp_jpps : jpps_from_sp) {
-        const auto& working_label = working_labels[sp_jpps.first];
-        if (!is_dt_initialized(working_label.dt_transfer)) {
-            continue;
-        }
-
         // we mark the jpp order
         for (const auto& jpp : sp_jpps.second) {
-            if (v.comp(jpp.order, Q[jpp.jp_idx])) {
+            const auto& working_label = working_labels[jpp.idx];
+            if (is_dt_initialized(working_label.dt_transfer) and v.comp(jpp.order, Q[jpp.jp_idx])) {
                 Q[jpp.jp_idx] = jpp.order;
             }
         }
@@ -195,37 +199,38 @@ void RAPTOR::clear(const bool clockwise, const DateTime bound) {
         lbl_list = clean_labels;
     }
 
-    best_labels.fill_values(bound, bound, DateTimeUtils::not_valid, DateTimeUtils::not_valid);
+    best_labels.init(data.dataRaptor->jp_container.get_jpps_values(), bound);
+    best_labels_for_snd_pass.init(data.dataRaptor->jp_container.get_jpps_values(), bound);
 }
 
-void RAPTOR::init(const map_stop_point_duration& dep,
+void RAPTOR::init(const map_jpp_duration& dep,
                   const DateTime bound,
                   const bool clockwise,
                   const type::Properties& properties) {
-    for (const auto& sp_dt : dep) {
-        if (!get_sp(sp_dt.first)->accessible(properties)) {
+    for (const auto& jpp_dt : dep) {
+        const JourneyPatternPoint& jpp = get_jpp(jpp_dt.first);
+        if (!get_sp(jpp.sp_idx)->accessible(properties)) {
             continue;
         }
-        const DateTime sn_dur = sp_dt.second.total_seconds();
+        const DateTime sn_dur = jpp_dt.second.total_seconds();
         const DateTime begin_dt = bound + (clockwise ? sn_dur : -sn_dur);
 
-        Label& label = labels[0][sp_dt.first];
+        Label& label = labels[0][jpp_dt.first];
         label.dt_transfer = begin_dt;
         label.walking_duration_transfer = sn_dur;
 
-        Label& best_label = best_labels[sp_dt.first];
+        Label& best_label = best_labels[jpp_dt.first];
         best_label.dt_transfer = begin_dt;
         best_label.walking_duration_transfer = begin_dt;
 
-        for (const auto& jpp : jpps_from_sp[sp_dt.first]) {
-            if (clockwise && Q[jpp.jp_idx] > jpp.order) {
-                Q[jpp.jp_idx] = jpp.order;
-            } else if (!clockwise && Q[jpp.jp_idx] < jpp.order) {
-                Q[jpp.jp_idx] = jpp.order;
-            }
+        if (clockwise && Q[jpp.jp_idx] > jpp.order.val) {
+            Q[jpp.jp_idx] = jpp.order.val;
+        } else if (!clockwise && Q[jpp.jp_idx] < jpp.order.val) {
+            Q[jpp.jp_idx] = jpp.order.val;
         }
     }
 }
+
 
 RAPTOR::NEXT_STOPTIME_TYPE RAPTOR::choose_next_stop_time_type(
     const DateTime& departure_datetime,
@@ -267,7 +272,8 @@ void RAPTOR::set_next_stop_time(const DateTime& departure_datetime,
     }
 }
 
-void RAPTOR::first_raptor_loop(const map_stop_point_duration& departures,
+void RAPTOR::first_raptor_loop(const map_jpp_duration& departures,
+
                                const DateTime& departure_datetime,
                                const nt::RTLevel rt_level,
                                const DateTime& bound_limit,
@@ -323,12 +329,12 @@ struct CompSndPhase {
         if (lhs.walking_dur != rhs.walking_dur) {
             return lhs.walking_dur < rhs.walking_dur;
         }
-        return lhs.sp_idx < rhs.sp_idx;  // just to avoid randomness
+        return lhs.jpp_idx < rhs.jpp_idx;  // just to avoid randomness
     }
 };
 
 std::vector<StartingPointSndPhase> make_starting_points_snd_phase(const RAPTOR& raptor,
-                                                                  const routing::map_stop_point_duration& arrs,
+                                                                  const routing::map_jpp_duration& arrs,
                                                                   const type::AccessibiliteParams& accessibilite_params,
                                                                   const bool clockwise) {
     std::vector<StartingPointSndPhase> res;
@@ -341,7 +347,8 @@ std::vector<StartingPointSndPhase> make_starting_points_snd_phase(const RAPTOR& 
             if (!is_dt_initialized(working_label.dt_pt)) {
                 continue;
             }
-            if (!raptor.get_sp(a.first)->accessible(accessibilite_params.properties)) {
+            const JourneyPatternPoint& jpp = raptor.get_jpp(a.first);
+            if (!raptor.get_sp(jpp.sp_idx)->accessible(accessibilite_params.properties)) {
                 continue;
             }
 
@@ -404,7 +411,7 @@ static Labels& snd_pass_best_labels(const bool clockwise, Labels& best_labels) {
     return best_labels;
 }
 // Set the departure bounds on best_labels_pts for the second pass.
-static void init_best_pts_snd_pass(const routing::map_stop_point_duration& departures,
+static void init_best_pts_snd_pass(const routing::map_jpp_duration& departures,
                                    const DateTime& departure_datetime,
                                    const bool clockwise,
                                    Labels& best_labels) {
@@ -443,6 +450,19 @@ std::vector<Path> RAPTOR::compute_all(const map_stop_point_duration& departures,
     return from_journeys_to_path(journeys);
 }
 
+map_jpp_duration make_map_jpp_duration_from(const map_stop_point_duration& sps_dur, const RAPTOR& raptor) {
+    map_jpp_duration res;
+    res.reserve(sps_dur.size());
+
+    for (const auto& sp_dur : sps_dur) {
+        for (const auto& jpp : raptor.jpps_from_sp[sp_dur.first]) {
+            res.emplace(jpp.idx, sp_dur.second);
+        }
+    }
+
+    return res;
+}
+
 RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& departures,
                                               const map_stop_point_duration& destinations,
                                               const DateTime& departure_datetime,
@@ -478,8 +498,10 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
     const auto& calc_dep = clockwise ? departures : destinations;
     const auto& calc_dest = clockwise ? destinations : departures;
 
-    first_raptor_loop(calc_dep, departure_datetime, rt_level, bound, max_transfers, accessibilite_params, clockwise,
-                      current_datetime);
+    auto jpps_dep = make_map_jpp_duration_from(calc_dep, *this);
+    auto jpps_dest = make_map_jpp_duration_from(calc_dest, *this);
+
+    first_raptor_loop(jpps_dep, departure_datetime, rt_level, bound, max_transfers, accessibilite_params, clockwise);
 
     LOG4CPLUS_TRACE(raptor_logger, "labels after first pass : " << std::endl << print_all_labels());
 
@@ -499,27 +521,30 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
     // (as in best_labels_pt) in the second pass.  Then, we can reuse
     // these bounds, modulo an off by one because of strict comparison
     // on best_labels.
-    auto starting_points = make_starting_points_snd_phase(*this, calc_dest, accessibilite_params, clockwise);
+    auto starting_points = make_starting_points_snd_phase(*this, jpps_dest, accessibilite_params, clockwise);
     swap(labels, first_pass_labels);
 
-    const auto inrows_labels = best_labels.inrow_labels();
-
-    auto best_labels_for_snd_pass = Labels(
-        // durations and transfers are swapped for the 2nd pass as we are going backward in time
-        inrows_labels[1],   // dt transfers as pts
-        inrows_labels[0],   // dt pts as transfers
-        inrows_labels[3],   // walking duration transfers as walking duration
-        inrows_labels[2]);  // walking duration pts as walking duration transfers
+    for (const auto* sp : data.pt_data->stop_points) {
+        for (const auto& jpp : jpps_from_sp[SpIdx(*sp)]) {
+            const Label& label = best_labels[jpp.idx];
+            Label& new_label = best_labels_for_snd_pass[jpp.idx];
+            new_label.dt_pt = label.dt_transfer;
+            new_label.dt_transfer = label.dt_pt;
+            new_label.walking_duration_pt = label.walking_duration_transfer;
+            new_label.walking_duration_transfer = label.walking_duration_pt;
+        }
+    }
 
     snd_pass_best_labels(clockwise, best_labels_for_snd_pass);
-    init_best_pts_snd_pass(calc_dep, departure_datetime, clockwise, best_labels_for_snd_pass);
+    init_best_pts_snd_pass(jpps_dep, departure_datetime, clockwise, best_labels_for_snd_pass);
 
     LOG4CPLUS_TRACE(raptor_logger, "starting points 2nd phase " << std::endl
                                                                 << print_starting_points_snd_phase(starting_points));
 
     size_t nb_snd_pass = 0, nb_useless = 0, last_usefull_2nd_pass = 0, supplementary_2nd_pass = 0;
     for (const auto& start : starting_points) {
-        navitia::type::StopPoint* start_stop_point = data.pt_data->stop_points[start.sp_idx.val];
+        const auto& jpp = get_jpp(start.jpp_idx);
+        navitia::type::StopPoint* start_stop_point = data.pt_data->stop_points[jpp.sp_idx.val];
 
         LOG4CPLUS_TRACE(raptor_logger, std::endl
                                            << "Second pass from " << start_stop_point->uri
@@ -545,10 +570,21 @@ RAPTOR::Journeys RAPTOR::compute_all_journeys(const map_stop_point_duration& dep
         const auto& working_labels = first_pass_labels[start.count];
 
         clear(!clockwise, departure_datetime + (clockwise ? -1 : 1));
-        map_stop_point_duration init_map;
-        init_map[start.sp_idx] = 0_s;
-        best_labels = best_labels_for_snd_pass;
-        const Label& working_label = working_labels[start.sp_idx];
+        map_jpp_duration init_map;
+        init_map[start.jpp_idx] = 0_s;
+
+        // best_labels <- best_labels_for_snd_pass;
+        for (const auto* sp : data.pt_data->stop_points) {
+            for (const auto& jpp : jpps_from_sp[SpIdx(*sp)]) {
+                const Label& label = best_labels_for_snd_pass[jpp.idx];
+                Label& new_label = best_labels[jpp.idx];
+                new_label.dt_pt = label.dt_pt;
+                new_label.dt_transfer = label.dt_transfer;
+                new_label.walking_duration_pt = label.walking_duration_pt;
+                new_label.walking_duration_transfer = label.walking_duration_transfer;
+            }
+        }
+        const Label& working_label = working_labels[start.jpp_idx];
         init(init_map, working_label.dt_pt, !clockwise, accessibilite_params.properties);
         boucleRAPTOR(accessibilite_params, !clockwise, rt_level, max_transfers);
 
@@ -584,7 +620,8 @@ void RAPTOR::isochrone(const map_stop_point_duration& departures,
                        const nt::RTLevel rt_level) {
     set_valid_jp_and_jpp(DateTimeUtils::date(departure_datetime), accessibilite_params, forbidden, allowed, rt_level);
 
-    first_raptor_loop(departures, departure_datetime, rt_level, b, max_transfers, accessibilite_params, clockwise);
+    auto jpp_departures = make_map_jpp_duration_from(departures, *this);
+    first_raptor_loop(jpp_departures, departure_datetime, rt_level, b, max_transfers, accessibilite_params, clockwise);
 }
 
 namespace {
@@ -789,12 +826,14 @@ void RAPTOR::raptor_loop(Visitor visitor,
                         workingDt = st.section_end(base_dt, visitor.clockwise());
                         // We check if there are no drop_off_only and if the local_zone is okay
 
-                        Label& best_label = best_labels[jpp.sp_idx];
-                        Label& working_label = working_labels[jpp.sp_idx];
+                        Label& best_label = best_labels[jpp.idx];
+                        Label& working_label = working_labels[jpp.idx];
 
-                        const bool has_better_label = visitor.comp(workingDt, best_label.dt_pt)
-                                                      || (workingDt == best_label.dt_pt
-                                                          && working_walking_duration < best_label.walking_duration_pt);
+                        const bool has_better_label =
+                            (!is_dt_initialized(best_label.dt_pt) && is_dt_initialized(workingDt))
+                            || visitor.comp(workingDt, best_label.dt_pt)
+                            || (workingDt == best_label.dt_pt
+                                && working_walking_duration < best_label.walking_duration_pt);
 
                         if (st.valid_end(visitor.clockwise())
                             && (l_zone == std::numeric_limits<uint16_t>::max() || l_zone != st.local_traffic_zone)
@@ -824,7 +863,7 @@ void RAPTOR::raptor_loop(Visitor visitor,
                     // We try to get on a vehicle, if we were already on a vehicle, but we arrived
                     // before on the previous via a connection, we try to catch a vehicle leaving this
                     // journey pattern point before
-                    const Label& prec_label = prec_labels[jpp.sp_idx];
+                    const Label& prec_label = prec_labels[jpp.idx];
 
                     // if we cannot board at this stop point, nothing to do
                     if (!is_dt_initialized(prec_label.dt_transfer) || !valid_stop_points[jpp.sp_idx.val]) {
@@ -914,8 +953,8 @@ void RAPTOR::raptor_loop(Visitor visitor,
                             //     LOG4CPLUS_TRACE(raptor_logger,
                             //                     "Switching boarding stop point : "
                             //                         << " from "
-                            //                         << data.pt_data->stop_points[boarding_stop_point.val]->uri << "
-                            //                         to "
+                            //                         << data.pt_data->stop_points[boarding_stop_point.val]->uri
+                            //                         << "to "
                             //                         << data.pt_data->stop_points[jpp.sp_idx.val]->uri
                             //                         << " working dt before : " << iso_string(workingDt, data)
                             //                         << " working dt after : " << iso_string(tmp_st_dt.second, data)
@@ -990,10 +1029,10 @@ std::vector<Path> RAPTOR::compute(const type::StopArea* departure,
                        forbidden_uri, {}, clockwise, direct_path_dur, 0, current_datetime);
 }
 
-int RAPTOR::best_round(SpIdx sp_idx) {
+int RAPTOR::best_round(JppIdx jpp_idx) {
+    const Label& best_label = best_labels[jpp_idx];
     for (size_t i = 0; i <= this->count; ++i) {
-        const Label& label = labels[i][sp_idx];
-        const Label& best_label = best_labels[sp_idx];
+        const Label& label = labels[i][jpp_idx];
         if (label.dt_pt == best_label.dt_pt) {
             return i;
         }
@@ -1003,49 +1042,84 @@ int RAPTOR::best_round(SpIdx sp_idx) {
 
 std::string RAPTOR::print_all_labels() {
     std::ostringstream output;
-    for (uint32_t stop_point_id = 0; stop_point_id < data.pt_data->stop_points.size(); ++stop_point_id) {
-        SpIdx sp_idx = SpIdx(stop_point_id);
-        navitia::type::StopPoint* stop_point = data.pt_data->stop_points[sp_idx.val];
+    for (const auto* sp : data.pt_data->stop_points) {
+        for (const auto& jpp : jpps_from_sp[SpIdx(*sp)]) {
+            bool print_stop_point = false;
+            for (auto& current_labels : labels) {
+                const Label& current_label = current_labels[jpp.idx];
+                if (is_dt_initialized(current_label.dt_pt) || is_dt_initialized(current_label.dt_transfer)) {
+                    print_stop_point = true;
+                    break;
+                }
+            }
 
-        bool print_stop_point = false;
-        for (auto& current_labels : labels) {
-            const Label& current_label = current_labels[sp_idx];
-            if (is_dt_initialized(current_label.dt_pt) || is_dt_initialized(current_label.dt_transfer)) {
-                print_stop_point = true;
-                break;
+            if (print_stop_point) {
+                output << "" << sp->uri << " : " << std::endl;
+
+                for (unsigned int count_id = 0; count_id < labels.size(); ++count_id) {
+                    Labels& current_labels = labels[count_id];
+                    const Label& label = current_labels[jpp.idx];
+                    if (!is_dt_initialized(label.dt_pt) && !is_dt_initialized(label.dt_transfer)) {
+                        continue;
+                    }
+                    output << "   count : " << count_id;
+                    output << " dt_pt : ";
+
+                    if (is_dt_initialized(label.dt_pt)) {
+                        output << iso_string(label.dt_pt, data);
+                        output << ", " << navitia::str(label.walking_duration_pt);
+                    } else {
+                        output << "not init";
+                    }
+
+                    output << " transfer_dt : ";
+
+                    if (is_dt_initialized(label.dt_transfer)) {
+                        output << iso_string(label.dt_transfer, data);
+                        output << ", " << navitia::str(label.walking_duration_transfer);
+                    } else {
+                        output << "not init";
+                    }
+
+                    output << std::endl;
+                }
             }
         }
+    }
+    return output.str();
+}
 
-        if (print_stop_point) {
-            output << "" << stop_point->uri << " : " << std::endl;
+std::string RAPTOR::print_labels(Labels& labels_to_print) {
+    std::ostringstream output;
 
-            for (unsigned int count_id = 0; count_id < labels.size(); ++count_id) {
-                Labels& current_labels = labels[count_id];
-                const Label& label = current_labels[sp_idx];
-                if (!is_dt_initialized(label.dt_pt) && !is_dt_initialized(label.dt_transfer)) {
-                    continue;
-                }
-                output << "   count : " << count_id;
-                output << " dt_pt : ";
+    for (const auto* sp : data.pt_data->stop_points) {
+        for (const auto& jpp : jpps_from_sp[SpIdx(*sp)]) {
+            output << "" << sp->uri << " : "
+                   << " jpp : " << jpp.idx.val << std::endl;
 
-                if (is_dt_initialized(label.dt_pt)) {
-                    output << iso_string(label.dt_pt, data);
-                    output << ", " << navitia::str(label.walking_duration_pt);
-                } else {
-                    output << "not init";
-                }
+            const Label& label = labels_to_print[jpp.idx];
+            // if (!is_dt_initialized(label.dt_pt) && !is_dt_initialized(label.dt_transfer)) {
+            //     continue;
+            // }
+            output << " dt_pt : ";
 
-                output << " transfer_dt : ";
-
-                if (is_dt_initialized(label.dt_transfer)) {
-                    output << iso_string(label.dt_transfer, data);
-                    output << ", " << navitia::str(label.walking_duration_transfer);
-                } else {
-                    output << "not init";
-                }
-
-                output << std::endl;
+            if (is_dt_initialized(label.dt_pt)) {
+                output << iso_string(label.dt_pt, data);
+                output << ", " << navitia::str(label.walking_duration_pt);
+            } else {
+                output << "not init";
             }
+
+            output << " transfer_dt : ";
+
+            if (is_dt_initialized(label.dt_transfer)) {
+                output << iso_string(label.dt_transfer, data);
+                output << ", " << navitia::str(label.walking_duration_transfer);
+            } else {
+                output << "not init";
+            }
+
+            output << std::endl;
         }
     }
     return output.str();
@@ -1053,8 +1127,9 @@ std::string RAPTOR::print_all_labels() {
 
 std::string RAPTOR::print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points) {
     std::ostringstream output;
-    for (auto start_point : starting_points) {
-        navitia::type::StopPoint* stop_point = data.pt_data->stop_points[start_point.sp_idx.val];
+    for (const auto& start_point : starting_points) {
+        const auto& jpp = get_jpp(start_point.jpp_idx);
+        const navitia::type::StopPoint* stop_point = get_sp(jpp.sp_idx);
         output << "" << stop_point->uri << " count : " << start_point.count
                << " end_dt : " << iso_string(start_point.end_dt, data)
                << " fallback_dur : " << navitia::str(start_point.walking_dur)

--- a/source/routing/raptor.cpp
+++ b/source/routing/raptor.cpp
@@ -231,7 +231,6 @@ void RAPTOR::init(const map_jpp_duration& dep,
     }
 }
 
-
 RAPTOR::NEXT_STOPTIME_TYPE RAPTOR::choose_next_stop_time_type(
     const DateTime& departure_datetime,
     const boost::optional<boost::posix_time::ptime>& current_datetime) const {

--- a/source/routing/raptor.h
+++ b/source/routing/raptor.h
@@ -61,7 +61,7 @@ namespace routing {
 DateTime limit_bound(const bool clockwise, const DateTime departure_datetime, const DateTime bound);
 
 struct StartingPointSndPhase {
-    SpIdx sp_idx;
+    JppIdx jpp_idx;
     unsigned count;
     DateTime end_dt;
     unsigned walking_dur;
@@ -92,6 +92,8 @@ struct RAPTOR {
     /// Contains the best arrival (or departure time) for each stoppoint
     Labels best_labels;
 
+    Labels best_labels_for_snd_pass;
+
     /// Number of transfers done for the moment
     unsigned int count;
     /// Are the journey pattern valid
@@ -108,7 +110,8 @@ struct RAPTOR {
     explicit RAPTOR(const navitia::type::Data& data)
         : data(data),
           uncached_next_st(std::make_shared<const NextStopTime>(data)),
-          best_labels(data.pt_data->stop_points),
+          best_labels(data.dataRaptor->jp_container.get_jpps_values()),
+          best_labels_for_snd_pass(data.dataRaptor->jp_container.get_jpps_values()),
           count(0),
           valid_journey_patterns(data.dataRaptor->jp_container.nb_jps()),
           Q(data.dataRaptor->jp_container.get_jps_values()),
@@ -121,13 +124,14 @@ struct RAPTOR {
     void clear(const bool clockwise, const DateTime bound);
 
     /// Initialize starting points
-    void init(const map_stop_point_duration& dep,
+    void init(const map_jpp_duration& dep,
               const DateTime bound,
               const bool clockwise,
               const type::Properties& properties);
 
     // pt_data object getters by typed idx
     const type::StopPoint* get_sp(SpIdx idx) const { return data.pt_data->stop_points[idx.val]; }
+    const JourneyPatternPoint& get_jpp(JppIdx idx) const { return data.dataRaptor->jp_container.get(idx); }
 
     /// Lance un calcul d'itinéraire entre deux stop areas avec aussi une borne
     std::vector<Path> compute(const type::StopArea* departure,
@@ -243,11 +247,11 @@ struct RAPTOR {
 
     /// Return the round that has found the best solution for this stop point
     /// Return -1 if no solution found
-    int best_round(SpIdx sp_idx);
+    int best_round(JppIdx jpp_idx);
 
     /// First raptor loop
     /// externalized for testing purposes
-    void first_raptor_loop(const map_stop_point_duration& departures,
+    void first_raptor_loop(const map_jpp_duration& departures,
                            const DateTime& departure_datetime,
                            const nt::RTLevel rt_level,
                            const DateTime& bound_limit,
@@ -259,6 +263,7 @@ struct RAPTOR {
     ~RAPTOR() = default;
 
     std::string print_all_labels();
+    std::string print_labels(Labels&);
     std::string print_starting_points_snd_phase(std::vector<StartingPointSndPhase>& starting_points);
 
 private:
@@ -272,6 +277,8 @@ private:
                             const bool clockwise,
                             const NEXT_STOPTIME_TYPE next_st_type);
 };
+
+map_jpp_duration make_map_jpp_duration_from(const map_stop_point_duration& sps_dur, const RAPTOR& raptor);
 
 }  // namespace routing
 }  // namespace navitia

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -960,48 +960,51 @@ static void add_isochrone_response(RAPTOR& raptor,
     pb_creator.fill(&origin, &pb_origin, 0);
     for (const type::StopPoint* sp : stop_points) {
         SpIdx sp_idx(*sp);
-        const auto best_lbl = raptor.best_labels[sp_idx].dt_pt;
-        if ((clockwise && best_lbl < bound) || (!clockwise && best_lbl > bound)) {
-            int round = raptor.best_round(sp_idx);
-            const auto& best_round_label = raptor.labels[round][sp_idx];
+        for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+            const auto best_lbl = raptor.best_labels[jpp.idx].dt_pt;
+            if ((clockwise && best_lbl < bound) || (!clockwise && best_lbl > bound)) {
+                int round = raptor.best_round(jpp.idx);
+                const auto& best_round_label = raptor.labels[round][jpp.idx];
 
-            if (round == -1 || !is_dt_initialized(best_round_label.dt_pt)) {
-                continue;
-            }
+                if (round == -1 || !is_dt_initialized(best_round_label.dt_pt)) {
+                    continue;
+                }
 
-            // get absolute value
-            int duration = best_lbl > init_dt ? best_lbl - init_dt : init_dt - best_lbl;
+                // get absolute value
+                int duration = best_lbl > init_dt ? best_lbl - init_dt : init_dt - best_lbl;
 
-            if (duration > max_duration) {
-                continue;
-            }
-            auto pb_journey = pb_creator.add_journeys();
+                if (duration > max_duration) {
+                    continue;
+                }
+                auto pb_journey = pb_creator.add_journeys();
 
-            uint64_t departure;
-            uint64_t arrival;
-            // Note: since there is no 2nd pass for the isochrone, the departure dt
-            // is the requested dt (or the arrival dt for non clockwise)
-            if (clockwise) {
-                departure = to_posix_timestamp(init_dt, raptor.data);
-                arrival = to_posix_timestamp(best_lbl, raptor.data);
-            } else {
-                departure = to_posix_timestamp(best_lbl, raptor.data);
-                arrival = to_posix_timestamp(init_dt, raptor.data);
-            }
-            const auto str_requested = to_posix_timestamp(init_dt, raptor.data);
-            pb_journey->set_arrival_date_time(arrival);
-            pb_journey->set_departure_date_time(departure);
-            pb_journey->set_requested_date_time(str_requested);
-            pb_journey->set_duration(duration);
-            pb_journey->set_nb_transfers(round - 1);
-            pb_creator.action_period = bt::time_period(navitia::to_posix_time(best_lbl - duration, raptor.data),
-                                                       navitia::to_posix_time(best_lbl, raptor.data) + bt::seconds(1));
-            if (clockwise) {
-                *pb_journey->mutable_origin() = pb_origin;
-                pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
-            } else {
-                pb_creator.fill(sp, pb_journey->mutable_origin(), 0);
-                *pb_journey->mutable_destination() = pb_origin;
+                uint64_t departure;
+                uint64_t arrival;
+                // Note: since there is no 2nd pass for the isochrone, the departure dt
+                // is the requested dt (or the arrival dt for non clockwise)
+                if (clockwise) {
+                    departure = to_posix_timestamp(init_dt, raptor.data);
+                    arrival = to_posix_timestamp(best_lbl, raptor.data);
+                } else {
+                    departure = to_posix_timestamp(best_lbl, raptor.data);
+                    arrival = to_posix_timestamp(init_dt, raptor.data);
+                }
+                const auto str_requested = to_posix_timestamp(init_dt, raptor.data);
+                pb_journey->set_arrival_date_time(arrival);
+                pb_journey->set_departure_date_time(departure);
+                pb_journey->set_requested_date_time(str_requested);
+                pb_journey->set_duration(duration);
+                pb_journey->set_nb_transfers(round - 1);
+                pb_creator.action_period =
+                    bt::time_period(navitia::to_posix_time(best_lbl - duration, raptor.data),
+                                    navitia::to_posix_time(best_lbl, raptor.data) + bt::seconds(1));
+                if (clockwise) {
+                    *pb_journey->mutable_origin() = pb_origin;
+                    pb_creator.fill(sp, pb_journey->mutable_destination(), 0);
+                } else {
+                    pb_creator.fill(sp, pb_journey->mutable_origin(), 0);
+                    *pb_journey->mutable_destination() = pb_origin;
+                }
             }
         }
     }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -480,22 +480,24 @@ struct RaptorSolutionReader {
                 continue;
             }
             const SpIdx end_sp_idx = SpIdx(*end_st.stop_point);
-            const auto& prev_label = raptor.labels[count - 1][end_sp_idx];
-            const DateTime end_limit = prev_label.dt_transfer;
-            if (v.comp(end_limit, cur_dt)) {
-                continue;
-            }
             if (!raptor.valid_stop_points[end_sp_idx.val]) {
                 continue;
             }
+            for (const auto& jpp : raptor.jpps_from_sp[end_sp_idx]) {
+                const auto& prev_label = raptor.labels[count - 1][jpp.idx];
+                const DateTime end_limit = prev_label.dt_transfer;
+                if (v.comp(end_limit, cur_dt)) {
+                    continue;
+                }
 
-            // great, we can end
-            if (count == 1) {
-                // we've finished, and it's a valid end as it is initialized
-                const PathElt new_path(*begin_st_dt.first, begin_st_dt.second, end_st, cur_dt, path);
-                handle_solution(new_path);
-            } else {
-                try_transfer(count - 1, end_sp_idx, StDt(&end_st, cur_dt), nb_stay_in, transfers);
+                // great, we can end
+                if (count == 1) {
+                    // we've finished, and it's a valid end as it is initialized
+                    const PathElt new_path(*begin_st_dt.first, begin_st_dt.second, end_st, cur_dt, path);
+                    handle_solution(new_path);
+                } else {
+                    try_transfer(count - 1, end_sp_idx, StDt(&end_st, cur_dt), nb_stay_in, transfers);
+                }
             }
         }
         return cur_dt;
@@ -510,14 +512,16 @@ struct RaptorSolutionReader {
                                              : raptor.data.dataRaptor->connections.backward_connections;
 
         for (const auto& conn : cnx_list[sp_idx]) {
-            const DateTime transfer_limit = raptor.labels[count][conn.sp_idx].dt_pt;
-            const DateTime transfer_end = v.combine(end_st_dt.second, conn.duration);
-            if (v.comp(transfer_limit, transfer_end)) {
-                continue;
-            }
+            for (const auto& jpp : raptor.jpps_from_sp[conn.sp_idx]) {
+                const DateTime transfer_limit = raptor.labels[count][jpp.idx].dt_pt;
+                const DateTime transfer_end = v.combine(end_st_dt.second, conn.duration);
+                if (v.comp(transfer_limit, transfer_end)) {
+                    continue;
+                }
 
-            // transfer is OK
-            try_begin_pt(count, conn.sp_idx, transfer_end, end_st_dt, nb_stay_in, transfers);
+                // transfer is OK
+                try_begin_pt(count, jpp, transfer_end, end_st_dt, nb_stay_in, transfers);
+            }
         }
     }
 
@@ -535,36 +539,32 @@ struct RaptorSolutionReader {
     }
 
     void try_begin_pt(const unsigned count,
-                      const SpIdx begin_sp_idx,
+                      const dataRAPTOR::JppsFromSp::Jpp& jpp,
                       const DateTime begin_dt,
                       const StDt& end_st_dt,
                       const unsigned nb_stay_in,
                       Transfers& transfers) {
         const unsigned transfer_t = v.clockwise() ? begin_dt - end_st_dt.second : end_st_dt.second - begin_dt;
-        const DateTime begin_limit = raptor.labels[count][begin_sp_idx].dt_pt;
-        for (const auto& jpp : raptor.jpps_from_sp[begin_sp_idx]) {
-            // trying to begin
-            // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
-            // v.clockwise());
-            const auto begin_st_dt =
-                raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
-                                               accessibilite_params.vehicle_properties, true, begin_limit);
-            if (begin_st_dt.first == nullptr) {
-                continue;
-            }
-            if (v.comp(begin_limit, begin_st_dt.second)) {
-                continue;
-            }
-            if (!raptor.valid_stop_points[begin_sp_idx.val]) {
-                continue;
-            }
+        const DateTime begin_limit = raptor.labels[count][jpp.idx].dt_pt;
 
-            // great, we can begin
-            const Transfer tr(get_vj_end(begin_st_dt), nb_stay_in,
-                              v.clockwise() ? begin_st_dt.second - begin_dt : begin_dt - begin_st_dt.second, transfer_t,
-                              end_st_dt, begin_st_dt);
-            transfers[jpp.jp_idx].add(tr);
+        // trying to begin
+        const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise());
+        if (begin_st_dt.first == nullptr) {
+            return;
         }
+        if (v.comp(begin_limit, begin_st_dt.second)) {
+            return;
+        }
+        const SpIdx& begin_sp_idx = raptor.get_jpp(jpp.idx).sp_idx;
+        if (!raptor.valid_stop_points[begin_sp_idx.val]) {
+            return;
+        }
+
+        // great, we can begin
+        const Transfer tr(get_vj_end(begin_st_dt), nb_stay_in,
+                          v.clockwise() ? begin_st_dt.second - begin_dt : begin_dt - begin_st_dt.second, transfer_t,
+                          end_st_dt, begin_st_dt);
+        transfers[jpp.jp_idx].add(tr);
     }
 
     void step(const unsigned count, const PathElt* path, const StDt& begin_st_dt) {
@@ -578,24 +578,20 @@ struct RaptorSolutionReader {
         }
     }
 
-    void begin_pt(const unsigned count, const SpIdx begin_sp_idx, const DateTime begin_dt) {
-        const DateTime begin_limit = raptor.labels[count][begin_sp_idx].dt_pt;
-        for (const auto& jpp : raptor.jpps_from_sp[begin_sp_idx]) {
-            // trying to begin
-            // const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt,
-            // v.clockwise());
-            const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(),
-                                                                    rt_level, accessibilite_params.vehicle_properties);
-            if (begin_st_dt.first == nullptr) {
-                continue;
-            }
-            if (v.comp(begin_limit, begin_st_dt.second)) {
-                continue;
-            }
+    void begin_pt(const unsigned count, const dataRAPTOR::JppsFromSp::Jpp& jpp, const DateTime begin_dt) {
+        const DateTime begin_limit = raptor.labels[count][jpp.idx].dt_pt;
 
-            // great, we can begin
-            step(count, nullptr, begin_st_dt);
+        // trying to begin
+        const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise());
+        if (begin_st_dt.first == nullptr) {
+            return;
         }
+        if (v.comp(begin_limit, begin_st_dt.second)) {
+            return;
+        }
+
+        // great, we can begin
+        step(count, nullptr, begin_st_dt);
     }
 };
 
@@ -612,41 +608,48 @@ void read_solutions(const RAPTOR& raptor,
                     const StartingPointSndPhase& end_point) {
     auto reader = RaptorSolutionReader<Visitor>(raptor, solutions, v, departure_datetime, deps, arrs, rt_level,
                                                 accessibilite_params, arrival_transfer_penalty, end_point);
-    const auto end_point_street_network_duration = (v.clockwise() ? arrs : deps).at(end_point.sp_idx);
+
+    const JppIdx& end_jpp_idx = end_point.jpp_idx;
+    const JourneyPatternPoint& end_jpp = raptor.get_jpp(end_jpp_idx);
+    const SpIdx& end_stop_point_idx = end_jpp.sp_idx;
+    const auto end_point_street_network_duration = (v.clockwise() ? arrs : deps).at(end_stop_point_idx);
+
     for (unsigned count = 1; count <= raptor.count; ++count) {
         const auto& working_labels = raptor.labels[count];
-        const auto& first_endpoint_label = raptor.labels[0][end_point.sp_idx];
+        const auto& first_endpoint_label = raptor.labels[0][end_point.jpp_idx];
 
         for (const auto& a : v.clockwise() ? deps : arrs) {
             SpIdx sp_idx = a.first;
-            const auto& working_label = working_labels[sp_idx];
             navitia::type::StopPoint* stop_point = raptor.data.pt_data->stop_points[sp_idx.val];
+            for (const auto& jpp : raptor.jpps_from_sp[sp_idx]) {
+                const auto& working_label = working_labels[jpp.idx];
 
-            if (!is_dt_initialized(working_label.dt_pt)) {
-                continue;
-            }
-            if (!raptor.get_sp(a.first)->accessible(accessibilite_params.properties)) {
-                continue;
-            }
-            reader.nb_sol_added = 0;
-            // we check that it's worth to explore this possible journey
-            auto transfer_duration = working_label.walking_duration_pt - end_point_street_network_duration;
-            auto j = make_bound_journey(working_label.dt_pt, a.second, first_endpoint_label.dt_transfer,
-                                        end_point_street_network_duration, count, navitia::seconds(transfer_duration),
-                                        v.clockwise());
-            LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey from " << stop_point->uri << " count : " << count
-                                                                  << std::endl
-                                                                  << j);
+                if (!is_dt_initialized(working_label.dt_pt)) {
+                    continue;
+                }
+                if (!raptor.get_sp(a.first)->accessible(accessibilite_params.properties)) {
+                    continue;
+                }
+                reader.nb_sol_added = 0;
+                // we check that it's worth to explore this possible journey
+                auto transfer_duration = working_label.walking_duration_pt - end_point_street_network_duration;
+                auto j = make_bound_journey(working_label.dt_pt, a.second, first_endpoint_label.dt_transfer,
+                                            end_point_street_network_duration, count,
+                                            navitia::seconds(transfer_duration), v.clockwise());
+                LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey from " << stop_point->uri << " count : " << count
+                                                                      << std::endl
+                                                                      << j);
 
-            if (reader.solutions.contains_better_than(j)) {
-                LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey discarded");
+                if (reader.solutions.contains_better_than(j)) {
+                    LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey discarded");
 
-                continue;
-            }
-            try {
-                LOG4CPLUS_DEBUG(raptor.raptor_logger, "try to build journey ");
-                reader.begin_pt(count, a.first, working_label.dt_pt);
-            } catch (stop_search&) {
+                    continue;
+                }
+                try {
+                    LOG4CPLUS_DEBUG(raptor.raptor_logger, "try to build journey ");
+                    reader.begin_pt(count, jpp, working_label.dt_pt);
+                } catch (stop_search&) {
+                }
             }
         }
     }

--- a/source/routing/raptor_solution_reader.cpp
+++ b/source/routing/raptor_solution_reader.cpp
@@ -548,7 +548,9 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count][jpp.idx].dt_pt;
 
         // trying to begin
-        const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise());
+        const auto begin_st_dt =
+            raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(), rt_level,
+                                           accessibilite_params.vehicle_properties, true, begin_limit);
         if (begin_st_dt.first == nullptr) {
             return;
         }
@@ -582,7 +584,8 @@ struct RaptorSolutionReader {
         const DateTime begin_limit = raptor.labels[count][jpp.idx].dt_pt;
 
         // trying to begin
-        const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise());
+        const auto begin_st_dt = raptor.next_st->next_stop_time(v.stop_event(), jpp.idx, begin_dt, v.clockwise(),
+                                                                rt_level, accessibilite_params.vehicle_properties);
         if (begin_st_dt.first == nullptr) {
             return;
         }
@@ -636,17 +639,17 @@ void read_solutions(const RAPTOR& raptor,
                 auto j = make_bound_journey(working_label.dt_pt, a.second, first_endpoint_label.dt_transfer,
                                             end_point_street_network_duration, count,
                                             navitia::seconds(transfer_duration), v.clockwise());
-                LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey from " << stop_point->uri << " count : " << count
+                LOG4CPLUS_TRACE(raptor.raptor_logger, "Journey from " << stop_point->uri << " count : " << count
                                                                       << std::endl
                                                                       << j);
 
                 if (reader.solutions.contains_better_than(j)) {
-                    LOG4CPLUS_DEBUG(raptor.raptor_logger, "Journey discarded");
+                    LOG4CPLUS_TRACE(raptor.raptor_logger, "Journey discarded");
 
                     continue;
                 }
                 try {
-                    LOG4CPLUS_DEBUG(raptor.raptor_logger, "try to build journey ");
+                    LOG4CPLUS_TRACE(raptor.raptor_logger, "try to build journey ");
                     reader.begin_pt(count, jpp, working_label.dt_pt);
                 } catch (stop_search&) {
                 }

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -53,8 +53,10 @@ struct Dominates {
           arrival_transfer_penalty(arrival_transfer_penalty),
           walking_transfer_penalty(walking_transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
+
         return lhs.better_on_dt(rhs, request_clockwise, arrival_transfer_penalty) && lhs.better_on_transfer(rhs)
                && lhs.better_on_sn(rhs, walking_transfer_penalty);
+
     }
 };
 

--- a/source/routing/raptor_solution_reader.h
+++ b/source/routing/raptor_solution_reader.h
@@ -53,10 +53,8 @@ struct Dominates {
           arrival_transfer_penalty(arrival_transfer_penalty),
           walking_transfer_penalty(walking_transfer_penalty) {}
     bool operator()(const Journey& lhs, const Journey& rhs) const {
-
         return lhs.better_on_dt(rhs, request_clockwise, arrival_transfer_penalty) && lhs.better_on_transfer(rhs)
                && lhs.better_on_sn(rhs, walking_transfer_penalty);
-
     }
 };
 

--- a/source/routing/raptor_utils.h
+++ b/source/routing/raptor_utils.h
@@ -50,6 +50,7 @@ using MvjIdx = Idx<type::MetaVehicleJourney>;
 using PhyModeIdx = Idx<type::PhysicalMode>;
 
 using map_stop_point_duration = boost::container::flat_map<SpIdx, navitia::time_duration>;
+using map_jpp_duration = boost::container::flat_map<JppIdx, navitia::time_duration>;
 
 inline bool is_dt_initialized(const DateTime dt) {
     return dt != DateTimeUtils::inf && dt != DateTimeUtils::min;

--- a/source/routing/tests/raptor_test.cpp
+++ b/source/routing/tests/raptor_test.cpp
@@ -1437,7 +1437,8 @@ BOOST_AUTO_TEST_CASE(finish_on_service_extension) {
     auto departure_time = DateTimeUtils::set(0, 7900);
     auto rt_level = nt::RTLevel::Base;
     raptor.set_valid_jp_and_jpp(DateTimeUtils::date(departure_time), {}, {}, {}, rt_level);
-    raptor.first_raptor_loop(departs, departure_time, rt_level, DateTimeUtils::inf,
+    auto jpp_departs = make_map_jpp_duration_from(departs, raptor);
+    raptor.first_raptor_loop(jpp_departs, departure_time, rt_level, DateTimeUtils::inf,
                              std::numeric_limits<uint32_t>::max(), {}, true);
 
     // and raptor has to stop on count 2
@@ -1474,7 +1475,8 @@ BOOST_AUTO_TEST_CASE(finish_on_foot_path) {
     auto departure_time = DateTimeUtils::set(0, 7900);
     auto rt_level = nt::RTLevel::Base;
     raptor.set_valid_jp_and_jpp(DateTimeUtils::date(departure_time), {}, {}, {}, rt_level);
-    raptor.first_raptor_loop(departs, departure_time, rt_level, DateTimeUtils::inf,
+    auto jpp_departs = make_map_jpp_duration_from(departs, raptor);
+    raptor.first_raptor_loop(jpp_departs, departure_time, rt_level, DateTimeUtils::inf,
                              std::numeric_limits<uint32_t>::max(), {}, true);
 
     // and raptor has to stop on count 2
@@ -3223,7 +3225,7 @@ BOOST_AUTO_TEST_CASE(forbidden_uri_in_stay_in) {
     auto res = raptor.compute(d.stop_areas_map.at("Stade"), d.stop_areas_map.at("LaJacquotte"), "09:30:00"_t, 0,
                               DateTimeUtils::inf, type::RTLevel::Base, 2_min, 2_min, true);
 
-    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_REQUIRE_EQUAL(res.size(), 2);
     using boost::posix_time::time_from_string;
 
     auto j = res[0];
@@ -3267,7 +3269,7 @@ BOOST_AUTO_TEST_CASE(test_jira1686_should_arrive_at_earliest) {
 
     auto res = RAPTOR(b.get_data()).compute_all(departures, arrivals, DateTimeUtils::set(2, "00:00"_t));
 
-    BOOST_REQUIRE_EQUAL(res.size(), 1);  // should be 2 ??
+    BOOST_REQUIRE_EQUAL(res.size(), 2);
     BOOST_REQUIRE_EQUAL(res[0].items[0].stop_points[0]->uri, "A");
 }
 
@@ -3295,8 +3297,8 @@ BOOST_AUTO_TEST_CASE(test_jira1686_should_arrive_at_earliest_with_direct_path) {
                                 5_min    // direct path duration <---------
                    );
 
-    BOOST_REQUIRE_EQUAL(res.size(), 0);  // should be 1 ??
-    // BOOST_REQUIRE_EQUAL(res[0].items[0].stop_points[0]->uri, "B");
+    BOOST_REQUIRE_EQUAL(res.size(), 1);
+    BOOST_REQUIRE_EQUAL(res[0].items[0].stop_points[0]->uri, "B");
 }
 
 BOOST_AUTO_TEST_CASE(test_jira1686_should_take_journey_with_minimum_walking_) {

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -195,6 +195,10 @@ BOOST_AUTO_TEST_CASE(simple_journey) {
 
   Testing that crow fly feature with no street network works
   for origin and destination, and with coordinates and stop areas.
+
+  Since PR #3413 JPP based Raptor's Labels,
+  we have two journeys proposed as results instead of one.
+  We get the earliest arrival journey for each route (with 2 as stop_point) (0 -> 2 and 1 -> 2)
  */
 BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     std::vector<std::string> forbidden;
@@ -231,8 +235,8 @@ BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     pbnavitia::Response resp = pb_creator.get_response();
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
-    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
-    pbnavitia::Journey journey = resp.journeys(0);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2);
+    pbnavitia::Journey journey = resp.journeys(1);
 
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
     pbnavitia::Section section = journey.sections(1);
@@ -263,8 +267,8 @@ BOOST_AUTO_TEST_CASE(simple_journey_with_crow_fly) {
     resp = pb_creator.get_response();
 
     BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
-    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
-    journey = resp.journeys(0);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 2);
+    journey = resp.journeys(1);
 
     BOOST_REQUIRE_EQUAL(journey.sections_size(), 3);
     section = journey.sections(1);
@@ -1827,7 +1831,7 @@ struct isochrone_fixture {
 };
 
 /**
- * classic isochrone from A, we should find 2 journeys
+ * classic isochrone from A, we should find 4 journeys
  */
 BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     nr::RAPTOR raptor(*(b.data));
@@ -1839,18 +1843,30 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
     nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker, nt::RTLevel::Base,
                        3 * 60 * 60);
     auto result = pb_creator.get_response();
-    BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
+    BOOST_REQUIRE_EQUAL(result.journeys_size(), 4);
 
-    std::cout << "1/ dep " << navitia::from_posix_timestamp(result.journeys(0).departure_date_time()) << std::endl;
-    std::cout << "1/ arr " << navitia::from_posix_timestamp(result.journeys(0).arrival_date_time()) << std::endl;
-    std::cout << "2/ dep " << navitia::from_posix_timestamp(result.journeys(1).departure_date_time()) << std::endl;
-    std::cout << "2/ arr " << navitia::from_posix_timestamp(result.journeys(1).arrival_date_time()) << std::endl;
+    for (int i(0); i < result.journeys_size(); ++i) {
+        std::cout << i << "/ dep " << navitia::from_posix_timestamp(result.journeys(i).departure_date_time())
+                  << std::endl;
+        std::cout << i << "/ arr " << navitia::from_posix_timestamp(result.journeys(i).arrival_date_time())
+                  << std::endl;
+    }
 
     // Note: since there is no 2nd pass for the isochrone, the departure dt is the requested dt
     BOOST_CHECK_EQUAL(result.journeys(0).departure_date_time(), "20150615T082000"_pts);
     BOOST_CHECK_EQUAL(result.journeys(0).arrival_date_time(), "20150615T083500"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).departure_date_time(), "20150615T082000"_pts);
-    BOOST_CHECK_EQUAL(result.journeys(1).arrival_date_time(), "20150615T093500"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(1).arrival_date_time(), "20150615T084500"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(2).departure_date_time(), "20150615T082000"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(2).arrival_date_time(), "20150615T093500"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(3).departure_date_time(), "20150615T082000"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(3).arrival_date_time(), "20150615T095000"_pts);
+
+    // DIff Results before / after  PR #3413 JPP based Raptor's Labels
+    // Before this PR, results journeys are only the one with earliest arrival time at each stops points (B and C here)
+    // So we expect 2 journeys for 2 stop points
+    // After this PR, results journeys are all the one with earliest arival for each couple (stop point, line)
+    // In this example with have 2 lines for each stop points B and C, so we expect 4 journeys as results
 
     {
         // We ask the same request with stop_point == center
@@ -1874,7 +1890,7 @@ BOOST_FIXTURE_TEST_CASE(isochrone, isochrone_fixture) {
 
 /**
  * reverse isochrone test, we want to arrive in B before 11:00,
- * we should find 2 journeys
+ * we should find 3 journeys
  */
 BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     nr::RAPTOR raptor(*(b.data));
@@ -1886,12 +1902,14 @@ BOOST_FIXTURE_TEST_CASE(reverse_isochrone, isochrone_fixture) {
     nr::make_isochrone(pb_creator, raptor, ep, "20150615T110000"_pts, false, {}, {}, {}, sn_worker, nt::RTLevel::Base,
                        3 * 60 * 60);
     auto result = pb_creator.get_response();
-    BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
+    BOOST_REQUIRE_EQUAL(result.journeys_size(), 3);
 
     BOOST_CHECK_EQUAL(result.journeys(0).departure_date_time(), "20150615T082900"_pts);
     BOOST_CHECK_EQUAL(result.journeys(0).arrival_date_time(), "20150615T110000"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).departure_date_time(), "20150615T082600"_pts);
     BOOST_CHECK_EQUAL(result.journeys(1).arrival_date_time(), "20150615T110000"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(2).departure_date_time(), "20150615T082500"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(2).arrival_date_time(), "20150615T110000"_pts);
 
     {
         // We ask the same request with stop_point == center
@@ -1927,10 +1945,12 @@ BOOST_FIXTURE_TEST_CASE(isochrone_duration_limit, isochrone_fixture) {
     nr::make_isochrone(pb_creator, raptor, ep, "20150615T082000"_pts, true, {}, {}, {}, sn_worker, nt::RTLevel::Base,
                        1 * 60 * 60);
     auto result = pb_creator.get_response();
-    BOOST_REQUIRE_EQUAL(result.journeys_size(), 1);
+    BOOST_REQUIRE_EQUAL(result.journeys_size(), 2);
 
     BOOST_CHECK_EQUAL(result.journeys(0).departure_date_time(), "20150615T082000"_pts);
     BOOST_CHECK_EQUAL(result.journeys(0).arrival_date_time(), "20150615T083500"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(1).departure_date_time(), "20150615T082000"_pts);
+    BOOST_CHECK_EQUAL(result.journeys(1).arrival_date_time(), "20150615T084500"_pts);
 }
 
 // test with disruption active


### PR DESCRIPTION
Follow up on https://github.com/CanalTP/navitia/pull/3413
We now penalize the walking duration with the waiting duration : i.e when comparing two journeys, we compare the quantity : 
` 2 * walking_duration + waiting_duration`
So that waiting for 1 more minute means we should reduce the walking duration by at least 30s

Todo : 

- [ ] validate the changes in artemis tests

- [ ] update artemis references

- [ ] update doc in confluence with the new formula


