### PR TITLE
[CI] Cache CI optimization

### DIFF
--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -39,6 +39,7 @@ jobs:
       with:
         key: ${{matrix.distribution}}-package
         max-size: 2000M
+        save: ${{ github.event_name == 'push' }}
     - name: dkpg-buildpackage
       run: |
         sed -i 's,git\@github.com:\([^/]*\)/\(.*\).git,https://github.com/\1/\2,' .gitmodules

--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -35,7 +35,7 @@ jobs:
     - name: install zip dependency
       run: apt update && apt install -y zip httpie dh-python
     - name: Restore ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ${{matrix.distribution}}-package
         max-size: 2000M

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -61,6 +61,7 @@ jobs:
       with:
         key: ${{matrix.os.docker_image}}-ci
         max-size: 2000M
+        save: ${{ github.event_name == 'push' }}
     - name: configure for Release
       run: mkdir build && cd ./build && cmake -DSTRIP_SYMBOLS=ON ../source
     - name: run

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -57,7 +57,7 @@ jobs:
       with:
           submodules: 'recursive'
     - name: Restore ccache
-      uses: hendrikmuhs/ccache-action@v1
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ${{matrix.os.docker_image}}-ci
         max-size: 2000M


### PR DESCRIPTION
Github action provides only 10Gb of cache per repo 
So in order to avoid frequent cache eviction on dev branch : 
- We save build cache only  when a PR is pushed on dev branch. 
- For all opened PR we retrieve the cache stored on dev branch but, the updated cache (eg after build step) will not be saved 