### PR TITLE
[tyr-worker] feat: trying to avoid 'logs forwarding' to fail the entire process

### DIFF
--- a/source/navitiacommon/navitiacommon/launch_exec.py
+++ b/source/navitiacommon/navitiacommon/launch_exec.py
@@ -118,13 +118,16 @@ def launch_exec_traces(exec_name, args, logger):
         while True:
             select.select([proc.stdout, proc.stderr], [], [])
 
-            for pipe in proc.stdout, proc.stderr:
-                log_pipe = read_async(pipe)
-                if log_pipe:
-                    logs, line = parse_log(log_pipe.decode("utf-8"))
-                    for l in logs:
-                        logger.log(l.level, l.msg)
-                        traces += "##  {}  ##".format(l.msg)
+            try:
+                for pipe in proc.stdout, proc.stderr:
+                    log_pipe = read_async(pipe)
+                    if log_pipe:
+                        logs, line = parse_log(log_pipe.decode("utf-8", errors="replace"))
+                        for l in logs:
+                            logger.log(l.level, l.msg)
+                            traces += "##  {}  ##".format(l.msg)
+            except Exception as e:
+                logger.error("error in forwarding logs but process continuing: {}".format(e))
 
             if proc.poll() is not None:
                 break


### PR DESCRIPTION
Let's try to protect us against any failure triggered by the log forwarding. Note that this PR is a best effort, but probably doesn't fix https://navitia.atlassian.net/browse/NAV-1653.

About the original ticket, after more searching, we think we now have a good explanation of what is going on (but it's hard to verify for sure).

The best hypothesis is:
- "log forwarding" apply the `.decode` operation per chunks (calling [`read_async()`](https://github.com/hove-io/navitia/blob/efd81032ddf4aa1e65c31bb979ce2e8edeef712b/source/navitiacommon/navitiacommon/launch_exec.py#L122) and therefore [`.read()`](https://github.com/hove-io/navitia/blob/efd81032ddf4aa1e65c31bb979ce2e8edeef712b/source/navitiacommon/navitiacommon/launch_exec.py#L82))
- the chunk contains multi-bytes characters like `é` and one of the chunk ends with only half of one of this multi-byte characters
  - note the error message which is `[...]donn\xc3', 4095, 4096, 'unexpected end of data')`
  - 4096 = 2¹² which looks pretty much like an ideal chunk size
  - the `\xc3` is missing something to represent `données` (in the logs, we have a full version of it a line above `donn\xc3\xa9es`)
  
If the hypothesis is correct, then https://github.com/hove-io/navitia/pull/3880 should have already fixed the problem. But this PR should also prevent a bit more.