### PR TITLE
[CI] publish_docker_compose - add Run button to trig manually

### DIFF
--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -1,6 +1,7 @@
 name: Publish Docker Compose Images
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows: ["Build Navitia Packages For Release"]
     branches: [release]


### PR DESCRIPTION
new feature : https://levelup.gitconnected.com/how-to-manually-trigger-a-github-actions-workflow-4712542f1960

for the moment we test for **publish_docker_compose**