### PR TITLE
[loki] Add _use_pt_socket parameter

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -748,8 +748,15 @@ class Instance(object):
         logger = logging.getLogger(__name__)
         deadline = datetime.utcnow() + timedelta(milliseconds=timeout)
         request.deadline = deadline.strftime('%Y%m%dT%H%M%S,%f')
-        pt_socket = request.requested_api == type_pb2.pt_planner
-        with self.socket(self.context, pt_socket) as socket:
+        # we use the pt_socket if :
+        #  - we are asking for the pt_planner api
+        #  - _use_pt_socket is set to True in the request's parameters
+        use_pt_socket = (
+            request.requested_api == type_pb2.pt_planner
+            and 'use_pt_socket' in kwargs
+            and kwargs['use_pt_socket']
+        )
+        with self.socket(self.context, use_pt_socket) as socket:
             if 'request_id' in kwargs and kwargs['request_id']:
                 request.request_id = kwargs['request_id']
             else:

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -748,14 +748,8 @@ class Instance(object):
         logger = logging.getLogger(__name__)
         deadline = datetime.utcnow() + timedelta(milliseconds=timeout)
         request.deadline = deadline.strftime('%Y%m%dT%H%M%S,%f')
-        # we use the pt_socket if :
-        #  - we are asking for the pt_planner api
-        #  - _use_pt_socket is set to True in the request's parameters
-        use_pt_socket = (
-            request.requested_api == type_pb2.pt_planner
-            and 'use_pt_socket' in kwargs
-            and kwargs['use_pt_socket']
-        )
+
+        use_pt_socket = 'use_pt_socket' in kwargs and kwargs['use_pt_socket']
         with self.socket(self.context, use_pt_socket) as socket:
             if 'request_id' in kwargs and kwargs['request_id']:
                 request.request_id = kwargs['request_id']

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -391,7 +391,8 @@ class Journeys(JourneyCommon):
         )
         parser_get.add_argument(
             "_use_pt_socket",
-            type=six.text_type,
+            type=BooleanType(),
+            default=False,
             hidden=True,
             help="Use the 'pt_zmq_socket' instead of 'zmq_socket' for pt_planner sub-requests. This has no effect if 'pt_zmq_socket' is not set in the instance configuration",
         )

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -390,6 +390,12 @@ class Journeys(JourneyCommon):
             help="debug param to specify a custom scenario",
         )
         parser_get.add_argument(
+            "_use_pt_socket",
+            type=six.text_type,
+            hidden=True,
+            help="Use the 'pt_zmq_socket' instead of 'zmq_socket' for pt_planner sub-requests. This has no effect if 'pt_zmq_socket' is not set in the instance configuration",
+        )
+        parser_get.add_argument(
             "_street_network", type=six.text_type, hidden=True, help="choose the streetnetwork component"
         )
         parser_get.add_argument("_walking_transfer_penalty", hidden=True, type=int)

--- a/source/jormungandr/jormungandr/planner.py
+++ b/source/jormungandr/jormungandr/planner.py
@@ -198,11 +198,21 @@ class Kraken(object):
         req.isochrone.journeys_request.CopyFrom(req.journeys)
         return req
 
-    def journeys(self, origins, destinations, datetime, clockwise, journey_parameters, bike_in_pt, request_id):
+    def journeys(
+        self,
+        origins,
+        destinations,
+        datetime,
+        clockwise,
+        journey_parameters,
+        bike_in_pt,
+        request_id,
+        use_pt_socket,
+    ):
         req = self._create_journeys_request(
             origins, destinations, datetime, clockwise, journey_parameters, bike_in_pt
         )
-        return self.instance.send_and_receive(req, request_id=request_id)
+        return self.instance.send_and_receive(req, request_id=request_id, use_pt_socket=use_pt_socket)
 
     def graphical_isochrones(
         self, origins, destinations, datetime, clockwise, graphical_isochrones_parameters, bike_in_pt

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/pt_journey.py
@@ -92,6 +92,7 @@ class PtJourney:
                 self._journey_params,
                 self._bike_in_pt,
                 self._request_id,
+                self._request.get('_use_pt_socket', False),
             )
 
     def _do_journeys_request(self):


### PR DESCRIPTION
When adding `&_override_scenario=distributed&_use_pt_socket=True` to a request, jormungandr will use the `pt_zmq_socket` to solve `pt_planner` distributed subrequest.
This will have no effect if pt_zmq_socket is not set in the jormungandr configuration file of the instance.

This will be useful to deploy and test the loki backend.