### PR TITLE
[Jormun] Include also error 400 from bragi to manage fallback kraken in autocomplete

### DIFF
--- a/source/jormungandr/jormungandr/autocomplete/geocodejson.py
+++ b/source/jormungandr/jormungandr/autocomplete/geocodejson.py
@@ -206,7 +206,10 @@ class GeocodeJson(AbstractAutocomplete):
     def _check_response(cls, response, uri):
         if response is None:
             raise GeocodeJsonError('impossible to access autocomplete service')
-        if response.status_code == 404:
+        if response.status_code in (400, 404):
+            logging.getLogger(__name__).error(
+                'Autocomplete request failed with HTTP code {} fallback kraken'.format(response.status_code)
+            )
             raise UnknownObject(uri)
         if response.status_code == 503:
             raise GeocodeJsonUnavailable('geocodejson responded with 503')


### PR DESCRIPTION
* For a query /places with a coverage jormungandr calls bragi or bragi7 and formats query result. 
* If bragi returns error 404 (object not found), jormungandr calls kraken.
* bragi7 (with es7) returns error 400 but not 404 if non object found for the query.
* In this PR we include error 400 along with 404 to call kraken (fallback kraken).
* For more details:  https://navitia.atlassian.net/browse/NAV-1338