### PR TITLE
fix the datetime set in backtracking correction

### DIFF
--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1407,22 +1407,23 @@ bool shorten_section(navitia::routing::Journey::Section& section,
         if (vj == vj_to_skip) {
             continue;
         }
+
+        if (section.get_in_dt < section.get_in_st->boarding_time) {
+            LOG4CPLUS_ERROR(logger, "Error : section.get_in_dt < section.get_in_st->boarding_time");
+            return false;
+        }
+        // determine midnigth of the day at which the vj is used
+        navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
             if (st.stop_point->stop_area->uri == stop_area_uri
                 && can_shorten_at(departures, destinations, st, clockwise)) {
-                // determine midnigth of the day at which the vj is used
-                // with protection from underflow
-                navitia::DateTime base_dt = 0;
-                if (section.get_in_dt > section.get_in_st->departure_time) {
-                    base_dt = section.get_in_dt - section.get_in_st->departure_time;
-                }
                 if (clockwise) {
                     section.get_out_st = &st;
-                    section.get_out_dt = base_dt + st.arrival_time;
+                    section.get_out_dt = base_dt + st.alighting_time;
                 } else {
                     section.get_in_st = &st;
-                    section.get_in_dt = base_dt + st.departure_time;
+                    section.get_in_dt = base_dt + st.boarding_time;
                 }
 
                 return true;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1397,10 +1397,6 @@ bool shorten_section_clockwise(navitia::routing::Journey::Section& section,
         navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
-            // if the end of original section is reached: no shortening on that section
-            if (&st == section.get_out_st) {
-                return false;
-            }
             // check stop_area is the same and it's possible to use stop_point to get out of PT
             if (st.stop_point->stop_area->uri == last_stop_area_uri
                 && navitia::contains(fallbacks, routing::SpIdx{st.stop_point->idx}) && st.drop_off_allowed()) {
@@ -1408,6 +1404,10 @@ bool shorten_section_clockwise(navitia::routing::Journey::Section& section,
                 section.get_out_dt = base_dt + st.alighting_time;
 
                 return true;
+            }
+            // if the end of original section is reached: interrupt search for shortening on that section
+            if (&st == section.get_out_st) {
+                return false;
             }
         }
     }
@@ -1443,10 +1443,6 @@ bool shorten_section_anticlockwise(navitia::routing::Journey::Section& section,
         navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.rbegin() + order.val, vj->stop_time_list.rend())) {
-            // if the start of original section is reached: no shortening on that section
-            if (&st == section.get_in_st) {
-                return false;
-            }
             // check stop_area is the same and it's possible to use stop_point to get in PT
             if (st.stop_point->stop_area->uri == first_stop_area_uri
                 && navitia::contains(fallbacks, routing::SpIdx{st.stop_point->idx}) && st.pick_up_allowed()) {
@@ -1454,6 +1450,10 @@ bool shorten_section_anticlockwise(navitia::routing::Journey::Section& section,
                 section.get_in_dt = base_dt + st.boarding_time;
 
                 return true;
+            }
+            // if the start of original section is reached: interrupt search for shortening on that section
+            if (&st == section.get_in_st) {
+                return false;
             }
         }
     }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1409,6 +1409,8 @@ bool shorten_section(navitia::routing::Journey::Section& section,
             return false;
         }
         // determine midnigth of the day at which the vj is used
+        // WARNING : this base_dt may need to be increased in case there is some stay-ins vehicle
+        // with stop_times that are past midnight
         navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1404,10 +1404,13 @@ bool shorten_section(navitia::routing::Journey::Section& section,
     // because of stay-ins, we may have several vj in one section, we have to scan the stop times
     // of all vjs
     for (const auto* vj = section.get_in_st->vehicle_journey; vj; (vj = vj->next_vj, order = type::RankStopTime(0))) {
+        if (vj == vj_to_skip) {
+            continue;
+        }
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
-            if (can_shorten_at(departures, destinations, st, clockwise)
-                && st.stop_point->stop_area->uri == stop_area_uri && vj != vj_to_skip) {
+            if (st.stop_point->stop_area->uri == stop_area_uri
+                && can_shorten_at(departures, destinations, st, clockwise)) {
                 // determine midnigth of the day at which the vj is used
                 // with protection from underflow
                 navitia::DateTime base_dt = 0;

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1397,6 +1397,10 @@ bool shorten_section_clockwise(navitia::routing::Journey::Section& section,
         navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
+            // if the end of original section is reached: no shortening on that section
+            if (&st == section.get_out_st) {
+                return false;
+            }
             // check stop_area is the same and it's possible to use stop_point to get out of PT
             if (st.stop_point->stop_area->uri == last_stop_area_uri
                 && navitia::contains(fallbacks, routing::SpIdx{st.stop_point->idx}) && st.drop_off_allowed()) {
@@ -1439,6 +1443,10 @@ bool shorten_section_anticlockwise(navitia::routing::Journey::Section& section,
         navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.rbegin() + order.val, vj->stop_time_list.rend())) {
+            // if the start of original section is reached: no shortening on that section
+            if (&st == section.get_in_st) {
+                return false;
+            }
             // check stop_area is the same and it's possible to use stop_point to get in PT
             if (st.stop_point->stop_area->uri == first_stop_area_uri
                 && navitia::contains(fallbacks, routing::SpIdx{st.stop_point->idx}) && st.pick_up_allowed()) {

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1404,10 +1404,6 @@ bool shorten_section(navitia::routing::Journey::Section& section,
     // because of stay-ins, we may have several vj in one section, we have to scan the stop times
     // of all vjs
     for (const auto* vj = section.get_in_st->vehicle_journey; vj; (vj = vj->next_vj, order = type::RankStopTime(0))) {
-        if (vj == vj_to_skip) {
-            continue;
-        }
-
         if (section.get_in_dt < section.get_in_st->boarding_time) {
             LOG4CPLUS_ERROR(logger, "Error : section.get_in_dt < section.get_in_st->boarding_time");
             return false;
@@ -1416,7 +1412,7 @@ bool shorten_section(navitia::routing::Journey::Section& section,
         navitia::DateTime base_dt = section.get_in_dt - section.get_in_st->boarding_time;
         for (const auto& st :
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
-            if (st.stop_point->stop_area->uri == stop_area_uri
+            if (st.stop_point->stop_area->uri == stop_area_uri && vj != vj_to_skip
                 && can_shorten_at(departures, destinations, st, clockwise)) {
                 if (clockwise) {
                     section.get_out_st = &st;
@@ -1433,7 +1429,7 @@ bool shorten_section(navitia::routing::Journey::Section& section,
             }
         }
     }
-    LOG4CPLUS_WARN(logger, "Error occurred when modifying backtracking journeys");
+    LOG4CPLUS_ERROR(logger, "Error occurred when modifying backtracking journeys");
     return false;
 }
 

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -1408,8 +1408,19 @@ bool shorten_section(navitia::routing::Journey::Section& section,
              boost::make_iterator_range(vj->stop_time_list.begin() + order.val, vj->stop_time_list.end())) {
             if (can_shorten_at(departures, destinations, st, clockwise)
                 && st.stop_point->stop_area->uri == stop_area_uri && vj != vj_to_skip) {
-                (clockwise ? section.get_out_st : section.get_in_st) = &st;
-                (clockwise ? section.get_out_dt : section.get_in_dt) = clockwise ? st.arrival_time : st.departure_time;
+                // determine midnigth of the day at which the vj is used
+                // with protection from underflow
+                navitia::DateTime base_dt = 0;
+                if (section.get_in_dt > section.get_in_st->departure_time) {
+                    base_dt = section.get_in_dt - section.get_in_st->departure_time;
+                }
+                if (clockwise) {
+                    section.get_out_st = &st;
+                    section.get_out_dt = base_dt + st.arrival_time;
+                } else {
+                    section.get_in_st = &st;
+                    section.get_in_dt = base_dt + st.departure_time;
+                }
 
                 return true;
             }

--- a/source/tyr/requirements_dev.txt
+++ b/source/tyr/requirements_dev.txt
@@ -3,6 +3,7 @@
 
 docker==3.4.1
 pytest==4.6.5
+pytest-cov==2.5.1
 python-dateutil==2.5.3
 mock==1.0.1
 jmespath==0.9.3


### PR DESCRIPTION
There was a confusion between the time-in-day (`st.arrival_time` and `st.departure_time`) and time-since-beginning-of-dataset (`section.get_out_dt` and `section.get_in_dt`).

So when a section was shorten, its modified endpoint was always set in the first day of the calendar.
We now compute the `base_dt` (that is midnight for the day on which the vj is used) from the section data, and then use this to set the correct datetime in the modified section.

Fix for https://navitia.atlassian.net/browse/NAV-1473