### PR TITLE
[Jormun] Integrate access point into journeys

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -694,8 +694,8 @@ void builder::add_access_point(const std::string& stop_point,
                                const bool is_exit,
                                const int length,
                                const int traversal_time,
-                               const double x,
-                               const double y) {
+                               const double lat,
+                               const double lon) {
     auto sp = data->pt_data->stop_points_map[stop_point];
     auto ap = navitia::type::AccessPoint();
     ap.name = access_point_name;
@@ -704,8 +704,8 @@ void builder::add_access_point(const std::string& stop_point,
     ap.is_exit = is_exit;
     ap.length = length;
     ap.traversal_time = traversal_time;
-    ap.coord.set_lat(x);
-    ap.coord.set_lon(y);
+    ap.coord.set_lat(lat);
+    ap.coord.set_lon(lon);
     sp->access_points.insert(ap);
 }
 

--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -374,8 +374,8 @@ struct builder {
                           const bool is_exit = true,
                           const int length = 0,
                           const int traversal_time = 0,
-                          const double x = 0,
-                          const double y = 0);
+                          const double lat = 0,
+                          const double lon = 0);
 
     void add_ticket(const std::string& ticket_id,
                     const std::string& line,

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -551,7 +551,7 @@ std::vector<nf::Autocomplete<nt::idx_t>::fl_quality> GeoRef::find_ways(
     return to_return;
 }
 
-void GeoRef::project_stop_points(const std::vector<type::StopPoint*>& stop_points) {
+void GeoRef::project_stop_points_and_access_points(const std::vector<type::StopPoint*>& stop_points) {
     enum class error {
         matched = 0,
         matched_walking,
@@ -566,9 +566,13 @@ void GeoRef::project_stop_points(const std::vector<type::StopPoint*>& stop_point
     navitia::flat_enum_map<error, int> access_point_messages{{{}}};
 
     this->projected_stop_points.clear();
-    this->projected_stop_points.reserve(stop_points.size() * 2);
+
+    this->projected_stop_points.reserve(stop_points.size());
 
     this->projected_coords.clear();
+    // This projection cache is used by distributed scenari. It contains projections for
+    // both stop points and access points. Since we cannot know the exact number of access points
+    // ahead of time, we just suppose every stop point has at least one access point. Thus the factor is 2.
     this->projected_coords.reserve(stop_points.size() * 2);
 
     auto update_message = [](navitia::flat_enum_map<error, int>& messages,

--- a/source/georef/georef.cpp
+++ b/source/georef/georef.cpp
@@ -615,16 +615,16 @@ void GeoRef::project_stop_points(const std::vector<type::StopPoint*>& stop_point
 
         update_message(stop_point_messages, pair, stop_point->coord);
 
-        for (const auto* ap : stop_point->access_points) {
-            auto it = projected_coords.find(ap->coord);
+        for (const auto& ap : stop_point->access_points) {
+            auto it = projected_coords.find(ap.coord);
             if (it != projected_coords.end()) {
                 continue;
             }
-            std::pair<GeoRef::ProjectionByMode, bool> ap_pair = project_coord(ap->coord);
-            this->projected_coords[ap->coord] = ap_pair.first;
+            std::pair<GeoRef::ProjectionByMode, bool> ap_pair = project_coord(ap.coord);
+            this->projected_coords[ap.coord] = ap_pair.first;
             ++access_points_num;
 
-            update_message(access_point_messages, ap_pair, ap->coord);
+            update_message(access_point_messages, ap_pair, ap.coord);
         };
     }
 

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -287,12 +287,12 @@ struct GeoRef {
      */
     void project_stop_points(const std::vector<type::StopPoint*>& stop_points);
 
-    /** project the stop point on all transportation mode
+    /** project the a coordinate on all transportation mode
      * return a pair with :
      * - the projected array
      * - a boolean corresponding to the fact that at least one projection has been found
      */
-    std::pair<ProjectionByMode, bool> project_stop_point(const type::StopPoint* stop_point) const;
+    std::pair<ProjectionByMode, bool> project_coord(const type::GeographicalCoord& coord) const;
 
     /** Retourne l'arc (segment) le plus proche
      *

--- a/source/georef/georef.h
+++ b/source/georef/georef.h
@@ -283,9 +283,9 @@ struct GeoRef {
     std::vector<Admin*> find_admins(const type::GeographicalCoord&, AdminRtree&) const;
 
     /**
-     * Project each stop_point on the georef network
+     * Project each stop_point and their access points(if any) on the georef network
      */
-    void project_stop_points(const std::vector<type::StopPoint*>& stop_points);
+    void project_stop_points_and_access_points(const std::vector<type::StopPoint*>& stop_points);
 
     /** project the a coordinate on all transportation mode
      * return a pair with :

--- a/source/georef/tests/georef_test.cpp
+++ b/source/georef/tests/georef_test.cpp
@@ -844,7 +844,7 @@ BOOST_AUTO_TEST_CASE(compute_nearest) {
     std::vector<StopPoint*> stop_points;
     stop_points.push_back(sp1);
     stop_points.push_back(sp2);
-    b.geo_ref.project_stop_points(stop_points);
+    b.geo_ref.project_stop_points_and_access_points(stop_points);
 
     GeographicalCoord o(0, 0);
 
@@ -1228,7 +1228,7 @@ BOOST_AUTO_TEST_CASE(two_scc) {
     std::vector<StopPoint*> stop_points;
     stop_points.push_back(sp1);
     stop_points.push_back(sp2);
-    b.geo_ref.project_stop_points(stop_points);
+    b.geo_ref.project_stop_points_and_access_points(stop_points);
 
     StreetNetwork w(b.geo_ref);
 
@@ -1496,7 +1496,7 @@ BOOST_AUTO_TEST_CASE(find_nearest_on_same_edge) {
     stop_points.push_back(sp1);
     stop_points.push_back(sp2);
     stop_points.push_back(sp3);
-    b.geo_ref.project_stop_points(stop_points);
+    b.geo_ref.project_stop_points_and_access_points(stop_points);
 
     StreetNetwork w(b.geo_ref);
     EntryPoint starting_point;

--- a/source/georef/tests/street_network_test.cpp
+++ b/source/georef/tests/street_network_test.cpp
@@ -104,7 +104,7 @@ const ProjectionData build_data(GraphBuilder& b, type::Data& data) {
     sp->idx = 0;
     data.pt_data->stop_points.push_back(sp);
     b.init();
-    b.geo_ref.project_stop_points(data.pt_data->stop_points);
+    b.geo_ref.project_stop_points_and_access_points(data.pt_data->stop_points);
 
     const GeoRef::ProjectionByMode& projections = b.geo_ref.projected_stop_points[sp->idx];
     const ProjectionData proj = projections[type::Mode_e::Walking];

--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -83,6 +83,7 @@ class Kraken(object):
         filter=None,
         stop_points_nearby_duration=300,
         request_id=None,
+        depth=2,
         forbidden_uris=[],
         allowed_id=[],
         **kwargs
@@ -95,7 +96,7 @@ class Kraken(object):
         req.requested_api = type_pb2.places_nearby
         req.places_nearby.uri = origin
         req.places_nearby.distance = kwargs.get(streetnetwork_mode, kwargs.get("walking")) * max_duration
-        req.places_nearby.depth = 2
+        req.places_nearby.depth = depth
         req.places_nearby.count = max_nb_crowfly
         req.places_nearby.start_page = 0
         req.disable_feedpublisher = True

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -732,13 +732,6 @@ class Journeys(JourneyCommon):
             hidden=True,
             help="used to adjust the search range in Asgard when computing matrix",
         )
-        parser_get.add_argument(
-            "_access_points",
-            type=BooleanType(),
-            default=False,
-            hidden=True,
-            help="use/disuse the entrance/exit in journeys computation",
-        )
 
     @add_tad_links()
     @add_debug_info()

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -732,6 +732,13 @@ class Journeys(JourneyCommon):
             hidden=True,
             help="used to adjust the search range in Asgard when computing matrix",
         )
+        parser_get.add_argument(
+            "_access_points",
+            type=BooleanType(),
+            default=False,
+            hidden=True,
+            help="used to adjust the search range in Asgard when computing matrix",
+        )
 
     @add_tad_links()
     @add_debug_info()

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -737,7 +737,7 @@ class Journeys(JourneyCommon):
             type=BooleanType(),
             default=False,
             hidden=True,
-            help="used to adjust the search range in Asgard when computing matrix",
+            help="use/disuse the entrance/exit in journeys computation",
         )
 
     @add_tad_links()

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -477,6 +477,13 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             hidden=True,
             help="active the asynchronous mode for the ridesharing services",
         )
+        parser_get.add_argument(
+            "_access_points",
+            type=BooleanType(),
+            default=False,
+            hidden=True,
+            help="use/disuse the entrance/exit in journeys computation",
+        )
 
     def parse_args(self, region=None, uri=None):
         args = self.parsers['get'].parse_args()

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -36,6 +36,7 @@ from jormungandr.interfaces.v1.serializer.pt import (
     VJDisplayInformationSerializer,
     StopDateTimeSerializer,
     StringListField,
+    AccessPointSerializer,
 )
 from jormungandr.interfaces.v1.serializer.time import DateTimeField
 from jormungandr.interfaces.v1.serializer.fields import (
@@ -179,8 +180,7 @@ class PathSerializer(PbNestedSerializer):
     direction = jsonschema.Field(schema_type=int, display_none=True)
     instruction = jsonschema.MethodField(schema_type=str, display_none=False)
     instruction_start_coordinate = jsonschema.MethodField(schema_type=lambda: CoordSerializer())
-    via_entrance_uri = jsonschema.MethodField(schema_type=str, display_none=False)
-    via_exit_uri = jsonschema.MethodField(schema_type=str, display_none=False)
+    via_uri = jsonschema.MethodField(schema_type=str, display_none=False)
 
     def get_id(self, obj):
         if obj.HasField(str('id')):
@@ -200,11 +200,8 @@ class PathSerializer(PbNestedSerializer):
         else:
             return None
 
-    def get_via_exit_uri(self, obj):
-        return obj.via_exit_uri if obj.HasField(str('via_exit_uri')) else None
-
-    def get_via_entrance_uri(self, obj):
-        return obj.via_entrance_uri if obj.HasField(str('via_entrance_uri')) else None
+    def get_via_uri(self, obj):
+        return obj.via_uri if obj.HasField(str('via_uri')) else None
 
 
 class ElevationSerializer(PbNestedSerializer):
@@ -354,8 +351,7 @@ class SectionSerializer(PbNestedSerializer):
 
     cycle_lane_length = PbIntField(display_none=False)
     elevations = ElevationSerializer(attr="street_network.elevations", many=True, display_none=False)
-    via_entrance = PlaceSerializer(display_none=False)
-    via_exit = PlaceSerializer(display_none=False)
+    vias = PlaceSerializer(many=True, display_none=False)
 
 
 class JourneySerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -351,7 +351,18 @@ class SectionSerializer(PbNestedSerializer):
 
     cycle_lane_length = PbIntField(display_none=False)
     elevations = ElevationSerializer(attr="street_network.elevations", many=True, display_none=False)
-    vias = PlaceSerializer(many=True, display_none=False)
+    vias = jsonschema.MethodField(many=True, display_none=False)
+
+    def get_vias(self, obj):
+        if not hasattr(obj, 'vias'):
+            return None
+        from navitiacommon import type_pb2
+
+        pt_obejcts = [
+            type_pb2.PtObject(name=ap.name, uri=ap.uri, embedded_type=type_pb2.ACCESS_POINT, access_point=ap)
+            for ap in obj.vias
+        ]
+        return PlaceSerializer(pt_obejcts, display_none=False, many=True).data
 
 
 class JourneySerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -346,6 +346,7 @@ class SectionSerializer(PbNestedSerializer):
 
     cycle_lane_length = PbIntField(display_none=False)
     elevations = ElevationSerializer(attr="street_network.elevations", many=True, display_none=False)
+    via = PlaceSerializer(display_none=False)
 
 
 class JourneySerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -346,7 +346,8 @@ class SectionSerializer(PbNestedSerializer):
 
     cycle_lane_length = PbIntField(display_none=False)
     elevations = ElevationSerializer(attr="street_network.elevations", many=True, display_none=False)
-    via = PlaceSerializer(display_none=False)
+    via_entrance = PlaceSerializer(display_none=False)
+    via_exit = PlaceSerializer(display_none=False)
 
 
 class JourneySerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -351,7 +351,7 @@ class SectionSerializer(PbNestedSerializer):
 
     cycle_lane_length = PbIntField(display_none=False)
     elevations = ElevationSerializer(attr="street_network.elevations", many=True, display_none=False)
-    vias = jsonschema.MethodField(many=True, display_none=False)
+    vias = jsonschema.MethodField(schema_type=PlaceSerializer(), many=True, display_none=False)
 
     def get_vias(self, obj):
         if not hasattr(obj, 'vias'):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -179,6 +179,8 @@ class PathSerializer(PbNestedSerializer):
     direction = jsonschema.Field(schema_type=int, display_none=True)
     instruction = jsonschema.MethodField(schema_type=str, display_none=False)
     instruction_start_coordinate = jsonschema.MethodField(schema_type=lambda: CoordSerializer())
+    via_entrance_uri = jsonschema.MethodField(schema_type=str, display_none=False)
+    via_exit_uri = jsonschema.MethodField(schema_type=str, display_none=False)
 
     def get_id(self, obj):
         if obj.HasField(str('id')):
@@ -197,6 +199,12 @@ class PathSerializer(PbNestedSerializer):
             return CoordSerializer(obj.instruction_start_coordinate, display_none=False).data
         else:
             return None
+
+    def get_via_exit_uri(self, obj):
+        return obj.via_exit_uri if obj.HasField(str('via_exit_uri')) else None
+
+    def get_via_entrance_uri(self, obj):
+        return obj.via_entrance_uri if obj.HasField(str('via_entrance_uri')) else None
 
 
 class ElevationSerializer(PbNestedSerializer):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -405,16 +405,16 @@ class EquipmentDetailsSerializer(PbNestedSerializer):
 
 class AccessPointSerializer(PbGenericSerializer):
     coord = CoordSerializer(required=False)
-    is_entrance = jsonschema.Field(schema_type=bool, display_none=False)
-    is_exit = jsonschema.Field(schema_type=bool, display_none=False)
-    pathway_mode = jsonschema.Field(schema_type=int, display_none=False)
-    length = jsonschema.Field(schema_type=int, display_none=False)
-    traversal_time = jsonschema.Field(schema_type=int, display_none=False)
-    stair_count = jsonschema.Field(schema_type=int, display_none=False)
-    max_slope = jsonschema.Field(schema_type=int, display_none=False)
-    min_width = jsonschema.Field(schema_type=int, display_none=False)
-    signposted_as = jsonschema.Field(schema_type=str, display_none=False)
-    reversed_signposted_as = jsonschema.Field(schema_type=str, display_none=False)
+    is_entrance = jsonschema.MethodField(schema_type=bool, display_none=False)
+    is_exit = jsonschema.MethodField(schema_type=bool, display_none=False)
+    pathway_mode = jsonschema.MethodField(schema_type=int, display_none=False)
+    length = jsonschema.MethodField(schema_type=int, display_none=False)
+    traversal_time = jsonschema.MethodField(schema_type=int, display_none=False)
+    stair_count = jsonschema.MethodField(schema_type=int, display_none=False)
+    max_slope = jsonschema.MethodField(schema_type=int, display_none=False)
+    min_width = jsonschema.MethodField(schema_type=int, display_none=False)
+    signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
+    reversed_signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
     parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
 
     def get_is_entrance(self, obj):

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -417,6 +417,36 @@ class AccessPointSerializer(PbGenericSerializer):
     reversed_signposted_as = jsonschema.Field(schema_type=str, display_none=False)
     parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
 
+    def get_is_entrance(self, obj):
+        return get_proto_attr_or_default(obj, 'is_entrance')
+
+    def get_is_exit(self, obj):
+        return get_proto_attr_or_default(obj, 'is_exit')
+
+    def get_pathway_mode(self, obj):
+        return get_proto_attr_or_default(obj, 'pathway_mode')
+
+    def get_length(self, obj):
+        return get_proto_attr_or_default(obj, 'length')
+
+    def get_traversal_time(self, obj):
+        return get_proto_attr_or_default(obj, 'traversal_time')
+
+    def get_stair_count(self, obj):
+        return get_proto_attr_or_default(obj, 'stair_count')
+
+    def get_max_slope(self, obj):
+        return get_proto_attr_or_default(obj, 'max_slope')
+
+    def get_min_width(self, obj):
+        return get_proto_attr_or_default(obj, 'min_width')
+
+    def get_signposted_as(self, obj):
+        return get_proto_attr_or_default(obj, 'signposted_as')
+
+    def get_reversed_signposted_as(self, obj):
+        return get_proto_attr_or_default(obj, 'reversed_signposted_as')
+
     def get_parent_station(self, obj):
         if obj.HasField(str('parent_station')):
             return StopAreaSerializer(obj.parent_station, display_none=False).data

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -403,6 +403,27 @@ class EquipmentDetailsSerializer(PbNestedSerializer):
     current_availability = CurrentAvailabilitySerializer(display_none=False, required=False)
 
 
+class AccessPointSerializer(PbGenericSerializer):
+    coord = CoordSerializer(required=False)
+    is_entrance = jsonschema.Field(schema_type=bool, display_none=False)
+    is_exit = jsonschema.Field(schema_type=bool, display_none=False)
+    pathway_mode = jsonschema.Field(schema_type=int, display_none=False)
+    length = jsonschema.Field(schema_type=int, display_none=False)
+    traversal_time = jsonschema.Field(schema_type=int, display_none=False)
+    stair_count = jsonschema.Field(schema_type=int, display_none=False)
+    max_slope = jsonschema.Field(schema_type=int, display_none=False)
+    min_width = jsonschema.Field(schema_type=int, display_none=False)
+    signposted_as = jsonschema.Field(schema_type=str, display_none=False)
+    reversed_signposted_as = jsonschema.Field(schema_type=str, display_none=False)
+    parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
+
+    def get_parent_station(self, obj):
+        if obj.HasField(str('parent_station')):
+            return StopAreaSerializer(obj.parent_station, display_none=False).data
+        else:
+            return None
+
+
 class StopPointSerializer(PbGenericSerializer):
     comments = CommentSerializer(many=True, display_none=False)
     comment = FirstCommentField(attr='comments', display_none=False)
@@ -419,9 +440,7 @@ class StopPointSerializer(PbGenericSerializer):
     fare_zone = jsonschema.MethodField(schema_type=lambda: FareZoneSerializer(), display_none=False)
     equipment_details = EquipmentDetailsSerializer(many=True)
     lines = jsonschema.MethodField(schema_type=lambda: LineSerializer(many=True), display_none=False)
-    access_points = jsonschema.MethodField(
-        schema_type=lambda: AccessPointSerializer(many=True), display_none=False
-    )
+    access_points = AccessPointSerializer(many=True, display_none=False)
 
     def get_fare_zone(self, obj):
         if obj.HasField(str('fare_zone')):
@@ -437,60 +456,6 @@ class StopPointSerializer(PbGenericSerializer):
 
     def get_lines(self, obj):
         return LineSerializer(obj.lines, many=True, display_none=False).data
-
-    def get_access_points(self, obj):
-        return AccessPointSerializer(obj.access_points, many=True, display_none=False).data
-
-
-class AccessPointSerializer(PbGenericSerializer):
-    coord = CoordSerializer(required=False)
-    is_entrance = jsonschema.MethodField(schema_type=bool, display_none=False)
-    is_exit = jsonschema.MethodField(schema_type=bool, display_none=False)
-    pathway_mode = jsonschema.MethodField(schema_type=int, display_none=False)
-    length = jsonschema.MethodField(schema_type=int, display_none=False)
-    traversal_time = jsonschema.MethodField(schema_type=int, display_none=False)
-    stair_count = jsonschema.MethodField(schema_type=int, display_none=False)
-    max_slope = jsonschema.MethodField(schema_type=int, display_none=False)
-    min_width = jsonschema.MethodField(schema_type=int, display_none=False)
-    signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
-    reversed_signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
-    parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
-
-    def get_is_entrance(self, obj):
-        return get_proto_attr_or_default(obj, 'is_entrance')
-
-    def get_is_exit(self, obj):
-        return get_proto_attr_or_default(obj, 'is_exit')
-
-    def get_pathway_mode(self, obj):
-        return get_proto_attr_or_default(obj, 'pathway_mode')
-
-    def get_length(self, obj):
-        return get_proto_attr_or_default(obj, 'length')
-
-    def get_traversal_time(self, obj):
-        return get_proto_attr_or_default(obj, 'traversal_time')
-
-    def get_stair_count(self, obj):
-        return get_proto_attr_or_default(obj, 'stair_count')
-
-    def get_max_slope(self, obj):
-        return get_proto_attr_or_default(obj, 'max_slope')
-
-    def get_min_width(self, obj):
-        return get_proto_attr_or_default(obj, 'min_width')
-
-    def get_signposted_as(self, obj):
-        return get_proto_attr_or_default(obj, 'signposted_as')
-
-    def get_reversed_signposted_as(self, obj):
-        return get_proto_attr_or_default(obj, 'reversed_signposted_as')
-
-    def get_parent_station(self, obj):
-        if obj.HasField(str('parent_station')):
-            return StopAreaSerializer(obj.parent_station, display_none=False).data
-        else:
-            return None
 
 
 class StopAreaSerializer(PbGenericSerializer):
@@ -531,6 +496,8 @@ class PlaceSerializer(PbGenericSerializer):
     embedded_type = EnumField(attr='embedded_type', pb_type=NavitiaType, display_none=True)
     address = AddressSerializer(display_none=False)
     poi = PoiSerializer(display_none=False)
+    access_point = AccessPointSerializer(display_none=False)
+
     distance = base.PbStrField(
         required=False, display_none=False, description='Distance to the object in meters'
     )

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
@@ -155,11 +155,11 @@ class FallbackDurations:
     def _update_fb_durations_from_access_point(
         self, fb_durations, access_point, duration, resp, access_points_map
     ):
-        for sp_uri, length, traveral_time in access_points_map[access_point.uri]:
+        for sp_uri, length, traversal_time in access_points_map[access_point.uri]:
             current_duration = fb_durations[sp_uri].duration if sp_uri in fb_durations else float('inf')
-            if (duration + traveral_time) < min(current_duration, self._max_duration_to_pt):
+            if (duration + traversal_time) < min(current_duration, self._max_duration_to_pt):
                 fb_durations[sp_uri] = DurationElement(
-                    duration + traveral_time, resp.routing_status, None, 0, access_point
+                    duration + traversal_time, resp.routing_status, None, 0, access_point
                 )
 
     def _do_request(self):
@@ -206,7 +206,8 @@ class FallbackDurations:
                 # if any of them are existent
                 if not p.stop_point.access_points:
                     places_isochrone.append(p)
-                self._retrieve_access_points(p.stop_point, access_points_map, places_isochrone)
+                else:
+                    self._retrieve_access_points(p.stop_point, access_points_map, places_isochrone)
 
         result = defaultdict(lambda: DurationElement(float('inf'), None, None, 0, None))
         # Since we have already places that have free access, we add them into the result
@@ -259,6 +260,7 @@ class FallbackDurations:
                 )
             return result
 
+        # the element in routing_response are ranged in the same order of element in places_isochrones
         for pos, r in enumerate(sn_routing_matrix.rows[0].routing_response):
             if r.routing_status == response_pb2.unreached:
                 continue

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/fallback_durations.py
@@ -276,6 +276,7 @@ class FallbackDurations:
                             result[sp_nearby.uri] = DurationElement(
                                 durations_sum,
                                 response_pb2.reached,
+                                # car park
                                 places_isochrone[pos],
                                 duration_to_stop_point,
                                 None,
@@ -287,9 +288,7 @@ class FallbackDurations:
                         and pt_object.embedded_type == type_pb2.STOP_POINT
                     ):
                         if duration < self._max_duration_to_pt:
-                            result[pt_object.uri] = DurationElement(
-                                duration, r.routing_status, None, 0, pt_object
-                            )
+                            result[pt_object.uri] = DurationElement(duration, r.routing_status, None, 0, None)
 
                     if (
                         isinstance(pt_object, type_pb2.PtObject)
@@ -304,6 +303,7 @@ class FallbackDurations:
 
         # We update the fallback duration matrix if the requested origin/destination is also
         # present in the fallback duration matrix, which means from stop_point_1 to itself, it takes 0 second
+        # Note that we consider, in this case, the via access_point is the stop_point itself.
         # Ex:
         #                stop_point1   stop_point2  stop_point3
         # stop_point_1         0(s)       ...          ...

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -321,9 +321,9 @@ def _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, f
         and via_access_point.embedded_type == type_pb2.ACCESS_POINT
     ):
         if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:
-            fallback_sections[-1].vias.append(via_access_point)
+            fallback_sections[-1].vias.append(via_access_point.access_point)
         else:
-            fallback_sections[0].vias.append(via_access_point)
+            fallback_sections[0].vias.append(via_access_point.access_point)
 
     journey.sections.extend(fallback_sections)
     journey.sections.sort(key=cmp_to_key(SectionSorter()))

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -272,15 +272,19 @@ def _extend_with_via_access_point(fallback_dp, pt_object, fallback_type, via_acc
         via.name = via_access_point.name
         # Use label in stead of name???
         via.instruction = "Enter {} via {}.".format(pt_object.stop_point.label, via_access_point.name)
+        via.via_entrance_uri = via_access_point.uri
+
     elif fallback_type == StreetNetworkPathType.ENDING_FALLBACK:
         path_items = dp_journey.sections[0].street_network.path_items
 
-        dp_journey.sections[0].street_network.path_items.add(
-            duration=traversal_time,
-            length=length,
-            name=via_access_point.name,
-            instruction="Exit {} via {}.".format(pt_object.stop_point.label, via_access_point.name),
-        )
+        via = dp_journey.sections[0].street_network.path_items.add()
+        via.duration = traversal_time
+        via.length = length
+        via.name = via_access_point.name
+        # Use label in stead of name???
+        via.instruction = "Exit {} via {}.".format(pt_object.stop_point.label, via_access_point.name)
+        via.via_exit_uri = via_access_point.uri
+
         # we cannot insert an element at the beginning of a list :(
         # a little algo to move the last element to the beginning
         tmp_item = response_pb2.PathItem()
@@ -635,7 +639,7 @@ def compute_fallback(
                 real_mode = dest_fallback_durations_pool.get_real_mode(arr_mode, dest_obj.uri)
 
             else:
-                dest_obj = dest_fallback_durations_pool.wait_and_get(dep_mode)[pt_dest.uri].via_access_point
+                dest_obj = dest_fallback_durations_pool.wait_and_get(arr_mode)[pt_dest.uri].via_access_point
                 real_mode = dest_fallback_durations_pool.get_real_mode(arr_mode, pt_dest.uri)
 
             streetnetwork_path_pool.add_async_request(

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -550,8 +550,11 @@ def compute_fallback(
             # here, if the mode is car, we have to find from which car park the stop_point is accessed
             if dep_mode == 'car':
                 orig_obj = orig_fallback_durations_pool.wait_and_get(dep_mode)[pt_orig.uri].car_park
+                real_mode = orig_fallback_durations_pool.get_real_mode(dep_mode, orig_obj.uri)
+            else:
+                orig_obj = orig_fallback_durations_pool.wait_and_get(dep_mode)[pt_orig.uri].via_access_point
+                real_mode = orig_fallback_durations_pool.get_real_mode(dep_mode, pt_orig.uri)
 
-            real_mode = orig_fallback_durations_pool.get_real_mode(dep_mode, orig_obj.uri)
             streetnetwork_path_pool.add_async_request(
                 from_obj,
                 orig_obj,
@@ -573,8 +576,12 @@ def compute_fallback(
             dest_obj = pt_dest
             if arr_mode == 'car':
                 dest_obj = dest_fallback_durations_pool.wait_and_get(arr_mode)[pt_dest.uri].car_park
+                real_mode = dest_fallback_durations_pool.get_real_mode(arr_mode, dest_obj.uri)
 
-            real_mode = dest_fallback_durations_pool.get_real_mode(arr_mode, dest_obj.uri)
+            else:
+                dest_obj = dest_fallback_durations_pool.wait_and_get(dep_mode)[pt_dest.uri].via_access_point
+                real_mode = dest_fallback_durations_pool.get_real_mode(arr_mode, pt_dest.uri)
+
             streetnetwork_path_pool.add_async_request(
                 dest_obj, to_obj, real_mode, fallback_extremity_arr, request, direct_path_type, to_sub_request_id
             )

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -320,9 +320,9 @@ def _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, f
         and via_access_point.embedded_type == type_pb2.ACCESS_POINT
     ):
         if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:
-            fallback_sections[-1].via.CopyFrom(via_access_point)
+            fallback_sections[-1].via_entrance.CopyFrom(via_access_point)
         else:
-            fallback_sections[0].via.CopyFrom(via_access_point)
+            fallback_sections[0].via_exit.CopyFrom(via_access_point)
 
     journey.sections.extend(fallback_sections)
     journey.sections.sort(key=cmp_to_key(SectionSorter()))

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -40,14 +40,13 @@ from jormungandr.utils import (
 from jormungandr.street_network.utils import crowfly_distance_between
 from jormungandr.fallback_modes import FallbackModes, all_fallback_modes
 from .helper_exceptions import *
-from navitiacommon import response_pb2
+from navitiacommon import response_pb2, type_pb2
 import copy
 import logging
 import six
 from functools import cmp_to_key
 from contextlib import contextmanager
 import time
-
 
 CAR_PARK_DURATION = 300  # secs
 allowed_physical_mode_for_transfert_path = (
@@ -252,7 +251,46 @@ def _extend_with_car_park(
     dp_journey.distances.walking += int(walking_speed * car_park_crowfly_duration)
 
 
-def _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, fallback_type):
+def _extend_with_via_access_point(fallback_dp, pt_object, fallback_type, via_access_point):
+    if (
+        isinstance(via_access_point, type_pb2.PtObject)
+        and via_access_point.embedded_type != type_pb2.ACCESS_POINT
+    ):
+        return
+
+    traversal_time = via_access_point.access_point.traversal_time
+    length = via_access_point.access_point.length
+
+    dp_journey = fallback_dp.journeys[0]
+    dp_journey.duration += traversal_time
+    dp_journey.distances.walking += length
+
+    if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:
+        via = dp_journey.sections[-1].street_network.path_items[-1]
+        via.duration = traversal_time
+        via.length = length
+        via.name = via_access_point.name
+        # Use label in stead of name???
+        via.instruction = "Enter {} via {}.".format(pt_object.stop_point.label, via_access_point.name)
+    elif fallback_type == StreetNetworkPathType.ENDING_FALLBACK:
+        path_items = dp_journey.sections[0].street_network.path_items
+
+        dp_journey.sections[0].street_network.path_items.add(
+            duration=traversal_time,
+            length=length,
+            name=via_access_point.name,
+            instruction="Exit {} via {}.".format(pt_object.stop_point.label, via_access_point.name),
+        )
+        # we cannot insert an element at the beginning of a list :(
+        # a little algo to move the last element to the beginning
+        tmp_item = response_pb2.PathItem()
+        for i in range(len(path_items)):
+            tmp_item.CopyFrom(path_items[i])
+            path_items[i].CopyFrom(path_items[-1])
+            path_items[-1].CopyFrom(tmp_item)
+
+
+def _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, fallback_type, via_access_point):
     """
     Replace journey's fallback sections with the given fallback_dp.
 
@@ -276,6 +314,15 @@ def _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, f
         fallback_sections[-1].destination.CopyFrom(journey.sections[0].origin)
     else:
         fallback_sections[0].origin.CopyFrom(journey.sections[-1].destination)
+
+    if (
+        isinstance(via_access_point, type_pb2.PtObject)
+        and via_access_point.embedded_type == type_pb2.ACCESS_POINT
+    ):
+        if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:
+            fallback_sections[-1].via.CopyFrom(via_access_point)
+        else:
+            fallback_sections[0].via.CopyFrom(via_access_point)
 
     journey.sections.extend(fallback_sections)
     journey.sections.sort(key=cmp_to_key(SectionSorter()))
@@ -420,9 +467,14 @@ def _build_fallback(
     pt_obj = fallback_logic.get_pt_boundaries(pt_journey)
     car_park = None
     car_park_crowfly_duration = None
+    via_access_point = None
 
     if mode == 'car':
-        _, _, car_park, car_park_crowfly_duration = fallback_durations[pt_obj.uri]
+        _, _, car_park, car_park_crowfly_duration, _ = fallback_durations[pt_obj.uri]
+    else:
+        # we retrieve the via_access_point from which the being/end of pt journeys is accessed by asking fallback_durations
+        # the via_access_point may be a stop_point or a access_point
+        _, _, _, _, via_access_point = fallback_durations[pt_obj.uri]
 
     if requested_obj.uri != pt_obj.uri:
         if pt_obj.uri in accessibles_by_crowfly.odt:
@@ -432,7 +484,7 @@ def _build_fallback(
             is_after_pt_sections = fallback_logic.is_after_pt_sections()
             pt_datetime = fallback_logic.get_pt_section_datetime(pt_journey)
             fallback_period_extremity = PeriodExtremity(pt_datetime, is_after_pt_sections)
-            orig, dest = fallback_logic.route_params(requested_obj, car_park or pt_obj)
+            orig, dest = fallback_logic.route_params(requested_obj, car_park or via_access_point)
 
             real_mode = fallback_durations_pool.get_real_mode(mode, pt_obj.uri)
             fallback_dp = streetnetwork_path_pool.wait_and_get(
@@ -460,7 +512,12 @@ def _build_fallback(
                         request['_car_park_duration'],
                         car_park_crowfly_duration,
                     )
-                _update_fallback_sections(pt_journey, fallback_dp_copy, fallback_period_extremity, fallback_type)
+                else:
+                    _extend_with_via_access_point(fallback_dp_copy, pt_obj, fallback_type, via_access_point)
+
+                _update_fallback_sections(
+                    pt_journey, fallback_dp_copy, fallback_period_extremity, fallback_type, via_access_point
+                )
 
                 # update distances and durations by mode if it's a proper computed streetnetwork fallback
                 if fallback_dp_copy and fallback_dp_copy.journeys:
@@ -573,7 +630,6 @@ def compute_fallback(
         fallback_extremity_arr = PeriodExtremity(pt_arrival, True)
         to_sub_request_id = "{}_{}_to".format(request_id, i)
         if to_obj.uri != pt_dest.uri and pt_dest.uri not in dest_all_free_access:
-            dest_obj = pt_dest
             if arr_mode == 'car':
                 dest_obj = dest_fallback_durations_pool.wait_and_get(arr_mode)[pt_dest.uri].car_park
                 real_mode = dest_fallback_durations_pool.get_real_mode(arr_mode, dest_obj.uri)

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
@@ -53,6 +53,7 @@ class ProximitiesByCrowfly:
         stop_points_nearby_duration,
         request,
         request_id,
+        depth,
     ):
         self._future_manager = future_manager
         self._instance = instance
@@ -67,6 +68,7 @@ class ProximitiesByCrowfly:
         self._value = None
         self._logger = logging.getLogger(__name__)
         self._request_id = request_id
+        self._depth = depth
         self._forbidden_uris = utils.get_poi_params(request['forbidden_uris[]'])
         self._allowed_id = utils.get_poi_params(request['allowed_id[]'])
         self._async_request()
@@ -83,6 +85,7 @@ class ProximitiesByCrowfly:
                 self._filter,
                 self._stop_points_nearby_duration,
                 self._request_id,
+                self._depth,
                 self._forbidden_uris,
                 self._allowed_id,
                 **self._speed_switcher
@@ -173,7 +176,9 @@ class ProximitiesByCrowflyPool:
         for mode in self._modes:
             object_type = type_pb2.STOP_POINT
             filter = None
+            depth = 3
             if mode == fm.FallbackModes.car.name:
+                depth = 2
                 object_type = type_pb2.POI
                 filter = "poi_type.uri=\"poi_type:amenity:parking\""
 
@@ -200,6 +205,7 @@ class ProximitiesByCrowflyPool:
                 stop_points_nearby_duration=self._request['_stop_points_nearby_duration'],
                 request=self._request,
                 request_id=self._request_id,
+                depth=depth,
             )
 
             self._value[mode] = p

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
@@ -176,7 +176,8 @@ class ProximitiesByCrowflyPool:
         for mode in self._modes:
             object_type = type_pb2.STOP_POINT
             filter = None
-            depth = 3
+            # if access_point is true, access points are filled in stop points
+            depth = 3 if self._request["_access_points"] else 2
             if mode == fm.FallbackModes.car.name:
                 depth = 2
                 object_type = type_pb2.POI

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/tests/helper_utils_test.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/tests/helper_utils_test.py
@@ -255,13 +255,15 @@ def test_update_fallback_sections_beginning_fallback():
     fallback_dp = create_car_journey_with_parking("20180618T050500", origin, destination)
     fallback_period_extremity = PeriodExtremity(str_to_time_stamp('20180618T050500'), False)
     fallback_type = StreetNetworkPathType.BEGINNING_FALLBACK
+    access_point = make_pt_object(type_pb2.ACCESS_POINT, 9.0, 9.0, "access_point_toto")
 
-    _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, fallback_type)
+    _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, fallback_type, access_point)
 
     # Car + Park + 4 PT
     assert len(journey.sections) == 6
     assert journey.sections[1].destination.uri == "stop_point_1"
     assert journey.sections[1].destination == journey.sections[2].origin
+    assert journey.sections[1].vias[0].uri == "access_point_toto"
 
 
 # Tests the insertion of a car section with leave parking at the end of a journey
@@ -273,9 +275,11 @@ def test_update_fallback_sections_ending_fallback():
     fallback_dp = create_car_journey_with_leave_parking("20180618T080500", origin, destination)
     fallback_period_extremity = PeriodExtremity(str_to_time_stamp('20180618T080500'), True)
     fallback_type = StreetNetworkPathType.ENDING_FALLBACK
+    access_point = make_pt_object(type_pb2.ACCESS_POINT, 9.0, 9.0, "access_point_toto")
 
-    _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, fallback_type)
+    _update_fallback_sections(journey, fallback_dp, fallback_period_extremity, fallback_type, access_point)
 
     assert len(journey.sections) == 6
     assert journey.sections[4].origin.uri == "stop_point_4"
     assert journey.sections[4].origin == journey.sections[3].destination
+    assert journey.sections[4].vias[0].uri == "access_point_toto"

--- a/source/jormungandr/jormungandr/street_network/car_with_park.py
+++ b/source/jormungandr/jormungandr/street_network/car_with_park.py
@@ -72,6 +72,7 @@ class CarWithPark(AbstractStreetNetworkService):
             filter,
             0,
             request_id,
+            2,
             get_poi_params(request['forbidden_uris[]']),
             get_poi_params(request['allowed_id[]']),
             **speed_switcher

--- a/source/jormungandr/jormungandr/street_network/tests/streetnetwork_test_utils.py
+++ b/source/jormungandr/jormungandr/street_network/tests/streetnetwork_test_utils.py
@@ -51,6 +51,9 @@ def make_pt_object(embedded_type, lon, lat, uri=None):
     elif embedded_type == type_pb2.POI:
         pt_object.poi.coord.lat = lat
         pt_object.poi.coord.lon = lon
+    elif embedded_type == type_pb2.ACCESS_POINT:
+        pt_object.access_point.coord.lat = lat
+        pt_object.access_point.coord.lon = lon
     return pt_object
 
 

--- a/source/jormungandr/jormungandr/street_network/tests/streetnetwork_test_utils.py
+++ b/source/jormungandr/jormungandr/street_network/tests/streetnetwork_test_utils.py
@@ -54,6 +54,7 @@ def make_pt_object(embedded_type, lon, lat, uri=None):
     elif embedded_type == type_pb2.ACCESS_POINT:
         pt_object.access_point.coord.lat = lat
         pt_object.access_point.coord.lon = lon
+        pt_object.access_point.uri = uri
     return pt_object
 
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -386,19 +386,22 @@ def get_pt_object_coord(pt_object):
     >>> coord.lat
     41.41
     """
-    if not isinstance(pt_object, type_pb2.PtObject):
+    if not (isinstance(pt_object, type_pb2.PtObject) or isinstance(pt_object, type_pb2.AccessPoint)):
         logging.getLogger(__name__).error('Invalid pt_object')
         raise InvalidArguments('Invalid pt_object')
 
-    map_coord = {
-        type_pb2.STOP_POINT: "stop_point",
-        type_pb2.STOP_AREA: "stop_area",
-        type_pb2.ADDRESS: "address",
-        type_pb2.ADMINISTRATIVE_REGION: "administrative_region",
-        type_pb2.POI: "poi",
-    }
-    attr = getattr(pt_object, map_coord.get(pt_object.embedded_type, ""), None)
-    coord = getattr(attr, "coord", None)
+    if isinstance(pt_object, type_pb2.AccessPoint):
+        coord = getattr(pt_object, "coord", None)
+    else:
+        map_coord = {
+            type_pb2.STOP_POINT: "stop_point",
+            type_pb2.STOP_AREA: "stop_area",
+            type_pb2.ADDRESS: "address",
+            type_pb2.ADMINISTRATIVE_REGION: "administrative_region",
+            type_pb2.POI: "poi",
+        }
+        attr = getattr(pt_object, map_coord.get(pt_object.embedded_type, ""), None)
+        coord = getattr(attr, "coord", None)
 
     if not coord:
         logging.getLogger(__name__).error('Invalid coord for ptobject type: {}'.format(pt_object.embedded_type))

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -386,7 +386,7 @@ def get_pt_object_coord(pt_object):
     >>> coord.lat
     41.41
     """
-    if not (isinstance(pt_object, type_pb2.PtObject)):
+    if not isinstance(pt_object, type_pb2.PtObject):
         logging.getLogger(__name__).error('Invalid pt_object')
         raise InvalidArguments('Invalid pt_object')
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -63,6 +63,8 @@ def get_uri_pt_object(pt_object):
     if pt_object.embedded_type == type_pb2.ADDRESS:
         coords = pt_object.uri.split(';')
         return "coord:{}:{}".format(coords[0], coords[1])
+    if pt_object.embedded_type == type_pb2.ACCESS_POINT:
+        return "coord:{}:{}".format(pt_object.access_point.coord.lon, pt_object.access_point.coord.lat)
     return pt_object.uri
 
 

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -386,22 +386,20 @@ def get_pt_object_coord(pt_object):
     >>> coord.lat
     41.41
     """
-    if not (isinstance(pt_object, type_pb2.PtObject) or isinstance(pt_object, type_pb2.AccessPoint)):
+    if not (isinstance(pt_object, type_pb2.PtObject)):
         logging.getLogger(__name__).error('Invalid pt_object')
         raise InvalidArguments('Invalid pt_object')
 
-    if isinstance(pt_object, type_pb2.AccessPoint):
-        coord = getattr(pt_object, "coord", None)
-    else:
-        map_coord = {
-            type_pb2.STOP_POINT: "stop_point",
-            type_pb2.STOP_AREA: "stop_area",
-            type_pb2.ADDRESS: "address",
-            type_pb2.ADMINISTRATIVE_REGION: "administrative_region",
-            type_pb2.POI: "poi",
-        }
-        attr = getattr(pt_object, map_coord.get(pt_object.embedded_type, ""), None)
-        coord = getattr(attr, "coord", None)
+    map_coord = {
+        type_pb2.STOP_POINT: "stop_point",
+        type_pb2.STOP_AREA: "stop_area",
+        type_pb2.ADDRESS: "address",
+        type_pb2.ADMINISTRATIVE_REGION: "administrative_region",
+        type_pb2.POI: "poi",
+        type_pb2.ACCESS_POINT: "access_point",
+    }
+    attr = getattr(pt_object, map_coord.get(pt_object.embedded_type, ""), None)
+    coord = getattr(attr, "coord", None)
 
     if not coord:
         logging.getLogger(__name__).error('Invalid coord for ptobject type: {}'.format(pt_object.embedded_type))

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -1233,3 +1233,18 @@ class TestRoutingWithTransfer(NewDefaultScenarioAbstractTestFixture):
         assert 'geojson' in journeys[0]['sections'][2]
         assert 'coordinates' in journeys[0]['sections'][2]['geojson']
         assert len(journeys[0]['sections'][2]['geojson']['coordinates']) == 2
+
+
+@dataset({"main_routing_test": {"scenario": "distributed"}})
+class TestJourneyWithAcessPoints(NewDefaultScenarioAbstractTestFixture):
+    def test_journey_with_access_points(self):
+        # we begin with a normal request to get the fallback duration in taxi
+        query = sub_query + "&datetime=20120614080000"
+
+        response = self.query(query)
+        journeys = response['journeys']
+
+        assert len(journeys) == 2
+
+        pt_journey = next((j for j in journeys if "non_pt" not in j.tags), None)
+        assert pt_journey

--- a/source/routing/tests/heat_map_test.cpp
+++ b/source/routing/tests/heat_map_test.cpp
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(heat_map_test) {
     const double speed = 0.8;
     const uint resolution = 100;
     auto stop_points = raptor.data.pt_data->stop_points;
-    (*b.data->geo_ref).project_stop_points(stop_points);
+    (*b.data->geo_ref).project_stop_points_and_access_points(stop_points);
     const auto max_duration = 36000;
     size_t step = 3;
     auto box = BoundBox();

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -526,11 +526,23 @@ struct routing_api_data {
         // Add a fare_zone in stop point A
         sp->fare_zone = "2";
 
+        // add access_point
+        b.add_access_point("stop_point:stopA", "access_point:A1", true, false, 1, 2, 0.000718649585563767,
+                           0.0010779743);
+        b.add_access_point("stop_point:stopA", "access_point:A2", false, true, 3, 4, 0.000718649585563767,
+                           0.0010779743);
+
         sp = b.get<nt::StopPoint>("stop_point:stopB");
         b.data->pt_data->codes.add(sp, "TCL_ASCENSEUR", "6");
         b.data->pt_data->codes.add(sp, "TCL_ASCENSEUR", "7");
         b.data->pt_data->codes.add(sp, "TCL_ASCENSEUR", "8");
         b.data->pt_data->codes.add(sp, "TCL_ASCENSEUR", "9");
+
+        // add access_point
+        b.add_access_point("stop_point:stopB", "access_point:B1", true, false, 1, 2, 0.0002694935945864127,
+                           8.98311981954709e-05);
+        b.add_access_point("stop_point:stopB", "access_point:B2", false, true, 3, 4, 0.0002694935945864127,
+                           8.98311981954709e-05);
 
         // Add codes on stop_area
         const auto* sa = b.get<nt::StopArea>("stopA");

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -274,7 +274,7 @@ void Data::build_uri() {
 void Data::build_proximity_list() {
     this->pt_data->build_proximity_list();
     this->geo_ref->build_proximity_list();
-    this->geo_ref->project_stop_points(this->pt_data->stop_points);
+    this->geo_ref->project_stop_points_and_access_points(this->pt_data->stop_points);
 }
 
 void Data::build_administrative_regions() {


### PR DESCRIPTION
https://navitia.atlassian.net/wiki/spaces/NAV/pages/7100538811/Les+Entr+es+Sorties

In this PR, we're taking AccessPoint into consideration when computing journeys. 

* When `distributed` is selected, stop_points will be requested surrounding the from/to coordinates. As we are about to collect access_points from stop_points,  `depth` must be set to 3.
* When computing fallback durations(street network routing matrix), stop points are no longer the destinations/origins but access points. But the final fallback duration map is still a map of `stop_point.uri` vs `DurationElement`. Note that the `DurationElement` contains all information of by which access point the underlying stop point is attainable, the distance and the traversal time.
* When computing fallbacks, requests are now (from, access_point_entrance) and (access_point_exit, to). 
* The final response is enriched with more information about access_point.  