### PR TITLE
Tyr should repost data to secondary tyr

### DIFF
--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -160,4 +160,6 @@ USE_SERPY = os.getenv('TYR_USE_SERPY', False)
 # deprecated and slow
 SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('TYR_SQLALCHEMY_TRACK_MODIFICATIONS', False)
 
-POST_DATA_TO_TYR = os.getenv('TYR_POST_DATA_TO_TYR', None)
+# Url of a secondary Tyr. The data posted to an instance of this Tyr via the '/jobs'
+# endpoint will be reposted to this url
+POST_DATA_TO_TYR = os.getenv('TYR_REPOST_DATA_TO_TYR', None)

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -162,4 +162,4 @@ SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('TYR_SQLALCHEMY_TRACK_MODIFICATIONS',
 
 # Url of a secondary Tyr. The data posted to an instance of this Tyr via the '/jobs'
 # endpoint will be reposted to this url
-POST_DATA_TO_TYR = os.getenv('TYR_REPOST_DATA_TO_TYR', None)
+POST_DATA_TO_TYR = os.getenv('TYR_POST_DATA_TO_TYR', None)

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -159,3 +159,5 @@ USE_SERPY = os.getenv('TYR_USE_SERPY', False)
 # https://flask-sqlalchemy.palletsprojects.com/en/2.x/signals/
 # deprecated and slow
 SQLALCHEMY_TRACK_MODIFICATIONS = os.getenv('TYR_SQLALCHEMY_TRACK_MODIFICATIONS', False)
+
+POST_DATA_TO_TYR = os.getenv('TYR_POST_DATA_TO_TYR', None)

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -356,7 +356,6 @@ def repost_to_another_url(logger, url, content, instance_name):
     content.seek(0)
     file_to_post = {"file": (content.filename, content.stream, content.mimetype)}
     secondary_url = '{}/jobs/{}'.format(url, instance_name)
-    secondary_url = '{}/jobs/ca-qc-sherbrooke'.format(url)
     nb_try = 0
     while nb_try < MAX_TRY_FOR_REPOST_TO_SECONDARY_TYR:
         try:

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -359,7 +359,7 @@ def repost_to_another_url(logger, url, content, instance_name):
     nb_try = 0
     while nb_try < MAX_TRY_FOR_REPOST_TO_SECONDARY_TYR:
         try:
-            resp = requests.post(secondary_url, files=file_to_post, verify=False)
+            resp = requests.post(secondary_url, files=file_to_post)
             logging.info('Info on posting data: {}'.format(resp.text))
             if resp.status_code == 200:
                 return True

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -43,9 +43,11 @@ import sys
 from flask import json
 from jsonschema import validate, ValidationError
 from tyr.formats import instance_config_format
+import requests
 
 END_POINT_NOT_EXIST_MSG = 'end_point doesn\'t exist'
 BILLING_PLAN_NOT_EXIST_MSG = 'billing plan doesn\'t exist'
+MAX_NB_CALLS = 3
 
 
 def get_message(key, email, args):
@@ -348,3 +350,21 @@ def hide_domain(email):
     if "@" not in email:
         return email
     return "{}******".format(email.split('@')[0])
+
+
+def repost_to_another_tyr(logger, url, content, instance_name):
+    content.seek(0)
+    file_to_post = {"file": (content.filename, content.stream, content.mimetype)}
+    url_secondary_tyr = '{}/jobs/{}'.format(url, instance_name)
+    nb_try = 0
+    while nb_try < MAX_NB_CALLS:
+        try:
+            resp = requests.post(url_secondary_tyr, files=file_to_post, verify=False)
+            logging.info('Info on posting data: {}'.format(resp.text))
+            if resp.status_code == 200:
+                return True
+            nb_try = nb_try + 1
+        except Exception as e:
+            logger.error("Error while posting data to secondary tyr: {i}: {e}".format(i=url_secondary_tyr, e=e))
+            return False
+    return False

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -47,7 +47,7 @@ import requests
 
 END_POINT_NOT_EXIST_MSG = 'end_point doesn\'t exist'
 BILLING_PLAN_NOT_EXIST_MSG = 'billing plan doesn\'t exist'
-MAX_NB_CALLS = 3
+MAX_TRY_FOR_REPOST_TO_SECONDARY_TYR = 3
 
 
 def get_message(key, email, args):
@@ -352,19 +352,20 @@ def hide_domain(email):
     return "{}******".format(email.split('@')[0])
 
 
-def repost_to_another_tyr(logger, url, content, instance_name):
+def repost_to_another_url(logger, url, content, instance_name):
     content.seek(0)
     file_to_post = {"file": (content.filename, content.stream, content.mimetype)}
-    url_secondary_tyr = '{}/jobs/{}'.format(url, instance_name)
+    secondary_url = '{}/jobs/{}'.format(url, instance_name)
+    secondary_url = '{}/jobs/ca-qc-sherbrooke'.format(url)
     nb_try = 0
-    while nb_try < MAX_NB_CALLS:
+    while nb_try < MAX_TRY_FOR_REPOST_TO_SECONDARY_TYR:
         try:
-            resp = requests.post(url_secondary_tyr, files=file_to_post, verify=False)
+            resp = requests.post(secondary_url, files=file_to_post, verify=False)
             logging.info('Info on posting data: {}'.format(resp.text))
             if resp.status_code == 200:
                 return True
             nb_try = nb_try + 1
         except Exception as e:
-            logger.error("Error while posting data to secondary tyr: {i}: {e}".format(i=url_secondary_tyr, e=e))
+            logger.error("Error while posting data to secondary tyr: {i}: {e}".format(i=secondary_url, e=e))
             return False
     return False

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -158,7 +158,7 @@ class Job(flask_restful.Resource):
         if not os.path.exists(instance.source_directory):
             return {'error': 'input folder unavailable'}, 500
 
-        if not utils.filename_has_valid_extension(filename):
+        if utils.filename_has_valid_extension(filename) == False:
             return (
                 {
                     'message': "Filename has invalid extension :'{}'".format(content.filename),

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -74,7 +74,10 @@ from tyr.helper import (
     hide_domain,
     create_autocomplete_instance_paths,
     create_repositories,
+    repost_to_another_tyr,
 )
+
+max_nb_calls = 3
 from tyr.tasks import (
     create_autocomplete_depot,
     remove_autocomplete_depot,
@@ -144,11 +147,19 @@ class Job(flask_restful.Resource):
         logger = get_instance_logger(instance)
         logger.info('content received: %s', content)
 
+        # Send content file to secondary tyr in aws and return an error message if failed
+        url_secondary_tyr = current_app.config.get('POST_DATA_TO_TYR', None)
+        if url_secondary_tyr is not None:
+            resp = repost_to_another_tyr(logger, url_secondary_tyr, content, instance_name)
+            if not resp:
+                return {'error': 'Upload to secondary tyr failed'}, 500
+            content.seek(0)
+
         instance = load_instance_config(instance_name)
         if not os.path.exists(instance.source_directory):
             return {'error': 'input folder unavailable'}, 500
 
-        if utils.filename_has_valid_extension(filename) == False:
+        if not utils.filename_has_valid_extension(filename):
             return (
                 {
                     'message': "Filename has invalid extension :'{}'".format(content.filename),
@@ -159,9 +170,9 @@ class Job(flask_restful.Resource):
 
         full_file_name = os.path.join(os.path.realpath(instance.source_directory), filename)
         tmp_file_name = full_file_name + ".tmp"
+
         content.save(tmp_file_name)
         shutil.move(tmp_file_name, full_file_name)
-
         return {'message': 'OK'}, 200
 
     def delete(self, id=None, instance_name=None):

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -74,10 +74,9 @@ from tyr.helper import (
     hide_domain,
     create_autocomplete_instance_paths,
     create_repositories,
-    repost_to_another_tyr,
+    repost_to_another_url,
 )
 
-max_nb_calls = 3
 from tyr.tasks import (
     create_autocomplete_depot,
     remove_autocomplete_depot,
@@ -150,7 +149,7 @@ class Job(flask_restful.Resource):
         # Send content file to secondary tyr in aws and return an error message if failed
         url_secondary_tyr = current_app.config.get('POST_DATA_TO_TYR', None)
         if url_secondary_tyr is not None:
-            resp = repost_to_another_tyr(logger, url_secondary_tyr, content, instance_name)
+            resp = repost_to_another_url(logger, url_secondary_tyr, content, instance_name)
             if not resp:
                 return {'error': 'Upload to secondary tyr failed'}, 500
             content.seek(0)


### PR DESCRIPTION
During migration transition period of navitia, TYR on-premise should post data toward secondary TYR (aws) if configured.

Note: 

- Autocomplete global data (`cosmogony`, `france-latest.osm.pbf` and `bano.csv.gz`) will not be re-posted.
- Difficult to add test but well tested between TYR dev onpremise and TYR sandbox. coverages: ca-qc-sherbrooke and fr-auv

Parameter added in fab_navitia : https://github.com/hove-io/fabric_navitia/pull/370
To activate in dev : https://github.com/hove-io/navitia_deployment_conf/pull/1051/

Do not forget to set the environment variable REQUESTS_CA_BUNDLE
export REQUESTS_CA_BUNDLE=/etc/ssl/certs
