### PR TITLE
[ZMQ] allow more than one frame to identify client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = https://github.com/jupp0r/prometheus-cpp
 [submodule "source/third_party/flann"]
 	path = source/third_party/flann
-	url = https://github.com/mariusmuja/flann
+	url = https://github.com/flann-lib/flann

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -99,16 +99,19 @@ inline void doWork(zmq::context_t& context,
             } while (more);
         } catch (const zmq::error_t&) {
             // on gére le cas du sighup durant un recv
+            LOG4CPLUS_WARN(logger, "Zmq error occured while receiving. I'll ignore this message.");
             continue;
         }
 
         // we should obtain at least 3 frames
         if (frames.size() < 3) {
+            LOG4CPLUS_WARN(logger, "Received a zmq message with less than 3 frames. I'll ignore it.");
             continue;
         }
 
         // the penultimate frame should be empty
         if (frames[frames.size() - 2] != "") {
+            LOG4CPLUS_WARN(logger, "Received a zmq message with a non empty penultimate frame. I'll ignore it.");
             continue;
         }
 

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -65,7 +65,7 @@ static void respond(zmq::socket_t& socket,
     socket.send(reply);
 }
 
-static pbnavitia::Response create_error_response(std::string  error_message, pbnavitia::Error_error_id error_id) {
+static pbnavitia::Response create_error_response(std::string error_message, pbnavitia::Error_error_id error_id) {
     pbnavitia::Response response;
     auto* error = response.mutable_error();
     error->set_id(pbnavitia::Error::invalid_protobuf_request);
@@ -108,7 +108,8 @@ inline void doWork(zmq::context_t& context,
         } catch (const zmq::error_t&) {
             // on gére le cas du sighup durant un recv
             LOG4CPLUS_WARN(logger, "Zmq error occured while receiving. I'll ignore this message.");
-            pbnavitia::Response response = create_error_response("zmq error occured while receiving", pbnavitia::Error::internal_error);
+            pbnavitia::Response response =
+                create_error_response("zmq error occured while receiving", pbnavitia::Error::internal_error);
             respond(socket, {}, response);
             continue;
         }
@@ -116,7 +117,8 @@ inline void doWork(zmq::context_t& context,
         // we should obtain at least 3 frames
         if (frames.size() < 3) {
             LOG4CPLUS_WARN(logger, "Received a zmq message with less than 3 frames. I'll ignore it.");
-            pbnavitia::Response response = create_error_response("Received a zmq message with less than 3 frames.", pbnavitia::Error::internal_error);
+            pbnavitia::Response response = create_error_response("Received a zmq message with less than 3 frames.",
+                                                                 pbnavitia::Error::internal_error);
             respond(socket, {}, response);
             continue;
         }
@@ -124,7 +126,8 @@ inline void doWork(zmq::context_t& context,
         // the penultimate frame should be empty
         if (frames[frames.size() - 2] != "") {
             LOG4CPLUS_WARN(logger, "Received a zmq message with a non empty penultimate frame. I'll ignore it.");
-            pbnavitia::Response response = create_error_response("Received a zmq message with a non empty penultimate frame.", pbnavitia::Error::internal_error);
+            pbnavitia::Response response = create_error_response(
+                "Received a zmq message with a non empty penultimate frame.", pbnavitia::Error::internal_error);
             respond(socket, {}, response);
             continue;
         }
@@ -144,7 +147,8 @@ inline void doWork(zmq::context_t& context,
         pbnavitia::API api = pbnavitia::UNKNOWN_API;
         if (!pb_req.ParseFromArray(payload.data(), payload.size())) {
             LOG4CPLUS_WARN(logger, "receive invalid protobuf");
-            pbnavitia::Response response = create_error_response("Receive invalid protobuf.", pbnavitia::Error::invalid_protobuf_request);
+            pbnavitia::Response response =
+                create_error_response("Receive invalid protobuf.", pbnavitia::Error::invalid_protobuf_request);
             respond(socket, frames, response);
             continue;
         }

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -44,7 +44,9 @@ www.navitia.io
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/optional/optional_io.hpp>
 
-static void respond(zmq::socket_t& socket, const std::vector<std::string>& client_id, const pbnavitia::Response& response) {
+static void respond(zmq::socket_t& socket,
+                    const std::vector<std::string>& client_id,
+                    const pbnavitia::Response& response) {
     zmq::message_t reply(response.ByteSize());
     try {
         response.SerializeToArray(reply.data(), response.ByteSize());
@@ -57,8 +59,7 @@ static void respond(zmq::socket_t& socket, const std::vector<std::string>& clien
         reply.rebuild(error_response.ByteSize());
         error_response.SerializeToArray(reply.data(), error_response.ByteSize());
     }
-    for(size_t idx = 0; idx < client_id.size(); ++idx) {
-
+    for (size_t idx = 0; idx < client_id.size(); ++idx) {
         z_send(socket, client_id[idx], ZMQ_SNDMORE);
     }
     socket.send(reply);
@@ -84,11 +85,9 @@ inline void doWork(zmq::context_t& context,
 
     std::vector<std::string> frames{};
 
-            
     while (run) {
-        
         size_t more = 0;
-        size_t more_size = sizeof (more);
+        size_t more_size = sizeof(more);
         frames.clear();
         try {
             do {
@@ -104,13 +103,13 @@ inline void doWork(zmq::context_t& context,
         }
 
         // we should obtain at least 3 frames
-        if (frames.size() <3) {
+        if (frames.size() < 3) {
             continue;
         }
 
         // the penultimate frame should be empty
         if (frames[frames.size() - 2] != "") {
-            continue;   
+            continue;
         }
 
         // the payload is the last frame
@@ -122,7 +121,6 @@ inline void doWork(zmq::context_t& context,
         std::string payload = frames.back();
         frames.pop_back();
 
-        
         navitia::InFlightGuard in_flight_guard(metrics.start_in_flight());
         pbnavitia::Request pb_req;
         pt::ptime start = pt::microsec_clock::universal_time();

--- a/source/kraken/kraken_zmq.h
+++ b/source/kraken/kraken_zmq.h
@@ -68,8 +68,8 @@ static void respond(zmq::socket_t& socket,
 static pbnavitia::Response create_error_response(std::string error_message, pbnavitia::Error_error_id error_id) {
     pbnavitia::Response response;
     auto* error = response.mutable_error();
-    error->set_id(pbnavitia::Error::invalid_protobuf_request);
-    error->set_message("receive invalid protobuf");
+    error->set_id(error_id);
+    error->set_message(error_message);
     return response;
 }
 


### PR DESCRIPTION
so that kraken can be behind several layers of ROUTER sockets (and we want to do that with the gormungandr frontend)

to be merged after https://github.com/hove-io/utils/pull/109