### PR TITLE
Add status.is_everyting_loaded

### DIFF
--- a/source/kraken/data_manager.h
+++ b/source/kraken/data_manager.h
@@ -133,6 +133,7 @@ public:
             try {
                 data->load_disruptions(*chaos_database, chaos_batch_size, contributors);
                 data->build_autocomplete_partial();
+                data->is_chaos_reloaded = true;
             } catch (const navitia::data::disruptions_broken_connection&) {
                 LOG4CPLUS_WARN(logger, "Load data without disruptions");
             } catch (const navitia::data::disruptions_loading_error&) {

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -49,12 +49,16 @@ public:
     void build_autocomplete_partial() {}
     mutable std::atomic<bool> loading;
     mutable std::atomic<bool> is_connected_to_rabbitmq;
+    mutable std::atomic<bool> is_chaos_reloaded{};
     static bool load_status;
     static bool last_load_succeeded;
     static bool destructor_called;
     size_t data_identifier;
 
-    Data(size_t data_identifier = 0) : data_identifier(data_identifier) { is_connected_to_rabbitmq = false; }
+    Data(size_t data_identifier = 0) : data_identifier(data_identifier) {
+        is_connected_to_rabbitmq = false;
+        is_chaos_reloaded = false;
+    }
 
     ~Data() { Data::destructor_called = true; }
 };

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -332,7 +332,7 @@ void Worker::status() {
         bool is_kirin_reloaded = d->is_realtime_loaded;
         is_everything_loaded = is_everything_loaded && is_kirin_reloaded;
     }
-    bool chaos_enabled = conf.chaos_database().has_value();
+    bool chaos_enabled != boost::none;
     if (chaos_enabled) {
         bool is_chaos_reloaded = d->is_chaos_reloaded;
         is_everything_loaded = is_everything_loaded && is_chaos_reloaded;

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -300,12 +300,7 @@ void Worker::status() {
     const auto* d = this->pb_creator.data;
     status->set_data_version(d->version);
     status->set_navitia_version(config::project_version);
-    if (conf.is_realtime_enabled()) {
-        bool everything_loaded = d->loaded && d->is_realtime_loaded;
-        status->set_loaded(everything_loaded);
-    } else {
-        status->set_loaded(d->loaded);
-    }
+    status->set_loaded(d->loaded);
     status->set_last_load_status(d->last_load_succeeded);
     status->set_last_load_at(pt::to_iso_string(d->last_load_at));
     status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded()));
@@ -328,6 +323,21 @@ void Worker::status() {
         status->set_end_production_date("");
         status->set_dataset_created_at("");
     }
+
+    bool base_data_loaded = d->loaded;
+    bool is_everything_loaded = base_data_loaded;
+
+    bool kirin_enabled = conf.is_realtime_enabled();
+    if (kirin_enabled) {
+        bool is_kirin_reloaded = d->is_realtime_loaded;
+        is_everything_loaded = is_everything_loaded && is_kirin_reloaded;
+    }
+    bool chaos_enabled = conf.chaos_database().has_value();
+    if (chaos_enabled) {
+        bool is_chaos_reloaded = d->is_chaos_reloaded;
+        is_everything_loaded = is_everything_loaded && is_chaos_reloaded;
+    }
+    status->set_is_everything_loaded(is_everything_loaded);
 }
 
 void Worker::metadatas() {

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -332,7 +332,7 @@ void Worker::status() {
         bool is_kirin_reloaded = d->is_realtime_loaded;
         is_everything_loaded = is_everything_loaded && is_kirin_reloaded;
     }
-    bool chaos_enabled != boost::none;
+    bool chaos_enabled = conf.chaos_database() != boost::none;
     if (chaos_enabled) {
         bool is_chaos_reloaded = d->is_chaos_reloaded;
         is_everything_loaded = is_everything_loaded && is_chaos_reloaded;

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -300,7 +300,12 @@ void Worker::status() {
     const auto* d = this->pb_creator.data;
     status->set_data_version(d->version);
     status->set_navitia_version(config::project_version);
-    status->set_loaded(d->loaded);
+    if (conf.is_realtime_enabled()) {
+        bool everything_loaded = d->loaded && d->is_realtime_loaded;
+        status->set_loaded(everything_loaded);
+    } else {
+        status->set_loaded(d->loaded);
+    }
     status->set_last_load_status(d->last_load_succeeded);
     status->set_last_load_at(pt::to_iso_string(d->last_load_at));
     status->set_last_rt_data_loaded(pt::to_iso_string(d->last_rt_data_loaded()));

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -191,7 +191,7 @@ def ready():
         return json.dumps({'error': 'zmq timed out'}), 503
     if proto_response.status == None:
         return json.dumps({'error': 'no status in zmq response'}), 500
-    if proto_response.status.loaded == True:
+    if proto_response.status.is_everythin_loaded == True:
         return json.dumps("ready"), 200
     return json.dumps("not ready"), 400
 

--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -191,7 +191,7 @@ def ready():
         return json.dumps({'error': 'zmq timed out'}), 503
     if proto_response.status == None:
         return json.dumps({'error': 'no status in zmq response'}), 500
-    if proto_response.status.is_everythin_loaded == True:
+    if proto_response.status.is_everything_loaded == True:
         return json.dumps("ready"), 200
     return json.dumps("not ready"), 400
 

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -91,6 +91,7 @@ Data::Data(size_t data_identifier)
     loaded = false;
     is_connected_to_rabbitmq = false;
     is_realtime_loaded = false;
+    is_chaos_reloaded = false;
 }
 
 Data::~Data() = default;
@@ -98,7 +99,7 @@ Data::~Data() = default;
 template <class Archive>
 void Data::save(Archive& ar, const unsigned int /*unused*/) const {
     ar& pt_data& geo_ref& meta& fare& last_load_at& loaded& last_load_succeeded& is_connected_to_rabbitmq&
-        is_realtime_loaded;
+        is_realtime_loaded& is_chaos_reloaded;
 }
 template <class Archive>
 void Data::load(Archive& ar, const unsigned int version) {
@@ -111,7 +112,7 @@ void Data::load(Archive& ar, const unsigned int version) {
         throw navitia::data::wrong_version(msg.str());
     }
     ar& pt_data& geo_ref& meta& fare& last_load_at& loaded& last_load_succeeded& is_connected_to_rabbitmq&
-        is_realtime_loaded;
+        is_realtime_loaded& is_chaos_reloaded;
 }
 SPLIT_SERIALIZABLE(Data)
 

--- a/source/type/data.h
+++ b/source/type/data.h
@@ -190,6 +190,8 @@ public:
 
     mutable std::atomic<bool> is_realtime_loaded{};
 
+    mutable std::atomic<bool> is_chaos_reloaded{};
+
     Data(size_t data_identifier = 0);
     ~Data();
 


### PR DESCRIPTION
Add a field `is_everything_loaded` to `status` response which is set to true if all the following are true: 

 -  the data.nav was successfully loaded
 - chaos database is configured AND chaos was successfully reloaded
 - is_realtime_enabled is configured to true AND kirin was successfully reloaded

Modify the `/ready `route in monitor to return true when `status.is_everything_loaded` is true.

Needs https://github.com/hove-io/navitia-proto/pull/189