### PR TITLE
[Jormun] handle asgard_language correctly in kraken.py

### DIFF
--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -142,12 +142,7 @@ class Kraken(AbstractStreetNetworkService):
                 return response_pb2.Response()
 
         req = self._create_direct_path_request(
-            mode,
-            pt_object_origin,
-            pt_object_destination,
-            fallback_extremity,
-            direct_path_request,
-            instance.asgard_language,
+            mode, pt_object_origin, pt_object_destination, fallback_extremity, direct_path_request
         )
 
         response = instance.send_and_receive(req, request_id=request_id)
@@ -185,7 +180,7 @@ class Kraken(AbstractStreetNetworkService):
         return mode
 
     def _create_direct_path_request(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, language
+        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, language="en-US"
     ):
         req = request_pb2.Request()
         req.requested_api = type_pb2.direct_path


### PR DESCRIPTION
Artemis is failing with the following stack trace :
```
 [2021-07-26 11:46:17,118] [None] [ERROR] [    9] [jormungandr.scenarios.helper_classes.streetnetwork_path] 
 Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/jormungandr/scenarios/helper_classes/streetnetwork_path.py", line 92, in _direct_path_with_fp
    self._request_id,
  File "/usr/lib/python2.7/dist-packages/jormungandr/street_network/street_network.py", line 107, in direct_path_with_fp
     request_id,
  File "/usr/lib/python2.7/dist-packages/jormungandr/street_network/kraken.py", line 150, in _direct_path
     instance.asgard_language,
  File "/usr/lib/python2.7/dist-packages/jormungandr/instance.py", line 97, in _getter
     return get_value_or_default(attr_name, self.get_models(), self.name)
  File "/usr/lib/python2.7/dist-packages/jormungandr/instance.py", line 244, in get_models
    if self.name not in g.instances_model:
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/local.py", line 348, in __getattr__
     return getattr(self._get_current_object(), name)
  File "/usr/local/lib/python2.7/dist-packages/werkzeug/local.py", line 307, in _get_current_object
     return self.__local()
  File "/usr/local/lib/python2.7/dist-packages/flask/globals.py", line 45, in _lookup_app_object
    raise RuntimeError(_app_ctx_err_msg)
 RuntimeError: Working outside of application context.

This typically means that you attempted to use functionality that needed
 to interface with the current application object in some way. To solve
 this, set up an application context with app.app_context().  See the
 documentation for more information.
```
This PR aims to fix that.

