### PR TITLE
Fix RailSection bug

### DIFF
--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -424,14 +424,10 @@ static boost::shared_ptr<nt::disruption::Impact> make_impact(const chaos::Impact
 
     impact->severity = make_severity(chaos_impact.severity(), holder);
 
-    auto log = log4cplus::Logger::getInstance("log");
-    LOG4CPLUS_WARN(log, "Make impact " << chaos_impact.id());
     for (auto& ptobj : make_pt_objects(chaos_impact.informed_entities(), pt_data)) {
-        LOG4CPLUS_WARN(log, "New pt object for impact " << chaos_impact.id());
         nt::disruption::Impact::link_informed_entity(std::move(ptobj), impact, meta.production_date,
                                                      nt::RTLevel::Adapted, pt_data);
     }
-    LOG4CPLUS_WARN(log, "Finished making impact " << chaos_impact.id());
     for (const auto& chaos_message : chaos_impact.messages()) {
         const auto& channel = chaos_message.channel();
         auto channel_types = create_channel_types(channel);

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -286,7 +286,7 @@ boost::optional<nt::disruption::RailSection> make_rail_section(const chaos::PtOb
         log_message += " blocked stop _areas: ";
         for (const auto& pb_bsa : pb_section.blocked_stop_areas()) {
             rail_section.blocked_stop_areas.emplace_back(pb_bsa.uri(), pb_bsa.order());
-            log_message += pb_bsa.uri() + ";";
+            log_message += pb_bsa.uri() + "_order_" + std::to_string(pb_bsa.order()) + ";";
         }
     }
 
@@ -424,11 +424,14 @@ static boost::shared_ptr<nt::disruption::Impact> make_impact(const chaos::Impact
 
     impact->severity = make_severity(chaos_impact.severity(), holder);
 
+    auto log = log4cplus::Logger::getInstance("log");
+    LOG4CPLUS_WARN(log, "Make impact " << chaos_impact.id());
     for (auto& ptobj : make_pt_objects(chaos_impact.informed_entities(), pt_data)) {
+        LOG4CPLUS_WARN(log, "New pt object for impact " << chaos_impact.id());
         nt::disruption::Impact::link_informed_entity(std::move(ptobj), impact, meta.production_date,
                                                      nt::RTLevel::Adapted, pt_data);
     }
-
+    LOG4CPLUS_WARN(log, "Finished making impact " << chaos_impact.id());
     for (const auto& chaos_message : chaos_impact.messages()) {
         const auto& channel = chaos_message.channel();
         auto channel_types = create_channel_types(channel);

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -490,13 +490,6 @@ std::vector<ImpactedVJ> get_impacted_vehicle_journeys(const RailSection& rs,
                                                       const boost::gregorian::date_period& production_period,
                                                       type::RTLevel rt_level);
 
-std::pair<BlockedSAList, ConcatenateBlockedSASequence> create_blocked_sa_sequence(const RailSection& rs);
-bool is_route_to_impact_content_sa_list(const BlockedSAList& blocked_sa_uri_sequence,
-                                        const boost::container::flat_set<StopArea*>& stop_area_list);
-bool blocked_sa_sequence_matching(const ConcatenateBlockedSASequence& concatenate_blocked_sa_uri_sequence_string,
-                                  const navitia::type::VehicleJourney& vj,
-                                  const std::set<RankStopTime>& st_rank_list);
-
 }  // namespace disruption
 
 }  // namespace type


### PR DESCRIPTION
When a RailSection impacts a vehicle journey already modified by a previous disruption, it sometimes fails.
The culprit seems to be the combination : 
```
section  = vj.get_sections_ranks(..)
blocked_sa_sequence_matching(..,vj,  section)
```
The first calls returns a list of stop_time ranks of the **base vj**,
while the function `blocked_sa_sequence_matching` interprets these ranks on the vj itself, not on the base vj.

So if vj already have some stop_times removed by a previous disruptions, the stop_time ranks of vj and base are different.

I really don't see the usefulness of `blocked_sa_sequence_matching` so I removed it :crossed_fingers: 