### PR TITLE
fix new release workflow

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -17,13 +17,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Free up space
-      run: |
-        rm -rf /usr/share/dotnet/*
-        rm -rf /usr/local/lib/android/*
-        echo "Free space:"
-        df -h
-
     - name: Install dependencies
       run: |
         apt update && apt install -y --force-yes zip httpie
@@ -112,8 +105,6 @@ jobs:
 
     - name: Create dockers images and push them
       run: |
-        docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
-
         components='jormungandr kraken tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
         for component in $components; do
             echo "*********  Building $component ***************"

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  debian_version: debian8
+  debian: debian8
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: navitia/${{ env.debian_version }}_dev
+      image: navitia/${{ env.debian }}_dev
       volumes:
          # Mount so we can delete files from docker and free up space (>20GB)
           - /usr/share/dotnet:/usr/share/dotnet

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -17,9 +17,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Free up space
+      run: |
+        sudo rm -rf /usr/share/dotnet/*
+        sudo rm -rf /usr/local/lib/android/*
+        echo "Free space:"
+        df -h
+
     - name: Install dependencies
       run: |
-        apt update && apt install -y --force-yes zip httpie
+        sudo apt update && sudo apt install -y --force-yes zip httpie
 
     - name: Checkout core_team_ci_tools
       uses: actions/checkout@v3

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -39,8 +39,9 @@ jobs:
     - name: Checkout core_team_ci_tools
       uses: actions/checkout@v3
       with:
-        path: core_team_ci_tools
         repository : 'hove-io/core_team_ci_tools'
+        path: core_team_ci_tools
+        token: ${{ secrets.access_token_github }}
 
     - name: Setup core_team_ci_tools python environment
       run: |

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -6,6 +6,8 @@ on:
       - dev
     tags:
       - '*'
+  pull_request:
+
 env:
   debian_version: debian8
 
@@ -15,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: navitia/${{env.debian_version}}_dev
+      image: navitia/${{ env.debian_version }}_dev
       volumes:
          # Mount so we can delete files from docker and free up space (>20GB)
           - /usr/share/dotnet:/usr/share/dotnet

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -16,14 +16,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    container:
-      image: navitia/debian8_dev
-      volumes:
-         # Mount so we can delete files from docker and free up space (>20GB)
-          - /usr/share/dotnet:/usr/share/dotnet
-          - /usr/local/lib/android:/usr/local/lib/android
-
-
     steps:
     - name: Free up space
       run: |
@@ -34,7 +26,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        apt update && apt install -y --force-yes zip httpie dh-python
+        apt update && apt install -y --force-yes zip httpie
 
     - name: Checkout core_team_ci_tools
       uses: actions/checkout@v3
@@ -77,13 +69,6 @@ jobs:
       run: |
         wget http://prdownloads.sourceforge.net/libkeepalive/libkeepalive-0.3.tar.gz
 
-    # - name: Restore ccache
-    #   uses: hendrikmuhs/ccache-action@v1.2
-    #   with:
-    #     key: ${{env.debian_version}-package
-    #     max-size: 2000M
-    #     save: ${{ github.event_name == 'push' }}
-
     - name: Checkout navitia
       uses: actions/checkout@v3
       with:
@@ -91,22 +76,32 @@ jobs:
         path: navitia
         fetch-depth: 0
 
-    - name: Build navitia packages
-      working-directory: navitia
+    - name: Restore ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: build_dockers
+        max-size: 2000M
+        save: ${{ github.event_name == 'push' }}
+
+    - name: Create master docker
+      run: |
+        docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
+
+    - name: Build packages in master docker
       # Will build navitia-*.deb packages in folder ../
       run: |
-        DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b
+        docker run -v `pwd`:/build/ -w /navitia/ navitia/master
 
 
     # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
-    - name: Choose dev navitia tag
-      if: github.event_name == 'push'
+    - name: Choose dev tag
+      if: github.event_name == 'pull_request'
       run: |
         echo "building version dev"
         echo "navitia_tag=dev" >> $GITHUB_ENV
         echo "aws_branch=dev" >> $GITHUB_ENV
 
-    - name: Choose release navitia tag
+    - name: Choose release tag
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         cd navitia

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -46,7 +46,7 @@ jobs:
             -o hove-io \
             -r mimirsbrunn \
             -t ${{secrets.access_token_github}} \
-            -w release.yml \
+            -w release7.yml \
             -a $mimirsbrunn_package \
             --output-dir .
         unzip -qo $mimirsbrunn_package
@@ -81,14 +81,13 @@ jobs:
       with:
         key: build_dockers
         max-size: 2000M
-        save: ${{ github.event_name == 'push' }}
 
     - name: Create master docker
       run: |
         docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
 
     - name: Build packages in master docker
-      # Will build navitia-*.deb packages in folder ../
+      # Will build navitia-*.deb packages in current folder
       run: |
         docker run -v `pwd`:/build/ -w /navitia/ navitia/master
 
@@ -117,8 +116,8 @@ jobs:
             echo "*********  Building $component ***************"
             docker build -t navitia/$component:${{env.navitia_tag}} -f  navitia/docker/${{env.debian_version}}/Dockerfile-${component} .
 
-            # add latest tag if navitia_tag != dev
-            if [[ "${{env.navitia_tag}}" != "dev" ]]; then
+            # add latest tag if we are making a release
+            if [[ "${{env.aws_branch}}" = "release" ]]; then
                 docker tag navitia/$component:${{env.navitia_tag}}  navitia/$component:latest
             fi
         done
@@ -169,4 +168,4 @@ jobs:
     # - name: success notification on navitia core team
     #   if: success()
     #   run: |
-    #       echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} image available.' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+    #       echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} images available.' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  debian: debian8
+  debian_version: debian8
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: navitia/${{ env.debian }}_dev
+      image: navitia/debian8_dev
       volumes:
          # Mount so we can delete files from docker and free up space (>20GB)
           - /usr/share/dotnet:/usr/share/dotnet
@@ -76,12 +76,12 @@ jobs:
       run: |
         wget http://prdownloads.sourceforge.net/libkeepalive/libkeepalive-0.3.tar.gz
 
-    - name: Restore ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ${{env.debian_version}-package
-        max-size: 2000M
-        save: ${{ github.event_name == 'push' }}
+    # - name: Restore ccache
+    #   uses: hendrikmuhs/ccache-action@v1.2
+    #   with:
+    #     key: ${{env.debian_version}-package
+    #     max-size: 2000M
+    #     save: ${{ github.event_name == 'push' }}
 
     - name: Checkout navitia
       uses: actions/checkout@v3
@@ -114,65 +114,65 @@ jobs:
         echo "navitia_tag=$version" >> $GITHUB_ENV
         echo "aws_branch=release" >> $GITHUB_ENV
 
-    - name: Create dockers images and push them
-      run: |
-        docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
+    # - name: Create dockers images and push them
+    #   run: |
+    #     docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
 
-        components='jormungandr kraken tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
-        for component in $components; do
-            echo "*********  Building $component ***************"
-            docker build -t navitia/$component:${{env.navitia_tag}} -f  navitia/docker/${{env.debian_version}}/Dockerfile-${component} .
+    #     components='jormungandr kraken tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
+    #     for component in $components; do
+    #         echo "*********  Building $component ***************"
+    #         docker build -t navitia/$component:${{env.navitia_tag}} -f  navitia/docker/${{env.debian_version}}/Dockerfile-${component} .
 
-            # add latest tag if navitia_tag != dev
-            if [[ "${{env.navitia_tag}}" != "dev" ]]; then
-                docker tag navitia/$component:${{env.navitia_tag}}  navitia/$component:latest
-            fi
-        done
+    #         # add latest tag if navitia_tag != dev
+    #         if [[ "${{env.navitia_tag}}" != "dev" ]]; then
+    #             docker tag navitia/$component:${{env.navitia_tag}}  navitia/$component:latest
+    #         fi
+    #     done
 
-        docker login -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+    #     docker login -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
 
-        for component in $components; do
-            echo "*********  Pushing $component ***************"
-            docker push --all-tags navitia/$component:${{env.navitia_tag}}
-        done
+    #     for component in $components; do
+    #         echo "*********  Pushing $component ***************"
+    #         docker push --all-tags navitia/$component:${{env.navitia_tag}}
+    #     done
 
-    - name: Generate token for aws images
-      id: app-token
-      uses: getsentry/action-github-app-token@v2.0.0
-      with:
-        app_id: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_ID }}
-        private_key: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_PEM }}
+    # - name: Generate token for aws images
+    #   id: app-token
+    #   uses: getsentry/action-github-app-token@v2.0.0
+    #   with:
+    #     app_id: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_ID }}
+    #     private_key: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_PEM }}
 
-    - name: Aws Dispatch Backend
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ steps.app-token.outputs.token }}
-        repository: hove-io/core-backend-aws-assets
-        event-type: build-trigger
-        client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag }}"}'
+    # - name: Aws Dispatch Backend
+    #   uses: peter-evans/repository-dispatch@v2
+    #   with:
+    #     token: ${{ steps.app-token.outputs.token }}
+    #     repository: hove-io/core-backend-aws-assets
+    #     event-type: build-trigger
+    #     client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag }}"}'
 
-    - name: Aws Dispatch Frontend
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ steps.app-token.outputs.token }}
-        repository: hove-io/core-front-aws-assets
-        event-type: build-trigger
-        client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag  }}"}'
+    # - name: Aws Dispatch Frontend
+    #   uses: peter-evans/repository-dispatch@v2
+    #   with:
+    #     token: ${{ steps.app-token.outputs.token }}
+    #     repository: hove-io/core-front-aws-assets
+    #     event-type: build-trigger
+    #     client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag  }}"}'
 
-    - name: Run artemis on push to dev
-      if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ secrets.access_token_github }}
-        repository: hove-io/artemis
-        event-type: run_artemis_ng
+    # - name: Run artemis on push to dev
+    #   if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    #   uses: peter-evans/repository-dispatch@v2
+    #   with:
+    #     token: ${{ secrets.access_token_github }}
+    #     repository: hove-io/artemis
+    #     event-type: run_artemis_ng
 
-    - name: failure notification
-      if: failure()
-      run: |
-          echo '{"text":":warning: Github Actions: build_dockers for ${{env.navitia_tag}} failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+    # - name: failure notification
+    #   if: failure()
+    #   run: |
+    #       echo '{"text":":warning: Github Actions: build_dockers for ${{env.navitia_tag}} failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
 
-    - name: success notification on navitia core team
-      if: success()
-      run: |
-          echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} image available.' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+    # - name: success notification on navitia core team
+    #   if: success()
+    #   run: |
+    #       echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} image available.' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -6,7 +6,6 @@ on:
       - dev
     tags:
       - '*'
-  pull_request:
 
 env:
   debian_version: debian8
@@ -94,7 +93,7 @@ jobs:
 
     # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
     - name: Choose dev tag
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
       run: |
         echo "building version dev"
         echo "navitia_tag=dev" >> $GITHUB_ENV
@@ -124,48 +123,48 @@ jobs:
 
         docker login -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
 
-        # for component in $components; do
-        #     echo "*********  Pushing $component ***************"
-        #     docker push --all-tags navitia/$component:${{env.navitia_tag}}
-        # done
+        for component in $components; do
+            echo "*********  Pushing $component ***************"
+            docker push --all-tags navitia/$component:${{env.navitia_tag}}
+        done
 
-    # - name: Generate token for aws images
-    #   id: app-token
-    #   uses: getsentry/action-github-app-token@v2.0.0
-    #   with:
-    #     app_id: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_ID }}
-    #     private_key: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_PEM }}
+    - name: Generate token for aws images
+      id: app-token
+      uses: getsentry/action-github-app-token@v2.0.0
+      with:
+        app_id: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_ID }}
+        private_key: ${{ secrets.GA_OS_WORKFLOW_TRIGGER_APP_PEM }}
 
-    # - name: Aws Dispatch Backend
-    #   uses: peter-evans/repository-dispatch@v2
-    #   with:
-    #     token: ${{ steps.app-token.outputs.token }}
-    #     repository: hove-io/core-backend-aws-assets
-    #     event-type: build-trigger
-    #     client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag }}"}'
+    - name: Aws Dispatch Backend
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        repository: hove-io/core-backend-aws-assets
+        event-type: build-trigger
+        client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag }}"}'
 
-    # - name: Aws Dispatch Frontend
-    #   uses: peter-evans/repository-dispatch@v2
-    #   with:
-    #     token: ${{ steps.app-token.outputs.token }}
-    #     repository: hove-io/core-front-aws-assets
-    #     event-type: build-trigger
-    #     client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag  }}"}'
+    - name: Aws Dispatch Frontend
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        repository: hove-io/core-front-aws-assets
+        event-type: build-trigger
+        client-payload: '{"branch": "${{ env.aws_branch }}", "tag": "${{ env.navitia_tag  }}"}'
 
-    # - name: Run artemis on push to dev
-    #   if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
-    #   uses: peter-evans/repository-dispatch@v2
-    #   with:
-    #     token: ${{ secrets.access_token_github }}
-    #     repository: hove-io/artemis
-    #     event-type: run_artemis_ng
+    - name: Run artemis on push to dev
+      if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.access_token_github }}
+        repository: hove-io/artemis
+        event-type: run_artemis_ng
 
-    # - name: failure notification
-    #   if: failure()
-    #   run: |
-    #       echo '{"text":":warning: Github Actions: build_dockers for ${{env.navitia_tag}} failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+    - name: failure notification
+      if: failure()
+      run: |
+          echo '{"text":":warning: Github Actions: build_dockers for ${{env.navitia_tag}} failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
 
-    # - name: success notification on navitia core team
-    #   if: success()
-    #   run: |
-    #       echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} images available.' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+    - name: success notification on navitia core team
+      if: success()
+      run: |
+          echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} images available.' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}

--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -100,7 +100,7 @@ jobs:
 
     # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable
     - name: Choose dev navitia tag
-      if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+      if: github.event_name == 'push'
       run: |
         echo "building version dev"
         echo "navitia_tag=dev" >> $GITHUB_ENV
@@ -115,27 +115,27 @@ jobs:
         echo "navitia_tag=$version" >> $GITHUB_ENV
         echo "aws_branch=release" >> $GITHUB_ENV
 
-    # - name: Create dockers images and push them
-    #   run: |
-    #     docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
+    - name: Create dockers images and push them
+      run: |
+        docker build -f navitia/docker/${{env.debian_version}}/Dockerfile-master -t navitia/master .
 
-    #     components='jormungandr kraken tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
-    #     for component in $components; do
-    #         echo "*********  Building $component ***************"
-    #         docker build -t navitia/$component:${{env.navitia_tag}} -f  navitia/docker/${{env.debian_version}}/Dockerfile-${component} .
+        components='jormungandr kraken tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
+        for component in $components; do
+            echo "*********  Building $component ***************"
+            docker build -t navitia/$component:${{env.navitia_tag}} -f  navitia/docker/${{env.debian_version}}/Dockerfile-${component} .
 
-    #         # add latest tag if navitia_tag != dev
-    #         if [[ "${{env.navitia_tag}}" != "dev" ]]; then
-    #             docker tag navitia/$component:${{env.navitia_tag}}  navitia/$component:latest
-    #         fi
-    #     done
+            # add latest tag if navitia_tag != dev
+            if [[ "${{env.navitia_tag}}" != "dev" ]]; then
+                docker tag navitia/$component:${{env.navitia_tag}}  navitia/$component:latest
+            fi
+        done
 
-    #     docker login -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
+        docker login -u ${{secrets.docker_user}} -p ${{secrets.docker_password}}
 
-    #     for component in $components; do
-    #         echo "*********  Pushing $component ***************"
-    #         docker push --all-tags navitia/$component:${{env.navitia_tag}}
-    #     done
+        # for component in $components; do
+        #     echo "*********  Pushing $component ***************"
+        #     docker push --all-tags navitia/$component:${{env.navitia_tag}}
+        # done
 
     # - name: Generate token for aws images
     #   id: app-token

--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -3,7 +3,7 @@ name: Build Navitia Packages For Dev Multi Distributions
 on:
   push:
     branches:
-      - dev
+      - dev_
 
 jobs:
   build:

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -3,7 +3,7 @@ name: Build Navitia Packages For Release
 on:
   push:
     branches:
-      - release
+      - release_
 
 
 jobs:

--- a/docker/build_kraken.sh
+++ b/docker/build_kraken.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd /build/navitia/
+DEB_BUILD_OPTIONS=nocheck dpkg-buildpackage -b
+cd ..
+chmod -R 777 .

--- a/docker/debian10/Dockerfile-master
+++ b/docker/debian10/Dockerfile-master
@@ -3,12 +3,16 @@ FROM debian:10-slim
 # update package list from providers
 RUN apt-get update && \
   apt-get upgrade -y && \
-  apt-get install -y ca-certificates && \
+  apt-get install -y ca-certificates  dh-python && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
  COPY navitia/docker/ca-certificates/*.crt /usr/local/share/ca-certificates/
+ COPY navitia/docker/build_kraken.sh /build_kraken.sh
+ RUN chmod +x /build_kraken.sh
  RUN update-ca-certificates
  # Python 'requests' package handle its own CA certificate list
  # Let's force it to use the OS's list
  ENV REQUESTS_CA_BUNDLE /etc/ssl/certs
+
+ ENTRYPOINT /build_kraken.sh

--- a/docker/debian8/Dockerfile-master
+++ b/docker/debian8/Dockerfile-master
@@ -1,7 +1,7 @@
 FROM navitia/debian8_dev
 
 # update package list from providers
-RUN apt-get update --fix-missing
+RUN apt-get update --force-yes --fix-missing || exit 0
 
 # upgrade installed packages
 RUN  apt-get upgrade -y --force-yes
@@ -12,10 +12,15 @@ RUN  apt-get upgrade -y --force-yes
 RUN apt-get install -y --force-yes postgresql-client \
         ca-certificates \
         netcat \
+        dh-python \
         curl
 
 COPY navitia/docker/ca-certificates/*.crt /usr/local/share/ca-certificates/
+COPY navitia/docker/build_kraken.sh /build_kraken.sh
+RUN chmod +x /build_kraken.sh
 RUN update-ca-certificates
 # Python 'requests' package handle its own CA certificate list
 # Let's force it to use the OS's list
 ENV REQUESTS_CA_BUNDLE /etc/ssl/certs
+
+ENTRYPOINT /build_kraken.sh

--- a/docker/debian8/Dockerfile-master
+++ b/docker/debian8/Dockerfile-master
@@ -3,8 +3,6 @@ FROM navitia/debian8_dev
 # update package list from providers
 RUN apt-get update --force-yes --fix-missing || exit 0
 
-# upgrade installed packages
-RUN  apt-get upgrade -y --force-yes
 
 # install postgresql-client for tyr-beat
 #         netcat for kraken


### PR DESCRIPTION
Fix the new release worflow.
In particular, adds a build_navitia.sh script to the navitia/master docker image. This image is now run to build navitia packages. You can do the same on your local computer.

I temporarily disabled the old workflows so avoid a double build/push of docker images. Another PR will clean things when the new workflow does work as expected.