### PR TITLE
Manage database resilience and add configuration_database in /status

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -42,6 +42,7 @@ import logging
 from jormungandr.new_relic import record_custom_parameter
 from jormungandr.authentication import get_user, get_token, get_app_name, get_used_coverages
 from jormungandr._version import __version__
+from jormungandr.utils import can_connect_to_database
 import six
 
 
@@ -88,12 +89,15 @@ def add_request_id(response, *args, **kwargs):
 def add_info_newrelic(response, *args, **kwargs):
     try:
         record_custom_parameter('navitia-request-id', request.id)
-        token = get_token()
-        user = get_user(token=token, abort_if_no_token=False)
-        app_name = get_app_name(token)
-        if user:
-            record_custom_parameter('user_id', str(user.id))
-        record_custom_parameter('token_name', app_name)
+
+        if can_connect_to_database():
+            token = get_token()
+            user = get_user(token=token, abort_if_no_token=False)
+            app_name = get_app_name(token)
+            if user:
+                record_custom_parameter('user_id', str(user.id))
+            record_custom_parameter('token_name', app_name)
+
         record_custom_parameter('version', __version__)
         coverages = get_used_coverages()
         if coverages:

--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -128,7 +128,7 @@ def has_access(region, api, abort, user):
     if current_app.config.get('PUBLIC', False):
         # if jormungandr is on public mode we skip the authentification process
         return True
-    if not can_connect_to_database:
+    if not can_connect_to_database():
         return True
 
     if not user:

--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -40,6 +40,7 @@ import datetime
 import base64
 from navitiacommon.models import User, Instance, Key
 from jormungandr import cache, memory_cache, app as current_app
+from jormungandr.utils import can_connect_to_database
 import six
 
 
@@ -127,6 +128,8 @@ def has_access(region, api, abort, user):
     if current_app.config.get('PUBLIC', False):
         # if jormungandr is on public mode we skip the authentification process
         return True
+    if not can_connect_to_database:
+        return True
 
     if not user:
         # no user --> no need to continue, we can abort, a user is mandatory even for free region
@@ -159,6 +162,8 @@ def cache_get_user(token):
     We allow this method to be cached even if it depends on the current time
     because we assume the cache time is small and the error can be tolerated.
     """
+    if not can_connect_to_database():
+        return None
     return User.get_from_token(token, datetime.datetime.now())
 
 

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -32,6 +32,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 from importlib import import_module
 from itertools import chain
 from navitiacommon import type_pb2
+from jormungandr.utils import can_connect_to_database
 
 import logging
 import datetime
@@ -103,6 +104,12 @@ class EquipmentProviderManager(object):
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._providers_getter
         ):
+            return
+
+        # If database is not accessible we update the value of self._last_update and exit
+        if not can_connect_to_database():
+            self.logger.debug('Database is not accessible')
+            self._last_update = datetime.datetime.utcnow()
             return
 
         self.logger.debug('Updating equipment providers from db')

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -38,7 +38,7 @@ from jormungandr.utils import can_connect_to_database
 
 class ExternalServiceManager(object):
     def __init__(
-        self, instance, external_service_configuration, external_service_getter=None, update_interval=10
+        self, instance, external_service_configuration, external_service_getter=None, update_interval=600
     ):
         self.logger = logging.getLogger(__name__)
         self._external_service_configuration = external_service_configuration

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -106,7 +106,13 @@ class ExternalServiceManager(object):
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._external_service_getter
-        ) or not can_connect_to_database():
+        ):
+            return
+
+        # If database is not accessible we update the value of self._last_update and exit
+        if not can_connect_to_database():
+            self.logger.debug('Database is not accessible')
+            self._last_update = datetime.datetime.utcnow()
             return
 
         self.logger.debug('Updating external services from db')

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -33,11 +33,12 @@ import logging
 import datetime
 from jormungandr import utils
 from jormungandr.exceptions import ConfigException
+from jormungandr.utils import can_connect_to_database
 
 
 class ExternalServiceManager(object):
     def __init__(
-        self, instance, external_service_configuration, external_service_getter=None, update_interval=600
+        self, instance, external_service_configuration, external_service_getter=None, update_interval=10
     ):
         self.logger = logging.getLogger(__name__)
         self._external_service_configuration = external_service_configuration
@@ -105,7 +106,7 @@ class ExternalServiceManager(object):
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._external_service_getter
-        ):
+        ) or not can_connect_to_database():
             return
 
         self.logger.debug('Updating external services from db')

--- a/source/jormungandr/jormungandr/external_services/tests/external_service_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/external_services/tests/external_service_provider_manager_test.py
@@ -212,9 +212,7 @@ def external_service_provider_manager_db_test():
     # one with navitia_service=free_floatings where as another with navitia_service=vehicle_occupancies
     # For api /free_floatings the service associated to navitia_service=free_floatings will be used
     # For api /vehicle_occupancies the service associated to navitia_service=vehicle_occupancies will be used
-    with app.app_context():
-        manager.update_config()
-
+    manager.update_config()
     assert len(manager._external_services_legacy) == 2
     service = manager._external_services_legacy.get('free_floatings', [])[0]
     assert service.service_url == "http://config_from_db/free_floatings"
@@ -230,8 +228,7 @@ def external_service_provider_manager_db_test():
 
     # services are re-initialized from the new configurations in the db (free_floating_services_getter_update)
     manager._external_service_getter = free_floating_services_getter_update
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert manager._last_update > manager_update
     assert len(manager._external_services_legacy) == 1
@@ -244,9 +241,7 @@ def external_service_provider_manager_db_test():
     # services are re-initialized from the new configurations in the db (vehicle_occcupancy_services_getter_update)
     manager_update = manager._last_update
     manager._external_service_getter = vehicle_occcupancy_services_getter_update
-    with app.app_context():
-        manager.update_config()
-
+    manager.update_config()
     assert manager._last_update > manager_update
     assert len(manager._external_services_legacy) == 1
     service = manager._external_services_legacy.get('vehicle_occupancies', [])[0]
@@ -258,9 +253,7 @@ def external_service_provider_manager_db_test():
     # No service is re-initialized from the new configurations in the db as the class is wrong one
     manager_update = manager._last_update
     manager._external_service_getter = services_getter_update_with_wrong_class
-    with app.app_context():
-        manager.update_config()
-
+    manager.update_config()
     assert len(manager._external_services_legacy) == 0
 
 
@@ -284,8 +277,7 @@ def external_service_provider_manager_config_from_file_and_db_test():
     # For api /free_floatings the service associated to navitia_service=free_floatings will be used
     # For api /vehicle_occupancies the service associated to navitia_service=vehicle_occupancies will be used
     # All the services from configuration file are all removed.
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._external_services_legacy) == 2
     service = manager._external_services_legacy.get('free_floatings', [])[0]

--- a/source/jormungandr/jormungandr/external_services/tests/external_service_provider_manager_test.py
+++ b/source/jormungandr/jormungandr/external_services/tests/external_service_provider_manager_test.py
@@ -32,6 +32,7 @@ from jormungandr.external_services.external_service_provider_manager import Exte
 from navitiacommon.models import ExternalService
 import datetime
 import pytest
+from jormungandr import app
 
 free_floating_valid_configuration = [
     {
@@ -211,7 +212,9 @@ def external_service_provider_manager_db_test():
     # one with navitia_service=free_floatings where as another with navitia_service=vehicle_occupancies
     # For api /free_floatings the service associated to navitia_service=free_floatings will be used
     # For api /vehicle_occupancies the service associated to navitia_service=vehicle_occupancies will be used
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._external_services_legacy) == 2
     service = manager._external_services_legacy.get('free_floatings', [])[0]
     assert service.service_url == "http://config_from_db/free_floatings"
@@ -227,7 +230,8 @@ def external_service_provider_manager_db_test():
 
     # services are re-initialized from the new configurations in the db (free_floating_services_getter_update)
     manager._external_service_getter = free_floating_services_getter_update
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
 
     assert manager._last_update > manager_update
     assert len(manager._external_services_legacy) == 1
@@ -240,7 +244,8 @@ def external_service_provider_manager_db_test():
     # services are re-initialized from the new configurations in the db (vehicle_occcupancy_services_getter_update)
     manager_update = manager._last_update
     manager._external_service_getter = vehicle_occcupancy_services_getter_update
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
 
     assert manager._last_update > manager_update
     assert len(manager._external_services_legacy) == 1
@@ -253,7 +258,9 @@ def external_service_provider_manager_db_test():
     # No service is re-initialized from the new configurations in the db as the class is wrong one
     manager_update = manager._last_update
     manager._external_service_getter = services_getter_update_with_wrong_class
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._external_services_legacy) == 0
 
 
@@ -277,7 +284,9 @@ def external_service_provider_manager_config_from_file_and_db_test():
     # For api /free_floatings the service associated to navitia_service=free_floatings will be used
     # For api /vehicle_occupancies the service associated to navitia_service=vehicle_occupancies will be used
     # All the services from configuration file are all removed.
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._external_services_legacy) == 2
     service = manager._external_services_legacy.get('free_floatings', [])[0]
     assert service.service_url == "http://config_from_db/free_floatings"

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -64,6 +64,7 @@ from datetime import datetime, timedelta
 from navitiacommon import default_values
 from jormungandr.equipments import EquipmentProviderManager
 from jormungandr.external_services import ExternalServiceManager
+from jormungandr.utils import can_connect_to_database
 
 type_to_pttype = {
     "stop_area": request_pb2.PlaceCodeRequest.StopArea,  # type: ignore
@@ -252,6 +253,8 @@ class Instance(object):
     @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_PARAMS'), 300))
     def _get_models(self):
         if app.config['DISABLE_DATABASE']:
+            return None
+        if not can_connect_to_database():
             return None
         return models.Instance.get_by_name(self.name)
 

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -203,26 +203,30 @@ class Instance(object):
         """
         :return: a callable query of equipment providers associated to the current instance in db
         """
-        return self._get_models().equipment_details_providers
+        models = self._get_models()
+        return models.equipment_details_providers if models else None
 
     def get_ridesharing_services_from_db(self):
         """
         :return: a callable query of ridesharing services associated to the current instance in db
         """
-        return self._get_models().ridesharing_services
+        models = self._get_models()
+        return models.ridesharing_services if models else None
 
     def get_external_service_providers_from_db(self):
         """
         :return: a callable query of external services associated to the current instance in db
         """
-        result = self._get_models().external_services or None
+        models = self._get_models()
+        result = models.external_services if models else None
         return [res for res in result if res.navitia_service in ['free_floatings', 'vehicle_occupancies']]
 
     def get_realtime_proxies_from_db(self):
         """
         :return: a callable query of external services associated to the current instance in db
         """
-        result = self._get_models().external_services
+        models = self._get_models()
+        result = models.external_services if models else None
         return [res for res in result if res.navitia_service == 'realtime_proxies']
 
     @property
@@ -893,7 +897,7 @@ class Instance(object):
         )
 
     def get_all_street_networks(self):
-        if app.config[str('DISABLE_DATABASE')]:
+        if app.config[str('DISABLE_DATABASE')] or not can_connect_to_database():
             return self._streetnetwork_backend_manager.get_all_street_networks_legacy(self)
         else:
             return self._streetnetwork_backend_manager.get_all_street_networks_db(self)

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -215,7 +215,7 @@ class Instance(object):
         """
         :return: a callable query of external services associated to the current instance in db
         """
-        result = self._get_models().external_services
+        result = self._get_models().external_services or None
         return [res for res in result if res.navitia_service in ['free_floatings', 'vehicle_occupancies']]
 
     def get_realtime_proxies_from_db(self):
@@ -252,9 +252,7 @@ class Instance(object):
     @memory_cache.memoize(app.config[str('MEMORY_CACHE_CONFIGURATION')].get(str('TIMEOUT_PARAMS'), 30))
     @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_PARAMS'), 300))
     def _get_models(self):
-        if app.config['DISABLE_DATABASE']:
-            return None
-        if not can_connect_to_database():
+        if app.config['DISABLE_DATABASE'] or not can_connect_to_database():
             return None
         return models.Instance.get_by_name(self.name)
 

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -267,10 +267,12 @@ class InstanceManager(object):
             self.thread_event.set()
 
     def _filter_authorized_instances(self, instances, api):
-        if not can_connect_to_database():
-            return instances
         if not instances:
             return None
+        # During the period database is not accessible, all the instances are valid for the user.
+        if not can_connect_to_database():
+            return instances
+
         user = authentication.get_user(token=authentication.get_token())
         valid_instances = [
             i for i in instances if authentication.has_access(i.name, abort=False, user=user, api=api)

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -41,6 +41,7 @@ from jormungandr.protobuf_to_dict import protobuf_to_dict
 from jormungandr.exceptions import ApiNotFound, RegionNotFound, DeadSocketException, InvalidArguments
 from jormungandr import authentication, cache, app
 from jormungandr.instance import Instance
+from jormungandr.utils import can_connect_to_database
 import gevent
 import os
 
@@ -266,6 +267,8 @@ class InstanceManager(object):
             self.thread_event.set()
 
     def _filter_authorized_instances(self, instances, api):
+        if not can_connect_to_database():
+            return instances
         if not instances:
             return None
         user = authentication.get_user(token=authentication.get_token())
@@ -341,7 +344,6 @@ class InstanceManager(object):
             ]
         else:
             available_instances = list(self.instances.values())
-
         valid_instances = self._filter_authorized_instances(available_instances, api)
         if available_instances and not valid_instances:
             # user doesn't have access to any of the instances

--- a/source/jormungandr/jormungandr/interfaces/v1/Status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Status.py
@@ -56,8 +56,8 @@ class Status(StatedResource):
         )
         logging.getLogger(__name__).info("status reponse: %s", response)
         if can_connect_to_database():
-            response['status']['database_connection'] = 'connected'
+            response['status']['configuration_database'] = 'connected'
         else:
-            response['status']['database_connection'] = 'no_SQL_connection'
+            response['status']['configuration_database'] = 'no_SQL_connection'
 
         return response, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/Status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Status.py
@@ -55,9 +55,8 @@ class Status(StatedResource):
             region_str
         )
         logging.getLogger(__name__).info("status reponse: %s", response)
-        if can_connect_to_database():
-            response['status']['configuration_database'] = 'connected'
-        else:
-            response['status']['configuration_database'] = 'no_SQL_connection'
+        response['status']['configuration_database'] = (
+            'connected' if can_connect_to_database() else 'no_SQL_connection'
+        )
 
         return response, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/Status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Status.py
@@ -34,6 +34,7 @@ from jormungandr.interfaces.v1.serializer.api import StatusSerializer
 from jormungandr.interfaces.v1.decorators import get_serializer
 from jormungandr.interfaces.v1.StatedResource import StatedResource
 from jormungandr.interfaces.v1 import add_common_status
+from jormungandr.utils import can_connect_to_database
 import logging
 
 
@@ -54,4 +55,9 @@ class Status(StatedResource):
             region_str
         )
         logging.getLogger(__name__).info("status reponse: %s", response)
+        if can_connect_to_database():
+            response['status']['database_connection'] = 'connected'
+        else:
+            response['status']['database_connection'] = 'no_SQL_connection'
+
         return response, 200

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -444,6 +444,7 @@ class TechnicalStatusSerializer(NullableDictSerializer):
     context = MethodField(schema_type=ContextSerializer(), display_none=False)
     warnings = base.BetaEndpointsSerializer()
     redis = status.RedisStatusSerializer(display_none=False)
+    database_connection = Field(schema_type=str, display_none=False)
 
     def get_context(self, obj):
         return ContextSerializer(obj, is_utc=True, display_none=False).data

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -444,7 +444,7 @@ class TechnicalStatusSerializer(NullableDictSerializer):
     context = MethodField(schema_type=ContextSerializer(), display_none=False)
     warnings = base.BetaEndpointsSerializer()
     redis = status.RedisStatusSerializer(display_none=False)
-    database_connection = Field(schema_type=str, display_none=False)
+    configuration_database = Field(schema_type=str, display_none=False)
 
     def get_context(self, obj):
         return ContextSerializer(obj, is_utc=True, display_none=False).data

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
@@ -247,7 +247,7 @@ class CommonStatusSerializer(NullableDictSerializer):
     last_rt_data_loaded = Field(schema_type=str, display_none=False)
     kraken_version = MethodField(schema_type=str, display_none=False)
     region_id = Field(schema_type=str, display_none=False, description='Identifier of the coverage')
-    database_connection = Field(schema_type=str, display_none=False)
+    configuration_database = Field(schema_type=str, display_none=False)
     error = CoverageErrorSerializer(display_none=False)
 
     def get_kraken_version(self, obj):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
@@ -213,7 +213,7 @@ class EquipmentProvidersServicesSerializer(NullableDictSerializer):
 
 
 class ExternalServiceProvidersServicesSerializer(NullableDictSerializer):
-    external_service_providers_keys = MethodField(schema_type=str, many=True, display_none=True)
+    external_service_providers_keys = MethodField(schema_type=str, many=True, display_none=False)
 
     def get_external_service_providers_keys(self, obj):
         return obj.get('external_service_providers_keys', [])
@@ -239,8 +239,8 @@ class CommonStatusSerializer(NullableDictSerializer):
     publication_date = Field(schema_type=str, display_none=False)
     street_networks = StreetNetworkSerializer(many=True, display_none=False)
     ridesharing_services = RidesharingServicesSerializer(many=True, display_none=False)
-    equipment_providers_services = EquipmentProvidersServicesSerializer()
-    external_providers_services = ExternalServiceProvidersServicesSerializer()
+    equipment_providers_services = EquipmentProvidersServicesSerializer(display_none=False)
+    external_providers_services = ExternalServiceProvidersServicesSerializer(display_none=False)
     start_production_date = Field(schema_type=str, display_none=False)
     last_load_status = Field(schema_type=bool, display_none=False)
     is_open_data = Field(schema_type=bool, display_none=False)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/status.py
@@ -247,6 +247,7 @@ class CommonStatusSerializer(NullableDictSerializer):
     last_rt_data_loaded = Field(schema_type=str, display_none=False)
     kraken_version = MethodField(schema_type=str, display_none=False)
     region_id = Field(schema_type=str, display_none=False, description='Identifier of the coverage')
+    database_connection = Field(schema_type=str, display_none=False)
     error = CoverageErrorSerializer(display_none=False)
 
     def get_kraken_version(self, obj):

--- a/source/jormungandr/jormungandr/interfaces/v1/test/add_common_status_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/add_common_status_tests.py
@@ -191,15 +191,14 @@ def add_common_status_test():
 
 
 def call_add_common_status(disable_database):
-    with app.app_context():
-        instance = FakeInstance(
-            disable_database,
-            ridesharing_configurations=instant_system_ridesharing_config,
-            equipment_details_config=sytral_equipment_details_config,
-            instance_equipment_providers=["sytral"],
-        )
-        response = {'status': {}}
-        add_common_status(response, instance)
+    instance = FakeInstance(
+        disable_database,
+        ridesharing_configurations=instant_system_ridesharing_config,
+        equipment_details_config=sytral_equipment_details_config,
+        instance_equipment_providers=["sytral"],
+    )
+    response = {'status': {}}
+    add_common_status(response, instance)
 
     assert response['status']["is_open_data"] is False
     assert response['status']["is_open_service"] is False
@@ -228,15 +227,14 @@ def call_add_common_status(disable_database):
 
 
 def call_add_common_status_with_Karos(disable_database):
-    with app.app_context():
-        instance = FakeInstance(
-            disable_database,
-            ridesharing_configurations=karos_system_ridesharing_config,
-            equipment_details_config=sytral_equipment_details_config,
-            instance_equipment_providers=["sytral"],
-        )
-        response = {'status': {}}
-        add_common_status(response, instance)
+    instance = FakeInstance(
+        disable_database,
+        ridesharing_configurations=karos_system_ridesharing_config,
+        equipment_details_config=sytral_equipment_details_config,
+        instance_equipment_providers=["sytral"],
+    )
+    response = {'status': {}}
+    add_common_status(response, instance)
 
     # We sort this list because the order is not important
     # And it is easier to compare

--- a/source/jormungandr/jormungandr/interfaces/v1/test/add_common_status_tests.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/test/add_common_status_tests.py
@@ -33,6 +33,7 @@ from jormungandr.street_network.kraken import Kraken
 from jormungandr.equipments import EquipmentProviderManager
 from jormungandr.street_network.streetnetwork_backend_manager import StreetNetworkBackendManager
 from jormungandr.tests.utils_test import compare_list_of_dicts
+from jormungandr import app
 
 from collections import OrderedDict
 
@@ -190,14 +191,15 @@ def add_common_status_test():
 
 
 def call_add_common_status(disable_database):
-    instance = FakeInstance(
-        disable_database,
-        ridesharing_configurations=instant_system_ridesharing_config,
-        equipment_details_config=sytral_equipment_details_config,
-        instance_equipment_providers=["sytral"],
-    )
-    response = {'status': {}}
-    add_common_status(response, instance)
+    with app.app_context():
+        instance = FakeInstance(
+            disable_database,
+            ridesharing_configurations=instant_system_ridesharing_config,
+            equipment_details_config=sytral_equipment_details_config,
+            instance_equipment_providers=["sytral"],
+        )
+        response = {'status': {}}
+        add_common_status(response, instance)
 
     assert response['status']["is_open_data"] is False
     assert response['status']["is_open_service"] is False
@@ -226,14 +228,15 @@ def call_add_common_status(disable_database):
 
 
 def call_add_common_status_with_Karos(disable_database):
-    instance = FakeInstance(
-        disable_database,
-        ridesharing_configurations=karos_system_ridesharing_config,
-        equipment_details_config=sytral_equipment_details_config,
-        instance_equipment_providers=["sytral"],
-    )
-    response = {'status': {}}
-    add_common_status(response, instance)
+    with app.app_context():
+        instance = FakeInstance(
+            disable_database,
+            ridesharing_configurations=karos_system_ridesharing_config,
+            equipment_details_config=sytral_equipment_details_config,
+            instance_equipment_providers=["sytral"],
+        )
+        response = {'status': {}}
+        add_common_status(response, instance)
 
     # We sort this list because the order is not important
     # And it is easier to compare

--- a/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
@@ -111,8 +111,8 @@ class TechnicalStatus(ModuleResource):
             response['redis'] = cache_status_op()
 
         if can_connect_to_database():
-            response['database_connection'] = 'connected'
+            response['configuration_database'] = 'connected'
         else:
-            response['database_connection'] = 'no_SQL_connection'
+            response['configuration_database'] = 'no_SQL_connection'
 
         return response

--- a/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
@@ -42,6 +42,7 @@ from jormungandr.interfaces.v1.decorators import get_serializer
 from jormungandr.interfaces.v1.serializer.api import TechnicalStatusSerializer
 from jormungandr.interfaces.v1.serializer.status import CommonStatusSerializer
 from jormungandr.interfaces.v1 import add_common_status
+from jormungandr.utils import can_connect_to_database
 
 
 class Index(ModuleResource):
@@ -108,5 +109,10 @@ class TechnicalStatus(ModuleResource):
         cache_status_op = getattr(cache.cache, "status", None)
         if callable(cache_status_op):
             response['redis'] = cache_status_op()
+
+        if can_connect_to_database():
+            response['database_connection'] = 'connected'
+        else:
+            response['database_connection'] = 'no_SQL_connection'
 
         return response

--- a/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/resources/Index.py
@@ -110,9 +110,6 @@ class TechnicalStatus(ModuleResource):
         if callable(cache_status_op):
             response['redis'] = cache_status_op()
 
-        if can_connect_to_database():
-            response['configuration_database'] = 'connected'
-        else:
-            response['configuration_database'] = 'no_SQL_connection'
+        response['configuration_database'] = 'connected' if can_connect_to_database() else 'no_SQL_connection'
 
         return response

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -28,6 +28,7 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 from jormungandr.parking_space_availability.abstract_provider_manager import AbstractProviderManager
+from jormungandr.utils import can_connect_to_database
 import logging
 import datetime
 
@@ -52,6 +53,12 @@ class BssProviderManager(AbstractProviderManager):
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._providers_getter
         ):
+            return
+
+        # If database is not accessible we update the value of self._last_update and exit
+        if not can_connect_to_database():
+            self.logger.debug('Database is not accessible')
+            self._last_update = datetime.datetime.utcnow()
             return
 
         logger = logging.getLogger(__name__)

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
@@ -32,7 +32,7 @@ from __future__ import absolute_import, print_function, unicode_literals, divisi
 from importlib import import_module
 import logging
 import datetime
-from copy import deepcopy
+from jormungandr.utils import can_connect_to_database
 
 
 class RealtimeProxyManager(object):
@@ -110,7 +110,7 @@ class RealtimeProxyManager(object):
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._realtime_proxies_getter
-        ):
+        ) or not can_connect_to_database():
             return
 
         self.logger.debug('Updating realtime proxies from db')

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
@@ -110,7 +110,13 @@ class RealtimeProxyManager(object):
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._realtime_proxies_getter
-        ) or not can_connect_to_database():
+        ):
+            return
+
+        # If database is not accessible we update the value of self._last_update and exit
+        if not can_connect_to_database():
+            self.logger.debug('Database is not accessible')
+            self._last_update = datetime.datetime.utcnow()
             return
 
         self.logger.debug('Updating realtime proxies from db')

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
@@ -253,8 +253,7 @@ def multi_proxy_conf_file_and_database_test():
     for rt_proxy in ["clever_age_TBC", "SytralRT", "Timeo_Amelys", "Siri_TAO", "siri_stif"]:
         assert rt_proxy in manager._realtime_proxies_legacy
 
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._realtime_proxies) == 5
     for rt_proxy in ["clever_age_TBC", "SytralRT", "Timeo_Amelys", "Siri_TAO", "siri_stif"]:
@@ -285,8 +284,7 @@ def proxy_conf_file_and_database_same_id_test():
     assert len(manager._realtime_proxies_legacy) == 1
     assert 'SytralRT' in manager._realtime_proxies_legacy
 
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._realtime_proxies) == 1
     assert 'SytralRT' in manager._realtime_proxies
@@ -318,8 +316,7 @@ def one_proxy_conf_file_and_database_different_id_test():
     assert 'SytralRT' in manager._realtime_proxies_legacy
     assert len(manager.get_all_realtime_proxies()) == 1
 
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._realtime_proxies_legacy) == 1
     assert 'SytralRT' in manager._realtime_proxies_legacy
@@ -344,8 +341,7 @@ def proxy_only_database_test():
     assert len(manager._realtime_proxies_legacy) == 0
     assert len(manager.get_all_realtime_proxies()) == 0
 
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._realtime_proxies_legacy) == 0
 
@@ -370,8 +366,7 @@ def update_proxy_database_test():
     assert len(manager._realtime_proxies_legacy) == 0
     assert len(manager.get_all_realtime_proxies()) == 0
 
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._realtime_proxies_legacy) == 0
 
@@ -393,8 +388,7 @@ def update_proxy_database_test():
         return [external_service]
 
     manager._realtime_proxies_getter = update_provider
-    with app.app_context():
-        manager.update_config()
+    manager.update_config()
 
     assert len(manager._realtime_proxies_legacy) == 0
 

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
@@ -32,6 +32,7 @@ import pytz
 from jormungandr.realtime_schedule.realtime_proxy_manager import RealtimeProxyManager
 from navitiacommon.models import ExternalService
 import datetime
+from jormungandr import app
 
 
 class MockInstance:
@@ -252,7 +253,8 @@ def multi_proxy_conf_file_and_database_test():
     for rt_proxy in ["clever_age_TBC", "SytralRT", "Timeo_Amelys", "Siri_TAO", "siri_stif"]:
         assert rt_proxy in manager._realtime_proxies_legacy
 
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
 
     assert len(manager._realtime_proxies) == 5
     for rt_proxy in ["clever_age_TBC", "SytralRT", "Timeo_Amelys", "Siri_TAO", "siri_stif"]:
@@ -283,7 +285,9 @@ def proxy_conf_file_and_database_same_id_test():
     assert len(manager._realtime_proxies_legacy) == 1
     assert 'SytralRT' in manager._realtime_proxies_legacy
 
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._realtime_proxies) == 1
     assert 'SytralRT' in manager._realtime_proxies
     assert len(manager._realtime_proxies_legacy) == 0
@@ -314,7 +318,9 @@ def one_proxy_conf_file_and_database_different_id_test():
     assert 'SytralRT' in manager._realtime_proxies_legacy
     assert len(manager.get_all_realtime_proxies()) == 1
 
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._realtime_proxies_legacy) == 1
     assert 'SytralRT' in manager._realtime_proxies_legacy
 
@@ -338,7 +344,9 @@ def proxy_only_database_test():
     assert len(manager._realtime_proxies_legacy) == 0
     assert len(manager.get_all_realtime_proxies()) == 0
 
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._realtime_proxies_legacy) == 0
 
     assert len(manager._realtime_proxies) == 1
@@ -362,7 +370,9 @@ def update_proxy_database_test():
     assert len(manager._realtime_proxies_legacy) == 0
     assert len(manager.get_all_realtime_proxies()) == 0
 
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._realtime_proxies_legacy) == 0
 
     assert len(manager._realtime_proxies) == 1
@@ -383,7 +393,9 @@ def update_proxy_database_test():
         return [external_service]
 
     manager._realtime_proxies_getter = update_provider
-    manager.update_config()
+    with app.app_context():
+        manager.update_config()
+
     assert len(manager._realtime_proxies_legacy) == 0
 
     assert len(manager._realtime_proxies) == 1

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -136,7 +136,13 @@ class RidesharingServiceManager(object):
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._rs_services_getter
-        ) or not can_connect_to_database():
+        ):
+            return
+
+        # If database is not accessible we update the value of self._last_update and exit
+        if not can_connect_to_database():
+            self.logger.debug('Database is not accessible')
+            self._last_update = datetime.datetime.utcnow()
             return
 
         self.logger.debug('Updating ridesharing services from db')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -43,6 +43,7 @@ from jormungandr.utils import PeriodExtremity
 from jormungandr.scenarios.journey_filter import to_be_deleted
 from jormungandr.scenarios.helper_classes.helper_future import FutureManager
 from importlib import import_module
+from jormungandr.utils import can_connect_to_database
 
 
 class RidesharingServiceManager(object):
@@ -135,7 +136,7 @@ class RidesharingServiceManager(object):
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._rs_services_getter
-        ):
+        ) or not can_connect_to_database():
             return
 
         self.logger.debug('Updating ridesharing services from db')

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
@@ -130,8 +130,7 @@ def two_ridesharing_service_manager_config_from_file_and_db_test():
         instance, ridesharing_services_config, rs_services_getter=mock_get_attr_instant_system
     )
     ridesharing_manager.init_ridesharing_services()
-    with app.app_context():
-        ridesharing_manager.update_config()
+    ridesharing_manager.update_config()
 
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 1
@@ -155,8 +154,7 @@ def two_same_ridesharing_service_manager_config_from_file_and_db_test():
         instance, ridesharing_services_config, rs_services_getter=mock_get_attr_instant_system
     )
     ridesharing_manager.init_ridesharing_services()
-    with app.app_context():
-        ridesharing_manager.update_config()
+    ridesharing_manager.update_config()
 
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 1
@@ -180,8 +178,7 @@ def ridesharing_service_manager_config_from_file_and_db_test():
         instance, [], rs_services_getter=mock_get_attr_instant_system_and_blablalines
     )
     ridesharing_manager.init_ridesharing_services()
-    with app.app_context():
-        ridesharing_manager.update_config()
+    ridesharing_manager.update_config()
 
     assert len(ridesharing_manager.ridesharing_services_configuration) == 0
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 2

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ridesharing_service_manager_test.py
@@ -32,6 +32,7 @@ from jormungandr.scenarios.ridesharing.ridesharing_service_manager import Ridesh
 from jormungandr.scenarios.ridesharing.blablalines import Blablalines
 from jormungandr.scenarios.ridesharing.instant_system import InstantSystem
 from navitiacommon.models.ridesharing_service import RidesharingService
+from jormungandr import app
 
 
 class MockInstance:
@@ -129,7 +130,9 @@ def two_ridesharing_service_manager_config_from_file_and_db_test():
         instance, ridesharing_services_config, rs_services_getter=mock_get_attr_instant_system
     )
     ridesharing_manager.init_ridesharing_services()
-    ridesharing_manager.update_config()
+    with app.app_context():
+        ridesharing_manager.update_config()
+
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 1
     assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"
@@ -152,7 +155,9 @@ def two_same_ridesharing_service_manager_config_from_file_and_db_test():
         instance, ridesharing_services_config, rs_services_getter=mock_get_attr_instant_system
     )
     ridesharing_manager.init_ridesharing_services()
-    ridesharing_manager.update_config()
+    with app.app_context():
+        ridesharing_manager.update_config()
+
     assert len(ridesharing_manager.ridesharing_services_configuration) == 1
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 1
     assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"
@@ -175,7 +180,9 @@ def ridesharing_service_manager_config_from_file_and_db_test():
         instance, [], rs_services_getter=mock_get_attr_instant_system_and_blablalines
     )
     ridesharing_manager.init_ridesharing_services()
-    ridesharing_manager.update_config()
+    with app.app_context():
+        ridesharing_manager.update_config()
+
     assert len(ridesharing_manager.ridesharing_services_configuration) == 0
     assert len(list(ridesharing_manager._ridesharing_services.values())) == 2
     assert ridesharing_manager._ridesharing_services["InstantSystem"].system_id == "instant_system"

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -128,9 +128,12 @@ class StreetNetworkBackendManager(object):
         except Exception:
             self.logger.exception('impossible to initialize streetnetwork backend')
 
+    def _can_connect_to_database(self):
+        return can_connect_to_database()
+
     def _update_config(self, instance):
         # type: (Instance) -> None
-        if not can_connect_to_database():
+        if not self._can_connect_to_database():
             return
         """
         Update list of streetnetwork backends from db

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -32,6 +32,7 @@ from jormungandr import fallback_modes as fm
 from jormungandr.exceptions import TechnicalError
 from jormungandr.instance import Instance
 from jormungandr.street_network.street_network import AbstractStreetNetworkService
+from jormungandr.utils import can_connect_to_database
 from navitiacommon.models.streetnetwork_backend import StreetNetworkBackend
 from collections import defaultdict
 import logging, itertools, copy, datetime
@@ -129,6 +130,8 @@ class StreetNetworkBackendManager(object):
 
     def _update_config(self, instance):
         # type: (Instance) -> None
+        if not can_connect_to_database():
+            return
         """
         Update list of streetnetwork backends from db
         """

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -133,15 +133,13 @@ class StreetNetworkBackendManager(object):
 
     def _update_config(self, instance):
         # type: (Instance) -> None
-        if not self._can_connect_to_database():
-            return
         """
         Update list of streetnetwork backends from db
         """
         if (
             self._last_update + datetime.timedelta(seconds=self._update_interval) > datetime.datetime.utcnow()
             or not self._sn_backends_getter
-        ):
+        ) or not self._can_connect_to_database():
             return
 
         self.logger.debug('Updating streetnetwork backends from db')

--- a/source/jormungandr/jormungandr/street_network/tests/streetnetwork_backend_manager_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/streetnetwork_backend_manager_test.py
@@ -36,6 +36,7 @@ from jormungandr.street_network.kraken import Kraken
 from jormungandr.street_network.valhalla import Valhalla
 from jormungandr.exceptions import ConfigException, TechnicalError
 from jormungandr.tests.utils_test import compare_list_of_dicts
+from mock import MagicMock
 
 import datetime
 
@@ -208,6 +209,7 @@ def streetnetwork_backend_manager_db_test():
 
     # 2 sn_backends defined in db are associated to the coverage
     # -> 2 sn_backends created
+    manager._can_connect_to_database = MagicMock(return_value=True)
     manager._update_config("instance")
 
     assert not manager._streetnetwork_backends_by_instance_legacy
@@ -223,6 +225,7 @@ def streetnetwork_backend_manager_db_test():
 
     # Sn_backend already existing is updated
     manager._sn_backends_getter = sn_backends_getter_update
+    manager._can_connect_to_database = MagicMock(return_value=True)
     manager._update_config("instance")
     assert manager._last_update > manager_update
     assert not manager._streetnetwork_backends_by_instance_legacy
@@ -234,6 +237,7 @@ def streetnetwork_backend_manager_db_test():
 
     # Long update interval so sn_backend shouldn't be updated
     manager = StreetNetworkBackendManager(sn_backends_getter_ok, 600)
+    manager._can_connect_to_database = MagicMock(return_value=True)
     manager._update_config("instance")
     assert not manager._streetnetwork_backends_by_instance_legacy
     assert len(manager._streetnetwork_backends) == 2
@@ -257,6 +261,7 @@ def wrong_streetnetwork_backend_test():
 
     # Sn_backend has a class wrongly formatted
     manager = StreetNetworkBackendManager(sn_backends_getter_wrong_class, -1)
+    manager._can_connect_to_database = MagicMock(return_value=True)
     manager._update_config("instance")
     assert not manager._streetnetwork_backends_by_instance_legacy
     assert not manager._streetnetwork_backends
@@ -382,6 +387,7 @@ def append_default_street_network_to_config_test():
 def get_street_network_db_test():
     manager = StreetNetworkBackendManager(sn_backends_getter_ok, -1)
 
+    manager._can_connect_to_database = MagicMock(return_value=True)
     sn = manager.get_street_network_db("instance", "kraken")
     assert sn is not None
     assert sn.timeout == 2
@@ -430,6 +436,7 @@ def get_all_street_networks_db_test():
     manager = StreetNetworkBackendManager(sn_backends_getter_ok, -1)
     instance = FakeInstance()
 
+    manager._can_connect_to_database = MagicMock(return_value=True)
     all_sn = manager.get_all_street_networks_db(instance)
     assert len(all_sn) == 2
 

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -151,6 +151,7 @@ def user_set(app, fake_user_type, user_name):
 
     def handler(sender, **kwargs):
         g.user = fake_user_type.get_from_token(user_name, valid_until=None)
+        g.can_connect_to_database = True
 
     with appcontext_pushed.connected_to(handler, app):
         yield

--- a/source/jormungandr/jormungandr/travelers_profile.py
+++ b/source/jormungandr/jormungandr/travelers_profile.py
@@ -123,9 +123,7 @@ class TravelerProfile(object):
         travelers_profile factory method,
         Return a traveler_profile constructed with default params or params retrieved from db
         """
-        if app.config[str('DISABLE_DATABASE')]:
-            return default_traveler_profiles[traveler_type]
-        if not can_connect_to_database():
+        if app.config[str('DISABLE_DATABASE')] or not can_connect_to_database():
             return default_traveler_profiles[traveler_type]
 
         # retrieve TravelerProfile from db with coverage and traveler_type

--- a/source/jormungandr/jormungandr/travelers_profile.py
+++ b/source/jormungandr/jormungandr/travelers_profile.py
@@ -29,6 +29,7 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 from jormungandr import app, cache, memory_cache
+from jormungandr.utils import can_connect_to_database
 from navitiacommon import models
 from navitiacommon.default_traveler_profile_params import (
     default_traveler_profile_params,
@@ -123,6 +124,8 @@ class TravelerProfile(object):
         Return a traveler_profile constructed with default params or params retrieved from db
         """
         if app.config[str('DISABLE_DATABASE')]:
+            return default_traveler_profiles[traveler_type]
+        if not can_connect_to_database():
             return default_traveler_profiles[traveler_type]
 
         # retrieve TravelerProfile from db with coverage and traveler_type

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -681,10 +681,8 @@ def can_connect_to_database():
         connection = engine.connect()
         connection.close()
         g.can_connect_to_database = True
-        print('++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++')
     except Exception:
         g.can_connect_to_database = False
-        print('--------------------------------------------------------------------------------------------')
         return False
 
     return True

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -34,7 +34,7 @@ from datetime import datetime
 from google.protobuf.descriptor import FieldDescriptor
 import pytz
 from jormungandr.timezone import get_timezone
-from navitiacommon import response_pb2, type_pb2
+from navitiacommon import response_pb2, type_pb2, models
 from navitiacommon.parser_args_type import DateTimeFormat
 from importlib import import_module
 import logging
@@ -43,7 +43,7 @@ from six.moves.urllib.parse import urlparse
 from jormungandr import new_relic
 from six.moves import zip, range
 from jormungandr.exceptions import TechnicalError
-from flask import request
+from flask import request, g
 import re
 import flask
 from contextlib import contextmanager
@@ -671,3 +671,20 @@ def has_invalid_reponse_code(objects):
 
 def journeys_absent(objects):
     return 'journeys' not in objects[0]
+
+
+def can_connect_to_database():
+    if hasattr(g, 'can_connect_to_database'):
+        return g.can_connect_to_database
+    try:
+        engine = models.db.engine
+        connection = engine.connect()
+        connection.close()
+        g.can_connect_to_database = True
+        print('++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++')
+    except Exception:
+        g.can_connect_to_database = False
+        print('--------------------------------------------------------------------------------------------')
+        return False
+
+    return True

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -674,6 +674,10 @@ def journeys_absent(objects):
 
 
 def can_connect_to_database():
+    # If g is not initialized we are out of app_context. This never happens for any service jormungandr
+    # in this case we return true to have retro-compatibility.
+    if not g:
+        return True
     if hasattr(g, 'can_connect_to_database'):
         return g.can_connect_to_database
     try:

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -32,6 +32,7 @@ from jormungandr import app
 from jormungandr.street_network.streetnetwork_backend_manager import StreetNetworkBackendManager
 from navitiacommon.models.streetnetwork_backend import StreetNetworkBackend
 from .tests_mechanism import config, NewDefaultScenarioAbstractTestFixture
+from mock import MagicMock
 from .journey_common_tests import *
 import operator
 import datetime
@@ -951,6 +952,7 @@ class TestKrakenDistributedWithDatabase(NewDefaultScenarioAbstractTestFixture):
         There is no error when multiples krakens are up and we call one of them after an other
         """
         manager = StreetNetworkBackendManager(self.sn_backends_getter)
+        manager._can_connect_to_database = MagicMock(return_value=True)
 
         i_manager.instances["main_routing_test"]._streetnetwork_backend_manager = manager
         i_manager.instances["min_nb_journeys_test"]._streetnetwork_backend_manager = manager


### PR DESCRIPTION
* Jormungandr in navitia connects to the database to validate user with or without token and uses configurations saved in the database via navitia-configurator. 
* For an unknown reason if the database is not available  or accessible, navitia should work without any connection to the database and using default configuration values.

* Api /status with or without coverage should return a response with information on one or all the coverages.

Tickets:
https://jira.kisio.org/browse/NAVITIAII-3565
https://jira.kisio.org/browse/NAVITIAII-3471

**Note: Tested in local with two coverages**
* Database available / not available
* Coverages available: 0, 1 and 2... 

Below are some screen shots:
Status without coverage and database connected:
![connected_status_sans_coverage](https://user-images.githubusercontent.com/5418640/131477079-7d9d68ce-5711-465e-aa02-5d138b54eedf.png)

Status with coverage and database connected:
![connected_coverage_avec_status](https://user-images.githubusercontent.com/5418640/131477446-33d5b957-a669-4a62-bb25-e07a98ff3b1b.png)

Status with coverage and database not available:
![no_SQL_connection_coverage_avec_status](https://user-images.githubusercontent.com/5418640/131477622-8f1e6375-67e0-4386-92a1-2ef02420bfac.png)

Coverage without status and database not available:
![no_SQL_connection_coverage_sans_status](https://user-images.githubusercontent.com/5418640/131477753-ed654feb-19ff-4bf0-988e-f10e3a1c4b38.png)

Status without coverage and database not available:
![no_SQL_connection_status_sans_coverage](https://user-images.githubusercontent.com/5418640/131478064-4d30466d-e138-4722-ac16-4627f36391f3.png)

