### PR TITLE
[Jormungandr] Fix section duration consistence with access point

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -270,7 +270,7 @@ def _extend_with_via_access_point(fallback_dp, pt_object, fallback_type, via_acc
         dp_journey.sections[0].street_network.duration += traversal_time
         dp_journey.sections[0].street_network.length += length
 
-        via = dp_journey.sections[-1].street_network.path_items[-1]
+        via = dp_journey.sections[-1].street_network.path_items.add()
         via.duration = traversal_time
         via.length = length
         via.name = via_access_point.name

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -260,9 +260,16 @@ def _extend_with_via_access_point(fallback_dp, pt_object, fallback_type, via_acc
 
     dp_journey = fallback_dp.journeys[0]
     dp_journey.duration += traversal_time
+    dp_journey.durations.total += traversal_time
+    dp_journey.durations.walking += traversal_time
     dp_journey.distances.walking += length
 
     if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:
+        dp_journey.sections[0].begin_date_time -= traversal_time
+        dp_journey.sections[0].duration += traversal_time
+        dp_journey.sections[0].street_network.duration += traversal_time
+        dp_journey.sections[0].street_network.length += length
+
         via = dp_journey.sections[-1].street_network.path_items[-1]
         via.duration = traversal_time
         via.length = length
@@ -272,6 +279,11 @@ def _extend_with_via_access_point(fallback_dp, pt_object, fallback_type, via_acc
         via.via_uri = via_access_point.uri
 
     elif fallback_type == StreetNetworkPathType.ENDING_FALLBACK:
+        dp_journey.sections[-1].end_date_time += traversal_time
+        dp_journey.sections[-1].duration += traversal_time
+        dp_journey.sections[-1].street_network.duration += traversal_time
+        dp_journey.sections[-1].street_network.length += length
+
         path_items = dp_journey.sections[0].street_network.path_items
 
         via = dp_journey.sections[0].street_network.path_items.add()

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -458,6 +458,9 @@ class TestJourneysDistributed(
         assert path['via_uri'] == "access_point:B1"
         assert path['instruction'] == "Then Enter stop_point:stopB (Condom) via access_point:B1."
 
+        path_sum = sum(p['duration'] for p in pt_journey['sections'][0]['path'])
+        assert pt_journey['sections'][0]['duration'] == pytest.approx(path_sum, 1.0)
+
         access_point = pt_journey['sections'][2]['vias'][0]['access_point']
         assert access_point["id"] == "access_point:A2"
         assert not access_point["is_entrance"]
@@ -470,6 +473,9 @@ class TestJourneysDistributed(
         assert path['length'] == 3
         assert path['via_uri'] == "access_point:A2"
         assert path['instruction'] == "Exit stop_point:stopA (Condom) via access_point:A2."
+
+        path_sum = sum(p['duration'] for p in pt_journey['sections'][2]['path'])
+        assert pt_journey['sections'][2]['duration'] == pytest.approx(path_sum, 1.0)
 
 
 @config({"scenario": "distributed"})


### PR DESCRIPTION
The traversal_time(from access point to stop_point) is not correctly integrated into section's datetime

![image (3)](https://user-images.githubusercontent.com/6093486/151172579-19c4e463-106a-42aa-aeb7-144242beeadf.png)
![image (4)](https://user-images.githubusercontent.com/6093486/151172631-afbe2bdb-9f83-44bc-93a6-cc6f298e97b9.png)

now the traversal_time is integrated correctly
![image](https://user-images.githubusercontent.com/6093486/151173715-b341a45a-c396-4fd9-8c05-a6b0d23061dc.png)
