### PR TITLE
[Config][AWS]: Management of tyr parameters by env variables

### DIFF
--- a/source/tyr/tests/integration/conftest.py
+++ b/source/tyr/tests/integration/conftest.py
@@ -144,3 +144,17 @@ def invalid_instance_env_variables():
     )
     yield
     del os.environ["TYR_INSTANCE_fr-se-lyon"]
+
+
+@pytest.fixture
+def valid_instance_env_variables_fr():
+    os.environ["TYR_INSTANCE_fr"] = (
+        '{"instance":{"name":"fr","source-directory":"/ed/source",'
+        '"backup-directory":"/ed/backup","aliases_file":"/ed/aliases",'
+        '"synonyms_file":"/ed/synonyms","target-file":"ed/target_file",'
+        '"tmp_file":"/ed/tmp_file","is-free":true,"exchange":"exchange"},'
+        '"database":{"host":"host1","dbname":"jormun","username":"user1",'
+        '"password":"pass1","port":492}}'
+    )
+    yield
+    del os.environ["TYR_INSTANCE_fr"]

--- a/source/tyr/tests/integration/conftest.py
+++ b/source/tyr/tests/integration/conftest.py
@@ -116,3 +116,31 @@ def enable_mimir2_and_mimir():
     yield
     app.config['MIMIR_URL'] = previous_mimir2_value
     app.config['MIMIR7_URL'] = previous_mimir_value
+
+
+@pytest.fixture
+def valid_instance_env_variables():
+    os.environ["TYR_INSTANCE_fr-se-lyon"] = (
+        '{"instance":{"name":"fr-se-lyon","source-directory":"/ed/source",'
+        '"backup-directory":"/ed/backup","aliases_file":"/ed/aliases",'
+        '"synonyms_file":"/ed/synonyms","target-file":"ed/target_file",'
+        '"tmp_file":"/ed/tmp_file","is-free":true,"exchange":"exchange"},'
+        '"database":{"host":"host1","dbname":"jormun","username":"user1",'
+        '"password":"pass1","port":492}}'
+    )
+    yield
+    del os.environ["TYR_INSTANCE_fr-se-lyon"]
+
+
+@pytest.fixture
+def invalid_instance_env_variables():
+    os.environ["TYR_INSTANCE_fr-se-lyon"] = (
+        '{"instance":{"name":"fr-se-lyon","source-directory":"/ed/source",'
+        '"backup-directory":"/ed/backup","aliases_file":"/ed/aliases",'
+        '"synonyms_file":"/ed/synonyms","target-file":"ed/target_file",'
+        '"tmp_file":"/ed/tmp_file","is-free":true,"exchange":"exchange"},'
+        '"database":{"host":"host1","dbname":"jormun","username":"user1",'
+        '"password":"pass1","port":"492"}}'
+    )
+    yield
+    del os.environ["TYR_INSTANCE_fr-se-lyon"]

--- a/source/tyr/tests/integration/datapost_test.py
+++ b/source/tyr/tests/integration/datapost_test.py
@@ -51,10 +51,10 @@ def create_instance_fr():
 @pytest.yield_fixture(scope="function", autouse=True)
 def autocomplete_path(tmpdir):
     with app.app_context():
-        current_ac_path = current_app.config['TYR_AUTOCOMPLETE_DIR']
-        current_app.config['TYR_AUTOCOMPLETE_DIR'] = tmpdir.strpath
+        current_ac_path = current_app.config['AUTOCOMPLETE_DIR']
+        current_app.config['AUTOCOMPLETE_DIR'] = tmpdir.strpath
         yield
-        current_app.config['TYR_AUTOCOMPLETE_DIR'] = current_ac_path
+        current_app.config['AUTOCOMPLETE_DIR'] = current_ac_path
 
 
 def get_jobs_from_db(id=None):

--- a/source/tyr/tests/integration/helper_test.py
+++ b/source/tyr/tests/integration/helper_test.py
@@ -28,7 +28,7 @@
 # www.navitia.io
 
 from __future__ import absolute_import, print_function, division
-from tyr.helper import is_activate_autocomplete_version, load_instance_config
+from tyr.helper import is_activate_autocomplete_version, load_instance_config, get_instances_name
 from tyr import app
 import pytest
 
@@ -95,3 +95,19 @@ def test_invalid_config_instance_from_env_variables(invalid_instance_env_variabl
     assert (
         str(exc.value) == 'Config is not valid for instance fr-se-lyon, error u\'492\' is not of type \'number\''
     )
+
+
+def test_get_instances_name(init_instances_dir, valid_instance_env_variables):
+    with app.app_context():
+        instancies = get_instances_name()
+        assert len(instancies) == 2
+        for name in ["fr", "fr-se-lyon"]:
+            assert name in instancies
+
+
+def test_get_instances_name_same_instance(init_instances_dir, valid_instance_env_variables_fr):
+    # the same instance in config file and env variables
+    with app.app_context():
+        instancies = get_instances_name()
+        assert len(instancies) == 1
+        assert "fr" in instancies

--- a/source/tyr/tests/integration/helper_test.py
+++ b/source/tyr/tests/integration/helper_test.py
@@ -92,9 +92,8 @@ def test_invalid_config_instance_from_env_variables(invalid_instance_env_variabl
     with pytest.raises(ValueError) as exc:
         load_instance_config("fr-se-lyon")
 
-    assert (
-        str(exc.value) == 'Config is not valid for instance fr-se-lyon, error u\'492\' is not of type \'number\''
-    )
+    assert "Config is not valid for instance fr-se-lyon" in str(exc.value)
+    assert "'492' is not of type 'number'" in str(exc.value)
 
 
 def test_get_instances_name(init_instances_dir, valid_instance_env_variables):

--- a/source/tyr/tests/integration/helper_test.py
+++ b/source/tyr/tests/integration/helper_test.py
@@ -99,15 +99,15 @@ def test_invalid_config_instance_from_env_variables(invalid_instance_env_variabl
 
 def test_get_instances_name(init_instances_dir, valid_instance_env_variables):
     with app.app_context():
-        instancies = get_instances_name()
-        assert len(instancies) == 2
+        instances = get_instances_name()
+        assert len(instances) == 2
         for name in ["fr", "fr-se-lyon"]:
-            assert name in instancies
+            assert name in instances
 
 
 def test_get_instances_name_same_instance(init_instances_dir, valid_instance_env_variables_fr):
     # the same instance in config file and env variables
     with app.app_context():
-        instancies = get_instances_name()
-        assert len(instancies) == 1
-        assert "fr" in instancies
+        instances = get_instances_name()
+        assert len(instances) == 1
+        assert "fr" in instances

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -1,5 +1,4 @@
 # encoding: utf-8
-import logging
 from datetime import timedelta
 from celery import schedules
 import os
@@ -15,7 +14,9 @@ KRAKEN_BROKER_URL = os.getenv('TYR_KRAKEN_BROKER_URL', 'amqp://guest:guest@local
 # URI for postgresql
 # postgresql://<user>:<password>@<host>:<port>/<dbname>
 # http://docs.sqlalchemy.org/en/rel_0_9/dialects/postgresql.html#psycopg2
-SQLALCHEMY_DATABASE_URI = 'postgresql://navitia:navitia@localhost/jormungandr'
+SQLALCHEMY_DATABASE_URI = os.getenv(
+    'TYR_SQLALCHEMY_DATABASE_URI', 'postgresql://navitia:navitia@localhost/jormungandr'
+)
 
 
 # URI for cities database
@@ -27,15 +28,15 @@ CITIES_DATABASE_URI = os.getenv('TYR_CITIES_DATABASE_URI', 'postgresql://navitia
 CITIES_OSM_FILE_PATH = os.getenv('TYR_CITIES_OSM_FILE_PATH', '.')
 
 # Path to the directory where the configuration file of each instance of ed are defined
-INSTANCES_DIR = '.'
+INSTANCES_DIR = os.getenv('TYR_INSTANCES_DIR', '.')
 
 # Path to the directory where the data sources for autocomplete are stocked
-TYR_AUTOCOMPLETE_DIR = "/srv/ed/autocomplete"
+TYR_AUTOCOMPLETE_DIR = os.getenv('TYR_TYR_AUTOCOMPLETE_DIR', "/srv/ed/autocomplete")
 
-AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP = 5
+AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP = os.getenv('TYR_AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP', 5)
 
 # Max number of dataset to keep per instance and type
-DATASET_MAX_BACKUPS_TO_KEEP = 1
+DATASET_MAX_BACKUPS_TO_KEEP = os.getenv('TYR_DATASET_MAX_BACKUPS_TO_KEEP', 1)
 
 # Period of time to keep job (in days)
 JOB_MAX_PERIOD_TO_KEEP = os.getenv('TYR_JOB_MAX_PERIOD_TO_KEEP', 60)

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -38,10 +38,10 @@ AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP = 5
 DATASET_MAX_BACKUPS_TO_KEEP = 1
 
 # Period of time to keep job (in days)
-JOB_MAX_PERIOD_TO_KEEP = 60
+JOB_MAX_PERIOD_TO_KEEP = os.getenv('TYR_JOB_MAX_PERIOD_TO_KEEP', 60)
 
 # Tyr v1: Items per page with pagination
-MAX_ITEMS_PER_PAGE = 10
+MAX_ITEMS_PER_PAGE = os.getenv('TYR_MAX_ITEMS_PER_PAGE', 10)
 
 
 # Log Level available
@@ -72,21 +72,21 @@ LOGGER = {
 
 REDIS_HOST = os.getenv('TYR_REDIS_HOST', '127.0.0.1')
 
-REDIS_PORT = 6379
+REDIS_PORT = os.getenv('TYR_REDIS_PORT', 6379)
 
 # index of the database use in redis, between 0 and 15 by default
-REDIS_DB = 0
+REDIS_DB = os.getenv('TYR_REDIS_DB', 0)
 
-REDIS_PASSWORD = None
+REDIS_PASSWORD = os.getenv('TYR_REDIS_PASSWORD', None)
 
 # Validate the presence of a mx record on the domain
-EMAIL_CHECK_MX = True
+EMAIL_CHECK_MX = os.getenv('TYR_EMAIL_CHECK_MX', True)
 
 # Validate the email by connecting to the smtp server, but doesn't send an email
-EMAIL_CHECK_SMTP = True
+EMAIL_CHECK_SMTP = os.getenv('TYR_EMAIL_CHECK_SMTP', True)
 
 # configuration of celery, don't edit
-CELERY_ACCEPT_CONTENT = ['pickle', 'json']
+CELERY_ACCEPT_CONTENT = os.getenv('TYR_CELERY_ACCEPT_CONTENT', ['pickle', 'json'])
 
 CELERYBEAT_SCHEDULE = {
     'udpate-data-every-30-seconds': {
@@ -127,12 +127,12 @@ CELERYBEAT_SCHEDULE = {
         'options': {'expires': 50},
     },
 }
-CELERY_TIMEZONE = 'UTC'
+CELERY_TIMEZONE = os.getenv('TYR_CELERY_TIMEZONE', 'UTC')
 
 # http://docs.celeryproject.org/en/master/configuration.html#std:setting-CELERYBEAT_SCHEDULE_FILENAME
-CELERYBEAT_SCHEDULE_FILENAME = '/tmp/celerybeat-schedule'
+CELERYBEAT_SCHEDULE_FILENAME = os.getenv('TYR_CELERYBEAT_SCHEDULE_FILENAME', '/tmp/celerybeat-schedule')
 
-CELERYD_HIJACK_ROOT_LOGGER = False
+CELERYD_HIJACK_ROOT_LOGGER = os.getenv('TYR_CELERYD_HIJACK_ROOT_LOGGER', False)
 
 MIMIR_URL = os.getenv('TYR_MIMIR_URL', None)
 
@@ -151,8 +151,8 @@ MINIO_LOKI_ACCESS_KEY = os.getenv('TYR_MINIO_LOKI_ACCESS_KEY', None)
 MINIO_LOKI_SECRET_KEY = os.getenv('TYR_MINIO_LOKI_SECRET_KEY', None)
 
 # we don't enable serpy for now
-USE_SERPY = False
+USE_SERPY = os.getenv('TYR_USE_SERPY', False)
 
 # https://flask-sqlalchemy.palletsprojects.com/en/2.x/signals/
 # deprecated and slow
-SQLALCHEMY_TRACK_MODIFICATIONS = False
+SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('TYR_SQLALCHEMY_TRACK_MODIFICATIONS', False)

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -31,7 +31,7 @@ CITIES_OSM_FILE_PATH = os.getenv('TYR_CITIES_OSM_FILE_PATH', '.')
 INSTANCES_DIR = os.getenv('TYR_INSTANCES_DIR', '.')
 
 # Path to the directory where the data sources for autocomplete are stocked
-TYR_AUTOCOMPLETE_DIR = os.getenv('TYR_TYR_AUTOCOMPLETE_DIR', "/srv/ed/autocomplete")
+AUTOCOMPLETE_DIR = os.getenv('TYR_AUTOCOMPLETE_DIR', "/srv/ed/autocomplete")
 
 AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP = os.getenv('TYR_AUOTOCOMPLETE_MAX_BACKUPS_TO_KEEP', 5)
 

--- a/source/tyr/tyr/formats.py
+++ b/source/tyr/tyr/formats.py
@@ -145,3 +145,34 @@ external_service_format = {
     },
     'required': ['klass', 'navitia_service', 'args'],
 }
+
+instance_config_format = {
+    'type': 'object',
+    'properties': {
+        "instance": {
+            'type': 'object',
+            'properties': {
+                'name': {'type': 'string'},
+                'source-directory': {'type': 'string'},
+                'backup-directory': {'type': 'string'},
+                'aliases_file': {'type': 'string'},
+                'synonyms_file': {'type': 'string'},
+                'target-file': {'type': 'string'},
+                'tmp_file': {'type': 'string'},
+                'is-free': {'type': 'boolean'},
+                'exchange': {'type': 'string'},
+            },
+            'required': ['name'],
+        },
+        "database": {
+            'type': 'object',
+            'properties': {
+                'host': {'type': 'string'},
+                'port': {'type': 'number'},
+                'dbname': {'type': 'string'},
+                'username': {'type': 'string'},
+                'password': {'type': 'string'},
+            },
+        },
+    },
+}

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -33,6 +33,7 @@ import logging.config
 import uuid
 import celery
 from celery.exceptions import TimeoutError
+import glob
 
 from configobj import ConfigObj, flatten_errors
 from validate import Validator
@@ -168,6 +169,20 @@ def get_config_instance_from_ini_file(instance_name):
         raise ValueError("Config is not valid: %s in %s" % (error, ini_file))
 
     return config
+
+
+def get_instances_name():
+    instances = list()
+    for instance_file in glob.glob(current_app.config['INSTANCES_DIR'] + '/*.ini'):
+        instance_name = os.path.basename(instance_file).replace('.ini', '')
+        instances.append(instance_name)
+    prefix = "TYR_INSTANCE_"
+    for key, value in os.environ.items():
+        if key.startswith(prefix):
+            instance_name = key.replace(prefix, "")
+            if instance_name not in instances:
+                instances.append(instance_name)
+    return instances
 
 
 def select_json_by_instance_name(instance_name):

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -40,8 +40,11 @@ from flask import current_app
 import os
 import sys
 import tempfile
+from flask import json
+from jsonschema import validate, ValidationError
 
 from werkzeug.utils import secure_filename
+from tyr.formats import instance_config_format
 
 END_POINT_NOT_EXIST_MSG = 'end_point doesn\'t exist'
 BILLING_PLAN_NOT_EXIST_MSG = 'billing plan doesn\'t exist'
@@ -127,7 +130,11 @@ def is_activate_autocomplete_version(version=2):
     return current_app.config.get('MIMIR7_URL', None) != None
 
 
-def load_instance_config(instance_name):
+def get_config_instance_from_ini_file(instance_name):
+    ini_file = os.path.join(os.path.realpath(current_app.config['INSTANCES_DIR']), instance_name + ".ini")
+    if not os.path.isfile(ini_file):
+        raise ValueError("File doesn't exists or is not a file %s" % ini_file)
+
     def b(unicode):
         """
         convert unicode to bytestring
@@ -152,10 +159,6 @@ def load_instance_config(instance_name):
     confspec.append(b(u'password = string()'))
     confspec.append(b(u'port = string(default="5432")'))
 
-    ini_file = os.path.join(os.path.realpath(current_app.config['INSTANCES_DIR']), instance_name + ".ini")
-    if not os.path.isfile(ini_file):
-        raise ValueError("File doesn't exists or is not a file %s" % ini_file)
-
     config = ConfigObj(ini_file, configspec=confspec, stringify=True)
     val = Validator()
     res = config.validate(val, preserve_errors=True)
@@ -163,6 +166,40 @@ def load_instance_config(instance_name):
     if type(res) is dict:
         error = build_error(config, res)
         raise ValueError("Config is not valid: %s in %s" % (error, ini_file))
+
+    return config
+
+
+def select_json_by_instance_name(instance_name):
+    prefix = "TYR_INSTANCE_"
+    for key, value in os.environ.items():
+        if key.startswith(prefix):
+            lower_key = key.lower()
+            lower_instance = "{}{}".format(prefix.lower(), instance_name.lower())
+            if lower_key == lower_instance:
+                return value
+    return None
+
+
+def get_config_instance_from_env_variables(instance_name):
+    config = select_json_by_instance_name(instance_name)
+    if not config:
+        return None
+    logging.getLogger(__name__).info("Initialisation, reading: %s", instance_name)
+    json_config = json.loads(config)
+    try:
+        validate(json_config, instance_config_format)
+    except ValidationError as e:
+        msg = "Config is not valid for instance {}, error {}".format(instance_name, str(e.message))
+        logging.getLogger(__name__).error(msg)
+        raise ValueError(msg)
+    return json_config
+
+
+def load_instance_config(instance_name):
+    config = get_config_instance_from_env_variables(instance_name)
+    if not config:
+        config = get_config_instance_from_ini_file(instance_name)
     instance = InstanceConfig()
     instance.source_directory = config['instance']['source-directory']
     instance.backup_directory = config['instance']['backup-directory']

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -64,7 +64,12 @@ from tyr.binarisation import (
 from tyr.binarisation import reload_data, move_to_backupdirectory
 from tyr import celery
 from navitiacommon import models, task_pb2, utils
-from tyr.helper import load_instance_config, get_instance_logger, is_activate_autocomplete_version
+from tyr.helper import (
+    load_instance_config,
+    get_instance_logger,
+    is_activate_autocomplete_version,
+    get_instances_name,
+)
 from navitiacommon.launch_exec import launch_exec
 from datetime import datetime, timedelta
 
@@ -573,8 +578,7 @@ def purge_jobs(days_to_keep=None):
 
 @celery.task()
 def scan_instances():
-    for instance_file in glob.glob(current_app.config['INSTANCES_DIR'] + '/*.ini'):
-        instance_name = os.path.basename(instance_file).replace('.ini', '')
+    for instance_name in get_instances_name():
         instance = models.Instance.query_all().filter_by(name=instance_name).first()
         if not instance:
             current_app.logger.info('new instances detected: %s', instance_name)

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -371,7 +371,7 @@ def import_autocomplete(files, autocomplete_instance, asynchronous=True, backup_
         'osm': {2: osm2mimir, 7: osm2mimir},
         'cosmogony': {2: cosmogony2mimir, 7: cosmogony2mimir},
     }
-    autocomplete_dir = current_app.config['TYR_AUTOCOMPLETE_DIR']
+    autocomplete_dir = current_app.config['AUTOCOMPLETE_DIR']
 
     # it's important for the admin to be loaded first, then addresses, then street, then poi
     import_order = ['cosmogony', 'bano', 'oa', 'osm']
@@ -460,7 +460,7 @@ def import_in_mimir(_file, instance, asynchronous=True):
 @celery.task()
 def update_autocomplete():
     current_app.logger.debug("Update autocomplete data")
-    autocomplete_dir = current_app.config['TYR_AUTOCOMPLETE_DIR']
+    autocomplete_dir = current_app.config['AUTOCOMPLETE_DIR']
     for autocomplete_instance in models.AutocompleteParameter.query.all():
         files = glob.glob(autocomplete_instance.source_dir(autocomplete_dir) + "/*")
         if files:
@@ -699,7 +699,7 @@ def heartbeat():
 
 @celery.task()
 def create_autocomplete_depot(name):
-    autocomplete_dir = current_app.config['TYR_AUTOCOMPLETE_DIR']
+    autocomplete_dir = current_app.config['AUTOCOMPLETE_DIR']
     autocomplete = models.AutocompleteParameter.query.filter_by(name=name).first_or_404()
     main_dir = autocomplete.main_dir(autocomplete_dir)
     try:
@@ -718,7 +718,7 @@ def create_autocomplete_depot(name):
 @celery.task()
 def remove_autocomplete_depot(name):
     logging.info('removing instance dir for {}'.format(name))
-    autocomplete_dir = current_app.config['TYR_AUTOCOMPLETE_DIR']
+    autocomplete_dir = current_app.config['AUTOCOMPLETE_DIR']
     if os.path.exists(autocomplete_dir):
         autocomplete = models.AutocompleteParameter.query.filter_by(name=name).first_or_404()
         main_dir = autocomplete.main_dir(autocomplete_dir)
@@ -740,7 +740,7 @@ def purge_autocomplete():
         dir_to_keep = set(
             os.path.realpath(os.path.dirname(dataset.name)) for dataset in ac_instance.last_datasets(max_backups)
         )
-        autocomplete_dir = current_app.config['TYR_AUTOCOMPLETE_DIR']
+        autocomplete_dir = current_app.config['AUTOCOMPLETE_DIR']
         backup_dir = os.path.join(autocomplete_dir, ac_instance.name, 'backup')
         all_backups = set(os.path.join(backup_dir, backup) for backup in os.listdir(backup_dir))
         to_remove = all_backups - dir_to_keep


### PR DESCRIPTION
Example for tyr instance :
**Old configration (fr.ini)**
![image](https://user-images.githubusercontent.com/4006603/178769543-4831aeb1-32fe-4aee-98c2-c742968c76c8.png)

**New configuration:**
`
TYR_INSTANCE_fr = {"instance":{"name":"fr","source-directory":"/srv/ed/source/fr","backup-directory":"/srv/ed/backup/fr/","aliases_file":"/usr/shared/ed/aliases_fr","synonyms_file":"/usr/shared/synonyms_fr","target-file":"/srv/kraken/exports/fr/data.nav.lz4","tmp_file":"/srv/ed/fr/datatmp.nav.lz4","is-free":false,"exchange":"exchange"},"database":{"host":"localhost1","dbname":"ed_fr","username":"ed_fr","password":"test","port":492}}`