### PR TITLE
[Jormun] add alternatives asgard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
     - id: black
       language_version: python3.8
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 3.9.2
     hooks:
     - id: flake8
       language_version: python2.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0  # Use the ref you want to point at
+    rev: v4.1.0  # Use the ref you want to point at
     hooks:
     -   id: trailing-whitespace
         exclude: ^source/tests/chaos/chaos_loading.sql # Otherwise, Sql commands get corrupted
@@ -19,7 +19,7 @@ repos:
     -   id: check-yaml
         args: [--allow-multiple-documents]
 -   repo: https://github.com/hove-io/navitia-pre-commit
-    rev: ccf8608238538007c77983a0a03e617b7afa6011
+    rev: master
     hooks:
     -   id: clang-format
         verbose: true
@@ -27,7 +27,7 @@ repos:
         files: \.(c|cc|cxx|cpp|h|hpp|hxx)$
         args: [-i]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.800
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports, --py2]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,12 +5,12 @@ repos:
     - id: black
       language_version: python3.8
 -   repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     - id: flake8
       language_version: python2.7
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0  # Use the ref you want to point at
+    rev: v4.2.0  # Use the ref you want to point at
     hooks:
     -   id: trailing-whitespace
         exclude: ^source/tests/chaos/chaos_loading.sql # Otherwise, Sql commands get corrupted
@@ -19,7 +19,7 @@ repos:
     -   id: check-yaml
         args: [--allow-multiple-documents]
 -   repo: https://github.com/hove-io/navitia-pre-commit
-    rev: master
+    rev: ccf8608238538007c77983a0a03e617b7afa6011
     hooks:
     -   id: clang-format
         verbose: true
@@ -27,7 +27,7 @@ repos:
         files: \.(c|cc|cxx|cpp|h|hpp|hxx)$
         args: [-i]
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.800
+    rev: v0.950
     hooks:
     -   id: mypy
         args: [--ignore-missing-imports, --py2]

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -122,7 +122,7 @@ BALANCED = DirectPathProfile(
     bike_use_living_streets=0.8, bike_maneuver_penalty=0, bike_use_roads=0.3, tag='balanced'
 )
 COMFORT = DirectPathProfile(
-    bike_use_living_streets=1, bike_maneuver_penalty=-10, bike_use_roads=0.2, bike_use_hills=0, tag='comfort'
+    bike_use_living_streets=1, bike_maneuver_penalty=0, bike_use_roads=0.2, bike_use_hills=0, tag='comfort'
 )
 SHORTEST = DirectPathProfile(bike_shortest=True, tag='shortest')
 

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -122,7 +122,7 @@ BALANCED = DirectPathProfile(
     bike_use_living_streets=0.8, bike_maneuver_penalty=0, bike_use_roads=0.3, tag='balanced'
 )
 COMFORT = DirectPathProfile(
-    bike_use_living_streets=1, bike_maneuver_penalty=-10, bike_use_roads=0.2, tag='comfort'
+    bike_use_living_streets=1, bike_maneuver_penalty=-10, bike_use_roads=0.2, bike_use_hills=0, tag='comfort'
 )
 SHORTEST = DirectPathProfile(bike_shortest=True, tag='shortest')
 

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -146,7 +146,12 @@ class Kraken(AbstractStreetNetworkService):
                 return response_pb2.Response()
 
         req = self._create_direct_path_request(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, direct_path_request, direct_path_type
+            mode,
+            pt_object_origin,
+            pt_object_destination,
+            fallback_extremity,
+            direct_path_request,
+            direct_path_type,
         )
 
         response = instance.send_and_receive(req, request_id=request_id)
@@ -185,7 +190,14 @@ class Kraken(AbstractStreetNetworkService):
         return mode
 
     def _create_direct_path_request(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type, language="en-US"
+        self,
+        mode,
+        pt_object_origin,
+        pt_object_destination,
+        fallback_extremity,
+        request,
+        direct_path_type,
+        language="en-US",
     ):
         return create_kraken_direct_path_request(
             self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, language

--- a/source/jormungandr/jormungandr/street_network/kraken.py
+++ b/source/jormungandr/jormungandr/street_network/kraken.py
@@ -146,7 +146,7 @@ class Kraken(AbstractStreetNetworkService):
                 return response_pb2.Response()
 
         req = self._create_direct_path_request(
-            mode, pt_object_origin, pt_object_destination, fallback_extremity, direct_path_request
+            mode, pt_object_origin, pt_object_destination, fallback_extremity, direct_path_request, direct_path_type
         )
 
         response = instance.send_and_receive(req, request_id=request_id)
@@ -185,7 +185,7 @@ class Kraken(AbstractStreetNetworkService):
         return mode
 
     def _create_direct_path_request(
-        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, language="en-US"
+        self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, direct_path_type, language="en-US"
     ):
         return create_kraken_direct_path_request(
             self, mode, pt_object_origin, pt_object_destination, fallback_extremity, request, language


### PR DESCRIPTION
https://navitia.atlassian.net/wiki/spaces/NAV/pages/11963105672/Valhalla+-+Alternatives+v+lo

Handle alternatives in Asgard. This feature is only available for bike mode and only activated when `direct_path=only_with_alternatives` is set.

The idea is to send a list of parameters instead of just one. Asgard is in charge of giving back different journeys regarding the received list of parameters from Jormungandr.

In order to tag the returned journeys correctly, every parameter to be sent is associated with a user tag (ex comfort, shortest, balanced... )  that the parameters are adjusted to represent.  
 
Asgard should be able to handle this feature once https://github.com/hove-io/asgard/pull/197/files is merged. 