### PR TITLE
Remove artemis launch on github actions

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -58,9 +58,4 @@ jobs:
     - name: run deploy on artemis machine https://jenkins-core.canaltp.fr/job/deploy-navitia
       if: ${{ github.event_name == 'push' }}
       run: http --ignore-stdin -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/deploy-navitia/buildWithParameters PLATFORM=artemis_debian8
-    - name: run artemis on github action
-      uses: mvasigh/dispatch-action@1.1.6
-      with:
-        token: ${{ secrets.ARTEMIS_GITHUB_TOKEN }}
-        repo: artemis
-        event_type: run_artemis_ng
+


### PR DESCRIPTION
Since the corresponding action has been removed in https://github.com/CanalTP/artemis/pull/405