### PR TITLE
[Jormungandr] Handle direct_path_mode more precisely when direct_path is only/only_with_alternatives

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -108,6 +108,15 @@ def get_kraken_calls(request):
     direct_path_mode = request.get('direct_path_mode', [])
 
     res = set()
+    # In the query we found:
+    # - direct_path_mode[] is not empty
+    # - direct_path_type is either 'only' or 'only_with_alternatives'
+    # on compute direct paths only for the specified mode
+    if direct_path_mode and direct_path_type in ('only', 'only_with_alternatives'):
+        for mode in direct_path_mode:
+            res.add((mode, mode, "only"))
+        return res
+
     if direct_path_type != "none":
         for mode in direct_path_mode:
             # to avoid duplicate tuples (mode1, mode2, "indifferent") and (mode1, mode2, "only")

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -113,9 +113,7 @@ def get_kraken_calls(request):
     # - direct_path_type is either 'only' or 'only_with_alternatives'
     # on compute direct paths only for the specified mode
     if direct_path_mode and direct_path_type in ('only', 'only_with_alternatives'):
-        for mode in direct_path_mode:
-            res.add((mode, mode, "only"))
-        return res
+        return set([(mode, mode, "only") for mode in direct_path_mode])
 
     if direct_path_type != "none":
         for mode in direct_path_mode:

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -406,6 +406,46 @@ def get_kraken_calls_test():
     }
     assert get_kraken_calls(req) == {("walking", "walking", "none")}
 
+    req = {
+        "origin_mode": ["walking"],
+        "destination_mode": ["walking"],
+        "direct_path_mode": ["bike", "car"],
+        "direct_path": "only",
+    }
+    assert get_kraken_calls(req) == {("bike", "bike", "only"), ("car", "car", "only")}
+
+    req = {
+        "origin_mode": ["walking"],
+        "destination_mode": ["walking"],
+        "direct_path_mode": ["bike", "car"],
+        "direct_path": "only_with_alternatives",
+    }
+    assert get_kraken_calls(req) == {("bike", "bike", "only"), ("car", "car", "only")}
+
+    req = {
+        "origin_mode": [],
+        "destination_mode": [],
+        "direct_path_mode": ["bike"],
+        "direct_path": "only",
+    }
+    assert get_kraken_calls(req) == {("bike", "bike", "only")}
+
+    req = {
+        "origin_mode": [],
+        "destination_mode": [],
+        "direct_path_mode": ["bike"],
+        "direct_path": "only_with_alternatives",
+    }
+    assert get_kraken_calls(req) == {("bike", "bike", "only")}
+
+    req = {
+        "origin_mode": ["walking", "bike"],
+        "destination_mode": ["walking"],
+        "direct_path_mode": [],
+        "direct_path": "only",
+    }
+    assert get_kraken_calls(req) == {("walking", "walking", "only"), ("bike", "walking", "only")}
+
 
 def get_kraken_calls_invalid_1_test():
     with pytest.raises(HTTPException):


### PR DESCRIPTION
What's happening currently:

request: `first_section_mode=[] direct_path_mode = ["bike"]  direct_path="only"`
what is really computed:   `walking, bike` then `walking` is filtered 

Example: https://playground.navitia.io/play.html?request=https%3A%2F%2Fapi.navitia.io%2Fv1%2Fcoverage%2Ffr-se-lyon%2Fjourneys%3Ffrom%3D4.80092%253B45.75784%26to%3D4.83489%253B45.76192%26_override_scenario%3Ddistributed%26_access_points%3Dtrue%26direct_path_mode%255B%255D%3Dbike%26direct_path%3Donly%26debug%3Dtrue%26

Pity that `walking` is computed whereas it's not required at all.

In this PR, we aim to compute only what is requested, nothing more, nothing less.

