### PR TITLE
[CI] allows double quotes in commit message

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -51,7 +51,9 @@ jobs:
       run: apt update && apt install -y httpie
     - name: run artemis NG on push
       if: ${{ github.event_name == 'push' }}
-      run: http --ignore-stdin -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/artemis_ng/buildWithParameters event=push navitia_branch=dev commit_id=${{ github.event.head_commit.id }} commit_message="" commit_timestamp=${{ github.event.head_commit.timestamp }} commit_url=${{ github.event.repository.html_url }} commit_username="${{ github.event.head_commit.author.name }}"
+      run: |
+        printf -v MSG "%q" '${{ github.event.head_commit.message }}'
+        http --ignore-stdin -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/artemis_ng/buildWithParameters event=push navitia_branch=dev commit_id=${{ github.event.head_commit.id }} commit_message="$MSG" commit_timestamp=${{ github.event.head_commit.timestamp }} commit_url=${{ github.event.repository.html_url }} commit_username="${{ github.event.head_commit.author.name }}"
     - name: run deploy on artemis machine https://jenkins-core.canaltp.fr/job/deploy-navitia
       if: ${{ github.event_name == 'push' }}
       run: http --ignore-stdin -v -f POST https://${{secrets.JENKINS_NG_TOKEN}}@jenkins-core.canaltp.fr/job/deploy-navitia/buildWithParameters PLATFORM=artemis_debian8


### PR DESCRIPTION
Allows to have double quotes in commit messages, and to pass that to artemis launcher.
Warning : this does not allows single quote in the commit message !