### PR TITLE
Added 'only_with_alternatives' parameter to direct_path (bike)

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -433,7 +433,7 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         )
         parser_get.add_argument(
             "direct_path",
-            type=OptionValue(['indifferent', 'only', 'none']),
+            type=OptionValue(['indifferent', 'only', 'none', 'only_with_alternatives']),
             default='indifferent',
             help="Specify if direct path should be suggested",
         )

--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -103,17 +103,23 @@ class Distributed(object):
         logger.debug("request_id : {}".format(request_id))
 
         requested_dep_modes_with_pt = {
-            mode for mode, _, direct_path_type in krakens_call if direct_path_type != "only"
+            mode
+            for mode, _, direct_path_type in krakens_call
+            if direct_path_type not in ("only", "only_with_alternatives")
         }
         requested_arr_modes_with_pt = {
-            mode for _, mode, direct_path_type in krakens_call if direct_path_type != "only"
+            mode
+            for _, mode, direct_path_type in krakens_call
+            if direct_path_type not in ("only", "only_with_alternatives")
         }
 
         # These are the modes in first_section_modes[] and direct_path_modes[]
         # We need to compute direct_paths for them either because we requested it with direct_path_modes[]
         # Or because we need them to optimize the pt_journey computation
         requested_direct_path_modes = {
-            mode for mode, _, direct_path_type in krakens_call if direct_path_type == "only"
+            mode
+            for mode, _, direct_path_type in krakens_call
+            if direct_path_type in ("only", "only_with_alternatives")
         }
         requested_direct_path_modes.update(requested_dep_modes_with_pt)
 
@@ -155,7 +161,10 @@ class Distributed(object):
 
             # if public transport is not requested, there is no need to continue,
             # we return all direct path without pt
-            if request['max_duration'] == 0 or request.get('direct_path', "") == "only":
+            if request['max_duration'] == 0 or request.get('direct_path', "") in (
+                "only",
+                "only_with_alternatives",
+            ):
                 res = [
                     context.streetnetwork_path_pool.wait_and_get(
                         requested_orig_obj=context.requested_orig_obj,

--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -87,6 +87,10 @@ class Distributed(object):
             for pt_j in e.pt_journeys.journeys
         }
 
+    @staticmethod
+    def is_type_only(direct_path_type):
+        return direct_path_type in ("only", "only_with_alternatives")
+
     def _compute_journeys(self, future_manager, request, instance, krakens_call, context, request_type):
         """
         For all krakens_call, call the kraken and aggregate the responses
@@ -103,23 +107,17 @@ class Distributed(object):
         logger.debug("request_id : {}".format(request_id))
 
         requested_dep_modes_with_pt = {
-            mode
-            for mode, _, direct_path_type in krakens_call
-            if direct_path_type not in ("only", "only_with_alternatives")
+            mode for mode, _, direct_path_type in krakens_call if not self.is_type_only(direct_path_type)
         }
         requested_arr_modes_with_pt = {
-            mode
-            for _, mode, direct_path_type in krakens_call
-            if direct_path_type not in ("only", "only_with_alternatives")
+            mode for _, mode, direct_path_type in krakens_call if not self.is_type_only(direct_path_type)
         }
 
         # These are the modes in first_section_modes[] and direct_path_modes[]
         # We need to compute direct_paths for them either because we requested it with direct_path_modes[]
         # Or because we need them to optimize the pt_journey computation
         requested_direct_path_modes = {
-            mode
-            for mode, _, direct_path_type in krakens_call
-            if direct_path_type in ("only", "only_with_alternatives")
+            mode for mode, _, direct_path_type in krakens_call if self.is_type_only(direct_path_type)
         }
         requested_direct_path_modes.update(requested_dep_modes_with_pt)
 

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -337,6 +337,8 @@ class FilterDirectPath(SingleJourneyFilter):
             return False
         elif self.dp == 'only' and 'non_pt' not in journey.tags:
             return False
+        elif self.dp == 'only_with_alternatives' and 'non_pt' not in journey.tags:
+            return False
         return True
 
 

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -335,9 +335,7 @@ class FilterDirectPath(SingleJourneyFilter):
         """
         if self.dp == 'none' and 'non_pt' in journey.tags:
             return False
-        elif self.dp == 'only' and 'non_pt' not in journey.tags:
-            return False
-        elif self.dp == 'only_with_alternatives' and 'non_pt' not in journey.tags:
+        elif self.dp in ('only', 'only_with_alternatives') and 'non_pt' not in journey.tags:
             return False
         return True
 

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -331,7 +331,7 @@ class FilterDirectPath(SingleJourneyFilter):
 
     def filter_func(self, journey):
         """
-        eliminates journeys that are not matching direct path parameter (none, only or indifferent)
+        eliminates journeys that are not matching direct path parameter (none, only, only_with_alternatives or indifferent)
         """
         if self.dp == 'none' and 'non_pt' in journey.tags:
             return False
@@ -462,7 +462,7 @@ def _crow_fly_sn_functor(_s):
 def similar_journeys_generator(journey, pt_functor, sn_functor=_sn_functor, crow_fly_functor=_sn_functor):
     def _similar_non_pt():
         for s in journey.sections:
-            yield "sn:{} type:{}".format(s.street_network.mode, s.type)
+            yield "sn:{} type:{} tags:{}".format(s.street_network.mode, s.type, journey.tags)
 
     def _similar_pt():
         for idx, s in enumerate(journey.sections):


### PR DESCRIPTION
Première PR :)
Ajout du paramètre 'only_with_alternatives' aux chemins bout-à-bout en vélo (direct_path), qui récupère les chemins depuis l'API geovelo. Celui-ci permet d'obtenir 3 itinéraires simultanément, au lien d'un seul avec le paramètre 'only'.

Ticket : https://navitia.atlassian.net/browse/NAV-1227