### PR TITLE
fix tag in status

### DIFF
--- a/source/cmake_modules/GetGitRevisionDescription.cmake
+++ b/source/cmake_modules/GetGitRevisionDescription.cmake
@@ -108,7 +108,7 @@ function(git_describe _var)
 		"${GIT_EXECUTABLE}"
 		describe
 		${hash}
-		${ARGN}
+		"--tags"
 		WORKING_DIRECTORY
 		"${CMAKE_SOURCE_DIR}"
 		RESULT_VARIABLE


### PR DESCRIPTION
use `git describe --tags` instead of `git describe` to recover the version tag in jormun and kraken