### PR TITLE
[Disruption] [rail_section]: Fix display disruptions with multi rail_sections on forward as well as backward direction

### DIFF
--- a/source/jormungandr/tests/rail_sections_tests.py
+++ b/source/jormungandr/tests/rail_sections_tests.py
@@ -612,6 +612,29 @@ class TestRailSections(AbstractTestFixture):
         for disruption, result in scenario.items():
             assert result == (disruption in d)
 
+        # Tests added to support https://navitia.atlassian.net/browse/NAV-1442
+        # stopCC-> stopEE / base_schedule: A disruption to display
+        scenario = {
+            'rail_section_on_line11': True,
+        }
+
+        r = journeys(_from='stopCC', to='stopEE')
+        assert len(r["journeys"]) == 1
+        assert get_used_vj(r) == [['vehicle_journey:vj:11-1']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:11-1'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # stopEE-> stopCC / base_schedule: A disruption to display
+        r = journeys(_from='stopEE', to='stopCC')
+        assert len(r["journeys"]) == 1
+        assert get_used_vj(r) == [['vehicle_journey:vj:11-2']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:11-2'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
         # Test on line 'line:100' impacted with a rail_section with severity=NO_SERVICE
         # Impacted from C1 to E1 with blocked stops D1 and E1
         # All the stops from stopDD to stopII are impacted
@@ -700,6 +723,46 @@ class TestRailSections(AbstractTestFixture):
         }
 
         r = journeys(_from='stopR1', to='stopP1')
+        assert len(r["journeys"]) == 1
+        assert get_used_vj(r) == [['vehicle_journey:vj:101-2']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:101-2'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # This test relates to https://navitia.atlassian.net/browse/NAV-1442
+        # stopS1 -> stopU1 / Base_schedule: A disruption to display on vj:101-1
+        scenario = {
+            'rail_section_on_line101': True,
+        }
+
+        r = journeys(_from='stopS1', to='stopU1')
+        assert len(r["journeys"]) == 1
+        assert get_used_vj(r) == [['vehicle_journey:vj:101-1']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:101-1'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # stopU1-> stopS1 / Base_schedule: A disruption to display on vj:101-2
+        scenario = {
+            'rail_section_on_line101': True,
+        }
+
+        r = journeys(_from='stopU1', to='stopS1')
+        assert len(r["journeys"]) == 1
+        assert get_used_vj(r) == [['vehicle_journey:vj:101-2']]
+        d = get_all_element_disruptions(r['journeys'], r)
+        assert impacted_headsigns(d) == {'vj:101-2'}
+        for disruption, result in scenario.items():
+            assert result == (disruption in d)
+
+        # stopU1-> stopR1 / Base_schedule: A disruption to display on vj:101-2
+        scenario = {
+            'rail_section_on_line101': True,
+        }
+
+        r = journeys(_from='stopU1', to='stopR1')
         assert len(r["journeys"]) == 1
         assert get_used_vj(r) == [['vehicle_journey:vj:101-2']]
         d = get_all_element_disruptions(r['journeys'], r)

--- a/source/tests/mock-kraken/rail_sections_test.cpp
+++ b/source/tests/mock-kraken/rail_sections_test.cpp
@@ -122,6 +122,7 @@ ed::builder create_complex_data_for_rail_section() {
         b.sa("stopAreaT1", 0., 44.)("stopT1", 0., 44.);
         b.sa("stopAreaU1", 0., 45.)("stopU1", 0., 45.);
         b.sa("stopAreaV1", 0., 46.)("stopV1", 0., 46.);
+        b.sa("stopAreaW1", 0., 88.)("stopW1", 0., 88.);
 
         b.sa("denfert_area", 0., 47.)("denfert", 0., 47.);
         b.sa("port_royal_area", 0., 48.)("port_royal", 0., 48.);
@@ -172,10 +173,10 @@ ed::builder create_complex_data_for_rail_section() {
 
         b.vj("line:101", "111111111111", "", true, "vj:101-1")
             .route("route101-1")("stopP1", "08:00"_t)("stopQ1", "08:05"_t)("stopR1", "08:10"_t)("stopS1", "08:15"_t)(
-                "stopT1", "08:20"_t)("stopU1", "08:25"_t)("stopV1", "08:30"_t);
+                "stopT1", "08:20"_t)("stopU1", "08:25"_t)("stopV1", "08:30"_t)("stopW1", "08:35"_t);
         b.vj("line:101", "111111", "", true, "vj:101-2")
-            .route("route101-2")("stopV1", "08:00"_t)("stopU1", "08:05"_t)("stopT1", "08:10"_t)("stopS1", "08:15"_t)(
-                "stopR1", "08:20"_t)("stopQ1", "08:25"_t)("stopP1", "08:30"_t);
+            .route("route101-2")("stopW1", "07:55"_t)("stopV1", "08:00"_t)("stopU1", "08:05"_t)("stopT1", "08:10"_t)(
+                "stopS1", "08:15"_t)("stopR1", "08:20"_t)("stopQ1", "08:25"_t)("stopP1", "08:30"_t);
 
         b.vj("line:RER-B", "111111111111", "", true, "vj:rer_b_nord")
             .route("route_rer_b_nord")("denfert", "08:00"_t)("port_royal", "08:05"_t)("luxembourg", "08:10"_t)(
@@ -312,9 +313,9 @@ int main(int argc, const char* const argv[]) {
                               *b.data->pt_data, *b.data->meta);
 
     // new impact with two rail_sections and severity level NO_SERVICE on route101-1 and route101-2
-    // route101-1: P1  Q1  R1 S1  T1  U1  V1
+    // route101-1: P1   Q1  R1  S1  T1  U1  V1  W1
     // rail_section: Start S1 / End   V1 / Blocked: T1, U1
-    // route101-2: V1  U1  T1 S1  R1  Q1  P1
+    // route101-2: W1   V1  U1  T1  S1  R1  Q1  P1
     // rail_section: Start V1 / End   S1 / Blocked: U1, T1
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line101")
                                   .severity(nt::disruption::Effect::NO_SERVICE)

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -506,8 +506,8 @@ bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
                     return true;
                 }
             }
-            return false;
         }
+        return false;
 
     } else {
         // else, no reason to not be interested by it


### PR DESCRIPTION
Forward rail_section:
* stops: P1    Q1   R1   S1    T1    U1    V1
* start : S1 / end : V1 / blocked stops: T1  U1

Backward rail_section:
* stops: V1    U1   T1   S1    R1    Q1    P1
* start : V1 / end : S1 / blocked stops: U1  T1

Journeys:
* S1 to U1 -> Disruption: Forward rail_section displayed -> OK
* U1 to S1 -> No  disruption displayed -> Error
* U1 to R1 -> Disruption: Backward rail_section displayed -> OK

After correction: 
* U1 to S1 -> Disruption: Backward rail_section displayed -> OK

For details: https://navitia.atlassian.net/browse/NAV-1442
