### PR TITLE
Revert "[ci] ci: allow to release through Github Actions"

### DIFF
--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -2,8 +2,6 @@ name: Build Navitia Packages For Release
 
 on:
   push:
-    tags:
-      - '*'
     branches:
       - release
 
@@ -82,7 +80,7 @@ jobs:
         path: ./builder_from_package
     - name: build, create and publish images for branch release
       working-directory: builder_from_package
-      run: ./build.sh -o ${{secrets.access_token_github}} -d debian8 -n -r -e push -t latest -b ${GITHUB_REF_NAME} -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+      run: ./build.sh -o ${{secrets.access_token_github}} -d debian8 -n -r -e push -t latest -b release -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
     - name: slack notification (the job has failed)
       if: failure()
       run: |

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -2,8 +2,6 @@ name: Clang-tidy
 
 on:
   push:
-    tags:
-    - '*'
     branches:
     - clang-tidy
     - release

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   workflow_run:
     workflows: ["Build Navitia Packages For Release", "Build Navitia Packages For Dev Multi Distributions"]
+    branches: [release, dev]
     types:
       - completed
 
@@ -20,11 +21,11 @@ jobs:
     - name: install httpie dependency
       run: sudo apt update && sudo apt install -y httpie
     - name: build, create and publish images for branch release
-      if: ${{ github.event.workflow_run.name == 'Build Navitia Packages For Release' }}
+      if: ${{ github.event.workflow_run.head_branch == 'release' }}
       working-directory: builder_from_package
-      run: ./build.sh -e push -o ${{secrets.access_token_github}} -t latest -b ${{ github.event.workflow_run.head_branch }} -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+      run: ./build.sh -e push -o ${{secrets.access_token_github}} -t latest -b release -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
     - name: build, create and publish images for branch dev
-      if: ${{ github.event.workflow_run.name == 'Build Navitia Packages For Dev Multi Distributions' }}
+      if: ${{ github.event.workflow_run.head_branch == 'dev' }}
       working-directory: builder_from_package
       run: ./build.sh -e push -o ${{secrets.access_token_github}} -t dev -b dev -r -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
     - name: slack notification (the job has failed)

--- a/.github/workflows/publish_hove_images_aws.yml
+++ b/.github/workflows/publish_hove_images_aws.yml
@@ -18,6 +18,7 @@ on:
 
   workflow_run:
     workflows: ["Build Navitia Packages For Release", "Build Navitia Packages For Dev Multi Distributions"]
+    branches: [release, dev]
     types:
       - completed
 
@@ -34,13 +35,13 @@ jobs:
           then
             echo "Workflow triggered due to finished upstream workflow"
             echo "::set-output name=branch::${{ github.event.workflow_run.head_branch }}"
-            if [[ '${{ github.event.workflow_run.head_branch }}' == 'release' || '${{ github.event.workflow_run.head_branch }}' =~ v[0-9]+.[0-9]+.[0-9]+ ]]
+            if [[ '${{ github.event.workflow_run.head_branch }}' == 'dev' ]]
             then
-              echo "Release branch, collecting last version"
+              echo "::set-output name=tag::dev"
+            else :
+              echo "Realease branch, collecting last version"
               VERSION=$(curl https://api.github.com/repos/hove-io/navitia/tags | jq --raw-output '.[0].name')
               echo "::set-output name=tag::$VERSION"
-            else :
-              echo "::set-output name=tag::dev"
             fi
           elif [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]
           then

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -2,8 +2,6 @@ name: Publish Navitia Documentation
 
 on:
   push:
-    tags:
-    - '*'
     branches:
       - release
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,12 +2,13 @@ name: CI
 
 on:
   push:
-    tags:
-    - '*'
     branches:
       - dev
       - auto/clang-tidy
   pull_request:
+  release:
+    types:
+      - created
 
 jobs:
   info:


### PR DESCRIPTION
Reverts hove-io/navitia#3885

Temporary revert, until the end of the Christmas vacations.

Not reverting https://github.com/hove-io/navitia-docker-compose/pull/151/files (nor https://github.com/hove-io/core_team_ci_tools/pull/10) as it's not necessary.