### PR TITLE
[ci] ci: allow to release through Github Actions

### DIFF
--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -82,7 +82,7 @@ jobs:
         path: ./builder_from_package
     - name: build, create and publish images for branch release
       working-directory: builder_from_package
-      run: ./build.sh -o ${{secrets.access_token_github}} -d debian8 -n -r -e push -t latest -b release -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+      run: ./build.sh -o ${{secrets.access_token_github}} -d debian8 -n -r -e push -t latest -b ${GITHUB_REF_NAME} -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
     - name: slack notification (the job has failed)
       if: failure()
       run: |

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -2,6 +2,8 @@ name: Build Navitia Packages For Release
 
 on:
   push:
+    tags:
+      - '*'
     branches:
       - release
 

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -2,6 +2,8 @@ name: Clang-tidy
 
 on:
   push:
+    tags:
+    - '*'
     branches:
     - clang-tidy
     - release

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Build Navitia Packages For Release", "Build Navitia Packages For Dev Multi Distributions"]
-    branches: [release, dev]
     types:
       - completed
 

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -20,11 +20,11 @@ jobs:
     - name: install httpie dependency
       run: sudo apt update && sudo apt install -y httpie
     - name: build, create and publish images for branch release
-      if: ${{ github.event.workflow_run.head_branch == 'release' }}
+      if: ${{ github.event.workflow_run.name == 'Build Navitia Packages For Release' }}
       working-directory: builder_from_package
-      run: ./build.sh -e push -o ${{secrets.access_token_github}} -t latest -b release -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+      run: ./build.sh -e push -o ${{secrets.access_token_github}} -t latest -b ${{ github.event.workflow_run.head_branch }} -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
     - name: build, create and publish images for branch dev
-      if: ${{ github.event.workflow_run.head_branch == 'dev' }}
+      if: ${{ github.event.workflow_run.name == 'Build Navitia Packages For Dev Multi Distributions' }}
       working-directory: builder_from_package
       run: ./build.sh -e push -o ${{secrets.access_token_github}} -t dev -b dev -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
     - name: slack notification (the job has failed)

--- a/.github/workflows/publish_hove_images_aws.yml
+++ b/.github/workflows/publish_hove_images_aws.yml
@@ -18,7 +18,6 @@ on:
 
   workflow_run:
     workflows: ["Build Navitia Packages For Release", "Build Navitia Packages For Dev Multi Distributions"]
-    branches: [release, dev]
     types:
       - completed
 

--- a/.github/workflows/publish_hove_images_aws.yml
+++ b/.github/workflows/publish_hove_images_aws.yml
@@ -34,13 +34,13 @@ jobs:
           then
             echo "Workflow triggered due to finished upstream workflow"
             echo "::set-output name=branch::${{ github.event.workflow_run.head_branch }}"
-            if [[ '${{ github.event.workflow_run.head_branch }}' == 'dev' ]]
+            if [[ '${{ github.event.workflow_run.head_branch }}' == 'release' || '${{ github.event.workflow_run.head_branch }}' =~ v[0-9]+.[0-9]+.[0-9]+ ]]
             then
-              echo "::set-output name=tag::dev"
-            else :
-              echo "Realease branch, collecting last version"
+              echo "Release branch, collecting last version"
               VERSION=$(curl https://api.github.com/repos/hove-io/navitia/tags | jq --raw-output '.[0].name')
               echo "::set-output name=tag::$VERSION"
+            else :
+              echo "::set-output name=tag::dev"
             fi
           elif [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]
           then

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -2,6 +2,8 @@ name: Publish Navitia Documentation
 
 on:
   push:
+    tags:
+    - '*'
     branches:
       - release
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,13 +2,12 @@ name: CI
 
 on:
   push:
+    tags:
+    - '*'
     branches:
       - dev
       - auto/clang-tidy
   pull_request:
-  release:
-    types:
-      - created
 
 jobs:
   info:


### PR DESCRIPTION
Let's try to make our life easier by allowing to make a release from Github Actions.

Everything should be triggered by the creation of a **tag** (which will be created when creating a Github Release).

This is an opinionated modification, since we won't use anymore the script for release. The script was essentially doing 2 things:
1. creates branches `release_x.y.z` and `release` and merge them into each other in a gigantic plate of spaghetti of branch merges
2. help for generating the changelog

For 1., I believe this is useless, let's tag directly the commit we estimate correct without merging forward and backward some branches (usually, the said commit is the last one `dev`).
For 2., Github releases can automatically generate the changelog :tada: note however that the changelog will be generated in Github, not anymore in `debian/changelog` (but since we also talk about not generating Debian package anymore... :shrug: ).

- [ ] need to merge https://github.com/hove-io/navitia-docker-compose/pull/151

Note: I removed the constraint `branches: [release, dev]` on some `workflow_run`, but they shouldn't break anything since they both depend on 2 jobs that already are triggered by either one of these branches (but now tags too).