### PR TITLE
[Jormun] Reduce coord precision for asgard

### DIFF
--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -96,7 +96,7 @@ class Asgard(TransientSocket, Kraken):
     def make_location(self, obj):
         coord = get_pt_object_coord(obj)
         return type_pb2.LocationContext(
-            place="", access_duration=0, lon=round(coord.lon, 6), lat=round(coord.lat, 6)
+            place="", access_duration=0, lon=round(coord.lon, 5), lat=round(coord.lat, 5)
         )
 
     def _get_street_network_routing_matrix(


### PR DESCRIPTION
Stop_points' coordinates may be different from one coverage to another, which means the same stop_points may be cached twice in Asgard's LRU cache. In order to save more RAM, we reduce the precision of stop_points' coords... 