### PR TITLE
[TYR] enable build_data remotely

### DIFF
--- a/source/tyr/manage_tyr.py
+++ b/source/tyr/manage_tyr.py
@@ -32,13 +32,14 @@
 
 from tyr import app, db, manager
 from flask_migrate import Migrate, MigrateCommand
-from tyr.command import ReloadKrakenCommand, BuildDataCommand, LoadDataCommand
+from tyr.command import ReloadKrakenCommand, BuildDataCommand, LoadDataCommand, BuildDataRemoteCommand
 
 
 migrate = Migrate(app, db)
 manager.add_command('db', MigrateCommand)
 manager.add_command('reload_kraken', ReloadKrakenCommand())
 manager.add_command('build_data', BuildDataCommand())
+manager.add_command('build_data_remote', BuildDataRemoteCommand())
 manager.add_command('load_data', LoadDataCommand())
 
 if __name__ == '__main__':

--- a/source/tyr/tyr/command/build_data_remote.py
+++ b/source/tyr/tyr/command/build_data_remote.py
@@ -50,8 +50,8 @@ class BuildDataRemoteCommand(Command):
 
     def run(self, instance_name=None, all_instances=False):
         if all_instances:
-            logging.info("Building all data")
+            logging.info("Launching ed2nav for all instances")
             return build_all_data.delay()
 
-        logging.info("Building {} data".format(instance_name))
+        logging.info("Launching ed2nav for instance: {}".format(instance_name))
         return build_data_with_instance_name.delay(instance_name)

--- a/source/tyr/tyr/command/build_data_remote.py
+++ b/source/tyr/tyr/command/build_data_remote.py
@@ -30,7 +30,6 @@
 from flask_script import Command, Option
 from tyr.tasks import build_all_data, build_data_with_instance_name
 import logging
-from navitiacommon import models
 
 
 class BuildDataRemoteCommand(Command):

--- a/source/tyr/tyr/command/build_data_remote.py
+++ b/source/tyr/tyr/command/build_data_remote.py
@@ -27,13 +27,31 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-from tyr.command.reload_kraken import ReloadKrakenCommand
-from tyr.command.build_data import BuildDataCommand
-from tyr.command.build_data_remote import BuildDataRemoteCommand
-from tyr.command.load_data import LoadDataCommand
-import tyr.command.purge
-import tyr.command.cities
-import tyr.command.bounding_shape
-import tyr.command.import_last_dataset
-import tyr.command.import_last_autocomplete_dataset
-import tyr.command.last_dataset
+from flask_script import Command, Option
+from tyr.tasks import build_all_data, build_data_with_instance_name
+import logging
+from navitiacommon import models
+
+
+class BuildDataRemoteCommand(Command):
+    """A command used to build all the datasets REMOTELY"""
+
+    def get_options(self):
+        return [
+            Option(
+                '-n',
+                '--name',
+                dest='instance_name',
+                help="name of the instance to build. If non given, build all instances",
+                default=None,
+            ),
+            Option('-a', '--all', dest='all_instances', action="store_true", help="build all instances"),
+        ]
+
+    def run(self, instance_name=None, all_instances=False):
+        if all_instances:
+            logging.info("Building all data")
+            return build_all_data.delay()
+
+        logging.info("Building {} data".format(instance_name))
+        return build_data_with_instance_name.delay(instance_name)

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -613,6 +613,12 @@ def build_all_data():
 
 
 @celery.task()
+def build_data_with_instance_name(instance_name):
+    instance = models.Instance.query_existing().filter_by(name=instance_name).first_or_404()
+    build_data(instance)
+
+
+@celery.task()
 def build_data(instance):
     job = models.Job()
     job.instance = instance


### PR DESCRIPTION
Enable sending `ed2nav` remotely

usage: 

* Just set `TYR_CELERY_BROKER_URL`

* if you want to binarize only one instance:  
```bash 
TYR_CONFIG_FILE=dev_settings.py python manage_tyr.py build_data_remote [-n|--name] my_instance_name
```
* if you want to binarize all instances:  
```bash 
TYR_CONFIG_FILE=dev_settings.py python manage_tyr.py build_data_remote [-a|--all]
```
