### PR TITLE
[Monitor] always return the 'loaded' field in response

### DIFF
--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -90,14 +90,6 @@ def monitor():
         resp = response_pb2.Response()
         resp.ParseFromString(pb)
 
-        # Kraken used to not respond on zmq status requests during the initial
-        # data load. So the zmq requests timed-out and here we responded with a "timeout" response.
-        # Now it does answer zmq requests even during the initial load.
-        # So to be backward compatible, we send a "timeout" response when the data
-        # is not yet loaded by kraken.
-        if resp.status.loaded == False:
-            return json.dumps({'status': 'timeout'}), 503
-
         response = {}
         return_code = 200
         if resp.error and resp.error.message:


### PR DESCRIPTION
Deployments failed because the monitor response did not contain the 'loaded' field, and the deployment script [use this field](https://github.com/hove-io/fabric_navitia/blob/3dac2039a02db87593c7368977681185d621e98e/fabfile/component/kraken.py#L371) to determine if the data is loaded, or if it should wait and ask kraken monitor again later