### PR TITLE
Kraken: Fix disruption's channel type list in a channel

### DIFF
--- a/source/kraken/fill_disruption_from_database.h
+++ b/source/kraken/fill_disruption_from_database.h
@@ -196,7 +196,8 @@ struct DisruptionDatabaseReader {
             fill_channel(const_it, channel);
             message_ids.insert(const_it["message_id"].template as<std::string>());
         }
-        if (impact && channel && (last_channel_type_id != const_it["channel_type_id"].template as<std::string>())) {
+        if (impact && channel && (channel->id() == const_it["channel_id"].template as<std::string>())
+            && (last_channel_type_id != const_it["channel_type_id"].template as<std::string>())) {
             fill_channel_type(const_it, channel);
             last_channel_type_id = const_it["channel_type_id"].template as<std::string>();
         }


### PR DESCRIPTION
**Note: Tested using fr-nw-tours data from CUS and chaos_cus with** @Msaglier 

**In chaos:**

channel1:
- channel_type1 (web)
-  channel_type2 (mobile)

Channel2:
- channel_type3 (title)

**Before correction In navitia:**

channel1:
- channel_type1 (web)
-  channel_type2 (mobile)

Channel2:
- channel_type1 (web)
-  channel_type2 (mobile)
- channel_type3 (title)

**After correction in navitia:**

channel1:
- channel_type1 (web)
-  channel_type2 (mobile)

Channel2:
- channel_type3 (title)

For more details: https://navitia.atlassian.net/browse/NAV-1688