### PR TITLE
[aws migration] use uri for kraken

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -85,6 +85,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("GENERAL.metrics_binding", po::value<std::string>(), "IP:PORT to serving metrics in http")
         ("GENERAL.core_file_size_limit", po::value<int>()->default_value(0), "ulimit that define the maximum size of a core file")
 
+        ("BROKER.uri", po::value<std::string>(), "rabbitmq connection uri")
         ("BROKER.host", po::value<std::string>()->default_value("localhost"), "host of rabbitmq")
         ("BROKER.port", po::value<int>()->default_value(5672), "port of rabbitmq")
         ("BROKER.username", po::value<std::string>()->default_value("guest"), "username for rabbitmq")
@@ -198,6 +199,12 @@ int Configuration::core_file_size_limit() const {
     return this->vm["GENERAL.core_file_size_limit"].as<int>();
 }
 
+boost::optional<std::string> Configuration::broker_uri() const {
+    if (this->vm.count("BROKER.uri") > 0) {
+        return this->vm["BROKER.uri"].as<std::string>();
+    }
+    return {};
+}
 std::string Configuration::broker_host() const {
     return this->vm["BROKER.host"].as<std::string>();
 }

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -51,6 +51,8 @@ public:
     int chaos_batch_size() const;
     int nb_threads() const;
 
+    boost::optional<std::string> broker_uri() const;
+
     std::string broker_host() const;
     int broker_port() const;
     std::string broker_username() const;

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -337,7 +337,8 @@ void MaintenanceWorker::listen_rabbitmq() {
 
 void MaintenanceWorker::init_rabbitmq() {
     std::string instance_name = conf.instance_name();
-    // connection through URI, if URI is provided, it will be used in the first place as other other connection options are neglected
+    // connection through URI, if URI is provided, it will be used in the first place as other other connection options
+    // are neglected
     boost::optional<std::string> broker_uri = conf.broker_uri();
     // connection through classic method
     std::string exchange_name = conf.broker_exchange();
@@ -358,7 +359,7 @@ void MaintenanceWorker::init_rabbitmq() {
     if (broker_uri) {
         LOG4CPLUS_INFO(logger, boost::format("connection to rabbitmq with uri: %s") % *broker_uri);
         channel = AmqpClient::Channel::CreateFromUri(*broker_uri);
-    }else {
+    } else {
         LOG4CPLUS_INFO(logger, boost::format("connection to rabbitmq: %s@%s:%s/%s") % username % host % port % vhost);
         channel = AmqpClient::Channel::Create(host, port, username, password, vhost);
     }

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -337,6 +337,9 @@ void MaintenanceWorker::listen_rabbitmq() {
 
 void MaintenanceWorker::init_rabbitmq() {
     std::string instance_name = conf.instance_name();
+    // connection through URI, if URI is provided, it will be used in the first place as other other connection options are neglected
+    boost::optional<std::string> broker_uri = conf.broker_uri();
+    // connection through classic method
     std::string exchange_name = conf.broker_exchange();
     std::string host = conf.broker_host();
     int port = conf.broker_port();
@@ -351,9 +354,14 @@ void MaintenanceWorker::init_rabbitmq() {
     queue_name_task = (boost::format("%s_task") % queue_name).str();
     queue_name_rt = (boost::format("%s_rt") % queue_name).str();
 
-    // connection
-    LOG4CPLUS_DEBUG(logger, boost::format("connection to rabbitmq: %s@%s:%s/%s") % username % host % port % vhost);
-    this->channel = AmqpClient::Channel::Create(host, port, username, password, vhost);
+    // connection through URI or classic method
+    if (broker_uri) {
+        LOG4CPLUS_INFO(logger, boost::format("connection to rabbitmq with uri: %s") % *broker_uri);
+        channel = AmqpClient::Channel::CreateFromUri(*broker_uri);
+    }else {
+        LOG4CPLUS_INFO(logger, boost::format("connection to rabbitmq: %s@%s:%s/%s") % username % host % port % vhost);
+        channel = AmqpClient::Channel::Create(host, port, username, password, vhost);
+    }
     if (!is_initialized) {
         // first we have to delete the queues, binding can change between two run, and it's don't seem possible
         // to unbind a queue if we don't know at what topic it's subscribed


### PR DESCRIPTION
Capability of connecting to rabbitmq via URI to reduce input variables, (instead of hostname, user, pwd etc... )