### PR TITLE
[loki] dont update pt planner from db

### DIFF
--- a/source/jormungandr/jormungandr/pt_planners_manager.py
+++ b/source/jormungandr/jormungandr/pt_planners_manager.py
@@ -87,7 +87,6 @@ class PtPlannersManager(object):
         return self.pt_planners.items()
 
     def get_pt_planner(self, pt_planner_id):
-        self.update_from_db()
 
         pt_planner = self.pt_planners.get(pt_planner_id)
         if pt_planner:


### PR DESCRIPTION
The db configuration for pt_planners overrides any configuration provided by environment variables.
Unfortunately, we cannot use a single configuration for all jormuns : depending on the az the jormun is located, it will access loki at a different endpoint. 
So we need to configure the loki pt_planner through environment variables, and disable the db configuration.
See https://github.com/hove-io/core-front-aws-infra/pull/209