### PR TITLE
Access Point: Expose access_point inside stop_point output api

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -688,6 +688,27 @@ void builder::connection(const std::string& name1, const std::string& name2, flo
     connexion->destination->stop_point_connection_list.push_back(connexion);
 }
 
+void builder::add_access_point(const std::string& stop_point,
+                               const std::string& access_point_name,
+                               const bool is_entrance,
+                               const bool is_exit,
+                               const int length,
+                               const int traversal_time,
+                               const double x,
+                               const double y) {
+    auto sp = data->pt_data->stop_points_map[stop_point];
+    auto* ap = new navitia::type::AccessPoint();
+    ap->name = access_point_name;
+    ap->uri = access_point_name;
+    ap->is_entrance = is_entrance;
+    ap->is_exit = is_exit;
+    ap->length = length;
+    ap->traversal_time = traversal_time;
+    ap->coord.set_lat(x);
+    ap->coord.set_lon(y);
+    sp->access_points.insert(ap);
+}
+
 void builder::add_ticket(const std::string& ticket_id,
                          const std::string& line,
                          const int cost,

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -38,6 +38,7 @@ www.navitia.io
 #include "type/message.h"
 #include "type/rt_level.h"
 #include "type/company.h"
+#include "type/access_point.h"
 #include "type/dataset.h"
 #include "type/contributor.h"
 #include "type/commercial_mode.h"
@@ -366,6 +367,15 @@ struct builder {
         collection.push_back(obj);
         return obj;
     }
+
+    void add_access_point(const std::string& stop_point,
+                          const std::string& access_point_name,
+                          const bool is_entrance = true,
+                          const bool is_exit = true,
+                          const int length = 0,
+                          const int traversal_time = 0,
+                          const double x = 0,
+                          const double y = 0);
 
     void add_ticket(const std::string& ticket_id,
                     const std::string& line,

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/base.py
@@ -398,3 +398,7 @@ class NestedPropertiesField(NestedPropertyField):
         if not value:
             return {}
         return {p.get('key'): p.get('value') for p in value}
+
+
+def get_proto_attr_or_default(obj, attr_name, default=None):
+    return getattr(obj, attr_name) if obj.HasField(str(attr_name)) else default

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -34,6 +34,7 @@ from jormungandr.interfaces.v1.serializer.base import (
     EnumListField,
     LiteralField,
     SortedGenericSerializer,
+    get_proto_attr_or_default,
 )
 from jormungandr.interfaces.v1.serializer.jsonschema.fields import Field, DateType
 from jormungandr.interfaces.v1.serializer.time import (
@@ -456,34 +457,34 @@ class AccessPointSerializer(PbGenericSerializer):
     parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
 
     def get_is_entrance(self, obj):
-        return obj.is_entrance if obj.HasField(str('is_entrance')) else None
+        return get_proto_attr_or_default(obj, 'is_entrance')
 
     def get_is_exit(self, obj):
-        return obj.is_exit if obj.HasField(str('is_exit')) else None
+        return get_proto_attr_or_default(obj, 'is_exit')
 
     def get_pathway_mode(self, obj):
-        return obj.pathway_mode if obj.HasField(str('pathway_mode')) else None
+        return get_proto_attr_or_default(obj, 'pathway_mode')
 
     def get_length(self, obj):
-        return obj.length if obj.HasField(str('length')) else None
+        return get_proto_attr_or_default(obj, 'length')
 
     def get_traversal_time(self, obj):
-        return obj.traversal_time if obj.HasField(str('traversal_time')) else None
+        return get_proto_attr_or_default(obj, 'traversal_time')
 
     def get_stair_count(self, obj):
-        return obj.stair_count if obj.HasField(str('stair_count')) else None
+        return get_proto_attr_or_default(obj, 'stair_count')
 
     def get_max_slope(self, obj):
-        return obj.max_slope if obj.HasField(str('max_slope')) else None
+        return get_proto_attr_or_default(obj, 'max_slope')
 
     def get_min_width(self, obj):
-        return obj.min_width if obj.HasField(str('min_width')) else None
+        return get_proto_attr_or_default(obj, 'min_width')
 
     def get_signposted_as(self, obj):
-        return obj.signposted_as if obj.HasField(str('signposted_as')) else None
+        return get_proto_attr_or_default(obj, 'signposted_as')
 
     def get_reversed_signposted_as(self, obj):
-        return obj.reversed_signposted_as if obj.HasField(str('reversed_signposted_as')) else None
+        return get_proto_attr_or_default(obj, 'reversed_signposted_as')
 
     def get_parent_station(self, obj):
         if obj.HasField(str('parent_station')):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -418,6 +418,9 @@ class StopPointSerializer(PbGenericSerializer):
     fare_zone = jsonschema.MethodField(schema_type=lambda: FareZoneSerializer(), display_none=False)
     equipment_details = EquipmentDetailsSerializer(many=True)
     lines = jsonschema.MethodField(schema_type=lambda: LineSerializer(many=True), display_none=False)
+    access_points = jsonschema.MethodField(
+        schema_type=lambda: AccessPointSerializer(many=True), display_none=False
+    )
 
     def get_fare_zone(self, obj):
         if obj.HasField(str('fare_zone')):
@@ -433,6 +436,60 @@ class StopPointSerializer(PbGenericSerializer):
 
     def get_lines(self, obj):
         return LineSerializer(obj.lines, many=True, display_none=False).data
+
+    def get_access_points(self, obj):
+        return AccessPointSerializer(obj.access_points, many=True, display_none=False).data
+
+
+class AccessPointSerializer(PbGenericSerializer):
+    coord = CoordSerializer(required=False)
+    is_entrance = jsonschema.MethodField(schema_type=bool, display_none=False)
+    is_exit = jsonschema.MethodField(schema_type=bool, display_none=False)
+    pathway_mode = jsonschema.MethodField(schema_type=int, display_none=False)
+    length = jsonschema.MethodField(schema_type=int, display_none=False)
+    traversal_time = jsonschema.MethodField(schema_type=int, display_none=False)
+    stair_count = jsonschema.MethodField(schema_type=int, display_none=False)
+    max_slope = jsonschema.MethodField(schema_type=int, display_none=False)
+    min_width = jsonschema.MethodField(schema_type=int, display_none=False)
+    signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
+    reversed_signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
+    parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
+
+    def get_is_entrance(self, obj):
+        return obj.is_entrance if obj.HasField(str('is_entrance')) else None
+
+    def get_is_exit(self, obj):
+        return obj.is_exit if obj.HasField(str('is_exit')) else None
+
+    def get_pathway_mode(self, obj):
+        return obj.pathway_mode if obj.HasField(str('pathway_mode')) else None
+
+    def get_length(self, obj):
+        return obj.length if obj.HasField(str('length')) else None
+
+    def get_traversal_time(self, obj):
+        return obj.traversal_time if obj.HasField(str('traversal_time')) else None
+
+    def get_stair_count(self, obj):
+        return obj.stair_count if obj.HasField(str('stair_count')) else None
+
+    def get_max_slope(self, obj):
+        return obj.max_slope if obj.HasField(str('max_slope')) else None
+
+    def get_min_width(self, obj):
+        return obj.min_width if obj.HasField(str('min_width')) else None
+
+    def get_signposted_as(self, obj):
+        return obj.signposted_as if obj.HasField(str('signposted_as')) else None
+
+    def get_reversed_signposted_as(self, obj):
+        return obj.reversed_signposted_as if obj.HasField(str('reversed_signposted_as')) else None
+
+    def get_parent_station(self, obj):
+        if obj.HasField(str('parent_station')):
+            return StopAreaSerializer(obj.parent_station, display_none=False).data
+        else:
+            return None
 
 
 class StopAreaSerializer(PbGenericSerializer):

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -99,6 +99,8 @@ class TestAccessPoints(AbstractTestFixture):
             # spA
             if pn['embedded_type'] == 'stop_point' and pn['name'] == 'spA':
                 assert len(get_not_null(pn['stop_point'], 'access_points')) == 2
+                assert access_point_is_present(pn['stop_point']['access_points'], 'AP1')
+                assert access_point_is_present(pn['stop_point']['access_points'], 'AP2')
                 for ap in pn['stop_point']['access_points']:
                     if ap['name'] == 'AP2':
                         assert ap['is_entrance'] == True

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -31,6 +31,13 @@ from .tests_mechanism import AbstractTestFixture, dataset
 from .check_utils import get_not_null, is_valid_places
 
 
+def access_point_is_present(access_point_list, access_point_name):
+    for ap in access_point_list:
+        if ap['name'] == access_point_name:
+            return True
+    return False
+
+
 @dataset({"access_points_test": {}})
 class TestAccessPoints(AbstractTestFixture):
     def test_access_points_with_stop_points(self):
@@ -41,6 +48,8 @@ class TestAccessPoints(AbstractTestFixture):
             # spA
             if sp['name'] == 'spA':
                 assert len(get_not_null(sp, 'access_points')) == 2
+                assert access_point_is_present(sp['access_points'], 'AP1')
+                assert access_point_is_present(sp['access_points'], 'AP2')
                 for ap in sp['access_points']:
                     if ap['name'] == 'AP2':
                         assert ap['is_entrance'] == True
@@ -55,13 +64,15 @@ class TestAccessPoints(AbstractTestFixture):
             # spC
             if sp['name'] == 'spC':
                 assert len(get_not_null(sp, 'access_points')) == 2
+                assert access_point_is_present(sp['access_points'], 'AP2')
+                assert access_point_is_present(sp['access_points'], 'AP3')
                 for ap in sp['access_points']:
                     if ap['name'] == 'AP3':
                         assert ap['is_entrance'] == True
                         assert ap['is_exit'] == False
                         assert ap['length'] == 12
                         assert ap['traversal_time'] == 36
-                    if ap['name'] == 'AP1':
+                    if ap['name'] == 'AP2':
                         assert ap['is_entrance'] == True
                         assert ap['is_exit'] == False
                         assert ap['length'] == 13

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -88,13 +88,14 @@ class TestAccessPoints(AbstractTestFixture):
             # spA
             if pn['embedded_type'] == 'stop_point' and pn['name'] == 'spA':
                 assert len(get_not_null(pn['stop_point'], 'access_points')) == 2
-                assert pn['stop_point']['access_points'][0]['name'] == 'AP2'
-                assert pn['stop_point']['access_points'][0]['is_entrance'] == True
-                assert pn['stop_point']['access_points'][0]['is_exit'] == False
-                assert pn['stop_point']['access_points'][0]['length'] == 13
-                assert pn['stop_point']['access_points'][0]['traversal_time'] == 26
-                assert pn['stop_point']['access_points'][1]['name'] == 'AP1'
-                assert pn['stop_point']['access_points'][1]['is_entrance'] == True
-                assert pn['stop_point']['access_points'][1]['is_exit'] == True
-                assert pn['stop_point']['access_points'][1]['length'] == 10
-                assert pn['stop_point']['access_points'][1]['traversal_time'] == 23
+                for ap in pn['stop_point']['access_points']:
+                    if ap['name'] == 'AP2':
+                        assert ap['is_entrance'] == True
+                        assert ap['is_exit'] == False
+                        assert ap['length'] == 13
+                        assert ap['traversal_time'] == 26
+                    if ap['name'] == 'AP1':
+                        assert ap['is_entrance'] == True
+                        assert ap['is_exit'] == True
+                        assert ap['length'] == 10
+                        assert ap['traversal_time'] == 23

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -41,29 +41,31 @@ class TestAccessPoints(AbstractTestFixture):
             # spA
             if sp['name'] == 'spA':
                 assert len(get_not_null(sp, 'access_points')) == 2
-                assert sp['access_points'][0]['name'] == 'AP2'
-                assert sp['access_points'][0]['is_entrance'] == True
-                assert sp['access_points'][0]['is_exit'] == False
-                assert sp['access_points'][0]['length'] == 13
-                assert sp['access_points'][0]['traversal_time'] == 26
-                assert sp['access_points'][1]['name'] == 'AP1'
-                assert sp['access_points'][1]['is_entrance'] == True
-                assert sp['access_points'][1]['is_exit'] == True
-                assert sp['access_points'][1]['length'] == 10
-                assert sp['access_points'][1]['traversal_time'] == 23
-            # spB
+                for ap in sp['access_points']:
+                    if ap['name'] == 'AP2':
+                        assert ap['is_entrance'] == True
+                        assert ap['is_exit'] == False
+                        assert ap['length'] == 13
+                        assert ap['traversal_time'] == 26
+                    if ap['name'] == 'AP1':
+                        assert ap['is_entrance'] == True
+                        assert ap['is_exit'] == True
+                        assert ap['length'] == 10
+                        assert ap['traversal_time'] == 23
+            # spC
             if sp['name'] == 'spC':
                 assert len(get_not_null(sp, 'access_points')) == 2
-                assert sp['access_points'][0]['name'] == 'AP3'
-                assert sp['access_points'][0]['is_entrance'] == True
-                assert sp['access_points'][0]['is_exit'] == False
-                assert sp['access_points'][0]['length'] == 12
-                assert sp['access_points'][0]['traversal_time'] == 36
-                assert sp['access_points'][1]['name'] == 'AP2'
-                assert sp['access_points'][1]['is_entrance'] == True
-                assert sp['access_points'][1]['is_exit'] == False
-                assert sp['access_points'][1]['length'] == 13
-                assert sp['access_points'][1]['traversal_time'] == 26
+                for ap in sp['access_points']:
+                    if ap['name'] == 'AP3':
+                        assert ap['is_entrance'] == True
+                        assert ap['is_exit'] == False
+                        assert ap['length'] == 12
+                        assert ap['traversal_time'] == 36
+                    if ap['name'] == 'AP1':
+                        assert ap['is_entrance'] == True
+                        assert ap['is_exit'] == False
+                        assert ap['length'] == 13
+                        assert ap['traversal_time'] == 26
 
         # without depth=3
         r = self.query_region('stop_points')

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2001-2021, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+from .tests_mechanism import AbstractTestFixture, dataset
+from .check_utils import get_not_null, is_valid_places
+
+
+@dataset({"access_points_test": {}})
+class TestAccessPoints(AbstractTestFixture):
+    def test_access_points_with_stop_points(self):
+        r = self.query_region('stop_points?depth=3')
+        assert len(get_not_null(r, 'stop_points')) == 7
+
+        for sp in r['stop_points']:
+            # spA
+            if sp['name'] == 'spA':
+                assert len(get_not_null(sp, 'access_points')) == 2
+                assert sp['access_points'][0]['name'] == 'AP2'
+                assert sp['access_points'][0]['is_entrance'] == True
+                assert sp['access_points'][0]['is_exit'] == False
+                assert sp['access_points'][0]['length'] == 13
+                assert sp['access_points'][0]['traversal_time'] == 26
+                assert sp['access_points'][1]['name'] == 'AP1'
+                assert sp['access_points'][1]['is_entrance'] == True
+                assert sp['access_points'][1]['is_exit'] == True
+                assert sp['access_points'][1]['length'] == 10
+                assert sp['access_points'][1]['traversal_time'] == 23
+            # spB
+            if sp['name'] == 'spC':
+                assert len(get_not_null(sp, 'access_points')) == 2
+                assert sp['access_points'][0]['name'] == 'AP3'
+                assert sp['access_points'][0]['is_entrance'] == True
+                assert sp['access_points'][0]['is_exit'] == False
+                assert sp['access_points'][0]['length'] == 12
+                assert sp['access_points'][0]['traversal_time'] == 36
+                assert sp['access_points'][1]['name'] == 'AP2'
+                assert sp['access_points'][1]['is_entrance'] == True
+                assert sp['access_points'][1]['is_exit'] == False
+                assert sp['access_points'][1]['length'] == 13
+                assert sp['access_points'][1]['traversal_time'] == 26
+
+        # without depth=3
+        r = self.query_region('stop_points')
+        assert len(get_not_null(r, 'stop_points')) == 7
+
+        for sp in r['stop_points']:
+            # spA
+            if sp['name'] == 'spA':
+                assert "access_points" not in sp
+            # spB
+            if sp['name'] == 'spC':
+                assert "access_points" not in sp
+
+    def test_access_points_with_places_nearby(self):
+        response = self.query_region("coords/2.362795;48.872871/places_nearby?depth=3")
+        assert len(response['places_nearby']) > 0
+        is_valid_places(response['places_nearby'])
+
+        for pn in response['places_nearby']:
+            # spA
+            if pn['embedded_type'] == 'stop_point' and pn['name'] == 'spA':
+                assert len(get_not_null(pn['stop_point'], 'access_points')) == 2
+                assert pn['stop_point']['access_points'][0]['name'] == 'AP2'
+                assert pn['stop_point']['access_points'][0]['is_entrance'] == True
+                assert pn['stop_point']['access_points'][0]['is_exit'] == False
+                assert pn['stop_point']['access_points'][0]['length'] == 13
+                assert pn['stop_point']['access_points'][0]['traversal_time'] == 26
+                assert pn['stop_point']['access_points'][1]['name'] == 'AP1'
+                assert pn['stop_point']['access_points'][1]['is_entrance'] == True
+                assert pn['stop_point']['access_points'][1]['is_exit'] == True
+                assert pn['stop_point']['access_points'][1]['length'] == 10
+                assert pn['stop_point']['access_points'][1]['traversal_time'] == 23

--- a/source/tests/mock-kraken/CMakeLists.txt
+++ b/source/tests/mock-kraken/CMakeLists.txt
@@ -14,6 +14,7 @@ install(TARGETS main_routing_test DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 add_executable(main_ptref_test main_ptref_test.cpp)
 add_executable(min_nb_journeys_test min_nb_journeys_test.cpp)
 add_executable(basic_routing_test basic_routing_test.cpp)
+add_executable(access_points_test access_points_test.cpp)
 add_executable(basic_schedule_test basic_schedule_test.cpp)
 add_executable(departure_board_test departure_board_test.cpp)
 install(TARGETS departure_board_test DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
@@ -34,6 +35,7 @@ add_custom_target(integration_tests_bin DEPENDS main_routing_test
                                                 main_ptref_test
                                                 min_nb_journeys_test
                                                 basic_routing_test
+                                                access_points_test
                                                 basic_schedule_test
                                                 departure_board_test
                                                 empty_routing_test
@@ -53,6 +55,7 @@ target_link_libraries(main_routing_test ${ALL_LIBS})
 target_link_libraries(main_ptref_test ${ALL_LIBS})
 target_link_libraries(min_nb_journeys_test ${ALL_LIBS})
 target_link_libraries(basic_routing_test ${ALL_LIBS})
+target_link_libraries(access_points_test ${ALL_LIBS})
 target_link_libraries(basic_schedule_test ${ALL_LIBS})
 target_link_libraries(departure_board_test ${ALL_LIBS})
 target_link_libraries(empty_routing_test ${ALL_LIBS})

--- a/source/tests/mock-kraken/access_points_test.cpp
+++ b/source/tests/mock-kraken/access_points_test.cpp
@@ -1,0 +1,61 @@
+/* Copyright © 2001-2016, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "utils/init.h"
+#include "mock_kraken.h"
+#include "type/pt_data.h"
+#include "tests/utils_test.h"
+
+using namespace navitia::georef;
+
+int main(int argc, const char* const argv[]) {
+    navitia::init_app();
+
+    ed::builder b("20210101", [](ed::builder& b) {
+        b.sa("A", 2.361795, 48.871871)("spA", 2.361795, 48.871871);
+        b.sa("B", 2.362795, 48.872871)("spB", 2.362795, 48.872871);
+        b.sa("C", 2.363795, 48.873871)("spC", 2.363795, 48.873871);
+        b.vj("A")("spA", "08:00"_t)("spB", "10:00"_t);
+        b.vj("B")("spC", "09:00"_t)("spD", "11:00"_t);
+        b.vj("C")("spA", "10:00"_t)("spC", "12:00"_t);
+    });
+
+    b.data->complete();
+    b.make();
+
+    b.add_access_point("spA", "AP1", true, true, 10, 23, 48.874871, 2.364795);
+    b.add_access_point("spA", "AP2", true, false, 13, 26, 48.875871, 2.365795);
+    b.add_access_point("spC", "AP3", true, false, 12, 36, 48.876871, 2.366795);
+    b.add_access_point("spC", "AP2", true, false, 13, 26, 48.875871, 2.365795);
+
+    mock_kraken kraken(b, argc, argv);
+
+    return 0;
+}

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -594,9 +594,9 @@ void PbCreator::Filler::fill_pb_object(const ng::Admin* adm, pbnavitia::Administ
     }
 }
 
-void PbCreator::Filler::fill_access_points(const std::set<nt::AccessPoint*> access_points,
+void PbCreator::Filler::fill_access_points(const std::set<nt::AccessPoint*>& access_points,
                                            pbnavitia::StopPoint* stop_point) {
-    for (auto access_point : access_points) {
+    for (const auto& access_point : access_points) {
         pbnavitia::AccessPoint* ap = stop_point->add_access_points();
         ap->set_name(access_point->name);
         ap->set_uri(access_point->uri);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -38,6 +38,7 @@ www.navitia.io
 #include "time_tables/thermometer.h"
 #include "type/geographical_coord.h"
 #include "type/type_utils.h"
+#include "type/access_point.h"
 #include "utils/exception.h"
 #include "utils/exception.h"
 #include "utils/functions.h"
@@ -593,6 +594,49 @@ void PbCreator::Filler::fill_pb_object(const ng::Admin* adm, pbnavitia::Administ
     }
 }
 
+void PbCreator::Filler::fill_access_points(const std::set<nt::AccessPoint*> access_points,
+                                           pbnavitia::StopPoint* stop_point) {
+    for (auto access_point : access_points) {
+        pbnavitia::AccessPoint* ap = stop_point->add_access_points();
+        ap->set_name(access_point->name);
+        ap->set_uri(access_point->uri);
+        if (access_point->coord.is_initialized()) {
+            ap->mutable_coord()->set_lon(access_point->coord.lon());
+            ap->mutable_coord()->set_lat(access_point->coord.lat());
+        }
+        ap->set_is_entrance(access_point->is_entrance);
+        ap->set_is_exit(access_point->is_exit);
+        if (access_point->pathway_mode != nt::ap_default_value) {
+            ap->set_pathway_mode(access_point->pathway_mode);
+        }
+        if (access_point->length != nt::ap_default_value) {
+            ap->set_length(access_point->length);
+        }
+        if (access_point->traversal_time != nt::ap_default_value) {
+            ap->set_traversal_time(access_point->traversal_time);
+        }
+        if (access_point->stair_count != nt::ap_default_value) {
+            ap->set_stair_count(access_point->stair_count);
+        }
+        if (access_point->max_slope != nt::ap_default_value) {
+            ap->set_max_slope(access_point->max_slope);
+        }
+        if (access_point->min_width != nt::ap_default_value) {
+            ap->set_min_width(access_point->min_width);
+        }
+        if (!access_point->signposted_as.empty()) {
+            ap->set_signposted_as(access_point->signposted_as);
+        }
+        if (!access_point->reversed_signposted_as.empty()) {
+            ap->set_reversed_signposted_as(access_point->reversed_signposted_as);
+        }
+        if (access_point->parent_station != nullptr) {
+            pbnavitia::StopArea* sa = ap->mutable_parent_station();
+            fill_pb_object(access_point->parent_station, sa);
+        }
+    }
+}
+
 void PbCreator::Filler::fill_pb_object(const nt::StopPoint* sp, pbnavitia::StopPoint* stop_point) {
     stop_point->set_uri(sp->uri);
     add_contributor(sp);
@@ -641,6 +685,10 @@ void PbCreator::Filler::fill_pb_object(const nt::StopPoint* sp, pbnavitia::StopP
     }
     if (depth > 0) {
         fill(sp->admin_list, stop_point->mutable_administrative_regions());
+    }
+    // access points
+    if (depth > 2) {
+        fill_access_points(sp->access_points, stop_point);
     }
 
     fill(sp->address, stop_point);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -528,6 +528,8 @@ private:
         void fill_pb_object(const ng::Address*, pbnavitia::Address*);
         void fill_pb_object(const nt::Comment*, pbnavitia::Note*);
 
+        void fill_access_points(const std::set<nt::AccessPoint*> access_points, pbnavitia::StopPoint* stop_point);
+
         // Used for place
         template <typename T>
         void fill_pb_object(const T* value, pbnavitia::PtObject* pt_object);

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -528,7 +528,7 @@ private:
         void fill_pb_object(const ng::Address*, pbnavitia::Address*);
         void fill_pb_object(const nt::Comment*, pbnavitia::Note*);
 
-        void fill_access_points(const std::set<nt::AccessPoint*> access_points, pbnavitia::StopPoint* stop_point);
+        void fill_access_points(const std::set<nt::AccessPoint*>& access_points, pbnavitia::StopPoint* stop_point);
 
         // Used for place
         template <typename T>


### PR DESCRIPTION
### Sum up

- Create a new ed builder function to add Access Point in test.
- Create a new kraken mock for future needs
- Fill the protobuf with a new field : the famous AccessPoint
- Expose within the api the Access Point list into Stop Point
- Tested with a real ntfs file with multiple AccessPoint.

A typical response is represented like that :

![accessPoint](https://user-images.githubusercontent.com/32099204/148400266-0c1e2db6-9d90-44f6-adb4-a2604961ade9.png)
