### PR TITLE
[Kraken] move deadline into dispatch to avoid crash

### DIFF
--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -88,6 +88,8 @@ public:
             throw navitia::exception("Giving a null Data to DataManager::set_data");
         }
         data->is_connected_to_rabbitmq = current_data->is_connected_to_rabbitmq.load();
+
+        std::lock_guard<std::mutex> lock(*mutex);
         current_data = std::move(data);
     }
     boost::shared_ptr<const Data> get_data() const {

--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -40,6 +40,7 @@ www.navitia.io
 
 #include <boost/make_shared.hpp>
 #include <boost/optional.hpp>
+#include <boost/thread.hpp>
 
 #include <mutex>
 #include <memory>
@@ -77,7 +78,7 @@ private:
         }
     }
 
-    std::unique_ptr<std::mutex> mutex = std::make_unique<std::mutex>();
+    std::unique_ptr<boost::shared_mutex> write = std::make_unique<boost::shared_mutex>();
 
 public:
     DataManager() : current_data(create_data(0)) { data_identifier = 0; }
@@ -89,11 +90,11 @@ public:
         }
         data->is_connected_to_rabbitmq = current_data->is_connected_to_rabbitmq.load();
 
-        std::lock_guard<std::mutex> lock(*mutex);
+        boost::lock_guard<boost::shared_mutex> lock(*write);
         current_data = std::move(data);
     }
     boost::shared_ptr<const Data> get_data() const {
-        std::lock_guard<std::mutex> lock(*mutex);
+        boost::shared_lock<boost::shared_mutex> lock(*write);
         return current_data;
     }
     boost::shared_ptr<Data> get_data_clone() {

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -128,8 +128,7 @@ inline void doWork(zmq::context_t& context,
         LOG4CPLUS_DEBUG(logger, "deadline set to " << deadline.get());
         const auto data = data_manager.get_data();
         try {
-            deadline.check();
-            w.dispatch(pb_req, *data);
+            w.dispatch(deadline, pb_req, *data);
             if (api != pbnavitia::METADATAS) {
                 LOG4CPLUS_TRACE(logger, "response: " << w.pb_creator.get_response().DebugString());
             }

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -128,7 +128,7 @@ inline void doWork(zmq::context_t& context,
         LOG4CPLUS_DEBUG(logger, "deadline set to " << deadline.get());
         const auto data = data_manager.get_data();
         try {
-            w.dispatch(deadline, pb_req, *data);
+            w.dispatch(pb_req, *data, deadline);
             if (api != pbnavitia::METADATAS) {
                 LOG4CPLUS_TRACE(logger, "response: " << w.pb_creator.get_response().DebugString());
             }

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -1076,12 +1076,16 @@ boost::optional<size_t> Worker::get_raptor_next_st_cache_miss() const {
     return boost::none;
 }
 
-void Worker::dispatch(const navitia::Deadline& deadline, const pbnavitia::Request& request, const nt::Data& data) {
+void Worker::dispatch(const pbnavitia::Request& request,
+                      const nt::Data& data,
+                      const boost::optional<const navitia::Deadline&>& deadline) {
     bool disable_geojson = get_geojson_state(request);
     boost::posix_time::ptime current_datetime = bt::from_time_t(request._current_datetime());
     this->init_worker_data(&data, current_datetime, null_time_period, disable_geojson, request.disable_feedpublisher(),
                            request.disable_disruption());
-    deadline.check();
+    if (deadline) {
+        deadline->check();
+    }
     // These api can respond even if the data isn't loaded
     if (request.requested_api() == pbnavitia::STATUS) {
         status();

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -44,6 +44,7 @@ www.navitia.io
 #include "time_tables/passages.h"
 #include "time_tables/route_schedules.h"
 #include "type/meta_data.h"
+#include "utils/deadline.h"
 
 #include <numeric>
 #include <utility>
@@ -1075,12 +1076,12 @@ boost::optional<size_t> Worker::get_raptor_next_st_cache_miss() const {
     return boost::none;
 }
 
-void Worker::dispatch(const pbnavitia::Request& request, const nt::Data& data) {
+void Worker::dispatch(const navitia::Deadline& deadline, const pbnavitia::Request& request, const nt::Data& data) {
     bool disable_geojson = get_geojson_state(request);
     boost::posix_time::ptime current_datetime = bt::from_time_t(request._current_datetime());
     this->init_worker_data(&data, current_datetime, null_time_period, disable_geojson, request.disable_feedpublisher(),
                            request.disable_disruption());
-
+    deadline.check();
     // These api can respond even if the data isn't loaded
     if (request.requested_api() == pbnavitia::STATUS) {
         status();

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -52,6 +52,8 @@ struct RAPTOR;
 
 namespace navitia {
 
+struct Deadline;
+
 struct JourneysArg {
     type::EntryPoints origins;
     type::AccessibiliteParams accessibilite_params;
@@ -91,7 +93,7 @@ public:
     // see: https://stackoverflow.com/questions/6012157/is-stdunique-ptrt-required-to-know-the-full-definition-of-t
     ~Worker();
 
-    void dispatch(const pbnavitia::Request& request, const nt::Data& data);
+    void dispatch(const navitia::Deadline& deadline, const pbnavitia::Request& request, const nt::Data& data);
     boost::optional<size_t> get_raptor_next_st_cache_miss() const;
 
 private:

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -93,7 +93,9 @@ public:
     // see: https://stackoverflow.com/questions/6012157/is-stdunique-ptrt-required-to-know-the-full-definition-of-t
     ~Worker();
 
-    void dispatch(const navitia::Deadline& deadline, const pbnavitia::Request& request, const nt::Data& data);
+    void dispatch(const pbnavitia::Request& request,
+                  const nt::Data& data,
+                  const boost::optional<const navitia::Deadline&>& deadline = boost::none);
     boost::optional<size_t> get_raptor_next_st_cache_miss() const;
 
 private:


### PR DESCRIPTION
move deadline into dispatch to avoid a crash

Kraken crashed because of the timeout(deadline is reached) when a metadata request is received. One of the pointers in `Worker` which is invalidated by the real-time handling remains invalid, which caused a crash in the handling of metrics. 

We moved deadline into the function `dispatch` so that, whether deadline is hit or not, the re-initialisation is always done