### PR TITLE
Use dev as base branch  + Fix clang tidy workflow

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -33,6 +33,8 @@ jobs:
       working-directory: ${{ runner.temp }}
       run: make tidy_fix || echo "Files have been tidied ! Let's commit them"
     - name: Commit and push changes
+      # Handle case with no clang-tidy fix
+      continue-on-error: true
       uses: peter-evans/create-pull-request@v3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -50,7 +52,9 @@ jobs:
         labels: not_in_changelog
         team-reviewers: CanalTP/coreteam
         branch: auto/clang-tidy
+        base: dev
     - name: Check outputs
+      if: ${{ success() }}
       run: |
         echo "Pull Request Number - ${{ env.PULL_REQUEST_NUMBER }}"
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
Clang-tidy workflow fails when there is no diff git
and use dev as base branch