### PR TITLE
Fixed url for geovelo CGU

### DIFF
--- a/source/jormungandr/jormungandr/street_network/geovelo.py
+++ b/source/jormungandr/jormungandr/street_network/geovelo.py
@@ -51,7 +51,7 @@ DEFAULT_GEOVELO_FEED_PUBLISHER = {
     'id': 'geovelo',
     'name': 'geovelo',
     'license': 'Private',
-    'url': 'http://about.geovelo.fr/cgu/',
+    'url': 'https://geovelo.fr/a-propos/cgu/',
 }
 
 


### PR DESCRIPTION
Fixed geovelo url for the cgu.
https://about.geovelo.fr/cgu/ -> https://geovelo.fr/a-propos/cgu/

Ticket : https://navitia.atlassian.net/browse/NAV-1251