### PR TITLE
[tyr-worker] docs: remove non-ascii characters

### DIFF
--- a/source/ed/fusio2ed.cpp
+++ b/source/ed/fusio2ed.cpp
@@ -193,16 +193,16 @@ int main(int argc, char* argv[]) {
     p.persist(data);
     save = (pt::microsec_clock::local_time() - start).total_milliseconds();
 
-    LOG4CPLUS_INFO(logger, "temps de traitement");
-    LOG4CPLUS_INFO(logger, "\t lecture des fichiers " << read << "ms");
-    LOG4CPLUS_INFO(logger, "\t completion des données " << complete << "ms");
-    LOG4CPLUS_INFO(logger, "\t netoyage des données " << clean << "ms");
-    LOG4CPLUS_INFO(logger, "\t trie des données " << sort << "ms");
+    LOG4CPLUS_INFO(logger, "processing times");
+    LOG4CPLUS_INFO(logger, "\t reading files " << read << "ms");
+    LOG4CPLUS_INFO(logger, "\t data completed " << complete << "ms");
+    LOG4CPLUS_INFO(logger, "\t data cleanup " << clean << "ms");
+    LOG4CPLUS_INFO(logger, "\t data ordering " << sort << "ms");
     if (vm.count("fare")) {
         LOG4CPLUS_INFO(logger, "\t fares loaded in : " << fare << "ms");
     }
-    LOG4CPLUS_INFO(logger, "\t Destination of routes " << main_destination << "ms");
-    LOG4CPLUS_INFO(logger, "\t enregistrement des données " << save << "ms");
+    LOG4CPLUS_INFO(logger, "\t route destination " << main_destination << "ms");
+    LOG4CPLUS_INFO(logger, "\t data saving " << save << "ms");
 
     return 0;
 }

--- a/source/ed/gtfs2ed.cpp
+++ b/source/ed/gtfs2ed.cpp
@@ -150,13 +150,13 @@ int main(int argc, char* argv[]) {
     p.persist(data);
     save = (pt::microsec_clock::local_time() - start).total_milliseconds();
 
-    LOG4CPLUS_INFO(logger, "temps de traitement");
-    LOG4CPLUS_INFO(logger, "\t lecture des fichiers " << read << "ms");
-    LOG4CPLUS_INFO(logger, "\t completion des données " << complete << "ms");
-    LOG4CPLUS_INFO(logger, "\t netoyage des données " << clean << "ms");
-    LOG4CPLUS_INFO(logger, "\t trie des données " << sort << "ms");
-    LOG4CPLUS_INFO(logger, "\t Destination of routes " << main_destination << "ms");
-    LOG4CPLUS_INFO(logger, "\t enregistrement des données " << save << "ms");
+    LOG4CPLUS_INFO(logger, "processing times");
+    LOG4CPLUS_INFO(logger, "\t reading files " << read << "ms");
+    LOG4CPLUS_INFO(logger, "\t data completed " << complete << "ms");
+    LOG4CPLUS_INFO(logger, "\t data cleanup " << clean << "ms");
+    LOG4CPLUS_INFO(logger, "\t data ordering " << sort << "ms");
+    LOG4CPLUS_INFO(logger, "\t route destination " << main_destination << "ms");
+    LOG4CPLUS_INFO(logger, "\t data saving " << save << "ms");
 
     return 0;
 }


### PR DESCRIPTION
Not sure that this is causing problem, but we noticed errors on `jormungandr` when handling the logs.

```
[2022-12-16 09:46:54,760] [ERROR] [ 41] [ celery.app.trace] Task tyr.binarisation.fusio2ed[b0e23fc1-aaa9-4ee4-af63-48a012480c03] raised unexpected: UnicodeDecodeError('utf8', '46:52,630] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert stop point connections ed_persistor.cpp:379 \n[22-12-16 09:46:52,630] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert admin stop area ed_persistor.cpp:380 \n[22-12-16 09:46:52,632] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert admin stop area ed_persistor.cpp:382 \n[22-12-16 09:46:52,632] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert comments ed_persistor.cpp:384 \n[22-12-16 09:46:53,169] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert comments ed_persistor.cpp:386 \n[22-12-16 09:46:53,169] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert fares ed_persistor.cpp:388 \n[22-12-16 09:46:53,169] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: truncate fare tables ed_persistor.cpp:435 \n[22-12-16 09:46:53,212] [fr-nw-tours.fusio2ed] [INFO ] [] - End: truncate fare tables ed_persistor.cpp:439 \n[22-12-16 09:46:53,212] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert prices ed_persistor.cpp:440 \n[22-12-16 09:46:53,213] [fr-nw-tours.fusio2ed] [INFO ] [] - dated ticket ed_persistor.cpp:1537 \n[22-12-16 09:46:53,214] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert prices ed_persistor.cpp:442 \n[22-12-16 09:46:53,214] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert transitions ed_persistor.cpp:443 \n[22-12-16 09:46:53,215] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert transitions ed_persistor.cpp:445 \n[22-12-16 09:46:53,215] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert origin destinations ed_persistor.cpp:446 \n[22-12-16 09:46:53,217] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert origin destinations ed_persistor.cpp:448 \n[22-12-16 09:46:53,217] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert fares ed_persistor.cpp:390 \n[22-12-16 09:46:53,217] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert week patterns ed_persistor.cpp:391 \n[22-12-16 09:46:53,217] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert week patterns ed_persistor.cpp:393 \n[22-12-16 09:46:53,217] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert calendars ed_persistor.cpp:394 \n[22-12-16 09:46:53,218] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert week calendars ed_persistor.cpp:396 \n[22-12-16 09:46:53,218] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert exception dates ed_persistor.cpp:397 \n[22-12-16 09:46:53,219] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert exception dates ed_persistor.cpp:399 \n[22-12-16 09:46:53,219] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert periods ed_persistor.cpp:400 \n[22-12-16 09:46:53,220] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert periods ed_persistor.cpp:402 \n[22-12-16 09:46:53,220] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert relation calendar line ed_persistor.cpp:403 \n[22-12-16 09:46:53,221] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert relation calendar line ed_persistor.cpp:405 \n[22-12-16 09:46:53,221] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert meta vehicle journeys ed_persistor.cpp:407 \n[22-12-16 09:46:53,482] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert meta vehicle journeys ed_persistor.cpp:409 \n[22-12-16 09:46:53,482] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert object codes ed_persistor.cpp:411 \n[22-12-16 09:46:54,661] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert object codes ed_persistor.cpp:413 \n[22-12-16 09:46:54,661] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: insert object properties ed_persistor.cpp:415 \n[22-12-16 09:46:54,662] [fr-nw-tours.fusio2ed] [INFO ] [] - End: insert object properties ed_persistor.cpp:417 \n[22-12-16 09:46:54,662] [fr-nw-tours.fusio2ed] [INFO ] [] - Begin: commit ed_persistor.cpp:419 \n[22-12-16 09:46:54,688] [fr-nw-tours.fusio2ed] [INFO ] [] - End: commit ed_persistor.cpp:421 \n[22-12-16 09:46:54,688] [fr-nw-tours.fusio2ed] [INFO ] [] - temps de traitement fusio2ed.cpp:196 \n[22-12-16 09:46:54,688] [fr-nw-tours.fusio2ed] [INFO ] [] - \t lecture des fichiers 31954ms fusio2ed.cpp:197 \n[22-12-16 09:46:54,688] [fr-nw-tours.fusio2ed] [INFO ] [] - \t completion des donn\xc3\xa9es 7528ms fusio2ed.cpp:198 \n[22-12-16 09:46:54,688] [fr-nw-tours.fusio2ed] [INFO ] [] - \t netoyage des donn\xc3', 4095, 4096, 'unexpected end of data')
```

At the very least, let's make the logs in English like the rest of them.

ref: NAV-1653