### PR TITLE
[jormungandr] implement access_points in transfer path

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -748,6 +748,7 @@ void builder::generate_dummy_basis() {
     this->data->pt_data->get_or_create_commercial_mode("Bus", "Bus");
     this->data->pt_data->get_or_create_commercial_mode("Car", "Car");
     this->data->pt_data->get_or_create_commercial_mode("Coach", "Autocar");
+    this->data->pt_data->get_or_create_commercial_mode("RapidTransit", "RER");
 
     for (navitia::type::CommercialMode* mt : this->data->pt_data->commercial_modes) {
         data->pt_data->get_or_create_physical_mode("physical_mode:" + mt->uri, mt->name, get_co2_emission(mt->uri));

--- a/source/jormungandr/jormungandr/georef.py
+++ b/source/jormungandr/jormungandr/georef.py
@@ -172,13 +172,13 @@ class Kraken(object):
             )
         return result.stop_points
 
-    def get_stop_points_from_uri(self, uri, request_id):
+    def get_stop_points_from_uri(self, uri, request_id, depth=0):
         req = request_pb2.Request()
         req.requested_api = type_pb2.PTREFERENTIAL
         req.ptref.requested_type = type_pb2.STOP_POINT
         req.ptref.count = 100
         req.ptref.start_page = 0
-        req.ptref.depth = 0
+        req.ptref.depth = depth
         req.ptref.filter = 'stop_point.uri = {uri}'.format(uri=uri)
         result = self.instance.send_and_receive(req, request_id=request_id)
         return result.stop_points

--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -318,7 +318,9 @@ class Distributed(object):
 
         journeys_to_complete = get_journeys_to_complete(responses, context, is_debug)
 
-        transfer_pool = TransferPool(future_manager=future_manager, instance=instance, request=request)
+        transfer_pool = TransferPool(
+            future_manager=future_manager, instance=instance, request=request, request_id=request_id
+        )
 
         if request['_transfer_path'] is True:
             for journey in journeys_to_complete:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -779,20 +779,27 @@ def complete_transfer(pt_journey, transfer_pool):
         transfer_pool.wait_and_complete(section)
 
 
-def prepend_first_and_append_last_coord(dp, origin, destination):
-    """
-    Insert/append origin and destination's coordinates to the geojson
-    """
+def is_valid_direct_path_streetwork(dp):
     if not dp or not dp.journeys or not dp.journeys[0].sections:
-        return
+        return False
 
+    # a valid journey's must comprise at least two coordinates
     nb_coords = sum((len(sec.street_network.coordinates) for sec in dp.journeys[0].sections))
     if nb_coords < 2:
+        return False
+    return True
+
+
+def prepend_first_coord(dp, pt_obj):
+    """
+    prepend pt_object's coord to journeys' coordinates (geojson)
+    """
+    if not is_valid_direct_path_streetwork(dp):
         return
 
     starting_coords = dp.journeys[0].sections[0].street_network.coordinates
     # we are inserting the coord of the origin at the beginning of the geojson
-    coord = get_pt_object_coord(origin)
+    coord = get_pt_object_coord(pt_obj)
     if starting_coords and coord != starting_coords[0]:
         starting_coords.add(lon=coord.lon, lat=coord.lat)
         # we cannot insert an element at the beginning of a list :(
@@ -803,8 +810,16 @@ def prepend_first_and_append_last_coord(dp, origin, destination):
             starting_coords[i].CopyFrom(starting_coords[-1])
             starting_coords[-1].CopyFrom(tmp)
 
+
+def append_last_coord(dp, pt_obj):
+    """
+    append pt_object's coord to journeys' coordinates (geojson)
+    """
+    if not is_valid_direct_path_streetwork(dp):
+        return
+
     ending_coords = dp.journeys[0].sections[-1].street_network.coordinates
     # we are appending the coord of the destination at the end of the geojson
-    coord = get_pt_object_coord(destination)
+    coord = get_pt_object_coord(pt_obj)
     if ending_coords and coord != ending_coords[-1]:
         ending_coords.add(lon=coord.lon, lat=coord.lat)

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -30,7 +30,7 @@ from __future__ import absolute_import
 from jormungandr import utils, new_relic
 from jormungandr.street_network.street_network import StreetNetworkPathType
 import logging
-from .helper_utils import timed_logger
+from .helper_utils import timed_logger, prepend_first_and_append_last_coord
 from navitiacommon import type_pb2, response_pb2
 from jormungandr.exceptions import GeoveloTechnicalError
 from .helper_exceptions import StreetNetworkException
@@ -139,7 +139,7 @@ class StreetNetworkPath:
 
         dp = self._direct_path_with_fp(self._streetnetwork_service)
 
-        self._add_first_and_last_coord(dp)
+        prepend_first_and_append_last_coord(dp, self._orig_obj, self._dest_obj)
 
         if getattr(dp, "journeys", None):
             dp.journeys[0].internal_id = str(utils.generate_id())

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -30,7 +30,7 @@ from __future__ import absolute_import
 from jormungandr import utils, new_relic
 from jormungandr.street_network.street_network import StreetNetworkPathType
 import logging
-from .helper_utils import timed_logger, prepend_first_and_append_last_coord
+from .helper_utils import timed_logger, prepend_first_coord, append_last_coord
 from navitiacommon import type_pb2, response_pb2
 from jormungandr.exceptions import GeoveloTechnicalError
 from .helper_exceptions import StreetNetworkException
@@ -101,33 +101,6 @@ class StreetNetworkPath:
                 logging.getLogger(__name__).exception('')
                 return None
 
-    def _add_first_and_last_coord(self, dp):
-        if not dp or not dp.journeys or not dp.journeys[0].sections:
-            return
-
-        nb_coords = sum((len(sec.street_network.coordinates) for sec in dp.journeys[0].sections))
-        if nb_coords < 2:
-            return
-
-        starting_coords = dp.journeys[0].sections[0].street_network.coordinates
-        # we are inserting the coord of the origin at the beginning of the geojson
-        coord = utils.get_pt_object_coord(self._orig_obj)
-        if starting_coords and coord != starting_coords[0]:
-            starting_coords.add(lon=coord.lon, lat=coord.lat)
-            # we cannot insert an element at the beginning of a list :(
-            # a little algo to move the last element to the beginning
-            tmp = type_pb2.GeographicalCoord()
-            for i in range(len(starting_coords)):
-                tmp.CopyFrom(starting_coords[i])
-                starting_coords[i].CopyFrom(starting_coords[-1])
-                starting_coords[-1].CopyFrom(tmp)
-
-        ending_coords = dp.journeys[0].sections[-1].street_network.coordinates
-        # we are appending the coord of the destination at the end of the geojson
-        coord = utils.get_pt_object_coord(self._dest_obj)
-        if ending_coords and coord != ending_coords[-1]:
-            ending_coords.add(lon=coord.lon, lat=coord.lat)
-
     def _do_request(self):
         self._logger.debug(
             "requesting %s direct path from %s to %s by %s",
@@ -138,8 +111,8 @@ class StreetNetworkPath:
         )
 
         dp = self._direct_path_with_fp(self._streetnetwork_service)
-
-        prepend_first_and_append_last_coord(dp, self._orig_obj, self._dest_obj)
+        prepend_first_coord(dp, self._orig_obj)
+        append_last_coord(dp, self._dest_obj)
 
         if getattr(dp, "journeys", None):
             dp.journeys[0].internal_id = str(utils.generate_id())

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
@@ -171,14 +171,16 @@ class TransferPool(object):
     def _do_access_point_transfer(self, section, prev_section_mode, next_section_mode):
         access_points = None
         if prev_section_mode in ACCESS_POINTS_PHYSICAL_MODES:
-            access_points = self._get_access_points(section.origin.uri, predicator=lambda ap: ap.is_entrance)
+            access_points = self._get_access_points(section.origin.uri, predicator=lambda ap: ap.is_exit)
             # if no access points are found for this stop point, which is supposed to have access points
             # we do nothing about the transfer path
             if not access_points:
                 return None
 
         elif next_section_mode in ACCESS_POINTS_PHYSICAL_MODES:
-            access_points = self._get_access_points(section.destination.uri, predicator=lambda ap: ap.is_exit)
+            access_points = self._get_access_points(
+                section.destination.uri, predicator=lambda ap: ap.is_entrance
+            )
             # if no access points are found for this stop point, which is supposed to have access points
             # we do nothing about the transfer path
             if not access_points:

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
@@ -26,12 +26,19 @@
 # channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
 # https://groups.google.com/d/forum/navitia
 # www.navitia.io
-from navitiacommon import response_pb2
+from __future__ import absolute_import, print_function, unicode_literals, division
+from collections import namedtuple
+from navitiacommon import response_pb2, type_pb2
 import itertools
 import logging
 from jormungandr.street_network.street_network import StreetNetworkPathType
 from jormungandr.utils import PeriodExtremity
 from jormungandr.fallback_modes import FallbackModes
+from jormungandr.scenarios.helper_classes.helper_utils import (
+    prepend_first_and_append_last_coord,
+    append_path_item_with_access_point,
+    prepend_path_item_with_access_point,
+)
 
 NO_ACCESS_POINTS_PHYSICAL_MODES = (
     'physical_mode:Bus',
@@ -53,9 +60,13 @@ NO_ACCESS_POINTS_TRANSFER = set(
 # if `(physical_mode:A, physical_mode:B) in ACCESS_POINTS_TRANSFER` then it means that a transfer
 # where we get out of a vehicle of  `physical_mode:A` and then get in a vehicle of `physical_mode:B`
 # **may use** an access point
+# Note that we don't handle (ACCESS_POINTS_PHYSICAL_MODES, ACCESS_POINTS_PHYSICAL_MODES) yet
 ACCESS_POINTS_TRANSFER = set(
     itertools.product(ACCESS_POINTS_PHYSICAL_MODES, NO_ACCESS_POINTS_PHYSICAL_MODES)
 ) | set(itertools.product(NO_ACCESS_POINTS_PHYSICAL_MODES, ACCESS_POINTS_PHYSICAL_MODES))
+
+
+TransferResult = namedtuple('TransferResult', ['direct_path', 'origin', 'destination'])
 
 
 class TransferPool(object):
@@ -64,11 +75,13 @@ class TransferPool(object):
         future_manager,
         instance,
         request,
+        request_id,
     ):
         self._future_manager = future_manager
         self._instance = instance
         self._request = request
-        self._streetnetwork_service = self._instance.get_street_network("walking", request)
+        self._request_id = request_id
+        self._streetnetwork_service = self._instance.get_street_network(FallbackModes.walking.name, request)
         self._transfers_future = dict()
         self._logger = logging.getLogger(__name__)
 
@@ -106,21 +119,25 @@ class TransferPool(object):
             next_section_mode = self.get_physical_mode(next_section)
 
             section_key = self._get_section_key(section)
+            if section_key in self._transfers_future:
+                continue
 
             if (prev_section_mode, next_section_mode) in NO_ACCESS_POINTS_TRANSFER:
-                if section_key not in self._transfers_future:
-                    self._transfers_future[section_key] = self._aysnc_no_access_point_transfer(section)
+                self._transfers_future[section_key] = self._aysnc_no_access_point_transfer(section)
             elif (prev_section_mode, next_section_mode) in ACCESS_POINTS_TRANSFER:
-                # TODO: there will be a whole new feature!
-                continue
+                self._transfers_future[section_key] = self._aysnc_access_point_transfer(
+                    section, prev_section_mode, next_section_mode
+                )
             else:
                 continue
 
     def _do_no_access_point_transfer(self, section):
-        sub_request_id = "transfer_{}_{}".format(section.origin.uri, section.destination.uri)
+        sub_request_id = "{}_transfer_{}_{}".format(
+            self._request_id, section.origin.uri, section.destination.uri
+        )
         direct_path_type = StreetNetworkPathType.DIRECT
         extremity = PeriodExtremity(section.end_date_time, False)
-        return self._streetnetwork_service.direct_path_with_fp(
+        direct_path = self._streetnetwork_service.direct_path_with_fp(
             self._instance,
             FallbackModes.walking.name,
             section.origin,
@@ -131,19 +148,181 @@ class TransferPool(object):
             sub_request_id,
         )
 
+        if direct_path and direct_path.journeys:
+            return TransferResult(direct_path, section.origin, section.destination)
+
+        return None
+
     def _aysnc_no_access_point_transfer(self, section):
         return self._future_manager.create_future(self._do_no_access_point_transfer, section)
+
+    def _get_access_points(self, stop_point_uri, predicator=lambda x: x):
+        sub_request_id = "{}_transfer_start_{}".format(self._request_id, stop_point_uri)
+        stop_points = self._instance.georef.get_stop_points_from_uri(stop_point_uri, sub_request_id, depth=3)
+        if not stop_points:
+            return None
+
+        return [
+            type_pb2.PtObject(name=ap.name, uri=ap.uri, embedded_type=type_pb2.ACCESS_POINT, access_point=ap)
+            for ap in stop_points[0].access_points
+            if predicator(ap)
+        ]
+
+    def _do_access_point_transfer(self, section, prev_section_mode, next_section_mode):
+        access_points = None
+        if prev_section_mode in ACCESS_POINTS_PHYSICAL_MODES:
+            access_points = self._get_access_points(section.origin.uri, predicator=lambda ap: ap.is_entrance)
+            # if no access points are found for this stop point, which is supposed to have access points
+            # we do nothing about the transfer path
+            if not access_points:
+                return None
+
+        elif next_section_mode in ACCESS_POINTS_PHYSICAL_MODES:
+            access_points = self._get_access_points(section.destination.uri, predicator=lambda ap: ap.is_exit)
+            # if no access points are found for this stop point, which is supposed to have access points
+            # we do nothing about the transfer path
+            if not access_points:
+                return None
+
+        # determine the origins and the destinations for matrix computation
+        origins = access_points if prev_section_mode in ACCESS_POINTS_PHYSICAL_MODES else [section.origin]
+        destinations = (
+            access_points if next_section_mode in ACCESS_POINTS_PHYSICAL_MODES else [section.destination]
+        )
+
+        if len(origins) > 1 and len(destinations) > 1:
+            self._logger.error(
+                "Error occurred when computing transfer path both origins and destinations's sizes are larger than 1"
+            )
+            return None
+
+        if len(origins) == 1 and len(destinations) == 1:
+            sub_request_id = "{}_transfer_{}_{}".format(self._request_id, origins[0].uri, destinations[0].uri)
+            direct_path_type = StreetNetworkPathType.DIRECT
+            extremity = PeriodExtremity(section.end_date_time, False)
+            direct_path = self._streetnetwork_service.direct_path_with_fp(
+                self._instance,
+                FallbackModes.walking.name,
+                origins[0],
+                destinations[0],
+                extremity,
+                self._request,
+                direct_path_type,
+                sub_request_id,
+            )
+            if direct_path and direct_path.journeys:
+                return TransferResult(direct_path, origins[0], destinations[0])
+            return None
+
+        sub_request_id = "{}_transfer_matrix".format(self._request_id)
+        routing_matrix = self._streetnetwork_service.get_street_network_routing_matrix(
+            self._instance,
+            origins,
+            destinations,
+            FallbackModes.walking.name,
+            section.duration * 2,
+            self._request,
+            sub_request_id,
+        )
+
+        # now it's time to find the best combo
+        # (stop_point -> access_points or access_points -> stop_point)
+
+        # since the matrix is not really a matrix(NxM) but a single row(1xN)...
+        best_access_point = None
+        best_duration = float('inf')
+        for i, ap in enumerate(access_points):
+            if routing_matrix.rows[0].routing_response[i].routing_status != response_pb2.reached:
+                continue
+            total_duration = routing_matrix.rows[0].routing_response[i].duration + ap.access_point.traversal_time
+            if total_duration < best_duration:
+                best_duration = total_duration
+                best_access_point = ap
+
+        # now we are going to compute the real path
+        origin = best_access_point if prev_section_mode in ACCESS_POINTS_PHYSICAL_MODES else section.origin
+        destination = (
+            best_access_point if next_section_mode in ACCESS_POINTS_PHYSICAL_MODES else section.destination
+        )
+
+        sub_request_id = "{}_transfer_{}_{}".format(self._request_id, origins[0].uri, destinations[0].uri)
+        direct_path_type = StreetNetworkPathType.DIRECT
+        extremity = PeriodExtremity(section.end_date_time, False)
+
+        direct_path = self._streetnetwork_service.direct_path_with_fp(
+            self._instance,
+            FallbackModes.walking.name,
+            origin,
+            destination,
+            extremity,
+            self._request,
+            direct_path_type,
+            sub_request_id,
+        )
+        if direct_path and direct_path.journeys:
+            return TransferResult(direct_path, origin, destination)
+
+        return None
+
+    def _aysnc_access_point_transfer(self, section, prev_section_mode, next_section_mode):
+        return self._future_manager.create_future(
+            self._do_access_point_transfer, section, prev_section_mode, next_section_mode
+        )
 
     @staticmethod
     def _get_section_key(section):
         return section.origin.uri, section.destination.uri
+
+    def _is_valid(self, transfer_result):
+        return (
+            transfer_result
+            and transfer_result.direct_path
+            and transfer_result.direct_path.journeys
+            and transfer_result.direct_path.journeys[0].sections
+        )
+
+    @staticmethod
+    def _is_access_point(pt_object):
+        return isinstance(pt_object, type_pb2.PtObject) and pt_object.embedded_type == type_pb2.ACCESS_POINT
+
+    @staticmethod
+    def _add_via_if_access_point(section, pt_object):
+        if TransferPool._is_access_point(pt_object):
+            section.vias.add().CopyFrom(pt_object.access_point)
 
     def wait_and_complete(self, section):
         future = self._transfers_future.get(self._get_section_key(section))
         if future is None:
             return
 
-        transfer_journey = future.wait_and_get()
-        if transfer_journey and transfer_journey.journeys:
-            new_section = transfer_journey.journeys[0].sections
-            section.street_network.CopyFrom(new_section[0].street_network)
+        transfer_result = future.wait_and_get()
+        if not self._is_valid(transfer_result):
+            return
+
+        transfer_direct_path = transfer_result.direct_path
+
+        if transfer_result.origin and transfer_result.destination:
+            prepend_first_and_append_last_coord(
+                transfer_direct_path, transfer_result.origin, transfer_result.destination
+            )
+
+        self._add_via_if_access_point(section, transfer_result.origin)
+        self._add_via_if_access_point(section, transfer_result.destination)
+
+        transfer_street_network = transfer_direct_path.journeys[0].sections[0].street_network
+
+        if self._is_access_point(transfer_result.origin):
+            prepend_path_item_with_access_point(
+                transfer_street_network.path_items,
+                section.origin.stop_point,
+                transfer_result.origin.access_point,
+            )
+
+        if self._is_access_point(transfer_result.destination):
+            append_path_item_with_access_point(
+                transfer_street_network.path_items,
+                section.destination.stop_point,
+                transfer_result.destination.access_point,
+            )
+
+        section.street_network.CopyFrom(transfer_street_network)

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(sans_filtre) {
     BOOST_CHECK_EQUAL(indexes.size(), 1);
 
     indexes = make_query(nt::Type_e::PhysicalMode, "", *(b.data));
-    BOOST_CHECK_EQUAL(indexes.size(), 7);
+    BOOST_CHECK_EQUAL(indexes.size(), 8);
 
     indexes = make_query(nt::Type_e::CommercialMode, "", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 7);
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(get_indexes_test) {
         b.connection("stop3", "stop2", 10 * 60);
     });
 
-    // On cherche à retrouver la ligne 1, en passant le stoparea en filtre
+    // On cherche �� retrouver la ligne 1, en passant le stoparea en filtre
     auto indexes = make_query(Type_e::Line, "stop_area.uri = stop1", *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, nt::make_indexes({0}));
 
@@ -336,12 +336,12 @@ BOOST_AUTO_TEST_CASE(forbidden_uri) {
 
 BOOST_AUTO_TEST_CASE(find_path_test) {
     auto res = find_path(nt::Type_e::Route);
-    // Cas où on veut partir et arriver au même point
+    // Cas o�� on veut partir et arriver au m��me point
     BOOST_CHECK(res[nt::Type_e::Route] == nt::Type_e::Route);
-    // On regarde qu'il y a un semblant d'itinéraire pour chaque type : il faut un prédécesseur
+    // On regarde qu'il y a un semblant d'itin��raire pour chaque type : il faut un pr��d��cesseur
     for (auto node_pred : res) {
-        // Route c'est lui même puisque c'est la source, et validity pattern est puni, donc il est seul dans son coin,
-        // de même pour POI et POIType
+        // Route c'est lui m��me puisque c'est la source, et validity pattern est puni, donc il est seul dans son coin,
+        // de m��me pour POI et POIType
         if (node_pred.first != Type_e::Route && node_pred.first != Type_e::ValidityPattern
             && node_pred.first != Type_e::POI && node_pred.first != Type_e::POIType
             && node_pred.first != Type_e::Contributor && node_pred.first != Type_e::Impact
@@ -349,9 +349,9 @@ BOOST_AUTO_TEST_CASE(find_path_test) {
             BOOST_CHECK(node_pred.first != node_pred.second);
     }
 
-    // On vérifie qu'il n'y ait pas de nœud qui ne soit pas atteignable depuis un autre nœud
-    // En connexité non forte, il y a un seul ensemble : validity pattern est relié (en un seul sens) au gros paté
-    // Avec les composantes fortement connexes : there must be only two : validity pattern est isolé car on ne peut y
+    // On v��rifie qu'il n'y ait pas de n��ud qui ne soit pas atteignable depuis un autre n��ud
+    // En connexit�� non forte, il y a un seul ensemble : validity pattern est reli�� (en un seul sens) au gros pat��
+    // Avec les composantes fortement connexes : there must be only two : validity pattern est isol�� car on ne peut y
     // aller
     Jointures j;
     std::vector<Jointures::vertex_t> component(boost::num_vertices(j.g));

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(get_indexes_test) {
         b.connection("stop3", "stop2", 10 * 60);
     });
 
-    // On cherche �� retrouver la ligne 1, en passant le stoparea en filtre
+    // On cherche à retrouver la ligne 1, en passant le stoparea en filtre
     auto indexes = make_query(Type_e::Line, "stop_area.uri = stop1", *b.data);
     BOOST_CHECK_EQUAL_RANGE(indexes, nt::make_indexes({0}));
 
@@ -336,12 +336,12 @@ BOOST_AUTO_TEST_CASE(forbidden_uri) {
 
 BOOST_AUTO_TEST_CASE(find_path_test) {
     auto res = find_path(nt::Type_e::Route);
-    // Cas o�� on veut partir et arriver au m��me point
+    // Cas où on veut partir et arriver au même point
     BOOST_CHECK(res[nt::Type_e::Route] == nt::Type_e::Route);
-    // On regarde qu'il y a un semblant d'itin��raire pour chaque type : il faut un pr��d��cesseur
+    // On regarde qu'il y a un semblant d'itinéraire pour chaque type : il faut un prédécesseur
     for (auto node_pred : res) {
-        // Route c'est lui m��me puisque c'est la source, et validity pattern est puni, donc il est seul dans son coin,
-        // de m��me pour POI et POIType
+        // Route c'est lui même puisque c'est la source, et validity pattern est puni, donc il est seul dans son coin,
+        // de même pour POI et POIType
         if (node_pred.first != Type_e::Route && node_pred.first != Type_e::ValidityPattern
             && node_pred.first != Type_e::POI && node_pred.first != Type_e::POIType
             && node_pred.first != Type_e::Contributor && node_pred.first != Type_e::Impact
@@ -349,9 +349,9 @@ BOOST_AUTO_TEST_CASE(find_path_test) {
             BOOST_CHECK(node_pred.first != node_pred.second);
     }
 
-    // On v��rifie qu'il n'y ait pas de n��ud qui ne soit pas atteignable depuis un autre n��ud
-    // En connexit�� non forte, il y a un seul ensemble : validity pattern est reli�� (en un seul sens) au gros pat��
-    // Avec les composantes fortement connexes : there must be only two : validity pattern est isol�� car on ne peut y
+    // On vérifie qu'il n'y ait pas de nœud qui ne soit pas atteignable depuis un autre nœud
+    // En connexité non forte, il y a un seul ensemble : validity pattern est relié (en un seul sens) au gros paté
+    // Avec les composantes fortement connexes : there must be only two : validity pattern est isolé car on ne peut y
     // aller
     Jointures j;
     std::vector<Jointures::vertex_t> component(boost::num_vertices(j.g));

--- a/source/ptreferential/tests/ptref_test.cpp
+++ b/source/ptreferential/tests/ptref_test.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(sans_filtre) {
     BOOST_CHECK_EQUAL(indexes.size(), 8);
 
     indexes = make_query(nt::Type_e::CommercialMode, "", *(b.data));
-    BOOST_CHECK_EQUAL(indexes.size(), 7);
+    BOOST_CHECK_EQUAL(indexes.size(), 8);
 
     indexes = make_query(nt::Type_e::Connection, "", *(b.data));
     BOOST_CHECK_EQUAL(indexes.size(), 2);

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -282,7 +282,7 @@ struct routing_api_data {
         b.data->geo_ref->ways.push_back(way);
 
         way = new navitia::georef::Way();
-        way->name = "rue ts Entr��e/Sortie";  // T->S
+        way->name = "rue ts Entrée/Sortie";  // T->S
         way->idx = 15;
         way->way_type = "rue";
         way->visible = false;

--- a/source/routing/tests/routing_api_test_data.h
+++ b/source/routing/tests/routing_api_test_data.h
@@ -282,7 +282,7 @@ struct routing_api_data {
         b.data->geo_ref->ways.push_back(way);
 
         way = new navitia::georef::Way();
-        way->name = "rue ts Entrée/Sortie";  // T->S
+        way->name = "rue ts Entr��e/Sortie";  // T->S
         way->idx = 15;
         way->way_type = "rue";
         way->visible = false;

--- a/source/routing/tests/routing_api_with_transfer_test_data.h
+++ b/source/routing/tests/routing_api_with_transfer_test_data.h
@@ -80,8 +80,8 @@ struct routing_api_data {
       A -----------------------------B---C
                                          |
                                          D---E----------------F
-
-
+                                         |
+                                         G
 
                     *) A->B has public transport
                     *) B->C->D->E are pedestrian streets
@@ -93,7 +93,8 @@ struct routing_api_data {
                                 C(100, 100)       2
                                 D( 70, 100)       3
                                 E( 70, 120)       4
-                                F( 70, 120)       4
+                                F( 70, 120)       5
+                                G( 50, 100)       6
         */
 
         boost::add_vertex(navitia::georef::Vertex(A), b.data->geo_ref->graph);
@@ -102,6 +103,7 @@ struct routing_api_data {
         boost::add_vertex(navitia::georef::Vertex(D), b.data->geo_ref->graph);
         boost::add_vertex(navitia::georef::Vertex(E), b.data->geo_ref->graph);
         boost::add_vertex(navitia::georef::Vertex(F), b.data->geo_ref->graph);
+        boost::add_vertex(navitia::georef::Vertex(G), b.data->geo_ref->graph);
 
         b.data->geo_ref->init();
 
@@ -151,6 +153,13 @@ struct routing_api_data {
         way->admin_list.push_back(admin);
         b.data->geo_ref->ways.push_back(way);
 
+        way = new navitia::georef::Way();
+        way->name = "rue dg";  // E->F
+        way->idx = 5;
+        way->way_type = "rue";
+        way->admin_list.push_back(admin);
+        b.data->geo_ref->ways.push_back(way);
+
         // B->C
         add_edges(1, *b.data->geo_ref, CC, BB, C, B, navitia::type::Mode_e::Walking);
         b.data->geo_ref->ways[1]->edges.emplace_back(CC, BB);
@@ -166,11 +175,16 @@ struct routing_api_data {
         b.data->geo_ref->ways[3]->edges.emplace_back(EE, DD);
         b.data->geo_ref->ways[3]->edges.emplace_back(DD, EE);
 
+        // D->G
+        add_edges(3, *b.data->geo_ref, DD, GG, D, G, navitia::type::Mode_e::Walking);
+        b.data->geo_ref->ways[3]->edges.emplace_back(DD, GG);
+        b.data->geo_ref->ways[3]->edges.emplace_back(GG, DD);
+
         b.generate_dummy_basis();
-        b.sa("stopA", A.lon(), A.lat());
-        b.sa("stopB", B.lon(), B.lat());
-        b.sa("stopE", E.lon(), E.lat());
-        b.sa("stopF", F.lon(), F.lat());
+        b.sa("stopA", A.lon(), A.lat())("stop_point:stopA", A.lon(), A.lat());
+        b.sa("stopB", B.lon(), B.lat())("stop_point:stopB", B.lon(), B.lat());
+        b.sa("stopE", E.lon(), E.lat())("stop_point:stopE", E.lon(), E.lat());
+        b.sa("stopF", F.lon(), F.lat())("stop_point:stopF", F.lon(), F.lat());
 
         if (activate_pt) {
             auto& builder_vj_FE =
@@ -189,14 +203,30 @@ struct routing_api_data {
             builder_vj_BAbis.vj->physical_mode = b.data->pt_data->physical_modes[1];  // Metro
 
             b.connection("stop_point:stopE", "stop_point:stopB", 120);
+
+            auto& builder_vj_AB =
+                b.vj("AB")("stop_point:stopA", "08:00:00"_t)("stop_point:stopB", "8:10:00"_t).st_shape({A, B});
+            b.lines["AB"]->code = "1AB";
+            builder_vj_AB.vj->physical_mode = b.data->pt_data->physical_modes[4];  // Bus
+
+            auto& builder_vj_EF =
+                b.vj("EF")("stop_point:stopE", "08:20:00"_t)("stop_point:stopF", "8:30:00"_t).st_shape({E, F});
+            b.lines["EF"]->code = "1EF";
+            builder_vj_EF.vj->physical_mode = b.data->pt_data->physical_modes[7];  // RER
+
+            b.connection("stop_point:stopB", "stop_point:stopE", 120);
         }
 
         b.data->complete();
         b.manage_admin();
         b.make();
 
+        // Add access points
+        b.add_access_point("stop_point:stopE", "access_point:E1", true, false, 100, 100, G.lat(), G.lon());
+        b.add_access_point("stop_point:stopE", "access_point:E2", true, true, 120, 120, G.lat(), G.lon());
+        b.add_access_point("stop_point:stopE", "access_point:E3", false, true, 90, 90, G.lat(), G.lon());
+
         // Add a main stop area to our admin
-        admin->main_stop_areas.push_back(b.data->pt_data->stop_areas_map["stopC"]);
 
         b.data->build_proximity_list();
         b.data->meta->production_date = boost::gregorian::date_period("20120614"_d, 365_days);
@@ -258,6 +288,7 @@ struct routing_api_data {
     int DD = 3;
     int EE = 4;
     int FF = 5;
+    int GG = 6;
 
     navitia::type::GeographicalCoord A = {120, 2000, false};
     navitia::type::GeographicalCoord B = {1990, 2000, false};
@@ -265,6 +296,7 @@ struct routing_api_data {
     navitia::type::GeographicalCoord D = {2000, 1900, false};
     navitia::type::GeographicalCoord E = {2010, 1900, false};
     navitia::type::GeographicalCoord F = {3000, 1900, false};
+    navitia::type::GeographicalCoord G = {2000, 1800, false};
 
     ed::builder b = {"20120614", ed::builder::make_builder, true, "routing api data"};
 

--- a/source/routing/tests/routing_api_with_transfer_test_data.h
+++ b/source/routing/tests/routing_api_with_transfer_test_data.h
@@ -117,48 +117,21 @@ struct routing_api_data {
         admin->coord = nt::GeographicalCoord(D.lon(), D.lat());
         admin->idx = 0;
 
-        navitia::georef::Way* way;
-        way = new navitia::georef::Way();
-        way->name = "rue ab";  // A->B
-        way->idx = 0;
-        way->way_type = "rue";
-        way->admin_list.push_back(admin);
-        b.data->geo_ref->ways.push_back(way);
+        auto add_way = [this, admin](const std::string& way_name, navitia::idx_t idx) {
+            auto way_ptr = std::make_unique<navitia::georef::Way>();
+            way_ptr->name = way_name;
+            way_ptr->idx = idx;
+            way_ptr->way_type = "rue";
+            way_ptr->admin_list.push_back(admin);
+            b.data->geo_ref->ways.push_back(way_ptr.release());
+        };
 
-        way = new navitia::georef::Way();
-        way->name = "rue bc";  // B->C
-        way->idx = 1;
-        way->way_type = "rue";
-        way->admin_list.push_back(admin);
-        b.data->geo_ref->ways.push_back(way);
-
-        way = new navitia::georef::Way();
-        way->name = "rue cd";  // C->D
-        way->idx = 2;
-        way->way_type = "rue";
-        way->admin_list.push_back(admin);
-        b.data->geo_ref->ways.push_back(way);
-
-        way = new navitia::georef::Way();
-        way->name = "rue de";  // D->E
-        way->idx = 3;
-        way->way_type = "rue";
-        way->admin_list.push_back(admin);
-        b.data->geo_ref->ways.push_back(way);
-
-        way = new navitia::georef::Way();
-        way->name = "rue ef";  // E->F
-        way->idx = 4;
-        way->way_type = "rue";
-        way->admin_list.push_back(admin);
-        b.data->geo_ref->ways.push_back(way);
-
-        way = new navitia::georef::Way();
-        way->name = "rue dg";  // E->F
-        way->idx = 5;
-        way->way_type = "rue";
-        way->admin_list.push_back(admin);
-        b.data->geo_ref->ways.push_back(way);
+        add_way("rue ab", 0);  // A->B
+        add_way("rue bc", 1);  // B->C
+        add_way("rue cd", 2);  // C->D
+        add_way("rue de", 3);  // D->E
+        add_way("rue ef", 4);  // E->F
+        add_way("rue dg", 5);  // D->G
 
         // B->C
         add_edges(1, *b.data->geo_ref, CC, BB, C, B, navitia::type::Mode_e::Walking);


### PR DESCRIPTION
With this PR. transfer paths are allowed between surface transport vehicles (`tramway`, `bus` etc...) and underground transport vehicles (`metro` etc...) **_via_** access points. 

Note that : 
* no transfer path will be calculated if access points are not available for the underlying underground transport vehicles. 
* no transfer path will be calculated if both stop points of the transfer are underground. (this case may be handled later)

How the access point (if multiple access points are present for the underlying stop point) is picked in a nutshell:

Let's say we need to calculate the path **from**  `stop_point:Tramway` **to** `stop_point: Metro`, given that  `stop_point: Metro` has 3 access points around it. The first step is to choose the eligible access points by requesting the `georef` all the access points of `stop_point:Metro` and filtering out those are `is_entrance == False`. Then we compute a matrix of `1xN` (reciprocally `Nx1` when transferring from `stop_point:Metro` to `stop_point:Tramway`). By adding up the `traversal_time` of each access points to the street network duration, we pick the most rapid access point to get to  `stop_point:Metro`. Then we launch the real street network computation between `stop_point:Tramway` and the chosen access point.

In the following example, the blue line (underground transport) has multiple access points,
![image](https://user-images.githubusercontent.com/6093486/207106045-1d61bc6a-8368-4ce3-839c-f01689bf216f.png)

but we finally chose the best/most rapid access point to get to the platform
![image](https://user-images.githubusercontent.com/6093486/207068491-e5ca6f61-27da-41d7-93e3-99bbf2640149.png)





