### PR TITLE
[CI] Adding debian 11 support

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -12,15 +12,20 @@ jobs:
 
     strategy:
         matrix:
-            distribution: [debian8, debian9, debian10]
+            distribution: [debian8, debian9, debian10, debian11]
 
     container:
       image: navitia/${{matrix.distribution}}_dev
+      volumes:
+          - /usr/share/dotnet:/usr/share/dotnet
+        # Mount /dotnet so we can delete files from docker and free up space (>20GB)
 
     steps:
+    - name: Free up space
+      run: rm -rf /usr/share/dotnet/*
     - uses: actions/checkout@v1
     - name: install zip dependency
-      run: apt update && apt install -y zip httpie
+      run: apt update && apt install -y zip httpie dh-python
     - name: dkpg-buildpackage
       run: |
         sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -13,15 +13,20 @@ jobs:
 
     strategy:
         matrix:
-            distribution: [debian8, debian9, debian10]
+            distribution: [debian8, debian9, debian10, debian11]
 
     container:
       image: navitia/${{matrix.distribution}}_dev
+      volumes:
+          - /usr/share/dotnet:/usr/share/dotnet
+        # Mount /dotnet so we can delete files from docker and free up space (>20GB)
 
     steps:
+    - name: Free up space
+      run: rm -rf /usr/share/dotnet/*
     - uses: actions/checkout@v1
     - name: install zip dependency
-      run: apt update && apt install -y zip httpie
+      run: apt update && apt install -y zip httpie dh-python
     - name: dkpg-buildpackage
       run: |
         sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
         matrix:
-            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev]
+            docker_image: [navitia/debian8_dev, navitia/debian9_dev, navitia/debian10_dev, navitia/debian11_dev]
 
     container:
         image: ${{matrix.docker_image}}
@@ -55,40 +55,38 @@ jobs:
     - uses: actions/checkout@v2
       with:
           submodules: 'recursive'
-    - name: Install dependencies for python2
-      run: pip install -r source/jormungandr/requirements_dev.txt
     - name: configure for Release
-      run: cmake -DSTRIP_SYMBOLS=ON source
+      run: mkdir build && cd ./build && cmake -DSTRIP_SYMBOLS=ON ../source
     - name: run
+      working-directory: ./build
       run: make -j $(nproc)
     - name: Tests python2
+      working-directory: ./build
       run: |
+        pip install virtualenv==20.4.7 -U
+        virtualenv -p /usr/bin/python navitia_py2
+        . navitia_py2/bin/activate
+        pip install -r ../source/jormungandr/requirements_dev.txt
         export JORMUNGANDR_BROKER_URL='amqp://guest:guest@rabbitmq:5672//'
         export KRAKEN_RABBITMQ_HOST='rabbitmq'
         ctest --output-on-failure
     - name: Tests python3
+      working-directory: ./build
+      if: matrix.docker_image != 'navitia/debian11_dev'
       run: |
-        pip install virtualenv -U
         virtualenv -p /usr/local/bin/python3.6 navitia_py3
         . navitia_py3/bin/activate
-        python -V
-        pip install -r source/jormungandr/requirements_dev.txt
+        pip install -r ../source/jormungandr/requirements_dev.txt
         export JORMUNGANDR_BROKER_URL='amqp://guest:guest@rabbitmq:5672//'
         export KRAKEN_RABBITMQ_HOST='rabbitmq'
         ctest --output-on-failure
         deactivate
-    - name: remove useless tests
-      run: |
-        rm -rf tests/mock_kraken kraken/tests ed/tests fare/tests routing/tests calendar/tests
-        rm -rf georef/tests proximity_list/tests time_tables/tests equipment/tests
-        rm -rf ptreferential/tests
-    - name: install Tyr dependencies for python2
-      run: |
-        pip install -r source/tyr/requirements_dev.txt
-        pip install -r source/sql/requirements.txt
     - name: docker_test for python2
+      working-directory: ./build
       run: |
-        python -V
+        . navitia_py2/bin/activate
+        pip install -r ../source/tyr/requirements_dev.txt
+        pip install -r ../source/sql/requirements.txt
         export NAVITIA_CHAOS_DUMP_PATH=$(echo $GITHUB_WORKSPACE/source/tests/chaos/chaos_loading.sql.gz | sed -e 's#__w#home/runner/work#')
         echo $NAVITIA_CHAOS_DUMP_PATH
         make docker_test
@@ -96,13 +94,13 @@ jobs:
         NAVITIA_DOCKER_NETWORK: ${{ job.container.network }}
         TYR_CELERY_BROKER_URL: 'amqp://guest:guest@rabbitmq:5672//'
         TYR_REDIS_HOST: 'redis'
-
     - name: docker_test for python3
+      working-directory: ./build
+      if: matrix.docker_image != 'navitia/debian11_dev'
       run: |
         . navitia_py3/bin/activate
-        python -V
-        pip install -r source/tyr/requirements_dev.txt
-        pip install -r source/sql/requirements.txt
+        pip install -r ../source/tyr/requirements_dev.txt
+        pip install -r ../source/sql/requirements.txt
         export NAVITIA_CHAOS_DUMP_PATH=$(echo $GITHUB_WORKSPACE/source/tests/chaos/chaos_loading.sql.gz | sed -e 's#__w#home/runner/work#')
         echo $NAVITIA_CHAOS_DUMP_PATH
         make docker_test

--- a/debian/rules
+++ b/debian/rules
@@ -9,14 +9,14 @@ override_dh_auto_configure:
 
 override_dh_auto_build:
 	dh_auto_build -- -j4
-	cd source/tyr && python$* setup.py build
+	cd source/tyr && python2.7 setup.py build
 	cd source/jormungandr && python2.7 setup.py build
 	cd source/navitiacommon && python2.7 setup.py build
 	cd source/monitor && python2.7 setup.py build
 
 override_dh_auto_install:
 	dh_auto_install
-	cd source/tyr && python$* setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
+	cd source/tyr && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
 	cd source/navitiacommon && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb
 	cd source/jormungandr && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb --force
 	cd source/monitor && python2.7 setup.py install --root=$(CURDIR)/debian/tmp --install-layout=deb

--- a/source/ed/docker_tests/CMakeLists.txt
+++ b/source/ed/docker_tests/CMakeLists.txt
@@ -52,9 +52,16 @@ target_link_libraries(ed_integration_test ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY
 # it is added as a post build command to 'make docker_test', called after all the build
 add_custom_target(run_test DEPENDS datanav_files ed_integration_test)
 
-SET(BOOST_TEST_SEPARATOR "")
-if(NOT ${Boost_VERSION} LESS 106000) #if boost version newer or equal 1.60, passing cli_params new way
-    SET(BOOST_TEST_SEPARATOR "--")
+# Starting Cmake 3.15 ${Boost_VERSION} is in X.Y.Z format
+# use ${Boost_VERSION_MACRO} instead
+if (${CMAKE_VERSION} VERSION_LESS "3.15.0")
+    if(NOT ${Boost_VERSION} LESS 106000) #if boost version newer or equal 1.60, passing cli_params new way
+        SET(BOOST_TEST_SEPARATOR "--")
+    endif()
+else()
+    if(NOT ${Boost_VERSION_MACRO} LESS 106000) #if boost version newer or equal 1.60, passing cli_params new way
+        SET(BOOST_TEST_SEPARATOR "--")
+    endif()
 endif()
 
 BUILD_BOOST_TEST_ARGS(ed_integration_test)

--- a/source/third_party/eos_portable_archive/portable_iarchive.hpp
+++ b/source/third_party/eos_portable_archive/portable_iarchive.hpp
@@ -63,7 +63,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and Ákos Maróy.
+ *       Contributions we made by Johan Rade and ?kos Mar?y.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -117,11 +117,17 @@
 #elif BOOST_VERSION < 106900
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#else
+#elif BOOST_VERSION < 107300
+#define BOOST_MATH_DISABLE_STD_FPCLASSIFY
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
+#else
+#define BOOST_MATH_DISABLE_STD_FPCLASSIFY
+#include <boost/endian/conversion.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
 #endif
-// namespace alias
+
+// namespace alias fp_classify
 #if BOOST_VERSION < 103800 || BOOST_VERSION >= 106900
 namespace fp = boost::math;
 #else
@@ -131,8 +137,10 @@ namespace fp = boost::spirit::math;
 // namespace alias endian
 #if BOOST_VERSION < 104800
 namespace endian = boost::detail;
-#else
+#elif BOOST_VERSION < 107300
 namespace endian = boost::spirit::detail;
+#else
+namespace endian = boost::endian;
 #endif
 
 #ifndef BOOST_NO_STD_WSTRING
@@ -157,153 +165,153 @@ namespace endian = boost::spirit::detail;
 
 namespace eos {
 
-	// forward declaration
-	class portable_iarchive;
+    // forward declaration
+    class portable_iarchive;
 
-	typedef boost::archive::basic_binary_iprimitive<
-		portable_iarchive
-	#if BOOST_VERSION < 103400
-		, std::istream
-	#else
-		, std::istream::char_type
-		, std::istream::traits_type
-	#endif
-	> portable_iprimitive;
+    typedef boost::archive::basic_binary_iprimitive<
+        portable_iarchive
+    #if BOOST_VERSION < 103400
+        , std::istream
+    #else
+        , std::istream::char_type
+        , std::istream::traits_type
+    #endif
+    > portable_iprimitive;
 
-	/**
-	 * \brief Portable binary input archive using little endian format.
-	 *
-	 * This archive addresses integer size, endianness and floating point types so
-	 * that data can be transferred across different systems. There may still be
-	 * constraints as to what systems are compatible and the user will have to take
-	 * care that e.g. a very large int being saved on a 64 bit machine will result
-	 * in a portable_archive_exception if loaded into an int on a 32 bit system.
-	 * A possible workaround to this would be to use fixed types like
-	 * boost::uint64_t in your serialization structures.
-	 *
-	 * \note The class is based on the portable binary example by Robert Ramey and
-	 *	     uses Beman Dawes endian library plus fp_utilities by Johan Rade.
-	 */
-	class portable_iarchive : public portable_iprimitive
+    /**
+     * \brief Portable binary input archive using little endian format.
+     *
+     * This archive addresses integer size, endianness and floating point types so
+     * that data can be transferred across different systems. There may still be
+     * constraints as to what systems are compatible and the user will have to take
+     * care that e.g. a very large int being saved on a 64 bit machine will result
+     * in a portable_archive_exception if loaded into an int on a 32 bit system.
+     * A possible workaround to this would be to use fixed types like
+     * boost::uint64_t in your serialization structures.
+     *
+     * \note The class is based on the portable binary example by Robert Ramey and
+     *	     uses Beman Dawes endian library plus fp_utilities by Johan Rade.
+     */
+    class portable_iarchive : public portable_iprimitive
 
-		// the example derives from common_oarchive but that lacks the
-		// load_override functions so we chose to stay one level higher
-		, public boost::archive::basic_binary_iarchive<portable_iarchive>
+        // the example derives from common_oarchive but that lacks the
+        // load_override functions so we chose to stay one level higher
+        , public boost::archive::basic_binary_iarchive<portable_iarchive>
 
-	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
-		// mix-in helper class for serializing shared_ptr
-		, public boost::archive::detail::shared_ptr_helper
-	#endif
-	{
-		// only needed for Robert's hack in basic_binary_iarchive::init
-		friend class boost::archive::basic_binary_iarchive<portable_iarchive>;
+    #if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
+        // mix-in helper class for serializing shared_ptr
+        , public boost::archive::detail::shared_ptr_helper
+    #endif
+    {
+        // only needed for Robert's hack in basic_binary_iarchive::init
+        friend class boost::archive::basic_binary_iarchive<portable_iarchive>;
 
-		// workaround for gcc: use a dummy struct
-		// as additional argument type for overloading
-		template <int> struct dummy { dummy(int) {}};
+        // workaround for gcc: use a dummy struct
+        // as additional argument type for overloading
+        template <int> struct dummy { dummy(int) {}};
 
-		// loads directly from stream
-		inline signed char load_signed_char()
-		{
-			signed char c;
-			portable_iprimitive::load(c);
-			return c;
-		}
+        // loads directly from stream
+        inline signed char load_signed_char()
+        {
+            signed char c;
+            portable_iprimitive::load(c);
+            return c;
+        }
 
-		// archive initialization
-		void init(unsigned flags)
-		{
-			using namespace boost::archive;
-			archive_version_type input_library_version(3);
+        // archive initialization
+        void init(unsigned flags)
+        {
+            using namespace boost::archive;
+            archive_version_type input_library_version(3);
 
-			// it is vital to have version information!
-			// if we don't have any we assume boost 1.33
-			if (flags & no_header)
-				set_library_version(input_library_version);
+            // it is vital to have version information!
+            // if we don't have any we assume boost 1.33
+            if (flags & no_header)
+                set_library_version(input_library_version);
 
-			// extract and check the magic eos byte
-			else if (load_signed_char() != magic_byte)
-				throw archive_exception(archive_exception::invalid_signature);
+            // extract and check the magic eos byte
+            else if (load_signed_char() != magic_byte)
+                throw archive_exception(archive_exception::invalid_signature);
 
-			else
-			{
-				// extract version information
-				operator>>(input_library_version);
+            else
+            {
+                // extract version information
+                operator>>(input_library_version);
 
-				// throw if file version is newer than we are
-				if (input_library_version > archive_version)
-					throw archive_exception(archive_exception::unsupported_version);
+                // throw if file version is newer than we are
+                if (input_library_version > archive_version)
+                    throw archive_exception(archive_exception::unsupported_version);
 
-				// else set the library version accordingly
-				else set_library_version(input_library_version);
-			}
-		}
+                // else set the library version accordingly
+                else set_library_version(input_library_version);
+            }
+        }
 
-	public:
-		/**
-		 * \brief Constructor on a stream using ios::binary mode!
-		 *
-		 * We cannot call basic_binary_iprimitive::init which tries to detect
-		 * if the binary archive stems from a different platform by examining
-		 * type sizes.
-		 *
-		 * We could have called basic_binary_iarchive::init which would create
-		 * the boost::serialization standard archive header containing also the
-		 * library version. Due to efficiency we stick with our own.
-		 */
-		portable_iarchive(std::istream& is, unsigned flags = 0)
-		#if BOOST_VERSION < 103400
-			: portable_iprimitive(is, flags & boost::archive::no_codecvt)
-		#else
-			: portable_iprimitive(*is.rdbuf(), flags & boost::archive::no_codecvt)
-		#endif
-			, boost::archive::basic_binary_iarchive<portable_iarchive>(flags)
-		{
-			init(flags);
-		}
+    public:
+        /**
+         * \brief Constructor on a stream using ios::binary mode!
+         *
+         * We cannot call basic_binary_iprimitive::init which tries to detect
+         * if the binary archive stems from a different platform by examining
+         * type sizes.
+         *
+         * We could have called basic_binary_iarchive::init which would create
+         * the boost::serialization standard archive header containing also the
+         * library version. Due to efficiency we stick with our own.
+         */
+        portable_iarchive(std::istream& is, unsigned flags = 0)
+        #if BOOST_VERSION < 103400
+            : portable_iprimitive(is, flags & boost::archive::no_codecvt)
+        #else
+            : portable_iprimitive(*is.rdbuf(), flags & boost::archive::no_codecvt)
+        #endif
+            , boost::archive::basic_binary_iarchive<portable_iarchive>(flags)
+        {
+            init(flags);
+        }
 
-	#if BOOST_VERSION >= 103400
-		portable_iarchive(std::streambuf& sb, unsigned flags = 0)
-			: portable_iprimitive(sb, flags & boost::archive::no_codecvt)
-			, boost::archive::basic_binary_iarchive<portable_iarchive>(flags)
-		{
-			init(flags);
-		}
-	#endif
+    #if BOOST_VERSION >= 103400
+        portable_iarchive(std::streambuf& sb, unsigned flags = 0)
+            : portable_iprimitive(sb, flags & boost::archive::no_codecvt)
+            , boost::archive::basic_binary_iarchive<portable_iarchive>(flags)
+        {
+            init(flags);
+        }
+    #endif
 
-		//! Load narrow strings.
-		void load(std::string& s)
-		{
-			portable_iprimitive::load(s);
-		}
+        //! Load narrow strings.
+        void load(std::string& s)
+        {
+            portable_iprimitive::load(s);
+        }
 
-	#ifndef BOOST_NO_STD_WSTRING
-		/**
-		 * \brief Load wide strings.
-		 *
-		 * This is rather tricky to get right for true portability as there
-		 * are so many different character encodings around. However, wide
-		 * strings that are encoded in one of the Unicode schemes only need
-		 * to be _transcoded_ which is a lot easier actually.
-		 *
-		 * We generate the output string to be encoded in the system's native
-		 * format, ie. UTF-16 on Windows and UTF-32 on Linux machines. Don't
-		 * know about Mac here so I can't really say about that.
-		 */
-		void load(std::wstring& s)
-		{
-			std::string utf8;
-			load(utf8);
-			s = boost::from_utf8(utf8);
-		}
-	#endif
+    #ifndef BOOST_NO_STD_WSTRING
+        /**
+         * \brief Load wide strings.
+         *
+         * This is rather tricky to get right for true portability as there
+         * are so many different character encodings around. However, wide
+         * strings that are encoded in one of the Unicode schemes only need
+         * to be _transcoded_ which is a lot easier actually.
+         *
+         * We generate the output string to be encoded in the system's native
+         * format, ie. UTF-16 on Windows and UTF-32 on Linux machines. Don't
+         * know about Mac here so I can't really say about that.
+         */
+        void load(std::wstring& s)
+        {
+            std::string utf8;
+            load(utf8);
+            s = boost::from_utf8(utf8);
+        }
+    #endif
 
         /**
          * \brief Loading bool type.
          *
          * Byte pattern is same as with integer types, so this function
          * is somewhat redundant but treating bool as integer generates
-		 * a lot of compiler warnings.
+         * a lot of compiler warnings.
          *
          * \note If you cannot compile your application and it says something
          * about load(bool) cannot convert your type A& into bool& then you
@@ -311,126 +319,130 @@ namespace eos {
          * portable_archive is not able to handle custom primitive types in
          * a general manner.
          */
-		void load(bool& b)
-		{
-			switch (signed char c = load_signed_char())
-			{
-			case 0: b = false; break;
-			case 1: b = load_signed_char(); break;
-			default: throw portable_archive_exception(c);
-			}
-		}
+        void load(bool& b)
+        {
+            switch (signed char c = load_signed_char())
+            {
+            case 0: b = false; break;
+            case 1: b = load_signed_char(); break;
+            default: throw portable_archive_exception(c);
+            }
+        }
 
-		/**
-		 * \brief Load integer types.
-		 *
-		 * First we load the size information ie. the number of bytes that
-		 * hold the actual data. Then we retrieve the data and transform it
-		 * to the original value by using load_little_endian.
-		 */
-		template <typename T>
-		typename boost::enable_if<boost::is_integral<T> >::type
-		load(T & t, dummy<2> = 0)
-		{
-			// get the number of bytes in the stream
-			if (signed char size = load_signed_char())
-			{
-				// check for negative value in unsigned type
-				if (size < 0 && boost::is_unsigned<T>::value)
-					throw portable_archive_exception();
+        /**
+         * \brief Load integer types.
+         *
+         * First we load the size information ie. the number of bytes that
+         * hold the actual data. Then we retrieve the data and transform it
+         * to the original value by using load_little_endian.
+         */
+        template <typename T>
+        typename boost::enable_if<boost::is_integral<T> >::type
+        load(T & t, dummy<2> = 0)
+        {
+            // get the number of bytes in the stream
+            if (signed char size = load_signed_char())
+            {
+                // check for negative value in unsigned type
+                if (size < 0 && boost::is_unsigned<T>::value)
+                    throw portable_archive_exception();
 
-				// check that our type T is large enough
-				else if ((unsigned) abs(size) > sizeof(T))
-					throw portable_archive_exception(size);
+                // check that our type T is large enough
+                else if ((unsigned) abs(size) > sizeof(T))
+                    throw portable_archive_exception(size);
 
-				// reconstruct the value
-				T temp = size < 0 ? -1 : 0;
-				load_binary(&temp, abs(size));
+                // reconstruct the value
+                T temp = size < 0 ? -1 : 0;
+                load_binary(&temp, abs(size));
 
-				// load the value from little endian - is is then converted
-				// to the target type T and fits it because size <= sizeof(T)
-				t = endian::load_little_endian<T, sizeof(T)>(&temp);
-			}
+                // load the value from little endian - is is then converted
+                // to the target type T and fits it because size <= sizeof(T)
+                #if BOOST_VERSION >= 107300
+                t = endian::little_to_native(temp);
+                #else
+                t = endian::load_little_endian<T, sizeof(T)>(&temp);
+                #endif
+            }
 
-			else t = 0; // zero optimization
-		}
+            else t = 0; // zero optimization
+        }
 
-		/**
-		 * \brief Load floating point types.
-		 *
-		 * We simply rely on fp_traits to set the bit pattern from the (unsigned)
-		 * integral type that was stored in the stream. Francois Mauger provided
-		 * standardized behaviour for special values like inf and NaN, that need to
-		 * be serialized in his application.
-		 *
-		 * \note by Johan Rade (author of the floating point utilities library):
-		 * Be warned that the math::detail::fp_traits<T>::type::get_bits() function
-		 * is *not* guaranteed to give you all bits of the floating point number. It
-		 * will give you all bits if and only if there is an integer type that has
-		 * the same size as the floating point you are copying from. It will not
-		 * give you all bits for double if there is no uint64_t. It will not give
-		 * you all bits for long double if sizeof(long double) > 8 or there is no
-		 * uint64_t.
-		 *
-		 * The member fp_traits<T>::type::coverage will tell you whether all bits
-		 * are copied. This is a typedef for either math::detail::all_bits or
-		 * math::detail::not_all_bits.
-		 *
-		 * If the function does not copy all bits, then it will copy the most
-		 * significant bits. So if you serialize and deserialize the way you
-		 * describe, and fp_traits<T>::type::coverage is math::detail::not_all_bits,
-		 * then your floating point numbers will be truncated. This will introduce
-		 * small rounding off errors.
-		 */
-		template <typename T>
-		typename boost::enable_if<boost::is_floating_point<T> >::type
-		load(T & t, dummy<3> = 0)
-		{
-			typedef typename fp::detail::fp_traits<T>::type traits;
+        /**
+         * \brief Load floating point types.
+         *
+         * We simply rely on fp_traits to set the bit pattern from the (unsigned)
+         * integral type that was stored in the stream. Francois Mauger provided
+         * standardized behaviour for special values like inf and NaN, that need to
+         * be serialized in his application.
+         *
+         * \note by Johan Rade (author of the floating point utilities library):
+         * Be warned that the math::detail::fp_traits<T>::type::get_bits() function
+         * is *not* guaranteed to give you all bits of the floating point number. It
+         * will give you all bits if and only if there is an integer type that has
+         * the same size as the floating point you are copying from. It will not
+         * give you all bits for double if there is no uint64_t. It will not give
+         * you all bits for long double if sizeof(long double) > 8 or there is no
+         * uint64_t.
+         *
+         * The member fp_traits<T>::type::coverage will tell you whether all bits
+         * are copied. This is a typedef for either math::detail::all_bits or
+         * math::detail::not_all_bits.
+         *
+         * If the function does not copy all bits, then it will copy the most
+         * significant bits. So if you serialize and deserialize the way you
+         * describe, and fp_traits<T>::type::coverage is math::detail::not_all_bits,
+         * then your floating point numbers will be truncated. This will introduce
+         * small rounding off errors.
+         */
+        template <typename T>
+        typename boost::enable_if<boost::is_floating_point<T> >::type
+        load(T & t, dummy<3> = 0)
+        {
+            typedef typename fp::detail::fp_traits<T>::type traits;
 
-			// if you end here there are three possibilities:
-			// 1. you're serializing a long double which is not portable
-			// 2. you're serializing a double but have no 64 bit integer
-			// 3. your machine is using an unknown floating point format
-			// after reading the note above you still might decide to
-			// deactivate this static assert and try if it works out.
-			typename traits::bits bits;
-			BOOST_STATIC_ASSERT(sizeof(bits) == sizeof(T));
-			BOOST_STATIC_ASSERT(std::numeric_limits<T>::is_iec559);
+            // if you end here there are three possibilities:
+            // 1. you're serializing a long double which is not portable
+            // 2. you're serializing a double but have no 64 bit integer
+            // 3. your machine is using an unknown floating point format
+            // after reading the note above you still might decide to
+            // deactivate this static assert and try if it works out.
+            typename traits::bits bits;
+            BOOST_STATIC_ASSERT(sizeof(bits) == sizeof(T));
+            BOOST_STATIC_ASSERT(std::numeric_limits<T>::is_iec559);
 
-			load(bits);
-			traits::set_bits(t, bits);
+            load(bits);
+            traits::set_bits(t, bits);
 
-			// if the no_infnan flag is set we must throw here
-			if (get_flags() & no_infnan && !fp::isfinite(t))
-				throw portable_archive_exception(t);
+            // if the no_infnan flag is set we must throw here
+            if (get_flags() & no_infnan && !fp::isfinite(t))
+                throw portable_archive_exception(t);
 
-			// if you end here your floating point type does not support
-			// denormalized numbers. this might be the case even though
-			// your type conforms to IEC 559 (and thus to IEEE 754)
-			if (std::numeric_limits<T>::has_denorm == std::denorm_absent
-				&& fp::fpclassify(t) == (int) FP_SUBNORMAL) // GCC4
-				throw portable_archive_exception(t);
-		}
+            // if you end here your floating point type does not support
+            // denormalized numbers. this might be the case even though
+            // your type conforms to IEC 559 (and thus to IEEE 754)
+            if (std::numeric_limits<T>::has_denorm == std::denorm_absent
+                && fp::fpclassify(t) == (int) FP_SUBNORMAL) // GCC4
+                throw portable_archive_exception(t);
+        }
 
-		// in boost 1.44 version_type was splitted into library_version_type and
-		// item_version_type, plus a whole bunch of additional strong typedefs.
-		template <typename T>
-		typename boost::disable_if<boost::is_arithmetic<T> >::type
-		load(T& t, dummy<4> = 0)
-		{
-			// we provide a generic load routine for all types that feature
-			// conversion operators into an unsigned integer value like those
-			// created through BOOST_STRONG_TYPEDEF(X, some unsigned int) like
-			// library_version_type, collection_size_type, item_version_type,
-			// class_id_type, object_id_type, version_type and tracking_type
-			load((typename boost::uint_t<sizeof(T)*CHAR_BIT>::least&)(t));
-		}
-	};
+        // in boost 1.44 version_type was splitted into library_version_type and
+        // item_version_type, plus a whole bunch of additional strong typedefs.
+        template <typename T>
+        typename boost::disable_if<boost::is_arithmetic<T> >::type
+        load(T& t, dummy<4> = 0)
+        {
+            // we provide a generic load routine for all types that feature
+            // conversion operators into an unsigned integer value like those
+            // created through BOOST_STRONG_TYPEDEF(X, some unsigned int) like
+            // library_version_type, collection_size_type, item_version_type,
+            // class_id_type, object_id_type, version_type and tracking_type
+            load((typename boost::uint_t<sizeof(T)*CHAR_BIT>::least&)(t));
+        }
+    };
 
-	// polymorphic portable binary iarchive typedef
-	typedef POLYMORPHIC(portable_iarchive) polymorphic_portable_iarchive;
-	#undef POLYMORPHIC
+    // polymorphic portable binary iarchive typedef
+    typedef POLYMORPHIC(portable_iarchive) polymorphic_portable_iarchive;
+    #undef POLYMORPHIC
 
 } // namespace eos
 
@@ -461,24 +473,24 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(eos::polymorphic_portable_iarchive)
 
 namespace boost { namespace archive {
 
-	// explicitly instantiate for this type of binary stream
-	template class basic_binary_iarchive<eos::portable_iarchive>;
+    // explicitly instantiate for this type of binary stream
+    template class basic_binary_iarchive<eos::portable_iarchive>;
 
-	template class basic_binary_iprimitive<
-		eos::portable_iarchive
-	#if BOOST_VERSION < 103400
-		, std::istream
-	#else
-		, std::istream::char_type
-		, std::istream::traits_type
-	#endif
-	>;
+    template class basic_binary_iprimitive<
+        eos::portable_iarchive
+    #if BOOST_VERSION < 103400
+        , std::istream
+    #else
+        , std::istream::char_type
+        , std::istream::traits_type
+    #endif
+    >;
 
 #if BOOST_VERSION < 104000
-	template class detail::archive_pointer_iserializer<eos::portable_iarchive>;
+    template class detail::archive_pointer_iserializer<eos::portable_iarchive>;
 #else
-	template class detail::archive_serializer_map<eos::portable_iarchive>;
-	//template class detail::archive_serializer_map<eos::polymorphic_portable_iarchive>;
+    template class detail::archive_serializer_map<eos::portable_iarchive>;
+    //template class detail::archive_serializer_map<eos::polymorphic_portable_iarchive>;
 #endif
 
 } } // namespace boost::archive

--- a/source/third_party/eos_portable_archive/portable_oarchive.hpp
+++ b/source/third_party/eos_portable_archive/portable_oarchive.hpp
@@ -66,7 +66,7 @@
  *       in binary floating point serialization as desired by some boost users.
  *       Instead we support only the most widely used IEEE 754 format and try to
  *       detect when requirements are not met and hence our approach must fail.
- *       Contributions we made by Johan Rade and Ákos Maróy.
+ *       Contributions we made by Johan Rade and ?kos Mar?y.
  *
  * \note Version 2.0 fixes a serious bug that effectively transformed most
  *       of negative integral values into positive values! For example the two
@@ -103,16 +103,16 @@
 
 // funny polymorphics
 #if BOOST_VERSION < 103500
-#include <boost/archive/detail/polymorphic_oarchive_impl.hpp>
-#define POLYMORPHIC(T) boost::archive::detail::polymorphic_oarchive_impl<T>
+#include <boost/archive/detail/polymorphic_iarchive_impl.hpp>
+#define POLYMORPHIC(T) boost::archive::detail::polymorphic_iarchive_impl<T>
 
 #elif BOOST_VERSION < 103600
-#include <boost/archive/detail/polymorphic_oarchive_dispatch.hpp>
-#define POLYMORPHIC(T) boost::archive::detail::polymorphic_oarchive_dispatch<T>
+#include <boost/archive/detail/polymorphic_iarchive_dispatch.hpp>
+#define POLYMORPHIC(T) boost::archive::detail::polymorphic_iarchive_dispatch<T>
 
 #else
-#include <boost/archive/detail/polymorphic_oarchive_route.hpp>
-#define POLYMORPHIC(T) boost::archive::detail::polymorphic_oarchive_route<T>
+#include <boost/archive/detail/polymorphic_iarchive_route.hpp>
+#define POLYMORPHIC(T) boost::archive::detail::polymorphic_iarchive_route<T>
 #endif
 
 // endian and fpclassify
@@ -125,8 +125,13 @@
 #elif BOOST_VERSION < 106900
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
 #include <boost/spirit/home/support/detail/math/fpclassify.hpp>
-#else
+#elif BOOST_VERSION < 107300
+#define BOOST_MATH_DISABLE_STD_FPCLASSIFY
 #include <boost/spirit/home/support/detail/endian/endian.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#else
+#define BOOST_MATH_DISABLE_STD_FPCLASSIFY
+#include <boost/endian/conversion.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #endif
 
@@ -140,8 +145,10 @@ namespace fp = boost::spirit::math;
 // namespace alias endian
 #if BOOST_VERSION < 104800
 namespace endian = boost::detail;
-#else
+#elif BOOST_VERSION < 107300
 namespace endian = boost::spirit::detail;
+#else
+namespace endian = boost::endian;
 #endif
 
 #ifndef BOOST_NO_STD_WSTRING
@@ -164,131 +171,132 @@ namespace endian = boost::spirit::detail;
 #error "VAX floating point format is not supported!"
 #endif
 
+
 namespace eos {
 
-	// forward declaration
-	class portable_oarchive;
+    // forward declaration
+    class portable_oarchive;
 
-	typedef boost::archive::basic_binary_oprimitive<
-		portable_oarchive
-	#if BOOST_VERSION < 103400
-		, std::ostream
-	#else
-		, std::ostream::char_type
-		, std::ostream::traits_type
-	#endif
-	> portable_oprimitive;
+    typedef boost::archive::basic_binary_oprimitive<
+        portable_oarchive
+    #if BOOST_VERSION < 103400
+        , std::ostream
+    #else
+        , std::ostream::char_type
+        , std::ostream::traits_type
+    #endif
+    > portable_oprimitive;
 
-	/**
-	 * \brief Portable binary output archive using little endian format.
-	 *
-	 * This archive addresses integer size, endianness and floating point types so
-	 * that data can be transferred across different systems. The archive consists
-	 * primarily of three different save implementations for integral types,
-	 * floating point types and string types. Those functions are templates and use
-	 * enable_if to be correctly selected for overloading.
-	 *
-	 * \note The class is based on the portable binary example by Robert Ramey and
-	 *       uses Beman Dawes endian library plus fp_utilities by Johan Rade.
-	 */
-	class portable_oarchive : public portable_oprimitive
+    /**
+     * \brief Portable binary output archive using little endian format.
+     *
+     * This archive addresses integer size, endianness and floating point types so
+     * that data can be transferred across different systems. The archive consists
+     * primarily of three different save implementations for integral types,
+     * floating point types and string types. Those functions are templates and use
+     * enable_if to be correctly selected for overloading.
+     *
+     * \note The class is based on the portable binary example by Robert Ramey and
+     *       uses Beman Dawes endian library plus fp_utilities by Johan Rade.
+     */
+    class portable_oarchive : public portable_oprimitive
 
-		// the example derives from common_oarchive but that lacks the
-		// save_override functions so we chose to stay one level higher
-		, public boost::archive::basic_binary_oarchive<portable_oarchive>
+        // the example derives from common_oarchive but that lacks the
+        // save_override functions so we chose to stay one level higher
+        , public boost::archive::basic_binary_oarchive<portable_oarchive>
 
-	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
-		// mix-in helper class for serializing shared_ptr
-		, public boost::archive::detail::shared_ptr_helper
-	#endif
-	{
-		// workaround for gcc: use a dummy struct
-		// as additional argument type for overloading
-		template<int> struct dummy { dummy(int) {}};
+    #if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105600
+        // mix-in helper class for serializing shared_ptr
+        , public boost::archive::detail::shared_ptr_helper
+    #endif
+    {
+        // workaround for gcc: use a dummy struct
+        // as additional argument type for overloading
+        template<int> struct dummy { dummy(int) {}};
 
-		// stores a signed char directly to stream
-		inline void save_signed_char(const signed char& c)
-		{
-			portable_oprimitive::save(c);
-		}
+        // stores a signed char directly to stream
+        inline void save_signed_char(const signed char& c)
+        {
+            portable_oprimitive::save(c);
+        }
 
-		// archive initialization
-		void init(unsigned flags)
-		{
-			// it is vital to have version information if the archive is
-			// to be parsed with a newer version of boost::serialization
-			// therefor we create a header, no header means boost 1.33
-			if (flags & boost::archive::no_header)
-				BOOST_ASSERT(archive_version == 3);
-			else
-			{
-				// write our minimalistic header (magic byte plus version)
-				// the boost archives write a string instead - by calling
-				// boost::archive::basic_binary_oarchive<derived_t>::init()
-				save_signed_char(magic_byte);
+        // archive initialization
+        void init(unsigned flags)
+        {
+            // it is vital to have version information if the archive is
+            // to be parsed with a newer version of boost::serialization
+            // therefor we create a header, no header means boost 1.33
+            if (flags & boost::archive::no_header)
+                BOOST_ASSERT(archive_version == 3);
+            else
+            {
+                // write our minimalistic header (magic byte plus version)
+                // the boost archives write a string instead - by calling
+                // boost::archive::basic_binary_oarchive<derived_t>::init()
+                save_signed_char(magic_byte);
 
-				// write current version
+                // write current version
 //				save<unsigned>(archive_version);
-				operator<<(archive_version);
-			}
-		}
+                operator<<(archive_version);
+            }
+        }
 
-	public:
-		/**
-		 * \brief Constructor on a stream using ios::binary mode!
-		 *
-		 * We cannot call basic_binary_oprimitive::init which stores type
-		 * sizes to the archive in order to detect transfers to non-compatible
-		 * platforms.
-		 *
-		 * We could have called basic_binary_oarchive::init which would create
-		 * the boost::serialization standard archive header containing also the
-		 * library version. Due to efficiency we stick with our own.
-		 */
-		portable_oarchive(std::ostream& os, unsigned flags = 0)
-		#if BOOST_VERSION < 103400
-			: portable_oprimitive(os, flags & boost::archive::no_codecvt)
-		#else
-			: portable_oprimitive(*os.rdbuf(), flags & boost::archive::no_codecvt)
-		#endif
-			, boost::archive::basic_binary_oarchive<portable_oarchive>(flags)
-		{
-			init(flags);
-		}
+    public:
+        /**
+         * \brief Constructor on a stream using ios::binary mode!
+         *
+         * We cannot call basic_binary_oprimitive::init which stores type
+         * sizes to the archive in order to detect transfers to non-compatible
+         * platforms.
+         *
+         * We could have called basic_binary_oarchive::init which would create
+         * the boost::serialization standard archive header containing also the
+         * library version. Due to efficiency we stick with our own.
+         */
+        portable_oarchive(std::ostream& os, unsigned flags = 0)
+        #if BOOST_VERSION < 103400
+            : portable_oprimitive(os, flags & boost::archive::no_codecvt)
+        #else
+            : portable_oprimitive(*os.rdbuf(), flags & boost::archive::no_codecvt)
+        #endif
+            , boost::archive::basic_binary_oarchive<portable_oarchive>(flags)
+        {
+            init(flags);
+        }
 
-	#if BOOST_VERSION >= 103400
-		portable_oarchive(std::streambuf& sb, unsigned flags = 0)
-			: portable_oprimitive(sb, flags & boost::archive::no_codecvt)
-			, boost::archive::basic_binary_oarchive<portable_oarchive>(flags)
-		{
-			init(flags);
-		}
-	#endif
+    #if BOOST_VERSION >= 103400
+        portable_oarchive(std::streambuf& sb, unsigned flags = 0)
+            : portable_oprimitive(sb, flags & boost::archive::no_codecvt)
+            , boost::archive::basic_binary_oarchive<portable_oarchive>(flags)
+        {
+            init(flags);
+        }
+    #endif
 
-		//! Save narrow strings.
-		void save(const std::string& s)
-		{
-			portable_oprimitive::save(s);
-		}
+        //! Save narrow strings.
+        void save(const std::string& s)
+        {
+            portable_oprimitive::save(s);
+        }
 
-	#ifndef BOOST_NO_STD_WSTRING
-		/**
-		 * \brief Save wide strings.
-		 *
-		 * This is rather tricky to get right for true portability as there
-		 * are so many different character encodings around. However, wide
-		 * strings that are encoded in one of the Unicode schemes only need
-		 * to be _transcoded_ which is a lot easier actually.
-		 *
-		 * We expect the input string to be encoded in the system's native
-		 * format, ie. UTF-16 on Windows and UTF-32 on Linux machines. Don't
-		 * know about Mac here so I can't really say about that.
-		 */
-		void save(const std::wstring& s)
-		{
-			save(boost::to_utf8(s));
-		}
-	#endif
+    #ifndef BOOST_NO_STD_WSTRING
+        /**
+         * \brief Save wide strings.
+         *
+         * This is rather tricky to get right for true portability as there
+         * are so many different character encodings around. However, wide
+         * strings that are encoded in one of the Unicode schemes only need
+         * to be _transcoded_ which is a lot easier actually.
+         *
+         * We expect the input string to be encoded in the system's native
+         * format, ie. UTF-16 on Windows and UTF-32 on Linux machines. Don't
+         * know about Mac here so I can't really say about that.
+         */
+        void save(const std::wstring& s)
+        {
+            save(boost::to_utf8(s));
+        }
+    #endif
 
         /**
          * \brief Saving bool type.
@@ -302,128 +310,132 @@ namespace eos {
          * portable_archive is not able to handle custom primitive types in
          * a general manner.
          */
-		void save(const bool& b)
-		{
-			save_signed_char(b);
-			if (b) save_signed_char('T');
-		}
+        void save(const bool& b)
+        {
+            save_signed_char(b);
+            if (b) save_signed_char('T');
+        }
 
-		/**
-		 * \brief Save integer types.
-		 *
-		 * First we save the size information ie. the number of bytes that hold the
-		 * actual data. We subsequently transform the data using store_little_endian
-		 * and store non-zero bytes to the stream.
-		 */
-		template <typename T>
-		typename boost::enable_if<boost::is_integral<T> >::type
-		save(const T & t, dummy<2> = 0)
-		{
-			if (T temp = t)
-			{
-				// examine the number of bytes
-				// needed to represent the number
-				signed char size = 0;
-				do { temp >>= CHAR_BIT; ++size; }
-				while (temp != 0 && temp != (T) -1);
+        /**
+         * \brief Save integer types.
+         *
+         * First we save the size information ie. the number of bytes that hold the
+         * actual data. We subsequently transform the data using store_little_endian
+         * and store non-zero bytes to the stream.
+         */
+        template <typename T>
+        typename boost::enable_if<boost::is_integral<T> >::type
+        save(const T & t, dummy<2> = 0)
+        {
+            if (T temp = t)
+            {
+                // examine the number of bytes
+                // needed to represent the number
+                signed char size = 0;
+                do { temp >>= CHAR_BIT; ++size; }
+                while (temp != 0 && temp != (T) -1);
 
-				// encode the sign bit into the size
-				save_signed_char(t > 0 ? size : -size);
-				BOOST_ASSERT(t > 0 || boost::is_signed<T>::value);
+                // encode the sign bit into the size
+                save_signed_char(t > 0 ? size : -size);
+                BOOST_ASSERT(t > 0 || boost::is_signed<T>::value);
 
-				// we choose to use little endian because this way we just
-				// save the first size bytes to the stream and skip the rest
-				endian::store_little_endian<T, sizeof(T)>(&temp, t);
-				save_binary(&temp, size);
-			}
-			// zero optimization
-			else save_signed_char(0);
-		}
+                // we choose to use little endian because this way we just
+                // save the first size bytes to the stream and skip the rest
+                #if BOOST_VERSION >= 107300
+                temp = endian::native_to_little(t);
+                #else
+                endian::store_little_endian<T, sizeof(T)>(&temp, t);
+                #endif
+                save_binary(&temp, size);
+            }
+            // zero optimization
+            else save_signed_char(0);
+        }
 
-		/**
-		 * \brief Save floating point types.
-		 *
-		 * We simply rely on fp_traits to extract the bit pattern into an (unsigned)
-		 * integral type and store that into the stream. Francois Mauger provided
-		 * standardized behaviour for special values like inf and NaN, that need to
-		 * be serialized in his application.
-		 *
-		 * \note by Johan Rade (author of the floating point utilities library):
-		 * Be warned that the math::detail::fp_traits<T>::type::get_bits() function
-		 * is *not* guaranteed to give you all bits of the floating point number. It
-		 * will give you all bits if and only if there is an integer type that has
-		 * the same size as the floating point you are copying from. It will not
-		 * give you all bits for double if there is no uint64_t. It will not give
-		 * you all bits for long double if sizeof(long double) > 8 or there is no
-		 * uint64_t.
-		 *
-		 * The member fp_traits<T>::type::coverage will tell you whether all bits
-		 * are copied. This is a typedef for either math::detail::all_bits or
-		 * math::detail::not_all_bits.
-		 *
-		 * If the function does not copy all bits, then it will copy the most
-		 * significant bits. So if you serialize and deserialize the way you
-		 * describe, and fp_traits<T>::type::coverage is math::detail::not_all_bits,
-		 * then your floating point numbers will be truncated. This will introduce
-		 * small rounding off errors.
-		 */
-		template <typename T>
-		typename boost::enable_if<boost::is_floating_point<T> >::type
-		save(const T & t, dummy<3> = 0)
-		{
-			typedef typename fp::detail::fp_traits<T>::type traits;
+        /**
+         * \brief Save floating point types.
+         *
+         * We simply rely on fp_traits to extract the bit pattern into an (unsigned)
+         * integral type and store that into the stream. Francois Mauger provided
+         * standardized behaviour for special values like inf and NaN, that need to
+         * be serialized in his application.
+         *
+         * \note by Johan Rade (author of the floating point utilities library):
+         * Be warned that the math::detail::fp_traits<T>::type::get_bits() function
+         * is *not* guaranteed to give you all bits of the floating point number. It
+         * will give you all bits if and only if there is an integer type that has
+         * the same size as the floating point you are copying from. It will not
+         * give you all bits for double if there is no uint64_t. It will not give
+         * you all bits for long double if sizeof(long double) > 8 or there is no
+         * uint64_t.
+         *
+         * The member fp_traits<T>::type::coverage will tell you whether all bits
+         * are copied. This is a typedef for either math::detail::all_bits or
+         * math::detail::not_all_bits.
+         *
+         * If the function does not copy all bits, then it will copy the most
+         * significant bits. So if you serialize and deserialize the way you
+         * describe, and fp_traits<T>::type::coverage is math::detail::not_all_bits,
+         * then your floating point numbers will be truncated. This will introduce
+         * small rounding off errors.
+         */
+        template <typename T>
+        typename boost::enable_if<boost::is_floating_point<T> >::type
+        save(const T & t, dummy<3> = 0)
+        {
+            typedef typename fp::detail::fp_traits<T>::type traits;
 
-			// if the no_infnan flag is set we must throw here
-			if (get_flags() & no_infnan && !fp::isfinite(t))
-				throw portable_archive_exception(t);
+            // if the no_infnan flag is set we must throw here
+            if (get_flags() & no_infnan && !fp::isfinite(t))
+                throw portable_archive_exception(t);
 
-			// if you end here there are three possibilities:
-			// 1. you're serializing a long double which is not portable
-			// 2. you're serializing a double but have no 64 bit integer
-			// 3. your machine is using an unknown floating point format
-			// after reading the note above you still might decide to
-			// deactivate this static assert and try if it works out.
-			typename traits::bits bits;
-			BOOST_STATIC_ASSERT(sizeof(bits) == sizeof(T));
-			BOOST_STATIC_ASSERT(std::numeric_limits<T>::is_iec559);
+            // if you end here there are three possibilities:
+            // 1. you're serializing a long double which is not portable
+            // 2. you're serializing a double but have no 64 bit integer
+            // 3. your machine is using an unknown floating point format
+            // after reading the note above you still might decide to
+            // deactivate this static assert and try if it works out.
+            typename traits::bits bits;
+            BOOST_STATIC_ASSERT(sizeof(bits) == sizeof(T));
+            BOOST_STATIC_ASSERT(std::numeric_limits<T>::is_iec559);
 
-			// examine value closely
-			switch (fp::fpclassify(t))
-			{
-			//case FP_ZERO: bits = 0; break;
-			#if BOOST_VERSION < 106900
-			case FP_NAN: bits = traits::exponent | traits::mantissa; break;
-			#else
-			case FP_NAN: bits = traits::exponent | traits::significand; break;
-			#endif
-			case FP_INFINITE: bits = traits::exponent | (t<0) * traits::sign; break;
-			case FP_SUBNORMAL: assert(std::numeric_limits<T>::has_denorm); // pass
-			case FP_ZERO: // note that floats can be ±0.0
-			case FP_NORMAL: traits::get_bits(t, bits); break;
-			default: throw portable_archive_exception(t);
-			}
+            // examine value closely
+            switch (fp::fpclassify(t))
+            {
+            //case FP_ZERO: bits = 0; break;
+            #if BOOST_VERSION < 106900
+            case FP_NAN: bits = traits::exponent | traits::mantissa; break;
+            #else
+            case FP_NAN: bits = traits::exponent | traits::significand; break;
+            #endif
+            case FP_INFINITE: bits = traits::exponent | (t<0) * traits::sign; break;
+            case FP_SUBNORMAL: assert(std::numeric_limits<T>::has_denorm); // pass
+            case FP_ZERO: // note that floats can be ?0.0
+            case FP_NORMAL: traits::get_bits(t, bits); break;
+            default: throw portable_archive_exception(t);
+            }
 
-			save(bits);
-		}
+            save(bits);
+        }
 
-		// in boost 1.44 version_type was splitted into library_version_type and
-		// item_version_type, plus a whole bunch of additional strong typedefs.
-		template <typename T>
-		typename boost::disable_if<boost::is_arithmetic<T> >::type
-		save(const T& t, dummy<4> = 0)
-		{
-			// we provide a generic save routine for all types that feature
-			// conversion operators into an unsigned integer value like those
-			// created through BOOST_STRONG_TYPEDEF(X, some unsigned int) like
-			// library_version_type, collection_size_type, item_version_type,
-			// class_id_type, object_id_type, version_type and tracking_type
-			save((typename boost::uint_t<sizeof(T)*CHAR_BIT>::least)(t));
-		}
-	};
+        // in boost 1.44 version_type was splitted into library_version_type and
+        // item_version_type, plus a whole bunch of additional strong typedefs.
+        template <typename T>
+        typename boost::disable_if<boost::is_arithmetic<T> >::type
+        save(const T& t, dummy<4> = 0)
+        {
+            // we provide a generic save routine for all types that feature
+            // conversion operators into an unsigned integer value like those
+            // created through BOOST_STRONG_TYPEDEF(X, some unsigned int) like
+            // library_version_type, collection_size_type, item_version_type,
+            // class_id_type, object_id_type, version_type and tracking_type
+            save((typename boost::uint_t<sizeof(T)*CHAR_BIT>::least)(t));
+        }
+    };
 
-	// polymorphic portable binary oarchive typedef
-	typedef POLYMORPHIC(portable_oarchive) polymorphic_portable_oarchive;
-	#undef POLYMORPHIC
+    // polymorphic portable binary oarchive typedef
+    typedef POLYMORPHIC(portable_oarchive) polymorphic_portable_oarchive;
+    #undef POLYMORPHIC
 
 } // namespace eos
 
@@ -453,24 +465,24 @@ BOOST_SERIALIZATION_REGISTER_ARCHIVE(eos::polymorphic_portable_oarchive)
 
 namespace boost { namespace archive {
 
-	// explicitly instantiate for this type of binary stream
-	template class basic_binary_oarchive<eos::portable_oarchive>;
+    // explicitly instantiate for this type of binary stream
+    template class basic_binary_oarchive<eos::portable_oarchive>;
 
-	template class basic_binary_oprimitive<
-		eos::portable_oarchive
-	#if BOOST_VERSION < 103400
-		, std::ostream
-	#else
-		, std::ostream::char_type
-		, std::ostream::traits_type
-	#endif
-	>;
+    template class basic_binary_oprimitive<
+        eos::portable_oarchive
+    #if BOOST_VERSION < 103400
+        , std::ostream
+    #else
+        , std::ostream::char_type
+        , std::ostream::traits_type
+    #endif
+    >;
 
 #if BOOST_VERSION < 104000
-	template class detail::archive_pointer_oserializer<eos::portable_oarchive>;
+    template class detail::archive_pointer_oserializer<eos::portable_oarchive>;
 #else
-	template class detail::archive_serializer_map<eos::portable_oarchive>;
-	//template class detail::archive_serializer_map<eos::polymorphic_portable_oarchive>;
+    template class detail::archive_serializer_map<eos::portable_oarchive>;
+    //template class detail::archive_serializer_map<eos::polymorphic_portable_oarchive>;
 #endif
 
 } } // namespace boost::archive


### PR DESCRIPTION
This PR make the following change:
- ensure navitia could be build on debian11 platform, without breaking compatibility with Debian 8 to 10

However, on Debian 11 we build, test and package navitia only with python2.7, for python3.9 an other PR will follow soon.