### PR TITLE
Here :  base duration for base datetime

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -120,6 +120,9 @@ def _align_fallback_direct_path_datetime(fallback_direct_path, fallback_extremit
         for s in journey.sections:
             s.begin_date_time += delta
             s.end_date_time += delta
+            if s.base_begin_date_time != None and s.base_end_date_time:
+                s.base_begin_date_time += delta
+                s.base_end_date_time += delta
     return fallback_direct_path
 
 
@@ -613,7 +616,7 @@ def compute_fallback(
         fallback = _get_fallback_logic(direct_path_type)
         pt_orig = fallback.get_pt_boundaries(journey)
         pt_departure = fallback.get_pt_section_datetime(journey)
-        fallback_extremity_dep = PeriodExtremity(pt_departure, True)
+        fallback_extremity_dep = PeriodExtremity(pt_departure, False)
         from_sub_request_id = "{}_{}_from".format(request_id, i)
         if from_obj.uri != pt_orig.uri and pt_orig.uri not in orig_all_free_access:
             # here, if the mode is car, we have to find from which car park the stop_point is accessed
@@ -641,7 +644,7 @@ def compute_fallback(
         fallback = _get_fallback_logic(direct_path_type)
         pt_dest = fallback.get_pt_boundaries(journey)
         pt_arrival = fallback.get_pt_section_datetime(journey)
-        fallback_extremity_arr = PeriodExtremity(pt_arrival, False)
+        fallback_extremity_arr = PeriodExtremity(pt_arrival, True)
         to_sub_request_id = "{}_{}_to".format(request_id, i)
         if to_obj.uri != pt_dest.uri and pt_dest.uri not in dest_all_free_access:
             if arr_mode == 'car':

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -613,7 +613,7 @@ def compute_fallback(
         fallback = _get_fallback_logic(direct_path_type)
         pt_orig = fallback.get_pt_boundaries(journey)
         pt_departure = fallback.get_pt_section_datetime(journey)
-        fallback_extremity_dep = PeriodExtremity(pt_departure, False)
+        fallback_extremity_dep = PeriodExtremity(pt_departure, True)
         from_sub_request_id = "{}_{}_from".format(request_id, i)
         if from_obj.uri != pt_orig.uri and pt_orig.uri not in orig_all_free_access:
             # here, if the mode is car, we have to find from which car park the stop_point is accessed
@@ -641,7 +641,7 @@ def compute_fallback(
         fallback = _get_fallback_logic(direct_path_type)
         pt_dest = fallback.get_pt_boundaries(journey)
         pt_arrival = fallback.get_pt_section_datetime(journey)
-        fallback_extremity_arr = PeriodExtremity(pt_arrival, True)
+        fallback_extremity_arr = PeriodExtremity(pt_arrival, False)
         to_sub_request_id = "{}_{}_to".format(request_id, i)
         if to_obj.uri != pt_dest.uri and pt_dest.uri not in dest_all_free_access:
             if arr_mode == 'car':

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -273,7 +273,7 @@ class Here(AbstractStreetNetworkService):
 
         section.duration = travel_time
         section.begin_date_time = journey.departure_date_time
-        section.end_date_time = section.begin_date_time + section.duration
+        section.end_date_time = journey.arrival_date_time
 
         # base duration impacts the base arrival and departure datetime
         if (

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -225,7 +225,6 @@ class Here(AbstractStreetNetworkService):
         resp.response_type = response_pb2.ITINERARY_FOUND
 
         journey = resp.journeys.add()
-
         # durations
         travel_time = here_section.get('summary', {}).get('duration', 0)
         base_duration = here_section.get('summary', {}).get('baseDuration', 0)
@@ -240,13 +239,17 @@ class Here(AbstractStreetNetworkService):
         else:
             journey.durations.taxi = travel_time
 
-        datetime, _ = fallback_extremity
+        datetime, clockwise = fallback_extremity
         if (
             direct_path_type == StreetNetworkPathType.BEGINNING_FALLBACK
             or direct_path_type == StreetNetworkPathType.DIRECT
         ):
-            journey.departure_date_time = datetime
-            journey.arrival_date_time = datetime + journey.duration
+            if clockwise == True:
+                journey.departure_date_time = datetime
+                journey.arrival_date_time = datetime + journey.duration
+            else:
+                journey.departure_date_time = datetime - journey.duration
+                journey.arrival_date_time = datetime
         else:
             journey.departure_date_time = datetime - journey.duration
             journey.arrival_date_time = datetime

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -224,6 +224,7 @@ class Here(AbstractStreetNetworkService):
 
         # durations
         travel_time = here_section.get('summary', {}).get('duration', 0)
+        base_duration = here_section.get('summary', {}).get('baseDuration', 0)
         journey.duration = travel_time
         journey.durations.total = travel_time
         if mode == 'walking':
@@ -267,10 +268,13 @@ class Here(AbstractStreetNetworkService):
         section.begin_date_time = journey.departure_date_time
         section.end_date_time = section.begin_date_time + section.duration
 
-        # since HERE can give us the base time, we display it.
-        # we do not try to do clever stuff (like taking the 'clockwise' into account) here
-        section.base_begin_date_time = section.begin_date_time
-        section.base_end_date_time = section.base_begin_date_time + travel_time
+        # base duration impacts the base arrival and departure datetime
+        if represents_start_fallback:
+            section.base_begin_date_time = section.begin_date_time + (travel_time - base_duration)
+            section.base_end_date_time = section.end_date_time
+        else:
+            section.base_begin_date_time = section.begin_date_time
+            section.base_end_date_time = section.end_date_time - (travel_time - base_duration)
 
         section.id = 'section_0'
         section.length = length

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -280,15 +280,8 @@ class Here(AbstractStreetNetworkService):
             direct_path_type == StreetNetworkPathType.BEGINNING_FALLBACK
             or direct_path_type == StreetNetworkPathType.DIRECT
         ):
-            print('LOVA ', direct_path_type)
-            print('LOVA begin ', section.begin_date_time)
-            print('LOVA end ', section.end_date_time)
             section.base_begin_date_time = section.begin_date_time + (travel_time - base_duration)
             section.base_end_date_time = section.end_date_time
-            print('LOVA base begin ', section.base_begin_date_time)
-            print('LOVA base end ', section.base_end_date_time)
-            print('LOVA ', travel_time)
-            print('LOVA ', base_duration)
         else:
             section.base_begin_date_time = section.begin_date_time
             section.base_end_date_time = section.end_date_time - (travel_time - base_duration)

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -36,7 +36,7 @@ from mock import MagicMock
 from jormungandr.exceptions import TechnicalError
 from jormungandr.street_network.here import Here
 from jormungandr.street_network.tests.streetnetwork_test_utils import make_pt_object
-from jormungandr.utils import PeriodExtremity, str_to_time_stamp
+from jormungandr.utils import PeriodExtremity, str_to_time_stamp, timestamp_to_str
 from navitiacommon import type_pb2, response_pb2
 
 
@@ -297,6 +297,8 @@ def here_basic_routing_test(valid_here_routing_response):
     assert section.origin == origin
     assert section.begin_date_time == str_to_time_stamp('20161010T152000')
     assert section.end_date_time == section.begin_date_time + section.duration
+    assert section.base_begin_date_time == str_to_time_stamp('20161010T152204')
+    assert section.base_end_date_time == section.begin_date_time + section.duration
     # dynamic_speed
     dynamic_speeds = section.street_network.dynamic_speeds
     assert len(dynamic_speeds) == 6

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -36,7 +36,7 @@ from mock import MagicMock
 from jormungandr.exceptions import TechnicalError
 from jormungandr.street_network.here import Here
 from jormungandr.street_network.tests.streetnetwork_test_utils import make_pt_object
-from jormungandr.utils import PeriodExtremity, str_to_time_stamp, timestamp_to_str
+from jormungandr.utils import PeriodExtremity, str_to_time_stamp
 from navitiacommon import type_pb2, response_pb2
 
 

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -315,7 +315,7 @@ def here_basic_routing_test(valid_here_routing_response):
     assert last_ds.traffic_speed == 13
     assert last_ds.geojson_offset == 769
 
-    # for a direct path
+    # for a direct path and clockiwe == True
     response = Here._read_response(
         response=valid_here_routing_response,
         mode='walking',
@@ -336,7 +336,7 @@ def here_basic_routing_test(valid_here_routing_response):
     assert section.base_end_date_time == section.begin_date_time + section.duration
 
     # for a ending fallback
-    fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), False)
+    fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), True)
     response = Here._read_response(
         response=valid_here_routing_response,
         mode='walking',
@@ -354,6 +354,48 @@ def here_basic_routing_test(valid_here_routing_response):
     assert section.end_date_time == str_to_time_stamp('20161010T152000')
     assert section.base_begin_date_time == str_to_time_stamp('20161010T152000') - section.duration
     assert section.base_end_date_time == section.end_date_time - (1468 - 1344)
+
+    # for a direct path and clockiwe == False
+    fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), False)
+    response = Here._read_response(
+        response=valid_here_routing_response,
+        mode='walking',
+        origin=origin,
+        destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20161010T152000')},
+        direct_path_type=StreetNetworkPathType.DIRECT,
+    )
+    assert response.status_code == 200
+    assert response.response_type == response_pb2.ITINERARY_FOUND
+    assert len(response.journeys) == 1
+    assert len(response.journeys[0].sections) == 1
+    section = response.journeys[0].sections[0]
+    assert section.end_date_time == str_to_time_stamp('20161010T152000')
+    assert section.begin_date_time == section.end_date_time - section.duration
+    assert section.base_end_date_time == section.end_date_time
+    assert section.base_begin_date_time == section.base_end_date_time - section.duration + (1468 - 1344)
+
+    # for a beginning fallback and clockiwe == False
+    fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), False)
+    response = Here._read_response(
+        response=valid_here_routing_response,
+        mode='walking',
+        origin=origin,
+        destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20161010T152000')},
+        direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK,
+    )
+    assert response.status_code == 200
+    assert response.response_type == response_pb2.ITINERARY_FOUND
+    assert len(response.journeys) == 1
+    assert len(response.journeys[0].sections) == 1
+    section = response.journeys[0].sections[0]
+    assert section.end_date_time == str_to_time_stamp('20161010T152000')
+    assert section.begin_date_time == section.end_date_time - section.duration
+    assert section.base_end_date_time == section.end_date_time
+    assert section.base_begin_date_time == section.base_end_date_time - section.duration + (1468 - 1344)
 
 
 def status_test():

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -36,6 +36,7 @@ from mock import MagicMock
 from jormungandr.exceptions import TechnicalError
 from jormungandr.street_network.here import Here
 from jormungandr.street_network.tests.streetnetwork_test_utils import make_pt_object
+from jormungandr.street_network.street_network import StreetNetworkPathType
 from jormungandr.utils import PeriodExtremity, str_to_time_stamp
 from navitiacommon import type_pb2, response_pb2
 
@@ -283,6 +284,7 @@ def here_basic_routing_test(valid_here_routing_response):
         destination=destination,
         fallback_extremity=fallback_extremity,
         request={'datetime': str_to_time_stamp('20170621T174600')},
+        direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK,
     )
     assert response.status_code == 200
     assert response.response_type == response_pb2.ITINERARY_FOUND

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -276,6 +276,8 @@ def test_matrix_timeout():
 def here_basic_routing_test(valid_here_routing_response):
     origin = make_pt_object(type_pb2.POI, 2.439938, 48.572841)
     destination = make_pt_object(type_pb2.STOP_AREA, 2.440548, 48.57307)
+
+    # for a beginning fallback
     fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), True)
     response = Here._read_response(
         response=valid_here_routing_response,
@@ -283,7 +285,7 @@ def here_basic_routing_test(valid_here_routing_response):
         origin=origin,
         destination=destination,
         fallback_extremity=fallback_extremity,
-        request={'datetime': str_to_time_stamp('20170621T174600')},
+        request={'datetime': str_to_time_stamp('20161010T152000')},
         direct_path_type=StreetNetworkPathType.BEGINNING_FALLBACK,
     )
     assert response.status_code == 200
@@ -299,7 +301,7 @@ def here_basic_routing_test(valid_here_routing_response):
     assert section.origin == origin
     assert section.begin_date_time == str_to_time_stamp('20161010T152000')
     assert section.end_date_time == section.begin_date_time + section.duration
-    assert section.base_begin_date_time == str_to_time_stamp('20161010T152204')
+    assert section.base_begin_date_time == str_to_time_stamp('20161010T152000') + (1468 - 1344)
     assert section.base_end_date_time == section.begin_date_time + section.duration
     # dynamic_speed
     dynamic_speeds = section.street_network.dynamic_speeds
@@ -312,6 +314,46 @@ def here_basic_routing_test(valid_here_routing_response):
     assert last_ds.base_speed == 13
     assert last_ds.traffic_speed == 13
     assert last_ds.geojson_offset == 769
+
+    # for a direct path
+    response = Here._read_response(
+        response=valid_here_routing_response,
+        mode='walking',
+        origin=origin,
+        destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20161010T152000')},
+        direct_path_type=StreetNetworkPathType.DIRECT,
+    )
+    assert response.status_code == 200
+    assert response.response_type == response_pb2.ITINERARY_FOUND
+    assert len(response.journeys) == 1
+    assert len(response.journeys[0].sections) == 1
+    section = response.journeys[0].sections[0]
+    assert section.begin_date_time == str_to_time_stamp('20161010T152000')
+    assert section.end_date_time == section.begin_date_time + section.duration
+    assert section.base_begin_date_time == str_to_time_stamp('20161010T152000') + (1468 - 1344)
+    assert section.base_end_date_time == section.begin_date_time + section.duration
+
+    # for a ending fallback
+    fallback_extremity = PeriodExtremity(str_to_time_stamp('20161010T152000'), False)
+    response = Here._read_response(
+        response=valid_here_routing_response,
+        mode='walking',
+        origin=origin,
+        destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20161010T152000')},
+        direct_path_type=StreetNetworkPathType.ENDING_FALLBACK,
+    )
+    assert response.status_code == 200
+    assert response.response_type == response_pb2.ITINERARY_FOUND
+    assert len(response.journeys) == 1
+    section = response.journeys[0].sections[0]
+    assert section.begin_date_time == str_to_time_stamp('20161010T152000') - section.duration
+    assert section.end_date_time == str_to_time_stamp('20161010T152000')
+    assert section.base_begin_date_time == str_to_time_stamp('20161010T152000') - section.duration
+    assert section.base_end_date_time == section.end_date_time - (1468 - 1344)
 
 
 def status_test():


### PR DESCRIPTION
### targets :dart: 

- Add the base date time feature with Here connector
- Fix the bug on base date time drift (I think it was an oblivion)
- clockwise is OKAY (departure/arrival)

Now the response is like this :

![base_date](https://user-images.githubusercontent.com/32099204/158619785-522825e4-198e-474c-87f2-50850b76e649.png)

This is the first section.
for a duration - base duration = 7 min 23 secs. So, we can start the journey 7 min 23 secs later for a _"Base Journey"_