### PR TITLE
Fix traffic_reports with forbidden_uris on physical_modes

### DIFF
--- a/source/disruption/traffic_reports_api.cpp
+++ b/source/disruption/traffic_reports_api.cpp
@@ -343,8 +343,17 @@ void TrafficReport::disruptions_list(const std::string& filter,
         return;
     }
 
-    type::Indexes network_idx = ptref::make_query(type::Type_e::Network, filter, forbidden_uris, d);
-    add_networks(network_idx, d, now, filter_period);
+    type::Indexes network_idx;
+    try {
+        network_idx = ptref::make_query(type::Type_e::Network, filter, forbidden_uris, d);
+    } catch (const std::exception&) {
+    }
+    if (network_idx.size() > 0) {
+        add_networks(network_idx, d, now, filter_period);
+    }
+    // Get networks without forbidden_uris as this filter is used to filter other pt_objects
+    // We should not exclude ant network at this level
+    network_idx = ptref::make_query(type::Type_e::Network, filter, d);
     add_lines(filter, forbidden_uris, d, now, filter_period);
     add_stop_areas(network_idx, filter, forbidden_uris, d, now, filter_period);
     add_vehicle_journeys(network_idx, filter, forbidden_uris, d, now, filter_period);

--- a/source/disruption/traffic_reports_api.cpp
+++ b/source/disruption/traffic_reports_api.cpp
@@ -348,9 +348,7 @@ void TrafficReport::disruptions_list(const std::string& filter,
         network_idx = ptref::make_query(type::Type_e::Network, filter, forbidden_uris, d);
     } catch (const std::exception&) {
     }
-    if (network_idx.size() > 0) {
-        add_networks(network_idx, d, now, filter_period);
-    }
+    add_networks(network_idx, d, now, filter_period);
     // Get networks without forbidden_uris as this filter is used to filter other pt_objects
     // We should not exclude ant network at this level
     network_idx = ptref::make_query(type::Type_e::Network, filter, d);

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -1069,7 +1069,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         # traffic_reports with forbidden_uris[]=physical_mode:0x0 (Tramway) gives empty result
         # as all the pt_objects impacted are related to physical_mode Tramway
         response = self.query_region(
-            'traffic_reports?_current_datetime=20120801T000000&depth=3&' 'forbidden_uris[]=physical_mode:0x0'
+            'traffic_reports?_current_datetime=20120801T000000&depth=3&forbidden_uris[]=physical_mode:0x0'
         )
         assert len(response['traffic_reports']) == 0
         assert len(response['disruptions']) == 0
@@ -1077,7 +1077,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         # traffic_reports with forbidden_uris[]=physical_mode:0x1 (Metro) filters all the objects impacted
         # and related to physical_mode Metro. stop_area 'stopA' is hence excluded
         response = self.query_region(
-            'traffic_reports?_current_datetime=20120801T000000&depth=3&' 'forbidden_uris[]=physical_mode:0x1'
+            'traffic_reports?_current_datetime=20120801T000000&depth=3&forbidden_uris[]=physical_mode:0x1'
         )
         assert len(response['traffic_reports']) == 1
         assert len(response['disruptions']) == 3

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -1044,6 +1044,8 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
                     return sa
             return None
 
+        mode_tramway = 'physical_mode:0x0'
+
         # Call traffic_reports and verify all the objects
         response = self.query_region('traffic_reports?_current_datetime=20120801T000000&depth=3')
         assert len(response['traffic_reports']) == 1
@@ -1052,19 +1054,19 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         assert len(response['traffic_reports'][0]['lines']) == 1
         assert response['traffic_reports'][0]['lines'][0]['id'] == 'A'
         assert len(response['traffic_reports'][0]['lines'][0]['physical_modes']) == 1
-        assert response['traffic_reports'][0]['lines'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
+        assert response['traffic_reports'][0]['lines'][0]['physical_modes'][0]['id'] == mode_tramway
         assert len(response['traffic_reports'][0]['stop_areas']) == 2
 
         stop_area = get_stop_area(response['traffic_reports'][0]['stop_areas'], 'stopA')
         assert stop_area['id'] == 'stopA'
         assert len(stop_area['physical_modes']) == 2
-        assert any(pm['id'] == 'physical_mode:0x0' for pm in stop_area['physical_modes'])
+        assert any(pm['id'] == mode_tramway for pm in stop_area['physical_modes'])
         assert any(pm['id'] == 'physical_mode:0x1' for pm in stop_area['physical_modes'])
 
         stop_area = get_stop_area(response['traffic_reports'][0]['stop_areas'], 'stopB')
         assert stop_area['id'] == 'stopB'
         assert len(stop_area['physical_modes']) == 1
-        assert stop_area['physical_modes'][0]['id'] == 'physical_mode:0x0'
+        assert stop_area['physical_modes'][0]['id'] == mode_tramway
 
         # traffic_reports with forbidden_uris[]=physical_mode:0x0 (Tramway) gives empty result
         # as all the pt_objects impacted are related to physical_mode Tramway
@@ -1085,11 +1087,11 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         assert len(response['traffic_reports'][0]['lines']) == 1
         assert response['traffic_reports'][0]['lines'][0]['id'] == 'A'
         assert len(response['traffic_reports'][0]['lines'][0]['physical_modes']) == 1
-        assert response['traffic_reports'][0]['lines'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
+        assert response['traffic_reports'][0]['lines'][0]['physical_modes'][0]['id'] == mode_tramway
         assert len(response['traffic_reports'][0]['stop_areas']) == 1
         assert response['traffic_reports'][0]['stop_areas'][0]['id'] == 'stopB'
         assert len(response['traffic_reports'][0]['stop_areas'][0]['physical_modes']) == 1
-        assert response['traffic_reports'][0]['stop_areas'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
+        assert response['traffic_reports'][0]['stop_areas'][0]['physical_modes'][0]['id'] == mode_tramway
 
     def test_disruption_with_and_without_tags(self):
         """

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -1037,6 +1037,13 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         """
         Here we test api /traffic_reports with parameters
         """
+
+        def get_stop_area(sas, sa_id):
+            for sa in sas:
+                if sa['id'] == sa_id:
+                    return sa
+            return None
+
         # Call traffic_reports and verify all the objects
         response = self.query_region('traffic_reports?_current_datetime=20120801T000000&depth=3')
         assert len(response['traffic_reports']) == 1
@@ -1044,15 +1051,20 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         assert response['traffic_reports'][0]['network']['id'] == 'base_network'
         assert len(response['traffic_reports'][0]['lines']) == 1
         assert response['traffic_reports'][0]['lines'][0]['id'] == 'A'
+        assert len(response['traffic_reports'][0]['lines'][0]['physical_modes']) == 1
         assert response['traffic_reports'][0]['lines'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
         assert len(response['traffic_reports'][0]['stop_areas']) == 2
-        assert response['traffic_reports'][0]['stop_areas'][0]['id'] == 'stopB'
-        assert len(response['traffic_reports'][0]['stop_areas'][0]['physical_modes']) == 1
-        assert response['traffic_reports'][0]['stop_areas'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
-        assert response['traffic_reports'][0]['stop_areas'][1]['id'] == 'stopA'
-        assert len(response['traffic_reports'][0]['stop_areas'][1]['physical_modes']) == 2
-        assert response['traffic_reports'][0]['stop_areas'][1]['physical_modes'][0]['id'] == 'physical_mode:0x0'
-        assert response['traffic_reports'][0]['stop_areas'][1]['physical_modes'][1]['id'] == 'physical_mode:0x1'
+
+        stop_area = get_stop_area(response['traffic_reports'][0]['stop_areas'], 'stopA')
+        assert stop_area['id'] == 'stopA'
+        assert len(stop_area['physical_modes']) == 2
+        assert any(pm['id'] == 'physical_mode:0x0' for pm in stop_area['physical_modes'])
+        assert any(pm['id'] == 'physical_mode:0x1' for pm in stop_area['physical_modes'])
+
+        stop_area = get_stop_area(response['traffic_reports'][0]['stop_areas'], 'stopB')
+        assert stop_area['id'] == 'stopB'
+        assert len(stop_area['physical_modes']) == 1
+        assert stop_area['physical_modes'][0]['id'] == 'physical_mode:0x0'
 
         # traffic_reports with forbidden_uris[]=physical_mode:0x0 (Tramway) gives empty result
         # as all the pt_objects impacted are related to physical_mode Tramway
@@ -1072,9 +1084,11 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
         assert response['traffic_reports'][0]['network']['id'] == 'base_network'
         assert len(response['traffic_reports'][0]['lines']) == 1
         assert response['traffic_reports'][0]['lines'][0]['id'] == 'A'
+        assert len(response['traffic_reports'][0]['lines'][0]['physical_modes']) == 1
         assert response['traffic_reports'][0]['lines'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
         assert len(response['traffic_reports'][0]['stop_areas']) == 1
         assert response['traffic_reports'][0]['stop_areas'][0]['id'] == 'stopB'
+        assert len(response['traffic_reports'][0]['stop_areas'][0]['physical_modes']) == 1
         assert response['traffic_reports'][0]['stop_areas'][0]['physical_modes'][0]['id'] == 'physical_mode:0x0'
 
     def test_disruption_with_and_without_tags(self):


### PR DESCRIPTION
* When we have fobidden_uris on physical_modes, it excludes network and hence no impact on pt_objects like lines, stop_areas, stop_points as well as vehicle_journeys of that network is added.
* In this case we may not add any impact on network but should do for all the other pt_objects as they are well filtered using parameters, filter and forbidden_uris.

Ticket: https://navitia.atlassian.net/browse/NAV-1034

Tests added 