### PR TITLE
Add attribute filter_odt_journeys in api instance

### DIFF
--- a/source/tyr/tests/integration/instance_test.py
+++ b/source/tyr/tests/integration/instance_test.py
@@ -174,6 +174,7 @@ def test_update_instances(create_instance):
         "default_pt_planner": 'loki',
         "pt_planners_configurations": loki_config,
         "ghost_words": GHOST_WORDS,
+        "filter_odt_journeys": False,
     }
     resp = api_get('/v0/instances/{}'.format(create_instance))
     assert resp[0]['access_points'] is False
@@ -219,6 +220,7 @@ def test_update_instances(create_instance):
     assert resp['default_pt_planner'] == 'loki'
     assert resp['pt_planners_configurations'] == loki_config
     assert resp['ghost_words'] == GHOST_WORDS
+    assert resp['filter_odt_journeys'] is False
 
 
 def test_update_instances_is_free(create_instance):
@@ -534,22 +536,26 @@ def test_update_forgotten_attributs_in_backend(create_instance):
     resp = api_get('/v0/instances/fr')
     assert resp[0]['max_additional_connections'] == 2
     assert resp[0]['successive_physical_mode_to_limit_id'] == 'physical_mode:Bus'
-    assert resp[0]['car_park_provider'] == True
+    assert resp[0]['car_park_provider'] is True
+    assert resp[0]['filter_odt_journeys'] is False
 
     params = {
         'max_additional_connections': 3,
         'successive_physical_mode_to_limit_id': 'physical_mode:Train',
         'car_park_provider': False,
+        'filter_odt_journeys': True,
     }
     resp = api_put('/v0/instances/fr', data=json.dumps(params), content_type='application/json')
     assert resp['max_additional_connections'] == 3
     assert resp['successive_physical_mode_to_limit_id'] == 'physical_mode:Train'
-    assert resp['car_park_provider'] == False
+    assert resp['car_park_provider'] is False
+    assert resp['filter_odt_journeys'] is True
 
     resp = api_get('/v0/instances/fr')
     assert resp[0]['max_additional_connections'] == 3
     assert resp[0]['successive_physical_mode_to_limit_id'] == 'physical_mode:Train'
-    assert resp[0]['car_park_provider'] == False
+    assert resp[0]['car_park_provider'] is False
+    assert resp[0]['filter_odt_journeys'] is True
 
 
 def test_update_taxi_speed(create_instance):

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -234,6 +234,7 @@ instance_fields = {
     'default_pt_planner': fields.Raw,
     'pt_planners_configurations': fields.Raw,
     'ghost_words': fields.List(fields.String),
+    'filter_odt_journeys': fields.Raw,
 }
 
 api_fields = {'id': fields.Raw, 'name': fields.Raw}

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -992,6 +992,14 @@ class Instance(flask_restful.Resource):
             default=instance.ghost_words,
         )
 
+        parser.add_argument(
+            'filter_odt_journeys',
+            type=inputs.boolean,
+            help='boolean to activate / deactivate filter on odt journeys',
+            location=('json', 'values'),
+            default=instance.filter_odt_journeys,
+        )
+
         args = parser.parse_args()
 
         try:
@@ -1088,6 +1096,7 @@ class Instance(flask_restful.Resource):
                         'default_pt_planner',
                         'pt_planners_configurations',
                         'ghost_words',
+                        'filter_odt_journeys',
                     ],
                 ),
                 maxlen=0,

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -995,7 +995,7 @@ class Instance(flask_restful.Resource):
         parser.add_argument(
             'filter_odt_journeys',
             type=inputs.boolean,
-            help='boolean to activate / deactivate filter on odt journeys',
+            help='boolean to activate / deactivate filter on on-demand transport journeys',
             location=('json', 'values'),
             default=instance.filter_odt_journeys,
         )


### PR DESCRIPTION
Add attribute filter_odt_journeys in api instance so that it's value (default value = false) can be modified by navitia-configurator.  
For details: https://navitia.atlassian.net/browse/NAV-1437

Relates to: https://github.com/hove-io/navitia-configurator/pull/699