### PR TITLE
Remove terminus_schedules without stop_times

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -206,7 +206,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
                 new_dt.properties.notes.extend([note])
         stop_schedule.date_times.sort(key=lambda dt: dt.date + dt.time)
         if not len(stop_schedule.date_times) and not stop_schedule.HasField('response_status'):
-            stop_schedule.response_status = type_pb2.ResponseStatus.no_departure_this_day
+            stop_schedule.response_status = type_pb2.no_departure_this_day
 
     # By default filter passage if they are on the same route point
     def _filter_base_passage(self, passage, route_point):

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -205,6 +205,8 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
                 )  # the id is a md5 of the direction to factorize them
                 new_dt.properties.notes.extend([note])
         stop_schedule.date_times.sort(key=lambda dt: dt.date + dt.time)
+        if not len(stop_schedule.date_times) and not stop_schedule.HasField('response_status'):
+            stop_schedule.response_status = type_pb2.ResponseStatus.no_departure_this_day
 
     # By default filter passage if they are on the same route point
     def _filter_base_passage(self, passage, route_point):

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -161,7 +161,9 @@ class Sytral(RealtimeProxy):
             direction = self._get_direction(
                 line_uri=line_uri, object_code=next_expected_st.get('direction'), default_value=direction_name
             )
-            next_passage = RealTimePassage(dt, direction_name, is_real_time, direction.uri)
+            next_passage = RealTimePassage(
+                dt, direction_name, is_real_time, direction.uri, way=next_expected_st.get('direction_type')
+            )
             next_passages.append(next_passage)
 
         return next_passages

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -226,6 +226,7 @@ class Timeo(RealtimeProxy):
                 raise RealtimeProxyError(timeo_internal_error_message)
 
         st_responses = timeo_resp.get('StopTimesResponse')
+        map_direction = {"A": "forward", "R": "backward"}
         # by construction there should be only one StopTimesResponse
         if not st_responses or len(st_responses) != 1:
             logging.getLogger(__name__).warning(
@@ -234,7 +235,9 @@ class Timeo(RealtimeProxy):
             )
             raise RealtimeProxyError('invalid response')
 
-        next_st = st_responses[0]['NextStopTimesMessage'].get("NextExpectedStopTime", [])
+        next_stoptimes_message = st_responses[0]['NextStopTimesMessage']
+        next_st = next_stoptimes_message.get("NextExpectedStopTime", [])
+        way = map_direction.get(next_stoptimes_message.get("Way"))
         new_next_st = [n_st for n_st in next_st if n_st.get("is_realtime", True)]
         if not len(new_next_st) and len(next_st):
             return None
@@ -247,7 +250,7 @@ class Timeo(RealtimeProxy):
                 object_code=next_expected_st.get('TerminusSAECode'),
                 default_value=next_expected_st.get('Destination'),
             )
-            next_passage = RealTimePassage(dt, direction.label, direction_uri=direction.uri)
+            next_passage = RealTimePassage(dt, direction.label, direction_uri=direction.uri, way=way)
             next_passages.append(next_passage)
 
         return next_passages

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -64,11 +64,12 @@ def get_realtime_system_code(route_point):
 
 
 class RealTimePassage(object):
-    def __init__(self, datetime, direction=None, is_real_time=True, direction_uri=None):
+    def __init__(self, datetime, direction=None, is_real_time=True, direction_uri=None, way=None):
         self.datetime = datetime
         self.direction = direction
         self.direction_uri = direction_uri
         self.is_real_time = is_real_time
+        self.way = way
 
 
 def _create_template_from_passage(passage):

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -894,6 +894,35 @@ class TestDepartures(AbstractTestFixture):
         assert tmp['additional_informations'] == 'no_departure_this_day'
         assert len(tmp['date_times']) == 0
 
+    def test_terminus_schedule_groub_by_destination_base_schedule_active_disruption(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='D:sp', dt='20160103T0700', data_freshness='&data_freshness=realtime', c_dt='20160103T0700'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj1"
+        assert tmp['additional_informations'] == 'active_disruption'
+        assert len(tmp['date_times']) == 0
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "E"
+        assert tmp['additional_informations'] == 'active_disruption'
+        assert len(tmp['date_times']) == 0
+
     def test_terminus_schedule_groub_by_destination_real_time_0(self):
         """
         Schema line:         /----------------------------

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -61,6 +61,27 @@ class MockTimeo(Timeo):
         resp = Obj()
         resp.status_code = 200
         json = {}
+        if url == "CC:sp":
+            json = {
+                "CorrelationID": "AA",
+                "StopTimesResponse": [
+                    {
+                        "StopID": "CC:sp",
+                        "StopTimeoCode": "AAAAA",
+                        "StopLongName": "Malraux",
+                        "StopShortName": "Malraux",
+                        "StopVocalName": "Malraux",
+                        "ReferenceTime": "09:54:53",
+                        "NextStopTimesMessage": {
+                            "LineID": "AAA",
+                            "Way": "A",
+                            "LineMainDirection": "DIRECTION AA",
+                            "NextExpectedStopTime": [],
+                        },
+                    }
+                ],
+                "MessageResponse": [{"ResponseCode": 0, "ResponseComment": "success"}],
+            }
         if url == 'BB:sp':
             json = {
                 "CorrelationID": "AA",
@@ -929,3 +950,17 @@ class TestDepartures(AbstractTestFixture):
         assert date_times[2]["date_time"] == "20160102T091352"
         assert date_times[3]["data_freshness"] == 'realtime'
         assert date_times[3]["date_time"] == "20160102T091552"
+
+    def test_terminus_schedule_groub_by_destination_empty_timeo_response(self):
+        query = self.query_template_ter.format(
+            sp='CC:sp', dt='20160102T0730', data_freshness='&data_freshness=realtime', c_dt='20160102T0730'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 1
+        tmp = terminus_schedules[0]
+
+        assert tmp["display_informations"]["direction"] == "EE"
+        assert len(tmp['date_times']) == 0
+        assert tmp['additional_informations'] == 'no_departure_this_day'

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -123,6 +123,7 @@ class MockTimeo(Timeo):
                                     "Destination": "DIRECTION AA",
                                     "TerminusSAECode": "Avj2",
                                 },
+                                {"NextStop": "10:25:52", "Destination": "DIRECTION AA", "TerminusSAECode": "E"},
                             ],
                         },
                     }
@@ -550,7 +551,329 @@ class TestDepartures(AbstractTestFixture):
         assert stop_time['data_freshness'] == 'base_schedule'
         assert stop_time['date_time'] == '20160102T113000'
 
-    def test_terminus_schedule_groub_by_destination(self):
+    def test_terminus_schedule_0(self):
+        """
+        Terminus_schedule
+                        // 1 line, 2 routes and 2 VJs
+                        // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D
+                        // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D
+
+                        // Active only, VJ1 : 04/01/2016, VJ2: 03/01/2016 and VJ1, VJ2: 07/01/2016
+        """
+        query = self.query_template_ter.format(
+            sp='TS_C:sp',
+            dt='20160104T0900',
+            data_freshness='&data_freshness=base_schedule',
+            c_dt='20160104T0900',
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        ts = terminus_schedules[0]
+        assert ts['display_informations']['direction'] == 'TS_D'
+        date_times = ts['date_times']
+        assert len(date_times) == 1
+        stop_time = date_times[0]
+        assert stop_time['data_freshness'] == 'base_schedule'
+        assert stop_time['date_time'] == '20160104T090000'
+
+        ts = terminus_schedules[1]
+        assert ts['additional_informations'] == 'no_departure_this_day'
+        assert ts['display_informations']['direction'] == 'TS_A'
+        assert len(ts['date_times']) == 0
+
+    def test_terminus_schedule_1(self):
+        """
+        Terminus_schedule
+                        // 1 line, 2 routes and 2 VJs
+                        // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D
+                        // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D
+
+                        // Active only, VJ1 : 04/01/2016, VJ2: 03/01/2016 and VJ1, VJ2: 07/01/2016
+        """
+        query = self.query_template_ter.format(
+            sp='TS_C:sp',
+            dt='20160103T0900',
+            data_freshness='&data_freshness=base_schedule',
+            c_dt='20160103T0900',
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        ts = terminus_schedules[0]
+        assert ts['additional_informations'] == 'no_departure_this_day'
+        assert ts['display_informations']['direction'] == 'TS_D'
+        assert len(ts['date_times']) == 0
+
+        ts = terminus_schedules[1]
+        assert ts['display_informations']['direction'] == 'TS_A'
+        date_times = ts['date_times']
+        assert len(date_times) == 1
+        stop_time = date_times[0]
+        assert stop_time['data_freshness'] == 'base_schedule'
+        assert stop_time['date_time'] == '20160103T091000'
+
+    def test_terminus_schedule_2(self):
+        """
+        Terminus_schedule
+                        // 1 line, 2 routes and 2 VJs
+                        // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D
+                        // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D
+
+                        // Active only, VJ1 : 04/01/2016, VJ2: 03/01/2016 and VJ1, VJ2: 07/01/2016
+        """
+        query = self.query_template_ter.format(
+            sp='TS_C:sp',
+            dt='20160105T0900',
+            data_freshness='&data_freshness=base_schedule',
+            c_dt='20160105T0900',
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        ts = terminus_schedules[0]
+        assert ts['additional_informations'] == 'no_departure_this_day'
+        assert ts['display_informations']['direction'] == 'TS_D'
+        assert len(ts['date_times']) == 0
+
+        ts = terminus_schedules[1]
+        assert ts['additional_informations'] == 'no_departure_this_day'
+        assert ts['display_informations']['direction'] == 'TS_A'
+        assert len(ts['date_times']) == 0
+
+    def test_terminus_schedule_2(self):
+        """
+        Terminus_schedule
+                        // 1 line, 2 routes and 2 VJs
+                        // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D
+                        // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D
+
+                        // Active only, VJ1 : 04/01/2016, VJ2: 03/01/2016 and VJ1, VJ2: 07/01/2016
+        """
+        query = self.query_template_ter.format(
+            sp='TS_C:sp',
+            dt='20160107T0900',
+            data_freshness='&data_freshness=base_schedule',
+            c_dt='20160107T0900',
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        ts = terminus_schedules[0]
+        assert ts['display_informations']['direction'] == 'TS_D'
+        assert len(ts['date_times']) == 1
+        stop_time = ts['date_times'][0]
+        assert stop_time['data_freshness'] == 'base_schedule'
+        assert stop_time['date_time'] == '20160107T090000'
+
+        ts = terminus_schedules[1]
+        assert ts['display_informations']['direction'] == 'TS_A'
+        assert len(ts['date_times']) == 1
+        stop_time = ts['date_times'][0]
+        assert stop_time['data_freshness'] == 'base_schedule'
+        assert stop_time['date_time'] == '20160107T091000'
+
+    def test_terminus_schedule_groub_by_destination_base_schedule_0(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='C:sp', dt='20160102T0900', data_freshness='&data_freshness=base_schedule', c_dt='20160102T0900'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 3
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj1"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160102T090000'
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "Avj2"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160102T091000'
+
+        tmp = terminus_schedules[2]
+        assert tmp['display_informations']['direction'] == "E"
+        assert len(tmp['date_times']) == 2
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160102T100000'
+        assert tmp['date_times'][1]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][1]['date_time'] == '20160102T111000'
+
+    def test_terminus_schedule_groub_by_destination_base_schedule_1(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='C:sp', dt='20160106T0900', data_freshness='&data_freshness=base_schedule', c_dt='20160106T0900'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 3
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj1"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160106T090000'
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "Avj2"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160106T091000'
+
+        tmp = terminus_schedules[2]
+        assert tmp['display_informations']['direction'] == "E"
+        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert len(tmp['date_times']) == 0
+
+    def test_terminus_schedule_groub_by_destination_base_schedule_2(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='C:sp', dt='20160107T0900', data_freshness='&data_freshness=base_schedule', c_dt='20160107T0900'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj1"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160107T090000'
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "E"
+        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert len(tmp['date_times']) == 0
+
+    def test_terminus_schedule_groub_by_destination_base_schedule_3(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='C:sp', dt='20160105T0900', data_freshness='&data_freshness=base_schedule', c_dt='20160105T0900'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj2"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160105T091000'
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "E"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160105T100000'
+
+    def test_terminus_schedule_groub_by_destination_base_schedule_4(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='C:sp', dt='20160101T0900', data_freshness='&data_freshness=base_schedule', c_dt='20160101T0900'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj1"
+        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert len(tmp['date_times']) == 0
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "E"
+        assert len(tmp['date_times']) == 1
+        assert tmp['date_times'][0]['data_freshness'] == 'base_schedule'
+        assert tmp['date_times'][0]['date_time'] == '20160101T111000'
+
+    def test_terminus_schedule_groub_by_destination_base_schedule_5(self):
+        """
+                          01  02  03  04  05  06  07  08  09      Direction
+         Active VJ1 :         *   *   *       *   *       *       AVj1
+         Active VJ2 :         *   *   *   *   *                   AVj2
+         Active VJ3 :         *   *   *   *               *       E
+         Active VJ4 :     *   *   *                               E
+
+        Schema line:          /---------------------------- Avj1
+          E ------------------
+                             \ ---------------------------- Avj2
+        """
+        query = self.query_template_ter.format(
+            sp='C:sp', dt='20160108T0900', data_freshness='&data_freshness=base_schedule', c_dt='20160108T0900'
+        )
+        response = self.query_region(query)
+        is_valid_notes(response["notes"])
+        terminus_schedules = response['terminus_schedules']
+        assert len(terminus_schedules) == 2
+        tmp = terminus_schedules[0]
+        assert tmp['display_informations']['direction'] == "Avj1"
+        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert len(tmp['date_times']) == 0
+
+        tmp = terminus_schedules[1]
+        assert tmp['display_informations']['direction'] == "E"
+        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert len(tmp['date_times']) == 0
+
+    def test_terminus_schedule_groub_by_destination_real_time_0(self):
         """
         Schema line:         /----------------------------
           ------------------
@@ -562,7 +885,7 @@ class TestDepartures(AbstractTestFixture):
         response = self.query_region(query)
         is_valid_notes(response["notes"])
         terminus_schedules = response['terminus_schedules']
-        assert len(terminus_schedules) == 2
+        assert len(terminus_schedules) == 3
         tmp = terminus_schedules[0]
 
         assert tmp["display_informations"]["direction"] == "Avj1"
@@ -579,6 +902,12 @@ class TestDepartures(AbstractTestFixture):
         assert date_times[0]["date_time"] == "20160102T091352"
         assert date_times[1]["data_freshness"] == 'realtime'
         assert date_times[1]["date_time"] == "20160102T091552"
+
+        tmp = terminus_schedules[2]
+        assert tmp["display_informations"]["direction"] == "E"
+        date_times = tmp['date_times']
+        assert date_times[0]["data_freshness"] == 'realtime'
+        assert date_times[0]["date_time"] == "20160102T092552"
 
     def test_terminus_schedule_groub_by_destination_terminus_partial(self):
         query = self.query_template_ter.format(

--- a/source/routing/next_stop_time.h
+++ b/source/routing/next_stop_time.h
@@ -71,7 +71,6 @@ struct NextStopTimeInterface {
         const bool check_freq = true,
         const boost::optional<DateTime>& bound = boost::none) const = 0;
     virtual ~NextStopTimeInterface() = default;
-    ;
 };
 
 struct NextStopTimeData {

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -659,7 +659,9 @@ void clean_terminus_schedules(const std::map<const type::Route*, vector_jpp_idx>
                     if (with_stop_times) {
                         map_route_stop_point.erase(it);
                         const auto& st_it = response_status.find(route_point);
-                        response_status.erase(st_it);
+                        if (st_it != response_status.end()) {
+                            response_status.erase(st_it);
+                        }
                     } else {
                         with_stop_times = true;
                     }

--- a/source/time_tables/departure_boards.h
+++ b/source/time_tables/departure_boards.h
@@ -39,6 +39,7 @@ namespace timetables {
 
 typedef std::vector<DateTime> vector_datetime;
 using vector_dt_st = std::vector<routing::datetime_stop_time>;
+using vector_jpp_idx = std::vector<routing::JppIdx>;
 using first_and_last_stop_time =
     std::pair<boost::optional<routing::datetime_stop_time>, boost::optional<routing::datetime_stop_time> >;
 
@@ -106,6 +107,15 @@ first_and_last_stop_time get_first_and_last_stop_time(const routing::datetime_st
                                                       const type::Data& data,
                                                       const type::RTLevel rt_level,
                                                       const int utc_offset);
+/**
+ * @brief clean_terminus_schedules
+ * @param map_route_route_point: Route and list of JourneyPatternPoint
+ * @param response_status: JourneyPatternPoint and Status
+ * @param map_route_stop_point: JourneyPatternPoint and list of StopTimes
+ */
+void clean_terminus_schedules(const std::map<const type::Route*, vector_jpp_idx>& map_route_route_point,
+                              std::map<routing::JppIdx, pbnavitia::ResponseStatus>& response_status,
+                              std::map<routing::JppIdx, vector_dt_st>& map_route_stop_point);
 
 }  // namespace timetables
 }  // namespace navitia

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -89,14 +89,22 @@ struct departure_board_fixture {
                 b.lines.find("T")->second->properties["realtime_system"] = "Kisio数字";
 
                 // Terminus_schedule
-                // 1 line, 2 routes and 2 VJs
+                // 1 line, 1 routes and 2 VJs
                 // * VJ1 : E->D->C->B->A1->AVj1
                 // * VJ2 : D->C->B->A2->AVj2
 
+                // * VJ3 : E<-D<-C->B<-A1<-AVj1
+                // * VJ4 : D<-C<-B<-A2<-AVj2
+
                 // * Route1       Avj2 <------A2---
                 // *                               |
-                // * Route2       Avj1 <------A1-------- B <- C <- D <- E
+                // * Route1       Avj1 <------A1-------- B <- C <- D <- E
                 // *
+                //                  01  02  03  04  05  06  07  08  09      Direction
+                // Active VJ1 :         *   *   *       *   *       *       AVj1
+                // Active VJ2 :         *   *   *   *   *                   AVj2
+                // Active VJ3 :         *   *   *   *               *       E
+                // Active VJ4 :     *   *   *                               E
 
                 b.sa("Avj1", 0., 0., false)("Avj1");
                 b.sa("Avj2", 0., 0., false)("Avj2");
@@ -107,10 +115,24 @@ struct departure_board_fixture {
                 b.sa("A1", 0., 0., false)("A1:sp");
                 b.sa("A2", 0., 0., false)("A2:sp");
 
-                b.vj("Line1").route("Route1").name("AVJ1")("E:sp", "07:45"_t)("D:sp", "08:00"_t)("C:sp", "09:00"_t)(
-                    "B:sp", "10:00"_t)("A1", "11:00"_t)("Avj1", "11:15"_t);
-                b.vj("Line1").route("Route2").name("AVJ2")("D:sp", "09:00"_t)("C:sp", "09:10"_t)("B:sp", "10:10"_t)(
-                    "A2", "11:10"_t)("Avj2", "11:25"_t);
+                b.vj("Line1", "101101110")
+                    .route("Route1")
+                    .name("AVJ1")("E:sp", "07:45"_t)("D:sp", "08:00"_t)("C:sp", "09:00"_t)("B:sp", "10:00"_t)(
+                        "A1", "11:00"_t)("Avj1", "11:15"_t);
+                b.vj("Line1", "100011110")
+                    .route("Route2_R")
+                    .name("AVJ3")("Avj1", "07:45"_t)("A1", "08:00"_t)("B:sp", "09:00"_t)("C:sp", "10:00"_t)(
+                        "D:sp", "11:00"_t)("E:sp", "11:15"_t);
+
+                b.vj("Line1", "000111110")
+                    .route("Route1")
+                    .name("AVJ2")("D:sp", "09:00"_t)("C:sp", "09:10"_t)("B:sp", "10:10"_t)("A2", "11:10"_t)("Avj2",
+                                                                                                            "11:25"_t);
+                b.vj("Line1", "000000111")
+                    .route("Route2_R")
+                    .name("AVJ4")("Avj2", "09:00"_t)("A2", "09:10"_t)("B:sp", "10:10"_t)("C:sp", "11:10"_t)("D:sp",
+                                                                                                            "11:25"_t);
+
                 b.lines.find("Line1")->second->properties["realtime_system"] = "Kisio数字";
 
                 // 1 line, 1 routes and 2 VJs
@@ -129,6 +151,33 @@ struct departure_board_fixture {
                     "CC:sp", "09:30"_t)("DD:sp", "10:10"_t);
                 b.lines.find("Line2")->second->properties["realtime_system"] = "Kisio数字";
 
+                // Terminus_schedule
+                // 1 line, 2 routes and 2 VJs
+                // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D
+                // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D
+
+                // Active only, VJ1 : 04/01/2016, VJ2: 03/01/2016 and VJ1, VJ2: 07/01/2016
+
+                b.sa("TS_A", 0., 0., false)("TS_A:sp");
+                b.sa("TS_B", 0., 0., false)("TS_B:sp");
+                b.sa("TS_C", 0., 0., false)("TS_C:sp");
+                b.sa("TS_D", 0., 0., false)("TS_D:sp");
+
+                b.vj("Line3", "001001000")
+                    .route("TS_Route1")
+                    .name("TS_AVJ1")("TS_A:sp", "07:45"_t)("TS_B:sp", "08:00"_t)("TS_C:sp", "09:00"_t)("TS_D:sp",
+                                                                                                       "10:00"_t);
+                b.vj("Line3", "001000100")
+                    .route("TS_Route2")
+                    .name("TS_AVJ2")("TS_D:sp", "09:00"_t)("TS_C:sp", "09:10"_t)("TS_B:sp", "10:10"_t)("TS_A:sp",
+                                                                                                       "11:10"_t);
+
+                b.lines.find("Line3")->second->properties["realtime_system"] = "Kisio数字";
+                b.lines.find("Line3")->second->opening_time =
+                    boost::make_optional(boost::posix_time::duration_from_string("06:00"));
+                b.lines.find("Line3")->second->closing_time =
+                    boost::make_optional(boost::posix_time::duration_from_string("14:00"));
+
                 auto* ad = new navitia::georef::Admin();
                 ad->name = "Quimper";
                 ad->uri = "Quimper";
@@ -144,9 +193,10 @@ struct departure_board_fixture {
 
                 b.data->complete();
                 b.data->compute_labels();
+                b.make();
             },
             true) {
-        b.data->meta->production_date = bg::date_period(bg::date(2016, 1, 1), bg::days(5));
+        b.data->meta->production_date = bg::date_period(bg::date(2016, 1, 1), bg::days(10));
 
         sp_ptr = b.data->pt_data->stop_points_map["BB:sp"];
         b.data->pt_data->codes.add(sp_ptr, "Kisio数字", "Kisio数字_BB:sp");

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -154,8 +154,8 @@ struct departure_board_fixture {
 
                 // Terminus_schedule
                 // 1 line, 2 routes and 2 VJs
-                // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D
-                // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D
+                // * Route1, VJ1 : TS_A->TS_B->TS_C->TS_D->TS_E
+                // * Route2, VJ2 : TS_A<-TS_B<-TS_C<-TS_D<-TS_E
 
                 // Active only, VJ1 : 04/01/2016, VJ2: 03/01/2016 and VJ1, VJ2: 07/01/2016
 
@@ -163,21 +163,28 @@ struct departure_board_fixture {
                 b.sa("TS_B", 0., 0., false)("TS_B:sp");
                 b.sa("TS_C", 0., 0., false)("TS_C:sp");
                 b.sa("TS_D", 0., 0., false)("TS_D:sp");
+                b.sa("TS_E", 0., 0., false)("TS_E:sp");
 
                 b.vj("Line3", "001001000")
                     .route("TS_Route1")
-                    .name("TS_AVJ1")("TS_A:sp", "07:45"_t)("TS_B:sp", "08:00"_t)("TS_C:sp", "09:00"_t)("TS_D:sp",
-                                                                                                       "10:00"_t);
+                    .name("TS_AVJ1")("TS_A:sp", "07:45"_t)("TS_B:sp", "08:00"_t)("TS_C:sp", "09:00"_t)(
+                        "TS_D:sp", "10:00"_t)("TS_E:sp", "10:10"_t);
                 b.vj("Line3", "001000100")
                     .route("TS_Route2")
-                    .name("TS_AVJ2")("TS_D:sp", "09:00"_t)("TS_C:sp", "09:10"_t)("TS_B:sp", "10:10"_t)("TS_A:sp",
-                                                                                                       "11:10"_t);
+                    .name("TS_AVJ2")("TS_D:sp", "08:45"_t)("TS_D:sp", "09:00"_t)("TS_C:sp", "09:10"_t)(
+                        "TS_B:sp", "10:10"_t)("TS_A:sp", "11:10"_t);
 
                 b.lines.find("Line3")->second->properties["realtime_system"] = "Kisio数字";
                 b.lines.find("Line3")->second->opening_time =
                     boost::make_optional(boost::posix_time::duration_from_string("06:00"));
                 b.lines.find("Line3")->second->closing_time =
                     boost::make_optional(boost::posix_time::duration_from_string("14:00"));
+                // Timeo R
+                auto it_rt = b.data->pt_data->routes_map.find("TS_Route1");
+                it_rt->second->direction_type = "backward";
+                // Timeo A
+                it_rt = b.data->pt_data->routes_map.find("TS_Route1");
+                it_rt->second->direction_type = "forward";
 
                 auto* ad = new navitia::georef::Admin();
                 ad->name = "Quimper";

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -6,6 +6,7 @@
 #include "type/pt_data.h"
 #include "kraken/realtime.h"
 #include "georef/adminref.h"
+#include "kraken/apply_disruption.h"
 
 namespace ntest = navitia::test;
 namespace bg = boost::gregorian;
@@ -194,6 +195,17 @@ struct departure_board_fixture {
                 b.data->complete();
                 b.data->compute_labels();
                 b.make();
+                // Disruption NO_SERVICE on StopArea
+                using btp = boost::posix_time::time_period;
+
+                navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "Disruption 1")
+                                              .severity(nt::disruption::Effect::NO_SERVICE)
+                                              .on(nt::Type_e::StopArea, "D", *b.data->pt_data)
+                                              .application_periods(btp("20160103T000000"_dt, "20160103T235900"_dt))
+                                              .publish(btp("20160103T000000"_dt, "20160103T235900"_dt))
+                                              .msg("Disruption on stop area D")
+                                              .get_disruption(),
+                                          *b.data->pt_data, *b.data->meta);
             },
             true) {
         b.data->meta->production_date = bg::date_period(bg::date(2016, 1, 1), bg::days(10));


### PR DESCRIPTION
Jira: [NAVP-1659](https://jira.kisio.org/browse/NAVP-1659)

Example:
**The parameters used**
![image](https://user-images.githubusercontent.com/4006603/123124499-06b21500-d448-11eb-8396-f28801922d0d.png)


**Before correction:**
![image](https://user-images.githubusercontent.com/4006603/123125022-76280480-d448-11eb-894a-5f28a14a7b0b.png)

**After correction:**
![image](https://user-images.githubusercontent.com/4006603/123124662-277a6a80-d448-11eb-90ac-1d41a9584bf3.png)


Bench:
**Command used**: 
`ab -n 1000 http://navitia/v1/coverage/fr-se-lyon/stop_areas/stop_area%3Atcl%3ASA%3A11273/lines/line%3Atcl%3AC8/terminus_schedules?data_freshness=base_schedule&`

**Before correction:**
![image](https://user-images.githubusercontent.com/4006603/123125464-d3bc5100-d448-11eb-9615-49119ae4ab5d.png)

**After correction:**
![image](https://user-images.githubusercontent.com/4006603/123125581-eafb3e80-d448-11eb-8d09-6534495db68c.png)
