### PR TITLE
set rabbitmq image to 3.8 in CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       rabbitmq:
-        image: rabbitmq:3-alpine
+        image: rabbitmq:3.8-alpine
         ports:
           - 5672:5672
 


### PR DESCRIPTION
To see if tests pass with this older version of rabbitmq image (latest is 3.9 since July 26 2021)