### PR TITLE
Add codes in new vjs

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -298,6 +298,7 @@ class TestKirinOnVJDelay(MockKirinDisruptionsFixture):
         )
 
         # A new vj is created, which the vj with the impact of the disruption
+        # Here:
         pt_response = self.query_region('vehicle_journeys')
         assert len(pt_response['vehicle_journeys']) == (initial_nb_vehicle_journeys + 1)
 

--- a/source/ptreferential/ptreferential_ng.cpp
+++ b/source/ptreferential/ptreferential_ng.cpp
@@ -346,6 +346,15 @@ struct Eval : boost::static_visitor<Indexes> {
             indexes = get_indexes_from_name(type, f.args.at(0), data);
         } else if (f.method == "has_code" && f.args.size() == 2) {
             indexes = get_indexes_from_code(type, f.args.at(0), f.args.at(1), data);
+            // For each vehicle_journey get  all realtime and add in the list
+            if (type == Type_e::VehicleJourney) {
+                const auto vjs = data.get_data<type::VehicleJourney>(indexes);
+                for (type::VehicleJourney* vj : vjs) {
+                    for (const auto& rt_vj : vj->meta_vj->get_rt_vj()) {
+                        indexes.insert(rt_vj->idx);
+                    }
+                }
+            }
         } else if (f.method == "has_code_type") {
             indexes = get_indexes_from_code_type(type, f.args, data);
         } else if ((type == Type_e::Route) && (f.method == "has_direction_type")) {

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -505,6 +505,11 @@ struct routing_api_data {
             b.vj("K", "0000000", "", false, "vjkA", "vjkA_hs")("stop_point:stopA", "17:01"_t)("stop_point:stopB",
                                                                                               "18:02"_t);
             b.lines["K"]->code = "1K";
+
+            // Add codes on vj
+            const auto* vj = b.get<nt::VehicleJourney>("vehicle_journey:vjA");
+            b.data->pt_data->codes.add(vj, "source", "source_code_vjA");
+            b.data->pt_data->codes.add(vj, "external_source", "external_code_vjA");
         }
 
         b.data->complete();

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -921,6 +921,11 @@ void PbCreator::Filler::fill_pb_object(const nt::VehicleJourney* vj, pbnavitia::
     }
     fill_messages(vj->meta_vj, vehicle_journey);
 
+    // For a realtime vj, we should get de base vj to fill codes
+    if (vj->realtime_level == nt::RTLevel::RealTime && !vj->meta_vj->get_base_vj().empty()) {
+        const auto& base_vjs = vj->meta_vj->get_base_vj();
+        vj = base_vjs.front().get();
+    }
     fill_codes(vj, vehicle_journey);
 }
 


### PR DESCRIPTION
* In ptreferential_ng, if vehicle_journey.has_code is present, for each vehicle_journey found, get all realtime vehicle_journey related to this vehicle_journey and add in the list.
* In  pb_converter, a realtime vehicle_journey is filled with it's base vehicle_journey codes.

For details refer to:
https://jira.kisio.org/browse/NAVITIAII-3605