### PR TITLE
Skip inserting last_dataset files into ed database

### DIFF
--- a/source/tyr/tyr/command/import_last_dataset.py
+++ b/source/tyr/tyr/command/import_last_dataset.py
@@ -36,7 +36,13 @@ from tyr.helper import get_instance_logger, wait_or_raise
 
 @manager.command
 def import_last_dataset(
-    instance_name, background=False, reload_kraken=False, custom_output_dir=None, nowait=False, allow_mimir=False
+    instance_name,
+    background=False,
+    reload_kraken=False,
+    custom_output_dir=None,
+    nowait=False,
+    allow_mimir=False,
+    skip_2ed=False,
 ):
     """
     reimport the last dataset of a instance
@@ -67,6 +73,7 @@ def import_last_dataset(
         reload=reload_kraken,
         custom_output_dir=custom_output_dir,
         skip_mimir=skip_mimir,
+        skip_2ed=skip_2ed,
     )
     if not nowait and future:
         wait_or_raise(future)

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -78,7 +78,14 @@ def finish_job(job_id):
 
 
 def import_data(
-    files, instance, backup_file, asynchronous=True, reload=True, custom_output_dir=None, skip_mimir=False
+    files,
+    instance,
+    backup_file,
+    asynchronous=True,
+    reload=True,
+    custom_output_dir=None,
+    skip_mimir=False,
+    skip_2ed=False,
 ):
     """
     import the data contains in the list of 'files' in the 'instance'
@@ -91,7 +98,7 @@ def import_data(
     :param reload: If True kraken would be reload at the end of the treatment
     :param custom_output_dir: subdirectory for the nav file created. If not given, the instance default one is taken
     :param skip_mimir: skip importing data into mimir
-
+    :param skip_2ed: skip inserting last_load_dataset files into ed database
     run the whole data import process:
 
     - data import in bdd (fusio2ed, gtfs2ed, poi2ed, ...)
@@ -115,41 +122,45 @@ def import_data(
         'shape': shape2ed,
     }
 
-    for _file in files:
-        filename = None
+    # For skip_2ed, skip inserting last_load_dataset files into ed database
+    if not skip_2ed:
+        for _file in files:
+            filename = None
 
-        dataset = models.DataSet()
-        # NOTE: for the moment we do not use the path to load the data here
-        # but we'll need to refactor this to take it into account
-        try:
-            dataset.type, _ = utils.type_of_data(_file)
-            dataset.family_type = utils.family_of_data(dataset.type)
-        except Exception:
-            if backup_file:
-                move_to_backupdirectory(_file, instance_config.backup_directory)
-            current_app.logger.debug(
-                "Corrupted source file : {} moved to {}".format(_file, instance_config.backup_directory)
-            )
-            continue
+            dataset = models.DataSet()
+            # NOTE: for the moment we do not use the path to load the data here
+            # but we'll need to refactor this to take it into account
+            try:
+                dataset.type, _ = utils.type_of_data(_file)
+                dataset.family_type = utils.family_of_data(dataset.type)
+            except Exception:
+                if backup_file:
+                    move_to_backupdirectory(_file, instance_config.backup_directory)
+                current_app.logger.debug(
+                    "Corrupted source file : {} moved to {}".format(_file, instance_config.backup_directory)
+                )
+                continue
 
-        if dataset.type in task:
-            if backup_file:
-                filename = move_to_backupdirectory(_file, instance_config.backup_directory, manage_sp_char=True)
+            if dataset.type in task:
+                if backup_file:
+                    filename = move_to_backupdirectory(
+                        _file, instance_config.backup_directory, manage_sp_char=True
+                    )
+                else:
+                    filename = _file
+                actions.append(task[dataset.type].si(instance_config, filename, dataset_uid=dataset.uid))
             else:
-                filename = _file
-            actions.append(task[dataset.type].si(instance_config, filename, dataset_uid=dataset.uid))
-        else:
-            # unknown type, we skip it
-            current_app.logger.debug("unknown file type: {} for file {}".format(dataset.type, _file))
-            continue
+                # unknown type, we skip it
+                current_app.logger.debug("unknown file type: {} for file {}".format(dataset.type, _file))
+                continue
 
-        # currently the name of a dataset is the path to it
-        dataset.name = filename
-        dataset.state = "pending"
-        models.db.session.add(dataset)
-        job.data_sets.append(dataset)
+            # currently the name of a dataset is the path to it
+            dataset.name = filename
+            dataset.state = "pending"
+            models.db.session.add(dataset)
+            job.data_sets.append(dataset)
 
-    if actions:
+    if actions or skip_2ed:
         models.db.session.add(job)
         models.db.session.commit()
         # We pass the job id to each tasks, but job need to be commited for having an id


### PR DESCRIPTION
Add an option to avoid all the actions of type xxx_2ed (inserting source data files into ed database) while using the command **import_last_dataset** in tyr

Jira: https://jira.kisio.org/browse/NAVITIAII-3647

* Tested in local with @benoit-bst on tyr having **two** coverages and 5 source data files(five xxx_2ed to be done).
* command line tested: 
** PYTHONPATH=/../navitiacommon TYR_CONFIG_FILE=dev_settings.py python manage_tyr.py import_last_dataset idfm --skip_2ed
** PYTHONPATH=/../navitiacommon TYR_CONFIG_FILE=dev_settings.py python manage_tyr.py import_last_dataset idfm
* Tested also adding a new data source in /source
* When command line used with --skip_2ed, there is no dataset attached to the job. This fact doesn't have any unwanted effect on **last_dataset**. 
