### PR TITLE
Avoid calling the database in case of exception for a period configured

### DIFF
--- a/source/jormungandr/jormungandr/authentication.py
+++ b/source/jormungandr/jormungandr/authentication.py
@@ -120,7 +120,7 @@ def can_read_user():
     try:
         User.query.options(noload('*')).first()
     except Exception as e:
-        logging.getLogger(__name__).error('No access to table User (error: {})'.format(e))
+        logging.getLogger(__name__).exception('No access to table User (error: {})'.format(e))
         g.can_connect_to_database = False
         return False
 
@@ -157,7 +157,7 @@ def has_access(region, api, abort, user):
     try:
         model_instance = Instance.get_by_name(region)
     except Exception as e:
-        logging.getLogger(__name__).error('No access to table Instance (error: {})'.format(e))
+        logging.getLogger(__name__).exception('No access to table Instance (error: {})'.format(e))
         g.can_connect_to_database = False
         return True
 
@@ -202,7 +202,7 @@ def uncached_get_user(token):
             user = get_unkown_user()
             logging.getLogger(__name__).warning('Invalid token : {}'.format(token[0:10]))
     except Exception as e:
-        logging.getLogger(__name__).error('No access to table User (error: {})'.format(e))
+        logging.getLogger(__name__).exception('No access to table User (error: {})'.format(e))
         g.can_connect_to_database = False
         return None
 
@@ -220,7 +220,7 @@ def cache_get_key(token):
     try:
         key = Key.get_by_token(token)
     except Exception as e:
-        logging.getLogger(__name__).error('No access to table key (error: {})'.format(e))
+        logging.getLogger(__name__).exception('No access to table key (error: {})'.format(e))
         g.can_connect_to_database = False
         return None
     return key

--- a/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
+++ b/source/jormungandr/jormungandr/equipments/equipment_provider_manager.py
@@ -121,6 +121,8 @@ class EquipmentProviderManager(object):
             self.logger.exception('No access to table equipments_provider (error: {})'.format(e))
             # database is not accessible, so let's use the values already present in self._equipment_providers and
             # self._equipment_providers_legacy
+            # avoid sending query to the database for another update_interval
+            self._last_update = datetime.datetime.utcnow()
             return
 
         if not providers:

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -123,6 +123,8 @@ class ExternalServiceManager(object):
         except Exception as e:
             self.logger.error('No access to table external_service (error: {})'.format(e))
             # database is not accessible, so let's use the values already present in self._external_services_legacy
+            # avoid sending query to the database for another update_interval
+            self._last_update = datetime.datetime.utcnow()
             return
 
         if not services:

--- a/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
+++ b/source/jormungandr/jormungandr/external_services/external_service_provider_manager.py
@@ -121,7 +121,7 @@ class ExternalServiceManager(object):
         try:
             services = self._external_service_getter()
         except Exception as e:
-            self.logger.error('No access to table external_service (error: {})'.format(e))
+            self.logger.exception('No access to table external_service (error: {})'.format(e))
             # database is not accessible, so let's use the values already present in self._external_services_legacy
             # avoid sending query to the database for another update_interval
             self._last_update = datetime.datetime.utcnow()

--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -229,7 +229,7 @@ class Instance(transient_socket.TransientSocket):
         :return: a callable query of external services associated to the current instance in db
         """
         models = self._get_models()
-        result = models.external_services if models else None
+        result = models.external_services if models else []
         return [
             res
             for res in result
@@ -278,7 +278,7 @@ class Instance(transient_socket.TransientSocket):
         try:
             instance_db = models.Instance.get_by_name(self.name)
         except Exception as e:
-            logging.getLogger(__name__).error('No access to table instance (error: {})'.format(e))
+            logging.getLogger(__name__).exception('No access to table instance (error: {})'.format(e))
             g.can_connect_to_database = False
             return self.instance_db
 

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -292,8 +292,7 @@ class InstanceManager(object):
         valid_instances = []
         if name:
             # Requests with a coverage
-            available_instance = self.instances[name]
-            if authentication.has_access(available_instance.name, abort=False, user=user, api=api):
+            if authentication.has_access(name, abort=False, user=user, api=api):
                 valid_instances = [self.instances[name]]
         else:
             # Requests without any coverage

--- a/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
+++ b/source/jormungandr/jormungandr/parking_space_availability/bss/bss_provider_manager.py
@@ -72,6 +72,8 @@ class BssProviderManager(AbstractProviderManager):
             logger.exception('No access to table bss_provider (error: {})'.format(e))
             # database is not accessible, so let's use the values already present in self._bss_providers and
             # self._bss_providers_legacy
+            # avoid sending query to the database for another update_interval
+            self._last_update = datetime.datetime.utcnow()
             return
 
         if not providers:

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -154,7 +154,7 @@ class StreetNetworkBackendManager(object):
         try:
             sn_backends = self._sn_backends_getter()
         except Exception as e:
-            self.logger.error('No access to table streetnetwork_backend (error: {})'.format(e))
+            self.logger.exception('No access to table streetnetwork_backend (error: {})'.format(e))
             # database is not accessible, so let's use the values already present in self._streetnetwork_backends
             # avoid sending query to the database for another update_interval
             self._last_update = datetime.datetime.utcnow()

--- a/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
+++ b/source/jormungandr/jormungandr/street_network/streetnetwork_backend_manager.py
@@ -156,6 +156,8 @@ class StreetNetworkBackendManager(object):
         except Exception as e:
             self.logger.error('No access to table streetnetwork_backend (error: {})'.format(e))
             # database is not accessible, so let's use the values already present in self._streetnetwork_backends
+            # avoid sending query to the database for another update_interval
+            self._last_update = datetime.datetime.utcnow()
             return
 
         if not sn_backends:

--- a/source/jormungandr/jormungandr/travelers_profile.py
+++ b/source/jormungandr/jormungandr/travelers_profile.py
@@ -132,7 +132,7 @@ class TravelerProfile(object):
         try:
             model = models.TravelerProfile.get_by_coverage_and_type(coverage, traveler_type)
         except Exception as e:
-            logging.getLogger(__name__).error('No access to table traveler_profile (error: {})'.format(e))
+            logging.getLogger(__name__).exception('No access to table traveler_profile (error: {})'.format(e))
             # If the table is not accessible return the default traveler profile for given traveler type
             return default_traveler_profiles[traveler_type]
 


### PR DESCRIPTION
If There is an exception while sending a query to the database, we should update last_update time to NOW so that no query is send to the data base for another update_interval as configured.

This correction avoids access to the data for each service as street_network, external_service as well as bss_provide for a period of update_interval as configured.

There are some minor modifications to reduce possible error. 

Relates to: https://navitia.atlassian.net/browse/NAV-1819