### PR TITLE
[Distributed] feat: collage from_coord and to_coord to geojson

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -96,7 +96,7 @@ class StreetNetworkPath:
                 logging.getLogger(__name__).exception('')
                 return None
 
-    def _replace_first_and_last_coord(self, dp):
+    def _add_first_and_last_coord(self, dp):
         if not dp or not dp.journeys or not dp.journeys[0].sections:
             return
 
@@ -132,7 +132,7 @@ class StreetNetworkPath:
 
         dp = self._direct_path_with_fp(self._streetnetwork_service)
 
-        self._replace_first_and_last_coord(dp)
+        self._add_first_and_last_coord(dp)
 
         if getattr(dp, "journeys", None):
             dp.journeys[0].internal_id = str(utils.generate_id())

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -104,7 +104,7 @@ class StreetNetworkPath:
         if len(dp_coords) < 2:
             return
 
-        # we are insert the coord of the origin at the beginning of the geojson
+        # we are inserting the coord of the origin at the beginning of the geojson
         coord = utils.get_pt_object_coord(self._orig_obj)
         if coord != dp_coords[0]:
             dp_coords.add(lon=coord.lon, lat=coord.lat)
@@ -116,7 +116,7 @@ class StreetNetworkPath:
                 dp_coords[i].CopyFrom(dp_coords[-1])
                 dp_coords[-1].CopyFrom(tmp)
 
-        # we are append the coord of the destination at the end of the geojson
+        # we are appending the coord of the destination at the end of the geojson
         coord = utils.get_pt_object_coord(self._dest_obj)
         if coord != dp_coords[-1]:
             dp_coords.add(lon=coord.lon, lat=coord.lat)

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -31,6 +31,7 @@ from jormungandr import utils, new_relic
 from jormungandr.street_network.street_network import StreetNetworkPathType
 import logging
 from .helper_utils import timed_logger
+from navitiacommon import type_pb2
 
 
 class StreetNetworkPath:
@@ -95,6 +96,31 @@ class StreetNetworkPath:
                 logging.getLogger(__name__).exception('')
                 return None
 
+    def _replace_first_and_last_coord(self, dp):
+        if not dp or not dp.journeys or not dp.journeys[0].sections:
+            return
+
+        dp_coords = dp.journeys[0].sections[0].street_network.coordinates
+        if len(dp_coords) < 2:
+            return
+
+        # we are insert the coord of the origin at the beginning of the geojson
+        coord = utils.get_pt_object_coord(self._orig_obj)
+        if coord != dp_coords[0]:
+            dp_coords.add(lon=coord.lon, lat=coord.lat)
+            # we cannot insert an element at the beginning of a list :(
+            # a little algo to move the last element to the beginning
+            tmp = type_pb2.GeographicalCoord()
+            for i in range(len(dp_coords)):
+                tmp.CopyFrom(dp_coords[i])
+                dp_coords[i].CopyFrom(dp_coords[-1])
+                dp_coords[-1].CopyFrom(tmp)
+
+        # we are append the coord of the destination at the end of the geojson
+        coord = utils.get_pt_object_coord(self._dest_obj)
+        if coord != dp_coords[-1]:
+            dp_coords.add(lon=coord.lon, lat=coord.lat)
+
     def _do_request(self):
         self._logger.debug(
             "requesting %s direct path from %s to %s by %s",
@@ -105,6 +131,8 @@ class StreetNetworkPath:
         )
 
         dp = self._direct_path_with_fp(self._streetnetwork_service)
+
+        self._replace_first_and_last_coord(dp)
 
         if getattr(dp, "journeys", None):
             dp.journeys[0].internal_id = str(utils.generate_id())

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -480,6 +480,27 @@ class TestJourneysDistributed(
         path_sum = sum(p['duration'] for p in pt_journey['sections'][2]['path'])
         assert pt_journey['sections'][2]['duration'] == pytest.approx(path_sum, 1.0)
 
+    def test_last_and_first_coord_in_geojson(self):
+        """
+        Test when departure/arrival fallback modes are different
+        """
+        query = journey_basic_query + "&first_section_mode[]=walking"
+        response = self.query_region(query)
+        check_best(response)
+        jrnys = response['journeys']
+        pt_journey = next((j for j in jrnys if 'non_pt' not in j['tags']), None)
+        assert pt_journey
+        from_coord = pt_journey['sections'][0]['from']['address']['coord']
+        to_coord = pt_journey['sections'][0]['to']['stop_point']['coord']
+
+        coords = pt_journey['sections'][0]['geojson']['coordinates']
+
+        assert coords[0][0] == pytest.approx(float(from_coord['lon']), 0.1e-5)
+        assert coords[0][1] == pytest.approx(float(from_coord['lat']), 0.1e-5)
+
+        assert coords[-1][0] == pytest.approx(float(to_coord['lon']), 0.1e-5)
+        assert coords[-1][1] == pytest.approx(float(to_coord['lat']), 0.1e-5)
+
 
 @config({"scenario": "distributed"})
 class TestDistributedJourneysWithPtref(JourneysWithPtref, NewDefaultScenarioAbstractTestFixture):


### PR DESCRIPTION
In this PR, the coordinates of `from` and `to` are add to the beginning and the end of the geojson when computing fallback and direct_path. So users can identify `from` and `to` in geojson more easily, plus it makes the geojson smoother when displaying

before:
![image](https://user-images.githubusercontent.com/6093486/159466471-f22dc491-d759-4115-808c-a2df9ae1e6cc.png)

after:
![image](https://user-images.githubusercontent.com/6093486/159466288-37d4599b-7163-4924-a767-3403b5203aa8.png)
