### PR TITLE
publish doc only on push on release branch

### DIFF
--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -3,7 +3,6 @@ name: Publish Navitia Documentation
 on:
   push:
     branches:
-      - dev
       - release
 
 jobs:


### PR DESCRIPTION
Now, when we do a new release, we push at the same time on the `dev` and `release` branch.
So this workflow is launched twice, and one of them will fail. See https://github.com/hove-io/navitia/actions/runs/2529287807

With this PR, the workflows will be launched only on push on the release branch