### PR TITLE
[Disruption] [rail_section]Modify apply_disruption to impact all sps after rs.end_point for rail_section

### DIFF
--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -3357,8 +3357,8 @@ void check_rail_section_impact(const ed::builder& b) {
     BOOST_REQUIRE_EQUAL(impact->is_rail_section_of(*vj->route->line), true);
     BOOST_REQUIRE_EQUAL(impact->is_only_rail_section(), true);
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopD")->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopE")->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopF")->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopE")->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopF")->get_impacts().size(), 1);
 
     // Deleting the disruption
     navitia::delete_disruption("rail_section_on_line1", *b.data->pt_data, *b.data->meta);
@@ -4508,10 +4508,10 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section) {
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopC")->get_impacts().size(), 1);
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopD")->get_impacts().size(), 1);
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopE")->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopF")->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopG")->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopH")->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopI")->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopF")->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopG")->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopH")->get_impacts().size(), 1);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopI")->get_impacts().size(), 1);
 
     // new rail_section disruption
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line1-2")
@@ -4554,9 +4554,9 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section) {
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopM")->get_impacts().size(), 1);
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopN")->get_impacts().size(), 1);
     BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopO")->get_impacts().size(), 1);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopG")->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopH")->get_impacts().size(), 0);
-    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopI")->get_impacts().size(), 0);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopG")->get_impacts().size(), 2);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopH")->get_impacts().size(), 2);
+    BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopI")->get_impacts().size(), 2);
 
     // new rail_section disruption
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line1-3")


### PR DESCRIPTION
**This correction includes:**
- For a rail_section with severity = NO_SERVICE, all the stop_points after rail_section.start_point are impacted (rail_section.start_point is only partially impacted)
- For a rail_section with severity = REDUCED_SERVICE, only stop_points between rail_section.start_point and rail_section.end_point are fully impacted (rail_section.start_point and rail_section.end_point are partially impacted).
- **Many tests are added on api /journeys, /departures, /arrivals, /stop_schedules ...**
- **Many comments added in the tests to explain**
- 

For details: 
- https://navitia.atlassian.net/browse/NAV-1254
- https://navitia.atlassian.net/wiki/spaces/NAV/pages/7089094547/Perturbation+tron+on+ferr+ICV+Transilien?focusedCommentId=11987977211#comment-11987977211