### PR TITLE
Jormun: Feat avoid pg authentication for bad token

### DIFF
--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -90,19 +90,21 @@ def add_info_newrelic(response, *args, **kwargs):
         record_custom_parameter('navitia-request-id', request.id)
 
         token = get_token()
+        # No log will be added in newrelic if token is absent in the request
         if token:
             user = get_user(token=token, abort_if_no_token=False)
             if user:
                 record_custom_parameter('user_id', str(user.id))
-            # This method verifies database connection and gets object Key only once when cache expires.
-            app_name = get_app_name(token)
-            if app_name:
-                record_custom_parameter('token_name', app_name)
+                # This method verifies database connection and gets object Key only once when cache expires.
+                app_name = get_app_name(token)
+                if app_name:
+                    record_custom_parameter('token_name', app_name)
 
-        record_custom_parameter('version', __version__)
-        coverages = get_used_coverages()
-        if coverages:
-            record_custom_parameter('coverage', coverages[0])
+            record_custom_parameter('version', __version__)
+            # No access to database required
+            coverages = get_used_coverages()
+            if coverages:
+                record_custom_parameter('coverage', coverages[0])
     except:
         logger = logging.getLogger(__name__)
         logger.exception('error while reporting to newrelic:')

--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -90,13 +90,14 @@ def add_info_newrelic(response, *args, **kwargs):
     try:
         record_custom_parameter('navitia-request-id', request.id)
 
-        if can_connect_to_database():
-            token = get_token()
+        token = get_token()
+        if token:
             user = get_user(token=token, abort_if_no_token=False)
-            app_name = get_app_name(token)
             if user:
                 record_custom_parameter('user_id', str(user.id))
-            record_custom_parameter('token_name', app_name)
+            app_name = get_app_name(token)
+            if app_name:
+                record_custom_parameter('token_name', app_name)
 
         record_custom_parameter('version', __version__)
         coverages = get_used_coverages()

--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -42,7 +42,6 @@ import logging
 from jormungandr.new_relic import record_custom_parameter
 from jormungandr.authentication import get_user, get_token, get_app_name, get_used_coverages
 from jormungandr._version import __version__
-from jormungandr.utils import can_connect_to_database
 import six
 
 
@@ -95,6 +94,7 @@ def add_info_newrelic(response, *args, **kwargs):
             user = get_user(token=token, abort_if_no_token=False)
             if user:
                 record_custom_parameter('user_id', str(user.id))
+            # This method connects and gets object Key only once when cache expires.
             app_name = get_app_name(token)
             if app_name:
                 record_custom_parameter('token_name', app_name)

--- a/source/jormungandr/jormungandr/api.py
+++ b/source/jormungandr/jormungandr/api.py
@@ -94,7 +94,7 @@ def add_info_newrelic(response, *args, **kwargs):
             user = get_user(token=token, abort_if_no_token=False)
             if user:
                 record_custom_parameter('user_id', str(user.id))
-            # This method connects and gets object Key only once when cache expires.
+            # This method verifies database connection and gets object Key only once when cache expires.
             app_name = get_app_name(token)
             if app_name:
                 record_custom_parameter('token_name', app_name)

--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -141,6 +141,7 @@ def has_access(region, api, abort, user):
     # if jormungandr is on public mode or database is not accessible, we skip the authentication process
     logging.getLogger(__name__).debug('User "has_access" to region/api not cached')
 
+    # Connection to database verified only once when cache expires.
     if current_app.config.get('PUBLIC', False) or (not can_connect_to_database()):
         return True
 
@@ -212,6 +213,7 @@ def uncached_get_user(token):
 )
 @cache.memoize(current_app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_AUTHENTICATION'), 300))
 def cache_get_key(token):
+    # This verification is done only once when cache expires.
     if not can_connect_to_database():
         return None
     try:

--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -200,6 +200,7 @@ def uncached_get_user(token):
         # if user doesn't exist for a token, get default token with user_type = no_access
         if not user:
             user = User.get_without_access()
+            logging.getLogger(__name__).warning('Invalid token : {}'.format(token[0:10]))
     except Exception as e:
         logging.getLogger(__name__).error('No access to table User (error: {})'.format(e))
         g.can_connect_to_database = False

--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -107,7 +107,7 @@ def get_token():
             # Python3 Compatibility 2: Decode bytes to string in order to use split()
             if isinstance(decoded, bytes):
                 decoded = decoded.decode()
-            return decoded.split(':')[0]
+            return decoded.split(':')[0].strip()
         except (binascii.Error, UnicodeDecodeError):
             logging.getLogger(__name__).exception('badly formated token %s', auth)
             flask_restful.abort(401, message="Unauthorized, invalid token", status=401)
@@ -193,11 +193,12 @@ def cache_get_user(token):
 
 def uncached_get_user(token):
     logging.getLogger(__name__).debug('Get User from token (uncached)')
-    if not can_connect_to_database():
-        logging.getLogger(__name__).debug('Cannot connect to database, we set User to None')
-        return None
     try:
         user = User.get_from_token(token, datetime.datetime.now())
+
+        # if user doesn't exist for a token, get default token with user_type = no_access
+        if not user:
+            user = User.get_without_access()
     except Exception as e:
         logging.getLogger(__name__).error('No access to table User (error: {})'.format(e))
         g.can_connect_to_database = False

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -222,7 +222,7 @@ class InstanceManager(object):
     def _filter_authorized_instances(self, instances, api):
         if not instances:
             return []
-        # get_user is cached and hence access to database only once when cache expires.
+        # get_user is cached hence access to database only once when cache expires.
         user = authentication.get_user(token=authentication.get_token())
         # has_access returns true if can_connect_to_database = false when cache expires for each coverage
         valid_instances = [

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -222,7 +222,9 @@ class InstanceManager(object):
     def _filter_authorized_instances(self, instances, api):
         if not instances:
             return []
+        # get_user is cached and hence access to database only once when cache expires.
         user = authentication.get_user(token=authentication.get_token())
+        # has_access returns true if can_connect_to_database = false when cache expires for each coverage
         valid_instances = [
             i for i in instances if authentication.has_access(i.name, abort=False, user=user, api=api)
         ]

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -222,10 +222,6 @@ class InstanceManager(object):
     def _filter_authorized_instances(self, instances, api):
         if not instances:
             return []
-        # During the period database is not accessible, all the instances are valid for the user.
-        if not can_connect_to_database():
-            return instances
-
         user = authentication.get_user(token=authentication.get_token())
         valid_instances = [
             i for i in instances if authentication.has_access(i.name, abort=False, user=user, api=api)

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -195,7 +195,7 @@ class User(db.Model, TimestampMixin):  # type: ignore
         return query.first()
 
     @classmethod
-    def get_without_access(cls,):
+    def get_without_access(cls):
         query = cls.query.filter(cls.type == 'no_access')
         return query.first()
 

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -129,7 +129,7 @@ class User(db.Model, TimestampMixin):  # type: ignore
     )
 
     type = db.Column(
-        db.Enum('with_free_instances', 'without_free_instances', 'super_user', name='user_type'),
+        db.Enum('with_free_instances', 'without_free_instances', 'super_user', 'no_access', name='user_type'),
         default='with_free_instances',
         nullable=False,
     )
@@ -192,6 +192,11 @@ class User(db.Model, TimestampMixin):  # type: ignore
         query = cls.query.join(Key).filter(
             Key.token == token, (Key.valid_until > valid_until) | (Key.valid_until == None)
         )
+        return query.first()
+
+    @classmethod
+    def get_without_access(cls,):
+        query = cls.query.filter(cls.type == 'no_access')
         return query.first()
 
     def has_access(self, instance_id, api_name):

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -196,7 +196,7 @@ class User(db.Model, TimestampMixin):  # type: ignore
 
     @classmethod
     def get_without_access(cls):
-        query = cls.query.filter(cls.type == 'no_access')
+        query = cls.query.filter(cls.type == 'no_access' and cls.login == 'user_without_access')
         return query.first()
 
     def has_access(self, instance_id, api_name):

--- a/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
+++ b/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
@@ -20,15 +20,8 @@ tmp_type = sa.Enum(*new_options, name='_user_type')
 
 
 def upgrade():
-    tmp_type.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE "user" ALTER COLUMN type DROP DEFAULT')
-    op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE _user_type USING type::text::_user_type')
-    old_type.drop(op.get_bind(), checkfirst=False)
-
-    new_type.create(op.get_bind(), checkfirst=False)
-    op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE user_type USING type::text::user_type')
-    op.execute('ALTER TABLE "user" ALTER COLUMN type SET DEFAULT \'with_free_instances\'')
-    tmp_type.drop(op.get_bind(), checkfirst=False)
+    op.execute("COMMIT")
+    op.execute("ALTER TYPE user_type ADD VALUE 'no_access'")
     op.execute(
         'INSERT INTO "user"(login, email, type) values(\'user_without_access\', \'user_without_access@noreply.com\', \'no_access\')'
     )

--- a/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
+++ b/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
@@ -29,6 +29,7 @@ def upgrade():
     op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE user_type USING type::text::user_type')
     op.execute('ALTER TABLE "user" ALTER COLUMN type SET DEFAULT \'with_free_instances\'')
     tmp_type.drop(op.get_bind(), checkfirst=False)
+    op.execute('INSERT INTO "user"(login, email, type) values(\'user_without_access\', \'user_without_access@noreply.com\', \'no_access\')')
 
 
 def downgrade():

--- a/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
+++ b/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
@@ -29,7 +29,9 @@ def upgrade():
     op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE user_type USING type::text::user_type')
     op.execute('ALTER TABLE "user" ALTER COLUMN type SET DEFAULT \'with_free_instances\'')
     tmp_type.drop(op.get_bind(), checkfirst=False)
-    op.execute('INSERT INTO "user"(login, email, type) values(\'user_without_access\', \'user_without_access@noreply.com\', \'no_access\')')
+    op.execute(
+        'INSERT INTO "user"(login, email, type) values(\'user_without_access\', \'user_without_access@noreply.com\', \'no_access\')'
+    )
 
 
 def downgrade():

--- a/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
+++ b/source/tyr/migrations/versions/04f9b89e3ef5_add_no_access_in_user_type.py
@@ -1,0 +1,44 @@
+"""Add a new type no_access in user_type
+
+Revision ID: 04f9b89e3ef5
+Revises: 75681b9c74aa
+Create Date: 2022-12-30 11:23:58.436438
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '04f9b89e3ef5'
+down_revision = '75681b9c74aa'
+
+from alembic import op
+import sqlalchemy as sa
+
+new_options = ('with_free_instances', 'without_free_instances', 'super_user', 'no_access')
+old_type = sa.Enum('with_free_instances', 'without_free_instances', 'super_user', name='user_type')
+new_type = sa.Enum(*new_options, name='user_type')
+tmp_type = sa.Enum(*new_options, name='_user_type')
+
+
+def upgrade():
+    tmp_type.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE "user" ALTER COLUMN type DROP DEFAULT')
+    op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE _user_type USING type::text::_user_type')
+    old_type.drop(op.get_bind(), checkfirst=False)
+
+    new_type.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE user_type USING type::text::user_type')
+    op.execute('ALTER TABLE "user" ALTER COLUMN type SET DEFAULT \'with_free_instances\'')
+    tmp_type.drop(op.get_bind(), checkfirst=False)
+
+
+def downgrade():
+    op.execute('DELETE FROM "user" where type = \'no_access\'')
+    tmp_type.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE "user" ALTER COLUMN type DROP DEFAULT')
+    op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE _user_type USING type::text::_user_type')
+    new_type.drop(op.get_bind(), checkfirst=False)
+
+    old_type.create(op.get_bind(), checkfirst=False)
+    op.execute('ALTER TABLE "user" ALTER COLUMN type TYPE user_type USING type::text::user_type')
+    op.execute('ALTER TABLE "user" ALTER COLUMN type SET DEFAULT \'with_free_instances\'')
+    tmp_type.drop(op.get_bind(), checkfirst=False)

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1239,9 +1239,9 @@ class User(flask_restful.Resource):
             type=str,
             required=False,
             default='with_free_instances',
-            help='type of user: [with_free_instances, without_free_instances, super_user]',
+            help='type of user: [with_free_instances, without_free_instances, super_user, no_access]',
             location=('json', 'values'),
-            choices=['with_free_instances', 'without_free_instances', 'super_user'],
+            choices=['with_free_instances', 'without_free_instances', 'super_user', 'no_access'],
         )
         parser.add_argument('shape', type=geojson_argument, required=False, location=('json', 'values'))
         parser.add_argument('default_coord', type=CoordFormat(), required=False, location=('json', 'values'))

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -1239,9 +1239,9 @@ class User(flask_restful.Resource):
             type=str,
             required=False,
             default='with_free_instances',
-            help='type of user: [with_free_instances, without_free_instances, super_user, no_access]',
+            help='type of user: [with_free_instances, without_free_instances, super_user]',
             location=('json', 'values'),
-            choices=['with_free_instances', 'without_free_instances', 'super_user', 'no_access'],
+            choices=['with_free_instances', 'without_free_instances', 'super_user'],
         )
         parser.add_argument('shape', type=geojson_argument, required=False, location=('json', 'values'))
         parser.add_argument('default_coord', type=CoordFormat(), required=False, location=('json', 'values'))


### PR DESCRIPTION
Some details of modifications:
- When no token provided (even with some empty spaces), no need to verify can_connect_to_database()
- Since we cache token - Object User, for a bad token (token not in database) we get a default user with type=no_access and cache it. There will be no access to the database during cache for this token.
- When database in not accessible, all the requests with a token (bad or good) will have access to all the apis when cache for each token is renewed.

For more details: https://navitia.atlassian.net/browse/NAV-1642