### PR TITLE
ci: change to the new channel for notifications

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -162,9 +162,9 @@ jobs:
     - name: failure notification
       if: failure()
       run: |
-          echo '{"text":":warning: Github Actions: build_dockers for ${{env.navitia_tag}} failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Github Actions: build_dockers for ${{env.navitia_tag}} failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
 
     - name: success notification on core team
       if: success()
       run: |
-          echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} images available."}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":octopus: Github Actions: build_dockers succeeded. New navitia ${{env.navitia_tag}} images available."}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}

--- a/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
+++ b/.github/workflows/build_navitia_packages_for_dev_multi_distribution.yml
@@ -56,7 +56,7 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure() && github.event_name == 'push'
       run: |
-          echo '{"text":":warning: Navitia Github Actions: build_navitia_${{matrix.distribution}}_packages_for_dev failed (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev+Multi+Distributions%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Navitia Github Actions: build_navitia_${{matrix.distribution}}_packages_for_dev failed (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Dev+Multi+Distributions%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
 
 
   docker:
@@ -82,7 +82,7 @@ jobs:
     - name: slack notification (the job has failed)
       if: ${{ failure() && github.event_name == 'push' }}
       run: |
-          echo '{"text":":warning: Navitia Github Actions: publish_docker_compose_images failed ! "}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Navitia Github Actions: publish_docker_compose_images failed ! "}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
 
   artemis:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_navitia_packages_for_release.yml
+++ b/.github/workflows/build_navitia_packages_for_release.yml
@@ -53,13 +53,13 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Github Actions: build_navitia_packages_for_release failed ! (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Github Actions: build_navitia_packages_for_release failed ! (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22). Navboys, this is a release alert !!!"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
 
     - name: notifications (the job has successed)
       if: success() && matrix.distribution == 'debian8'
       run: |
           version_number=$(head -n 1 debian/changelog | cut -d'(' -f 2 | cut -d')' -f 1)
-          echo '{"text":":information_source: Navitia Github Actions: build_navitia_packages_for_release succeded -' $version_number 'navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":information_source: Navitia Github Actions: build_navitia_packages_for_release succeded -' $version_number 'navitia debian packages are available"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
           echo '{"text":":octopus: Navitia Release: The version' $version_number 'is available. changelog: https://github.com/hove-io/navitia/releases/tag/v'$version_number'"}' | http --json POST ${{secrets.SLACK_NAVITIA_URL}}
 
   docker:
@@ -84,4 +84,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Navitia Github Actions: publish_docker_compose_images failed ! "}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Navitia Github Actions: publish_docker_compose_images failed ! "}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}

--- a/.github/workflows/publish_docker_compose_images.yml
+++ b/.github/workflows/publish_docker_compose_images.yml
@@ -31,5 +31,5 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Navitia Github Actions: publish_docker_compose_images failed ! (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Navitia Github Actions: publish_docker_compose_images failed ! (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Publish+Docker+Compose+Images%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
 

--- a/.github/workflows/publish_navitia_documentation.yml
+++ b/.github/workflows/publish_navitia_documentation.yml
@@ -33,4 +33,4 @@ jobs:
     - name: slack notification (the job has failed)
       if: failure()
       run: |
-          echo '{"text":":warning: Navitia Github Actions: publish_navitia_documentation failed ! (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_CORE_TEAM_URL}}
+          echo '{"text":":warning: Navitia Github Actions: publish_navitia_documentation failed ! (https://github.com/hove-io/navitia/actions?query=workflow%3A%22Publish+Navitia+Documentation%22)"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}


### PR DESCRIPTION
This should push to the new channel Slack. The secret `SLACK_NAVITIA_TEAM_URL` has already been configured.