### PR TITLE
Pr co2 emission physical mode

### DIFF
--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -73,6 +73,21 @@ class Kraken(object):
             return None
         return response.car_co2_emission
 
+
+    def get_car_co2_emission(self, distance, request_id):
+        logger = logging.getLogger(__name__)
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.car_co2_emission
+        req.car_co2_emission.distance = distance
+
+        response = self.instance.send_and_receive(req, request_id=request_id)
+        if response.error and response.error.id == response_pb2.Error.error_id.Value('no_solution'):
+            logger.error("Cannot compute car co2 emission with the distance {}".format(distance))
+            return None
+
+        return response.car_co2_emission
+
+
     def get_crow_fly(
         self,
         origin,

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -929,31 +929,37 @@ void Worker::heat_map(const pbnavitia::HeatMapRequest& request) {
                                     end_speed, end_mode, request.resolution(), center_and_stop_points.second);
 }
 
-void Worker::car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request) {
+void Worker::car_co2_emission(const pbnavitia::CarCO2EmissionRequest& request) {
     const auto* data = this->pb_creator.data;
-    auto get_geographical_coord = [&](const pbnavitia::LocationContext& location) {
-        auto origin_type = data->get_type_of_id(location.place());
-        auto origin = type::EntryPoint{origin_type, location.place(), location.access_duration()};
-        auto coordinates = coord_of_entry_point(origin, *data);
-        return navitia::type::GeographicalCoord{coordinates.lon(), coordinates.lat()};
-    };
-    navitia::type::GeographicalCoord origin;
-    navitia::type::GeographicalCoord destin;
-    try {
-        origin = get_geographical_coord(request.origin());
-        destin = get_geographical_coord(request.destination());
-    } catch (const navitia::coord_conversion_exception& e) {
-        this->pb_creator.fill_pb_error(pbnavitia::Error::bad_format, e.what());
-        return;
-    }
+    auto distance = request.distance();
+    auto co2_estimation_coeff = 1;
 
-    auto distance = origin.distance_to(destin);
+    if (!request.has_distance()) {
+        auto get_geographical_coord = [&](const pbnavitia::LocationContext& location) {
+            auto origin_type = data->get_type_of_id(location.place());
+            auto origin = type::EntryPoint{origin_type, location.place(), location.access_duration()};
+            auto coordinates = coord_of_entry_point(origin, *data);
+            return navitia::type::GeographicalCoord{coordinates.lon(), coordinates.lat()};
+        };
+        navitia::type::GeographicalCoord origin;
+        navitia::type::GeographicalCoord destin;
+        try {
+            origin = get_geographical_coord(request.origin());
+            destin = get_geographical_coord(request.destination());
+        } catch (const navitia::coord_conversion_exception& e) {
+            this->pb_creator.fill_pb_error(pbnavitia::Error::bad_format, e.what());
+            return;
+        }
+
+        co2_estimation_coeff = CO2_ESTIMATION_COEFF;
+        distance = origin.distance_to(destin);
+    }
     auto car_mode = data->pt_data->physical_modes_map.find("physical_mode:Car");
 
     if (car_mode != data->pt_data->physical_modes_map.end() && car_mode->second->co2_emission) {
         auto co2_emission = this->pb_creator.mutable_car_co2_emission();
         co2_emission->set_unit("gEC");
-        co2_emission->set_value(CO2_ESTIMATION_COEFF * distance / 1000.0 * car_mode->second->co2_emission.get());
+        co2_emission->set_value(co2_estimation_coeff * distance / 1000.0 * car_mode->second->co2_emission.get());
         return;
     }
     this->pb_creator.fill_pb_error(pbnavitia::Error::no_solution,
@@ -1154,7 +1160,7 @@ void Worker::dispatch(const pbnavitia::Request& request,
             geo_status();
             break;
         case pbnavitia::car_co2_emission:
-            car_co2_emission_on_crow_fly(request.car_co2_emission());
+            car_co2_emission(request.car_co2_emission());
             break;
         case pbnavitia::direct_path:
             direct_path(request);

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -131,7 +131,7 @@ private:
     bool set_journeys_args(const pbnavitia::JourneysRequest& request, JourneysArg& arg, const std::string& name);
     void graphical_isochrone(const pbnavitia::GraphicalIsochroneRequest& request);
     void heat_map(const pbnavitia::HeatMapRequest& request);
-    void car_co2_emission_on_crow_fly(const pbnavitia::CarCO2EmissionRequest& request);
+    void car_co2_emission(const pbnavitia::CarCO2EmissionRequest& request);
     void direct_path(const pbnavitia::Request& request);
 
     /*


### PR DESCRIPTION
Hello,

This PR discussed with @pbench is about calculating missing CO2 emission value for car section provided by another backend than kraken (like asgard) in journey service.

The check about missing co2 is done in new_default scenario which will call kraken in order to do the calculation with a distance parameter (the street_network length of the car section).

Thank you.