### PR TITLE
Jormun: Fix journey's sections sorter

### DIFF
--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -458,6 +458,8 @@ PeriodExtremity = namedtuple('PeriodExtremity', ['datetime', 'represents_start']
 
 class SectionSorter(object):
     def __call__(self, a, b):
+        if a.begin_date_time == b.begin_date_time and a.end_date_time == b.end_date_time:
+            return -1 if a.destination.uri == b.origin.uri else 1
         if a.begin_date_time != b.begin_date_time:
             return -1 if a.begin_date_time < b.begin_date_time else 1
         else:

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -458,12 +458,16 @@ PeriodExtremity = namedtuple('PeriodExtremity', ['datetime', 'represents_start']
 
 class SectionSorter(object):
     def __call__(self, a, b):
-        if a.begin_date_time == b.begin_date_time and a.end_date_time == b.end_date_time:
-            return -1 if a.destination.uri == b.origin.uri else 1
         if a.begin_date_time != b.begin_date_time:
             return -1 if a.begin_date_time < b.begin_date_time else 1
-        else:
+        elif a.end_date_time != b.end_date_time:
             return -1 if a.end_date_time < b.end_date_time else 1
+        elif a.destination.uri == b.origin.uri:
+            return -1
+        elif a.origin.uri == b.destination.uri:
+            return 1
+        else:
+            return 0
 
 
 def make_namedtuple(typename, *fields, **fields_with_default):


### PR DESCRIPTION
Jira: [NAV-1678](https://navitia.atlassian.net/browse/NAV-1678)
The sort of sections is random when two sections have the same departure_date_time and arrival_date_time

**Before correction:**
![image](https://user-images.githubusercontent.com/4006603/210813071-8824312c-589e-4d5e-9300-c4c4604fc5ca.png)



[NAV-1678]: https://navitia.atlassian.net/browse/NAV-1678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ