### PR TITLE
Manage database resilience if at least one table is not accessible

### DIFF
--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -114,6 +114,16 @@ def get_token():
         return auth
 
 
+def can_read_user():
+    try:
+        User.can_read()
+    except Exception as e:
+        logging.getLogger(__name__).error('No access to table User (error: {})'.format(e))
+        g.can_connect_to_database = False
+        return False
+    return True
+
+
 @memory_cache.memoize(
     current_app.config[str('MEMORY_CACHE_CONFIGURATION')].get(str('TIMEOUT_AUTHENTICATION'), 30)
 )
@@ -133,9 +143,19 @@ def has_access(region, api, abort, user):
 
     if not user:
         # no user --> no need to continue, we can abort, a user is mandatory even for free region
-        abort_request(user=user)
+        # To manage database error of the following type we should fetch one more time from database
+        # Can connect to database but at least one table/attribute is not accessible due to transaction problem
+        if can_read_user():
+            abort_request(user=user)
 
-    model_instance = Instance.get_by_name(region)
+        if not can_connect_to_database():
+            return True
+    try:
+        model_instance = Instance.get_by_name(region)
+    except Exception as e:
+        logging.getLogger(__name__).error('No access to table Instance (error: {})'.format(e))
+        g.can_connect_to_database = False
+        return True
 
     if not model_instance:
         if abort:
@@ -164,7 +184,14 @@ def cache_get_user(token):
     """
     if not can_connect_to_database():
         return None
-    return User.get_from_token(token, datetime.datetime.now())
+    try:
+        user = User.get_from_token(token, datetime.datetime.now())
+    except Exception as e:
+        logging.getLogger(__name__).error('No access to table User (error: {})'.format(e))
+        g.can_connect_to_database = False
+        return None
+
+    return user
 
 
 @memory_cache.memoize(
@@ -174,7 +201,13 @@ def cache_get_user(token):
 def cache_get_key(token):
     if not can_connect_to_database():
         return None
-    return Key.get_by_token(token)
+    try:
+        key = Key.get_by_token(token)
+    except Exception as e:
+        logging.getLogger(__name__).error('No access to table key (error: {})'.format(e))
+        g.can_connect_to_database = False
+        return None
+    return key
 
 
 @memory_cache.memoize(
@@ -196,7 +229,14 @@ def get_all_available_instances(user):
 
     if not user:
         # for not-public navitia a user is mandatory
-        abort_request(user=user)
+        # To manage database error of the following type we should fetch one more time from database
+        # Can connect to database but at least one table/attribute is not accessible due to transaction problem
+        if can_read_user():
+            abort_request(user=user)
+
+        if not can_connect_to_database():
+            return None
+
     if not user.have_access_to_free_instances:
         # only users with access to opendata can use the global /places
         abort_request(user=user)

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -5,6 +5,7 @@ import os
 import json
 from flask_restful.inputs import boolean
 
+# sql queries will return an exception if the query did not succeed before `statement_timeout`
 DEFAULT_SQLALCHEMY_ENGINE_OPTIONS = {'connect_args': {"options": "-c statement_timeout=1000"}}  # 1000ms
 
 # path of the configuration file for each instances

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -6,7 +6,7 @@ import json
 from flask_restful.inputs import boolean
 
 # sql queries will return an exception if the query did not succeed before `statement_timeout`
-DEFAULT_SQLALCHEMY_ENGINE_OPTIONS = {'connect_args': {"options": "-c statement_timeout=1000"}}  # 1000ms
+DEFAULT_SQLALCHEMY_ENGINE_OPTIONS = {"connect_args": {"options": "-c statement_timeout=1000"}}  # 1000ms
 
 # path of the configuration file for each instances
 INSTANCES_DIR = os.getenv('JORMUNGANDR_INSTANCES_DIR', '/etc/jormungandr.d')

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -5,6 +5,8 @@ import os
 import json
 from flask_restful.inputs import boolean
 
+DEFAULT_SQLALCHEMY_ENGINE_OPTIONS = {'connect_args': {"options": "-c statement_timeout=1000"}}  # 1000ms
+
 # path of the configuration file for each instances
 INSTANCES_DIR = os.getenv('JORMUNGANDR_INSTANCES_DIR', '/etc/jormungandr.d')
 
@@ -211,6 +213,11 @@ if boolean(os.getenv('JORMUNGANDR_DISABLE_SQLPOOLING', False)):
     from sqlalchemy.pool import NullPool
 
     SQLALCHEMY_POOLCLASS = NullPool
+
+
+SQLALCHEMY_ENGINE_OPTIONS = (
+    json.loads(os.getenv('JORMUNGANDR_SQLALCHEMY_ENGINE_OPTIONS', '{}')) or DEFAULT_SQLALCHEMY_ENGINE_OPTIONS
+)
 
 MAX_JOURNEYS_CALLS = int(os.getenv('JORMUNGANDR_MAX_JOURNEYS_CALLS', 20))
 

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -115,11 +115,12 @@ class EquipmentProviderManager(object):
         self.logger.debug('Updating equipment providers from db')
         self._last_update = datetime.datetime.utcnow()
 
-        providers = []
         try:
             providers = self._providers_getter()
-        except Exception:
-            self.logger.exception('Failure to retrieve equipments providers configuration')
+        except Exception as e:
+            self.logger.exception('No access to table equipments_provider (error: {})'.format(e))
+            return
+
         if not providers:
             self.logger.debug('No providers/All providers disabled in db')
             self._equipment_providers = {}

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -119,6 +119,8 @@ class EquipmentProviderManager(object):
             providers = self._providers_getter()
         except Exception as e:
             self.logger.exception('No access to table equipments_provider (error: {})'.format(e))
+            # database is not accessible, so let's use the values already present in self._equipment_providers and
+            # self._equipment_providers_legacy
             return
 
         if not providers:

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -122,6 +122,7 @@ class ExternalServiceManager(object):
             services = self._external_service_getter()
         except Exception as e:
             self.logger.error('No access to table external_service (error: {})'.format(e))
+            # database is not accessible, so let's use the values already present in self._external_services_legacy
             return
 
         if not services:

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -118,11 +118,12 @@ class ExternalServiceManager(object):
         self.logger.debug('Updating external services from db')
         self._last_update = datetime.datetime.utcnow()
 
-        services = []
         try:
             services = self._external_service_getter()
-        except Exception:
-            self.logger.exception('Failure to retrieve external service configuration')
+        except Exception as e:
+            self.logger.error('No access to table external_service (error: {})'.format(e))
+            return
+
         if not services:
             self.logger.debug('No external service/All external services disabled in db')
             self._external_services_last_update = {}

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -266,7 +266,14 @@ class Instance(object):
             return None
         if not can_connect_to_database():
             return self.instance_db
-        self.instance_db = models.Instance.get_by_name(self.name)
+        try:
+            instance_db = models.Instance.get_by_name(self.name)
+        except Exception as e:
+            logging.getLogger(__name__).error('No access to table instance (error: {})'.format(e))
+            g.can_connect_to_database = False
+            return self.instance_db
+
+        self.instance_db = instance_db
         return self.instance_db
 
     def scenario(self, override_scenario=None):

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -199,6 +199,11 @@ class Places(ResourceUri):
             response = i_manager.dispatch(args, "places", instance_name=self.region)
         else:
             available_instances = get_all_available_instances(user)
+
+            # If no instance available most probably due to database error
+            if (not user) and (not available_instances):
+                raise TechnicalError('world wide autocompletion service not available temporarily')
+
             # If parameter '_autocomplete' is absent use 'bragi' as default value
             if args["_autocomplete"] is None:
                 args["_autocomplete"] = 'bragi'
@@ -268,6 +273,10 @@ class PlaceUri(ResourceUri):
         else:
             user = authentication.get_user(token=authentication.get_token(), abort_if_no_token=False)
             available_instances = get_all_available_instances(user)
+
+            # If no instance available most probably due to database error
+            if (not user) and (not available_instances):
+                raise TechnicalError('world wide autocompletion service not available temporarily')
 
             # If parameter '_autocomplete' is absent use 'bragi' as default value
             if args["_autocomplete"] is None:

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -70,6 +70,8 @@ class BssProviderManager(AbstractProviderManager):
             providers = self._providers_getter()
         except Exception as e:
             logger.exception('No access to table bss_provider (error: {})'.format(e))
+            # database is not accessible, so let's use the values already present in self._bss_providers and
+            # self._bss_providers_legacy
             return
 
         if not providers:

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -66,11 +66,12 @@ class BssProviderManager(AbstractProviderManager):
         logger.debug('updating bss providers')
         self._last_update = datetime.datetime.utcnow()
 
-        providers = None
         try:
             providers = self._providers_getter()
-        except Exception:
-            logger.exception('failure to retrieve bss configuration')
+        except Exception as e:
+            logger.exception('No access to table bss_provider (error: {})'.format(e))
+            return
+
         if not providers:
             logger.debug('all providers have be disabled')
             self._bss_providers = {}

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
@@ -126,6 +126,7 @@ class RealtimeProxyManager(object):
             realtime_proxies = self._realtime_proxies_getter()
         except Exception as e:
             self.logger.exception('Failure to retrieve realtime proxies configuration (error: {})'.format(e))
+            # database is not accessible, so let's use the values already present in self._realtime_proxies
             return
 
         if not realtime_proxies:

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy_manager.py
@@ -122,11 +122,12 @@ class RealtimeProxyManager(object):
         self.logger.debug('Updating realtime proxies from db')
         self._last_update = datetime.datetime.utcnow()
 
-        realtime_proxies = []
         try:
             realtime_proxies = self._realtime_proxies_getter()
-        except Exception:
-            self.logger.exception('Failure to retrieve realtime proxies configuration')
+        except Exception as e:
+            self.logger.exception('Failure to retrieve realtime proxies configuration (error: {})'.format(e))
+            return
+
         if not realtime_proxies:
             self.logger.debug('No realtime proxies available in db')
             self._realtime_proxies = {}

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -152,6 +152,7 @@ class RidesharingServiceManager(object):
             services = self._rs_services_getter()
         except Exception as e:
             self.logger.exception('Failure to retrieve ridesharing services configuration (error: {})'.format(e))
+            # database is not accessible, so let's use the values already present in self._ridesharing_services_legacy
             return
 
         if not services:

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -148,11 +148,12 @@ class RidesharingServiceManager(object):
         self.logger.debug('Updating ridesharing services from db')
         self._last_update = datetime.datetime.utcnow()
 
-        services = []
         try:
             services = self._rs_services_getter()
-        except Exception:
-            self.logger.exception('Failure to retrieve ridesharing services configuration')
+        except Exception as e:
+            self.logger.exception('Failure to retrieve ridesharing services configuration (error: {})'.format(e))
+            return
+
         if not services:
             self.logger.debug('No ridesharing services available in db')
             self._ridesharing_services = {}

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -151,16 +151,16 @@ class StreetNetworkBackendManager(object):
         self.logger.debug('Updating streetnetwork backends from db')
         self._last_update = datetime.datetime.utcnow()
 
-        sn_backends = []  # type: List[StreetNetworkBackend]
         try:
             sn_backends = self._sn_backends_getter()
-        except Exception:
-            self.logger.exception('Failure to retrieve streetnetwork backends configuration')
+        except Exception as e:
+            self.logger.error('No access to table streetnetwork_backend (error: {})'.format(e))
+            return
+
         if not sn_backends:
             self.logger.debug('No streetnetwork backends/All streetnetwork backends disabled in db')
             self._streetnetwork_backends = {}
             self._streetnetwork_backends_last_update = {}
-
             return
 
         for sn_backend in sn_backends:

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -155,6 +155,7 @@ class StreetNetworkBackendManager(object):
             sn_backends = self._sn_backends_getter()
         except Exception as e:
             self.logger.error('No access to table streetnetwork_backend (error: {})'.format(e))
+            # database is not accessible, so let's use the values already present in self._streetnetwork_backends
             return
 
         if not sn_backends:

--- a/source/jormungandr/jormungandr/travelers_profile.py
+++ b/source/jormungandr/jormungandr/travelers_profile.py
@@ -38,6 +38,7 @@ from navitiacommon.default_traveler_profile_params import (
 from six.moves import map
 from six import text_type
 from typing import Dict, Text, List, Optional
+import logging
 
 
 class TravelerProfile(object):
@@ -128,7 +129,13 @@ class TravelerProfile(object):
 
         # retrieve TravelerProfile from db with coverage and traveler_type
         # if the record doesn't exist, we use pre-defined default traveler profile
-        model = models.TravelerProfile.get_by_coverage_and_type(coverage, traveler_type)
+        try:
+            model = models.TravelerProfile.get_by_coverage_and_type(coverage, traveler_type)
+        except Exception as e:
+            logging.getLogger(__name__).error('No access to table traveler_profile (error: {})'.format(e))
+            # If the table is not accessible return the default traveler profile for given traveler type
+            return default_traveler_profiles[traveler_type]
+
         if model is None:
             return default_traveler_profiles[traveler_type]
 

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -201,6 +201,10 @@ class User(db.Model, TimestampMixin):  # type: ignore
 
         return False
 
+    @classmethod
+    def can_read(cls):
+        return cls.query.first()
+
     def has_shape(self):
         return self.shape is not None and self.shape != 'null'
 

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -201,10 +201,6 @@ class User(db.Model, TimestampMixin):  # type: ignore
 
         return False
 
-    @classmethod
-    def can_read(cls):
-        return cls.query.first()
-
     def has_shape(self):
         return self.shape is not None and self.shape != 'null'
 


### PR DESCRIPTION
This feature is related to the failure while deploying navitia in PROD last Monday (24/01/2022).
* Navitia was not accessible during 2 hours as the table billing_plan was locked.
* This correction add more verification and use the already existing mechanism **can_connect_to_database()**.
* The database component (SQLAlchemy) is configured to throw a statement_timeout after 1000 ms (with a default configuration).
* Need to wait for maximum of 2 timeouts (one per navitia query) for each cache period.
* After the first time_out catch,  **can_connect_to_database()** mechanism is used and user is authorized without verification to continue query navitia.

Doc: https://navitia.atlassian.net/wiki/spaces/NAV/pages/11942920554/20220122+-+Incident+de+prod+pendant+la+livraison+de+navitia+v14

**Note: Difficult to add test. I request at least someone to test in his/her machine.** 