### PR TITLE
[jormungandr] fix cycle_lane_length

### DIFF
--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -260,8 +260,9 @@ class Asgard(TransientSocket, Kraken):
         for section in response.journeys[0].sections:
             # do not add cycle_lane_length for bss_rent/bss_return & walking sections
             if section.type == response_pb2.STREET_NETWORK and section.street_network.mode == response_pb2.Bike:
-                path_items = section.street_network.path_items
-                cycle_lane_length = sum((path.length for path in path_items if _is_cycle_lane(path)))
+                cycle_lane_length = sum(
+                    (s.length for s in section.street_network.street_information if _is_cycle_lane(s))
+                )
                 # Since path.length are doubles and we want an int32 in the proto
                 section.cycle_lane_length = int(cycle_lane_length)
 

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -68,7 +68,7 @@ journey_basic_query = "journeys?from={from_coord}&to={to_coord}&datetime={dateti
     from_coord=s_coord, to_coord=r_coord, datetime="20120614T080000"
 )
 
-# Create 4 path items of 10 meters each.
+# Create 4 street information.
 # The first is not a cycle lane, the others are.
 def add_cycle_path_type_in_section(section):
     street_information = section.street_network.street_information.add()

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -71,21 +71,21 @@ journey_basic_query = "journeys?from={from_coord}&to={to_coord}&datetime={dateti
 # Create 4 path items of 10 meters each.
 # The first is not a cycle lane, the others are.
 def add_cycle_path_type_in_section(section):
-    path_item = section.street_network.path_items.add()
-    path_item.length = 10
-    path_item.cycle_path_type = response_pb2.NoCycleLane
+    street_information = section.street_network.street_information.add()
+    street_information.length = 10
+    street_information.cycle_path_type = response_pb2.NoCycleLane
 
-    path_item = section.street_network.path_items.add()
-    path_item.length = 10
-    path_item.cycle_path_type = response_pb2.SharedCycleWay
+    street_information = section.street_network.street_information.add()
+    street_information.length = 20
+    street_information.cycle_path_type = response_pb2.SharedCycleWay
 
-    path_item = section.street_network.path_items.add()
-    path_item.length = 10
-    path_item.cycle_path_type = response_pb2.DedicatedCycleWay
+    street_information = section.street_network.street_information.add()
+    street_information.length = 30
+    street_information.cycle_path_type = response_pb2.DedicatedCycleWay
 
-    path_item = section.street_network.path_items.add()
-    path_item.length = 10
-    path_item.cycle_path_type = response_pb2.SeparatedCycleWay
+    street_information = section.street_network.street_information.add()
+    street_information.length = 40
+    street_information.cycle_path_type = response_pb2.SeparatedCycleWay
 
 
 def journey_response(journey, mode):
@@ -395,7 +395,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][1]['duration'] == 1000
         assert response['journeys'][1]['sections'][0]['co2_emission'] == {'value': 0, 'unit': 'gEC'}
         assert response['journeys'][1]['co2_emission'] == {'value': 0, 'unit': 'gEC'}
-        assert response['journeys'][1]['sections'][0]['cycle_lane_length'] == 30
+        assert response['journeys'][1]['sections'][0]['cycle_lane_length'] == 90
 
         # walking direct path from asgard
         assert 'walking' in response['journeys'][2]['tags']


### PR DESCRIPTION
the calculation of cycle_lane_lenght was incorrectly based on the length of `path_items`. 

`path_items` contain partially cycle_lane information which is not reliable to calculate the cycle_lane_length . 

With this  PR: https://github.com/hove-io/asgard/pull/220, cycle_lane_length is precisely stored in street_information.