### PR TITLE
A disrupted journey is not "reliable"

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -755,8 +755,6 @@ reliable_fallback_modes = [response_pb2.Bike, response_pb2.Walking]
 #  - there is no disruptions linked to the journey
 def is_reliable_journey(journey):
     found_a_pt_section_with_reliable_mode = False
-    logger = logging.getLogger(__name__)
-    logger.info("{}".format(journey))
 
     # if there is a disruption linked to this journey
     # then the field most_serious_disruption_effect should be

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -752,8 +752,18 @@ reliable_fallback_modes = [response_pb2.Bike, response_pb2.Walking]
 #  - a journey has at least one public transport section
 #  - all public transport sections use reliable physical modes
 #  - start and end fallbacks use reliable fallback mode
+#  - there is no disruptions linked to the journey
 def is_reliable_journey(journey):
     found_a_pt_section_with_reliable_mode = False
+    logger = logging.getLogger(__name__)
+    logger.info("{}".format(journey))
+
+    # if there is a disruption linked to this journey
+    # then the field most_serious_disruption_effect should be
+    # filled by kraken
+    if journey.HasField("most_serious_disruption_effect"):
+        return False
+
     for section in journey.sections:
 
         # if this section uses a non reliable fallback mode

--- a/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/qualifier_tests.py
@@ -268,6 +268,10 @@ def reliable_journey_test():
     journey.sections[1].uris.physical_mode = "physical_mode:Train"
     assert is_reliable_journey(journey) == True
 
+    journey.most_serious_disruption_effect = "SIGNIFICANT_DELAYS"
+
+    assert is_reliable_journey(journey) == False
+
 
 def reliable_journey_with_fallbacks_test():
     journey = response_pb2.Journey()


### PR DESCRIPTION
Do not put the tag "reliable" on a journey that have a linked disruption.
To determine if a journey has a linked disruption, jormun looks at the "most_serious_disruption_effect" field of kraken's response.
This field is set by kraken only if a disruption impacts the journey.