### PR TITLE
[Jormungandr] Fix greenlet for python2.7 and python3.6

### DIFF
--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -53,3 +53,4 @@ kombu==5.0.2  ; python_version >= "3.9"
 redis==2.10.6
 flexpolyline==0.1.0
 newrelic==2.70.0.51
+greenlet==0.4.15 ; python_version == "2.7"

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -53,4 +53,4 @@ kombu==5.0.2  ; python_version >= "3.9"
 redis==2.10.6
 flexpolyline==0.1.0
 newrelic==2.70.0.51
-greenlet==0.4.15 ; python_version == "2.7"
+greenlet==0.4.15 ; python_version <= "3.6"


### PR DESCRIPTION
Due to an update in gevent, the current version of greenlet that gevent depends on is no longer compatible with python2.7, thus we fix the version forcibly ...
