### PR TITLE
[Kraken] Fix aging problem when both kirin & chaos are active

### DIFF
--- a/source/ed/build_helper.h
+++ b/source/ed/build_helper.h
@@ -409,6 +409,10 @@ struct builder {
     navitia::georef::Way* add_way(const std::string& name, const std::string& way_type, const bool visible = true);
 
     const navitia::type::Data& get_data() { return *data.get(); }
+
+    const navitia::type::MetaVehicleJourney* get_meta_vj(const std::string& meta_vj_uri) const {
+        return data->pt_data->meta_vjs.get_mut(meta_vj_uri);
+    }
 };
 
 }  // namespace ed

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -833,7 +833,7 @@ def check_stop_schedule(response, reference):
 
         for (resp_dt, ref_st) in zip_longest(resp['date_times'], ref.date_times):
             assert get_not_null(resp_dt, 'date_time') == ref_st.dt
-            assert get_not_null(resp_dt, 'links')[0]['id'] == ref_st.vj
+            assert get_not_null(resp_dt, 'links')[0]['id'].find(ref_st.vj) == 0
 
 
 def check_departures(response, reference):
@@ -934,9 +934,9 @@ class TestSchedules(AbstractTestFixture):
                     sp='S1',
                     route='A:0',
                     date_times=[
-                        SchedDT(dt='20160101T090700', vj='vehicle_journey:A:vj1:modified:0:delay_vj1'),
-                        SchedDT(dt='20160101T100700', vj='vehicle_journey:A:vj2:modified:0:delay_vj2'),
-                        SchedDT(dt='20160101T110700', vj='vehicle_journey:A:vj3:modified:0:delay_vj3'),
+                        SchedDT(dt='20160101T090700', vj='vehicle_journey:A:vj1:RealTime:'),
+                        SchedDT(dt='20160101T100700', vj='vehicle_journey:A:vj2:RealTime:'),
+                        SchedDT(dt='20160101T110700', vj='vehicle_journey:A:vj3:RealTime:'),
                     ],
                 ),
                 StopSchedule(
@@ -1016,7 +1016,7 @@ class TestSchedules(AbstractTestFixture):
                 StopSchedule(
                     sp='S1',
                     route='A:0',
-                    date_times=[SchedDT(dt='20160101T090700', vj='vehicle_journey:A:vj1:modified:0:delay_vj1')],
+                    date_times=[SchedDT(dt='20160101T090700', vj='vehicle_journey:A:vj1:RealTime:')],
                 ),
                 StopSchedule(
                     sp='S1', route='B:1', date_times=[SchedDT(dt='20160101T113000', vj='vehicle_journey:B:vj1')]

--- a/source/jormungandr/tests/rail_sections_tests.py
+++ b/source/jormungandr/tests/rail_sections_tests.py
@@ -472,7 +472,10 @@ class TestRailSections(AbstractTestFixture):
         # stopAA-> stopBB / realtime: No disruption
         r = journeys(_from='stopAA', to='stopBB', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:0:rail_section_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[0]['id']]]
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -544,7 +547,10 @@ class TestRailSections(AbstractTestFixture):
         # stopAA-> stopFF / realtime: No disruption to display
         r = journeys(_from='stopAA', to='stopGG', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:0:rail_section_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[0]['id']]]
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -566,7 +572,11 @@ class TestRailSections(AbstractTestFixture):
         # stopCC-> stopFF / realtime: No disruption
         r = journeys(_from='stopCC', to='stopFF', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:0:rail_section_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[0]['id']]]
+
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -606,7 +616,11 @@ class TestRailSections(AbstractTestFixture):
         # stopGG-> stopII / realtime: No disruption
         r = journeys(_from='stopGG', to='stopII', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:0:rail_section_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[0]['id']]]
+
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -908,7 +922,11 @@ class TestRailSections(AbstractTestFixture):
         # stopAA-> stopBB / realtime: No disruption
         r = journeys(_from='stopAA', to='stopBB', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:1:rail_section_bis_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[1]['id']]]
+
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -980,7 +998,11 @@ class TestRailSections(AbstractTestFixture):
         # stopAA-> stopFF / realtime: No disruption to display
         r = journeys(_from='stopAA', to='stopGG', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:1:rail_section_bis_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[1]['id']]]
+
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -1002,7 +1024,11 @@ class TestRailSections(AbstractTestFixture):
         # stopCC-> stopFF / realtime: No disruption
         r = journeys(_from='stopCC', to='stopFF', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:1:rail_section_bis_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[1]['id']]]
+
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():
@@ -1042,7 +1068,11 @@ class TestRailSections(AbstractTestFixture):
         # stopGG-> stopII / realtime: No disruption
         r = journeys(_from='stopGG', to='stopII', data_freshness="realtime")
         assert len(r["journeys"]) == 1
-        assert get_used_vj(r) == [['vehicle_journey:vj:11-1:Adapted:1:rail_section_bis_on_line11']]
+
+        vjs = self.query_region('trips/vj:11-1/vehicle_journeys')['vehicle_journeys']
+        impacted_vjs = [vj for vj in vjs if 'vehicle_journey:vj:11-1:Adapted:' in vj['id']]
+        assert get_used_vj(r) == [[impacted_vjs[1]['id']]]
+
         d = get_all_element_disruptions(r['journeys'], r)
         assert not impacted_headsigns(d)
         for disruption, result in scenario.items():

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -189,18 +189,6 @@ type::ValidityPattern compute_base_disrupted_vp(const std::vector<boost::posix_t
     return vp;
 }
 
-std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
-    std::stringstream impacts_uris;
-    for (auto& mvj_impacts : mvj.modified_by) {
-        if (auto i = mvj_impacts.lock()) {
-            if (impacts_uris.str().find(i->disruption->uri) == std::string::npos) {
-                impacts_uris << ":" << i->disruption->uri;
-            }
-        }
-    }
-    return impacts_uris.str();
-}
-
 nt::Route* get_or_create_route(const nt::disruption::Impact& impact, nt::PT_Data& pt_data) {
     nt::Network* network = pt_data.get_or_create_network("network:additional_service", "additional service");
     nt::CommercialMode* comm_mode =

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -101,6 +101,18 @@ nt::VehicleJourney* create_vj_from_old_vj(nt::MetaVehicleJourney* mvj,
     return new_vj;
 }
 
+std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
+    std::stringstream impacts_uris;
+    for (auto& mvj_impacts : mvj.modified_by) {
+        if (auto i = mvj_impacts.lock()) {
+            if (impacts_uris.str().find(i->disruption->uri) == std::string::npos) {
+                impacts_uris << ":" << i->disruption->uri;
+            }
+        }
+    }
+    return impacts_uris.str();
+}
+
 std::string make_new_vj_uri(const nt::MetaVehicleJourney* mvj, nt::RTLevel rt_level) {
     boost::uuids::random_generator gen;
     return "vehicle_journey:" + mvj->uri + ":" + type::get_string_from_rt_level(rt_level) + ":"
@@ -314,7 +326,6 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 }
             }
 
-            auto nb_rt_vj = mvj->get_rt_vj().size();
             auto new_vj_uri = make_new_vj_uri(mvj, rt_level);
 
             std::vector<type::StopTime> stoptimes;  // we copy all the stoptimes
@@ -487,7 +498,6 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 mvj->cancel_vj(rt_level, impact->application_periods, pt_data);
                 continue;
             }
-            auto nb_rt_vj = mvj->get_vjs_at(rt_level).size();
             auto new_vj_uri = make_new_vj_uri(mvj, rt_level);
 
             new_vp.days = new_vp.days & (vj->validity_patterns[rt_level]->days >> vj->shift);
@@ -555,7 +565,6 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 mvj->cancel_vj(rt_level, impact->application_periods, pt_data);
                 continue;
             }
-            auto nb_rt_vj = mvj->get_vjs_at(rt_level).size();
             auto new_vj_uri = make_new_vj_uri(mvj, rt_level);
 
             new_vp.days = new_vp.days & (vj->validity_patterns[rt_level]->days >> vj->shift);
@@ -710,7 +719,6 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             auto mvj = vj->meta_vj;
             mvj->push_unique_impact(impact);
 
-            auto nb_rt_vj = mvj->get_vjs_at(rt_level).size();
             auto new_vj_uri = make_new_vj_uri(mvj, rt_level);
 
             new_vp.days = new_vp.days & (vj->validity_patterns[rt_level]->days >> vj->shift);

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -101,18 +101,6 @@ nt::VehicleJourney* create_vj_from_old_vj(nt::MetaVehicleJourney* mvj,
     return new_vj;
 }
 
-std::string concatenate_impact_uris(const nt::MetaVehicleJourney& mvj) {
-    std::stringstream impacts_uris;
-    for (auto& mvj_impacts : mvj.modified_by) {
-        if (auto i = mvj_impacts.lock()) {
-            if (impacts_uris.str().find(i->disruption->uri) == std::string::npos) {
-                impacts_uris << ":" << i->disruption->uri;
-            }
-        }
-    }
-    return impacts_uris.str();
-}
-
 std::string make_new_vj_uri(const nt::MetaVehicleJourney* mvj, nt::RTLevel rt_level) {
     boost::uuids::random_generator gen;
     return "vehicle_journey:" + mvj->uri + ":" + type::get_string_from_rt_level(rt_level) + ":"

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -92,7 +92,9 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.vhost", po::value<std::string>()->default_value("/"), "vhost for rabbitmq")
         ("BROKER.exchange", po::value<std::string>()->default_value("navitia"), "exchange used in rabbitmq")
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
-        ("BROKER.timeout", po::value<int>()->default_value(100), "timeout for maintenance worker in millisecond")
+        ("BROKER.timeout", po::value<int>()->default_value(200), "timeout for maintenance worker in millisecond")
+        ("BROKER.max_batch_nb", po::value<int>()->default_value(5000), "max size of the realtime message")
+        ("BROKER.retrieving_timeout", po::value<int>()->default_value(10000), "max duration the worker is going to spend when retrieving messages")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
         ("BROKER.reconnect_wait", po::value<int>()->default_value(1), "Wait duration between connection attempts to rabbitmq, in seconds")
         ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")
@@ -230,6 +232,14 @@ std::string Configuration::broker_exchange() const {
 
 int Configuration::broker_timeout() const {
     return vm["BROKER.timeout"].as<int>();
+}
+
+int Configuration::retrieving_timeout() const {
+    return vm["BROKER.retrieving_timeout"].as<int>();
+}
+
+int Configuration::broker_max_batch_nb() const {
+    return vm["BROKER.max_batch_nb"].as<int>();
 }
 
 int Configuration::broker_sleeptime() const {

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -94,7 +94,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
         ("BROKER.timeout", po::value<int>()->default_value(200), "timeout for maintenance worker in millisecond")
         ("BROKER.max_batch_nb", po::value<int>()->default_value(5000), "max number of realtime messages retrieved in a batch")
-        ("BROKER.retrieving_timeout", po::value<int>()->default_value(10000), "max duration the worker is going to spend when retrieving messages")
+        ("BROKER.total_retrieving_timeout", po::value<int>()->default_value(10000), "max total duration the worker is going to spend when retrieving messages")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
         ("BROKER.reconnect_wait", po::value<int>()->default_value(1), "Wait duration between connection attempts to rabbitmq, in seconds")
         ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -234,8 +234,8 @@ int Configuration::broker_timeout() const {
     return vm["BROKER.timeout"].as<int>();
 }
 
-int Configuration::retrieving_timeout() const {
-    return vm["BROKER.retrieving_timeout"].as<int>();
+int Configuration::total_retrieving_timeout() const {
+    return vm["BROKER.total_retrieving_timeout"].as<int>();
 }
 
 int Configuration::broker_max_batch_nb() const {

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -93,7 +93,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.exchange", po::value<std::string>()->default_value("navitia"), "exchange used in rabbitmq")
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
         ("BROKER.timeout", po::value<int>()->default_value(200), "timeout for maintenance worker in millisecond")
-        ("BROKER.max_batch_nb", po::value<int>()->default_value(5000), "max size of the realtime message")
+        ("BROKER.max_batch_nb", po::value<int>()->default_value(5000), "max number of realtime messages retrieved in a batch")
         ("BROKER.retrieving_timeout", po::value<int>()->default_value(10000), "max duration the worker is going to spend when retrieving messages")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
         ("BROKER.reconnect_wait", po::value<int>()->default_value(1), "Wait duration between connection attempts to rabbitmq, in seconds")

--- a/source/kraken/configuration.cpp
+++ b/source/kraken/configuration.cpp
@@ -94,7 +94,7 @@ po::options_description get_options_description(const boost::optional<std::strin
         ("BROKER.rt_topics", po::value<std::vector<std::string>>(), "list of realtime topic for this instance")
         ("BROKER.timeout", po::value<int>()->default_value(200), "timeout for maintenance worker in millisecond")
         ("BROKER.max_batch_nb", po::value<int>()->default_value(5000), "max number of realtime messages retrieved in a batch")
-        ("BROKER.total_retrieving_timeout", po::value<int>()->default_value(10000), "max total duration the worker is going to spend when retrieving messages")
+        ("BROKER.total_retrieving_timeout", po::value<int>()->default_value(10000), "max total duration the worker is going to spend when retrieving messages, in milliseconds")
         ("BROKER.sleeptime", po::value<int>()->default_value(1), "sleeptime for maintenance worker in second")
         ("BROKER.reconnect_wait", po::value<int>()->default_value(1), "Wait duration between connection attempts to rabbitmq, in seconds")
         ("BROKER.queue", po::value<std::string>(), "rabbitmq's queue name to be bound")

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -64,7 +64,7 @@ public:
     bool broker_queue_auto_delete() const;
     int broker_queue_expire() const;
     int broker_timeout() const;
-    int retrieving_timeout() const;
+    int total_retrieving_timeout() const;
     int broker_max_batch_nb() const;
     int broker_sleeptime() const;
     int broker_reconnect_wait() const;

--- a/source/kraken/configuration.h
+++ b/source/kraken/configuration.h
@@ -64,6 +64,8 @@ public:
     bool broker_queue_auto_delete() const;
     int broker_queue_expire() const;
     int broker_timeout() const;
+    int retrieving_timeout() const;
+    int broker_max_batch_nb() const;
     int broker_sleeptime() const;
     int broker_reconnect_wait() const;
     bool is_realtime_enabled() const;

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -366,8 +366,7 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
     bool autocomplete_rebuilding_activated = false;
     auto rt_action = RTAction::chaos;
 
-    std::unordered_set<std::string> applied_visited_id;
-    for (auto& envelope : boost::adaptors::reverse(envelopes)) {
+    for (auto& envelope : envelopes) {
         const auto routing_key = envelope->RoutingKey();
         LOG4CPLUS_DEBUG(logger, "realtime info received from " << routing_key);
         assert(envelope);
@@ -378,10 +377,6 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         }
         LOG4CPLUS_TRACE(logger, "received entity: " << feed_message.DebugString());
         for (const auto& entity : feed_message.entity()) {
-            auto res = applied_visited_id.insert(entity.id());
-            if (!res.second) {
-                continue;
-            }
             if (!data) {
                 pt::ptime copy_begin = pt::microsec_clock::universal_time();
                 data = data_manager.get_data_clone();

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -462,7 +462,6 @@ std::vector<AmqpClient::Envelope::ptr_t> MaintenanceWorker::consume_in_batch(con
     auto begin = pt::microsec_clock::universal_time();
 
     auto retrieving_timeout = conf.retrieving_timeout();
-    pt::time_duration duration = pt::milliseconds{0};
     while (consumed_nb < max_nb
            && (pt::microsec_clock::universal_time() - begin).total_milliseconds() < retrieving_timeout) {
         AmqpClient::Envelope::ptr_t envelope{};

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -461,7 +461,7 @@ std::vector<AmqpClient::Envelope::ptr_t> MaintenanceWorker::consume_in_batch(con
     size_t consumed_nb = 0;
     auto begin = pt::microsec_clock::universal_time();
 
-    auto retrieving_timeout = conf.retrieving_timeout();
+    auto retrieving_timeout = conf.total_retrieving_timeout();
     while (consumed_nb < max_nb
            && (pt::microsec_clock::universal_time() - begin).total_milliseconds() < retrieving_timeout) {
         AmqpClient::Envelope::ptr_t envelope{};

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -43,6 +43,7 @@ www.navitia.io
 #include <boost/algorithm/string/join.hpp>
 #include <boost/optional.hpp>
 #include <boost/thread/thread.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 
 #include <chrono>
 #include <csignal>
@@ -364,7 +365,9 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
     pt::ptime begin = pt::microsec_clock::universal_time();
     bool autocomplete_rebuilding_activated = false;
     auto rt_action = RTAction::chaos;
-    for (auto& envelope : envelopes) {
+
+    std::unordered_set<std::string> applied_visited_id;
+    for (auto& envelope : boost::adaptors::reverse(envelopes)) {
         const auto routing_key = envelope->RoutingKey();
         LOG4CPLUS_DEBUG(logger, "realtime info received from " << routing_key);
         assert(envelope);
@@ -375,6 +378,10 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         }
         LOG4CPLUS_TRACE(logger, "received entity: " << feed_message.DebugString());
         for (const auto& entity : feed_message.entity()) {
+            auto res = applied_visited_id.insert(entity.id());
+            if (!res.second) {
+                continue;
+            }
             if (!data) {
                 pt::ptime copy_begin = pt::microsec_clock::universal_time();
                 data = data_manager.get_data_clone();
@@ -452,7 +459,12 @@ std::vector<AmqpClient::Envelope::ptr_t> MaintenanceWorker::consume_in_batch(con
     std::vector<AmqpClient::Envelope::ptr_t> envelopes;
     envelopes.reserve(max_nb);
     size_t consumed_nb = 0;
-    while (consumed_nb < max_nb) {
+    auto begin = pt::microsec_clock::universal_time();
+
+    auto retrieving_timeout = conf.retrieving_timeout();
+    pt::time_duration duration = pt::milliseconds{0};
+    while (consumed_nb < max_nb
+           && (pt::microsec_clock::universal_time() - begin).total_milliseconds() < retrieving_timeout) {
         AmqpClient::Envelope::ptr_t envelope{};
 
         /* !
@@ -499,7 +511,7 @@ void MaintenanceWorker::listen_rabbitmq() {
 
         // Arbitrary Number: we suppose that disruptions can be handled very quickly so that,
         // in theory, we can handle a batch of 5000 disruptions in one time very quickly too.
-        size_t max_batch_nb = 5000;
+        size_t max_batch_nb = conf.broker_max_batch_nb();
 
         try {
             auto rt_envelopes = consume_in_batch(rt_tag, max_batch_nb, timeout_ms, no_ack);

--- a/source/kraken/tests/apply_disruption_test.cpp
+++ b/source/kraken/tests/apply_disruption_test.cpp
@@ -427,11 +427,14 @@ BOOST_AUTO_TEST_CASE(add_stop_area_impact_on_vj_pass_midnight) {
                         vj->adapted_validity_pattern()->days);
 
     // Adapted VJ
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj 0:Adapted:1:stop_area_closed"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "0000000"),
-                        vj->base_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "0000111"),
-                        vj->adapted_validity_pattern()->days);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj 0");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "0000000"),
+                        adapted_vj->base_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "0000111"),
+                        adapted_vj->adapted_validity_pattern()->days);
 
     auto res = compute(*b.data, nt::RTLevel::Adapted, "A1", "A2", "23:00"_t, 1);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -481,9 +484,13 @@ BOOST_AUTO_TEST_CASE(add_stop_point_impact_check_vp_filtering_last_day) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111000"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111100"), base_vp);
 
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:stop_point:20_closed");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    // Adapted VJ
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000100"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
@@ -534,11 +541,14 @@ BOOST_AUTO_TEST_CASE(add_impact_with_sevral_application_period) {
                         vj->adapted_validity_pattern()->days);
 
     // Adapted VJ
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:0:stop3_closed"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000000"),
-                        vj->base_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "100111"),
-                        vj->adapted_validity_pattern()->days);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "000000"),
+                        adapted_vj->base_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "100111"),
+                        adapted_vj->adapted_validity_pattern()->days);
 
     // 2012/6/15 8:00
     auto res = compute(*b.data, nt::RTLevel::Base, "stop1", "stop3", "08:00"_t, 1);
@@ -594,11 +604,16 @@ BOOST_AUTO_TEST_CASE(remove_stop_point_impact) {
                         vj->adapted_validity_pattern()->days);
 
     // Adapted VJ
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:0:stop3_closed"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000000"),
-                        vj->base_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "100111"),
-                        vj->adapted_validity_pattern()->days);
+
+    // Adapted VJ
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "000000"),
+                        adapted_vj->base_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "100111"),
+                        adapted_vj->adapted_validity_pattern()->days);
 
     navitia::delete_disruption("stop3_closed", *b.data->pt_data, *b.data->meta);
     navitia::delete_disruption("stop3_closed", *b.data->pt_data, *b.data->meta);
@@ -648,14 +663,17 @@ BOOST_AUTO_TEST_CASE(remove_all_stop_point) {
                         vj->adapted_validity_pattern()->days);
 
     // Adapted VJ
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:1:stop1_closed:stop2_closed:stop3_closed"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000000"),
-                        vj->base_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "111111"),
-                        vj->adapted_validity_pattern()->days);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "000000"),
+                        adapted_vj->base_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "111111"),
+                        adapted_vj->adapted_validity_pattern()->days);
 
     // in Adapted Vj, all stop point is blocked....
-    BOOST_REQUIRE(vj->stop_time_list.empty());
+    BOOST_REQUIRE(adapted_vj->stop_time_list.empty());
 
     auto res = compute(*b.data, nt::RTLevel::Adapted, "stop1", "stop3", "8:00"_t, 1);
     BOOST_REQUIRE_EQUAL(res.size(), 0);
@@ -689,9 +707,14 @@ BOOST_AUTO_TEST_CASE(stop_point_no_service_with_shift) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "111011"),
                         vj1->rt_validity_pattern()->days);
 
-    auto* vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:modified:0:bob"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "001000"),
-                        vj->rt_validity_pattern()->days);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "001000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    std::string first_rt_vj_uri = rt_vj->uri;
 
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "stop2_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
@@ -703,17 +726,24 @@ BOOST_AUTO_TEST_CASE(stop_point_no_service_with_shift) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "111011"),
                         vj1->rt_validity_pattern()->days);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:RealTime:1:bob:stop2_closed"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->base_validity_pattern()->days.to_string(), "000000"),
-                        vj->base_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "001000"),
-                        vj->rt_validity_pattern()->days);
+    // always only one rt vj
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 1);
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+
+    // A new vj is created, the uri must be different
+    BOOST_ASSERT(first_rt_vj_uri != rt_vj->uri);
+
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->base_validity_pattern()->days.to_string(), "000000"),
+                        rt_vj->base_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "001000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 1);
     auto* s1 = b.data->pt_data->stop_points_map["stop1"];
     auto* s3 = b.data->pt_data->stop_points_map["stop3"];
 
-    check_vj(vj, {{"00:05"_t, "00:05"_t, s1}, {"02:05"_t, "02:05"_t, s3}});
+    check_vj(rt_vj, {{"00:05"_t, "00:05"_t, s1}, {"02:05"_t, "02:05"_t, s3}});
 
     auto res = compute(*b.data, nt::RTLevel::RealTime, "stop1", "stop3", "8:00"_t, 3);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -723,9 +753,11 @@ BOOST_AUTO_TEST_CASE(stop_point_no_service_with_shift) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "111011"),
                         vj1->rt_validity_pattern()->days);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:modified:0:bob"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "001000"),
-                        vj->rt_validity_pattern()->days);
+    // always only one rt vj
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "001000"),
+                        rt_vj->rt_validity_pattern()->days);
 
     navitia::delete_disruption("bob", *b.data->pt_data, *b.data->meta);
 
@@ -763,11 +795,15 @@ BOOST_AUTO_TEST_CASE(test_shift_of_a_disrupted_delayed_train) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "000000"),
                         vj1->rt_validity_pattern()->days);
 
-    auto* vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:modified:0:bob"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "0001000"),
-                        vj->rt_validity_pattern()->days);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 1);
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "0001000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 1);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::RealTime, "stop1_closed")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
@@ -780,15 +816,18 @@ BOOST_AUTO_TEST_CASE(test_shift_of_a_disrupted_delayed_train) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "000000"),
                         vj1->rt_validity_pattern()->days);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:RealTime:1:bob:stop1_closed"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "010000"),
-                        vj->rt_validity_pattern()->days);
+    meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 2);
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "010000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 2);
 
     auto* stop2 = b.data->pt_data->stop_points_map["stop2"];
     auto* stop3 = b.data->pt_data->stop_points_map["stop3"];
-    check_vj(vj, {{"00:05"_t, "00:05"_t, stop2}, {"01:00"_t, "01:00"_t, stop3}});
+    check_vj(rt_vj, {{"00:05"_t, "00:05"_t, stop2}, {"01:00"_t, "01:00"_t, stop3}});
 
     auto res = compute(*b.data, nt::RTLevel::Base, "stop1", "stop3", "23:00"_t, 2);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -812,11 +851,13 @@ BOOST_AUTO_TEST_CASE(test_shift_of_a_disrupted_delayed_train) {
 
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:modified:0:bob"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "0001000"),
-                        vj->rt_validity_pattern()->days);
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 1);
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "0001000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 1);
 
     navitia::delete_disruption("bob", *b.data->pt_data, *b.data->meta);
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
@@ -866,12 +907,15 @@ BOOST_AUTO_TEST_CASE(disrupted_stop_point_then_delayed) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "000000"),
                         vj1->rt_validity_pattern()->days);
 
-    auto* vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:RealTime:0:stop1_closed"];
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
 
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "001000"),
-                        vj->rt_validity_pattern()->days);
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 1);
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "001000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 1);
 
     auto trip_update = ntest::make_trip_update_message("vj:1", "20120616",
                                                        {
@@ -886,15 +930,17 @@ BOOST_AUTO_TEST_CASE(disrupted_stop_point_then_delayed) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "000000"),
                         vj1->rt_validity_pattern()->days);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:modified:1:bob"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "0010000"),
-                        vj->rt_validity_pattern()->days);
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 2);
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "0010000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 2);
 
     auto* stop2 = b.data->pt_data->stop_points_map["stop2"];
     auto* stop3 = b.data->pt_data->stop_points_map["stop3"];
-    check_vj(vj, {{"00:15"_t, "00:15"_t, stop2}, {"01:00"_t, "01:00"_t, stop3}});
+    check_vj(rt_vj, {{"00:15"_t, "00:15"_t, stop2}, {"01:00"_t, "01:00"_t, stop3}});
 
     auto res = compute(*b.data, nt::RTLevel::Base, "stop1", "stop3", "23:00"_t, 2);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
@@ -918,11 +964,13 @@ BOOST_AUTO_TEST_CASE(disrupted_stop_point_then_delayed) {
     navitia::delete_disruption("stop1_closed", *b.data->pt_data, *b.data->meta);
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 2);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:modified:0:bob"];
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->rt_validity_pattern()->days.to_string(), "010000"),
-                        vj->rt_validity_pattern()->days);
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
 
-    BOOST_REQUIRE_EQUAL(vj->shift, 2);
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj->rt_validity_pattern()->days.to_string(), "010000"),
+                        rt_vj->rt_validity_pattern()->days);
+
+    BOOST_REQUIRE_EQUAL(rt_vj->shift, 2);
 
     navitia::delete_disruption("bob", *b.data->pt_data, *b.data->meta);
     BOOST_CHECK_EQUAL(b.data->pt_data->vehicle_journeys.size(), 1);
@@ -1137,32 +1185,44 @@ BOOST_AUTO_TEST_CASE(add_simple_impact_on_line_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "001100"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().departure_time, "08:11"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().arrival_time, "08:40"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().departure_time, "08:11"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().arrival_time, "08:40"_t);
 
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:2:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:2");
+
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000010"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().departure_time, "09:11"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().arrival_time, "09:40"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().departure_time, "09:11"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().arrival_time, "09:40"_t);
 
     // vj:3 shouldn't be affected by the disruption. On the 6th the disruption stops at 9am but its first
     // stop_time starts at 10am
-    BOOST_CHECK(b.get<nt::VehicleJourney>("vehicle_journey:vj:3:Adapted:0:line_section_on_line:A_diverted") == nullptr);
+    meta_vj = b.get_meta_vj("vj:3");
+    BOOST_CHECK(meta_vj->get_adapted_vj().size() == 0);
+    BOOST_CHECK(meta_vj->get_rt_vj().size() == 0);
 
     // Deleting the disruption
     navitia::delete_disruption("line_section_on_line:A_diverted", *b.data->pt_data, *b.data->meta);
@@ -1240,7 +1300,9 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
     // Check adapted vjs
     BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
 
-    const auto* adapted_vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:first_ls_B_C");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
     BOOST_REQUIRE(adapted_vj);
     BOOST_CHECK(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
     BOOST_CHECK(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
@@ -1280,8 +1342,8 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
     // Check adapted vjs, there should be only 1
     BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
 
-    const auto* second_adapted_vj =
-        b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:first_ls_B_C:Adapted:1:second_ls_E_F");
+    const auto* second_adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
     BOOST_REQUIRE(second_adapted_vj);
     BOOST_CHECK(ba::ends_with(second_adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
     BOOST_CHECK(ba::ends_with(second_adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
@@ -1319,9 +1381,11 @@ BOOST_AUTO_TEST_CASE(multiple_impact_on_line_section) {
     // the 3 impacts should be there
     BOOST_CHECK_EQUAL(meta_vj->get_impacts().size(), 3);
 
+    // Check adapted vjs, there should be only 1
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+
     // Check adapted vjs, there should only be the last one
-    const auto* third_adapted_vj = b.get<nt::VehicleJourney>(
-        "vehicle_journey:vj:1:Adapted:0:first_ls_B_C:Adapted:1:second_ls_E_F:Adapted:1:third_ls_C_G");
+    const auto* third_adapted_vj = meta_vj->get_adapted_vj()[0].get();
     BOOST_REQUIRE(third_adapted_vj);
     BOOST_CHECK(ba::ends_with(third_adapted_vj->adapted_validity_pattern()->days.to_string(), "000111"));
     BOOST_CHECK(ba::ends_with(third_adapted_vj->base_validity_pattern()->days.to_string(), "000000"));
@@ -1364,17 +1428,20 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_with_vj_pass_midnight) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "001001"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const auto* meta_vj = vj->meta_vj;
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().departure_time, "23:01"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().arrival_time, "26:00"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().departure_time, "23:01"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().arrival_time, "26:00"_t);
 
     // Deleting the disruption
     navitia::delete_disruption("line_section_on_line:A_diverted", *b.data->pt_data, *b.data->meta);
@@ -1555,39 +1622,46 @@ BOOST_AUTO_TEST_CASE(add_line_section_impact_on_line_with_repeated_stops) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     // Check adapted vjs
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
-    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    BOOST_CHECK_EQUAL(meta_vj->get_impacts().size(), 1);
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // 6 stop_times since we don't impact the first iteration of each loop
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 6);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(0).stop_point->uri, "s1");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "s2");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "s3");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(3).stop_point->uri, "s4");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(4).stop_point->uri, "s5");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(5).stop_point->uri, "s6");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 6);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(0).stop_point->uri, "s1");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(1).stop_point->uri, "s2");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(2).stop_point->uri, "s3");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(3).stop_point->uri, "s4");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(4).stop_point->uri, "s5");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(5).stop_point->uri, "s6");
 
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:2:Adapted:0:line_section_sa1_sa5_routesA1-2-3");
-    BOOST_CHECK_EQUAL(vj->meta_vj->get_impacts().size(), 1);
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:2");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    BOOST_CHECK_EQUAL(adapted_vj->meta_vj->get_impacts().size(), 1);
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 5);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 5);
     std::vector<std::string> target_uris = {"s1", "s5", "s4", "s3", "s6"};
-    for (size_t i = 0; i < vj->stop_time_list.size(); i++) {
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(i).stop_point->uri, target_uris.at(i));
+    for (size_t i = 0; i < adapted_vj->stop_time_list.size(); i++) {
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(i).stop_point->uri, target_uris.at(i));
     }
 
     // route:A3 shouldn't be impacted, the adapted vj shouldn't exist
-    BOOST_CHECK(b.get<nt::VehicleJourney>("vehicle_journey:vj:3:Adapted:0:line_section_sa1_sa5_routesA1-2-3")
-                == nullptr);
+    meta_vj = b.get_meta_vj("vj:3");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 0);
+
     // route:A4 wasn't in the list of impacted route
-    BOOST_CHECK(b.get<nt::VehicleJourney>("vehicle_journey:vj:4:Adapted:0:line_section_sa1_sa5_routesA1-2-3")
-                == nullptr);
+    meta_vj = b.get_meta_vj("vj:4");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 0);
 
     // Deleting the disruption
     navitia::delete_disruption("line_section_sa1_sa5_routesA1-2-3", *b.data->pt_data, *b.data->meta);
@@ -1737,37 +1811,46 @@ BOOST_AUTO_TEST_CASE(add_multiple_impact_on_line_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "001000"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "001100"), base_vp);
 
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_stop:area4-5");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 3);
+
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000011"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:1:line_section_on_line:A_stop:area3-4");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    adapted_vj = meta_vj->get_adapted_vj()[1].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "001000"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:3:Adapted:0:line_section_on_line:A_stop:area3-4");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    //     vj = b.get<nt::VehicleJourney>(
+    // "vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_stop:area4-5:Adapted:2:line_section_on_line:A_stop:"
+    // "area3-4");
+
+    adapted_vj = meta_vj->get_adapted_vj()[2].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000100"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
-    vj = b.get<nt::VehicleJourney>(
-        "vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_stop:area4-5:Adapted:2:line_section_on_line:A_stop:"
-        "area3-4");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    // adapted_vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:3:Adapted:0:line_section_on_line:A_stop:area3-4");
+
+    meta_vj = b.get_meta_vj("vj:3");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000100"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
-    vj = b.get<nt::VehicleJourney>(
-        "vehicle_journey:vj:2:Adapted:0:line_section_on_line:A_stop:area4-5:Adapted:1:line_section_on_line:A_stop:"
-        "area3-4");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:2");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 }
@@ -1875,19 +1958,22 @@ BOOST_AUTO_TEST_CASE(impact_with_boarding_alighting_times) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().alighting_time, "08:45"_t);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "1111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "0000000"), base_vp);
     // The adapted vj should have only 2 stop_times and kept the boarding_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().departure_time, "08:11"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().boarding_time, "08:06"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().arrival_time, "08:40"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().alighting_time, "08:45"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().departure_time, "08:11"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().boarding_time, "08:06"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().arrival_time, "08:40"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().alighting_time, "08:45"_t);
 }
 
 BOOST_AUTO_TEST_CASE(impact_lollipop_with_boarding_alighting_times) {
@@ -1934,18 +2020,21 @@ BOOST_AUTO_TEST_CASE(impact_lollipop_with_boarding_alighting_times) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(3).alighting_time, "08:45"_t);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "1111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "0000000"), base_vp);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(0).boarding_time, "08:06"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(0).alighting_time, "08:10"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:01"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).alighting_time, "08:40"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).boarding_time, "08:41"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).alighting_time, "08:45"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(0).boarding_time, "08:06"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(0).alighting_time, "08:10"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(1).boarding_time, "08:01"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(1).alighting_time, "08:40"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(2).boarding_time, "08:41"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(2).alighting_time, "08:45"_t);
 }
 
 /*
@@ -2048,8 +2137,9 @@ BOOST_AUTO_TEST_CASE(test_indexes_after_applying_disruption) {
     BOOST_REQUIRE_EQUAL(resp.vehicle_journeys(1).uri(), "vehicle_journey:vj:1");
     BOOST_REQUIRE_EQUAL(resp.vehicle_journeys(2).uri(), "vehicle_journey:vj:2");
     BOOST_REQUIRE_EQUAL(resp.vehicle_journeys(3).uri(), "vehicle_journey:vj:3");
-    BOOST_REQUIRE_EQUAL(resp.vehicle_journeys(4).uri(), "vehicle_journey:vj:3:Adapted:0:Disruption_C1");
-    BOOST_REQUIRE_EQUAL(resp.vehicle_journeys(5).uri(), "vehicle_journey:vj:2:Adapted:1:Disruption_C:Disruption_D");
+
+    BOOST_CHECK(boost::algorithm::contains(resp.vehicle_journeys(4).uri(), "vehicle_journey:vj:3:Adapted:"));
+    BOOST_CHECK(boost::algorithm::contains(resp.vehicle_journeys(5).uri(), "vehicle_journey:vj:2:Adapted:"));
 }
 
 BOOST_AUTO_TEST_CASE(significant_delay_on_stop_point_dont_remove_it) {
@@ -2142,15 +2232,16 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
     BOOST_CHECK_MESSAGE(ba::ends_with(vj1->rt_validity_pattern()->days.to_string(), "11110111"),
                         vj1->rt_validity_pattern()->days);
 
-    auto rt_vj1 =
-        b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:0:Penguins on fire at Montparnasse"];
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
 
-    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj1->base_validity_pattern()->days.to_string(), "00000000"),
-                        rt_vj1->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj1->adapted_validity_pattern()->days.to_string(), "00001000"),
-                        rt_vj1->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00001000"),
-                        rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "00000000"),
+                        adapted_vj->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "00001000"),
+                        adapted_vj->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->rt_validity_pattern()->days.to_string(), "00001000"),
+                        adapted_vj->rt_validity_pattern()->days);
 
     navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "coffee spilled on the line")
                                   .severity(nt::disruption::Effect::NO_SERVICE)
@@ -2159,12 +2250,12 @@ BOOST_AUTO_TEST_CASE(test_adapted_disruptions_on_stop_point_then_line) {
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
-    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj1->base_validity_pattern()->days.to_string(), "00000000"),
-                        rt_vj1->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj1->adapted_validity_pattern()->days.to_string(), "00000000"),
-                        rt_vj1->rt_validity_pattern()->days);
-    BOOST_CHECK_MESSAGE(ba::ends_with(rt_vj1->rt_validity_pattern()->days.to_string(), "00000000"),
-                        rt_vj1->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->base_validity_pattern()->days.to_string(), "00000000"),
+                        adapted_vj->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "00000000"),
+                        adapted_vj->rt_validity_pattern()->days);
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->rt_validity_pattern()->days.to_string(), "00000000"),
+                        adapted_vj->rt_validity_pattern()->days);
 }
 
 // We check that with a disruption with two impacts impacting the same vj the update is working.
@@ -2376,15 +2467,18 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section_with_successive_stop_in_same_are
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:20");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:20");
 }
 
 /*
@@ -2436,17 +2530,20 @@ BOOST_AUTO_TEST_CASE(add_impact_lollipop_vj_impact_stop_only_once) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have 3 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).departure_time, "08:41"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(1).departure_time, "08:41"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 }
 
 // Show a limitation of the current algorithm
@@ -2489,16 +2586,19 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have 3 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 
     // And a second time on a slightly different calendar
     navitia::apply_disruption(
@@ -2525,11 +2625,10 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     }
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>(
-        "vehicle_journey:vj:1:Adapted:0:line_section_on_line:A_diverted:Adapted:2:line_section_on_line:A_diverted_"
-        "twice");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 2);
+    adapted_vj = meta_vj->get_adapted_vj()[1].get();
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have 3 stop_times
@@ -2539,9 +2638,9 @@ BOOST_AUTO_TEST_CASE(limitation_impact_repeated_stop_points_same_stop_time) {
     // of rank 1 for the stop_time initially of rank 3 (both are on stop_point:20).
     // We are lead to believe it is impacted even if it is not in reality.
     // Nothing we can do really since there is no hard link between the adapted stop_time and base one
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);  // Should be 3 [10, 20, 40]
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);  // Should be 3 [10, 20, 40]
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
 }
 
 BOOST_AUTO_TEST_CASE(impact_with_same_start_date_application_patterns) {
@@ -3322,31 +3421,34 @@ void check_rail_section_impact(const ed::builder& b) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:A-1:Adapted:0:rail_section_on_line1");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:A-1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times, for A, B and C stop point
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
     // stopA
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].pick_up_allowed(), true);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].drop_off_allowed(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].skipped_stop(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].departure_time, "08:00"_t);
-    // stopB
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].pick_up_allowed(), true);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].drop_off_allowed(), true);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].skipped_stop(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].departure_time, "08:10"_t);
-    // stopC
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopC");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].pick_up_allowed(), false);  // pick-up is forbidden now
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].drop_off_allowed(), true);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].skipped_stop(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].departure_time, "08:20"_t);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].pick_up_allowed(), true);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].drop_off_allowed(), false);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].departure_time, "08:00"_t);
+    // stopB            adapted_vj
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].pick_up_allowed(), true);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].drop_off_allowed(), true);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].departure_time, "08:10"_t);
+    // stopC            adapted_vj
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopC");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].pick_up_allowed(), false);  // pick-up is forbidden now
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].drop_off_allowed(), true);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].departure_time, "08:20"_t);
 
     // disruption
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
@@ -3479,48 +3581,51 @@ BOOST_AUTO_TEST_CASE(classic_impact_with_rail_section) {
         BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
         // Check the adapted vj
-        vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:A-1:Adapted:0:rail_section_on_line1");
-        adapted_vp = vj->adapted_validity_pattern()->days;
-        base_vp = vj->base_validity_pattern()->days;
+        const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:A-1");
+        BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+        const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+        adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+        base_vp = adapted_vj->base_validity_pattern()->days;
         BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
         BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 6);
-        // stopA
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].pick_up_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].drop_off_allowed(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].skipped_stop(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].departure_time, "08:00"_t);
-        // stopB
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].pick_up_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].drop_off_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].skipped_stop(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].departure_time, "08:10"_t);
-        // stopC
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopC");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].pick_up_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].drop_off_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].skipped_stop(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].departure_time, "08:20"_t);
-        // stopD
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].stop_point->uri, "stopD");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].pick_up_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].drop_off_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].skipped_stop(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].departure_time, "08:30"_t);
-        // stopE
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].stop_point->uri, "stopE");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].pick_up_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].drop_off_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].skipped_stop(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].departure_time, "08:40"_t);
-        // stopF
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].stop_point->uri, "stopF");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].pick_up_allowed(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].drop_off_allowed(), true);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].skipped_stop(), false);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].departure_time, "08:50"_t);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 6);
+        // stopA            adapted_vj
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].pick_up_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].drop_off_allowed(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].skipped_stop(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].departure_time, "08:00"_t);
+        // stopB            adapted_vj
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].pick_up_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].drop_off_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].skipped_stop(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].departure_time, "08:10"_t);
+        // stopC            adapted_vj
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopC");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].pick_up_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].drop_off_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].skipped_stop(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].departure_time, "08:20"_t);
+        // stopD            adapted_vj
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].stop_point->uri, "stopD");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].pick_up_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].drop_off_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].skipped_stop(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].departure_time, "08:30"_t);
+        // stopE            adapted_vj
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].stop_point->uri, "stopE");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].pick_up_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].drop_off_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].skipped_stop(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].departure_time, "08:40"_t);
+        // stopF            adapted_vj
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].stop_point->uri, "stopF");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].pick_up_allowed(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].drop_off_allowed(), true);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].skipped_stop(), false);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].departure_time, "08:50"_t);
         // disruption
         BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
         BOOST_REQUIRE_EQUAL(b.get<nt::StopPoint>("stopA")->get_impacts().size(), 0);
@@ -3826,16 +3931,19 @@ BOOST_AUTO_TEST_CASE(classic_impact_with_long_rail_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:A-1:Adapted:0:rail_section_on_line1");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:A-1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times, for A, B and C stop point
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopC");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopC");
 
     // disruption
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
@@ -3921,16 +4029,19 @@ BOOST_AUTO_TEST_CASE(classic_impact_rail_section_with_start_and_end_sa_in_blocke
         BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
         // Check the adapted vj
-        vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:A-1:Adapted:0:rail_section_on_line1");
-        adapted_vp = vj->adapted_validity_pattern()->days;
-        base_vp = vj->base_validity_pattern()->days;
+        const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:A-1");
+        BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+        const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+        adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+        base_vp = adapted_vj->base_validity_pattern()->days;
         BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
         BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
         // The adapted vj should have only 2 stop_times, for A, B and C stop point
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopC");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopC");
 
         // disruption
         BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
@@ -3992,15 +4103,18 @@ BOOST_AUTO_TEST_CASE(classic_impact_rail_section_with_start_and_end_sa_in_blocke
         BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "111111"), base_vp);
 
         // Check the adapted vj
-        vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:A-1:Adapted:0:rail_section_on_line1");
-        adapted_vp = vj->adapted_validity_pattern()->days;
-        base_vp = vj->base_validity_pattern()->days;
+        const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:A-1");
+        BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+        const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+        adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+        base_vp = adapted_vj->base_validity_pattern()->days;
         BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
         BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
         // The adapted vj should have only 2 stop_times, for A and B stop point
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-        BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+        BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
 
         // disruption
         BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
@@ -4427,15 +4541,18 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:rail_section_on_line1-1");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times, for A and B stop point
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
 
     // disruption
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
@@ -4470,15 +4587,18 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:4:Adapted:0:rail_section_on_line1-2");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:4");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times, for A and B stop point
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
 
     // disruptions
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 2);
@@ -4515,15 +4635,18 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:5:Adapted:0:rail_section_on_line1-3");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:5");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times, for A and B stop point
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 2);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 2);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
 
     // disruptions
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 3);
@@ -4591,20 +4714,23 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section_reduced_service) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:rail_section_on_line1-1");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 7 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 7);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopE");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].stop_point->uri, "stopF");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].stop_point->uri, "stopG");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].stop_point->uri, "stopH");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[6].stop_point->uri, "stopI");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 7);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopE");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].stop_point->uri, "stopF");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].stop_point->uri, "stopG");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].stop_point->uri, "stopH");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[6].stop_point->uri, "stopI");
 
     // disruption
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);
@@ -4639,19 +4765,22 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section_reduced_service) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:4:Adapted:0:rail_section_on_line1-2");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:4");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 6 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 6);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopO");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].stop_point->uri, "stopG");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].stop_point->uri, "stopH");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].stop_point->uri, "stopI");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 6);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopO");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].stop_point->uri, "stopG");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].stop_point->uri, "stopH");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].stop_point->uri, "stopI");
 
     // disruptions
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 2);
@@ -4688,16 +4817,19 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section_reduced_service) {
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:5:Adapted:0:rail_section_on_line1-3");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:5");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 2 stop_times, for A and B stop point
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopA");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopB");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopR");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 3);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopA");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopB");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopR");
 
     // disruptions
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 3);
@@ -4760,19 +4892,22 @@ BOOST_AUTO_TEST_CASE(complex_impact_with_rail_section_reduced_service_first_stop
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "111110"), adapted_vp);
 
     // Check the adapted vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:Adapted:0:rail_section_on_line1-1");
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000001"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
     // The adapted vj should have only 7 stop_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 6);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[0].stop_point->uri, "stopD");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[1].stop_point->uri, "stopE");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].stop_point->uri, "stopF");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[3].stop_point->uri, "stopG");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[4].stop_point->uri, "stopH");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[5].stop_point->uri, "stopI");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list.size(), 6);
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[0].stop_point->uri, "stopD");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[1].stop_point->uri, "stopE");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[2].stop_point->uri, "stopF");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[3].stop_point->uri, "stopG");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[4].stop_point->uri, "stopH");
+    BOOST_REQUIRE_EQUAL(adapted_vj->stop_time_list[5].stop_point->uri, "stopI");
 
     // disruption
     BOOST_REQUIRE_EQUAL(b.data->pt_data->disruption_holder.nb_disruptions(), 1);

--- a/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
+++ b/source/kraken/tests/fill_disruption_from_chaos_tests.cpp
@@ -41,6 +41,7 @@ www.navitia.io
 #include "kraken/apply_disruption.h"
 #include "type/chaos.pb.h"
 #include "type/gtfs-realtime.pb.h"
+#include "type/meta_vehicle_journey.h"
 #include <boost/range/algorithm/for_each.hpp>
 #include <boost/range/algorithm/find_if.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -269,29 +270,42 @@ BOOST_AUTO_TEST_CASE(add_impact_and_update_on_stop_area) {
 
     navitia::make_and_apply_disruption(disruption, *b.data->pt_data, *b.data->meta);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 4);
-    auto vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:1:test01"];
-    BOOST_CHECK(vj->base_validity_pattern()->days.none());
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000110"),
-                        vj->adapted_validity_pattern()->days);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:2:Adapted:1:test01"];
-    BOOST_CHECK(vj->base_validity_pattern()->days.none());
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000110"),
-                        vj->adapted_validity_pattern()->days);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    BOOST_CHECK(adapted_vj->base_validity_pattern()->days.none());
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "000110"),
+                        adapted_vj->adapted_validity_pattern()->days);
+
+    meta_vj = b.get_meta_vj("vj:2");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    BOOST_CHECK(adapted_vj->base_validity_pattern()->days.none());
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "000110"),
+                        adapted_vj->adapted_validity_pattern()->days);
     check(*b.data);
 
     navitia::make_and_apply_disruption(disruption, *b.data->pt_data, *b.data->meta);
     BOOST_REQUIRE_EQUAL(b.data->pt_data->vehicle_journeys.size(), 4);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:1:test01"];
-    BOOST_CHECK(vj->base_validity_pattern()->days.none());
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000110"),
-                        vj->adapted_validity_pattern()->days);
+    meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:2:Adapted:1:test01"];
-    BOOST_CHECK(vj->base_validity_pattern()->days.none());
-    BOOST_CHECK_MESSAGE(ba::ends_with(vj->adapted_validity_pattern()->days.to_string(), "000110"),
-                        vj->adapted_validity_pattern()->days);
+    BOOST_CHECK(adapted_vj->base_validity_pattern()->days.none());
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "000110"),
+                        adapted_vj->adapted_validity_pattern()->days);
+
+    meta_vj = b.get_meta_vj("vj:2");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    BOOST_CHECK(adapted_vj->base_validity_pattern()->days.none());
+    BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vj->adapted_validity_pattern()->days.to_string(), "000110"),
+                        adapted_vj->adapted_validity_pattern()->days);
 
     check(*b.data);
 
@@ -501,21 +515,30 @@ BOOST_AUTO_TEST_CASE(add_impact_on_line_section) {
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "100100"), base_vp);
 
     // Check the created vj, they shouldn't have any base validity pattern
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:1:Adapted:0:dis_ls1"];
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    const auto* adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000111"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:2:Adapted:0:dis_ls1"];
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:2");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000011"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 
-    vj = b.data->pt_data->vehicle_journeys_map["vehicle_journey:vj:3:Adapted:0:dis_ls1"];
-    adapted_vp = vj->adapted_validity_pattern()->days;
-    base_vp = vj->base_validity_pattern()->days;
+    meta_vj = b.get_meta_vj("vj:3");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_adapted_vj().size(), 1);
+    adapted_vj = meta_vj->get_adapted_vj()[0].get();
+
+    adapted_vp = adapted_vj->adapted_validity_pattern()->days;
+    base_vp = adapted_vj->base_validity_pattern()->days;
     BOOST_CHECK_MESSAGE(ba::ends_with(adapted_vp.to_string(), "000100"), adapted_vp);
     BOOST_CHECK_MESSAGE(ba::ends_with(base_vp.to_string(), "000000"), base_vp);
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -1775,24 +1775,26 @@ BOOST_AUTO_TEST_CASE(delays_with_boarding_alighting_times) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().alighting_time, "08:45"_t);
 
     // Check the realtime vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:0:feed");
-    BOOST_CHECK_EQUAL(vj->name, "vj:1");
-    BOOST_CHECK_END_VP(vj->rt_validity_pattern(), "0000010");
-    BOOST_CHECK_END_VP(vj->base_validity_pattern(), "0000000");
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+
+    BOOST_CHECK_EQUAL(rt_vj->name, "vj:1");
+    BOOST_CHECK_END_VP(rt_vj->rt_validity_pattern(), "0000010");
+    BOOST_CHECK_END_VP(rt_vj->base_validity_pattern(), "0000000");
     // The realtime vj should have all 4 stop_times and kept the boarding_times
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().stop_point->uri, "stop_point:10");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().departure_time, "08:11"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.front().boarding_time, "08:06"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).departure_time, "08:21"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:21"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "stop_point:30");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).departure_time, "08:41"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.at(2).boarding_time, "08:41"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().stop_point->uri, "stop_point:40");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().arrival_time, "08:50"_t);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.back().alighting_time, "08:55"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.size(), 4);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.front().stop_point->uri, "stop_point:10");
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.front().departure_time, "08:11"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.front().boarding_time, "08:06"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.at(1).departure_time, "08:21"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.at(1).boarding_time, "08:21"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.at(2).stop_point->uri, "stop_point:30");
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.at(2).departure_time, "08:41"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.at(2).boarding_time, "08:41"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.back().stop_point->uri, "stop_point:40");
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.back().arrival_time, "08:50"_t);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.back().alighting_time, "08:55"_t);
 }
 
 BOOST_AUTO_TEST_CASE(delays_on_lollipop_with_boarding_alighting_times) {
@@ -1823,23 +1825,25 @@ BOOST_AUTO_TEST_CASE(delays_on_lollipop_with_boarding_alighting_times) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
 
     // Check the realtime vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:0:feed");
-    BOOST_CHECK_END_VP(vj->rt_validity_pattern(), "0000010");
-    BOOST_CHECK_END_VP(vj->base_validity_pattern(), "0000000");
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+
+    BOOST_CHECK_END_VP(rt_vj->rt_validity_pattern(), "0000010");
+    BOOST_CHECK_END_VP(rt_vj->base_validity_pattern(), "0000000");
 
     // The realtime vj should have all 3 stop_times
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(0).stop_point->uri, "stop_point:10");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(0).departure_time, "08:11"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(0).boarding_time,
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(0).stop_point->uri, "stop_point:10");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(0).departure_time, "08:11"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(0).boarding_time,
                       "08:06"_t);  // Boarding time is 5 min (300s) before departure
 
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).departure_time, "08:21"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:21"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).stop_point->uri, "stop_point:20");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).departure_time, "08:21"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).boarding_time, "08:21"_t);
 
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "stop_point:10");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).arrival_time, "08:40"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).alighting_time,
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).stop_point->uri, "stop_point:10");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).arrival_time, "08:40"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).alighting_time,
                       "08:45"_t);  // Alighting time is 5 min (300s) after arrival
 }
 
@@ -1866,27 +1870,28 @@ BOOST_AUTO_TEST_CASE(simple_skipped_stop) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
 
     // Check the realtime vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:0:feed");
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
     // The realtime vj should have all 3 stop_times but lose the ability to pickup/dropoff on B
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 3);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().stop_point->uri, "A");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().departure_time, "08:10"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().boarding_time, "08:10"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().pick_up_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().drop_off_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().skipped_stop(), false);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "B");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).departure_time, "08:20"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:20"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).pick_up_allowed(), false);  // disabled
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).drop_off_allowed(), false);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).skipped_stop(), false);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "C");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).arrival_time, "08:30"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).alighting_time, "08:30"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).pick_up_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).drop_off_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.size(), 3);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().stop_point->uri, "A");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().departure_time, "08:10"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().boarding_time, "08:10"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().pick_up_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().drop_off_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().skipped_stop(), false);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).stop_point->uri, "B");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).departure_time, "08:20"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).boarding_time, "08:20"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).pick_up_allowed(), false);  // disabled
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).drop_off_allowed(), false);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).skipped_stop(), false);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).stop_point->uri, "C");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).arrival_time, "08:30"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).alighting_time, "08:30"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).pick_up_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).drop_off_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).skipped_stop(), false);
 
     auto get_journeys = [&](nt::RTLevel level, const std::string& from, const std::string& to) {
         return raptor.compute(b.get<nt::StopArea>(from), b.get<nt::StopArea>(to), "08:00"_t, 0,
@@ -1943,35 +1948,40 @@ BOOST_AUTO_TEST_CASE(skipped_stop_then_delay) {
     BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
 
     // Check the realtime vj
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:0:feed");
-    BOOST_CHECK_END_VP(vj->rt_validity_pattern(), "0000001");
-    BOOST_CHECK_END_VP(vj->base_validity_pattern(), "0000000");
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    // two disruptions applied, there should be only one realtime vj
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    auto rt_vj = meta_vj->get_rt_vj()[0].get();
+
+    BOOST_CHECK_END_VP(rt_vj->rt_validity_pattern(), "0000001");
+    BOOST_CHECK_END_VP(rt_vj->base_validity_pattern(), "0000000");
     // The realtime vj should have all 3 stop_times but lose the ability to pickup/dropoff on B
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().stop_point->uri, "A");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().departure_time, "08:10"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().boarding_time, "08:10"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().pick_up_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().drop_off_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.front().skipped_stop(), false);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).stop_point->uri, "B");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).departure_time, "08:20"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).boarding_time, "08:20"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).pick_up_allowed(), false);  // disabled
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).drop_off_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(1).skipped_stop(), false);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).stop_point->uri, "C");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).arrival_time, "08:35"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).alighting_time, "08:35"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).pick_up_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).drop_off_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(2).skipped_stop(), false);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(3).stop_point->uri, "D");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(3).arrival_time, "08:40"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(3).alighting_time, "08:40"_t);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(3).pick_up_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(3).drop_off_allowed(), true);
-    BOOST_CHECK_EQUAL(vj->stop_time_list.at(3).skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.size(), 4);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().stop_point->uri, "A");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().departure_time, "08:10"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().boarding_time, "08:10"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().pick_up_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().drop_off_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.front().skipped_stop(), false);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).stop_point->uri, "B");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).departure_time, "08:20"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).boarding_time, "08:20"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).pick_up_allowed(), false);  // disabled
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).drop_off_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(1).skipped_stop(), false);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).stop_point->uri, "C");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).arrival_time, "08:35"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).alighting_time, "08:35"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).pick_up_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).drop_off_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(2).skipped_stop(), false);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(3).stop_point->uri, "D");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(3).arrival_time, "08:40"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(3).alighting_time, "08:40"_t);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(3).pick_up_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(3).drop_off_allowed(), true);
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.at(3).skipped_stop(), false);
 
     auto get_journeys = [&](nt::RTLevel level, const std::string& from, const std::string& to) {
         return raptor.compute(b.get<nt::StopArea>(from), b.get<nt::StopArea>(to), "08:00"_t, 0,
@@ -2332,11 +2342,16 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
 
     // Check the realtime vj with a newly added stop_time
     // Il should be initialize with skipped_stop = false
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:0:feed-1");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].pick_up_allowed(), true);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].drop_off_allowed(), true);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].skipped_stop(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
+    // Check the realtime vj
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    // two disruptions applied, there should be only one realtime vj
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].pick_up_allowed(), true);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].drop_off_allowed(), true);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.size(), 4);
 
     // The new stop_time added should be in stop_date_times
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
@@ -2370,11 +2385,15 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
     b.finalize_disruption_batch();
 
     // Check the realtime vj after the recently added stop_time is deleted
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:1:feed-2");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].pick_up_allowed(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].drop_off_allowed(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].skipped_stop(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
+    meta_vj = b.get_meta_vj("vj:1");
+    // two disruptions applied, there should be only one realtime vj
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].pick_up_allowed(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].drop_off_allowed(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].skipped_stop(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.size(), 4);
 
     // The new stop_time added should be in stop_date_times
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
@@ -2412,11 +2431,15 @@ BOOST_AUTO_TEST_CASE(add_modify_and_delete_new_stop_time_in_the_trip) {
     b.finalize_disruption_batch();
 
     // Check the realtime vj after the recently added stop_time is deleted twice
-    vj = b.get<nt::VehicleJourney>("vehicle_journey:vj:1:modified:1:feed-3");
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list.size(), 4);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].pick_up_allowed(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].drop_off_allowed(), false);
-    BOOST_REQUIRE_EQUAL(vj->stop_time_list[2].skipped_stop(), false);
+    meta_vj = b.get_meta_vj("vj:1");
+    // two disruptions applied, there should be only one realtime vj
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list.size(), 4);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].pick_up_allowed(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].drop_off_allowed(), false);
+    BOOST_REQUIRE_EQUAL(rt_vj->stop_time_list[2].skipped_stop(), false);
 
     res = compute("20171101T073000", "stop_point:A", "stop_point:C");
     BOOST_CHECK_EQUAL(res.impacts_size(), 3);
@@ -3059,24 +3082,27 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_CHECK_EQUAL(vj->adapted_validity_pattern()->days, year("11111111"));
     BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, year("11111111"));
 
-    vj = pt_data.vehicle_journeys_map["vehicle_journey:vj_new_trip:modified:0:feed-1"];
-    BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
-    BOOST_CHECK_EQUAL(vj->company->name, comp_name);
-    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
-    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
-    BOOST_CHECK_EQUAL(vj->dataset->uri, dataset_uri);
-    BOOST_CHECK_EQUAL(vj->dataset->name, dataset_name);
-    BOOST_CHECK_EQUAL(vj->dataset->contributor->uri, contributor_uri);
-    BOOST_CHECK_EQUAL(vj->dataset->contributor->name, contributor_name);
-    BOOST_CHECK_EQUAL(vj->uri, "vehicle_journey:vj_new_trip:modified:0:feed-1");
-    BOOST_CHECK_EQUAL(vj->idx, 1);
-    BOOST_CHECK_EQUAL(vj->name, "");
-    BOOST_CHECK_EQUAL(vj->headsign, "");
-    BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.size(), 4);
-    BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));
-    BOOST_CHECK_EQUAL(vj->adapted_validity_pattern()->days, year("00000000"));
-    BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, year("00000001"));
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj_new_trip");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_EQUAL(rt_vj->company->uri, comp_uri);
+    BOOST_CHECK_EQUAL(rt_vj->company->name, comp_name);
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->name, phy_mode_name);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->uri, dataset_uri);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->name, dataset_name);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->contributor->uri, contributor_uri);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->contributor->name, contributor_name);
+    BOOST_ASSERT(boost::algorithm::contains(rt_vj->uri, "RealTime"));
+    BOOST_CHECK_EQUAL(rt_vj->idx, 1);
+    BOOST_CHECK_EQUAL(rt_vj->name, "");
+    BOOST_CHECK_EQUAL(rt_vj->headsign, "");
+    BOOST_CHECK_EQUAL(rt_vj->meta_vj->get_label(), "vj_new_trip");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.size(), 4);
+    BOOST_CHECK_EQUAL(rt_vj->base_validity_pattern()->days, year("00000000"));
+    BOOST_CHECK_EQUAL(rt_vj->adapted_validity_pattern()->days, year("00000000"));
+    BOOST_CHECK_EQUAL(rt_vj->rt_validity_pattern()->days, year("00000001"));
 
     // verify that filters &since and &until work well with vehicle_jouneys added by realtime (added trip)
     // Note: For backward compatibility parameter &data_freshness with base_schedule is added and works
@@ -3209,25 +3235,28 @@ BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {
     BOOST_REQUIRE_EQUAL(pt_data.vehicle_journeys.size(), 3);
 
     // New VJ
-    vj = pt_data.vehicle_journeys_map["vehicle_journey:vj_new_trip_2:modified:0:feed-2"];
-    BOOST_CHECK_EQUAL(vj->company->uri, comp_uri);
-    BOOST_CHECK_EQUAL(vj->company->name, comp_name);
-    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
-    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
-    BOOST_CHECK_EQUAL(vj->dataset->uri, dataset_uri);
-    BOOST_CHECK_EQUAL(vj->dataset->name, dataset_name);
-    BOOST_CHECK_EQUAL(vj->dataset->contributor->uri, contributor_uri);
-    BOOST_CHECK_EQUAL(vj->dataset->contributor->name, contributor_name);
-    BOOST_CHECK_EQUAL(vj->uri, "vehicle_journey:vj_new_trip_2:modified:0:feed-2");
-    BOOST_CHECK_EQUAL(vj->idx, 2);
-    BOOST_CHECK_EQUAL(vj->name, "trip_headsign");
-    BOOST_CHECK_EQUAL(vj->headsign, "trip_headsign");
-    BOOST_CHECK_EQUAL(vj->meta_vj->get_label(), "vj_new_trip_2");
-    BOOST_CHECK_EQUAL(vj->stop_time_list.size(), 4);
-    BOOST_CHECK_EQUAL(vj->base_validity_pattern()->days, year("00000000"));
-    BOOST_CHECK_EQUAL(vj->adapted_validity_pattern()->days, year("00000000"));
-    BOOST_CHECK_EQUAL(vj->rt_validity_pattern()->days, year("00000001"));
-    auto st = vj->stop_time_list.front();
+    meta_vj = b.get_meta_vj("vj_new_trip_2");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_EQUAL(rt_vj->company->uri, comp_uri);
+    BOOST_CHECK_EQUAL(rt_vj->company->name, comp_name);
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->name, phy_mode_name);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->uri, dataset_uri);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->name, dataset_name);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->contributor->uri, contributor_uri);
+    BOOST_CHECK_EQUAL(rt_vj->dataset->contributor->name, contributor_name);
+    BOOST_ASSERT(boost::algorithm::contains(rt_vj->uri, "RealTime"));
+    BOOST_CHECK_EQUAL(rt_vj->idx, 2);
+    BOOST_CHECK_EQUAL(rt_vj->name, "trip_headsign");
+    BOOST_CHECK_EQUAL(rt_vj->headsign, "trip_headsign");
+    BOOST_CHECK_EQUAL(rt_vj->meta_vj->get_label(), "vj_new_trip_2");
+    BOOST_CHECK_EQUAL(rt_vj->stop_time_list.size(), 4);
+    BOOST_CHECK_EQUAL(rt_vj->base_validity_pattern()->days, year("00000000"));
+    BOOST_CHECK_EQUAL(rt_vj->adapted_validity_pattern()->days, year("00000000"));
+    BOOST_CHECK_EQUAL(rt_vj->rt_validity_pattern()->days, year("00000001"));
+    auto st = rt_vj->stop_time_list.front();
     BOOST_CHECK_EQUAL(pt_data.headsign_handler.get_headsign(st), "trip_headsign");
 
     // New trip added
@@ -3587,9 +3616,12 @@ BOOST_FIXTURE_TEST_CASE(physical_mode_id_only_impact_additional_service, AddTrip
     b.finalize_disruption_batch();
 
     // physical mode =  base VJ physical mode
-    vj = pt_data.vehicle_journeys_map["vehicle_journey:vj:1:modified:0:feed-1"];
-    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
-    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
+    const navitia::type::MetaVehicleJourney* meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    const auto* rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->name, phy_mode_name);
 
     update_trip = ntest::make_trip_update_message("vj:1", "20190101",
                                                   {
@@ -3605,9 +3637,13 @@ BOOST_FIXTURE_TEST_CASE(physical_mode_id_only_impact_additional_service, AddTrip
     b.finalize_disruption_batch();
 
     // physical mode =  base VJ physical mode
-    vj = pt_data.vehicle_journeys_map["vehicle_journey:vj:1:modified:0:feed-1"];
-    BOOST_CHECK_EQUAL(vj->physical_mode->uri, phy_mode_uri);
-    BOOST_CHECK_EQUAL(vj->physical_mode->name, phy_mode_name);
+    // physical mode =  base VJ physical mode
+    meta_vj = b.get_meta_vj("vj:1");
+    BOOST_REQUIRE_EQUAL(meta_vj->get_rt_vj().size(), 1);
+
+    rt_vj = meta_vj->get_rt_vj()[0].get();
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->uri, phy_mode_uri);
+    BOOST_CHECK_EQUAL(rt_vj->physical_mode->name, phy_mode_name);
 }
 
 BOOST_FIXTURE_TEST_CASE(cannot_add_new_trip_if_id_corresponds_to_a_base_VJ_the_same_day, AddTripDataset) {

--- a/source/position/tests/position_api_tests.cpp
+++ b/source/position/tests/position_api_tests.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -387,8 +387,8 @@ BOOST_FIXTURE_TEST_CASE(test_one_vehicle_position_is_active_realtime_delay, posi
     BOOST_REQUIRE_EQUAL(vehicle_position.vehicle_journey_positions(0).vehicle_journey().uri(), "vehicle_journey:AA");
     BOOST_REQUIRE_EQUAL(vehicle_position.vehicle_journey_positions(0).vehicle_journey().codes().size(), 0);
 
-    BOOST_REQUIRE_EQUAL(vehicle_position.vehicle_journey_positions(1).vehicle_journey().uri(),
-                        "vehicle_journey:BB:modified:0:bob");
+    BOOST_CHECK(boost::algorithm::contains(vehicle_position.vehicle_journey_positions(1).vehicle_journey().uri(),
+                                           "vehicle_journey:BB:RealTime:"));
     BOOST_REQUIRE_EQUAL(vehicle_position.vehicle_journey_positions(1).vehicle_journey().codes().size(), 0);
 }
 
@@ -424,8 +424,8 @@ VJ: KB:         |***************************************************************
     auto vehicle_position = resp.vehicle_positions(0);
     BOOST_REQUIRE_EQUAL(vehicle_position.line().uri(), "line:stop_area:stop01_stop_area:stop02");
     BOOST_REQUIRE_EQUAL(vehicle_position.vehicle_journey_positions().size(), 1);
-    BOOST_REQUIRE_EQUAL(vehicle_position.vehicle_journey_positions(0).vehicle_journey().uri(),
-                        "vehicle_journey:vj_new_trip:modified:0:bob");
+    BOOST_CHECK(boost::algorithm::contains(vehicle_position.vehicle_journey_positions(0).vehicle_journey().uri(),
+                                           "vehicle_journey:vj_new_trip:RealTime:"));
 
     vehicle_position = resp.vehicle_positions(1);
     BOOST_REQUIRE_EQUAL(vehicle_position.line().uri(), "line:AA");

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -337,9 +337,10 @@ struct departure_board_fixture {
                 RTStopTime("stopP3", "20160104T0017"_pts).delay(4_min),
             });
         navitia::handle_realtime("bib", "20160101T1337"_dt, trip_update, *b.data, true, true);
+        const auto* mvj_vjP = b.get_meta_vj("vjP:1");
+        auto* rt_vj_vjP = mvj_vjP->get_rt_vj()[0].get();
 
-        auto* vj = b.data->pt_data->vehicle_journeys_map.at("vehicle_journey:vjP:1:modified:0:bib");
-        b.data->pt_data->codes.add(vj, "source", "vehicle_journey:vjP:1:modified:0:bib");
+        b.data->pt_data->codes.add(rt_vj_vjP, "source", rt_vj_vjP->uri);
 
         //
         //      20160103                    |    20160104
@@ -366,8 +367,11 @@ struct departure_board_fixture {
                 RTStopTime("stopQ3", "20160104T0016"_pts).delay(21_min),
             });
         navitia::handle_realtime("Q", "20160101T1337"_dt, trip_update_q, *b.data, true, true);
-        vj = b.data->pt_data->vehicle_journeys_map.at("vehicle_journey:vjQ:1:modified:0:Q");
-        b.data->pt_data->codes.add(vj, "source", "vehicle_journey:vjQ:1:modified:0:Q");
+
+        const auto* mvj_vjQ = b.get_meta_vj("vjQ:1");
+        auto* rt_vj_vjQ = mvj_vjQ->get_rt_vj()[0].get();
+
+        b.data->pt_data->codes.add(rt_vj_vjQ, "source", rt_vj_vjQ->uri);
 
         b.data->build_raptor();
     }


### PR DESCRIPTION
https://navitia.atlassian.net/browse/NAV-1650

In this PR, several issues are tackled. 

1. when both kirin and chaos are active, we observed a slow memory leak and the disruption's integration speed is slowly exacerbated.  This is due to the infinitely growing uri of the `vehicle_journey` impacted by `RailSecion` and `LineSection`. During my test, I spotted  one of these gargantuan uri attained a length of 33998 characters.

~~2.   A trip may be impacted several times by the disruptions/trip_update from kirin, whereas only the last trip_update will be taken into account. In order to avoid applying trip_updates redundantly, aka faster disruption integration ratio, we just apply the newest trip_update by reversing the buffer and ignoring the older ones which have the same id.~~ To be tackled in another PR

3. Kraken didn't poll all messages from rabbitmq, even though the buffer was not yet full. (5000 by default)
![image](https://user-images.githubusercontent.com/6093486/212330547-20d63846-3f18-41db-a35d-1c345f9b8eb7.png)
This is due to the low timeout(100ms in prod) in `BasicConsumeMessage`. A fast way to fix that is to augment that timeout. The risk is that if disruptions are arriving every (timeout -1ms), in the worst case, we have to wait `buffer_size*(timeout -1ms)` to fill the buffer (ex: 5000*(500-1)ms ~= 25s) before kraken starts to handle them. The solution is to add another timeout to limit that waiting time.    
