### PR TITLE
[Distributed] feat: ability to use loki as crowfly service

### DIFF
--- a/source/jormungandr/jormungandr/pt_planners/kraken.py
+++ b/source/jormungandr/jormungandr/pt_planners/kraken.py
@@ -28,9 +28,11 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 
-from jormungandr.pt_planners.common import ZmqSocket
+from jormungandr.pt_planners.common import ZmqSocket, get_crow_fly
 from jormungandr import utils, app
 from .pt_planner import AbstractPtPlanner
+from navitiacommon import type_pb2, request_pb2
+import logging
 
 
 class Kraken(ZmqSocket, AbstractPtPlanner):
@@ -56,3 +58,34 @@ class Kraken(ZmqSocket, AbstractPtPlanner):
             origins, destinations, datetime, clockwise, graphical_isochrones_parameters, bike_in_pt
         )
         return self.send_and_receive(req)
+
+    def get_crow_fly(
+        self,
+        origin,
+        streetnetwork_mode,
+        max_duration,
+        max_nb_crowfly,
+        object_type=type_pb2.STOP_POINT,
+        filter=None,
+        stop_points_nearby_duration=300,
+        request_id=None,
+        depth=2,
+        forbidden_uris=[],
+        allowed_id=[],
+        **kwargs
+    ):
+        return get_crow_fly(
+            self,
+            origin,
+            streetnetwork_mode,
+            max_duration,
+            max_nb_crowfly,
+            object_type,
+            filter,
+            stop_points_nearby_duration,
+            request_id,
+            depth,
+            forbidden_uris,
+            allowed_id,
+            **kwargs
+        )

--- a/source/jormungandr/jormungandr/pt_planners/loki.py
+++ b/source/jormungandr/jormungandr/pt_planners/loki.py
@@ -34,6 +34,10 @@ from .pt_planner import AbstractPtPlanner
 from navitiacommon import type_pb2
 
 
+class PlannerLokiException(Exception):
+    pass
+
+
 class Loki(ZmqSocket, AbstractPtPlanner):
     def __init__(
         self,
@@ -76,6 +80,12 @@ class Loki(ZmqSocket, AbstractPtPlanner):
         allowed_id=[],
         **kwargs
     ):
+        if object_type != type_pb2.STOP_POINT:
+            raise PlannerLokiException('Loki can only handle requests with object_type=type_pb2.STOP_POINT')
+
+        if filter is not None:
+            raise PlannerLokiException('Loki can only handle requests with filter that is not empty')
+
         return get_crow_fly(
             self,
             origin,

--- a/source/jormungandr/jormungandr/pt_planners/loki.py
+++ b/source/jormungandr/jormungandr/pt_planners/loki.py
@@ -28,9 +28,10 @@
 # www.navitia.io
 from __future__ import absolute_import, print_function, unicode_literals, division
 
-from jormungandr.pt_planners.common import ZmqSocket
+from jormungandr.pt_planners.common import ZmqSocket, get_crow_fly
 from jormungandr import utils, app
 from .pt_planner import AbstractPtPlanner
+from navitiacommon import type_pb2
 
 
 class Loki(ZmqSocket, AbstractPtPlanner):
@@ -59,3 +60,34 @@ class Loki(ZmqSocket, AbstractPtPlanner):
         self, origins, destinations, datetime, clockwise, graphical_isochrones_parameters, bike_in_pt
     ):
         raise NotImplementedError("Too bad, you cannot ask loki for graphical isochrones :)")
+
+    def get_crow_fly(
+        self,
+        origin,
+        streetnetwork_mode,
+        max_duration,
+        max_nb_crowfly,
+        object_type=type_pb2.STOP_POINT,
+        filter=None,
+        stop_points_nearby_duration=300,
+        request_id=None,
+        depth=2,
+        forbidden_uris=[],
+        allowed_id=[],
+        **kwargs
+    ):
+        return get_crow_fly(
+            self,
+            origin,
+            streetnetwork_mode,
+            max_duration,
+            max_nb_crowfly,
+            object_type,
+            filter,
+            stop_points_nearby_duration,
+            request_id,
+            depth,
+            forbidden_uris,
+            allowed_id,
+            **kwargs
+        )

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
@@ -71,12 +71,13 @@ class ProximitiesByCrowfly:
         self._depth = depth
         self._forbidden_uris = utils.get_poi_params(request['forbidden_uris[]'])
         self._allowed_id = utils.get_poi_params(request['allowed_id[]'])
+        self._pt_planner = self._instance.get_pt_planner(request['_pt_planner'])
         self._async_request()
 
     @new_relic.distributedEvent("get_crowfly", "street_network")
     def _get_crow_fly(self):
         with timed_logger(self._logger, 'get_crow_fly_calling_external_service', self._request_id):
-            return self._instance.georef.get_crow_fly(
+            return self._pt_planner.get_crow_fly(
                 utils.get_uri_pt_object(self._requested_place_obj),
                 self._mode,
                 self._max_duration,


### PR DESCRIPTION
`get_crowfly` in distributed is based on `kraken` exclusively. With the PR, `get_crowfly` can be switched to `loki`. 

Note that, `get_crowfly` based on `loki` can only do `stop_points`(with `access_points` which depends on the params).