### PR TITLE
access point: fix negatif stair count

### DIFF
--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -633,7 +633,7 @@ void EdReader::fill_access_point_field(const navitia::type::AccessPoint& access_
     auto new_access_point = navitia::type::AccessPoint(access_point);
 
     if (!const_it["pathway_mode"].is_null()) {
-        new_access_point.pathway_mode = const_it["pathway_mode"].as<unsigned int>();
+        new_access_point.pathway_mode = const_it["pathway_mode"].as<int>();
     }
     if (!const_it["is_bidirectional"].is_null()) {
         const bool is_bidirectional = const_it["is_bidirectional"].as<bool>();
@@ -651,19 +651,19 @@ void EdReader::fill_access_point_field(const navitia::type::AccessPoint& access_
         }
     }
     if (!const_it["length"].is_null()) {
-        new_access_point.length = const_it["length"].as<unsigned int>();
+        new_access_point.length = const_it["length"].as<int>();
     }
     if (!const_it["traversal_time"].is_null()) {
-        new_access_point.traversal_time = const_it["traversal_time"].as<unsigned int>();
+        new_access_point.traversal_time = const_it["traversal_time"].as<int>();
     }
     if (!const_it["stair_count"].is_null()) {
-        new_access_point.stair_count = const_it["stair_count"].as<unsigned int>();
+        new_access_point.stair_count = const_it["stair_count"].as<int>();
     }
     if (!const_it["max_slope"].is_null()) {
-        new_access_point.max_slope = const_it["max_slope"].as<unsigned int>();
+        new_access_point.max_slope = const_it["max_slope"].as<int>();
     }
     if (!const_it["min_width"].is_null()) {
-        new_access_point.min_width = const_it["min_width"].as<unsigned int>();
+        new_access_point.min_width = const_it["min_width"].as<int>();
     }
     if (!const_it["signposted_as"].is_null()) {
         const_it["signposted_as"].to(new_access_point.signposted_as);


### PR DESCRIPTION
## target
During the bina, an error occured
```
Launching /home/bbrisset/dev/build/navitia_docker/release/ed/ed2nav -o ./data.nav.lz4 --connection-string xxxxxxxxx --cities-connection-string xxxxxxxxx                            
2022-01-21 09:15:31 ed_handler terminate called after throwing an instance of 'pqxx::failure'                                                                                                                      
2022-01-21 09:15:31 ed_handler   what():  Could not convert string to unsigned integer: '-22
```

The filed **stair_count** was screwed up with a neg value. But the **NTFS** allows a neg field (https://github.com/CanalTP/ntfs-specification/blob/master/ntfs_fr.md#pathwaystxt-optionnel) because it is **Entier**

So we need to fix it :screwdriver: 
Now _entier_ is for int and not _uint_

