### PR TITLE
Fix action put on api billing_plans without lockable and notify_threshold_list

### DIFF
--- a/source/tyr/tests/integration/billing_plans_test.py
+++ b/source/tyr/tests/integration/billing_plans_test.py
@@ -118,7 +118,7 @@ def test_actions_on_billing_plans():
 
     # Modify certain attributes of the existing billing_plan
     # Will update only modified attributes.
-    billing_plan = {'max_request_count': 101, 'lockable': False, 'notify_threshold_list': [75, 100]}
+    billing_plan = {'max_request_count': 101, 'lockable': True, 'notify_threshold_list': [75, 100]}
     data = json.dumps(billing_plan)
 
     # Put without id
@@ -140,7 +140,7 @@ def test_actions_on_billing_plans():
     assert resp['name'] == 'bp_test_1'
     assert resp['max_request_count'] == 101
     assert resp['end_point']['name'] == 'navitia.io'
-    assert resp['lockable'] is False
+    assert resp['lockable'] is True
     assert resp['default'] is False
     assert resp['notify_threshold_list'] == [75, 100]
     assert resp['end_point']['name'] == 'navitia.io'
@@ -148,3 +148,15 @@ def test_actions_on_billing_plans():
     # Get all billing_plans
     resp = api_get('/v0/billing_plans/')
     assert len(resp) == 6
+
+    # Put without lockable and notify_threshold_list should not modify existing values
+    # notify_threshold_list = [75, 100] and lockable = True
+    billing_plan = {'max_request_count': 101}
+    data = json.dumps(billing_plan)
+    resp = api_put('/v0/billing_plans/6', data=data, content_type='application/json')
+    assert resp['name'] == 'bp_test_1'
+    assert resp['max_request_count'] == 101
+    assert resp['end_point']['name'] == 'navitia.io'
+    assert resp['lockable'] is True
+    assert resp['notify_threshold_list'] == [75, 100]
+    assert resp['end_point']['name'] == 'navitia.io'

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1960,7 +1960,7 @@ class BillingPlan(flask_restful.Resource):
             'lockable',
             type=bool,
             required=False,
-            default=False,
+            default=billing_plan.lockable,
             help='block access to navitia when request count > max_request_count ',
             location=('json', 'values'),
         )
@@ -1969,6 +1969,7 @@ class BillingPlan(flask_restful.Resource):
             type=int,
             action='append',
             required=False,
+            default=billing_plan.notify_threshold_list,
             help='Request threshold list to send notifications',
             location=('json', 'values'),
         )


### PR DESCRIPTION
* This correction is related to error occurred in quota_manager. 
* When we modify an existing billing_plan without attributes lockable and notify_threshold_list, they are modified to False and NULL respectively.
* After correction if attributes lockable and/or notify_threshold_list, their value should not be modified.
