### PR TITLE
Second try for IAM Credentials for S3 bucket

### DIFF
--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -149,7 +149,7 @@ MINIO_URL = os.getenv('TYR_MINIO_URL', None)
 
 MINIO_BUCKET_NAME = os.getenv('TYR_MINIO_BUCKET_NAME', None)
 
-MINIO_USE_IAM_PROVIDER = os.getenv('TYR_MINIO_USE_IAM_PROVIDER', False)
+MINIO_USE_IAM_PROVIDER = os.getenv('TYR_MINIO_USE_IAM_PROVIDER', 'true').lower() in ['1', 'true', 'yes']
 
 MINIO_ACCESS_KEY = os.getenv('TYR_MINIO_ACCESS_KEY', None)
 

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -145,13 +145,15 @@ MIMIR_CONFIG_DIR = os.getenv('MIMIR_CONFIG_DIR', "/etc/mimir/")
 
 MIMIR_PLATFORM_TAG = os.getenv('TYR_MIMIR_PLATFORM_TAG', 'default')
 
-MINIO_LOKI_URL = os.getenv('TYR_MINIO_LOKI_URL', None)
+MINIO_URL = os.getenv('TYR_MINIO_URL', None)
 
-MINIO_LOKI_BUCKET_NAME = os.getenv('TYR_MINIO_LOKI_BUCKET_NAME', None)
+MINIO_BUCKET_NAME = os.getenv('TYR_MINIO_BUCKET_NAME', None)
 
-MINIO_LOKI_ACCESS_KEY = os.getenv('TYR_MINIO_LOKI_ACCESS_KEY', None)
+MINIO_USE_IAM_PROVIDER = os.getenv('TYR_MINIO_USE_IAM_PROVIDER', False)
 
-MINIO_LOKI_SECRET_KEY = os.getenv('TYR_MINIO_LOKI_SECRET_KEY', None)
+MINIO_ACCESS_KEY = os.getenv('TYR_MINIO_ACCESS_KEY', None)
+
+MINIO_SECRET_KEY = os.getenv('TYR_MINIO_SECRET_KEY', None)
 
 # we don't enable serpy for now
 USE_SERPY = os.getenv('TYR_USE_SERPY', False)

--- a/source/tyr/tyr/minio.py
+++ b/source/tyr/tyr/minio.py
@@ -54,11 +54,11 @@ class MinioWrapper:
             self.session_token = None
             if self.access_key is None:
                 raise Exception(
-                    "MINIO_ACCESS_KEY is not configured but needed since MINIO_IAM_PROVIDER is False"
+                    "MINIO_ACCESS_KEY is not configured but needed since MINIO_USE_IAM_PROVIDER is False"
                 )
             if self.secret_key is None:
                 raise Exception(
-                    "MINIO_SECRET_KEY is not configured but needed since MINIO_IAM_PROVIDER is False"
+                    "MINIO_SECRET_KEY is not configured but needed since MINIO_USE_IAM_PROVIDER is False"
                 )
 
     def upload_file(

--- a/source/tyr/tyr/minio.py
+++ b/source/tyr/tyr/minio.py
@@ -74,7 +74,7 @@ class MinioWrapper:
             endpoint=self.endpoint,
             access_key=self.access_key,
             secret_key=self.secret_key,
-            token=self.session_token,
+            session_token=self.session_token,
         )
         client.fput_object(self.bucket_name, file_key, filename, metadata=metadata, content_type=content_type)
 

--- a/source/tyr/tyr/minio.py
+++ b/source/tyr/tyr/minio.py
@@ -28,10 +28,10 @@
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
 
-
+from __future__ import absolute_import
 import os
 import requests
-import minio
+from minio import Minio
 
 
 from flask import current_app
@@ -70,7 +70,7 @@ class MinioWrapper:
     ):
         if self.use_iam_provider:
             self.retrieve_credentials()
-        client = minio.Minio(
+        client = Minio(
             endpoint=self.endpoint,
             access_key=self.access_key,
             secret_key=self.secret_key,

--- a/source/tyr/tyr/minio.py
+++ b/source/tyr/tyr/minio.py
@@ -30,13 +30,74 @@
 
 
 import os
+import requests
+from minio import Minio
 
 from flask import current_app
 
 
-class MinioConfig:
+class MinioWrapper:
     def __init__(self):
-        self.host = current_app.config['MINIO_LOKI_URL']
-        self.key = current_app.config['MINIO_LOKI_ACCESS_KEY']
-        self.secret = current_app.config['MINIO_LOKI_SECRET_KEY']
-        self.bucket = current_app.config['MINIO_LOKI_BUCKET_NAME']
+        self.endpoint = current_app.config.get('MINIO_URL', None)
+        self.bucket_name = current_app.config.get('MINIO_BUCKET_NAME', None)
+        if self.endpoint is None:
+            raise Exception("MINIO_URL is not configured")
+        if self.bucket_name is None:
+            raise Exception("MINIO_BUCKET_NAME is not configured")
+
+        self.use_iam_provider = current_app.config.get('MINIO_USE_IAM_PROVIDER', False)
+
+        if not self.use_iam_provider:
+            self.access_key = current_app.config.get("MINIO_ACCESS_KEY", None)
+            self.secret_key = current_app.config.get("MINIO_SECRET_KEY", None)
+            self.session_token = None
+            if self.access_key is None:
+                raise Exception(
+                    "MINIO_ACCESS_KEY is not configured but needed since MINIO_IAM_PROVIDER is False"
+                )
+            if self.secret_key is None:
+                raise Exception(
+                    "MINIO_SECRET_KEY is not configured but needed since MINIO_IAM_PROVIDER is False"
+                )
+
+    def upload_file(
+        self,
+        filename,  # path to the file to upload
+        file_key,  # path where the file will be put in the bucket
+        metadata={},  # tags that will be applied to the file in the bucket
+        content_type="application/zip",
+    ):
+        if self.use_iam_provider:
+            self.retrieve_credentials()
+        client = Minio(
+            endpoint=self.endpoint,
+            access_key=self.access_key,
+            secret_key=self.secret_key,
+            token=self.session_token,
+        )
+        client.fput_object(self.bucket_name, file_key, filename, metadata=metadata, content_type=content_type)
+
+    def retrieve_credentials(self):
+        """Retrieve credentials from ECS IAM Role"""
+
+        # see https://stackoverflow.com/questions/57065458/cannot-access-instance-metadata-from-within-a-fargate-task
+        # and https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
+
+        relative_uri = os.environ.get("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", None)
+        if relative_uri is None:
+            raise Exception("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is not configured")
+
+        credentials_url = "http://169.254.170.2" + relative_uri
+
+        resp = requests.get(credentials_url)
+        if resp.status_code != 200:
+            raise Exception(
+                "Failed to retreive IAM credentials from {} : status code is {}".format(
+                    credentials_url, resp.status_code
+                )
+            )
+
+        json = resp.json()
+        self.access_key = json["AccessKeyId"]
+        self.secret_key = json["SecretAccessKey"]
+        self.session_token = json["Token"]

--- a/source/tyr/tyr/minio.py
+++ b/source/tyr/tyr/minio.py
@@ -31,7 +31,8 @@
 
 import os
 import requests
-from minio import Minio
+import minio
+
 
 from flask import current_app
 
@@ -69,7 +70,7 @@ class MinioWrapper:
     ):
         if self.use_iam_provider:
             self.retrieve_credentials()
-        client = Minio(
+        client = minio.Minio(
             endpoint=self.endpoint,
             access_key=self.access_key,
             secret_key=self.secret_key,


### PR DESCRIPTION
The version 7.1 of the minio python package does handle IAM credentials out of the box, but it seems to not be compatible with python 2.7 https://github.com/hove-io/navitia/pull/3846

The last minio version which seems to be compatible with python 2.7 is minio 6.0. 
Unfortunately, it seems  minio 6.0 is not up to date with IAM credentials handling for ecs tasks.
So here I try to backport to minio 6.0 the way IAM credentials are handled for ecs tasks in minio 7.1 

See : 
https://stackoverflow.com/questions/57065458/cannot-access-instance-metadata-from-within-a-fargate-task
https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
https://github.com/minio/minio-py/blob/d45ba0cc1fb7b2cbcd8dfd2648c7851100929ccc/minio/credentials/providers.py#L343
