### PR TITLE
Fix: one-line json content

### DIFF
--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -342,7 +342,9 @@ def osm2ed(self, instance_config, osm_filename, job_id, dataset_uid):
         params = ["-i", osm_filename]
         if poi_types_json:
             params.append('-p')
-            params.append(u'{}'.format(poi_types_json))
+            import json
+            # poi_types_json is just unicode string... we use this trick to one-line the json content
+            params.append(u'{}'.format(json.dumps(json.loads(poi_types_json))))
 
         common_params = make_ed_common_params(instance_config, 'osm2ed')
         params.extend(common_params)


### PR DESCRIPTION
tested on dev and aws

poi_types_json is just Unicode string with carriage return, whereas the command line `osm2ed` need it to be formatted in one-line.
  
we use this `json` to one-line the json content