### PR TITLE
kraken: feed publisher name are required, it can not be null

### DIFF
--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -326,6 +326,8 @@ void Worker::metadatas() {
         }
         if (!d->meta->publisher_name.empty()) {
             metadatas->set_name(d->meta->publisher_name);
+        } else {
+            metadatas->set_name("");
         }
         metadatas->set_last_load_at(navitia::to_posix_timestamp(d->last_load_at));
         metadatas->set_dataset_created_at(pt::to_iso_string(d->meta->dataset_created_at));
@@ -350,6 +352,8 @@ void Worker::feed_publisher() {
         pt_feed_publisher->set_id(d->meta->instance_name);
         if (!d->meta->publisher_name.empty()) {
             pt_feed_publisher->set_name(d->meta->publisher_name);
+        } else {
+            pt_feed_publisher->set_name("");
         }
         if (!d->meta->publisher_url.empty()) {
             pt_feed_publisher->set_url(d->meta->publisher_url);


### PR DESCRIPTION
### issue
https://jira.kisio.org/browse/NAVITIAII-3433
into the schema, _feed publisher name_ are **required**... We have no choice to expose it even if it is empty.
```
"Coverage": {
			"required": [
            ----->		"name",
				"shape",
				"id"
			],
			"type": "object",
			"properties": {
				"name": {
					"type": "string",
					"description": "Name of the coverage"
				},
```

### Before/After
![before_fp](https://user-images.githubusercontent.com/32099204/119715241-113ab800-be64-11eb-893e-b42da2b50184.png) -> ![after_fp](https://user-images.githubusercontent.com/32099204/119715256-1435a880-be64-11eb-884c-6ca0e751367a.png)

