### PR TITLE
fix DetachedInstanceException

### DIFF
--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -609,7 +609,7 @@ def reload_kraken(instance_id):
 @celery.task()
 def build_all_data():
     for instance in models.Instance.query_existing().all():
-        build_data(instance)
+        build_data.delay(instance)
 
 
 @celery.task()


### PR DESCRIPTION
Fix a little bug when sending task to build data for instances

Now `ed2nav`  are queued and launched at the same time

![image](https://user-images.githubusercontent.com/6093486/197144957-9757c858-4aca-4acc-bacf-4e351d92802c.png)