### PR TITLE
Uptimize search of disruptions for a physical_mode

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2446,6 +2446,10 @@ class TestKirinUpdateTripWithPhysicalMode(MockKirinDisruptionsFixture):
         assert len(pt_response['physical_modes']) == 1
         assert pt_response['physical_modes'][0]['name'] == 'Tramway'
 
+        # Check disruptions with physical_modes
+        disruptions_from_mode = self.query_region('physical_modes/physical_mode:0x0/disruptions')
+        assert len(disruptions_from_mode['disruptions']) == 1
+
 
 @dataset(MAIN_ROUTING_TEST_SETTING)
 class TestKirinAddTripWithHeadSign(MockKirinDisruptionsFixture):

--- a/source/ptreferential/ptreferential_utils.cpp
+++ b/source/ptreferential/ptreferential_utils.cpp
@@ -72,19 +72,18 @@ Indexes get_corresponding(Indexes indexes, Type_e from, const Type_e to, const D
     // Exceptional case: if from = PhysicalMode and to = Impact
     // 1. Get all vehicle_journeys impacted
     // 2. Keep only vehicle_journeys with physical_mode in the parameter
-
     if (from == Type_e::PhysicalMode && to == Type_e::Impact) {
         auto vj_idxs = get_indexes_by_impacts(Type_e::VehicleJourney, data, false);
         const auto vjs = data.get_data<type::VehicleJourney>(vj_idxs);
-        Indexes vj_indexes, temp;
+        Indexes impact_indexes, temp;
         for (type::VehicleJourney* vj : vjs) {
             if (indexes.find(vj->physical_mode->idx) != indexes.cend()) {
-                // Add Impact on vj
+                // Add Impact on vehicle_journeys having PhysicalMode
                 temp = vj->get(Type_e::Impact, *(data.pt_data.get()));
-                vj_indexes.insert(temp.begin(), temp.end());
+                impact_indexes.insert(temp.begin(), temp.end());
             }
         }
-        return vj_indexes;
+        return impact_indexes;
     }
 
     const std::map<Type_e, Type_e> path = find_path(to);

--- a/source/ptreferential/ptreferential_utils.h
+++ b/source/ptreferential/ptreferential_utils.h
@@ -52,7 +52,7 @@ type::Indexes get_corresponding(type::Indexes indexes,
                                 const type::Type_e to,
                                 const type::Data& data);
 type::Type_e type_by_caption(const std::string& type);
-type::Indexes get_indexes_by_impacts(const type::Type_e& type_e, const type::Data& d);
+type::Indexes get_indexes_by_impacts(const type::Type_e& type_e, const type::Data& d, bool only_no_service = true);
 type::Indexes get_impacts_by_tags(const std::vector<std::string>& tag_name, const type::Data& d);
 type::Indexes filter_on_period(const type::Indexes& indexes,
                                const type::Type_e requested_type,


### PR DESCRIPTION
Tested with gtfs-rt from kirin on coverage sncf of dev -> compared between dev and in local with the same data and gtfs-rt
For details refer to https://jira.kisio.org/browse/NAVITIAII-3622