### PR TITLE
Read rt topics env var

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -29,9 +29,6 @@ www.navitia.io
 */
 
 #include "configuration.h"
-
-#include "utils/exception.h"
-
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/optional.hpp>

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -35,6 +35,7 @@ www.navitia.io
 
 #include <fstream>
 #include <iostream>
+#include "utils/functions.h"
 
 namespace po = boost::program_options;
 
@@ -250,7 +251,11 @@ std::vector<std::string> Configuration::rt_topics() const {
     if (!this->vm.count("BROKER.rt_topics")) {
         return std::vector<std::string>();
     }
-    return this->vm["BROKER.rt_topics"].as<std::vector<std::string>>();
+    std::vector<std::string> result = this->vm["BROKER.rt_topics"].as<std::vector<std::string>>();
+    if (result.size() == 1) {
+        return split_string(result.at(0), ";");
+    }
+    return result;
 }
 
 int Configuration::kirin_retry_timeout() const {

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -109,9 +109,7 @@ static std::string env_parser(std::string env) {
         return "";
     }
     boost::algorithm::replace_first(env, "KRAKEN_", "");
-    boost::algorithm::replace_first(env, "GENERAL_", "GENERAL.");
-    boost::algorithm::replace_first(env, "BROKER_", "BROKER.");
-    boost::algorithm::replace_first(env, "CHAOS_", "CHAOS.");
+    boost::algorithm::replace_first(env, "_", ".");
     if (!boost::algorithm::starts_with(env, "GENERAL") && !boost::algorithm::starts_with(env, "BROKER")
         && !boost::algorithm::starts_with(env, "CHAOS")) {
         // it doesn't look like one of our var, we ignore it

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -111,7 +111,9 @@ static std::string env_parser(std::string env) {
         return "";
     }
     boost::algorithm::replace_first(env, "KRAKEN_", "");
-    boost::algorithm::replace_first(env, "_", ".");
+    boost::algorithm::replace_first(env, "GENERAL_", "GENERAL.");
+    boost::algorithm::replace_first(env, "BROKER_", "BROKER.");
+    boost::algorithm::replace_first(env, "CHAOS_", "CHAOS.");
     if (!boost::algorithm::starts_with(env, "GENERAL") && !boost::algorithm::starts_with(env, "BROKER")
         && !boost::algorithm::starts_with(env, "CHAOS")) {
         // it doesn't look like one of our var, we ignore it


### PR DESCRIPTION
For env-var names, fix the way `_` is replaced to avoid replacing it in "final" parameters.

Also interpretation of `rt_topics` value to expand it to a vector (separator `;`) if it's a unique value (especially to allow list in env-var).

Result:
`$ KRAKEN_BROKER_rt_topics=rt1;rt2;rt3 ./kraken` should work as expected