### PR TITLE
Robust tag

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -753,18 +753,17 @@ robust_fallback_modes = [response_pb2.Bike, response_pb2.Walking]
 #  - all public transport sections use robust physical modes
 #  - start and end fallbacks use robust fallback mode
 def is_robust_journey(journey):
-    found_a_robust_mode = False
-    found_a_non_robust_fallback = False
+    found_a_pt_section_with_robust_mode = False
     for section in journey.sections:
 
-        # check if this section uses a non robust fallback mode
+        # if this section uses a non robust fallback mode
+        # the journey is not robust
         if section.HasField("street_network"):
             street_network = section.street_network
             if street_network.HasField("mode"):
                 mode = street_network.mode
                 if mode not in robust_fallback_modes:
-                    found_a_non_robust_fallback = True
-                    break
+                    return False
 
         if section.type != response_pb2.PUBLIC_TRANSPORT:
             continue
@@ -777,7 +776,7 @@ def is_robust_journey(journey):
             found_a_robust_mode = True
         else:
             return False
-    return found_a_robust_mode and not found_a_non_robust_fallback
+    return found_a_pt_section_with_robust_mode
 
 
 def type_journeys(resp, req):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -773,7 +773,7 @@ def is_robust_journey(journey):
         if not uris.HasField("physical_mode"):
             continue
         if uris.physical_mode in robust_physical_modes:
-            found_a_robust_mode = True
+            found_a_pt_section_with_robust_mode = True
         else:
             return False
     return found_a_pt_section_with_robust_mode

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -739,8 +739,17 @@ def tag_robust_journeys(responses):
                 j.tags.append("robust")
 
 
-robust_physical_modes = ["physical_mode:RapidTransit", "physical_mode:Metro"]
-# returns true if a journey uses only robust physical modes
+robust_physical_modes = [
+    "physical_mode:RapidTransit",
+    "physical_mode:Metro",
+    "physical_mode:Train",
+    "physical_mode:RailShuttle",
+    "physical_mode:LocalTrain",
+    "physical_mode:LongDistanceTrain",
+]
+# returns true if :
+#  - a journey has at least one public transport section
+#   - all public transport sections use robust physical modes
 def is_robust_journey(journey):
     found_a_robust_mode = False
     for section in journey.sections:
@@ -751,7 +760,10 @@ def is_robust_journey(journey):
         uris = section.uris
         if not uris.HasField("physical_mode"):
             continue
+        print(uris.physical_mode)
+        print(uris.physical_mode in robust_physical_modes)
         if uris.physical_mode in robust_physical_modes:
+            print("coucou")
             found_a_robust_mode = True
         else:
             return False

--- a/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
@@ -28,6 +28,7 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 from jormungandr.scenarios import qualifier
+from jormungandr.scenarios.new_default import is_robust_journey
 import navitiacommon.response_pb2 as response_pb2
 from jormungandr.utils import str_to_time_stamp
 from six.moves import range
@@ -242,3 +243,29 @@ def qualifier_nontransport_duration_with_tc_test():
     journey.sections[-1].duration = 864
 
     assert qualifier.get_nontransport_duration(journey) == 2797
+
+
+def tag_robust_journey_test():
+    journey = response_pb2.Journey()
+    assert is_robust_journey(journey) == False
+
+    journey.sections.add()
+    journey.sections[0].type = response_pb2.PUBLIC_TRANSPORT
+    journey.sections[0].uris.physical_mode = "physical_mode:Bus"
+
+    assert is_robust_journey(journey) == False
+
+    journey.sections[0].uris.physical_mode = "physical_mode:Train"
+    print("{}".format(journey))
+
+    assert is_robust_journey(journey) == True
+
+    journey.sections.add()
+    journey.sections[1].type = response_pb2.PUBLIC_TRANSPORT
+    journey.sections[1].uris.physical_mode = "physical_mode:Bus"
+
+    assert is_robust_journey(journey) == False
+
+    journey.sections[1].uris.physical_mode = "physical_mode:Train"
+
+    assert is_robust_journey(journey) == True

--- a/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
@@ -245,7 +245,7 @@ def qualifier_nontransport_duration_with_tc_test():
     assert qualifier.get_nontransport_duration(journey) == 2797
 
 
-def tag_robust_journey_test():
+def robust_journey_test():
     journey = response_pb2.Journey()
     assert is_robust_journey(journey) == False
 
@@ -256,7 +256,6 @@ def tag_robust_journey_test():
     assert is_robust_journey(journey) == False
 
     journey.sections[0].uris.physical_mode = "physical_mode:Train"
-    print("{}".format(journey))
 
     assert is_robust_journey(journey) == True
 
@@ -267,5 +266,34 @@ def tag_robust_journey_test():
     assert is_robust_journey(journey) == False
 
     journey.sections[1].uris.physical_mode = "physical_mode:Train"
+    assert is_robust_journey(journey) == True
+
+
+def robust_journey_with_fallbacks_test():
+    journey = response_pb2.Journey()
+    assert is_robust_journey(journey) == False
+
+    journey.sections.add()
+    journey.sections[0].street_network.mode = response_pb2.Bike
+
+    # no public transport in the journey, so it should not be tagged as robust
+    assert is_robust_journey(journey) == False
+
+    journey.sections.add()
+    journey.sections[1].type = response_pb2.PUBLIC_TRANSPORT
+    journey.sections[1].uris.physical_mode = "physical_mode:Bus"
+
+    assert is_robust_journey(journey) == False
+
+    journey.sections[1].uris.physical_mode = "physical_mode:Train"
+
+    assert is_robust_journey(journey) == True
+
+    journey.sections.add()
+    journey.sections[2].street_network.mode = response_pb2.Car
+
+    assert is_robust_journey(journey) == False
+
+    journey.sections[2].street_network.mode = response_pb2.Walking
 
     assert is_robust_journey(journey) == True

--- a/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
@@ -297,3 +297,7 @@ def robust_journey_with_fallbacks_test():
     journey.sections[2].street_network.mode = response_pb2.Walking
 
     assert is_robust_journey(journey) == True
+
+    journey.sections[0].street_network.mode = response_pb2.Car
+
+    assert is_robust_journey(journey) == False


### PR DESCRIPTION
Tag a journey as "robust" if all the following are true : 
  - fallbacks are either absent, walk or bike
  - the journey has at least one public transport section
  - all public transport sections use a robust physical mode 

robust physical modes are :
```
    "physical_mode:RapidTransit",
    "physical_mode:Metro",
    "physical_mode:Train",
    "physical_mode:RailShuttle",
    "physical_mode:LocalTrain",
    "physical_mode:LongDistanceTrain",
```

