### PR TITLE
Filter disruption on current status 

### DIFF
--- a/source/disruption/line_reports_api.h
+++ b/source/disruption/line_reports_api.h
@@ -31,6 +31,9 @@ www.navitia.io
 #pragma once
 #include "type/data.h"
 #include "type/pb_converter.h"
+#include "type/message.h"
+
+namespace nt = navitia::type;
 
 namespace navitia {
 namespace disruption {
@@ -42,6 +45,7 @@ void line_reports(navitia::PbCreator& pb_creator,
                   size_t start_page,
                   const std::string& filter,
                   const std::vector<std::string>& forbidden_uris,
+                  const std::vector<nt::disruption::ActiveStatus>& filter_status,
                   const boost::optional<boost::posix_time::ptime>& since,
                   const boost::optional<boost::posix_time::ptime>& until);
 }  // namespace disruption

--- a/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/LineReports.py
@@ -31,7 +31,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 
-from navitiacommon.parser_args_type import BooleanType, DateTimeFormat, DepthArgument
+from navitiacommon.parser_args_type import BooleanType, DateTimeFormat, DepthArgument, OptionValue
 from jormungandr import i_manager, timezone
 from jormungandr.interfaces.parsers import default_count_arg_type
 from jormungandr.interfaces.v1.decorators import get_obj_serializer
@@ -41,6 +41,7 @@ from jormungandr.interfaces.v1.serializer import api
 from jormungandr.interfaces.common import split_uri
 from jormungandr.resources_utils import ResourceUtc
 from jormungandr.utils import date_to_timestamp
+from navitiacommon.type_pb2 import ActiveStatus
 from flask.globals import g
 from datetime import datetime
 import six
@@ -86,6 +87,15 @@ class LineReports(ResourceUri, ResourceUtc):
             hidden=True,
             action="append",
             help="If filled, will restrain the search within the given disruption tags",
+        )
+        parser_get.add_argument(
+            "filter_status[]",
+            type=OptionValue(ActiveStatus.keys()),
+            help="filter_status uris",
+            dest="filter_status[]",
+            default=[],
+            action="append",
+            schema_metadata={'format': 'pt-object'},
         )
 
         self.collection = 'line_reports'

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -34,6 +34,7 @@ from jormungandr.utils import date_to_timestamp, timestamp_to_str, dt_to_str, ti
 
 import navitiacommon.type_pb2 as type_pb2
 import navitiacommon.request_pb2 as request_pb2
+from navitiacommon.type_pb2 import ActiveStatus
 from jormungandr.interfaces.common import pb_odt_level
 from jormungandr.scenarios.utils import places_type, pt_object_type, add_link
 from jormungandr.scenarios.utils import build_pagination
@@ -124,6 +125,10 @@ class Scenario(object):
         if request["forbidden_uris[]"]:
             for forbidden_uri in request["forbidden_uris[]"]:
                 req.line_reports.forbidden_uris.append(forbidden_uri)
+
+        if request["filter_status[]"]:
+            for filter_status in request["filter_status[]"]:
+                req.line_reports.filter_status.append(ActiveStatus.Value(filter_status))
 
         if request['since']:
             req.line_reports.since_datetime = request['since']

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -213,8 +213,8 @@ static type::RTLevel get_realtime_level(pbnavitia::RTLevel pb_level) {
     }
 }
 
-static nt::disruption::ActiveStatus get_active_status(pbnavitia::ActiveStatus pb_level) {
-    switch (pb_level) {
+static nt::disruption::ActiveStatus from_pb_active_status(pbnavitia::ActiveStatus pb_active_status) {
+    switch (pb_active_status) {
         case pbnavitia::past:
             return nt::disruption::ActiveStatus::past;
         case pbnavitia::active:
@@ -440,7 +440,7 @@ void Worker::line_reports(const pbnavitia::LineReportsRequest& request) {
     }
     std::vector<nt::disruption::ActiveStatus> filter_status;
     for (const auto& filter_st : request.filter_status()) {
-        filter_status.push_back(get_active_status(pbnavitia::ActiveStatus(filter_st)));
+        filter_status.push_back(from_pb_active_status(pbnavitia::ActiveStatus(filter_st)));
     }
     navitia::disruption::line_reports(
         this->pb_creator, *data, request.depth(), request.count(), request.start_page(), request.filter(),

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -213,6 +213,19 @@ static type::RTLevel get_realtime_level(pbnavitia::RTLevel pb_level) {
     }
 }
 
+static nt::disruption::ActiveStatus get_active_status(pbnavitia::ActiveStatus pb_level) {
+    switch (pb_level) {
+        case pbnavitia::past:
+            return nt::disruption::ActiveStatus::past;
+        case pbnavitia::active:
+            return nt::disruption::ActiveStatus::active;
+        case pbnavitia::future:
+            return nt::disruption::ActiveStatus::future;
+        default:
+            throw navitia::recoverable_exception("unhandled disruption active status");
+    }
+}
+
 template <class T>
 std::vector<std::string> vector_of_admins(const T& admin) {
     std::vector<std::string> result;
@@ -425,9 +438,14 @@ void Worker::line_reports(const pbnavitia::LineReportsRequest& request) {
     for (const auto& uri : request.forbidden_uris()) {
         forbidden_uris.push_back(uri);
     }
+    std::vector<nt::disruption::ActiveStatus> filter_status;
+    for (const auto& filter_st : request.filter_status()) {
+        filter_status.push_back(get_active_status(pbnavitia::ActiveStatus(filter_st)));
+    }
     navitia::disruption::line_reports(
         this->pb_creator, *data, request.depth(), request.count(), request.start_page(), request.filter(),
-        forbidden_uris, boost::make_optional(request.has_since_datetime(), bt::from_time_t(request.since_datetime())),
+        forbidden_uris, filter_status,
+        boost::make_optional(request.has_since_datetime(), bt::from_time_t(request.since_datetime())),
         boost::make_optional(request.has_until_datetime(), bt::from_time_t(request.until_datetime())));
 }
 

--- a/source/type/fwd_type.h
+++ b/source/type/fwd_type.h
@@ -88,6 +88,7 @@ struct Disruption;
 struct Impact;
 struct Message;
 struct ApplicationPattern;
+enum class ActiveStatus;
 }  // namespace disruption
 }  // namespace type
 }  // namespace navitia

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -429,7 +429,7 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date,
         return false;
     }
 
-    // if we have a active_period, we check if the impact applies on this period
+    // if we have a active_period we check if the impact applies on this period
     if (active_period.is_null()) {
         return true;
     }
@@ -440,6 +440,23 @@ bool Impact::is_valid(const boost::posix_time::ptime& publication_date,
         }
     }
     return false;
+}
+
+ActiveStatus Impact::get_active_status(const boost::posix_time::ptime& publication_date) const {
+    bool is_future = false;
+    for (const auto& period : application_periods) {
+        if (period.contains(publication_date)) {
+            return ActiveStatus::active;
+        }
+        if (!period.is_null() && period.begin() >= publication_date) {
+            is_future = true;
+        }
+    }
+
+    if (is_future) {
+        return ActiveStatus::future;
+    }
+    return ActiveStatus::past;
 }
 
 bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -64,6 +64,8 @@ enum class Effect {
     STOP_MOVED
 };
 
+enum class ActiveStatus { past = 0, active = 1, future = 2 };
+
 enum class ChannelType { web = 0, sms, email, mobile, notification, twitter, facebook, unknown_type, title, beacon };
 
 inline std::string to_string(Effect effect) {
@@ -354,6 +356,7 @@ struct Impact {
     bool is_line_section_of(const Line&) const;
     bool is_only_rail_section() const;
     bool is_rail_section_of(const Line&) const;
+    ActiveStatus get_active_status(const boost::posix_time::ptime& publication_date) const;
     Indexes get(Type_e target, PT_Data& pt_data) const;
     const type::ValidityPattern get_impact_vp(const boost::gregorian::date_period& production_date) const;
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -41,6 +41,7 @@ www.navitia.io
 #include "utils/exception.h"
 #include "utils/exception.h"
 #include "utils/functions.h"
+#include "type/type_utils.h"
 
 #include <boost/algorithm/cxx11/none_of.hpp>
 #include <boost/date_time/date_defs.hpp>
@@ -1143,20 +1144,7 @@ void PbCreator::Filler::fill_informed_entity(const nd::PtObj& ptobj,
 }
 
 static pbnavitia::ActiveStatus compute_disruption_status(const nd::Impact& impact, const pt::ptime& now) {
-    bool is_future = false;
-    for (const auto& period : impact.application_periods) {
-        if (period.contains(now)) {
-            return pbnavitia::active;
-        }
-        if (!period.is_null() && period.begin() >= now) {
-            is_future = true;
-        }
-    }
-
-    if (is_future) {
-        return pbnavitia::future;
-    }
-    return pbnavitia::past;
+    return to_pb_active_status(impact.get_active_status(now));
 }
 
 static pbnavitia::Severity_Effect get_severity_effect(nd::Effect e) {

--- a/source/type/type_interfaces.cpp
+++ b/source/type/type_interfaces.cpp
@@ -29,8 +29,9 @@ www.navitia.io
 */
 
 #include "type/type_interfaces.h"
-#include "type/message.h"
 #include "utils/functions.h"
+#include "type/type.pb.h"
+#include "type/message.h"
 
 namespace navitia {
 namespace type {
@@ -83,6 +84,7 @@ std::vector<boost::shared_ptr<disruption::Impact>> HasMessages::get_publishable_
 
 bool HasMessages::has_applicable_message(const boost::posix_time::ptime& current_time,
                                          const boost::posix_time::time_period& action_period,
+                                         const std::vector<disruption::ActiveStatus>& filter_status,
                                          const Line* line) const {
     for (const auto& i : this->impacts) {
         auto impact = i.lock();
@@ -96,7 +98,13 @@ bool HasMessages::has_applicable_message(const boost::posix_time::ptime& current
             continue;
         }
         if (impact->is_valid(current_time, action_period)) {
-            return true;
+            // if filter empty == no filter
+            // else we return true only if active status is wanted
+            if (filter_status.empty()
+                || std::find(filter_status.begin(), filter_status.end(), impact->get_active_status(current_time))
+                       != filter_status.end()) {
+                return true;
+            }
         }
     }
     return false;

--- a/source/type/type_interfaces.h
+++ b/source/type/type_interfaces.h
@@ -249,6 +249,7 @@ public:
 
     bool has_applicable_message(const boost::posix_time::ptime& current_time,
                                 const boost::posix_time::time_period& action_period,
+                                const std::vector<disruption::ActiveStatus>& filter_status = {},
                                 const Line* line = nullptr) const;
 
     bool has_publishable_message(const boost::posix_time::ptime& current_time) const;

--- a/source/type/type_utils.cpp
+++ b/source/type/type_utils.cpp
@@ -81,4 +81,18 @@ pbnavitia::RTLevel to_pb_realtime_level(const navitia::type::RTLevel realtime_le
             throw navitia::exception("realtime level case not handled");
     }
 }
+
+pbnavitia::ActiveStatus to_pb_active_status(navitia::type::disruption::ActiveStatus active_status) {
+    switch (active_status) {
+        case nt::disruption::ActiveStatus::past:
+            return pbnavitia::past;
+        case nt::disruption::ActiveStatus::active:
+            return pbnavitia::active;
+        case nt::disruption::ActiveStatus::future:
+            return pbnavitia::future;
+        default:
+            throw navitia::recoverable_exception("unhandled disruption active status");
+    }
+}
+
 }  // namespace navitia

--- a/source/type/type_utils.h
+++ b/source/type/type_utils.h
@@ -50,4 +50,6 @@ const type::StopTime& earliest_stop_time(const std::vector<type::StopTime>& sts)
 
 pbnavitia::RTLevel to_pb_realtime_level(const navitia::type::RTLevel realtime_level);
 
+pbnavitia::ActiveStatus to_pb_active_status(navitia::type::disruption::ActiveStatus active_status);
+
 }  // namespace navitia


### PR DESCRIPTION
The status of a disruption could be past/active/future. 
Thank to this PR, an user could retrieve only a limited set of disruption based on the status. 