### PR TITLE
Init ridesharing connector OuestGo

### DIFF
--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -184,6 +184,9 @@ CIRCUIT_BREAKER_ASGARD_TIMEOUT_S = 60  # the circuit breaker retries after this 
 CIRCUIT_BREAKER_MAX_KLAXIT_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_KLAXIT_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 
+CIRCUIT_BREAKER_MAX_OUESTGO_FAIL = 4  # max instance call failures before stopping attempt
+CIRCUIT_BREAKER_OUESTGO_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
+
 CIRCUIT_BREAKER_MAX_FORSETI_FAIL = 4  # max instance call failures before stopping attempt
 CIRCUIT_BREAKER_FORSETI_TIMEOUT_S = 60  # the circuit breaker retries after this timeout (in seconds)
 

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
@@ -41,7 +41,8 @@ from jormungandr.scenarios.ridesharing.ridesharing_service import (
     RsFeedPublisher,
     RidesharingServiceError,
 )
-from jormungandr.utils import decode_polyline, Coords
+from jormungandr.utils import Coords
+from jormungandr.street_network.utils import crowfly_distance_between
 from navitiacommon import type_pb2
 import jormungandr.street_network.utils
 
@@ -129,9 +130,7 @@ class Blablalines(AbstractRidesharingService):
 
             res.origin_pickup_duration = offer.get('departure_to_pickup_walking_time')
             res.origin_pickup_shape = None  # Not specified
-            res.origin_pickup_distance = int(
-                jormungandr.street_network.utils.crowfly_distance_between(departure_coord, pickup_coord)
-            )
+            res.origin_pickup_distance = int(crowfly_distance_between(departure_coord, pickup_coord))
 
             # drop off coord
             dropoff_lat = offer.get('dropoff_latitude')
@@ -146,9 +145,7 @@ class Blablalines(AbstractRidesharingService):
 
             res.dropoff_dest_duration = offer.get('dropoff_to_arrival_walking_time')
             res.dropoff_dest_shape = None  # Not specified
-            res.dropoff_dest_distance = int(
-                jormungandr.street_network.utils.crowfly_distance_between(dropoff_coord, arrival_coord)
-            )
+            res.dropoff_dest_distance = int(crowfly_distance_between(dropoff_coord, arrival_coord))
 
             res.shape = self._retreive_main_shape(offer, 'journey_polyline', res.pickup_place, res.dropoff_place)
 

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -1,0 +1,243 @@
+# Copyright (c) 2001-2022, Hove and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Hove (www.hove.com).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+import logging
+import pybreaker
+
+from jormungandr import app
+import jormungandr.scenarios.ridesharing.ridesharing_journey as rsj
+from jormungandr.scenarios.ridesharing.ridesharing_service import (
+    AbstractRidesharingService,
+    RsFeedPublisher,
+    RidesharingServiceError,
+)
+from jormungandr.utils import Coords, get_weekday, make_timestamp_from_str
+from jormungandr.street_network.utils import crowfly_distance_between, get_manhattan_duration
+
+DEFAULT_OUESTGO_FEED_PUBLISHER = {
+    'id': 'OUESTGO',
+    'name': 'OuestGo',
+    'license': 'Private',
+    'url': 'https://www.ouestgo.fr/',
+}
+
+
+class Ouestgo(AbstractRidesharingService):
+    def __init__(
+        self,
+        service_url,
+        api_key,
+        network,
+        feed_publisher=DEFAULT_OUESTGO_FEED_PUBLISHER,
+        timeout=2,
+        driver_state=1,
+        passenger_state=0,
+    ):
+        self.service_url = service_url
+        self.api_key = api_key
+        self.network = network
+        self.system_id = 'ouestgo'
+        self.timeout = timeout
+        self.feed_publisher = None if feed_publisher is None else RsFeedPublisher(**feed_publisher)
+        self.driver_state = driver_state
+        self.passenger_state = passenger_state
+
+        self.journey_metadata = rsj.MetaData(
+            system_id=self.system_id, network=self.network, rating_scale_min=None, rating_scale_max=None
+        )
+
+        self.logger = logging.getLogger("{} {}".format(__name__, self.system_id))
+
+        self.breaker = pybreaker.CircuitBreaker(
+            fail_max=app.config.get(str('CIRCUIT_BREAKER_MAX_OUESTGO_FAIL'), 4),
+            reset_timeout=app.config.get(str('CIRCUIT_BREAKER_OUESTGO_TIMEOUT_S'), 60),
+        )
+        self.call_params = ''
+
+    def status(self):
+        return {
+            'id': self.system_id,
+            'class': self.__class__.__name__,
+            'circuit_breaker': {
+                'current_state': self.breaker.current_state,
+                'fail_counter': self.breaker.fail_counter,
+                'reset_timeout': self.breaker.reset_timeout,
+            },
+            'network': self.network,
+        }
+
+    def _make_response(self, raw_json, request_datetime, from_coord, to_coord, instance_params):
+        if not raw_json:
+            return []
+
+        ridesharing_journeys = []
+        for offer in raw_json:
+            # Verify that the ride-sharing serves the requested day
+            # min_date format: "2022-11-18"
+            min_date = offer.get('journeys', {}).get('outward', {}).get('mindate')
+            # Format datetime value properly to transform into timestamp
+            min_datetime_str = '{}T{}Z'.format(min_date.replace('-', ''), '020000')
+            min_datetime = make_timestamp_from_str(min_datetime_str)
+            circulation_day = get_weekday(min_datetime)
+            if not circulation_day:
+                continue
+
+            # min_time format: 09:50:00 probably in utc ?
+            min_time = offer.get('journeys', {}).get('outward', {}).get(circulation_day, {}).get('mintime')
+            pickup_datetime_str = '{}T{}Z'.format(min_date.replace('-', ''), min_time.replace(':', ''))
+            pickup_datetime = make_timestamp_from_str(pickup_datetime_str)
+            if pickup_datetime > request_datetime:
+                res = rsj.RidesharingJourney()
+                res.metadata = self.journey_metadata
+                res.distance = offer.get('journeys', {}).get('distance')
+                res.ridesharing_ad = offer.get('journeys', {}).get('url')
+                res.duration = offer.get('journeys', {}).get('duration')
+
+                # coord of departure on foot to arrive at ride-sharing point
+                lat, lon = from_coord.split(',')
+                departure_coord = Coords(lat=lat, lon=lon)
+
+                # ride-sharing pick up coord
+                pickup_lat = float(offer.get('journeys', {}).get('from', {}).get('latitude'))
+                pickup_lon = float(offer.get('journeys', {}).get('from', {}).get('longitude'))
+                pickup_coord = Coords(lat=pickup_lat, lon=pickup_lon)
+
+                res.pickup_place = rsj.Place(addr='', lat=pickup_lat, lon=pickup_lon)
+
+                res.origin_pickup_shape = None  # Not specified
+                res.origin_pickup_distance = int(crowfly_distance_between(departure_coord, pickup_coord))
+                # we choose to calculate with speed=1.12 the average speed for a walker
+                res.origin_pickup_duration = get_manhattan_duration(
+                    res.origin_pickup_distance, instance_params.walking_speed
+                )
+
+                # ride-sharing drop off coord
+                dropoff_lat = float(offer.get('journeys', {}).get('to', {}).get('latitude'))
+                dropoff_lon = float(offer.get('journeys', {}).get('to', {}).get('longitude'))
+                dropoff_coord = Coords(lat=dropoff_lat, lon=dropoff_lon)
+
+                res.dropoff_place = rsj.Place(addr='', lat=dropoff_lat, lon=dropoff_lon)
+
+                # arrival coord to final destination or any mode of transport
+                lat, lon = to_coord.split(',')
+                arrival_coord = Coords(lat=lat, lon=lon)
+
+                res.dropoff_dest_shape = None  # Not specified
+                res.dropoff_dest_distance = int(crowfly_distance_between(dropoff_coord, arrival_coord))
+                # we choose to calculate with speed=1.12 the average speed for a walker
+                res.dropoff_dest_duration = get_manhattan_duration(
+                    res.dropoff_dest_distance, instance_params.walking_speed
+                )
+
+                res.shape = None
+
+                res.price = float(offer.get('journeys', {}).get('cost', {}).get('variable')) * 100.0
+                res.currency = "centime"
+
+                res.available_seats = offer.get('journeys', {}).get('driver', {}).get('seats')
+                res.total_seats = None
+
+                res.pickup_date_time = pickup_datetime
+                res.departure_date_time = res.pickup_date_time - res.origin_pickup_duration
+                res.dropoff_date_time = res.pickup_date_time + res.duration
+                res.arrival_date_time = res.dropoff_date_time + res.dropoff_dest_duration
+
+                gender_map = {'male': rsj.Gender.MALE, 'female': rsj.Gender.FEMALE}
+                driver_gender = offer.get('journeys', {}).get('driver', {}).get('gender')
+                driver_alias = offer.get('journeys', {}).get('driver', {}).get('alias')
+                driver_grade = None
+                driver_image = offer.get('journeys', {}).get('driver', {}).get('image')
+                res.driver = rsj.Individual(
+                    alias=driver_alias,
+                    gender=gender_map.get(driver_gender, rsj.Gender.UNKNOWN),
+                    image=driver_image,
+                    rate=driver_grade,
+                    rate_count=None,
+                )
+
+                ridesharing_journeys.append(res)
+
+        return ridesharing_journeys
+
+    def _request_journeys(self, from_coord, to_coord, period_extremity, instance_params, limit=None):
+        """
+
+        :param from_coord: lat,lon ex: '48.109377,-1.682103'
+        :param to_coord: lat,lon ex: '48.020335,-1.743929'
+        :param period_extremity: a tuple of [timestamp(utc), clockwise]
+        :param limit: optional
+        :return:
+        """
+        dep_lat, dep_lon = from_coord.split(',')
+        arr_lat, arr_lon = to_coord.split(',')
+
+        params = {
+            'apikey': self.api_key,
+            'p[passenger][state]': self.passenger_state,
+            'p[driver][state]': self.driver_state,
+            'p[from][latitude]': dep_lat,
+            'p[from][longitude]': dep_lon,
+            'p[to][latitude]': arr_lat,
+            'p[to][longitude]': arr_lon,
+            'signature': 'toto',
+            'timestamp': period_extremity.datetime,
+        }
+
+        headers = {'Authentication': 'key={}'.format(self.api_key)}
+
+        resp = self._call_service(params=params, headers=headers)
+
+        if not resp or resp.status_code != 200:
+            logging.getLogger(__name__).error(
+                'Ouestgo API service unavailable, impossible to query : %s',
+                resp.url,
+                extra={'ridesharing_service_id': self._get_rs_id(), 'status_code': resp.status_code},
+            )
+            raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
+
+        if resp:
+            r = self._make_response(resp.json(), period_extremity.datetime, from_coord, to_coord, instance_params)
+            self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
+            logging.getLogger('stat.ridesharing.ouestgo').info(
+                'Received ridesharing offers : %s',
+                len(r),
+                extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': len(r)},
+            )
+            return r
+        self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=0)
+        logging.getLogger('stat.ridesharing.Ouestgo').info(
+            'Received ridesharing offers : 0',
+            extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': 0},
+        )
+        return []
+
+    def _get_feed_publisher(self):
+        return self.feed_publisher

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -234,12 +234,6 @@ class Ouestgo(AbstractRidesharingService):
                 extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': len(r)},
             )
             return r
-        self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=0)
-        logging.getLogger('stat.ridesharing.Ouestgo').info(
-            'Received ridesharing offers : 0',
-            extra={'ridesharing_service_id': self._get_rs_id(), 'nb_ridesharing_offers': 0},
-        )
-        return []
 
     def _get_feed_publisher(self):
         return self.feed_publisher

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -224,7 +224,9 @@ class Ouestgo(AbstractRidesharingService):
             raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
 
         if resp:
-            r = self._make_response(resp.json(), period_extremity.datetime, from_coord, to_coord, instance_params)
+            r = self._make_response(
+                resp.json(), period_extremity.datetime, from_coord, to_coord, instance_params
+            )
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
             logging.getLogger('stat.ridesharing.ouestgo').info(
                 'Received ridesharing offers : %s',

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing.md
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing.md
@@ -83,3 +83,30 @@ Insert into **Jormun** configuration:
     }
  ]
 ```
+
+## Ouestgo
+
+Also provides an external API that delivers ridesharing offers.<br>
+As with other connectors Navitia exposes the offers inside **ridesharing_journeys** json output field.<br>
+Ouest documentation : https://api.test.ouestgo.mobicoop.io/doc
+
+### How to connect Ouestgo with Navitia.
+
+Insert into **Jormun** configuration:
+
+```
+ "ridesharing": [
+    {
+      "id": "ouestgo",
+      "args": {
+        "api_key": "rdex_kisio",
+        "network": "Ouestgo",
+        "service_url": "https://api.test.ouestgo.mobicoop.io/rdex/journeys",
+        "timeout": 15,
+        "driver_state": 1,
+        "passenger_state": 0
+      },
+      "class": "jormungandr.scenarios.ridesharing.ouestgo.Ouestgo"
+    }
+  ]
+```

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -387,7 +387,8 @@ class RidesharingServiceManager(object):
             # TODO CO2 = length * coeffCar / (totalSeats  + 1)
             rs_section.length = int(rsj.distance)
 
-            rs_section.shape.extend(rsj.shape)
+            if rsj.shape:
+                rs_section.shape.extend(rsj.shape)
 
             if rsj.pickup_date_time:
                 rs_section.begin_date_time = rsj.pickup_date_time

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2001-2022, Hove and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Hove (www.hove.com).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+
+from __future__ import absolute_import, print_function, unicode_literals, division
+
+from jormungandr.scenarios.ridesharing.ouestgo import Ouestgo, DEFAULT_OUESTGO_FEED_PUBLISHER
+from jormungandr.scenarios.ridesharing.ridesharing_service_manager import RidesharingServiceManager
+from jormungandr.scenarios.ridesharing.ridesharing_journey import Gender
+from jormungandr.scenarios.ridesharing.ridesharing_service import RsFeedPublisher, RidesharingServiceError
+
+import mock
+from jormungandr.tests import utils_test
+from jormungandr import utils
+import json
+import re  # https://stackoverflow.com/a/9312242/1614576
+import requests_mock
+import pytest
+
+
+fake_response = """
+    [
+        {
+            "journeys": {
+                "uuid": 225,
+                "operator": "Ouestgo",
+                "origin": "test.ouestgo.mobicoop.io",
+                "url": "https://test.ouestgo.mobicoop.io/covoiturage/rdex/9e2922c777e583cfae11",
+                "driver": {
+                    "uuid": 12,
+                    "alias": "Corentin K.",
+                    "image": null,
+                    "gender": "male",
+                    "seats": 3,
+                    "state": 1
+                },
+            "passenger": {
+                "uuid": 12,
+                "alias": "Corentin K.",
+                "image": null,
+                "gender": "male",
+                "persons": 0,
+                "state": 0
+            },
+            "from": {
+                "address": null,
+                "city": "Nancy",
+                "postalcode": "54100",
+                "country": "France",
+                "latitude": "48.687930",
+                "longitude": "6.171514"
+            },
+            "to": {
+                "address": null,
+                "city": "Metz",
+                "postalcode": "57000",
+                "country": "France",
+                "latitude": "49.108385",
+                "longitude": "6.194897"
+            },
+            "distance": 56546,
+            "duration": 2345,
+            "route": null,
+            "number_of_waypoints": 0,
+            "waypoints": {},
+            "cost": {
+                "variable": "0.059649"
+            },
+            "details": null,
+            "vehicle": null,
+            "frequency": "punctual",
+            "type": "one-way",
+            "real_time": null,
+            "stopped": null,
+            "days": {
+                "monday": 0,
+                "tuesday": 1,
+                "wednesday": 0,
+                "thursday": 0,
+                "friday": 0,
+                "saturday": 0,
+                "sunday": 0
+            },
+            "outward": {
+                "mindate": "2022-11-22",
+                "maxdate": "2022-11-22",
+                "monday": null,
+                "tuesday": {
+                    "mintime": "08:45:00",
+                    "maxtime": "09:15:00"
+                },
+                "wednesday": null,
+                "thursday": null,
+                "friday": null,
+                "saturday": null,
+                "sunday": null
+            },
+            "return": null
+        }
+      }
+    ]
+"""
+
+regex = re.compile(r'\\(?![/u"])')
+fixed = regex.sub(r"\\\\", fake_response)
+
+mock_get = mock.MagicMock(return_value=utils_test.MockResponse(json.loads(fixed), 200, '{}'))
+
+DUMMY_OUESTGO_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 'url': 'http://w.tf'}
+
+
+# A hack class
+class DummyInstance:
+    name = ''
+    walking_speed = 1.12
+
+
+def get_ridesharing_service_test():
+    configs = [
+        {
+            "class": "jormungandr.scenarios.ridesharing.ouestgo.Ouestgo",
+            "args": {
+                "service_url": "toto",
+                "api_key": "toto key",
+                "network": "N",
+                "driver_state": 1,
+                "passenger_state": 0,
+                "feed_publisher": DUMMY_OUESTGO_FEED_PUBLISHER,
+            },
+        },
+        {
+            "class": "jormungandr.scenarios.ridesharing.ouestgo.Ouestgo",
+            "args": {"service_url": "tata", "api_key": "tata key", "network": "M"},
+        },
+    ]
+    instance = DummyInstance()
+    ridesharing_service_manager = RidesharingServiceManager(instance, configs)
+    ridesharing_service_manager.init_ridesharing_services()
+    services = ridesharing_service_manager.get_all_ridesharing_services()
+
+    assert len(services) == 2
+
+    assert services[0].service_url == 'toto'
+    assert services[0].api_key == 'toto key'
+    assert services[0].network == 'N'
+    assert services[0].system_id == 'ouestgo'
+    assert services[0]._get_feed_publisher() == RsFeedPublisher(**DUMMY_OUESTGO_FEED_PUBLISHER)
+
+    assert services[1].service_url == 'tata'
+    assert services[1].api_key == 'tata key'
+    assert services[1].network == 'M'
+    assert services[1].system_id == 'ouestgo'
+    assert services[1]._get_feed_publisher() == RsFeedPublisher(**DEFAULT_OUESTGO_FEED_PUBLISHER)
+
+
+def ouestgo_basic_test():
+    with mock.patch('requests.get', mock_get):
+
+        ouestgo = Ouestgo(
+            service_url='dummyUrl',
+            api_key='dummyApiKey',
+            network='dummyNetwork',
+            feed_publisher=DUMMY_OUESTGO_FEED_PUBLISHER,
+        )
+        from_coord = '48.68793,6.171514'
+        to_coord = '49.108385,6.194897'
+
+        period_extremity = utils.PeriodExtremity(
+            datetime=utils.make_timestamp_from_str("20221121T084122"), represents_start=True
+        )
+        ridesharing_journeys, feed_publisher = ouestgo.request_journeys_with_feed_publisher(
+            from_coord=from_coord,
+            to_coord=to_coord,
+            period_extremity=period_extremity,
+            instance_params=DummyInstance(),
+        )
+
+        assert len(ridesharing_journeys) == 1
+        assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
+        assert ridesharing_journeys[0].metadata.system_id == 'ouestgo'
+        assert ridesharing_journeys[0].ridesharing_ad == \
+               'https://test.ouestgo.mobicoop.io/covoiturage/rdex/9e2922c777e583cfae11'
+
+        assert ridesharing_journeys[0].pickup_place.addr == ""  # address is not provided in mock
+        assert ridesharing_journeys[0].pickup_place.lat == 48.687930
+        assert ridesharing_journeys[0].pickup_place.lon == 6.171514
+
+        assert ridesharing_journeys[0].dropoff_place.addr == ""  # address is not provided in mock
+        assert ridesharing_journeys[0].dropoff_place.lat == 49.108385
+        assert ridesharing_journeys[0].dropoff_place.lon == 6.194897
+
+        assert ridesharing_journeys[0].shape is None
+        assert ridesharing_journeys[0].price == 5.9649
+        assert ridesharing_journeys[0].currency == 'centime'
+
+        assert ridesharing_journeys[0].total_seats is None
+        assert ridesharing_journeys[0].available_seats == 3
+
+        assert ridesharing_journeys[0].driver.alias == 'Corentin K.'
+        assert ridesharing_journeys[0].driver.gender == Gender.MALE
+        assert ridesharing_journeys[0].driver.image is None
+        assert ridesharing_journeys[0].driver.rate is None
+        assert ridesharing_journeys[0].driver.rate_count is None
+
+        assert feed_publisher == RsFeedPublisher(**DUMMY_OUESTGO_FEED_PUBLISHER)
+
+
+def test_request_journeys_should_raise_on_non_200():
+    with requests_mock.Mocker() as mock:
+        ouestgo = Ouestgo(service_url='http://ouestgo', api_key='ApiKey', network='Network')
+
+        mock.get('http://ouestgo', status_code=401, text='{this is the http response}')
+
+        with pytest.raises(RidesharingServiceError) as e:
+            ouestgo._request_journeys(
+                '1.2,3.4',
+                '5.6,7.8',
+                utils.PeriodExtremity(
+                    datetime=utils.make_timestamp_from_str("20221121T084122"), represents_start=True
+                ),
+                DummyInstance(),
+            )
+
+        exception_params = e.value.get_params().values()
+        assert 401 in exception_params
+        assert '{this is the http response}' in exception_params

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
@@ -205,8 +205,10 @@ def ouestgo_basic_test():
         assert len(ridesharing_journeys) == 1
         assert ridesharing_journeys[0].metadata.network == 'dummyNetwork'
         assert ridesharing_journeys[0].metadata.system_id == 'ouestgo'
-        assert ridesharing_journeys[0].ridesharing_ad == \
-               'https://test.ouestgo.mobicoop.io/covoiturage/rdex/9e2922c777e583cfae11'
+        assert (
+            ridesharing_journeys[0].ridesharing_ad
+            == 'https://test.ouestgo.mobicoop.io/covoiturage/rdex/9e2922c777e583cfae11'
+        )
 
         assert ridesharing_journeys[0].pickup_place.addr == ""  # address is not provided in mock
         assert ridesharing_journeys[0].pickup_place.lat == 48.687930

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -819,4 +819,3 @@ def get_weekday(timestamp):
         return WEEK_DAYS_MAPPING[date_time.weekday()]
     except ValueError:
         return None
-

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -57,6 +57,7 @@ PY3 = sys.version_info[0] == 3
 DATETIME_FORMAT = "%Y%m%dT%H%M%S"
 UTC_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 NOT_A_DATE_TIME = "not-a-date-time"
+WEEK_DAYS_MAPPING = ("monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday")
 
 
 def get_uri_pt_object(pt_object):
@@ -810,3 +811,12 @@ def remove_ghost_words(query_string, ghost_words):
     for gw in ghost_words:
         query_string = query_string.replace(gw, '').strip()
     return query_string
+
+
+def get_weekday(timestamp):
+    try:
+        date_time = datetime.fromtimestamp(timestamp)
+        return WEEK_DAYS_MAPPING[date_time.weekday()]
+    except ValueError:
+        return None
+

--- a/source/jormungandr/tests/ouestgo_routing_tests.py
+++ b/source/jormungandr/tests/ouestgo_routing_tests.py
@@ -1,0 +1,252 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2001-2022, Hove and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Hove (www.hove.com).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+from __future__ import absolute_import, print_function, unicode_literals, division
+import pytest
+
+from jormungandr.tests.utils_test import MockResponse
+from tests.check_utils import get_not_null, get_links_dict
+from tests.tests_mechanism import dataset, NewDefaultScenarioAbstractTestFixture
+
+DUMMY_OUESTGO_FEED_PUBLISHER = {'id': '10', 'name': 'ouestgo', 'license': 'I dunno', 'url': 'http://ouest.tf'}
+
+MOCKED_INSTANCE_CONF = {
+    'scenario': 'new_default',
+    'instance_config': {
+        'ridesharing': [
+            {
+                "args": {
+                    "service_url": "http://ouestgo.fr",
+                    "api_key": "key",
+                    "network": "Super Covoit",
+                    "timeout": 15,
+                    "driver_state": 1,
+                    "passenger_state": 0,
+                    "feed_publisher": DUMMY_OUESTGO_FEED_PUBLISHER,
+                },
+                "class": "jormungandr.scenarios.ridesharing.ouestgo.Ouestgo",
+            }
+        ]
+    },
+}
+
+
+OUESTGO_RESPONSE = [
+    {
+        "journeys": {
+            "uuid": 910,
+            "operator": "Ouestgo",
+            "origin": "test.ouestgo.mobicoop.io",
+            "url": "https://test.ouestgo.mobicoop.io/covoiturage/rdex/8e975ea22a915a2d7c01",
+            "driver": {
+                "uuid": 2,
+                "alias": "Colin P.",
+                "image": None,
+                "gender": "male",
+                "seats": 3,
+                "state": 1
+            },
+            "passenger": {
+                "uuid": 2,
+                "alias": "Colin P.",
+                "image": None,
+                "gender": "male",
+                "persons": 0,
+                "state": 0
+            },
+            "from": {
+                "address": None,
+                "city": "Nancy",
+                "postalcode": "54100",
+                "country": "France",
+                "latitude": "0.0000898312",
+                "longitude": "0.0000898312"
+            },
+            "to": {
+                "address": None,
+                "city": "Amnéville",
+                "postalcode": "57360",
+                "country": "France",
+                "latitude": "0.00071865",
+                "longitude": "0.00188646"
+            },
+            "distance": 18869,
+            "duration": 1301,
+            "route": None,
+            "number_of_waypoints": 0,
+            "waypoints": {},
+            "cost": {
+                "variable": "1"
+            },
+            "details": None,
+            "vehicle": None,
+            "frequency": "punctual",
+            "type": "one-way",
+            "real_time": None,
+            "stopped": None,
+            "days": {
+                "monday": 0,
+                "tuesday": 0,
+                "wednesday": 0,
+                "thursday": 0,
+                "friday": 1,
+                "saturday": 0,
+                "sunday": 0
+            },
+            "outward": {
+                "mindate": "2012-06-14",
+                "maxdate": "2012-06-14",
+                "monday": None,
+                "tuesday": None,
+                "wednesday": None,
+                "thursday":  {
+                    "mintime": "08:55:00",
+                    "maxtime": "09:15:00"
+                },
+                "friday": None,
+                "saturday": None,
+                "sunday": None
+            },
+            "return": None
+        }
+    }
+]
+
+
+def mock_ouestgo(_, params, headers):
+    return MockResponse(OUESTGO_RESPONSE, 200)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mock_http_ouestgo(monkeypatch):
+    monkeypatch.setattr(
+        'jormungandr.scenarios.ridesharing.ouestgo.Ouestgo._call_service', mock_ouestgo
+    )
+
+
+@dataset({'main_routing_test': MOCKED_INSTANCE_CONF})
+class TestOuestgo(NewDefaultScenarioAbstractTestFixture):
+    """
+    Integration test with Ouestgo
+    Note: '&forbidden_uris[]=PM' used to avoid line 'PM' and it's vj=vjPB in /journeys
+    """
+
+    def test_basic_ride_sharing(self):
+        """
+        test ridesharing_journeys details
+        """
+        q = (
+            "journeys?from=0.0000898312;0.0000698312&to=0.00188646;0.00071865&datetime=20120614T075500&"
+            "first_section_mode[]={first}&last_section_mode[]={last}&forbidden_uris[]=PM&_min_ridesharing=0".format(
+                first='ridesharing', last='walking'
+            )
+        )
+        response = self.query_region(q)
+        self.is_valid_journey_response(response, q, check_journey_links=False)
+
+        # Check links: ridesharing_journeys
+        links = get_links_dict(response)
+        link = links["ridesharing_journeys"]
+        assert link["rel"] == "ridesharing_journeys"
+        assert link["type"] == "ridesharing_journeys"
+        assert link["href"].startswith("http://localhost/v1/coverage/main_routing_test/")
+        journeys = get_not_null(response, 'journeys')
+        assert len(journeys) == 1
+        tickets = response.get('tickets')
+        assert len(tickets) == 1
+        assert tickets[0].get('cost').get('currency') == 'centime'
+        assert tickets[0].get('cost').get('value') == '100.0'
+        ticket = tickets[0]
+
+        ridesharing_kraken = journeys[0]
+        assert 'ridesharing' in ridesharing_kraken['tags']
+        assert 'non_pt' in ridesharing_kraken['tags']
+        assert ridesharing_kraken.get('type') == 'best'
+        assert ridesharing_kraken.get('durations').get('ridesharing') > 0
+        assert ridesharing_kraken.get('durations').get('total') == ridesharing_kraken['durations']['ridesharing']
+        assert ridesharing_kraken.get('distances').get('ridesharing') > 0
+
+        rs_sections = ridesharing_kraken.get('sections')
+        assert len(rs_sections) == 1
+        assert rs_sections[0].get('mode') == 'ridesharing'
+        assert rs_sections[0].get('type') == 'street_network'
+
+        sections = ridesharing_kraken.get('sections')
+
+        rs_journeys = sections[0].get('ridesharing_journeys')
+        assert len(rs_journeys) == 1
+        assert rs_journeys[0].get('distances').get('ridesharing') == 18869
+        assert rs_journeys[0].get('durations').get('walking') == 2
+        assert rs_journeys[0].get('durations').get('ridesharing') == 1301
+        assert 'ridesharing' in rs_journeys[0].get('tags')
+        rsj_sections = rs_journeys[0].get('sections')
+        assert len(rsj_sections) == 3
+
+        assert rsj_sections[0].get('type') == 'crow_fly'
+        assert rsj_sections[0].get('mode') == 'walking'
+        assert rsj_sections[0].get('duration') == 2
+        assert (rsj_sections[0].get('departure_date_time') == '20120614T085458')
+        assert rsj_sections[0].get('arrival_date_time') == '20120614T085500'
+
+        assert rsj_sections[1].get('type') == 'ridesharing'
+        assert rsj_sections[1].get('duration') == 1301
+        assert rsj_sections[1].get('departure_date_time') == '20120614T085500'
+        assert rsj_sections[1].get('arrival_date_time') == '20120614T091641'
+
+        rsj_info = rsj_sections[1].get('ridesharing_informations')
+        assert rsj_info.get('network') == 'Super Covoit'
+        assert rsj_info.get('operator') == 'ouestgo'
+        assert rsj_info.get('seats').get('available') == 3
+
+        assert 'total' not in rsj_info.get('seats')
+
+        rsj_links = rsj_sections[1].get('links')
+        assert len(rsj_links) == 2
+        assert rsj_links[0].get('rel') == 'ridesharing_ad'
+        assert rsj_links[0].get('type') == 'ridesharing_ad'
+
+        assert rsj_links[1].get('rel') == 'tickets'
+        assert rsj_links[1].get('type') == 'ticket'
+        assert rsj_links[1].get('id') == ticket['id']
+        assert ticket['links'][0]['id'] == rsj_sections[1]['id']
+        assert rs_journeys[0].get('fare').get('total').get('value') == tickets[0].get('cost').get('value')
+
+        assert rsj_sections[2].get('type') == 'crow_fly'
+        assert rsj_sections[2].get('mode') == 'walking'
+        assert rsj_sections[2].get('duration') == 0
+        assert rsj_sections[2].get('departure_date_time') == '20120614T091641'
+        assert rsj_sections[2].get('arrival_date_time') == '20120614T091641'
+
+        fps = response['feed_publishers']
+        assert len(fps) == 2
+
+        def equals_to_dummy_fp(fp):
+            return fp == DUMMY_OUESTGO_FEED_PUBLISHER
+
+        assert any(equals_to_dummy_fp(fp) for fp in fps)

--- a/source/jormungandr/tests/ouestgo_routing_tests.py
+++ b/source/jormungandr/tests/ouestgo_routing_tests.py
@@ -64,21 +64,14 @@ OUESTGO_RESPONSE = [
             "operator": "Ouestgo",
             "origin": "test.ouestgo.mobicoop.io",
             "url": "https://test.ouestgo.mobicoop.io/covoiturage/rdex/8e975ea22a915a2d7c01",
-            "driver": {
-                "uuid": 2,
-                "alias": "Colin P.",
-                "image": None,
-                "gender": "male",
-                "seats": 3,
-                "state": 1
-            },
+            "driver": {"uuid": 2, "alias": "Colin P.", "image": None, "gender": "male", "seats": 3, "state": 1},
             "passenger": {
                 "uuid": 2,
                 "alias": "Colin P.",
                 "image": None,
                 "gender": "male",
                 "persons": 0,
-                "state": 0
+                "state": 0,
             },
             "from": {
                 "address": None,
@@ -86,7 +79,7 @@ OUESTGO_RESPONSE = [
                 "postalcode": "54100",
                 "country": "France",
                 "latitude": "0.0000898312",
-                "longitude": "0.0000898312"
+                "longitude": "0.0000898312",
             },
             "to": {
                 "address": None,
@@ -94,16 +87,14 @@ OUESTGO_RESPONSE = [
                 "postalcode": "57360",
                 "country": "France",
                 "latitude": "0.00071865",
-                "longitude": "0.00188646"
+                "longitude": "0.00188646",
             },
             "distance": 18869,
             "duration": 1301,
             "route": None,
             "number_of_waypoints": 0,
             "waypoints": {},
-            "cost": {
-                "variable": "1"
-            },
+            "cost": {"variable": "1"},
             "details": None,
             "vehicle": None,
             "frequency": "punctual",
@@ -117,7 +108,7 @@ OUESTGO_RESPONSE = [
                 "thursday": 0,
                 "friday": 1,
                 "saturday": 0,
-                "sunday": 0
+                "sunday": 0,
             },
             "outward": {
                 "mindate": "2012-06-14",
@@ -125,15 +116,12 @@ OUESTGO_RESPONSE = [
                 "monday": None,
                 "tuesday": None,
                 "wednesday": None,
-                "thursday":  {
-                    "mintime": "08:55:00",
-                    "maxtime": "09:15:00"
-                },
+                "thursday":  {"mintime": "08:55:00", "maxtime": "09:15:00"},
                 "friday": None,
                 "saturday": None,
-                "sunday": None
+                "sunday": None,
             },
-            "return": None
+            "return": None,
         }
     }
 ]
@@ -145,9 +133,7 @@ def mock_ouestgo(_, params, headers):
 
 @pytest.fixture(scope="function", autouse=True)
 def mock_http_ouestgo(monkeypatch):
-    monkeypatch.setattr(
-        'jormungandr.scenarios.ridesharing.ouestgo.Ouestgo._call_service', mock_ouestgo
-    )
+    monkeypatch.setattr('jormungandr.scenarios.ridesharing.ouestgo.Ouestgo._call_service', mock_ouestgo)
 
 
 @dataset({'main_routing_test': MOCKED_INSTANCE_CONF})
@@ -211,7 +197,7 @@ class TestOuestgo(NewDefaultScenarioAbstractTestFixture):
         assert rsj_sections[0].get('type') == 'crow_fly'
         assert rsj_sections[0].get('mode') == 'walking'
         assert rsj_sections[0].get('duration') == 2
-        assert (rsj_sections[0].get('departure_date_time') == '20120614T085458')
+        assert rsj_sections[0].get('departure_date_time') == '20120614T085458'
         assert rsj_sections[0].get('arrival_date_time') == '20120614T085500'
 
         assert rsj_sections[1].get('type') == 'ridesharing'

--- a/source/jormungandr/tests/ouestgo_routing_tests.py
+++ b/source/jormungandr/tests/ouestgo_routing_tests.py
@@ -116,7 +116,7 @@ OUESTGO_RESPONSE = [
                 "monday": None,
                 "tuesday": None,
                 "wednesday": None,
-                "thursday":  {"mintime": "08:55:00", "maxtime": "09:15:00"},
+                "thursday": {"mintime": "08:55:00", "maxtime": "09:15:00"},
                 "friday": None,
                 "saturday": None,
                 "sunday": None,


### PR DESCRIPTION
Initialization to use a new ride-sharing connector OuestGo.
Developed with limited information:
- Internal document not completed yet : https://navitia.atlassian.net/wiki/spaces/NAV/pages/12047908929/Ouestgo
- Document of the connector : https://api.test.ouestgo.mobicoop.io/doc

For details: https://navitia.atlassian.net/browse/NAV-1558

**Note: Can be tested with a QA if needed.**
