### PR TITLE
[Jormungandr] Filter On Demand Transport journeys

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -695,6 +695,8 @@ class Instance(object):
     default_pt_planner = _make_property_getter('default_pt_planner')
     pt_planners_configurations = _make_property_getter('pt_planners_configurations')
 
+    filter_odt_journeys = _make_property_getter('filter_odt_journeys')
+
     def get_pt_planner(self, pt_planner_id=None):
         pt_planner_id = pt_planner_id or self.default_pt_planner
         return self._pt_planner_manager.get_pt_planner(pt_planner_id)

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -376,9 +376,8 @@ class Journeys(JourneyCommon):
             help='Activate debug mode.\n' 'No journeys are filtered in this mode.',
         )
         parser_get.add_argument(
-            "_filter_odt",
+            "_filter_odt_journeys",
             type=BooleanType(),
-            default=True,
             hidden=True,
             help='Filter journeys that uses On Demand Transport if they arrive later/depart earlier than a pure public transport journey.',
         )
@@ -849,6 +848,9 @@ class Journeys(JourneyCommon):
 
             if args.get('bss_return_penalty') is None:
                 args['bss_return_penalty'] = mod.bss_return_penalty
+
+            if args.get('_filter_odt_journeys') is None:
+                args['_filter_odt_journeys'] = mod.filter_odt_journeys
 
         # When computing 'same_journey_schedules'(is_journey_schedules=True), some parameters need to be overridden
         # because they are contradictory to the request

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -376,6 +376,13 @@ class Journeys(JourneyCommon):
             help='Activate debug mode.\n' 'No journeys are filtered in this mode.',
         )
         parser_get.add_argument(
+            "_filter_odt",
+            type=BooleanType(),
+            default=True,
+            hidden=True,
+            help='Filter journeys that uses On Demand Transport if they arrive later/depart earlier than a pure public transport journey.',
+        )
+        parser_get.add_argument(
             "show_codes",
             type=BooleanType(),
             default=False,

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -654,7 +654,7 @@ def apply_final_journey_filters(response_list, instance, request):
         journey_pairs_pool = itertools.combinations(journeys, 2)
         filter_shared_sections_journeys(journey_pairs_pool, request)
 
-    filter_odt = get_or_default(request, '_odt_filter', False)
+    filter_odt = get_or_default(request, '_filter_odt', False)
     if filter_odt:
         journeys = journey_generator(response_list)
         filter_odt_journeys(journeys, request)

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -911,13 +911,10 @@ def _filter_odt_journeys_clockwise(journeys, debug):
     that arrive earlier
     """
     # let's find the the earliest arrival time among public transport journeys
-    earliest_arrival_pt_journey = None
-    for journey in journeys:
-        if _contains_pt_section(journey) and not _contains_odt(journey):
-            if earliest_arrival_pt_journey is None:
-                earliest_arrival_pt_journey = journey
-            elif journey.arrival_date_time < earliest_arrival_pt_journey.arrival_date_time:
-                earliest_arrival_pt_journey = journey
+    earliest_arrival_pt_journey = portable_min(
+        (j for j in journeys if _contains_pt_section(j) and not _contains_odt(j)),
+        key=lambda j: j.arrival_date_time,
+    )
 
     # no pt journey found, so there is nothing to filter
     if earliest_arrival_pt_journey is None:
@@ -938,14 +935,11 @@ def _filter_odt_journeys_counter_clockwise(journeys, debug):
     eliminates a journey that uses On Demand Transport if there is a public transport journey
     that depart later
     """
-    # let's find the the earliest arrival time among public transport journeys
-    latest_departure_pt_journey = None
-    for journey in journeys:
-        if _contains_pt_section(journey) and not _contains_odt(journey):
-            if latest_departure_pt_journey is None:
-                latest_departure_pt_journey = journey
-            elif journey.departure_date_time > latest_departure_pt_journey.departure_date_time:
-                latest_departure_pt_journey = journey
+    # let's find the the latest departure time among public transport journeys
+    latest_departure_pt_journey = portable_min(
+        (j for j in journeys if _contains_pt_section(j) and not _contains_odt(j)),
+        key=lambda j: -1 * j.departure_date_time,
+    )
 
     # no pt journey found, so there is nothing to filter
     if latest_departure_pt_journey is None:

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -910,7 +910,7 @@ def _filter_odt_journeys_clockwise(journeys, debug):
     eliminates a journey that uses On Demand Transport if there is a public transport journey
     that arrive earlier
     """
-    # let's find the the earliest arrival time among public transport journeys
+    # let's find the earliest arrival time among public transport journeys
     earliest_arrival_pt_journey = portable_min(
         (j for j in journeys if _contains_pt_section(j) and not _contains_odt(j)),
         key=lambda j: j.arrival_date_time,
@@ -935,7 +935,7 @@ def _filter_odt_journeys_counter_clockwise(journeys, debug):
     eliminates a journey that uses On Demand Transport if there is a public transport journey
     that depart later
     """
-    # let's find the the latest departure time among public transport journeys
+    # let's find the latest departure time among public transport journeys
     latest_departure_pt_journey = portable_min(
         (j for j in journeys if _contains_pt_section(j) and not _contains_odt(j)),
         key=lambda j: -1 * j.departure_date_time,

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -971,10 +971,10 @@ def _contains_pt_section(journey):
 def _contains_odt(journey):
     for section in journey.sections:
         for info in section.additional_informations:
-            if (
-                info == response_pb2.ODT_WITH_ZONE
-                or info == response_pb2.ODT_WITH_STOP_POINT
-                or info == response_pb2.ODT_WITH_STOP_TIME
+            if info in (
+                response_pb2.ODT_WITH_ZONE,
+                response_pb2.ODT_WITH_STOP_POINT,
+                response_pb2.ODT_WITH_STOP_TIME,
             ):
                 return True
     return False

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -955,7 +955,7 @@ def _filter_odt_journeys_counter_clockwise(journeys, debug):
     for journey in journeys:
         if (
             _contains_odt(journey)
-            and journey.departure_date_time <= latest_departure_pt_journey.arrival_date_time
+            and journey.departure_date_time <= latest_departure_pt_journey.departure_date_time
         ):
             mark_as_dead(
                 journey,

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -654,7 +654,7 @@ def apply_final_journey_filters(response_list, instance, request):
         journey_pairs_pool = itertools.combinations(journeys, 2)
         filter_shared_sections_journeys(journey_pairs_pool, request)
 
-    filter_odt = get_or_default(request, '_filter_odt', False)
+    filter_odt = get_or_default(request, '_filter_odt_journeys', False)
     if filter_odt:
         journeys = journey_generator(response_list)
         filter_odt_journeys(journeys, request)

--- a/source/jormungandr/jormungandr/scenarios/tests/journey_filter_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/journey_filter_tests.py
@@ -101,3 +101,47 @@ def remove_excess_terminus_with_2items_uri_in_display_information_test():
 
     journey_filter.remove_excess_terminus(response)
     assert len(response.terminus) == 1
+
+
+def filter_odt_journeys_clockwise_test():
+    request = {"clockwise": True}
+
+    response = response_pb2.Response()
+    # a public transport journey
+    pt_journey = response.journeys.add()
+    pt_journey.arrival_date_time = 10
+    pt_section = pt_journey.sections.add()
+    pt_section.type = response_pb2.PUBLIC_TRANSPORT
+
+    # an On Demand Transport journey
+    # that arrives after the public transport journey
+    odt_journey = response.journeys.add()
+    odt_section = odt_journey.sections.add()
+    odt_section.additional_informations.append(response_pb2.ODT_WITH_ZONE)
+    odt_journey.arrival_date_time = 11
+
+    journey_filter.filter_odt_journeys(response.journeys, request)
+
+    assert odt_journey.tags[0] == "to_delete"
+
+
+def filter_odt_journeys_counter_clockwise_test():
+    request = {"clockwise": False}
+
+    response = response_pb2.Response()
+    # a public transport journey
+    pt_journey = response.journeys.add()
+    pt_journey.departure_date_time = 10
+    pt_section = pt_journey.sections.add()
+    pt_section.type = response_pb2.PUBLIC_TRANSPORT
+
+    # an On Demand Transport journey
+    # that depart before the public transport journey
+    odt_journey = response.journeys.add()
+    odt_section = odt_journey.sections.add()
+    odt_section.additional_informations.append(response_pb2.ODT_WITH_ZONE)
+    odt_journey.departure_date_time = 9
+
+    journey_filter.filter_odt_journeys(response.journeys, request)
+
+    assert odt_journey.tags[0] == "to_delete"

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -217,6 +217,8 @@ access_points = False
 
 default_pt_planner = 'kraken'
 
+filter_odt_journeys = True
+
 # {
 #     "kraken": {
 #         "class": "jormungandr.pt_planners.kraken.Kraken",

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -217,7 +217,7 @@ access_points = False
 
 default_pt_planner = 'kraken'
 
-filter_odt_journeys = True
+filter_odt_journeys = False
 
 # {
 #     "kraken": {

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -722,6 +722,13 @@ class Instance(db.Model):  # type: ignore
         server_default=json.dumps(default_values.pt_planners_configurations),
     )
 
+    filter_odt_journeys = db.Column(
+        db.Boolean,
+        default=default_values.filter_odt_journeys,
+        nullable=False,
+        server_default=str(default_values.filter_odt_journeys),
+    )
+
     def __init__(self, name=None, is_free=False, authorizations=None, jobs=None):
         self.name = name
         self.is_free = is_free

--- a/source/tyr/migrations/versions/45b018b3198b_.py
+++ b/source/tyr/migrations/versions/45b018b3198b_.py
@@ -1,0 +1,31 @@
+"""empty message
+
+Revision ID: 45b018b3198b
+Revises: 535dfe5be550
+Create Date: 2022-06-16 14:42:38.533188
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '45b018b3198b'
+down_revision = '535dfe5be550'
+
+from alembic import op
+import sqlalchemy as sa
+from navitiacommon import default_values
+
+
+def upgrade():
+    op.add_column(
+        'instance',
+        sa.Column(
+            'filter_odt_journeys',
+            sa.Boolean(),
+            server_default='{}'.format(default_values.filter_odt_journeys),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column('instance', 'filter_odt_journeys')


### PR DESCRIPTION
Add a parameter `filter_odt_journeys`.
When set to true, jormun will filter a journey that uses On Demand Transport if there is another journey that uses only public transport and arrives earlier.

The parameter can be configured on a coverage throught navitia configurator, and throught the hidden api parameter `_filter_odt_journeys`

https://navitia.atlassian.net/browse/NAV-1010