### PR TITLE
ed: read access_point and pathway table then aggregate it

### DIFF
--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -458,9 +458,11 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
         BOOST_REQUIRE_EQUAL(ap->traversal_time, 87);
         BOOST_REQUIRE_EQUAL(ap->is_entrance, true);
         BOOST_REQUIRE_EQUAL(ap->is_exit, true);
-        BOOST_REQUIRE_EQUAL(ap->stair_count, -1);  // no value
-        BOOST_REQUIRE_EQUAL(ap->max_slope, -1);    // no value
-        BOOST_REQUIRE_EQUAL(ap->min_width, -1);    // no value
+        BOOST_REQUIRE_EQUAL(ap->stair_count, -1);             // no value
+        BOOST_REQUIRE_EQUAL(ap->max_slope, -1);               // no value
+        BOOST_REQUIRE_EQUAL(ap->min_width, -1);               // no value
+        BOOST_REQUIRE_EQUAL(ap->signposted_as, "");           // no value
+        BOOST_REQUIRE_EQUAL(ap->reversed_signposted_as, "");  // no value
         BOOST_CHECK_CLOSE(ap->coord.lat(), 45.0614, 0.001);
         BOOST_CHECK_CLOSE(ap->coord.lon(), 0.6155, 0.001);
     }
@@ -473,9 +475,11 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
         BOOST_REQUIRE_EQUAL(ap->traversal_time, 87);
         BOOST_REQUIRE_EQUAL(ap->is_entrance, exit);
         BOOST_REQUIRE_EQUAL(ap->is_exit, true);
-        BOOST_REQUIRE_EQUAL(ap->stair_count, 3);  // no value
-        BOOST_REQUIRE_EQUAL(ap->max_slope, 30);   // no value
-        BOOST_REQUIRE_EQUAL(ap->min_width, 2);    // no value
+        BOOST_REQUIRE_EQUAL(ap->stair_count, 3);
+        BOOST_REQUIRE_EQUAL(ap->max_slope, 30);
+        BOOST_REQUIRE_EQUAL(ap->min_width, 2);
+        BOOST_REQUIRE_EQUAL(ap->signposted_as, "");           // no value
+        BOOST_REQUIRE_EQUAL(ap->reversed_signposted_as, "");  // no value
         BOOST_CHECK_CLOSE(ap->coord.lat(), 45.0614, 0.001);
         BOOST_CHECK_CLOSE(ap->coord.lon(), 0.6155, 0.001);
     }

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -473,7 +473,7 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
         BOOST_REQUIRE_EQUAL(ap->stop_code, "stop_code_io_2");
         BOOST_REQUIRE_EQUAL(ap->length, 68);
         BOOST_REQUIRE_EQUAL(ap->traversal_time, 87);
-        BOOST_REQUIRE_EQUAL(ap->is_entrance, exit);
+        BOOST_REQUIRE_EQUAL(ap->is_entrance, false);
         BOOST_REQUIRE_EQUAL(ap->is_exit, true);
         BOOST_REQUIRE_EQUAL(ap->stair_count, 3);
         BOOST_REQUIRE_EQUAL(ap->max_slope, 30);

--- a/source/ed/docker_tests/ed_integration_tests.cpp
+++ b/source/ed/docker_tests/ed_integration_tests.cpp
@@ -37,6 +37,7 @@ www.navitia.io
 #include "type/data.h"
 #include "type/pt_data.h"
 #include "type/meta_data.h"
+#include "type/access_point.h"
 #include "type/contributor.h"
 #include "type/meta_vehicle_journey.h"
 #include "type/dataset.h"
@@ -447,6 +448,37 @@ BOOST_FIXTURE_TEST_CASE(ntfs_v5_test, ArgsFixture) {
     BOOST_REQUIRE_EQUAL(data.pt_data->stop_points_map["stop_point:SP:J"]->address->number, 0);
     BOOST_REQUIRE_EQUAL(data.pt_data->stop_points_map["stop_point:SP:J"]->address->way->name,
                         "FACE AU 23 SP:J STREET_NAME");
+
+    // Access Point
+    BOOST_REQUIRE_EQUAL(data.pt_data->stop_points_map["stop_point:SP:A"]->access_points.size(), 1);
+    for (const auto& ap : data.pt_data->stop_points_map["stop_point:SP:A"]->access_points) {
+        BOOST_REQUIRE_EQUAL(ap->uri, "IO:1");
+        BOOST_REQUIRE_EQUAL(ap->stop_code, "stop_code_io_1");
+        BOOST_REQUIRE_EQUAL(ap->length, 68);
+        BOOST_REQUIRE_EQUAL(ap->traversal_time, 87);
+        BOOST_REQUIRE_EQUAL(ap->is_entrance, true);
+        BOOST_REQUIRE_EQUAL(ap->is_exit, true);
+        BOOST_REQUIRE_EQUAL(ap->stair_count, -1);  // no value
+        BOOST_REQUIRE_EQUAL(ap->max_slope, -1);    // no value
+        BOOST_REQUIRE_EQUAL(ap->min_width, -1);    // no value
+        BOOST_CHECK_CLOSE(ap->coord.lat(), 45.0614, 0.001);
+        BOOST_CHECK_CLOSE(ap->coord.lon(), 0.6155, 0.001);
+    }
+
+    BOOST_REQUIRE_EQUAL(data.pt_data->stop_points_map["stop_point:SP:B"]->access_points.size(), 1);
+    for (const auto& ap : data.pt_data->stop_points_map["stop_point:SP:B"]->access_points) {
+        BOOST_REQUIRE_EQUAL(ap->uri, "IO:2");
+        BOOST_REQUIRE_EQUAL(ap->stop_code, "stop_code_io_2");
+        BOOST_REQUIRE_EQUAL(ap->length, 68);
+        BOOST_REQUIRE_EQUAL(ap->traversal_time, 87);
+        BOOST_REQUIRE_EQUAL(ap->is_entrance, exit);
+        BOOST_REQUIRE_EQUAL(ap->is_exit, true);
+        BOOST_REQUIRE_EQUAL(ap->stair_count, 3);  // no value
+        BOOST_REQUIRE_EQUAL(ap->max_slope, 30);   // no value
+        BOOST_REQUIRE_EQUAL(ap->min_width, 2);    // no value
+        BOOST_CHECK_CLOSE(ap->coord.lat(), 45.0614, 0.001);
+        BOOST_CHECK_CLOSE(ap->coord.lon(), 0.6155, 0.001);
+    }
 
     check_ntfs(data);
 }

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -666,8 +666,8 @@ void EdReader::fill_access_point_field(navitia::type::AccessPoint* access_point,
     if (!const_it["signposted_as"].is_null()) {
         const_it["signposted_as"].to(access_point->signposted_as);
     }
-    if (!const_it["reverse_signposted_as"].is_null()) {
-        const_it["reverse_signposted_as"].to(access_point->reversed_signposted_as);
+    if (!const_it["reversed_signposted_as"].is_null()) {
+        const_it["reversed_signposted_as"].to(access_point->reversed_signposted_as);
     }
     // link with SP
     auto sp_key = uri_to_idx_stop_point.find(sp_id);
@@ -727,7 +727,7 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
         "max_slope, "
         "min_width, "
         "signposted_as, "
-        "reverse_signposted_as "
+        "reversed_signposted_as "
         "FROM navitia.pathway";
 
     result = work.exec(request);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -751,6 +751,9 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
             fill_access_point_field(to_access_p->second, const_it, false, from_stop_id);
             continue;
         }
+
+        // An other case exists: StopPoint <=> StopPoint connection.
+        // In the future, it will be handled like AccessPoint <=> SP
     }
 }
 

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -670,7 +670,7 @@ void EdReader::fill_access_point_field(navitia::type::AccessPoint* access_point,
         const_it["reversed_signposted_as"].to(access_point->reversed_signposted_as);
     }
     // link with SP
-    auto sp_key = uri_to_idx_stop_point.find(sp_id);
+    auto sp_key = uri_to_idx_stop_point.find("stop_point:" + sp_id);
     if (sp_key != uri_to_idx_stop_point.end()) {
         auto sp = stop_point_map.find(sp_key->second);
         if (sp != stop_point_map.end()) {
@@ -699,7 +699,7 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
         ap->coord.set_lon(const_it["lon"].as<double>());
         ap->coord.set_lat(const_it["lat"].as<double>());
         // parent station is Stop Area
-        auto sa_key = uri_to_idx_stop_area.find(const_it["parent_station"].as<std::string>());
+        auto sa_key = uri_to_idx_stop_area.find("stop_area:" + const_it["parent_station"].as<std::string>());
         if (sa_key != uri_to_idx_stop_area.end()) {
             auto sa = stop_area_map.find(sa_key->second);
             if (sa != stop_area_map.end()) {

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -684,10 +684,10 @@ void EdReader::fill_access_point_field(navitia::type::AccessPoint* access_point,
 void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
     // access_point
     std::string request =
-        "SELECT ap.id as id, ap.name as name, ar.uri as uri, "
-        "ST_X(ap.coord::geometry) as lon, ST_Y(ap.coord::geometry) as lat,"
-        "ap.stop_code as stop_code,"
-        "ap.parent_station as parent_station"
+        "SELECT id, name, uri, "
+        "ST_X(coord::geometry) as lon, ST_Y(coord::geometry) as lat, "
+        "stop_code, "
+        "parent_station "
         "FROM navitia.access_point";
 
     pqxx::result result = work.exec(request);
@@ -716,18 +716,18 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
 
     // Pathway
     request =
-        "SELECT pw.id as id, pw.name as name, pw.uri as uri, "
-        "pw.from_stop_id as from_stop_id,"
-        "pw.to_stop_id as to_stop_id,"
-        "pw.pathway_mode as pathway_mode"
-        "pw.is_bidirectional as is_bidirectional"
-        "pw.length as length"
-        "pw.traversal_time as traversal_time"
-        "pw.stair_count as stair_count"
-        "pw.max_slope as max_slope"
-        "pw.min_width as min_width"
-        "pw.signposted_as as signposted_as"
-        "pw.reverse_signposted_as as reverse_signposted_as"
+        "SELECT id, name, uri, "
+        "from_stop_id, "
+        "to_stop_id, "
+        "pathway_mode, "
+        "is_bidirectional, "
+        "length, "
+        "traversal_time, "
+        "stair_count, "
+        "max_slope, "
+        "min_width, "
+        "signposted_as, "
+        "reverse_signposted_as "
         "FROM navitia.pathway";
 
     result = work.exec(request);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -32,6 +32,7 @@ www.navitia.io
 
 #include "ed/connectors/fare_utils.h"
 #include "type/meta_data.h"
+#include "type/access_point.h"
 #include "type/network.h"
 #include "type/company.h"
 #include "type/contributor.h"
@@ -79,6 +80,7 @@ void EdReader::fill(navitia::type::Data& data,
 
     this->fill_stop_areas(data, work);
     this->fill_stop_points(data, work);
+    this->fill_access_points(data, work);
     this->fill_ntfs_addresses(work);
 
     this->fill_lines(data, work);
@@ -546,6 +548,7 @@ void EdReader::fill_stop_areas(nt::Data& data, pqxx::work& work) {
 
         data.pt_data->stop_areas.push_back(sa);
         this->stop_area_map[const_it["id"].as<idx_t>()] = sa;
+        this->uri_to_idx_stop_area[const_it["uri"].as<std::string>()] = const_it["id"].as<idx_t>();
     }
 }
 
@@ -619,6 +622,133 @@ void EdReader::fill_stop_points(nt::Data& data, pqxx::work& work) {
         }
         data.pt_data->stop_points.push_back(sp);
         this->stop_point_map[const_it["id"].as<idx_t>()] = sp;
+        this->uri_to_idx_stop_point[const_it["uri"].as<std::string>()] = const_it["id"].as<idx_t>();
+    }
+}
+
+void EdReader::fill_access_point_field(navitia::type::AccessPoint* access_point,
+                                       const pqxx::result::iterator const_it,
+                                       const bool from_access_point,
+                                       std::string& sp_id) {
+    if (!const_it["pathway_mode"].is_null()) {
+        access_point->pathway_mode = const_it["pathway_mode"].as<unsigned int>();
+    }
+    if (!const_it["is_bidirectional"].is_null()) {
+        bool is_bidirectional = const_it["is_bidirectional"].as<bool>();
+        if (is_bidirectional) {
+            access_point->is_entrance = true;
+            access_point->is_exit = true;
+        } else {
+            if (from_access_point) {
+                access_point->is_entrance = true;
+                access_point->is_exit = false;
+            } else {
+                access_point->is_entrance = false;
+                access_point->is_exit = true;
+            }
+        }
+    }
+    if (!const_it["length"].is_null()) {
+        access_point->length = const_it["length"].as<unsigned int>();
+    }
+    if (!const_it["traversal_time"].is_null()) {
+        access_point->traversal_time = const_it["traversal_time"].as<unsigned int>();
+    }
+    if (!const_it["stair_count"].is_null()) {
+        access_point->stair_count = const_it["stair_count"].as<unsigned int>();
+    }
+    if (!const_it["max_slope"].is_null()) {
+        access_point->max_slope = const_it["max_slope"].as<unsigned int>();
+    }
+    if (!const_it["min_width"].is_null()) {
+        access_point->min_width = const_it["min_width"].as<unsigned int>();
+    }
+    if (!const_it["signposted_as"].is_null()) {
+        const_it["signposted_as"].to(access_point->signposted_as);
+    }
+    if (!const_it["reverse_signposted_as"].is_null()) {
+        const_it["reverse_signposted_as"].to(access_point->reversed_signposted_as);
+    }
+    // link with SP
+    auto sp_key = uri_to_idx_stop_point.find(sp_id);
+    if (sp_key != uri_to_idx_stop_point.end()) {
+        auto sp = stop_point_map.find(sp_key->second);
+        if (sp != stop_point_map.end()) {
+            sp->second->access_points.insert(access_point);
+        }
+    } else {
+        LOG4CPLUS_ERROR(log, "pathway.to_stop_id not match with a stop point uri " << sp_id);
+    }
+}
+
+void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
+    // access_point
+    std::string request =
+        "SELECT ap.id as id, ap.name as name, ar.uri as uri, "
+        "ST_X(ap.coord::geometry) as lon, ST_Y(ap.coord::geometry) as lat,"
+        "ap.stop_code as stop_code,"
+        "ap.parent_station as prent_station"
+        "FROM navitia.access_point";
+
+    pqxx::result result = work.exec(request);
+    for (auto const_it = result.begin(); const_it != result.end(); ++const_it) {
+        auto* ap = new nt::AccessPoint();
+        const_it["uri"].to(ap->uri);
+        const_it["name"].to(ap->name);
+        const_it["stop_code"].to(ap->stop_code);
+        ap->coord.set_lon(const_it["lon"].as<double>());
+        ap->coord.set_lat(const_it["lat"].as<double>());
+        // parent station is Stop Area
+        auto sa_key = uri_to_idx_stop_area.find(const_it["parent_station"].as<std::string>());
+        if (sa_key != uri_to_idx_stop_area.end()) {
+            auto sa = stop_area_map.find(sa_key->second);
+            if (sa != stop_area_map.end()) {
+                ap->parent_station = sa->second;
+            }
+        } else {
+            LOG4CPLUS_ERROR(log, "access_point.parent_station not match with a stop area uri "
+                                     << const_it["parent_station"].as<std::string>());
+        }
+
+        // store access_point temporary before finishing in a SP link
+        access_point_map[const_it["uri"].as<std::string>()] = ap;
+    }
+
+    // Pathway
+    request =
+        "SELECT pw.id as id, pw.name as name, pw.uri as uri, "
+        "pw.from_stop_id as from_stop_id,"
+        "pw.to_stop_id as to_stop_id,"
+        "pw.pathway_mode as pathway_mode"
+        "pw.is_bidirectional as is_bidirectional"
+        "pw.length as length"
+        "pw.traversal_time as traversal_time"
+        "pw.stair_count as stair_count"
+        "pw.max_slope as max_slope"
+        "pw.min_width as min_width"
+        "pw.signposted_as as signposted_as"
+        "pw.reverse_signposted_as as reverse_signposted_as"
+        "FROM navitia.pathway";
+
+    result = work.exec(request);
+    for (auto const_it = result.begin(); const_it != result.end(); ++const_it) {
+        std::string from_stop_id;
+        const_it["from_stop_id"].to(from_stop_id);
+        std::string to_stop_id;
+        const_it["to_stop_id"].to(to_stop_id);
+
+        // Access Point URI match for from_stop_id
+        auto from_access_p = access_point_map.find(from_stop_id);
+        if (from_access_p != access_point_map.end()) {
+            fill_access_point_field(from_access_p->second, const_it, true, to_stop_id);
+            continue;
+        }
+        // Access Point URI match for to_stop_id
+        auto to_access_p = access_point_map.find(to_stop_id);
+        if (to_access_p != access_point_map.end()) {
+            fill_access_point_field(to_access_p->second, const_it, false, from_stop_id);
+            continue;
+        }
     }
 }
 

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -629,12 +629,12 @@ void EdReader::fill_stop_points(nt::Data& data, pqxx::work& work) {
 void EdReader::fill_access_point_field(navitia::type::AccessPoint* access_point,
                                        const pqxx::result::iterator const_it,
                                        const bool from_access_point,
-                                       std::string& sp_id) {
+                                       const std::string& sp_id) {
     if (!const_it["pathway_mode"].is_null()) {
         access_point->pathway_mode = const_it["pathway_mode"].as<unsigned int>();
     }
     if (!const_it["is_bidirectional"].is_null()) {
-        bool is_bidirectional = const_it["is_bidirectional"].as<bool>();
+        const bool is_bidirectional = const_it["is_bidirectional"].as<bool>();
         if (is_bidirectional) {
             access_point->is_entrance = true;
             access_point->is_exit = true;
@@ -710,7 +710,7 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
                                      << const_it["parent_station"].as<std::string>());
         }
 
-        // store access_point temporary before finishing in a SP link
+        // store access_point temporarily before finishing in a SP link
         access_point_map[const_it["uri"].as<std::string>()] = ap;
     }
 
@@ -738,12 +738,14 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
         const_it["to_stop_id"].to(to_stop_id);
 
         // Access Point URI match for from_stop_id
+        // so, to_stop_id have to be a StopPoint
         auto from_access_p = access_point_map.find(from_stop_id);
         if (from_access_p != access_point_map.end()) {
             fill_access_point_field(from_access_p->second, const_it, true, to_stop_id);
             continue;
         }
         // Access Point URI match for to_stop_id
+        // so, from_stop_id have to be a StopPoint
         auto to_access_p = access_point_map.find(to_stop_id);
         if (to_access_p != access_point_map.end()) {
             fill_access_point_field(to_access_p->second, const_it, false, from_stop_id);

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -687,7 +687,7 @@ void EdReader::fill_access_points(nt::Data& data, pqxx::work& work) {
         "SELECT ap.id as id, ap.name as name, ar.uri as uri, "
         "ST_X(ap.coord::geometry) as lon, ST_Y(ap.coord::geometry) as lat,"
         "ap.stop_code as stop_code,"
-        "ap.parent_station as prent_station"
+        "ap.parent_station as parent_station"
         "FROM navitia.access_point";
 
     pqxx::result result = work.exec(request);

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -74,7 +74,10 @@ private:
     std::unordered_map<idx_t, navitia::type::Contributor*> contributor_map;
     std::unordered_map<idx_t, navitia::type::Dataset*> dataset_map;
     std::unordered_map<idx_t, navitia::type::StopArea*> stop_area_map;
+    std::unordered_map<std::string, idx_t> uri_to_idx_stop_area;
     std::unordered_map<idx_t, navitia::type::StopPoint*> stop_point_map;
+    std::unordered_map<std::string, idx_t> uri_to_idx_stop_point;
+    std::unordered_map<std::string, navitia::type::AccessPoint*> access_point_map;
     std::unordered_map<idx_t, navitia::type::Line*> line_map;
     std::unordered_map<idx_t, navitia::type::LineGroup*> line_group_map;
     std::unordered_map<idx_t, navitia::type::Route*> route_map;
@@ -121,6 +124,11 @@ private:
 
     void fill_stop_areas(navitia::type::Data& data, pqxx::work& work);
     void fill_stop_points(navitia::type::Data& data, pqxx::work& work);
+    void fill_access_point_field(navitia::type::AccessPoint* access_point,
+                                 const pqxx::result::iterator const_it,
+                                 const bool from_access_point,
+                                 std::string& sp_id);
+    void fill_access_points(navitia::type::Data& data, pqxx::work& work);
     void fill_ntfs_addresses(pqxx::work& work);
     void fill_lines(navitia::type::Data& data, pqxx::work& work);
     void fill_line_groups(navitia::type::Data& data, pqxx::work& work);

--- a/source/ed/ed_reader.h
+++ b/source/ed/ed_reader.h
@@ -127,7 +127,7 @@ private:
     void fill_access_point_field(navitia::type::AccessPoint* access_point,
                                  const pqxx::result::iterator const_it,
                                  const bool from_access_point,
-                                 std::string& sp_id);
+                                 const std::string& sp_id);
     void fill_access_points(navitia::type::Data& data, pqxx::work& work);
     void fill_ntfs_addresses(pqxx::work& work);
     void fill_lines(navitia::type::Data& data, pqxx::work& work);

--- a/source/type/access_point.cpp
+++ b/source/type/access_point.cpp
@@ -28,11 +28,6 @@ www.navitia.io
 */
 #include "type/access_point.h"
 
-#include "type/connection.h"
-#include "type/dataset.h"
-#include "type/indexes.h"
-#include "type/pt_data.h"
-#include "type/route.h"
 #include "type/stop_area.h"
 #include "type/serialization.h"
 #include "georef/georef.h"

--- a/source/type/access_point.cpp
+++ b/source/type/access_point.cpp
@@ -33,8 +33,8 @@ www.navitia.io
 #include "type/indexes.h"
 #include "type/pt_data.h"
 #include "type/route.h"
-#include "type/serialization.h"
 #include "type/stop_area.h"
+#include "type/serialization.h"
 #include "georef/georef.h"
 
 #include <boost/serialization/weak_ptr.hpp>
@@ -43,13 +43,14 @@ namespace navitia {
 namespace type {
 template <class Archive>
 void AccessPoint::serialize(Archive& ar, const unsigned int /*unused*/) {
-    ar& uri& name& stop_area& coord& idx;
+    ar& uri& name& stop_code& is_entrance& is_exit& pathway_mode& length& traversal_time& stair_count& max_slope&
+        min_width& signposted_as& reversed_signposted_as& parent_station& coord& idx;
 }
 SERIALIZABLE(AccessPoint)
 
 bool AccessPoint::operator<(const AccessPoint& other) const {
-    if (this->stop_area != other.stop_area) {
-        return *this->stop_area < *other.stop_area;
+    if (this->parent_station != other.parent_station) {
+        return *this->parent_station < *other.parent_station;
     }
     std::string lower_name = strip_accents_and_lower(this->name);
     std::string lower_other_name = strip_accents_and_lower(other.name);

--- a/source/type/access_point.h
+++ b/source/type/access_point.h
@@ -40,26 +40,26 @@ struct AccessPoint : public Header, Nameable, hasProperties, HasMessages {
     const static Type_e type = Type_e::AccessPoint;
 
     // parameters
-    std::string stop_code;
-    bool is_entrance;
-    bool is_exit;
-    uint pathway_mode;
-    uint length;
-    uint traversal_time;
-    uint stair_count;
-    uint max_slope;
-    uint min_width;
-    std::string signposted_as;
-    std::string reversed_signposted_as;
+    std::string stop_code = "";
+    bool is_entrance = false;
+    bool is_exit = false;
+    uint pathway_mode = 0;
+    uint length = 0;
+    uint traversal_time = 0;
+    uint stair_count = 0;
+    uint max_slope = 0;
+    uint min_width = 0;
+    std::string signposted_as = "";
+    std::string reversed_signposted_as = "";
 
     GeographicalCoord coord;
 
-    StopArea* parent_station;
+    StopArea* parent_station = nullptr;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);
 
-    AccessPoint() : parent_station(nullptr) {}
+    AccessPoint() = default;
 
     bool operator<(const AccessPoint& other) const;
 };

--- a/source/type/access_point.h
+++ b/source/type/access_point.h
@@ -43,12 +43,12 @@ struct AccessPoint : public Header, Nameable, hasProperties, HasMessages {
     std::string stop_code = "";
     bool is_entrance = false;
     bool is_exit = false;
-    uint pathway_mode = 0;
-    uint length = 0;
-    uint traversal_time = 0;
-    uint stair_count = 0;
-    uint max_slope = 0;
-    uint min_width = 0;
+    uint pathway_mode = -1;
+    uint length = -1;
+    uint traversal_time = -1;
+    uint stair_count = -1;
+    uint max_slope = -1;
+    uint min_width = -1;
     std::string signposted_as = "";
     std::string reversed_signposted_as = "";
 

--- a/source/type/access_point.h
+++ b/source/type/access_point.h
@@ -36,6 +36,8 @@ www.navitia.io
 namespace navitia {
 namespace type {
 
+const static int ap_default_value = -1;
+
 struct AccessPoint : public Header, Nameable, hasProperties, HasMessages {
     const static Type_e type = Type_e::AccessPoint;
 
@@ -43,12 +45,12 @@ struct AccessPoint : public Header, Nameable, hasProperties, HasMessages {
     std::string stop_code = "";
     bool is_entrance = false;
     bool is_exit = false;
-    uint pathway_mode = -1;
-    uint length = -1;
-    uint traversal_time = -1;
-    uint stair_count = -1;
-    uint max_slope = -1;
-    uint min_width = -1;
+    int pathway_mode = ap_default_value;
+    int length = ap_default_value;
+    int traversal_time = ap_default_value;
+    int stair_count = ap_default_value;
+    int max_slope = ap_default_value;
+    int min_width = ap_default_value;
     std::string signposted_as = "";
     std::string reversed_signposted_as = "";
 

--- a/source/type/access_point.h
+++ b/source/type/access_point.h
@@ -33,24 +33,33 @@ www.navitia.io
 #include "type/type_interfaces.h"
 #include "type/geographical_coord.h"
 
-#include <boost/container/flat_set.hpp>
-
-#include <vector>
-#include <set>
-
 namespace navitia {
 namespace type {
 
 struct AccessPoint : public Header, Nameable, hasProperties, HasMessages {
     const static Type_e type = Type_e::AccessPoint;
+
+    // parameters
+    std::string stop_code;
+    bool is_entrance;
+    bool is_exit;
+    uint pathway_mode;
+    uint length;
+    uint traversal_time;
+    uint stair_count;
+    uint max_slope;
+    uint min_width;
+    std::string signposted_as;
+    std::string reversed_signposted_as;
+
     GeographicalCoord coord;
 
-    StopArea* stop_area;
+    StopArea* parent_station;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);
 
-    AccessPoint() : stop_area(nullptr) {}
+    AccessPoint() : parent_station(nullptr) {}
 
     bool operator<(const AccessPoint& other) const;
 };

--- a/source/type/stop_point.cpp
+++ b/source/type/stop_point.cpp
@@ -45,10 +45,9 @@ namespace navitia {
 namespace type {
 template <class Archive>
 void StopPoint::serialize(Archive& ar, const unsigned int /*unused*/) {
-    // The *_list are not serialized here to avoid stack abuse
-    // during serialization and deserialization.
-    //
-    // stop_point_connection_list is managed by StopPointConnection
+    // stop_point_connection_list is managed by StopPointConnection because
+    // we want to save seria/deseria to perform some optimizations.
+    // Handle inside connection.cpp
     ar& uri& label& name& stop_area& coord& fare_zone& is_zonal& address_id& idx& platform_code& admin_list&
         access_points& _properties& impacts& dataset_list& address;
 }

--- a/source/type/stop_point.cpp
+++ b/source/type/stop_point.cpp
@@ -36,6 +36,7 @@ www.navitia.io
 #include "type/route.h"
 #include "type/serialization.h"
 #include "type/stop_area.h"
+#include "type/access_point.h"
 #include "georef/georef.h"
 
 #include <boost/serialization/weak_ptr.hpp>
@@ -49,7 +50,7 @@ void StopPoint::serialize(Archive& ar, const unsigned int /*unused*/) {
     //
     // stop_point_connection_list is managed by StopPointConnection
     ar& uri& label& name& stop_area& coord& fare_zone& is_zonal& address_id& idx& platform_code& admin_list&
-        _properties& impacts& dataset_list& address;
+        access_points& _properties& impacts& dataset_list& address;
 }
 SERIALIZABLE(StopPoint)
 

--- a/source/type/stop_point.h
+++ b/source/type/stop_point.h
@@ -53,6 +53,7 @@ struct StopPoint : public Header, Nameable, hasProperties, HasMessages {
 
     StopArea* stop_area;
     std::vector<navitia::georef::Admin*> admin_list;
+    std::set<navitia::type::AccessPoint*> access_points;
     Network* network;
     std::vector<StopPointConnection*> stop_point_connection_list;
     std::set<Dataset*> dataset_list;


### PR DESCRIPTION
This is the second part of the Epic **Entrance/Exit**. 
Following the first job https://github.com/CanalTP/navitia/pull/3614, we have to read the ED table to create the new AccessPoint vector linked into each StopPoint.
That is an AccessPoint -> https://github.com/CanalTP/navitia/pull/3616/files#diff-640a43f77adb4783b283fa233d472b13b5228d3313ce7e83bce717d1ea0e9740R39

At the end **AccessPoint** are exposed inside **StopPoint** like this -> https://github.com/CanalTP/navitia/pull/3616/files#diff-e0441f873b68f4bee05b0865750b7d996e6e4f706b2d9a297dbacc64dfb9a388R56