### PR TITLE
Remove/clarify `show_codes`

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -118,7 +118,7 @@ if 'MODULES' in rest_api.app.config:
     rest_api.module_loader.run()
 else:
     rest_api.app.logger.warning(
-        'MODULES isn\'t defined in config. No module will be loaded, then no route ' 'will be defined.'
+        'MODULES isn\'t defined in config. No module will be loaded, then no route will be defined.'
     )
 
 if rest_api.app.config.get('ACTIVATE_PROFILING'):

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -373,15 +373,15 @@ class Journeys(JourneyCommon):
             type=BooleanType(),
             default=False,
             hidden=True,
-            help='Activate debug mode.\n' 'No journeys are filtered in this mode.',
+            help='Activate debug mode.\nNo journeys are filtered in this mode.',
         )
         parser_get.add_argument(
             "show_codes",
             type=BooleanType(),
-            default=False,
+            default=True,
             hidden=True,
             deprecated=True,
-            help="DEPRECATED, show more identification codes",
+            help="DEPRECATED (always True), show more identification codes",
         )
         parser_get.add_argument(
             "_override_scenario",

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -124,7 +124,12 @@ class Schedules(ResourceUri, ResourceUtc):
             help="Distance range of the query. Used only if a coord is in the query",
         )
         parser_get.add_argument(
-            "show_codes", type=BooleanType(), default=False, help="show more identification codes"
+            "show_codes",
+            type=BooleanType(),
+            default=True,
+            hidden=True,
+            deprecated=True,
+            help="DEPRECATED (always True), show more identification codes",
         )
         # Note: no default param for data freshness, the default depends on the API
         parser_get.add_argument(

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -93,7 +93,12 @@ class Uri(ResourceUri, ResourceUtc):
         )
         parser.add_argument("headsign", type=six.text_type, help="filter vehicle journeys on headsign")
         parser.add_argument(
-            "show_codes", type=BooleanType(), default=False, help="show more identification codes"
+            "show_codes",
+            type=BooleanType(),
+            default=True,
+            hidden=True,
+            deprecated=True,
+            help="DEPRECATED (always True), show more identification codes",
         )
         parser.add_argument(
             "odt_level",

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -176,14 +176,14 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             "from",
             type=six.text_type,
             dest="origin",
-            help='The id of the departure of your journey. ' 'If not provided an isochrone is computed.',
+            help='The id of the departure of your journey. If not provided an isochrone is computed.',
             schema_metadata={'format': 'place'},
         )
         parser_get.add_argument(
             "to",
             type=six.text_type,
             dest="destination",
-            help='The id of the arrival of your journey. ' 'If not provided an isochrone is computed.',
+            help='The id of the arrival of your journey. If not provided an isochrone is computed.',
             schema_metadata={'format': 'place'},
         )
         parser_get.add_argument(
@@ -302,12 +302,12 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "walking_speed",
             type=SpeedRange(),
-            help='Walking speed for the fallback sections.\n' 'Speed unit must be in meter/second',
+            help='Walking speed for the fallback sections.\nSpeed unit must be in meter/second',
         )
         parser_get.add_argument(
             "bike_speed",
             type=SpeedRange(),
-            help='Biking speed for the fallback sections.\n' 'Speed unit must be in meter/second',
+            help='Biking speed for the fallback sections.\nSpeed unit must be in meter/second',
         )
         parser_get.add_argument(
             "bss_speed",
@@ -319,13 +319,13 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "car_speed",
             type=SpeedRange(),
-            help='Driving speed for the fallback sections.\n' 'Speed unit must be in meter/second',
+            help='Driving speed for the fallback sections.\nSpeed unit must be in meter/second',
         )
         parser_get.add_argument(
             "ridesharing_speed",
             type=SpeedRange(),
             dest="ridesharing_speed",
-            help='ridesharing speed for the fallback sections.\n' 'Speed unit must be in meter/second',
+            help='ridesharing speed for the fallback sections.\nSpeed unit must be in meter/second',
         )
         parser_get.add_argument(
             "car_no_park_speed",
@@ -336,7 +336,7 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         parser_get.add_argument(
             "taxi_speed",
             type=SpeedRange(),
-            help='taxi speed speed for the fallback sections.\n' 'Speed unit must be in meter/second',
+            help='taxi speed speed for the fallback sections.\nSpeed unit must be in meter/second',
         )
         parser_get.add_argument(
             "forbidden_uris[]",

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -91,7 +91,7 @@ class ContextSerializer(PbNestedSerializer):
     timezone = MethodField(
         schema_type=str,
         display_none=False,
-        description='Timezone of any datetime in the response, ' 'default value Africa/Abidjan (UTC)',
+        description='Timezone of any datetime in the response, default value Africa/Abidjan (UTC)',
     )
 
     def get_car_direct_path(self, obj):
@@ -282,11 +282,11 @@ class CoverageSerializer(NullableDictSerializer):
     id = Field(attr="region_id", schema_type=str, display_none=True, description='Identifier of the coverage')
     start_production_date = Field(
         schema_type=str,
-        description='Beginning of the production period. ' 'We only have data on this production period',
+        description='Beginning of the production period. We only have data on this production period',
     )
     end_production_date = Field(
         schema_type=str,
-        description='End of the production period. ' 'We only have data on this production period',
+        description='End of the production period. We only have data on this production period',
     )
     last_load_at = LambdaField(
         method=lambda _, o: CoverageUTCDateTimeField('last_load_at').to_value(o),

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -505,7 +505,7 @@ class StopAreaSerializer(PbGenericSerializer):
     administrative_regions = AdminSerializer(
         many=True,
         display_none=False,
-        description='Administrative regions of the stop area ' 'in which is the stop area',
+        description='Administrative regions of the stop area in which is the stop area',
     )
     stop_points = StopPointSerializer(
         many=True, display_none=False, description='Stop points contained in this stop area'

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/stands.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/stands.py
@@ -41,9 +41,7 @@ class StandsStatus(Enum):
 class Stands(object):
     def __init__(self, available_places, available_bikes, status=None):
         if status is not None and not isinstance(status, StandsStatus):
-            logging.getLogger(__name__).error(
-                'status must be a StandsStatus enum value, ' 'obtained: {}', status
-            )
+            logging.getLogger(__name__).error('status must be a StandsStatus enum value, obtained: {}', status)
             self.status = None
         else:
             self.status = status.name  # can't serialize enum value with ujson as it's a recursive struct

--- a/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/cleverage.py
@@ -106,12 +106,12 @@ class Cleverage(RealtimeProxy):
             return self.breaker.call(requests.get, url, timeout=self.timeout, headers=self.service_args)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
-                'Cleverage RT service dead, using base ' 'schedule (error: {}'.format(e)
+                'Cleverage RT service dead, using base schedule (error: {}'.format(e)
             )
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error(
-                'Cleverage RT service timeout, using base ' 'schedule (error: {}'.format(t)
+                'Cleverage RT service timeout, using base schedule (error: {}'.format(t)
             )
             raise RealtimeProxyError('timeout')
         except Exception as e:

--- a/source/jormungandr/jormungandr/realtime_schedule/siri.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/siri.py
@@ -274,13 +274,11 @@ class Siri(RealtimeProxy):
                 timeout=self.timeout,
             )
         except pybreaker.CircuitBreakerError as e:
-            logging.getLogger(__name__).error(
-                'siri RT service dead, using base ' 'schedule (error: {}'.format(e)
-            )
+            logging.getLogger(__name__).error('siri RT service dead, using base schedule (error: {}'.format(e))
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error(
-                'siri RT service timeout, using base ' 'schedule (error: {}'.format(t)
+                'siri RT service timeout, using base schedule (error: {}'.format(t)
             )
             raise RealtimeProxyError('timeout')
         except Exception as e:

--- a/source/jormungandr/jormungandr/realtime_schedule/synthese.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/synthese.py
@@ -149,12 +149,12 @@ class Synthese(RealtimeProxy):
             return self.breaker.call(requests.get, url, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
-                'Synthese RT service dead, using base ' 'schedule (error: {}'.format(e)
+                'Synthese RT service dead, using base schedule (error: {}'.format(e)
             )
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error(
-                'Synthese RT service timeout, using base ' 'schedule (error: {}'.format(t)
+                'Synthese RT service timeout, using base schedule (error: {}'.format(t)
             )
             raise RealtimeProxyError('timeout')
         except redis.ConnectionError:

--- a/source/jormungandr/jormungandr/realtime_schedule/sytral.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/sytral.py
@@ -121,13 +121,13 @@ class Sytral(RealtimeProxy):
             return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
-                'systralRT service dead, using base ' 'schedule (error: {}'.format(e),
+                'systralRT service dead, using base schedule (error: {}'.format(e),
                 extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('circuit breaker open')
         except requests.Timeout as t:
             logging.getLogger(__name__).error(
-                'systralRT service timeout, using base ' 'schedule (error: {}'.format(t),
+                'systralRT service timeout, using base schedule (error: {}'.format(t),
                 extra={'rt_system_id': six.text_type(self.rt_system_id)},
             )
             raise RealtimeProxyError('timeout')

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -562,7 +562,7 @@ def culling_journeys(resp, request):
         """
         for j in remaining_journeys[max(0, max_nb_journeys - len(aggregated_journeys)) :]:
             journey_filter.mark_as_dead(
-                j, is_debug, 'max_nb_journeys >= len(aggregated_journeys), ' 'Filtered by max_nb_journeys'
+                j, is_debug, 'max_nb_journeys >= len(aggregated_journeys), Filtered by max_nb_journeys'
             )
         journey_filter.delete_journeys((resp,), request)
         return
@@ -573,7 +573,7 @@ def culling_journeys(resp, request):
     """
     for j in remaining_journeys:
         journey_filter.mark_as_dead(
-            j, is_debug, 'Filtered by max_nb_journeys, ' 'max_nb_journeys < len(aggregated_journeys)'
+            j, is_debug, 'Filtered by max_nb_journeys, max_nb_journeys < len(aggregated_journeys)'
         )
 
     logger.debug('Trying to culling the journeys')

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -372,7 +372,7 @@ class TestOverlappingAuthentication(AbstractTestAuthentication):
             assert status == 403
             # we get a 404 (because 'stopbidon' cannot be found) and not a 403
             _, status = self.query_no_assert(
-                'v1/coverage/empty_routing_test/stop_areas/' 'stopbidon/stop_schedules'
+                'v1/coverage/empty_routing_test/stop_areas/stopbidon/stop_schedules'
             )
             assert status == 404
 
@@ -385,14 +385,14 @@ class TestOverlappingAuthentication(AbstractTestAuthentication):
             _, status = self.query_no_assert('v1/coverage/departure_board_test/stop_areas/stop1/stop_schedules')
             assert status == 403
             _, status = self.query_no_assert(
-                'v1/coverage/empty_routing_test/stop_areas/' 'stopbidon/stop_schedules'
+                'v1/coverage/empty_routing_test/stop_areas/stopbidon/stop_schedules'
             )
             assert status == 403
 
     def test_stop_schedules_for_bobitto(self):
         with user_set(app, FakeUserAuth, 'bobitto'):
             response = self.query(
-                'v1/coverage/main_routing_test/stop_areas/' 'stopA/stop_schedules?from_datetime=20120614T080000'
+                'v1/coverage/main_routing_test/stop_areas/stopA/stop_schedules?from_datetime=20120614T080000'
             )
             assert 'error' not in response
             response = self.query(

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -1128,7 +1128,7 @@ class TestChaosDisruptionsUpdate(ChaosDisruptionsFixture):
 
         # query with parameter filter
         disruptions = self.query_region(
-            'disruptions?since=20120801T000000' '&filter=stop_area.id="stopA" or stop_area.id="stopB"'
+            'disruptions?since=20120801T000000&filter=stop_area.id="stopA" or stop_area.id="stopB"'
         )['disruptions']
         assert len(disruptions) == 4
 

--- a/source/jormungandr/tests/journey_common_tests.py
+++ b/source/jormungandr/tests/journey_common_tests.py
@@ -1816,7 +1816,7 @@ class JourneysWithPtref:
 @dataset({"main_routing_test": {}})
 class JourneyMinBikeMinCar(object):
     def test_first_section_mode_and_last_section_mode_bike(self):
-        query = '{sub_query}&last_section_mode[]=bike&first_section_mode[]=bike&' 'datetime={datetime}'.format(
+        query = '{sub_query}&last_section_mode[]=bike&first_section_mode[]=bike&datetime={datetime}'.format(
             sub_query=sub_query, datetime="20120614T080000"
         )
         response = self.query_region(query)
@@ -1929,7 +1929,7 @@ class JourneyMinBikeMinCar(object):
         assert response['journeys'][-1]['sections'][0]['duration'] == 276
 
     def test_first_section_mode_and_last_section_mode_car(self):
-        query = '{sub_query}&last_section_mode[]=car&first_section_mode[]=car&' 'datetime={datetime}'.format(
+        query = '{sub_query}&last_section_mode[]=car&first_section_mode[]=car&datetime={datetime}'.format(
             sub_query=sub_query, datetime="20120614T070000"
         )
         response = self.query_region(query)
@@ -2160,14 +2160,14 @@ class JourneysTimeFrameDuration:
         # Time frame to catch only the first journeys, timeframe_duration = 10 min (60*10=600).
         # Even though a journey's departure is later than the timeframe, we still keep it
         query = (
-            'journeys?from={_from}&' 'to={to}&' 'datetime={datetime}&' 'timeframe_duration={timeframe_duration}&'
+            'journeys?from={_from}&to={to}&datetime={datetime}&timeframe_duration={timeframe_duration}&'
         ).format(_from='stop_area:sa1', to='stop_area:sa3', datetime='20180315T080000', timeframe_duration=600)
         response = self.query_region(query)
         assert 1 <= len(response['journeys'])
 
         # Time frame to catch journeys in the first hour, timeframe_duration = 1 H (60*60=3600).
         query = (
-            'journeys?from={_from}&' 'to={to}&' 'datetime={datetime}&' 'timeframe_duration={timeframe_duration}&'
+            'journeys?from={_from}&to={to}&datetime={datetime}&timeframe_duration={timeframe_duration}&'
         ).format(_from='stop_area:sa1', to='stop_area:sa3', datetime='20180315T080000', timeframe_duration=3600)
         response = self.query_region(query)
         assert 6 <= len(response['journeys'])
@@ -2201,7 +2201,7 @@ class JourneysTimeFrameDuration:
         as there is simply no contraint
         """
         query = (
-            'journeys?from={_from}&' 'to={to}&' 'datetime={datetime}&' 'timeframe_duration={timeframe_duration}&'
+            'journeys?from={_from}&to={to}&datetime={datetime}&timeframe_duration={timeframe_duration}&'
         ).format(_from='stop_area:sa1', to='stop_area:sa3', datetime='20180315T080000', timeframe_duration=0)
         response = self.query_region(query)
         assert 1 == len(response['journeys'])
@@ -2258,7 +2258,7 @@ class JourneysTimeFrameDuration:
         The response must not contains the last jouneys because we filter with a max time frame of 24H
         """
         query = (
-            'journeys?from={_from}&' 'to={to}&' 'datetime={datetime}&' 'timeframe_duration={timeframe_duration}&'
+            'journeys?from={_from}&to={to}&datetime={datetime}&timeframe_duration={timeframe_duration}&'
         ).format(_from='stop_area:sa1', to='stop_area:sa3', datetime='20180315T080000', timeframe_duration=87300)
         response = self.query_region(query)
         assert 20 == len(response['journeys'])

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -91,8 +91,8 @@ DepartureCheck = namedtuple('DepartureCheck', ['route', 'dt', 'data_freshness', 
 @dataset({"basic_schedule_test": {'instance_config': {'realtime_proxies': MOCKED_PROXY_CONF}}})
 class TestDepartures(AbstractTestFixture):
 
-    query_template_scs = 'stop_points/{sp}/stop_schedules?from_datetime={dt}&show_codes=true{data_freshness}'
-    query_template_ter = 'stop_points/{sp}/terminus_schedules?from_datetime={dt}&show_codes=true{data_freshness}'
+    query_template_scs = 'stop_points/{sp}/stop_schedules?from_datetime={dt}{data_freshness}'
+    query_template_ter = 'stop_points/{sp}/terminus_schedules?from_datetime={dt}{data_freshness}'
 
     def test_stop_schedule(self):
         query = self.query_template_scs.format(sp='C:S0', dt='20160102T1100', data_freshness='')
@@ -192,10 +192,7 @@ class TestDepartures(AbstractTestFixture):
             assert dt['data_freshness'] == 'base_schedule'
 
     def test_departures_realtime_informations(self):
-        query = (
-            'stop_areas/S42/departures?from_datetime=20160102T1000&show_codes=true&count=7'
-            '&_current_datetime=20160102T1000'
-        )
+        query = 'stop_areas/S42/departures?from_datetime=20160102T1000&count=7&_current_datetime=20160102T1000'
         response = self.query_region(query)
 
         assert "departures" in response
@@ -298,7 +295,7 @@ class TestDepartures(AbstractTestFixture):
         # expected output, 2 realtime ->
         # "pagination" { "items_on_page": 2, "items_per_page": 100,
         #                "start_page": 0,"total_result": 2}
-        query = 'stop_areas/S42/lines/J/departures?' 'from_datetime=20160102T1000&show_codes=true&count=100'
+        query = 'stop_areas/S42/lines/J/departures?from_datetime=20160102T1000&count=100'
         response = self.query_region(query)
         assert "departures" in response
         assert len(response["departures"]) == 2
@@ -315,7 +312,7 @@ class TestDepartures(AbstractTestFixture):
         #                "start_page": 0,"total_result": 2}
         query = (
             'stop_areas/S42/lines/J/departures?'
-            'from_datetime=20160102T1000&show_codes=true&count=100'
+            'from_datetime=20160102T1000&count=100'
             '&data_freshness=realtime'
         )
         response = self.query_region(query)
@@ -334,7 +331,7 @@ class TestDepartures(AbstractTestFixture):
         #                "start_page": 0,"total_result": 1}
         query = (
             'stop_areas/S42/lines/J/departures?'
-            'from_datetime=20160102T1000&show_codes=true&count=100'
+            'from_datetime=20160102T1000&count=100'
             '&data_freshness=base_schedule'
         )
         response = self.query_region(query)
@@ -420,7 +417,7 @@ MOCKED_PROXY_CONF = [
 @dataset({"basic_schedule_test": {'instance_config': {'realtime_proxies': MOCKED_PROXY_CONF}}})
 class TestDeparturesWithAnotherSource(AbstractTestFixture):
 
-    query_template = 'stop_points/{sp}/stop_schedules?from_datetime={dt}&show_codes=true{data_freshness}'
+    query_template = 'stop_points/{sp}/stop_schedules?from_datetime={dt}{data_freshness}'
 
     def test_departure_with_another_source(self):
         query = self.query_template.format(sp='C:S1', dt='20160102T1000', data_freshness='')
@@ -461,7 +458,7 @@ class MockedTestProxyWithTimezone(MockedTestProxy):
 @dataset({"basic_schedule_test": {'instance_config': {'realtime_proxies': MOCKED_PROXY_WITH_TIMEZONE_CONF}}})
 class TestDeparturesWithTimeZone(AbstractTestFixture):
 
-    query_template = 'stop_points/{sp}/stop_schedules?from_datetime={dt}&show_codes=true{data_freshness}'
+    query_template = 'stop_points/{sp}/stop_schedules?from_datetime={dt}{data_freshness}'
 
     def test_departure_with_timezone(self):
         query = self.query_template.format(

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -372,12 +372,10 @@ MOCKED_PROXY_CONF = [
 @dataset({"basic_schedule_test": {'instance_config': {'realtime_proxies': MOCKED_PROXY_CONF}}})
 class TestDepartures(AbstractTestFixture):
     query_template_scs = (
-        'stop_points/{sp}/stop_schedules?from_datetime={dt}&show_codes=true{data_freshness}'
-        '&_current_datetime={c_dt}'
+        'stop_points/{sp}/stop_schedules?from_datetime={dt}{data_freshness}&_current_datetime={c_dt}'
     )
     query_template_ter = (
-        'stop_points/{sp}/terminus_schedules?from_datetime={dt}&show_codes=true{data_freshness}'
-        '&_current_datetime={c_dt}'
+        'stop_points/{sp}/terminus_schedules?from_datetime={dt}{data_freshness}&_current_datetime={c_dt}'
     )
 
     def test_stop_schedule_without_rt(self):

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -408,7 +408,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_line_codes(self):
         """test line formating"""
-        response = self.query_region("lines/line:A?show_codes=true")
+        response = self.query_region("lines/line:A?")
 
         lines = get_not_null(response, 'lines')
 
@@ -692,29 +692,29 @@ class TestPtRef(AbstractTestFixture):
 
     def test_line_by_code(self):
         """test the filter=type.has_code(key, value)"""
-        response = self.query_region("lines?filter=line.has_code(codeB, B)&show_codes=true")
+        response = self.query_region("lines?filter=line.has_code(codeB, B)")
         lines = get_not_null(response, 'lines')
         assert len(lines) == 1
         assert 'B' in [code['value'] for code in lines[0]['codes'] if code['type'] == 'codeB']
 
-        response = self.query_region("lines?filter=line.has_code(codeB, Bise)&show_codes=true")
+        response = self.query_region("lines?filter=line.has_code(codeB, Bise)")
         lines = get_not_null(response, 'lines')
         assert len(lines) == 1
         assert 'B' in [code['value'] for code in lines[0]['codes'] if code['type'] == 'codeB']
 
-        response = self.query_region("lines?filter=line.has_code(codeC, C)&show_codes=true")
+        response = self.query_region("lines?filter=line.has_code(codeC, C)")
         lines = get_not_null(response, 'lines')
         assert len(lines) == 1
         assert 'B' in [code['value'] for code in lines[0]['codes'] if code['type'] == 'codeB']
 
         response, code = self.query_no_assert(
-            "v1/coverage/main_ptref_test/lines?filter=line.has_code(codeB, rien)&show_codes=true"
+            "v1/coverage/main_ptref_test/lines?filter=line.has_code(codeB, rien)"
         )
         assert code == 400
         assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
 
         response, code = self.query_no_assert(
-            "v1/coverage/main_ptref_test/lines?filter=line.has_code(codeC, rien)&show_codes=true"
+            "v1/coverage/main_ptref_test/lines?filter=line.has_code(codeC, rien)"
         )
         assert code == 400
         assert get_not_null(response, 'error')['message'] == 'ptref : Filters: Unable to find object'
@@ -941,7 +941,7 @@ class TestPtRef(AbstractTestFixture):
 class TestPtRefRoutingAndPtrefCov(AbstractTestFixture):
     def test_external_code(self):
         """test the strange and ugly external code api"""
-        response = self.query("v1/lines?external_code=A&show_codes=true")
+        response = self.query("v1/lines?external_code=A")
         lines = get_not_null(response, 'lines')
         assert len(lines) == 1
         assert 'A' in [code['value'] for code in lines[0]['codes'] if code['type'] == 'external_code']

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -771,12 +771,12 @@ class TestPtRef(AbstractTestFixture):
         assert disruptions[0]['disruption_id'] == 'Disruption On line:A'
 
         response = self.query_region(
-            'pt_objects?q=line:A&type[]=line&_current_datetime=20140115T235959' '&disable_disruption=true'
+            'pt_objects?q=line:A&type[]=line&_current_datetime=20140115T235959&disable_disruption=true'
         )
         assert len(response['disruptions']) == 0
 
         response = self.query_region(
-            'pt_objects?q=line:A&type[]=line&_current_datetime=20140115T235959' '&disable_disruption=false'
+            'pt_objects?q=line:A&type[]=line&_current_datetime=20140115T235959&disable_disruption=false'
         )
         assert len(response['disruptions']) == 1
 
@@ -1105,7 +1105,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
 
     def test_headsign_with_resource_uri(self):
         """test usage of headsign with resource uri"""
-        response = self.query_region('physical_modes/physical_mode:0x0/vehicle_journeys' '?headsign=vjA_hs')
+        response = self.query_region('physical_modes/physical_mode:0x0/vehicle_journeys?headsign=vjA_hs')
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')
         assert len(vjs) == 1
@@ -1113,7 +1113,7 @@ class TestPtRefRoutingCov(AbstractTestFixture):
     def test_headsign_with_code_filter_and_resource_uri(self):
         """test usage of headsign with code filter and resource uri"""
         response = self.query_region(
-            'physical_modes/physical_mode:0x0/vehicle_journeys' '?headsign=vjA_hs&filter=line.code=1A'
+            'physical_modes/physical_mode:0x0/vehicle_journeys?headsign=vjA_hs&filter=line.code=1A'
         )
         assert 'error' not in response
         vjs = get_not_null(response, 'vehicle_journeys')

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -408,7 +408,7 @@ class TestPtRef(AbstractTestFixture):
 
     def test_line_codes(self):
         """test line formating"""
-        response = self.query_region("lines/line:A?")
+        response = self.query_region("lines/line:A")
 
         lines = get_not_null(response, 'lines')
 

--- a/source/jormungandr/tests/schema_tests.py
+++ b/source/jormungandr/tests/schema_tests.py
@@ -274,7 +274,7 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
         # so the '/' is urlencoded as %2F to be able to test the call
 
         obj, errors = self._check_schema(
-            '/v1/coverage/main_routing_test/stop_areas%2FstopB/stop_schedules?' 'from_datetime=20120614T165200',
+            '/v1/coverage/main_routing_test/stop_areas%2FstopB/stop_schedules?from_datetime=20120614T165200',
             hard_check=False,
         )
 
@@ -302,7 +302,7 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
         # so the '/' is urlencoded as %2F to be able to test the call
 
         _, errors = self._check_schema(
-            '/v1/coverage/main_routing_test/routes%2FA:0/route_schedules?' 'from_datetime=20120614T165200',
+            '/v1/coverage/main_routing_test/routes%2FA:0/route_schedules?from_datetime=20120614T165200',
             hard_check=False,
         )
 
@@ -317,16 +317,16 @@ class TestSwaggerSchema(AbstractTestFixture, SchemaChecker):
 
     def test_departures(self):
         self._check_schema(
-            '/v1/coverage/main_routing_test/stop_areas%2FstopB/departures?' 'from_datetime=20120614T165200'
+            '/v1/coverage/main_routing_test/stop_areas%2FstopB/departures?from_datetime=20120614T165200'
         )
 
     def test_arrivals(self):
         self._check_schema(
-            '/v1/coverage/main_routing_test/stop_areas%2FstopB/arrivals?' 'from_datetime=20120614T165200'
+            '/v1/coverage/main_routing_test/stop_areas%2FstopB/arrivals?from_datetime=20120614T165200'
         )
 
     def test_traffic_reports(self):
-        self._check_schema('/v1/coverage/main_routing_test/traffic_reports?' '_current_datetime=20120801T0000')
+        self._check_schema('/v1/coverage/main_routing_test/traffic_reports?_current_datetime=20120801T0000')
 
     def test_places_nearby(self):
         self._check_schema('/v1/coverage/main_routing_test/stop_areas%2FstopA/places_nearby')

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -667,7 +667,7 @@ class Instance(flask_restful.Resource):
         parser.add_argument(
             'max_nb_crowfly_by_mode',
             type=dict,
-            help='maximum nb of crowfly, used before computing the fallback matrix,' ' in distributed scenario',
+            help='maximum nb of crowfly, used before computing the fallback matrix, in distributed scenario',
             location=('json', 'values'),
             default=instance.max_nb_crowfly_by_mode,
         )


### PR DESCRIPTION
After https://github.com/hove-io/kirin/pull/461
Deprecated `show_codes` param could be clarified a bit and (almost) completely removed from code and tests, 6 years after : https://github.com/hove-io/navitia/pull/1460/files?file-filters%5B%5D=.cpp&file-filters%5B%5D=.h&file-filters%5B%5D=No+extension&show-viewed-files=true#diff-0da9a72ca256117c2335159ce8965c541e991c56489b40e6358047929f0334fbL321

Also (review by commit):

* Removed some useless `' '` (close/open string) left by black formatting

TODO:

- [ ] merge/rebase https://github.com/hove-io/navitia-proto/pull/183