### PR TITLE
change timeout value for metadata API 

### DIFF
--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -361,7 +361,7 @@ class InstanceManager(object):
             req.requested_api = type_pb2.METADATAS
 
             try:
-                resp = self.instances[key_region].send_and_receive(req, request_id=request_id, timeout=1000)
+                resp = self.instances[key_region].send_and_receive(req, request_id=request_id)
                 resp_dict = protobuf_to_dict(resp.metadatas)
             except DeadSocketException:
                 resp_dict = {


### PR DESCRIPTION
For Metadata API timeout value was set to 1000 ms. 
With this PR the new value is set by env var INSTANCE_TIMEOUT (default 10000ms) 
This could be usefull on slow platform like customer