### PR TITLE
Readyness endpoint

### DIFF
--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -127,7 +127,8 @@ int main(int argn, char** argv) {
 
     const navitia::Metrics metrics(conf.metrics_binding(), conf.instance_name());
 
-    threads.create_thread(navitia::MaintenanceWorker(data_manager, conf, metrics));
+    threads.create_thread(
+        [&data_manager, conf, &metrics] { return navitia::MaintenanceWorker(data_manager, conf, metrics); });
     //
     // Data have been loaded, we can now accept connections
     try {

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -44,9 +44,6 @@ context = zmq.Context()
 
 
 def get_kraken_uri(instance_name):
-    uri = os.environ.get("KRAKEN_GENERAL_zmq_socket")
-    if uri:
-        return uri
     config_file = '{path}/{instance}/kraken.ini'.format(path=app.config['KRAKEN_DIR'], instance=instance_name)
     parser = ConfigParser()
     parser.read(config_file)
@@ -57,11 +54,14 @@ def get_kraken_uri(instance_name):
     return uri
 
 
+# Monitor several kraken instances through http://MONITOR_HOST/?instance=my_instance_name
+# Where 'my_instance_name' must be a subdirectory of app.config['KRAKEN_DIR']
+# that contains a 'kraken.ini' file
 @app.route('/')
 def monitor():
     instance = request.args.get('instance')
     if not instance:
-        return json.dumps({'error': ['instance invalid']}), 400
+        return json.dumps({'error': ['no instance given']}), 400
 
     try:
         uri = get_kraken_uri(instance)
@@ -101,6 +101,14 @@ def monitor():
         response['kraken_version'] = resp.status.navitia_version
         response['data_version'] = resp.status.data_version
 
+        # Kraken used to not respond on zmq status requests during the initial
+        # data load. So the zmq requests timed-out and here we responded with a "timeout" response.
+        #  Now it does answer zmq requests even during the initial load.
+        # So to be backward compatible, we send a "timeout" response when the data
+        # is not yet loaded by kraken.
+        if resp.status.loaded == False:
+            return json.dumps({'status': 'timeout'}), 503
+
         if resp.status.last_load_status == False and 'status' not in response:
             response['status'] = 'last load failed'
 
@@ -110,6 +118,108 @@ def monitor():
             return_code = 503
 
         return json.dumps(response), return_code
+    finally:
+        sock.close()
+
+
+# Status of a single kraken through http://MONITOR_HOST/status
+# The kraken is accessed through the zmq socket defined in "KRAKEN_GENERAL_zmq_socket"
+# Performs a zmq status request to kraken
+# and dumps the response into json
+@app.route('/status')
+def status():
+    zmq_socket = os.environ.get("KRAKEN_GENERAL_zmq_socket")
+    if not zmq_socket:
+        return json.dumps({'error': ['no zmq socket configured']}), 500
+    zmq_timeout_in_ms = os.environ.get("MONITOR_KRAKEN_ZMQ_TIMEOUT", 10000)
+    proto_response = request_kraken_zmq_status(zmq_socket, zmq_timeout_in_ms)
+    if proto_response == None:
+        return json.dumps({'error': 'zmq timed out'}), 503
+
+    json_response = {}
+    if proto_response.error and proto_response.error.message:
+        json_response['error'] = proto_response.error.message
+
+    if proto_response.status:
+        proto_status = proto_response.status
+        json_response['publication_date'] = proto_status.publication_date
+        json_response['start_production_date'] = proto_status.start_production_date
+        json_response['end_production_date'] = proto_status.end_production_date
+        json_response['data_version'] = proto_status.data_version
+        json_response['navitia_version'] = proto_status.navitia_version
+        json_response['data_sources'] = [source for source in proto_status.data_sources]
+        json_response['last_load_at'] = proto_status.last_load_at
+        json_response['last_load_status'] = proto_status.last_load_status
+        json_response['loaded'] = proto_status.loaded
+        json_response['nb_threads'] = proto_status.nb_threads
+        json_response['is_connected_to_rabbitmq'] = proto_status.is_connected_to_rabbitmq
+        json_response['status'] = proto_status.status
+        json_response['last_rt_data_loaded'] = proto_status.last_rt_data_loaded
+        json_response['is_realtime_loaded'] = proto_status.is_realtime_loaded
+        json_response['dataset_created_at'] = proto_status.dataset_created_at
+        json_response['rt_contributors'] = [source for source in proto_status.rt_contributors]
+        json_response['disruption_error'] = proto_status.disruption_error
+
+    if proto_response.metadatas:
+        proto_metadatas = proto_response.metadatas
+        json_response['timezone'] = proto_metadatas.timezone
+        json_response['name'] = proto_metadatas.name
+
+    return json.dumps(json_response), 200
+
+
+# Health of a single kraken through http://MONITOR_HOST/health
+# The kraken is accessed through the zmq socket defined in "KRAKEN_GENERAL_zmq_socket"
+# Respond with a 200 when kraken gives a response on a zmq status request
+@app.route('/health')
+def health():
+    zmq_socket = os.environ.get("KRAKEN_GENERAL_zmq_socket")
+    if not zmq_socket:
+        return json.dumps({'error': ['no zmq socket configured']}), 500
+    zmq_timeout_in_ms = os.environ.get("MONITOR_KRAKEN_ZMQ_TIMEOUT", 10000)
+    proto_response = request_kraken_zmq_status(zmq_socket, zmq_timeout_in_ms)
+    if proto_response == None:
+        return json.dumps({'error': 'zmq timed out'}), 503
+    return json.dumps("alive"), 200
+
+
+# Readyness of a single kraken through http://MONITOR_HOST/ready
+# The kraken is accessed through the zmq socket defined in "KRAKEN_GENERAL_zmq_socket"
+# Respond with a 200 when :
+#  - kraken gives a response on a zmq status request
+#  - the "loaded" field of the status response is set to True
+@app.route('/ready')
+def ready():
+    zmq_socket = os.environ.get("KRAKEN_GENERAL_zmq_socket")
+    if not zmq_socket:
+        return json.dumps({'error': ['no zmq socket configured']}), 500
+    zmq_timeout_in_ms = os.environ.get("MONITOR_KRAKEN_ZMQ_TIMEOUT", 10000)
+    proto_response = request_kraken_zmq_status(zmq_socket, zmq_timeout_in_ms)
+    if proto_response == None:
+        return json.dumps({'error': 'zmq timed out'}), 503
+    if proto_response.status == None:
+        return json.dumps({'error': 'no status in zmq response'}), 500
+    if proto_response.status.loaded == True:
+        return json.dumps("ready"), 200
+    return json.dumps("not ready"), 400
+
+
+def request_kraken_zmq_status(zmq_socket, zmq_timeout_in_ms):
+    sock = context.socket(zmq.REQ)
+    # discard messages when socket closed
+    sock.setsockopt(zmq.LINGER, 0)
+    try:
+        sock.connect(zmq_socket)
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.STATUS
+        sock.send(req.SerializeToString())
+        if sock.poll(zmq_timeout_in_ms) < 1:
+            return None
+
+        response_bytes = sock.recv()
+        proto_response = response_pb2.Response()
+        proto_response.ParseFromString(response_bytes)
+        return proto_response
     finally:
         sock.close()
 

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -103,7 +103,7 @@ def monitor():
 
         # Kraken used to not respond on zmq status requests during the initial
         # data load. So the zmq requests timed-out and here we responded with a "timeout" response.
-        #  Now it does answer zmq requests even during the initial load.
+        # Now it does answer zmq requests even during the initial load.
         # So to be backward compatible, we send a "timeout" response when the data
         # is not yet loaded by kraken.
         if resp.status.loaded == False:


### PR DESCRIPTION
Enable a readyness check for kraken by  moving the initial data load from the main thread into the "maintenance" thread. Consequently, the zmq thread is started and alive even before the initial data load completed, and kraken can answer zmq status requests immediately.

Adds three endpoints in the app "monitor_kraken" : 
- `/health `that returns a 200 when it obtains a response from kraken to a zmq status request, disregarding the content of the response
- `/ready` that returns a 200 when it it obtains a status response from kraken in which the field "loaded" is true
- `/status` that returns the content of the status response obtained from kraken

Note that these 3 endpoints are configured to call a **single** kraken, which is called through the zmq socket defined in the environment variable `KRAKEN_GENERAL_zmq_socket`.
In contrast, the "old" endpoint is used to monitor **several** kraken instance, and is configured through the python config `app.config['KRAKEN_DIR']`

Also note the "hack" to ensure backward compatibility with the current deployment mechanism https://github.com/hove-io/navitia/blob/b0c78408300724adb8cfd6b7f951daa01d781df7/source/monitor/monitor_kraken/app.py#L104-L108