### PR TITLE
[RabbitMq] Do not create realtime queue before data is loaded + add queue time to live

### DIFF
--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -94,6 +94,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
         ("BROKER.timeout", po::value<int>()->default_value(100), "timeout for maintenance worker in millisecond")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
+        ("BROKER.reconnect_wait", po::value<int>()->default_value(1), "Wait duration between connection attempts to rabbitmq, in seconds")
         ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")
         ("BROKER.queue_auto_delete", po::value<bool>()->default_value(false), "auto delete rabbitmq's queue when unbind")
         ("BROKER.queue_expire", po::value<int>()->default_value(7200), "Rabbitmq queues created by kraken will be deleted by rabbitmq after this duration , in seconds")
@@ -233,6 +234,10 @@ int Configuration::broker_timeout() const {
 
 int Configuration::broker_sleeptime() const {
     return vm["BROKER.sleeptime"].as<int>();
+}
+
+int Configuration::broker_reconnect_wait() const {
+    return vm["BROKER.reconnect_wait"].as<int>();
 }
 
 std::string Configuration::broker_queue(const std::string& default_queue) const {

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -96,6 +96,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
         ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")
         ("BROKER.queue_auto_delete", po::value<bool>()->default_value(false), "auto delete rabbitmq's queue when unbind")
+        ("BROKER.queue_ttl", po::value<int>()->default_value(7200), "Time To Live for rabbitmq queues created by kraken, in seconds")
 
         ("CHAOS.database", po::value<std::string>(), "Chaos database connection string")
         ("CHAOS.batch_size", po::value<int>()->default_value(1000000), "Chaos database row batch size");
@@ -243,6 +244,10 @@ std::string Configuration::broker_queue(const std::string& default_queue) const 
 
 bool Configuration::broker_queue_auto_delete() const {
     return vm["BROKER.queue_auto_delete"].as<bool>();
+}
+
+int Configuration::broker_queue_ttl() const {
+    return vm["BROKER.queue_ttl"].as<int>();
 }
 
 std::vector<std::string> Configuration::rt_topics() const {

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -96,7 +96,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
         ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")
         ("BROKER.queue_auto_delete", po::value<bool>()->default_value(false), "auto delete rabbitmq's queue when unbind")
-        ("BROKER.queue_ttl", po::value<int>()->default_value(7200), "Time To Live for rabbitmq queues created by kraken, in seconds")
+        ("BROKER.queue_expire", po::value<int>()->default_value(7200), "Rabbitmq queues created by kraken will be deleted by rabbitmq after this duration , in seconds")
 
         ("CHAOS.database", po::value<std::string>(), "Chaos database connection string")
         ("CHAOS.batch_size", po::value<int>()->default_value(1000000), "Chaos database row batch size");
@@ -246,8 +246,8 @@ bool Configuration::broker_queue_auto_delete() const {
     return vm["BROKER.queue_auto_delete"].as<bool>();
 }
 
-int Configuration::broker_queue_ttl() const {
-    return vm["BROKER.queue_ttl"].as<int>();
+int Configuration::broker_queue_expire() const {
+    return vm["BROKER.queue_expire"].as<int>();
 }
 
 std::vector<std::string> Configuration::rt_topics() const {

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -62,7 +62,7 @@ public:
     std::string broker_exchange() const;
     std::string broker_queue(const std::string& default_queue) const;
     bool broker_queue_auto_delete() const;
-    int broker_queue_ttl() const;
+    int broker_queue_expire() const;
     int broker_timeout() const;
     int broker_sleeptime() const;
     bool is_realtime_enabled() const;

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -62,6 +62,7 @@ public:
     std::string broker_exchange() const;
     std::string broker_queue(const std::string& default_queue) const;
     bool broker_queue_auto_delete() const;
+    int broker_queue_ttl() const;
     int broker_timeout() const;
     int broker_sleeptime() const;
     bool is_realtime_enabled() const;

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -65,6 +65,7 @@ public:
     int broker_queue_expire() const;
     int broker_timeout() const;
     int broker_sleeptime() const;
+    int broker_reconnect_wait() const;
     bool is_realtime_enabled() const;
     bool is_realtime_add_enabled() const;
     bool is_realtime_add_trip_enabled() const;

--- a/source/kraken/kraken_zmq.cpp
+++ b/source/kraken/kraken_zmq.cpp
@@ -129,7 +129,7 @@ int main(int argn, char** argv) {
 
     threads.create_thread([&data_manager, conf, &metrics] {
         navitia::MaintenanceWorker maintenance_worker = navitia::MaintenanceWorker(data_manager, conf, metrics);
-        return maintenance_worker();
+        return maintenance_worker.run();
     });
     //
     // Data have been loaded, we can now accept connections

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -62,7 +62,7 @@ void MaintenanceWorker::run() {
 
     if (!is_data_loaded()) {
         // The data is not loaded, so we wait for a reload message on the task queue
-        // that results in a successfull data load.
+        // that results in a successful data load.
         // We may be disconnected from rabbitmq during this wait,
         // and reconnection to rabbitmq is handled by this while(true) loop
         while (true) {
@@ -70,7 +70,7 @@ void MaintenanceWorker::run() {
                 open_channel_to_rabbitmq();
                 create_task_queue();
                 // will return when a reload message on the task queue
-                // arrived and resulted in a successfull data load
+                // arrived and resulted in a successful data load
                 listen_to_task_queue_until_data_loaded();
                 // data is loaded, let's break from the while(true)  loop
                 break;
@@ -186,7 +186,7 @@ void MaintenanceWorker::create_task_queue() {
     std::string queue_name = conf.broker_queue(default_queue_name);
     queue_name_task = (boost::format("%s_task") % queue_name).str();
 
-    // first we have to delete the queues, binding can change between two run, and it's don't seem possible
+    // first we have to delete the queues, binding can change between two run, and it doesn't seem possible
     // to unbind a queue if we don't know at what topic it's subscribed
     // if the queue doesn't exist an exception is throw...
     try {
@@ -250,7 +250,7 @@ void MaintenanceWorker::create_realtime_queue() {
     std::string queue_name = conf.broker_queue(default_queue_name);
     queue_name_rt = (boost::format("%s_rt") % queue_name).str();
 
-    // first we have to delete the queues, binding can change between two run, and it's don't seem possible
+    // first we have to delete the queues, binding can change between two run, and it doesn't seem possible
     // to unbind a queue if we don't know at what topic it's subscribed
     // if the queue doesn't exist an exception is throw...
     try {
@@ -271,7 +271,7 @@ void MaintenanceWorker::create_realtime_queue() {
 
     channel->DeclareQueue(this->queue_name_rt, passive, durable, exclusive, auto_delete_queue, args);
     LOG4CPLUS_INFO(logger, "queue for disruptions: " << this->queue_name_rt);
-    // binding the queue to the exchange for all task for this instance
+    // binding the queue to the exchange for all tasks for this instance
     LOG4CPLUS_INFO(logger, "subscribing to [" << boost::algorithm::join(conf.rt_topics(), ", ") << "]");
     for (const auto& topic : conf.rt_topics()) {
         channel->BindQueue(queue_name_rt, exchange_name, topic);

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -267,7 +267,7 @@ void MaintenanceWorker::create_realtime_queue() {
     bool auto_delete_queue = conf.broker_queue_auto_delete();
 
     AmqpClient::Table args;
-    args.insert(std::make_pair("x-expires", conf.broker_queue_expires() * 1000));
+    args.insert(std::make_pair("x-expires", conf.broker_queue_expire() * 1000));
 
     channel->DeclareQueue(this->queue_name_rt, passive, durable, exclusive, auto_delete_queue, args);
     LOG4CPLUS_INFO(logger, "queue for disruptions: " << this->queue_name_rt);

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -214,7 +214,11 @@ void MaintenanceWorker::create_task_queue() {
         bool durable = true;
         bool exclusive = false;
         bool auto_delete_queue = conf.broker_queue_auto_delete();
-        channel->DeclareQueue(queue_name_task, passive, durable, exclusive, auto_delete_queue);
+
+        AmqpClient::Table args;
+        args.insert(std::make_pair("x-expires", conf.broker_queue_ttl() * 1000));
+
+        channel->DeclareQueue(queue_name_task, passive, durable, exclusive, auto_delete_queue, args);
         LOG4CPLUS_INFO(logger, "binding queue for tasks: " << this->queue_name_task);
 
         // binding the queue to the exchange for all task for this instance
@@ -273,7 +277,10 @@ void MaintenanceWorker::create_realtime_queue() {
         bool exclusive = false;
         bool auto_delete_queue = conf.broker_queue_auto_delete();
 
-        channel->DeclareQueue(this->queue_name_rt, passive, durable, exclusive, auto_delete_queue);
+        AmqpClient::Table args;
+        args.insert(std::make_pair("x-expires", conf.broker_queue_ttl() * 1000));
+
+        channel->DeclareQueue(this->queue_name_rt, passive, durable, exclusive, auto_delete_queue, args);
         LOG4CPLUS_INFO(logger, "queue for disruptions: " << this->queue_name_rt);
         // binding the queue to the exchange for all task for this instance
         LOG4CPLUS_INFO(logger, "subscribing to [" << boost::algorithm::join(conf.rt_topics(), ", ") << "]");

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -121,7 +121,7 @@ void MaintenanceWorker::run() {
     }
 }
 
-bool MaintenanceWorker::is_data_loaded() {
+bool MaintenanceWorker::is_data_loaded() const {
     const auto data = data_manager.get_data();
     return data->loaded;
 }
@@ -540,8 +540,6 @@ MaintenanceWorker::MaintenanceWorker(DataManager<type::Data>& data_manager,
       logger(log4cplus::Logger::getInstance(LOG4CPLUS_TEXT("background"))),
       conf(std::move(conf)),
       metrics(metrics),
-      next_try_realtime_loading(pt::microsec_clock::universal_time()),
-      task_queue_created(false),
-      realtime_queue_created(false) {}
+      next_try_realtime_loading(pt::microsec_clock::universal_time()) {}
 
 }  // namespace navitia

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -72,10 +72,8 @@ void MaintenanceWorker::run() {
                 // will return when a reload message on the task queue
                 // arrived and resulted in a successfull data load
                 listen_to_task_queue_until_data_loaded();
-                if (is_data_loaded()) {
-                    // data is loaded, let's break from the while(true)  loop
-                    break;
-                }
+                // data is loaded, let's break from the while(true)  loop
+                break;
             } catch (const std::runtime_error& ex) {
                 LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
                 data_manager.get_data()->is_connected_to_rabbitmq = false;

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -267,7 +267,7 @@ void MaintenanceWorker::create_realtime_queue() {
     bool auto_delete_queue = conf.broker_queue_auto_delete();
 
     AmqpClient::Table args;
-    args.insert(std::make_pair("x-expires", conf.broker_queue_ttl() * 1000));
+    args.insert(std::make_pair("x-expires", conf.broker_queue_expires() * 1000));
 
     channel->DeclareQueue(this->queue_name_rt, passive, durable, exclusive, auto_delete_queue, args);
     LOG4CPLUS_INFO(logger, "queue for disruptions: " << this->queue_name_rt);

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -78,7 +78,7 @@ void MaintenanceWorker::run() {
                 LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
                 data_manager.get_data()->is_connected_to_rabbitmq = false;
                 channel_opened = false;
-                sleep(10);
+                std::this_thread::sleep_for(10);
             }
         }
     }
@@ -98,7 +98,7 @@ void MaintenanceWorker::run() {
             LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
             data_manager.get_data()->is_connected_to_rabbitmq = false;
             channel_opened = false;
-            sleep(10);
+            std::this_thread::sleep_for(10);
         }
     }
 }

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -203,7 +203,7 @@ void MaintenanceWorker::create_task_queue() {
     bool auto_delete_queue = conf.broker_queue_auto_delete();
 
     AmqpClient::Table args;
-    args.insert(std::make_pair("x-expires", conf.broker_queue_ttl() * 1000));
+    args.insert(std::make_pair("x-expires", conf.broker_queue_expire() * 1000));
 
     channel->DeclareQueue(queue_name_task, passive, durable, exclusive, auto_delete_queue, args);
     LOG4CPLUS_INFO(logger, "binding queue for tasks: " << this->queue_name_task);

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -78,7 +78,7 @@ void MaintenanceWorker::run() {
                 LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
                 data_manager.get_data()->is_connected_to_rabbitmq = false;
                 channel_opened = false;
-                std::this_thread::sleep_for(std::chrono::seconds(1));
+                std::this_thread::sleep_for(std::chrono::seconds(conf.broker_reconnect_wait()));
             }
         }
     }
@@ -98,7 +98,7 @@ void MaintenanceWorker::run() {
             LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
             data_manager.get_data()->is_connected_to_rabbitmq = false;
             channel_opened = false;
-            std::this_thread::sleep_for(std::chrono::seconds(1));
+            std::this_thread::sleep_for(std::chrono::seconds(conf.broker_reconnect_wait()));
         }
     }
 }

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -78,7 +78,7 @@ void MaintenanceWorker::run() {
                 LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
                 data_manager.get_data()->is_connected_to_rabbitmq = false;
                 channel_opened = false;
-                std::this_thread::sleep_for(10);
+                std::this_thread::sleep_for(std::chrono::seconds(1));
             }
         }
     }
@@ -98,7 +98,7 @@ void MaintenanceWorker::run() {
             LOG4CPLUS_ERROR(logger, "Connection to rabbitmq failed: " << ex.what());
             data_manager.get_data()->is_connected_to_rabbitmq = false;
             channel_opened = false;
-            std::this_thread::sleep_for(10);
+            std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     }
 }

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -50,7 +50,6 @@ private:
 
     const Metrics& metrics;
 
-    
     // nom de la queue créer pour ce worker
     std::string queue_name_task;
     std::string queue_name_rt;
@@ -59,16 +58,12 @@ private:
 
     AmqpClient::Channel::ptr_t channel;
 
-
-
     void listen_rabbitmq();
 
     void handle_task_in_batch(const std::vector<AmqpClient::Envelope::ptr_t>& envelopes);
     void handle_rt_in_batch(const std::vector<AmqpClient::Envelope::ptr_t>& envelopes);
 
     void load_realtime();
-
-
 
     /*!
      * This function will consume message in batch. It calls
@@ -89,12 +84,10 @@ private:
 public:
     MaintenanceWorker(DataManager<type::Data>& data_manager, const kraken::Configuration conf, const Metrics& metrics);
 
-
-    // try to read data.nav.lz4 
+    // try to read data.nav.lz4
     // and reload chaos disruption
     void load_data();
     bool is_data_loaded();
-
 
     void open_channel_to_rabbitmq();
 
@@ -103,7 +96,6 @@ public:
     void listen_to_task_queue();
 
     void bind_to_realtime_queue();
-
 
     void run();
 };

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -50,20 +50,25 @@ private:
 
     const Metrics& metrics;
 
-    AmqpClient::Channel::ptr_t channel;
+    
     // nom de la queue créer pour ce worker
     std::string queue_name_task;
     std::string queue_name_rt;
 
     boost::posix_time::ptime next_try_realtime_loading;
 
-    void init_rabbitmq();
+    AmqpClient::Channel::ptr_t channel;
+
+
+
     void listen_rabbitmq();
 
     void handle_task_in_batch(const std::vector<AmqpClient::Envelope::ptr_t>& envelopes);
     void handle_rt_in_batch(const std::vector<AmqpClient::Envelope::ptr_t>& envelopes);
 
     void load_realtime();
+
+
 
     /*!
      * This function will consume message in batch. It calls
@@ -84,11 +89,23 @@ private:
 public:
     MaintenanceWorker(DataManager<type::Data>& data_manager, const kraken::Configuration conf, const Metrics& metrics);
 
-    bool load_and_switch();
 
+    // try to read data.nav.lz4 
+    // and reload chaos disruption
     void load_data();
+    bool is_data_loaded();
 
-    void operator()();
+
+    void open_channel_to_rabbitmq();
+
+    void bind_to_task_queue();
+
+    void listen_to_task_queue();
+
+    void bind_to_realtime_queue();
+
+
+    void run();
 };
 
 }  // namespace navitia

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -58,8 +58,8 @@ private:
 
     AmqpClient::Channel::ptr_t channel;
 
-    bool task_queue_created;
-    bool realtime_queue_created;
+    bool task_queue_created = false;
+    bool realtime_queue_created = false;
 
     void listen_rabbitmq();
 
@@ -82,7 +82,6 @@ private:
                                                               size_t max_nb,
                                                               size_t timeout_ms,
                                                               bool no_ack);
-    bool is_initialized = false;
 
 public:
     MaintenanceWorker(DataManager<type::Data>& data_manager, const kraken::Configuration conf, const Metrics& metrics);

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -89,7 +89,7 @@ public:
     // try to read data.nav.lz4
     // and reload chaos disruption
     void load_data();
-    bool is_data_loaded();
+    bool is_data_loaded() const;
 
     void open_channel_to_rabbitmq();
 

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -58,6 +58,8 @@ private:
 
     AmqpClient::Channel::ptr_t channel;
 
+    bool channel_opened = false;
+
     bool task_queue_created = false;
     bool realtime_queue_created = false;
 

--- a/source/kraken/maintenance_worker.h
+++ b/source/kraken/maintenance_worker.h
@@ -58,6 +58,9 @@ private:
 
     AmqpClient::Channel::ptr_t channel;
 
+    bool task_queue_created;
+    bool realtime_queue_created;
+
     void listen_rabbitmq();
 
     void handle_task_in_batch(const std::vector<AmqpClient::Envelope::ptr_t>& envelopes);
@@ -91,11 +94,11 @@ public:
 
     void open_channel_to_rabbitmq();
 
-    void bind_to_task_queue();
+    void create_task_queue();
 
-    void listen_to_task_queue();
+    void listen_to_task_queue_until_data_loaded();
 
-    void bind_to_realtime_queue();
+    void create_realtime_queue();
 
     void run();
 };

--- a/source/tests/mock-kraken/mock_kraken.h
+++ b/source/tests/mock-kraken/mock_kraken.h
@@ -71,10 +71,10 @@ struct mock_kraken {
 
         // this option is not parsed by get_options_description because it is used only here
         if (std::find(other_options.begin(), other_options.end(), "spawn_maintenance_worker") != other_options.end()) {
-                threads.create_thread([&data_manager, conf, &metrics] {
-                    navitia::MaintenanceWorker maintenance_worker = navitia::MaintenanceWorker(data_manager, conf, metrics);
-                    return maintenance_worker.run();
-                });
+            threads.create_thread([&data_manager, conf, &metrics] {
+                navitia::MaintenanceWorker maintenance_worker = navitia::MaintenanceWorker(data_manager, conf, metrics);
+                return maintenance_worker.run();
+            });
         }
 
         // Launch only one thread for the tests

--- a/source/tests/mock-kraken/mock_kraken.h
+++ b/source/tests/mock-kraken/mock_kraken.h
@@ -72,7 +72,7 @@ struct mock_kraken {
         // this option is not parsed by get_options_description because it is used only here
         if (std::find(other_options.begin(), other_options.end(), "spawn_maintenance_worker") != other_options.end()) {
             threads.create_thread([&data_manager, conf, &metrics] {
-                navitia::MaintenanceWorker maintenance_worker = navitia::MaintenanceWorker(data_manager, conf, metrics);
+                auto maintenance_worker = navitia::MaintenanceWorker(data_manager, conf, metrics);
                 return maintenance_worker.run();
             });
         }


### PR DESCRIPTION
- Create the realtime queue only when the data has been successfully loaded (otherwise the queue just grows for nothing)
- add a time to live to the created queues, thanks to the `x-expires` [flag](https://www.rabbitmq.com/ttl.html#queue-ttl). It defaults to 2h, and can be configure with `BROKER.queue_expire`(in seconds)
- add a new parameter `BROKER.reconnect_wait` that specify (in seconds) how long kraken will wait between two attempts to connect do rabbitmq. Defaults to 1 second.