### PR TITLE
[Jormungandr] fix access_points in journeys

### DIFF
--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -532,6 +532,10 @@ struct routing_api_data {
         b.add_access_point("stop_point:stopA", "access_point:A2", false, true, 3, 4, 0.000718649585563767,
                            0.0010779743);
 
+        // this access_point is supposed to trigger a bug in distributed which is covered by a test in jormungandr
+        b.add_access_point("stop_point:stopB", "access_point:A1", true, true, 42, 42, 0.000718649585563767,
+                           0.0010779743);
+
         sp = b.get<nt::StopPoint>("stop_point:stopB");
         b.data->pt_data->codes.add(sp, "TCL_ASCENSEUR", "6");
         b.data->pt_data->codes.add(sp, "TCL_ASCENSEUR", "7");


### PR DESCRIPTION
the traversal time and length of the access point shown in the following journeys does not match those in the data

![image](https://user-images.githubusercontent.com/6093486/155557727-734ad513-932b-42e7-8813-41c9394439ec.png)

![image](https://user-images.githubusercontent.com/6093486/155557772-7b7abdd2-0c20-4135-b296-db1ed8c7139a.png)
