### PR TITLE
Access points entry point

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -81,6 +81,7 @@ add_subdirectory(cities)
 add_subdirectory(tools)
 add_subdirectory(equipment)
 add_subdirectory(position)
+add_subdirectory(access_point)
 
 # Add tests
 if(NOT SKIP_TESTS)

--- a/source/access_point/CMakeLists.txt
+++ b/source/access_point/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(access_point_api access_point_api.cpp)
+target_link_libraries(access_point_api pb_lib)
+
+# Add tests
+if(NOT SKIP_TESTS)
+    add_subdirectory(tests)
+endif(NOT SKIP_TESTS)

--- a/source/access_point/access_point_api.cpp
+++ b/source/access_point/access_point_api.cpp
@@ -63,8 +63,8 @@ void access_points(PbCreator& pb_creator,
         const auto stop_points = data.get_data<type::StopPoint>(stop_point_indexes);
 
         // make Acess Point unique in to the response
-        for (auto& _sp : stop_points) {
-            for (auto& ap : _sp->access_points) {
+        for (const auto& _sp : stop_points) {
+            for (const auto& ap : _sp->access_points) {
                 auto it = ap_list.find(ap.name);
                 if (it == ap_list.end()) {
                     ap_list[ap.name] = ap;

--- a/source/access_point/access_point_api.cpp
+++ b/source/access_point/access_point_api.cpp
@@ -61,6 +61,8 @@ void access_points(PbCreator& pb_creator,
         const type::Indexes stop_point_indexes =
             ptref::make_query(type::Type_e::StopPoint, filter, forbidden_uris, data);
         const auto stop_points = data.get_data<type::StopPoint>(stop_point_indexes);
+
+        // make Acess Point unique in to the response
         for (auto& _sp : stop_points) {
             for (auto& ap : _sp->access_points) {
                 auto it = ap_list.find(ap.name);

--- a/source/access_point/access_point_api.cpp
+++ b/source/access_point/access_point_api.cpp
@@ -1,0 +1,95 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "access_point_api.h"
+#include "type/access_point.h"
+
+#include "utils/paginate.h"
+
+#include <boost/range/algorithm.hpp>
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace navitia {
+namespace access_point {
+
+namespace {
+
+void fill_access_point_to_pb(const access_point::AccessPointList& ap_list, PbCreator& pb_creator, int depth) {
+    for (const auto& ap : ap_list) {
+        auto pb_ap = pb_creator.add_access_points();
+        pb_creator.fill(ap.second, pb_ap, depth);
+    }
+}
+
+}  // namespace
+
+void access_points(PbCreator& pb_creator,
+                   const std::string& filter,
+                   int count,
+                   int depth,
+                   int start_page,
+                   const ForbiddenUris& forbidden_uris) {
+    const type::Data& data = *pb_creator.data;
+    AccessPointList ap_list;
+    try {
+        const type::Indexes stop_point_indexes =
+            ptref::make_query(type::Type_e::StopPoint, filter, forbidden_uris, data);
+        const auto stop_points = data.get_data<type::StopPoint>(stop_point_indexes);
+        for (auto& _sp : stop_points) {
+            for (auto& ap : _sp->access_points) {
+                auto it = ap_list.find(ap.name);
+                if (it == ap_list.end()) {
+                    ap_list[ap.name] = ap;
+                }
+            }
+        }
+
+        const auto paginated_result = paginate(ap_list, count, start_page);
+        fill_access_point_to_pb(paginated_result, pb_creator, depth);
+
+        pb_creator.make_paginate(ap_list.size(), start_page, count, paginated_result.size());
+
+    } catch (const ptref::parsing_error& parse_error) {
+        pb_creator.fill_pb_error(pbnavitia::Error::unable_to_parse, "Unable to parse filter" + parse_error.more);
+        return;
+    } catch (const ptref::ptref_error& ptref_error) {
+        pb_creator.fill_pb_error(pbnavitia::Error::bad_filter, "ptref : " + ptref_error.more);
+        return;
+    }
+}
+
+}  // namespace access_point
+}  // namespace navitia

--- a/source/access_point/access_point_api.cpp
+++ b/source/access_point/access_point_api.cpp
@@ -35,13 +35,6 @@ www.navitia.io
 
 #include <boost/range/algorithm.hpp>
 
-#include <algorithm>
-#include <map>
-#include <string>
-#include <tuple>
-#include <utility>
-#include <vector>
-
 namespace navitia {
 namespace access_point {
 

--- a/source/access_point/access_point_api.h
+++ b/source/access_point/access_point_api.h
@@ -1,0 +1,53 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+
+#include "type/pb_converter.h"
+
+#include <string>
+#include <vector>
+#include <unordered_set>
+
+namespace navitia {
+namespace access_point {
+
+using ForbiddenUris = std::vector<std::string>;
+using AccessPointList = std::unordered_map<std::string, type::AccessPoint>;
+
+void access_points(PbCreator& pb_creator,
+                   const std::string& filter,
+                   int count,
+                   int depth = 0,
+                   int start_page = 0,
+                   const ForbiddenUris& forbidden_uris = {});
+
+}  // namespace access_point
+}  // namespace navitia

--- a/source/access_point/tests/CMakeLists.txt
+++ b/source/access_point/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(access_point_test access_point_api_tests.cpp)
+target_link_libraries(access_point_test access_point_api ed ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY})
+ADD_BOOST_TEST(access_point_test)

--- a/source/access_point/tests/access_point_api_tests.cpp
+++ b/source/access_point/tests/access_point_api_tests.cpp
@@ -1,0 +1,186 @@
+/* Copyright © 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Canal TP (www.canaltp.fr).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE access_point_test
+
+#include <boost/test/unit_test.hpp>
+
+#include "ed/build_helper.h"
+#include "access_point/access_point_api.h"
+#include "ptreferential/ptreferential.h"
+#include "utils/logger.h"
+#include "type/pt_data.h"
+#include "tests/utils_test.h"
+
+#include <string>
+#include <vector>
+#include <map>
+#include <set>
+
+using namespace navitia;
+using boost::posix_time::time_period;
+using std::map;
+using std::multiset;
+using std::pair;
+using std::set;
+using std::string;
+using std::vector;
+
+struct logger_initialized {
+    logger_initialized() { navitia::init_logger(); }
+};
+BOOST_GLOBAL_FIXTURE(logger_initialized);
+
+namespace {
+
+class AccessPointTestFixture {
+public:
+    ed::builder b;
+    const type::Data& data;
+
+    AccessPointTestFixture() : b("20190101"), data(*b.data) {
+        b.sa("saA", 2.361795, 48.871871)("spA", 2.361795, 48.871871);
+        b.sa("saB", 2.362795, 48.872871)("spB", 2.362795, 48.872871);
+        b.sa("saC", 2.363795, 48.873871)("spC", 2.363795, 48.873871);
+        b.vj("A")("spA", "08:00"_t)("spB", "10:00"_t);
+        b.vj("B")("spC", "09:00"_t)("spD", "11:00"_t);
+        b.vj("C")("spA", "10:00"_t)("spC", "12:00"_t);
+        b.data->complete();
+        b.make();
+
+        b.add_access_point("spA", "AP1", true, true, 10, 23, 48.874871, 2.364795);
+        b.add_access_point("spA", "AP2", true, false, 13, 26, 48.875871, 2.365795);
+        b.add_access_point("spC", "AP3", true, false, 12, 36, 48.876871, 2.366795);
+        b.add_access_point("spC", "AP2", true, false, 13, 26, 48.875871, 2.365795);
+    }
+};
+
+void complete_pb_creator(navitia::PbCreator& pb_creator, const type::Data& data) {
+    const ptime since = "20190101T000000"_dt;
+    const ptime until = "21190101T000000"_dt;
+    pb_creator.init(&data, since, time_period(since, until));
+}
+
+bool ap_comp(pbnavitia::AccessPoint& ap1, pbnavitia::AccessPoint& ap2) {
+    return ap1.uri() < ap2.uri();
+}
+
+BOOST_FIXTURE_TEST_CASE(test_access_point_reading, AccessPointTestFixture) {
+    string filter = "";
+    int count = 20;
+    int depth = 0;
+    int start_page = 0;
+    vector<string> forbidden_uris = {};
+
+    navitia::PbCreator pb_creator;
+    complete_pb_creator(pb_creator, data);
+    access_point::access_points(pb_creator, filter, count, depth, start_page, forbidden_uris);
+    pbnavitia::Response resp = pb_creator.get_response();
+    BOOST_REQUIRE_EQUAL(resp.access_points().size(), 3);
+    auto access_points = resp.access_points();
+    sort(access_points.begin(), access_points.end(), ap_comp);
+    auto ap = access_points[0];
+    BOOST_REQUIRE_EQUAL(ap.uri(), "AP1");
+    BOOST_REQUIRE_EQUAL(ap.is_entrance(), true);
+    BOOST_REQUIRE_EQUAL(ap.is_exit(), true);
+    BOOST_REQUIRE_EQUAL(ap.length(), 10);
+    BOOST_REQUIRE_EQUAL(ap.traversal_time(), 23);
+    ap = access_points[1];
+    BOOST_REQUIRE_EQUAL(ap.uri(), "AP2");
+    BOOST_REQUIRE_EQUAL(ap.is_entrance(), true);
+    BOOST_REQUIRE_EQUAL(ap.is_exit(), false);
+    BOOST_REQUIRE_EQUAL(ap.length(), 13);
+    BOOST_REQUIRE_EQUAL(ap.traversal_time(), 26);
+    ap = access_points[2];
+    BOOST_REQUIRE_EQUAL(ap.uri(), "AP3");
+    BOOST_REQUIRE_EQUAL(ap.is_entrance(), true);
+    BOOST_REQUIRE_EQUAL(ap.is_exit(), false);
+    BOOST_REQUIRE_EQUAL(ap.length(), 12);
+    BOOST_REQUIRE_EQUAL(ap.traversal_time(), 36);
+}
+
+BOOST_FIXTURE_TEST_CASE(test_access_point_filtering, AccessPointTestFixture) {
+    {
+        string filter = "stop_point.uri=spA";
+        int count = 20;
+        int depth = 0;
+        int start_page = 0;
+        vector<string> forbidden_uris = {};
+
+        navitia::PbCreator pb_creator;
+        complete_pb_creator(pb_creator, data);
+        access_point::access_points(pb_creator, filter, count, depth, start_page, forbidden_uris);
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.access_points().size(), 2);
+
+        auto access_points = resp.access_points();
+        sort(access_points.begin(), access_points.end(), ap_comp);
+        auto ap = access_points[0];
+        BOOST_REQUIRE_EQUAL(ap.uri(), "AP1");
+        ap = access_points[1];
+        BOOST_REQUIRE_EQUAL(ap.uri(), "AP2");
+    }
+    {
+        string filter = "stop_point.uri=spB";
+        int count = 20;
+        int depth = 0;
+        int start_page = 0;
+        vector<string> forbidden_uris = {};
+
+        navitia::PbCreator pb_creator;
+        complete_pb_creator(pb_creator, data);
+        access_point::access_points(pb_creator, filter, count, depth, start_page, forbidden_uris);
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.access_points().size(), 0);
+    }
+    {
+        string filter = "stop_area.uri=saC";
+        int count = 20;
+        int depth = 0;
+        int start_page = 0;
+        vector<string> forbidden_uris = {};
+
+        navitia::PbCreator pb_creator;
+        complete_pb_creator(pb_creator, data);
+        access_point::access_points(pb_creator, filter, count, depth, start_page, forbidden_uris);
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.access_points().size(), 2);
+
+        auto access_points = resp.access_points();
+        sort(access_points.begin(), access_points.end(), ap_comp);
+        auto ap = access_points[0];
+        BOOST_REQUIRE_EQUAL(ap.uri(), "AP2");
+        ap = access_points[1];
+        BOOST_REQUIRE_EQUAL(ap.uri(), "AP3");
+    }
+}
+
+}  // namespace

--- a/source/access_point/tests/access_point_api_tests.cpp
+++ b/source/access_point/tests/access_point_api_tests.cpp
@@ -35,9 +35,7 @@ www.navitia.io
 
 #include "ed/build_helper.h"
 #include "access_point/access_point_api.h"
-#include "ptreferential/ptreferential.h"
 #include "utils/logger.h"
-#include "type/pt_data.h"
 #include "tests/utils_test.h"
 
 #include <string>
@@ -47,10 +45,6 @@ www.navitia.io
 
 using namespace navitia;
 using boost::posix_time::time_period;
-using std::map;
-using std::multiset;
-using std::pair;
-using std::set;
 using std::string;
 using std::vector;
 

--- a/source/access_point/tests/access_point_api_tests.cpp
+++ b/source/access_point/tests/access_point_api_tests.cpp
@@ -43,6 +43,7 @@ www.navitia.io
 #include <map>
 #include <set>
 
+using namespace std;
 using namespace navitia;
 using boost::posix_time::time_period;
 using std::string;

--- a/source/jormungandr/jormungandr/interfaces/v1/AccessPoints.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/AccessPoints.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+
+#  Copyright (c) 2001-2019, Canal TP and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Canal TP (www.canaltp.fr).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# IRC #navitia on freenode
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from jormungandr import i_manager, timezone
+from jormungandr.interfaces.parsers import default_count_arg_type
+from jormungandr.interfaces.v1.decorators import get_obj_serializer
+from jormungandr.interfaces.v1.errors import ManageError
+from jormungandr.interfaces.v1.ResourceUri import ResourceUri
+from jormungandr.interfaces.v1.serializer import api
+from jormungandr.resources_utils import ResourceUtc
+import six
+
+
+class AccessPoints(ResourceUri, ResourceUtc):
+    def __init__(self):
+        ResourceUri.__init__(self, output_type_serializer=api.AccessPointsSerializer)
+        ResourceUtc.__init__(self)
+        parser_get = self.parsers["get"]
+        parser_get.add_argument("depth", type=int, default=1, help="The depth of your object")
+        parser_get.add_argument(
+            "count", type=default_count_arg_type, default=25, help="Number of objects per page"
+        )
+        parser_get.add_argument("start_page", type=int, default=0, help="The current page")
+        parser_get.add_argument(
+            "forbidden_uris[]",
+            type=six.text_type,
+            help="forbidden uris",
+            dest="forbidden_uris[]",
+            default=[],
+            action="append",
+            schema_metadata={'format': 'pt-object'},
+        )
+
+        self.collection = 'access_points'
+        self.get_decorators.insert(0, ManageError())
+        self.get_decorators.insert(1, get_obj_serializer(self))
+
+    def options(self, **kwargs):
+        return self.api_description(**kwargs)
+
+    def get(self, region=None, lon=None, lat=None, uri=None):
+        self.region = i_manager.get_region(region, lon, lat)
+        timezone.set_request_timezone(self.region)
+        args = self.parsers["get"].parse_args()
+
+        uris = []
+        if uri:
+            if uri[-1] == "/":
+                uri = uri[:-1]
+            uris = uri.split("/")
+        args["filter"] = self.get_filter(uris, args)
+
+        response = i_manager.dispatch(args, "access_points", instance_name=self.region)
+
+        return response

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -180,6 +180,7 @@ class add_coverage_link(generate_links):
             "traffic_reports",
             "line_reports",
             "equipment_reports",
+            "access_points",
         ]
 
         if app.config['GRAPHICAL_ISOCHRONE']:

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -68,7 +68,7 @@ from jormungandr.utils import (
     NOT_A_DATE_TIME,
     navitia_utcfromtimestamp,
 )
-from jormungandr.interfaces.v1.serializer.pt import AddressSerializer
+from jormungandr.interfaces.v1.serializer.pt import AddressSerializer, AccessPointSerializer
 from jormungandr.interfaces.v1.serializer import jsonschema
 from jormungandr.interfaces.v1.serializer.status import CoverageErrorSerializer
 
@@ -375,6 +375,11 @@ class LineReportsSerializer(PTReferentialSerializer):
 
 class EquipmentReportsSerializer(PTReferentialSerializer):
     equipment_reports = report.EquipmentReportSerializer(many=True, display_none=True)
+    warnings = base.BetaEndpointsSerializer()
+
+
+class AccessPointsSerializer(PTReferentialSerializer):
+    access_points = AccessPointSerializer(many=True, display_none=True)
     warnings = base.BetaEndpointsSerializer()
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -415,6 +415,7 @@ class AccessPointSerializer(PbGenericSerializer):
     min_width = jsonschema.MethodField(schema_type=int, display_none=False)
     signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
     reversed_signposted_as = jsonschema.MethodField(schema_type=str, display_none=False)
+    stop_code = jsonschema.MethodField(schema_type=str, display_none=False)
     parent_station = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer(), display_none=False)
 
     def get_is_entrance(self, obj):
@@ -446,6 +447,9 @@ class AccessPointSerializer(PbGenericSerializer):
 
     def get_reversed_signposted_as(self, obj):
         return get_proto_attr_or_default(obj, 'reversed_signposted_as')
+
+    def get_stop_code(self, obj):
+        return get_proto_attr_or_default(obj, 'stop_code')
 
     def get_parent_station(self, obj):
         if obj.HasField(str('parent_station')):

--- a/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
+++ b/source/jormungandr/jormungandr/modules/v1_routing/v1_routing.py
@@ -47,6 +47,7 @@ from jormungandr.interfaces.v1 import (
     JSONSchema,
     LineReports,
     EquipmentReports,
+    AccessPoints,
     VehiclePositions,
     free_floatings,
     users,
@@ -281,6 +282,17 @@ class V1Routing(AModule):
             '/coord/' + lon_lat + 'equipment_reports',
             '/coords/' + lon_lat + 'equipment_reports',
             endpoint='equipment_reports',
+        )
+
+        self.add_resource(
+            AccessPoints.AccessPoints,
+            region + 'access_points',
+            coord + 'access_points',
+            region + '<uri:uri>/access_points',
+            coord + '<uri:uri>/access_points',
+            '/coord/' + lon_lat + 'access_points',
+            '/coords/' + lon_lat + 'access_points',
+            endpoint='access_points',
         )
 
         self.add_resource(

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -154,6 +154,21 @@ class Scenario(object):
         resp = instance.send_and_receive(req)
         return resp
 
+    def access_points(self, request, instance):
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.access_points
+        req.access_points.depth = request['depth']
+        req.access_points.filter = request['filter']
+        req.access_points.count = request['count']
+        req.access_points.start_page = request['start_page']
+
+        if request["forbidden_uris[]"]:
+            for forbidden_uri in request["forbidden_uris[]"]:
+                req.access_points.forbidden_uris.append(forbidden_uri)
+
+        resp = instance.send_and_receive(req)
+        return resp
+
     def vehicle_positions(self, request, instance):
         req = request_pb2.Request()
         req.requested_api = type_pb2.vehicle_positions

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -112,3 +112,43 @@ class TestAccessPoints(AbstractTestFixture):
                         assert ap['is_exit'] == True
                         assert ap['length'] == 10
                         assert ap['traversal_time'] == 23
+
+    def test_access_points_api(self):
+        r = self.query_region('access_points')
+        assert len(get_not_null(r, 'access_points')) == 3
+
+        for ap in r['access_points']:
+            if ap['name'] == 'AP1':
+                assert ap['is_entrance'] == True
+                assert ap['is_exit'] == True
+                assert ap['length'] == 10
+                assert ap['traversal_time'] == 23
+            if ap['name'] == 'AP2':
+                assert ap['is_entrance'] == True
+                assert ap['is_exit'] == False
+                assert ap['length'] == 13
+                assert ap['traversal_time'] == 26
+            if ap['name'] == 'AP3':
+                assert ap['is_entrance'] == True
+                assert ap['is_exit'] == False
+                assert ap['length'] == 12
+                assert ap['traversal_time'] == 36
+
+    def test_access_points_api_with_filter(self):
+        r = self.query_region('stop_points/spA/access_points')
+        assert len(get_not_null(r, 'access_points')) == 2
+
+        for ap in r['access_points']:
+            if ap['name'] == 'AP1':
+                assert ap['is_entrance'] == True
+                assert ap['is_exit'] == True
+                assert ap['length'] == 10
+                assert ap['traversal_time'] == 23
+            if ap['name'] == 'AP2':
+                assert ap['is_entrance'] == True
+                assert ap['is_exit'] == False
+                assert ap['length'] == 13
+                assert ap['traversal_time'] == 26
+
+        r = self.query_region('stop_points/spB/access_points')
+        assert len(r['access_points']) == 0

--- a/source/kraken/CMakeLists.txt
+++ b/source/kraken/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(workers
     SimpleAmqpClient
     equipment_api
     position_api
+    access_point_api
     disruption_api
     calendar_api
     time_tables

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 #include "disruption/line_reports_api.h"
 #include "disruption/traffic_reports_api.h"
 #include "equipment/equipment_api.h"
+#include "access_point/access_point_api.h"
 #include "position/position_api.h"
 #include "proximity_list/proximitylist_api.h"
 #include "ptreferential/ptreferential.h"
@@ -1179,6 +1180,9 @@ void Worker::dispatch(const pbnavitia::Request& request,
         case pbnavitia::vehicle_positions:
             vehicle_positions(request.vehicle_positions());
             break;
+        case pbnavitia::access_points:
+            access_points(request.access_points());
+            break;
         default:
             LOG4CPLUS_WARN(logger, "Unknown API : " + API_Name(request.requested_api()));
             this->pb_creator.fill_pb_error(pbnavitia::Error::unknown_api, "Unknown API");
@@ -1253,12 +1257,21 @@ void Worker::equipment_reports(const pbnavitia::EquipmentReportsRequest& equipme
     equipment::equipment_reports(this->pb_creator, equipment_reports.filter(), equipment_reports.count(),
                                  equipment_reports.depth(), equipment_reports.start_page(), forbidden_uris);
 }
+
 void Worker::vehicle_positions(const pbnavitia::VehiclePositionsRequest& vehcile_positions) {
     const auto& proto_uris = vehcile_positions.forbidden_uris();
     std::vector<std::string> forbidden_uris(proto_uris.begin(), proto_uris.end());
 
     position::vehicle_positions(this->pb_creator, vehcile_positions.filter(), vehcile_positions.count(),
                                 vehcile_positions.depth(), vehcile_positions.start_page(), forbidden_uris);
+}
+
+void Worker::access_points(const pbnavitia::AccessPointsRequest& access_points) {
+    const auto& proto_uris = access_points.forbidden_uris();
+    std::vector<std::string> forbidden_uris(proto_uris.begin(), proto_uris.end());
+
+    access_point::access_points(this->pb_creator, access_points.filter(), access_points.count(), access_points.depth(),
+                                access_points.start_page(), forbidden_uris);
 }
 
 }  // namespace navitia

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -144,6 +144,7 @@ private:
     void get_matching_routes(const pbnavitia::MatchingRoute&);
     void equipment_reports(const pbnavitia::EquipmentReportsRequest& equipment_reports);
     void vehicle_positions(const pbnavitia::VehiclePositionsRequest& vehcile_positions);
+    void access_points(const pbnavitia::AccessPointsRequest& access_points);
 };
 
 type::EntryPoint make_sn_entry_point(const std::string& place,

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -627,6 +627,9 @@ void PbCreator::Filler::create_access_point(const nt::AccessPoint& access_point,
     if (!access_point.reversed_signposted_as.empty()) {
         ap->set_reversed_signposted_as(access_point.reversed_signposted_as);
     }
+    if (!access_point.stop_code.empty()) {
+        ap->set_stop_code(access_point.stop_code);
+    }
     if (access_point.parent_station != nullptr) {
         pbnavitia::StopArea* sa = ap->mutable_parent_station();
         fill_pb_object(access_point.parent_station, sa);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -594,46 +594,54 @@ void PbCreator::Filler::fill_pb_object(const ng::Admin* adm, pbnavitia::Administ
     }
 }
 
+void PbCreator::Filler::create_access_point(const nt::AccessPoint& access_point, pbnavitia::AccessPoint* ap) {
+    ap->set_name(access_point.name);
+    ap->set_uri(access_point.uri);
+    if (access_point.coord.is_initialized()) {
+        ap->mutable_coord()->set_lon(access_point.coord.lon());
+        ap->mutable_coord()->set_lat(access_point.coord.lat());
+    }
+    ap->set_is_entrance(access_point.is_entrance);
+    ap->set_is_exit(access_point.is_exit);
+    if (access_point.pathway_mode != nt::ap_default_value) {
+        ap->set_pathway_mode(access_point.pathway_mode);
+    }
+    if (access_point.length != nt::ap_default_value) {
+        ap->set_length(access_point.length);
+    }
+    if (access_point.traversal_time != nt::ap_default_value) {
+        ap->set_traversal_time(access_point.traversal_time);
+    }
+    if (access_point.stair_count != nt::ap_default_value) {
+        ap->set_stair_count(access_point.stair_count);
+    }
+    if (access_point.max_slope != nt::ap_default_value) {
+        ap->set_max_slope(access_point.max_slope);
+    }
+    if (access_point.min_width != nt::ap_default_value) {
+        ap->set_min_width(access_point.min_width);
+    }
+    if (!access_point.signposted_as.empty()) {
+        ap->set_signposted_as(access_point.signposted_as);
+    }
+    if (!access_point.reversed_signposted_as.empty()) {
+        ap->set_reversed_signposted_as(access_point.reversed_signposted_as);
+    }
+    if (access_point.parent_station != nullptr) {
+        pbnavitia::StopArea* sa = ap->mutable_parent_station();
+        fill_pb_object(access_point.parent_station, sa);
+    }
+}
+
+void PbCreator::Filler::fill_pb_object(const nt::AccessPoint& ap, pbnavitia::AccessPoint* pb_ap) {
+    create_access_point(ap, pb_ap);
+}
+
 void PbCreator::Filler::fill_access_points(const std::set<nt::AccessPoint>& access_points,
                                            pbnavitia::StopPoint* stop_point) {
     for (const auto& access_point : access_points) {
         pbnavitia::AccessPoint* ap = stop_point->add_access_points();
-        ap->set_name(access_point.name);
-        ap->set_uri(access_point.uri);
-        if (access_point.coord.is_initialized()) {
-            ap->mutable_coord()->set_lon(access_point.coord.lon());
-            ap->mutable_coord()->set_lat(access_point.coord.lat());
-        }
-        ap->set_is_entrance(access_point.is_entrance);
-        ap->set_is_exit(access_point.is_exit);
-        if (access_point.pathway_mode != nt::ap_default_value) {
-            ap->set_pathway_mode(access_point.pathway_mode);
-        }
-        if (access_point.length != nt::ap_default_value) {
-            ap->set_length(access_point.length);
-        }
-        if (access_point.traversal_time != nt::ap_default_value) {
-            ap->set_traversal_time(access_point.traversal_time);
-        }
-        if (access_point.stair_count != nt::ap_default_value) {
-            ap->set_stair_count(access_point.stair_count);
-        }
-        if (access_point.max_slope != nt::ap_default_value) {
-            ap->set_max_slope(access_point.max_slope);
-        }
-        if (access_point.min_width != nt::ap_default_value) {
-            ap->set_min_width(access_point.min_width);
-        }
-        if (!access_point.signposted_as.empty()) {
-            ap->set_signposted_as(access_point.signposted_as);
-        }
-        if (!access_point.reversed_signposted_as.empty()) {
-            ap->set_reversed_signposted_as(access_point.reversed_signposted_as);
-        }
-        if (access_point.parent_station != nullptr) {
-            pbnavitia::StopArea* sa = ap->mutable_parent_station();
-            fill_pb_object(access_point.parent_station, sa);
-        }
+        create_access_point(access_point, ap);
     }
 }
 
@@ -2310,6 +2318,10 @@ pbnavitia::EquipmentReport* PbCreator::add_equipment_reports() {
 
 pbnavitia::VehiclePosition* PbCreator::add_vehicle_positions() {
     return response.add_vehicle_positions();
+}
+
+pbnavitia::AccessPoint* PbCreator::add_access_points() {
+    return response.add_access_points();
 }
 
 bool PbCreator::has_error() {

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -318,6 +318,7 @@ struct PbCreator {
     pbnavitia::RoutePoint* add_route_points();
     pbnavitia::EquipmentReport* add_equipment_reports();
     pbnavitia::VehiclePosition* add_vehicle_positions();
+    pbnavitia::AccessPoint* add_access_points();
 
     ::google::protobuf::RepeatedPtrField<pbnavitia::PtObject>* get_mutable_places();
     bool has_error();
@@ -527,7 +528,9 @@ private:
         void fill_pb_object(const ng::Address*, pbnavitia::PtObject*);
         void fill_pb_object(const ng::Address*, pbnavitia::Address*);
         void fill_pb_object(const nt::Comment*, pbnavitia::Note*);
+        void fill_pb_object(const nt::AccessPoint&, pbnavitia::AccessPoint*);
 
+        void create_access_point(const nt::AccessPoint& access_point, pbnavitia::AccessPoint* ap);
         void fill_access_points(const std::set<nt::AccessPoint>& access_points, pbnavitia::StopPoint* stop_point);
 
         // Used for place


### PR DESCRIPTION
I am a little bit sorry because the PR is just huge... I mixed the **Kraken** and the **Jormungandr** part.
Some details to understand more easly
- Into sources, we have a complete folder with all the _access_points_ kraken part (sources/access_point)
- **navitia-proto** is updated the req and resp https://github.com/CanalTP/navitia-proto/pull/174
- the jormun part to expose the entry point -> https://github.com/CanalTP/navitia/compare/dev...benoit-bst:access_points_entry_point?expand=1#diff-8e8d1a1627b9a84ca31f69d538e5c5ea45941cf946eb927f4111979fef4cdbe8R44
- **Kraken** and **Jormun** parts are tested and a lot of tests by hand was done

_TODO_ : Had a piece of documentation into slate

At the end of this work the API can expose Access Point :tulip: 

![ap_gare_de_lyon](https://user-images.githubusercontent.com/32099204/150757583-68689567-0fc3-45b1-9cce-1dcf97fad131.png)



