### PR TITLE
Replace _get_authorized_instances

### DIFF
--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -39,6 +39,7 @@ import glob
 import logging
 from jormungandr.protobuf_to_dict import protobuf_to_dict
 from jormungandr.exceptions import ApiNotFound, RegionNotFound, DeadSocketException, InvalidArguments
+from jormungandr.authentication import get_all_available_instances
 from jormungandr import authentication, cache, app
 from jormungandr.instance import Instance
 import gevent
@@ -99,7 +100,7 @@ class InstanceManager(object):
         self.start_ping = start_ping
         self.instances = {}
         self.context = zmq.Context()
-        self.is_ready = False
+        self.is_ready = False  # type: bool
 
     def __repr__(self):
         return '<InstanceManager>'
@@ -297,7 +298,7 @@ class InstanceManager(object):
         else:
             # Requests without any coverage
             # fetch all the authorized instances (free + private) using cached function has_access()
-            authorized_instances = self._get_authorized_instances(user, api)
+            authorized_instances = get_all_available_instances(user)  # self._get_authorized_instances(user, api)
             if not authorized_instances:
                 # user doesn't have access to any of the instances
                 context = 'User has no access to any instance'

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -40,7 +40,7 @@ import logging
 from jormungandr.protobuf_to_dict import protobuf_to_dict
 from jormungandr.exceptions import ApiNotFound, RegionNotFound, DeadSocketException, InvalidArguments
 from jormungandr.authentication import abort_request, can_read_user
-from jormungandr import authentication, cache, app
+from jormungandr import authentication, cache, memory_cache, app
 from jormungandr.instance import Instance
 import gevent
 import os
@@ -343,6 +343,8 @@ class InstanceManager(object):
             response['regions'].append(resp_dict)
         return response
 
+    @memory_cache.memoize(app.config[str('MEMORY_CACHE_CONFIGURATION')].get(str('TIMEOUT_AUTHENTICATION'), 30))
+    @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_AUTHENTICATION'), 300))
     def get_all_available_instances(self, user):
         result = []
         if app.config.get('PUBLIC', False) or app.config.get('DISABLE_DATABASE', False):

--- a/source/jormungandr/jormungandr/tests/instance_manager_tests.py
+++ b/source/jormungandr/jormungandr/tests/instance_manager_tests.py
@@ -52,7 +52,12 @@ def manager():
     return instance_manager
 
 
-def get_instances_test(manager):
+def get_instances_test(manager, mocker):
+    mock = mocker.patch.object(
+        manager,
+        'get_all_available_instances',
+        return_value=[manager.instances['paris'], manager.instances['pdl']],
+    )
     with app.test_request_context('/'):
         instances = manager.get_instances()
         assert len(instances) == 2
@@ -67,6 +72,11 @@ def get_instances_by_coord_test(manager, mocker):
     mock = mocker.patch.object(
         manager, '_all_keys_of_coord_in_instances', return_value=[manager.instances['paris']]
     )
+    mock = mocker.patch.object(
+        manager,
+        'get_all_available_instances',
+        return_value=[manager.instances['paris'], manager.instances['pdl']],
+    )
     with app.test_request_context('/'):
         instances = manager.get_instances(lon=4, lat=3)
         assert len(instances) == 1
@@ -76,6 +86,11 @@ def get_instances_by_coord_test(manager, mocker):
 
 def get_instances_by_object_id_test(manager, mocker):
     mock = mocker.patch.object(manager, '_all_keys_of_id_in_instances', return_value=[manager.instances['pdl']])
+    mock = mocker.patch.object(
+        manager,
+        'get_all_available_instances',
+        return_value=[manager.instances['paris'], manager.instances['pdl']],
+    )
     with app.test_request_context('/'):
         instances = manager.get_instances(object_id='sa:pdl')
         assert len(instances) == 1

--- a/source/jormungandr/tests/coverage_tests.py
+++ b/source/jormungandr/tests/coverage_tests.py
@@ -29,11 +29,24 @@
 from __future__ import absolute_import, print_function, unicode_literals, division
 from .tests_mechanism import AbstractTestFixture, dataset
 from .check_utils import *
+from jormungandr import app
 import logging
 
 
+class CoverageTestFixture(AbstractTestFixture):
+    def setUp(self):
+        self.old_public_val = app.config['PUBLIC']
+        app.config['PUBLIC'] = True
+        self.old_db_val = app.config['DISABLE_DATABASE']
+        app.config['DISABLE_DATABASE'] = True
+
+    def tearDown(self):
+        app.config['PUBLIC'] = self.old_public_val
+        app.config['DISABLE_DATABASE'] = self.old_db_val
+
+
 @dataset({"main_routing_test": {}, "null_status_test": {}})
-class TestNullStatus(AbstractTestFixture):
+class TestNullStatus(CoverageTestFixture):
     """
     Test with an empty coverage
     """


### PR DESCRIPTION
Recover instances authorized for a user with a single database call, instead of one database call for each configured instance