### PR TITLE
Manage ghost words per coverage in api /places

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -119,6 +119,7 @@ class Instance(object):
         streetnetwork_backend_manager,
         external_service_provider_configurations,
         pt_planners_configurations,
+        ghost_words=None,
         instance_db=None,
     ):
         self.geom = None
@@ -202,6 +203,7 @@ class Instance(object):
             )
         self.external_service_provider_manager.init_external_services()
         self.instance_db = instance_db
+        self._ghost_words = ghost_words or []
 
     def get_providers_from_db(self):
         """
@@ -660,6 +662,14 @@ class Instance(object):
         # type: () -> int
         instance_db = self.get_models()
         return get_value_or_default('max_taxi_direct_path_distance', instance_db, self.name)
+
+    @property
+    def ghost_words(self):
+        # type: () -> List
+        if self._ghost_words:
+            return self._ghost_words
+        instance_db = self.get_models()
+        return get_value_or_default('ghost_words', instance_db, self.name)
 
     # TODO: refactorise all properties
     taxi_speed = _make_property_getter('taxi_speed')

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -123,6 +123,7 @@ class InstanceManager(object):
             self._streetnetwork_backend_manager,
             config.get('external_services_providers', []),
             config.get('pt_planners', {}),
+            config.get('ghost_words', []),
         )
         self.instances[instance.name] = instance
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -197,7 +197,7 @@ class Places(ResourceUri):
             if not args['shape']:
                 args['shape'] = build_instance_shape(instance)
             timezone.set_request_timezone(self.region)
-            # If attribute ghost_words contains any word then remove it from the search text.
+            # If attribute ghost_words contains any word then remove it from the search text
             if instance.ghost_words:
                 query_string = args.get('q')
                 query_string = remove_ghost_words(query_string, instance.ghost_words)

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -804,3 +804,9 @@ def create_graphical_isochrones_request(
 
     req.isochrone.journeys_request.CopyFrom(req.journeys)
     return req
+
+
+def remove_ghost_words(query_string, ghost_words):
+    for gw in ghost_words:
+        query_string = query_string.replace(gw, '').strip()
+    return query_string

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -34,8 +34,10 @@ import logging
 from .tests_mechanism import AbstractTestFixture, dataset
 from .check_utils import *
 
+MOCKED_INSTANCE_CONF = {'instance_config': {'ghost_words': ["gare de ", "gare du ", "gare des ", "gare d'", "gare d "]}}
 
-@dataset({"main_routing_test": {}})
+
+@dataset({"main_routing_test": MOCKED_INSTANCE_CONF})
 class TestPlaces(AbstractTestFixture):
     """
     Test places responses
@@ -436,6 +438,41 @@ class TestPlaces(AbstractTestFixture):
                 assert len(place['stop_point'].get('lines')) > 0
             else:
                 assert place['stop_point'].get('lines') is None
+
+    def test_places_stop_areas(self):
+        """ Here we test the new feature to exclude ghost words as 'gare de ', 'gare du ', 'gare d ' + 'toto'
+            from the queries
+            Data contains Bourget,  gare de Bourgil and gare du Bourg
+        """
+        response, status = self.query_region("places?q=stopA", check=False)
+        assert status == 200
+        places = response['places']
+        assert len(response['places']) == 1
+        assert places[0]["id"] == "stopA"
+
+        # Search with 'gare de'
+        response, status = self.query_region("places?q=gare de stop", check=False)
+        assert status == 200
+        assert len(response['places']) == 3
+
+        # Search with 'gare de'
+        response, status = self.query_region("places?q=gare du stop", check=False)
+        assert status == 200
+        assert len(response['places']) == 3
+
+        # Search with 'gare d '
+        response, status = self.query_region("places?q=gare d stop", check=False)
+        assert status == 200
+        assert len(response['places']) == 3
+
+        response, status = self.query_region("places?q=gare d'stop", check=False)
+        assert status == 200
+        assert len(response['places']) == 3
+
+        # Search with 'gare d'
+        response, status = self.query_region("places?q=gare dstop", check=False)
+        assert status == 200
+        assert "places" not in response
 
 
 @dataset({"basic_routing_test": {}})

--- a/source/jormungandr/tests/places_tests.py
+++ b/source/jormungandr/tests/places_tests.py
@@ -34,7 +34,9 @@ import logging
 from .tests_mechanism import AbstractTestFixture, dataset
 from .check_utils import *
 
-MOCKED_INSTANCE_CONF = {'instance_config': {'ghost_words': ["gare de ", "gare du ", "gare des ", "gare d'", "gare d "]}}
+MOCKED_INSTANCE_CONF = {
+    'instance_config': {'ghost_words': ["gare de ", "gare du ", "gare des ", "gare d'", "gare d "]}
+}
 
 
 @dataset({"main_routing_test": MOCKED_INSTANCE_CONF})
@@ -440,9 +442,9 @@ class TestPlaces(AbstractTestFixture):
                 assert place['stop_point'].get('lines') is None
 
     def test_places_stop_areas(self):
-        """ Here we test the new feature to exclude ghost words as 'gare de ', 'gare du ', 'gare d ' + 'toto'
-            from the queries
-            Data contains Bourget,  gare de Bourgil and gare du Bourg
+        """Here we test the new feature to exclude ghost words as 'gare de ', 'gare du ', 'gare d ' + 'toto'
+        from the queries
+        Data contains Bourget,  gare de Bourgil and gare du Bourg
         """
         response, status = self.query_region("places?q=stopA", check=False)
         assert status == 200

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -35,6 +35,7 @@ This parameters can be used directly by jormungandr if the instance is not known
 
 import logging
 import sys
+from typing import List
 
 max_walking_duration_to_pt = 30 * 60
 
@@ -219,7 +220,7 @@ default_pt_planner = 'kraken'
 
 filter_odt_journeys = False
 
-ghost_words = [] # type: List[str]
+ghost_words = []  # type: List[str]
 
 # {
 #     "kraken": {

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -219,6 +219,8 @@ default_pt_planner = 'kraken'
 
 filter_odt_journeys = False
 
+ghost_words = []
+
 # {
 #     "kraken": {
 #         "class": "jormungandr.pt_planners.kraken.Kraken",

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -219,7 +219,7 @@ default_pt_planner = 'kraken'
 
 filter_odt_journeys = False
 
-ghost_words = []
+ghost_words = [] # type: List[str]
 
 # {
 #     "kraken": {

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -729,6 +729,8 @@ class Instance(db.Model):  # type: ignore
         server_default=str(default_values.filter_odt_journeys),
     )
 
+    ghost_words = db.Column(ARRAY(db.Text), nullable=True, server_default="{}")
+
     def __init__(self, name=None, is_free=False, authorizations=None, jobs=None):
         self.name = name
         self.is_free = is_free

--- a/source/tyr/migrations/versions/75681b9c74aa_add_ghost_words.py
+++ b/source/tyr/migrations/versions/75681b9c74aa_add_ghost_words.py
@@ -16,7 +16,9 @@ from sqlalchemy.dialects import postgresql
 
 
 def upgrade():
-    op.add_column('instance', sa.Column('ghost_words', postgresql.ARRAY(sa.Text()), server_default='{}', nullable=True))
+    op.add_column(
+        'instance', sa.Column('ghost_words', postgresql.ARRAY(sa.Text()), server_default='{}', nullable=True)
+    )
 
 
 def downgrade():

--- a/source/tyr/migrations/versions/75681b9c74aa_add_ghost_words.py
+++ b/source/tyr/migrations/versions/75681b9c74aa_add_ghost_words.py
@@ -1,0 +1,23 @@
+"""Add attribute ghost_words in the table instance
+
+Revision ID: 75681b9c74aa
+Revises: 45b018b3198b
+Create Date: 2022-11-15 09:24:40.871668
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '75681b9c74aa'
+down_revision = '45b018b3198b'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+def upgrade():
+    op.add_column('instance', sa.Column('ghost_words', postgresql.ARRAY(sa.Text()), server_default='{}', nullable=True))
+
+
+def downgrade():
+    op.drop_column('instance', 'ghost_words')

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -233,6 +233,7 @@ instance_fields = {
     'asgard_language': fields.Raw,
     'default_pt_planner': fields.Raw,
     'pt_planners_configurations': fields.Raw,
+    'ghost_words': fields.List(fields.String),
 }
 
 api_fields = {'id': fields.Raw, 'name': fields.Raw}

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -982,6 +982,16 @@ class Instance(flask_restful.Resource):
             default=instance.pt_planners_configurations,
         )
 
+        parser.add_argument(
+            'ghost_words',
+            type=str,
+            action='append',
+            required=False,
+            help='List of ghost words to remove from search query string for api /places',
+            location=('json', 'values'),
+            default=instance.ghost_words,
+        )
+
         args = parser.parse_args()
 
         try:
@@ -1077,6 +1087,7 @@ class Instance(flask_restful.Resource):
                         'bss_return_penalty',
                         'default_pt_planner',
                         'pt_planners_configurations',
+                        'ghost_words',
                     ],
                 ),
                 maxlen=0,


### PR DESCRIPTION
* Use of ghost words per coverage in the bdd jormungandr and can be modified by the WS TYR
* It's a list of texts.
For details:  https://navitia.atlassian.net/browse/NAV-1547

Note: Integration tests of jormun as well as tyr should explain how it should work.
