### PR TITLE
Jormun: rail section into jormun

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -252,6 +252,7 @@ class ImpactedSerializer(PbNestedSerializer):
     pt_object = PtObjectSerializer(display_none=False)
     impacted_stops = ImpactedStopSerializer(many=True, display_none=False)
     impacted_section = ImpactedSectionSerializer(display_none=False)
+    impacted_rail_section = ImpactedSectionSerializer(display_none=False)
 
 
 class StringListField(Field):

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1448,3 +1448,33 @@ def get_schedule(scs, sp_uri, line_code):
 
 def get_disruption(disruptions, disrupt_id):
     return next((d for d in disruptions if d['id'] == disrupt_id), None)
+
+
+# Looking for (identifiable) objects impacted by 'disruptions' inputed
+def impacted_ids(disruptions):
+    # for the impacted object returns:
+    #  * id
+    #  * or the id of the vehicle_journey for stop_schedule.date_time
+    def get_id(obj):
+        id = obj.impacted_object.get('id')
+        if id is None:
+            # stop_schedule.date_time case
+            assert obj.impacted_object['links'][0]['type'] == 'vehicle_journey'
+            id = obj.impacted_object['links'][0]['id']
+        return id
+
+    ids = set()
+    for d in disruptions.values():
+        ids.update(set(get_id(o) for o in d))
+
+    return ids
+
+
+def impacted_headsigns(disruptions):
+    # for the impacted object returns the headsign (for the display_information field)
+
+    ids = set()
+    for d in disruptions.values():
+        ids.update(set(o.impacted_object.get('headsign') for o in d))
+
+    return ids

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -1150,6 +1150,28 @@ def is_valid_line_section_disruption(disruption):
     is_valid_pt_object(get_not_null(line_section, 'to'))
 
 
+def is_valid_rail_section_disruption(disruption):
+    """
+    a rail section disruption is a classic disruption with it's line as the impacted object
+    and aside this a 'rail_section' section with additional information on the rail section
+    """
+    is_valid_disruption(disruption, chaos_disrup=False)
+
+    rail_section_impacted = next(
+        (
+            d
+            for d in get_not_null(disruption, 'impacted_objects')
+            if d['pt_object']['embedded_type'] == 'line' and d.get('impacted_rail_section')
+        ),
+        None,
+    )
+
+    assert rail_section_impacted
+    rail_section = get_not_null(rail_section_impacted, 'impacted_rail_section')
+    is_valid_pt_object(get_not_null(rail_section, 'from'))
+    is_valid_pt_object(get_not_null(rail_section, 'to'))
+
+
 def is_valid_disruption(disruption, chaos_disrup=True):
     get_not_null(disruption, 'id')
     get_not_null(disruption, 'disruption_id')

--- a/source/jormungandr/tests/line_sections_tests.py
+++ b/source/jormungandr/tests/line_sections_tests.py
@@ -35,38 +35,10 @@ from .check_utils import (
     is_valid_line_section_disruption,
     get_used_vj,
     get_all_element_disruptions,
+    impacted_ids,
+    impacted_headsigns,
 )
 import pytest
-
-
-# Looking for (identifiable) objects impacted by 'disruptions' inputed
-def impacted_ids(disruptions):
-    # for the impacted object returns:
-    #  * id
-    #  * or the id of the vehicle_journey for stop_schedule.date_time
-    def get_id(obj):
-        id = obj.impacted_object.get('id')
-        if id is None:
-            # stop_schedule.date_time case
-            assert obj.impacted_object['links'][0]['type'] == 'vehicle_journey'
-            id = obj.impacted_object['links'][0]['id']
-        return id
-
-    ids = set()
-    for d in disruptions.values():
-        ids.update(set(get_id(o) for o in d))
-
-    return ids
-
-
-def impacted_headsigns(disruptions):
-    # for the impacted object returns the headsign (for the display_information field)
-
-    ids = set()
-    for d in disruptions.values():
-        ids.update(set(o.impacted_object.get('headsign') for o in d))
-
-    return ids
 
 
 @dataset({"line_sections_test": {}})

--- a/source/jormungandr/tests/rail_sections_tests.py
+++ b/source/jormungandr/tests/rail_sections_tests.py
@@ -284,6 +284,23 @@ class TestRailSections(AbstractTestFixture):
         assert False == self.has_disruption(ObjGetter('lines', 'line:2'), 'rail_section_on_line1-3')
         assert False == self.has_disruption(ObjGetter('lines', 'line:2'), 'rail_section_on_line1-3')
 
+    def test_line_reports_impacted_by_line_section(self):
+        r = self.default_query('line_reports')
+        assert len(get_not_null(r, 'disruptions')) == 3
+        is_valid_rail_section_disruption(r['disruptions'][0])
+        is_valid_rail_section_disruption(r['disruptions'][1])
+        is_valid_rail_section_disruption(r['disruptions'][2])
+
+    def test_terminus_schedules_impacted_by_line_section(self):
+        r = self.default_query('lines/line:1/terminus_schedules')
+        assert len(get_not_null(r, 'disruptions')) == 3
+        is_valid_rail_section_disruption(r['disruptions'][0])
+        is_valid_rail_section_disruption(r['disruptions'][1])
+        is_valid_rail_section_disruption(r['disruptions'][2])
+
+        r = self.default_query('lines/line:2/terminus_schedules')
+        assert len(r['disruptions']) == 0
+
     def test_journeys_with_rail_section(self):
         """
         for /journeys, we should display a rail section disruption only if we use an impacted section

--- a/source/jormungandr/tests/rail_sections_tests.py
+++ b/source/jormungandr/tests/rail_sections_tests.py
@@ -1,0 +1,732 @@
+# Copyright (c) 2001-2021, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+from .tests_mechanism import AbstractTestFixture, dataset
+from .check_utils import (
+    ObjGetter,
+    has_disruption,
+    get_not_null,
+    is_valid_line_section_disruption,
+    is_valid_rail_section_disruption,
+    get_used_vj,
+    get_all_element_disruptions,
+)
+import pytest
+
+
+# Looking for (identifiable) objects impacted by 'disruptions' inputed
+def impacted_ids(disruptions):
+    # for the impacted object returns:
+    #  * id
+    #  * or the id of the vehicle_journey for stop_schedule.date_time
+    def get_id(obj):
+        id = obj.impacted_object.get('id')
+        if id is None:
+            # stop_schedule.date_time case
+            assert obj.impacted_object['links'][0]['type'] == 'vehicle_journey'
+            id = obj.impacted_object['links'][0]['id']
+        return id
+
+    ids = set()
+    for d in disruptions.values():
+        ids.update(set(get_id(o) for o in d))
+
+    return ids
+
+
+def impacted_headsigns(disruptions):
+    # for the impacted object returns the headsign (for the display_information field)
+
+    ids = set()
+    for d in disruptions.values():
+        ids.update(set(o.impacted_object.get('headsign') for o in d))
+
+    return ids
+
+
+@dataset({"rail_sections_test": {}})
+class TestRailSections(AbstractTestFixture):
+    def default_query(self, q, **kwargs):
+        """
+        query navitia with a current date in the publication period of the impacts
+        """
+        return self.query_region('{}?_current_datetime=20170101T100000'.format(q), **kwargs)
+
+    def has_disruption(self, object_get, disruption_uri):
+        """
+        Little helper calling the detail of an object and checking it's disruptions
+        """
+        r = self.default_query('{col}/{uri}'.format(col=object_get.collection, uri=object_get.uri))
+        return has_disruption(r, object_get, disruption_uri)
+
+    def has_tf_disruption(self, q, disruption):
+        """
+        checks a disruption is present in traffic report response to the request provided
+        """
+        r = self.default_query(q)
+
+        return any(disruption == d['disruption_id'] for d in r.get('disruptions', []))
+
+    def has_tf_linked_disruption(self, q, disruption, object_get):
+        """
+        checks a disruption is present in traffic report response to
+        the request provided
+        also check that the disruption is linked to the specified object
+        """
+        r = self.default_query(q)
+
+        if not (
+            r.get('disruptions')
+            and r.get('traffic_reports')
+            and r['traffic_reports'][0].get(object_get.collection)
+        ):
+            return False
+
+        if disruption not in [d['disruption_id'] for d in r['disruptions']]:
+            return False
+
+        for obj in r['traffic_reports'][0][object_get.collection]:
+            if obj['id'] == object_get.uri:
+                return any(disruption == link['id'] for link in obj.get('links', []))
+
+        return False
+
+    def has_dis(self, q, disruption_label):
+        r = self.default_query(q)
+        return disruption_label in (d['disruption_id'] for d in r['disruptions'])
+
+    def test_disruption_api_with_rail_section(self):
+        r = self.default_query('disruptions')
+        assert len(get_not_null(r, 'disruptions')) == 3
+        assert r['disruptions'][0]['id'] == 'rail_section_on_line1-1'
+        assert r['disruptions'][1]['id'] == 'rail_section_on_line1-2'
+        assert r['disruptions'][2]['id'] == 'rail_section_on_line1-3'
+
+    def test_stop_points_api_with_rail_section(self):
+        r = self.default_query('stop_points/stopC')
+        assert len(get_not_null(r, 'disruptions')) == 2
+        is_valid_rail_section_disruption(r['disruptions'][0])
+        is_valid_rail_section_disruption(r['disruptions'][1])
+
+    def test_on_stop_areas(self):
+        """
+        the rail section disruption is not linked to a stop area, we cannot directly find our disruption
+        """
+        for disruption_label in [
+            'rail_section_on_line1-1',
+            'rail_section_on_line1-2',
+            'rail_section_on_line1-3',
+        ]:
+            for stop_area in [
+                'stopAreaA',
+                'stopAreaB',
+                'stopAreaC',
+                'stopAreaD',
+                'stopAreaE',
+                'stopAreaF',
+                'stopAreaG',
+                'stopAreaH',
+                'stopAreaI',
+                'stopAreaJ',
+                'stopAreaK',
+                'stopAreaL',
+                'stopAreaM',
+                'stopAreaN',
+                'stopAreaO',
+                'stopAreaP',
+                'stopAreaQ',
+                'stopAreaR',
+            ]:
+                assert not self.has_disruption(ObjGetter('stop_areas', stop_area), disruption_label)
+
+    def test_on_stop_points(self):
+        """
+        the rail section disruption should be linked to the impacted stop_points
+        """
+        scenario = {
+            'stopA': False,
+            'stopB': True,
+            'stopC': True,
+            'stopD': True,
+            'stopE': True,
+            'stopF': False,
+            'stopG': False,
+            'stopH': False,
+            'stopI': False,
+            'stopJ': False,
+            'stopK': False,
+            'stopL': False,
+            'stopM': False,
+            'stopN': False,
+            'stopO': False,
+            'stopP': False,
+            'stopQ': False,
+            'stopR': False,
+        }
+        for stop_point, result in scenario.items():
+            assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'rail_section_on_line1-1')
+
+        scenario = {
+            'stopA': False,
+            'stopB': True,
+            'stopC': True,
+            'stopD': True,
+            'stopE': False,
+            'stopF': False,
+            'stopG': False,
+            'stopH': False,
+            'stopI': False,
+            'stopJ': False,
+            'stopK': False,
+            'stopL': False,
+            'stopM': True,
+            'stopN': True,
+            'stopO': True,
+            'stopP': False,
+            'stopQ': False,
+            'stopR': False,
+        }
+        for stop_point, result in scenario.items():
+            assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'rail_section_on_line1-2')
+
+        scenario = {
+            'stopA': False,
+            'stopB': False,
+            'stopC': False,
+            'stopD': False,
+            'stopE': False,
+            'stopF': False,
+            'stopG': False,
+            'stopH': False,
+            'stopI': False,
+            'stopJ': False,
+            'stopK': False,
+            'stopL': False,
+            'stopM': False,
+            'stopN': False,
+            'stopO': False,
+            'stopP': True,
+            'stopQ': True,
+            'stopR': True,
+        }
+        for stop_point, result in scenario.items():
+            assert result == self.has_disruption(ObjGetter('stop_points', stop_point), 'rail_section_on_line1-3')
+
+    def test_on_vehicle_journeys(self):
+        """
+        the rail section disruption should be linked to the impacted vehicle journeys
+        """
+
+        scenario = {
+            'vehicle_journey:vj:1': True,
+            'vehicle_journey:vj:2': False,
+            'vehicle_journey:vj:3': False,
+            'vehicle_journey:vj:4': False,
+            'vehicle_journey:vj:5': False,
+            'vehicle_journey:vj:6': False,
+        }
+        for vj, result in scenario.items():
+            assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'rail_section_on_line1-1')
+
+        scenario = {
+            'vehicle_journey:vj:1': False,
+            'vehicle_journey:vj:2': False,
+            'vehicle_journey:vj:3': False,
+            'vehicle_journey:vj:4': True,
+            'vehicle_journey:vj:5': False,
+            'vehicle_journey:vj:6': False,
+        }
+        for vj, result in scenario.items():
+            assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'rail_section_on_line1-2')
+
+        scenario = {
+            'vehicle_journey:vj:1': False,
+            'vehicle_journey:vj:2': False,
+            'vehicle_journey:vj:3': False,
+            'vehicle_journey:vj:4': False,
+            'vehicle_journey:vj:5': True,
+            'vehicle_journey:vj:6': False,
+        }
+        for vj, result in scenario.items():
+            assert result == self.has_disruption(ObjGetter('vehicle_journeys', vj), 'rail_section_on_line1-3')
+
+    def test_line_impacted_by_line_section(self):
+        assert True == self.has_disruption(ObjGetter('lines', 'line:1'), 'rail_section_on_line1-1')
+        assert True == self.has_disruption(ObjGetter('lines', 'line:1'), 'rail_section_on_line1-2')
+        assert True == self.has_disruption(ObjGetter('lines', 'line:1'), 'rail_section_on_line1-3')
+        assert False == self.has_disruption(ObjGetter('lines', 'line:2'), 'rail_section_on_line1-3')
+        assert False == self.has_disruption(ObjGetter('lines', 'line:2'), 'rail_section_on_line1-3')
+        assert False == self.has_disruption(ObjGetter('lines', 'line:2'), 'rail_section_on_line1-3')
+
+    def test_journeys_with_rail_section(self):
+        """
+        for /journeys, we should display a rail section disruption only if we use an impacted section
+
+        We do all the calls as base_schedule to see the disruption but not be really impacted by them
+
+        In this test we leave at 08:00 so we'll use vj:1:1 (that is impacted) during the application
+        period of the impact
+        """
+        # with this departure time we should take 'vj:1:1' that is impacted
+        date = '20170102T080000'
+        current = '_current_datetime=20170101T080000'
+
+        def journey_query(_from, to):
+            return 'journeys?from={fr}&to={to}&datetime={dt}&{cur}&data_freshness=base_schedule'.format(
+                fr=_from, to=to, dt=date, cur=current
+            )
+
+        def journeys(_from, to):
+            q = journey_query(_from=_from, to=to)
+            r = self.query_region(q)
+            self.is_valid_journey_response(r, q)
+            return r
+
+        # stopI -> stopG
+        scenario = {
+            'rail_section_on_line1-1': False,
+            'rail_section_on_line1-2': False,
+            'rail_section_on_line1-3': False,
+        }
+
+        # There is no impact on stopI->stopG with vj:2
+        r = journeys(_from='stopI', to='stopG')
+        assert get_used_vj(r) == [['vehicle_journey:vj:2']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert not impacted_headsigns(d)
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # stopE -> stopF
+        scenario = {
+            'rail_section_on_line1-1': True,
+            'rail_section_on_line1-2': False,
+            'rail_section_on_line1-3': False,
+        }
+
+        r = journeys(_from='stopE', to='stopF')
+        assert get_used_vj(r) == [['vehicle_journey:vj:1']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:1'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # stopM -> stopO
+        scenario = {
+            'rail_section_on_line1-1': False,
+            'rail_section_on_line1-2': True,
+            'rail_section_on_line1-3': False,
+        }
+
+        r = journeys(_from='stopM', to='stopO')
+        assert get_used_vj(r) == [['vehicle_journey:vj:4']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:4'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # stopA -> stopR
+        scenario = {
+            'rail_section_on_line1-1': False,
+            'rail_section_on_line1-2': False,
+            'rail_section_on_line1-3': True,
+        }
+
+        r = journeys(_from='stopA', to='stopR')
+        assert get_used_vj(r) == [['vehicle_journey:vj:5']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:5'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+    def test_traffic_reports_on_stop_areas(self):
+        """
+        we should be able to find the related rail section disruption with /traffic_report
+        """
+
+        # rail_section_on_line1-1
+        scenario = {
+            'stopAreaA': False,
+            'stopAreaB': True,
+            'stopAreaC': True,
+            'stopAreaD': True,
+            'stopAreaE': True,
+            'stopAreaF': False,
+            'stopAreaG': False,
+            'stopAreaH': False,
+            'stopAreaI': False,
+        }
+
+        for sa, result in scenario.items():
+            assert result == self.has_tf_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa), 'rail_section_on_line1-1'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa),
+                'rail_section_on_line1-1',
+                ObjGetter('stop_areas', sa),
+            )
+
+        # rail_section_on_line1-2
+        scenario = {
+            'stopAreaA': False,
+            'stopAreaB': True,
+            'stopAreaC': True,
+            'stopAreaD': True,
+            'stopAreaM': True,
+            'stopAreaN': True,
+            'stopAreaO': True,
+            'stopAreaG': False,
+            'stopAreaH': False,
+            'stopAreaI': False,
+        }
+
+        for sa, result in scenario.items():
+            assert result == self.has_tf_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa), 'rail_section_on_line1-2'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa),
+                'rail_section_on_line1-2',
+                ObjGetter('stop_areas', sa),
+            )
+
+        # rail_section_on_line1-3
+        scenario = {
+            'stopAreaA': False,
+            'stopAreaB': False,
+            'stopAreaC': False,
+            'stopAreaP': True,
+            'stopAreaQ': True,
+            'stopAreaR': True,
+        }
+
+        for sa, result in scenario.items():
+            assert result == self.has_tf_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa), 'rail_section_on_line1-3'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_areas/{}/traffic_reports'.format(sa),
+                'rail_section_on_line1-3',
+                ObjGetter('stop_areas', sa),
+            )
+
+    def test_traffic_reports_on_networks(self):
+        for disruption_label in [
+            'rail_section_on_line1-1',
+            'rail_section_on_line1-2',
+            'rail_section_on_line1-3',
+        ]:
+            assert self.has_dis('networks/base_network/traffic_reports', disruption_label)
+
+        r = self.default_query('traffic_reports')
+        # only one network (base_network) is disrupted
+        assert len(r['traffic_reports']) == 1
+        assert len(r['traffic_reports'][0]['stop_areas']) == 10
+
+        for sa in r['traffic_reports'][0]['stop_areas']:
+            if sa['id'] in ['stopAreaB', 'stopAreaC', 'stopAreaD']:
+                assert len(sa['links']) == 2
+        for sa in r['traffic_reports'][0]['stop_areas']:
+            if sa['id'] in [
+                'stopAreaE',
+                'stopAreaM',
+                'stopAreaN',
+                'stopAreaO',
+                'stopAreaP',
+                'stopAreaQ',
+                'stopAreaR',
+            ]:
+                assert len(sa['links']) == 1
+
+    def test_traffic_reports_on_vjs(self):
+        """
+        for /traffic_reports on vjs it's a bit the same as the lines
+        we display a rail section disruption if it impacts the stops of the vj
+        """
+        # all VJ are imapcted because they all have stopB with an impact
+        scenario = {
+            'vehicle_journey:vj:1': True,
+            'vehicle_journey:vj:2': True,
+            'vehicle_journey:vj:3': True,
+            'vehicle_journey:vj:4': True,
+            'vehicle_journey:vj:5': True,
+            'vehicle_journey:vj:6': True,
+        }
+
+        for disruption_label in [
+            'rail_section_on_line1-1',
+            'rail_section_on_line1-2',
+            # 'rail_section_on_line1-3',
+        ]:
+            for vj, result in scenario.items():
+                assert result == self.has_dis('vehicle_journeys/{}/traffic_reports'.format(vj), disruption_label)
+
+        scenario = {
+            'vehicle_journey:vj:1': False,
+            'vehicle_journey:vj:2': False,
+            'vehicle_journey:vj:3': False,
+            'vehicle_journey:vj:4': False,
+            'vehicle_journey:vj:5': True,
+            'vehicle_journey:vj:6': True,
+        }
+        for vj, result in scenario.items():
+            assert result == self.has_dis(
+                'vehicle_journeys/{}/traffic_reports'.format(vj), 'rail_section_on_line1-3'
+            )
+
+    def test_traffic_reports_on_stop_points(self):
+        """
+        for /traffic_reports on stop_points there is a rail section disruption link if it impacts the stop_point
+        """
+
+        # rail_section_on_line1-1
+        scenario = {
+            'stopA': False,
+            'stopB': True,
+            'stopC': True,
+            'stopD': True,
+            'stopE': True,
+            'stopF': False,
+            'stopG': False,
+            'stopH': False,
+            'stopI': False,
+            'stopJ': False,
+            'stopK': False,
+            'stopL': False,
+            'stopM': False,
+            'stopN': False,
+            'stopO': False,
+            'stopP': False,
+            'stopQ': False,
+            'stopR': False,
+        }
+        for sp, result in scenario.items():
+            sa = sp[0:4] + 'Area' + sp[-1]
+            assert result == self.has_tf_disruption(
+                'stop_points/{}/traffic_reports'.format(sp), 'rail_section_on_line1-1'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_points/{}/traffic_reports'.format(sp),
+                'rail_section_on_line1-1',
+                ObjGetter('stop_areas', sa),
+            )
+
+        # rail_section_on_line1-2
+        scenario = {
+            'stopA': False,
+            'stopB': True,
+            'stopC': True,
+            'stopD': True,
+            'stopE': False,
+            'stopF': False,
+            'stopG': False,
+            'stopH': False,
+            'stopI': False,
+            'stopJ': False,
+            'stopK': False,
+            'stopL': False,
+            'stopM': True,
+            'stopN': True,
+            'stopO': True,
+            'stopP': False,
+            'stopQ': False,
+            'stopR': False,
+        }
+        for sp, result in scenario.items():
+            sa = sp[0:4] + 'Area' + sp[-1]
+            assert result == self.has_tf_disruption(
+                'stop_points/{}/traffic_reports'.format(sp), 'rail_section_on_line1-2'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_points/{}/traffic_reports'.format(sp),
+                'rail_section_on_line1-2',
+                ObjGetter('stop_areas', sa),
+            )
+
+        # rail_section_on_line1-3
+        scenario = {
+            'stopA': False,
+            'stopB': False,
+            'stopC': False,
+            'stopD': False,
+            'stopE': False,
+            'stopF': False,
+            'stopG': False,
+            'stopH': False,
+            'stopI': False,
+            'stopJ': False,
+            'stopK': False,
+            'stopL': False,
+            'stopM': False,
+            'stopN': False,
+            'stopO': False,
+            'stopP': True,
+            'stopQ': True,
+            'stopR': True,
+        }
+        for sp, result in scenario.items():
+            sa = sp[0:4] + 'Area' + sp[-1]
+            assert result == self.has_tf_disruption(
+                'stop_points/{}/traffic_reports'.format(sp), 'rail_section_on_line1-3'
+            )
+            assert result == self.has_tf_linked_disruption(
+                'stop_points/{}/traffic_reports'.format(sp),
+                'rail_section_on_line1-3',
+                ObjGetter('stop_areas', sa),
+            )
+
+    def test_traffic_reports_on_routes(self):
+        """
+        for routes since we display the impacts on all the stops (but we do not display a route object)
+        we display the disruption even if the route has not been directly impacted
+        """
+        scenario = {
+            'route1': True,
+            'route2': True,
+            'route3': True,
+            'route4': True,
+            'route5': True,
+            'route6': True,
+            'route2-1': False,
+        }
+        for route, result in scenario.items():
+            assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'rail_section_on_line1-1')
+
+        scenario = {
+            'route1': True,
+            'route2': True,
+            'route3': True,
+            'route4': True,
+            'route5': True,
+            'route6': True,
+            'route2-1': False,
+        }
+        for route, result in scenario.items():
+            assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'rail_section_on_line1-2')
+
+        scenario = {
+            'route1': False,
+            'route2': False,
+            'route3': False,
+            'route4': False,
+            'route5': True,
+            'route6': True,
+            'route2-1': False,
+        }
+        for route, result in scenario.items():
+            assert result == self.has_dis('routes/{}/traffic_reports'.format(route), 'rail_section_on_line1-3')
+
+    def test_route_schedule_impacted_by_line_section(self):
+        cur = '_current_datetime=20170101T100000'
+        dt = 'from_datetime=20170101T080000'
+        fresh = 'data_freshness=base_schedule'
+        query = 'lines/{l}/departures?{cur}&{d}&{f}'
+
+        # line:1
+        scenario = {
+            'rail_section_on_line1-1': True,
+            'rail_section_on_line1-2': True,
+            'rail_section_on_line1-3': True,
+        }
+        r = self.query_region(query.format(l='line:1', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['departures'], r)
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+        assert impacted_headsigns(d) == {'vj:1', 'vj:4', 'vj:5'}
+
+        # line:2
+        scenario = {
+            'rail_section_on_line1-1': False,
+            'rail_section_on_line1-2': False,
+            'rail_section_on_line1-3': False,
+        }
+        r = self.query_region(query.format(l='line:2', cur=cur, d=dt, f=fresh))
+        d = get_all_element_disruptions(r['departures'], r)
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+    def test_stops_schedules_and_departures_impacted_by_line_section(self):
+        """
+        For /departures we display rail section impact if the stoppoint is part of a line section impact
+        """
+        cur = '_current_datetime=20170101T100000'
+        dt = 'from_datetime=20170101T080000'
+        fresh = 'data_freshness=base_schedule'
+        query = 'stop_areas/{sa}/{q}?{cur}&{d}&{f}'
+
+        for q in ['departures', 'stop_schedules']:
+            # stopAreaA
+            scenario = {
+                'rail_section_on_line1-1': True,
+                'rail_section_on_line1-2': True,
+                'rail_section_on_line1-3': True,
+            }
+            r = self.query_region(query.format(sa='stopAreaA', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.items():
+                assert result == (disruption in d)
+            if q == 'departures':
+                assert impacted_headsigns(d) == {'vj:1', 'vj:4', 'vj:5'}
+            if q == 'stop_schedules':
+                assert impacted_ids(d) == {
+                    'vehicle_journey:vj:1',
+                    'vehicle_journey:vj:4',
+                    'vehicle_journey:vj:5',
+                }
+
+            # stopAreaM
+            scenario = {
+                'rail_section_on_line1-1': False,
+                'rail_section_on_line1-2': True,
+                'rail_section_on_line1-3': False,
+            }
+            r = self.query_region(query.format(sa='stopAreaM', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.items():
+                assert result == (disruption in d)
+            if q == 'departures':
+                assert impacted_headsigns(d) == {'vj:4'}
+            if q == 'stop_schedules':
+                assert impacted_ids(d) == {'vehicle_journey:vj:4'}
+
+            # stopAreaQ
+            scenario = {
+                'rail_section_on_line1-1': False,
+                'rail_section_on_line1-2': False,
+                'rail_section_on_line1-3': True,
+            }
+            r = self.query_region(query.format(sa='stopAreaQ', cur=cur, d=dt, f=fresh, q=q))
+            d = get_all_element_disruptions(r[q], r)
+            for disruption, result in scenario.items():
+                assert result == (disruption in d)
+            if q == 'departures':
+                assert impacted_headsigns(d) == {'vj:5'}
+            if q == 'stop_schedules':
+                assert impacted_ids(d) == {'vehicle_journey:vj:5'}

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -271,11 +271,11 @@ boost::optional<nt::disruption::RailSection> make_rail_section(const chaos::PtOb
             return boost::none;
         }
         if (!pb_section.has_line()) {
-            auto* route = find_or_default(pb_section.routes()[0].uri(), pt_data.routes_map);
+            auto* route = find_or_default(pb_section.routes().Get(0).uri(), pt_data.routes_map);
             if (route) {
                 rail_section.line = route->line;
             } else {
-                LOG4CPLUS_WARN(log, "fill_disruption_from_chaos: route id " << pb_section.routes()[0].uri()
+                LOG4CPLUS_WARN(log, "fill_disruption_from_chaos: route id " << pb_section.routes().Get(0).uri()
                                                                             << " in RailSection invalid!");
             }
         }

--- a/source/kraken/make_disruption_from_chaos.h
+++ b/source/kraken/make_disruption_from_chaos.h
@@ -54,6 +54,8 @@ void make_and_apply_disruption(const chaos::Disruption& chaos_disruption,
 
 boost::optional<type::disruption::LineSection> make_line_section(const chaos::PtObject& chaos_section,
                                                                  type::PT_Data& pt_data);
+boost::optional<type::disruption::RailSection> make_rail_section(const chaos::PtObject& chaos_section,
+                                                                 type::PT_Data& pt_data);
 
 bool is_publishable(const transit_realtime::TimeRange& publication_period,
                     boost::posix_time::time_period production_period);

--- a/source/ptreferential/ptreferential_api.cpp
+++ b/source/ptreferential/ptreferential_api.cpp
@@ -50,7 +50,8 @@ static void extract_data(navitia::PbCreator& pb_creator,
                          const type::Indexes& rows,
                          const int depth) {
     pb_creator.action_period = data.meta->production_period();
-    const auto with_line_sections = DumpMessageOptions{DumpMessage::Yes, DumpLineSectionMessage::Yes};
+    auto with_line_sections = DumpMessageOptions{DumpMessage::Yes, DumpLineSectionMessage::Yes};
+    with_line_sections.dump_rail_section = DumpRailSectionMessage::Yes;
     switch (requested_type) {
         case Type_e::ValidityPattern:
             pb_creator.pb_fill(data.get_data<nt::ValidityPattern>(rows), depth);

--- a/source/scripts/disruption/disruptor.py
+++ b/source/scripts/disruption/disruptor.py
@@ -219,7 +219,6 @@ class Disruption(object):
                 oPtObj = rail_section.blocked_stop_areas.add()
                 oPtObj.uri = bsa[0]
                 oPtObj.order = bsa[1]
-                rail_section.blocked_stop_areas.append(oPtObj)
 
         # Message with one channel and two channel types: web
         message = impact.messages.add()

--- a/source/scripts/disruption/disruptor.py
+++ b/source/scripts/disruption/disruptor.py
@@ -210,6 +210,16 @@ class Disruption(object):
             pb_end = rail_section.end_point
             pb_end.uri = self.impacted_obj.end
             pb_end.pt_object_type = chaos_pb2.PtObject.stop_area
+            for route_uri in self.impacted_obj.routes:
+                ptobject_rs = impact.informed_entities.add()
+                ptobject_rs.uri = route_uri
+                ptobject_rs.pt_object_type = chaos_pb2.PtObject.route
+                rail_section.routes.append(ptobject_rs)
+            for bsa in self.impacted_obj.blocked_stop_areas:
+                oPtObj = rail_section.blocked_stop_areas.add()
+                oPtObj.uri = bsa[0]
+                oPtObj.order = bsa[1]
+                rail_section.blocked_stop_areas.append(oPtObj)
 
         # Message with one channel and two channel types: web
         message = impact.messages.add()

--- a/source/tests/mock-kraken/CMakeLists.txt
+++ b/source/tests/mock-kraken/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(null_status_test null_status_test.cpp)
 add_executable(main_routing_without_pt_test main_routing_without_pt_test.cpp)
 add_executable(multiple_schedules multiple_schedules.cpp)
 add_executable(line_sections_test line_sections_test.cpp)
+add_executable(rail_sections_test rail_sections_test.cpp)
 add_executable(timezone_cape_verde_test timezone_cape_verde_test.cpp)
 add_executable(timezone_hong_kong_test timezone_hong_kong_test.cpp)
 
@@ -39,6 +40,7 @@ add_custom_target(integration_tests_bin DEPENDS main_routing_test
                                                 main_routing_without_pt_test
                                                 multiple_schedules
                                                 line_sections_test
+                                                rail_sections_test
                                                 timezone_cape_verde_test
                                                 timezone_hong_kong_test)
 
@@ -56,5 +58,6 @@ target_link_libraries(null_status_test ${ALL_LIBS})
 target_link_libraries(main_routing_without_pt_test ${ALL_LIBS})
 target_link_libraries(multiple_schedules ${ALL_LIBS})
 target_link_libraries(line_sections_test ${ALL_LIBS})
+target_link_libraries(rail_sections_test ${ALL_LIBS})
 target_link_libraries(timezone_cape_verde_test ${ALL_LIBS})
 target_link_libraries(timezone_hong_kong_test ${ALL_LIBS})

--- a/source/tests/mock-kraken/rail_sections_test.cpp
+++ b/source/tests/mock-kraken/rail_sections_test.cpp
@@ -1,0 +1,184 @@
+/* Copyright © 2001-2021, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "utils/init.h"
+#include "ed/build_helper.h"
+#include "kraken/apply_disruption.h"
+#include "mock_kraken.h"
+#include "tests/utils_test.h"
+
+namespace bg = boost::gregorian;
+using btp = boost::posix_time::time_period;
+
+ed::builder create_complex_data_for_rail_section() {
+    /*
+     *
+     *          |------- J ------ K ------ L --------
+     *          |                                   |
+     *          |                                   |
+     * A x----- B ------ C ------ D ------ E ------ F ------ G ------ H -----x I
+     *                   |        |                          |
+     *                   |        |                          |
+     *                   |        |                          |
+     *                   |        |------- M ------ N ------ O
+     *                   |
+     *                   P ------ Q -----x R
+     *
+     * route 1 : A B C D E F G H I
+     * route 2 : I H G F E D C B A
+     * route 3 : A B J K L F G H I
+     * route 4 : A B C D M N O G H I
+     * route 5 : A B C P Q R
+     * route 6 : R Q P C B A
+     *
+     */
+    ed::builder b("20170101", [](ed::builder& b) {
+        b.sa("stopAreaA", 0., 1.)("stopA", 0., 1.);
+        b.sa("stopAreaB", 0., 2.)("stopB", 0., 2.);
+        b.sa("stopAreaC", 0., 3.)("stopC", 0., 3.);
+        b.sa("stopAreaD", 0., 4.)("stopD", 0., 4.);
+        b.sa("stopAreaE", 0., 5.)("stopE", 0., 5.);
+        b.sa("stopAreaF", 0., 6.)("stopF", 0., 6.);
+        b.sa("stopAreaG", 0., 7.)("stopG", 0., 7.);
+        b.sa("stopAreaH", 0., 8.)("stopH", 0., 8.);
+        b.sa("stopAreaI", 0., 9.)("stopI", 0., 9.);
+        b.sa("stopAreaJ", 0., 10.)("stopJ", 0., 10.);
+        b.sa("stopAreaK", 0., 11.)("stopK", 0., 11.);
+        b.sa("stopAreaL", 0., 12.)("stopL", 0., 12.);
+        b.sa("stopAreaM", 0., 13.)("stopM", 0., 13.);
+        b.sa("stopAreaN", 0., 14.)("stopN", 0., 14.);
+        b.sa("stopAreaO", 0., 15.)("stopO", 0., 15.);
+        b.sa("stopAreaP", 0., 16.)("stopP", 0., 16.);
+        b.sa("stopAreaQ", 0., 17.)("stopQ", 0., 17.);
+        b.sa("stopAreaR", 0., 18.)("stopR", 0., 18.);
+        b.sa("stopAreaW", 0., 15.)("stopW", 0., 15.);
+        b.sa("stopAreaX", 0., 16.)("stopX", 0., 16.);
+        b.sa("stopAreaY", 0., 17.)("stopY", 0., 17.);
+        b.sa("stopAreaZ", 0., 18.)("stopZ", 0., 18.);
+        b.vj("line:1", "111111", "", true, "vj:1")
+            .route("route1")("stopA", "08:00"_t)("stopB", "08:05"_t)("stopC", "08:10"_t)("stopD", "08:15"_t)(
+                "stopE", "08:20"_t)("stopF", "08:25"_t)("stopG", "08:30"_t)("stopH", "08:35"_t)("stopI", "08:40"_t);
+        b.vj("line:1", "111111", "", true, "vj:2")
+            .route("route2")("stopI", "08:00"_t)("stopH", "08:05"_t)("stopG", "08:10"_t)("stopF", "08:15"_t)(
+                "stopE", "08:20"_t)("stopD", "08:25"_t)("stopC", "08:30"_t)("stopB", "08:35"_t)("stopA", "08:40"_t);
+        b.vj("line:1", "111111", "", true, "vj:3")
+            .route("route3")("stopA", "08:00"_t)("stopB", "08:05"_t)("stopJ", "08:10"_t)("stopK", "08:15"_t)(
+                "stopL", "08:20"_t)("stopF", "08:25"_t)("stopG", "08:30"_t)("stopH", "08:35"_t)("stopI", "08:40"_t);
+        b.vj("line:1", "111111", "", true, "vj:4")
+            .route("route4")("stopA", "08:00"_t)("stopB", "08:05"_t)("stopC", "08:10"_t)("stopD", "08:15"_t)(
+                "stopM", "08:20"_t)("stopN", "08:25"_t)("stopO", "08:30"_t)("stopG", "08:35"_t)("stopH", "08:40"_t)(
+                "stopI", "08:40"_t);
+        b.vj("line:1", "111111", "", true, "vj:5")
+            .route("route5")("stopA", "08:00"_t)("stopB", "08:05"_t)("stopC", "08:10"_t)("stopP", "08:15"_t)(
+                "stopQ", "08:20"_t)("stopR", "08:25"_t);
+        b.vj("line:1", "111111", "", true, "vj:6")
+            .route("route6")("stopR", "08:00"_t)("stopQ", "08:05"_t)("stopP", "08:10"_t)("stopC", "08:15"_t)(
+                "stopB", "08:20"_t)("stopA", "08:25"_t);
+        b.vj("line:2", "111111", "", true, "vj:2-1")
+            .route("route2-1")("stopW", "08:00"_t)("stopX", "08:05"_t)("stopY", "08:10"_t)("stopZ", "08:15"_t);
+    });
+
+    b.data->meta->production_date = bg::date_period(bg::date(2017, 1, 1), bg::days(30));
+
+    return b;
+}
+
+int main(int argc, const char* const argv[]) {
+    navitia::init_app();
+
+    /**
+     * We want to impact like this
+
+
+              |------- J ------ K ------ L --------
+              |                                   |
+              |        X        X        X        |
+     A x----- B ------ C ------ D ------ E ------ F ------ G ------ H -----x I
+                       |        |                          |
+                       |        |                          |
+                       |        |                          |
+                       |        |------- M ------ N ------ O
+                       |                 X        X        X
+                       |
+                       P ------ Q -----x R
+                       X        X      X
+
+       X -> SA blocked : C-D-E-M-N-O-P-Q-R
+
+       It can be the representation of a broken rail between B and C for all routes with B-C section
+
+       We can't do this with a single disruption. We need 3 Disruptions :
+       -> route1 - start_point B - End point E - blocked_stop_areas C D
+       -> route4 - start_point B - End point O - blocked_stop_areas C D M N
+       -> route5 - start_point P - End point R - blocked_stop_areas Q
+    */
+    ed::builder b = create_complex_data_for_rail_section();
+
+    b.make();
+    b.build_autocomplete();
+
+    // new rail_section disruption on route 1
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line1-1")
+                                  .severity(nt::disruption::Effect::NO_SERVICE)
+                                  .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                                  .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                                  .on_rail_section("line:1", "stopAreaB", "stopAreaE",
+                                                   {
+                                                       std::make_pair("stopAreaC", 1),
+                                                       std::make_pair("stopAreaD", 2),
+                                                   },
+                                                   {"route1"}, *b.data->pt_data)
+                                  .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+    // new rail_section disruption on route 4
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line1-2")
+                                  .severity(nt::disruption::Effect::NO_SERVICE)
+                                  .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                                  .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                                  .on_rail_section("line:1", "stopAreaB", "stopAreaO",
+                                                   {std::make_pair("stopAreaC", 1), std::make_pair("stopAreaD", 2),
+                                                    std::make_pair("stopAreaM", 3), std::make_pair("stopAreaN", 4)},
+                                                   {"route4"}, *b.data->pt_data)
+                                  .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+    // new rail_section disruption on route 5
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line1-3")
+                                  .severity(nt::disruption::Effect::NO_SERVICE)
+                                  .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                                  .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                                  .on_rail_section("line:1", "stopAreaP", "stopAreaR", {std::make_pair("stopAreaQ", 1)},
+                                                   {"route5"}, *b.data->pt_data)
+                                  .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    mock_kraken kraken(b, argc, argv);
+
+    return 0;
+}

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -472,6 +472,9 @@ bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
     // line section not relevant
     auto line_section_impacted_obj_it = boost::find_if(
         informed_entities(), [](const PtObj& ptobj) { return boost::get<LineSection>(&ptobj) != nullptr; });
+    // rail section not relevant
+    auto rail_section_impacted_obj_it = boost::find_if(
+        informed_entities(), [](const PtObj& ptobj) { return boost::get<RailSection>(&ptobj) != nullptr; });
     if (line_section_impacted_obj_it != informed_entities().end()) {
         // note in this we take the premise that an impact
         // cannot impact a line section AND a vj
@@ -486,29 +489,12 @@ bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
             }
         }
         return false;
+    } else if (rail_section_impacted_obj_it != informed_entities().end()) {
+        return true;
+    } else {
+        // else, no reason to not be interested by it
+        return true;
     }
-
-    // rail section not relevant
-    auto rail_section_impacted_obj_it = boost::find_if(
-        informed_entities(), [](const PtObj& ptobj) { return boost::get<RailSection>(&ptobj) != nullptr; });
-    if (rail_section_impacted_obj_it != informed_entities().end()) {
-        // note in this we take the premise that an impact
-        // cannot impact a line section AND a vj
-
-        // if the origin or the destination is impacted by the same impact
-        // it means the section is impacted
-        for (const auto& st : {stop_times.front(), stop_times.back()}) {
-            for (const auto& sp_message : st->stop_point->get_impacts()) {
-                if (sp_message.get() == this) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    // else, no reason to not be interested by it
-    return true;
 }
 
 bool Impact::is_only_line_section() const {

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -251,9 +251,11 @@ std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const RailSection& rs,
     };
 
     for (const auto* route : routes) {
-        if (!is_route_to_impact_content_sa_list(blocked_sa_uri_sequence.first, route->stop_area_list)) {
-            continue;
-        }
+        // TODO : fix the stop_area_list issue
+        // The list is empty
+        // if (!is_route_to_impact_content_sa_list(blocked_sa_uri_sequence.first, route->stop_area_list)) {
+        // continue;
+        //}
 
         // Loop on each vj
         route->for_each_vehicle_journey(apply_impacts_on_vj);
@@ -614,9 +616,11 @@ std::set<StopPoint*> get_stop_points_section(const RailSection& rs) {
     }
     auto blocked_sa_uri_sequence = create_blocked_sa_sequence(rs);
     for (const auto* route : routes) {
-        if (!is_route_to_impact_content_sa_list(blocked_sa_uri_sequence.first, route->stop_area_list)) {
-            continue;
-        }
+        // TODO : fix the stop_area_list issue
+        // The list is empty
+        // if (!is_route_to_impact_content_sa_list(blocked_sa_uri_sequence.first, route->stop_area_list)) {
+        // continue;
+        //}
         route->for_each_vehicle_journey([&](const VehicleJourney& vj) {
             auto ranks = vj.get_sections_ranks(rs.start_point, rs.end_point);
             if ((!ranks.empty() && rs.blocked_stop_areas.empty())


### PR DESCRIPTION
Following the work within _kraken_ ([PR](https://github.com/CanalTP/navitia/pull/3447)), we have to complete **Jormungandr** to expose _rail_section disruption_

I chose to do like **line_section**. There is a [full test file](https://github.com/CanalTP/navitia/blob/dev/source/jormungandr/tests/line_sections_tests.py) that can inspire us.
finally, rail section tests cover, API:
- journeys
- route_schedule
- stop_schedules
- traffic_report
- departures
- disruptions
- stop_points
- stop areas
- vehicle_journeys
- line_reports
- terminus_schedules

for the occasion, a complete network is created, see tests :
```
              |------- J ------ K ------ L --------
              |                                   |
              |        X        X        X        |
     A x----- B ------ C ------ D ------ E ------ F ------ G ------ H -----x I
                       |        |                          |
                       |        |                          |
                       |        |                          |
                       |        |------- M ------ N ------ O
                       |                 X        X        X
                       |
                       P ------ Q -----x R
                       X        X      X

X is an impact
```

Extra : 

- update disruptor with all rail section options
- Add the retreiving of rabbit msg for rail section