### PR TITLE
[Kraken] For request datetime before production_date we allow 24 hours in the request

### DIFF
--- a/source/time_tables/tests/passages_test.cpp
+++ b/source/time_tables/tests/passages_test.cpp
@@ -97,4 +97,16 @@ BOOST_AUTO_TEST_CASE(next_passages_on_last_production_day) {
     BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
     BOOST_REQUIRE_EQUAL(resp.next_departures(0).stop_date_time().departure_date_time(), "20170107T080600"_pts);
     BOOST_REQUIRE_EQUAL(resp.next_departures(1).stop_date_time().departure_date_time(), "20170107T090600"_pts);
+
+    // Production_date.begin = 20170101, request_datetime = 20161231T080000 and request_datetime is not included
+    // in production_date period. The request_datetime is well within 24 hours before production_date.begin
+    // In such cas instead of raising date out of bound, we init request dates as
+    // date_time = 0, max_datetime = 86400 - 57600(=24 - 8 * 60 * 60)
+    navitia::PbCreator pb_creator_pdep_1(data_ptr, bt::second_clock::universal_time(), null_time_period);
+    passages(pb_creator_pdep_1, "stop_point.uri=stop2", {}, "20161231T080000"_dt, 86400, 10, 3,
+             navitia::type::AccessibiliteParams(), nt::RTLevel::Base, pbnavitia::NEXT_DEPARTURES, 10, 0);
+    resp = pb_creator_pdep_1.get_response();
+    BOOST_REQUIRE_EQUAL(resp.next_departures().size(), 2);
+    BOOST_REQUIRE_EQUAL(resp.next_departures(0).stop_date_time().departure_date_time(), "20170101T080600"_pts);
+    BOOST_REQUIRE_EQUAL(resp.next_departures(1).stop_date_time().departure_date_time(), "20170101T090600"_pts);
 }


### PR DESCRIPTION
1. A binarized data contains production_date (only date) and is taken as UTC for example 20211122 to  20220120
2. In a request with from_datetime = 20211122T000000, after conversion in UTC, it becomes 20211121T230000
3. In the request duration may be used (default value = 86400)
4. Since the from_datetime is not included in production_date period (= 20211122 to  20220120), the response is **Error: date is out of bound**
5. After correction we initialize request date parameters as start_date_time = 0 (20211122T000000 and duration = 82800 (23 heure).

For details: https://jira.kisio.org/browse/NAVITIAII-3736