### PR TITLE
healthcheck returns 503 when not ready

### DIFF
--- a/source/monitor/monitor_kraken/app.py
+++ b/source/monitor/monitor_kraken/app.py
@@ -193,7 +193,7 @@ def ready():
         return json.dumps({'error': 'no status in zmq response'}), 500
     if proto_response.status.loaded == True:
         return json.dumps("ready"), 200
-    return json.dumps("not ready"), 400
+    return json.dumps("not ready"), 503
 
 
 def request_kraken_zmq_status(zmq_socket, zmq_timeout_in_ms):


### PR DESCRIPTION
The /ready route of the monitor now returns a 503 instead of a 400 when kraken is not ready