### PR TITLE
[Here] fix: dynamic speed has to be float

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py
@@ -229,8 +229,8 @@ class ElevationSerializer(PbNestedSerializer):
 
 
 class DynamicSpeedSerializer(PbNestedSerializer):
-    base_speed = jsonschema.MethodField(schema_type=int, display_none=False)
-    traffic_speed = jsonschema.MethodField(schema_type=int, display_none=False)
+    base_speed = jsonschema.MethodField(schema_type=float, display_none=False)
+    traffic_speed = jsonschema.MethodField(schema_type=float, display_none=False)
     geojson_offset = jsonschema.MethodField(schema_type=int, display_none=False)
 
     def get_base_speed(self, obj):

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -331,8 +331,8 @@ class Here(AbstractStreetNetworkService):
             dynamic_speed = section.street_network.dynamic_speeds.add()
             dynamic_speed.geojson_offset = span.get('offset', 0)
             dynamic_speed_info = span.get('dynamicSpeedInfo', {})
-            dynamic_speed.base_speed = int(dynamic_speed_info.get('baseSpeed', 0))
-            dynamic_speed.traffic_speed = int(dynamic_speed_info.get('trafficSpeed', 0))
+            dynamic_speed.base_speed = round(float(dynamic_speed_info.get('baseSpeed', 0)), 2)
+            dynamic_speed.traffic_speed = round(float(dynamic_speed_info.get('trafficSpeed', 0)), 2)
 
         # instruction
         for idx, maneuver in enumerate(here_section.get('actions', [])):

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -307,12 +307,12 @@ def here_basic_routing_test(valid_here_routing_response):
     dynamic_speeds = section.street_network.dynamic_speeds
     assert len(dynamic_speeds) == 6
     first_ds = dynamic_speeds[0]
-    assert first_ds.base_speed == 13
-    assert first_ds.traffic_speed == 11
+    assert round(first_ds.base_speed, 2) == 13.89
+    assert round(first_ds.traffic_speed, 2) == 11.94
     assert first_ds.geojson_offset == 0
     last_ds = dynamic_speeds[5]
-    assert last_ds.base_speed == 13
-    assert last_ds.traffic_speed == 13
+    assert round(last_ds.base_speed, 2) == 13.89
+    assert round(last_ds.traffic_speed, 2) == 13.89
     assert last_ds.geojson_offset == 769
 
     # for a direct path and clockiwe == True


### PR DESCRIPTION
I thought the speed was in **km/h**. Huge mistake, because in fact this is in **m/s**

ref: NAV-984