### PR TITLE
Fix query in cities database

### DIFF
--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -147,30 +147,24 @@ struct FindAdminWithCities {
 
     result_type get_admins_from_cities(const navitia::type::GeographicalCoord& c, georef::AdminRtree& admin_tree) {
         /*
-            For all admins that contain the coordinate in their boundary shape,
-            we want to search in db for their own inner admins as well.
+            We only fetch admins containings the coordinate in their boundary shape
+            because a left join between above result and another query using boundary shape
+            is very very slow.
 
-            +-----------------------------+
-            |A                            |
-            |   +-------+      +-------+  |
-            |   |B      |      |C      |  |
-            |   |       |      |   X   |  |
-            |   |       |      +-------+  |
-            |   |   Y   |  +------+       |
-            |   |       |  |D     |       |
-            |   +-------+  |      |       |
-            |              +------+       |
-            +-----------------------------+
+            +--------------------+
+            |A                   |
+            |                    |
+            |                    |
+            |                  +-|-------------+
+            |                  |X|             |
+            +------------------|+       B      |
+                               |               |
+                               |               |
+                               +---------------+
 
             For instance, when looking at 'X', we want:
-                - admins {A, C} to be returned
-                - BUT admins {A, B, C, D} added in the cache
+                - admins {A, B} to be returned and will be added in the cache
 
-            This is so that when looking at 'Y':
-                - admins {A, B} to be returned by the cache
-
-            If we don't search for all inner admins, looking for 'Y' would result in:
-                - admin {A} to be only returned by the cache
         */
         const auto sql_req = boost::format(R"sql(
             SELECT

--- a/source/ed/ed2nav.cpp
+++ b/source/ed/ed2nav.cpp
@@ -183,18 +183,12 @@ struct FindAdminWithCities {
                 ST_Y(coord::geometry) as lat,
                 ST_ASTEXT(boundary) as boundary
             FROM
-                administrative_regions,
-                (
-                    SELECT boundary as within_bound
-                    FROM administrative_regions
+                administrative_regions
                     WHERE ST_DWithin(
                     ST_GeographyFromText('POINT(%.16f %.16f)'),
                     boundary, 0.001
-                    )
-                ) AS within
-            WHERE
-                ST_DWithin(within_bound, boundary, 0.001)
-            )sql") % c.lon() % c.lat();
+                    ))sql") % c.lon()
+                             % c.lat();
         pqxx::result db_result = work->exec(sql_req.str());
 
         auto not_in_insee_admins_map = [&](const pqxx_row& row) {


### PR DESCRIPTION
* The deployment of navitia release v12.0.0 in production took much more time than normal deployment duration with bina.
* A query with outer join and two ST_DWithin() conditions on cities was the cause. It was modified two years ago to optimize action 'ed2nav' for the coverage 'furet' as explained in the [PR](https://github.com/CanalTP/navitia/pull/3099/)   
* Advance charging of admins in cache with outer join penalizes rather than optimizing the response time.
* Followings are some statistiques of bina durations:
1. ee (estonia): **02h56m00s to 00h02m00s**
2. ie (ireland): **04h29m00s to 00h07m00s**
3. dk (denmark): **02h04m00s to 00h08m00s**
4. sncf: **00h15m00s to 00h03m00s**
5. furet: **00h19m00s to 00h10m00s**
6. Fr-se-lyon: **00h04m00s to 00h03h30s**
7. idfm: **00h10m30s to 00h05m00s**
7. fr-transilien: **00h10m00s to 00h05m00s**

For more details : https://jira.kisio.org/browse/NAVITIAII-3513

