### PR TITLE
Fix bug bypass_disruption link

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -395,9 +395,11 @@ class Scenario(object):
         cloned_params = request.args.to_dict(flat=False)
         cloned_params['region'] = instance.name  # we add the region in the args to have fully qualified links
 
+        # we compute bypass_disruptions link first
+        # to avoid other link to mess up with it ...
+        self._add_bypass_disruptions_link(resp, cloned_params)
+
         self._add_next_link(resp, cloned_params, clockwise)
         self._add_prev_link(resp, cloned_params, clockwise)
         # we also compute first/last journey link
         self._add_first_last_links(resp, cloned_params)
-        # we also compute bypass_disruptions link
-        self._add_bypass_disruptions_link(resp, cloned_params)

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -349,6 +349,8 @@ class Scenario(object):
 
     def _add_bypass_disruptions_link(self, resp, params):
         # find first impact wit a NO_SERVICE severity
+        if 'data_freshness' in params and params['data_freshness'] == 'realtime':
+            return
         found = next((True for impact in resp.impacts if impact.severity.effect == Severity.NO_SERVICE), False)
         if found:
             cloned_params = copy.deepcopy(params)


### PR DESCRIPTION
This PR fix the bypass_disruption link : 
Previously the bypass_disruption link was the last link to be filled, therefore added parameters by prev/next link were present in bypass_disruption link. 
Now : The first link to be filled is bypass_disruption link, but we use a copy of dict parameters, so data_freshness=realtime will not be present in prev/next link