### PR TITLE
[Docs] minor fixes on formatting 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,12 +102,13 @@ But bare in mind, it requires python 3.6+ to run.
 
 ### C++ formatting
 
-Our pre-commit hooks are running [Clang-format](https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html) to format our c++ codebase. You'll need version 6.0 in order to pass our CI.
+Our pre-commit hooks are running [Clang-format](https://releases.llvm.org/10.0.0/tools/clang/docs/ClangFormat.html) to format our c++ codebase.
+You'll need version 10 (or above) in order to pass our CI.
 ```sh
-sudo apt install clang-format-6.0
+sudo apt install clang-format-10  # available on Ubuntu 20.04
 ```
 
 In case you might want to run Clang-format on the entire codebase, you can do:
 ```sh
-pre-commit run clang-format-6.0 --all
+pre-commit run clang-format --all
 ```


### PR DESCRIPTION
~After a `pre-commit run --all`.
Not sure if I used an up-to-date version of tools though, rejecting this PR is possible (hoping that CI does it if needed).~

I didn't see https://github.com/hove-io/navitia/pull/3727, so:

* Switch doc to clang-format 10 (above seems to work fine too, 11 for me, 14 on ubuntu-22.04).
* ~Pin `ubuntu-20.04` to avoid blind update of `ubuntu-latest` on github-actions
  cf. https://github.com/actions/virtual-environments#available-environments~
  After discussions, it's not really necessary.