### PR TITLE
[Jormungandr] Fix failure of caching instances list

### DIFF
--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -298,7 +298,7 @@ class InstanceManager(object):
         else:
             # Requests without any coverage
             # fetch all the authorized instances (free + private) using cached function has_access()
-            authorized_instances_name = self.get_all_available_instances(user)
+            authorized_instances_name = self.get_all_available_instances_names(user)
             authorized_instances = [self.instances[i_name] for i_name in authorized_instances_name]
             if not authorized_instances:
                 # user doesn't have access to any of the instances
@@ -346,7 +346,7 @@ class InstanceManager(object):
 
     @memory_cache.memoize(app.config[str('MEMORY_CACHE_CONFIGURATION')].get(str('TIMEOUT_AUTHENTICATION'), 30))
     @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_AUTHENTICATION'), 300))
-    def get_all_available_instances(self, user):
+    def get_all_available_instances_names(self, user):
         result = []
         if app.config.get('PUBLIC', False) or app.config.get('DISABLE_DATABASE', False):
             return [key for key in self.instances]

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -298,7 +298,8 @@ class InstanceManager(object):
         else:
             # Requests without any coverage
             # fetch all the authorized instances (free + private) using cached function has_access()
-            authorized_instances = self.get_all_available_instances(user)
+            authorized_instances_name = self.get_all_available_instances(user)
+            authorized_instances = [self.instances[i_name] for i_name in authorized_instances_name]
             if not authorized_instances:
                 # user doesn't have access to any of the instances
                 context = 'User has no access to any instance'
@@ -348,7 +349,7 @@ class InstanceManager(object):
     def get_all_available_instances(self, user):
         result = []
         if app.config.get('PUBLIC', False) or app.config.get('DISABLE_DATABASE', False):
-            return list(self.instances.values())
+            return [key for key in self.instances]
 
         if not user:
             logging.getLogger(__name__).warning('get all available instances no user')
@@ -363,5 +364,5 @@ class InstanceManager(object):
         bdd_instances = user.get_all_available_instances()
         for bdd_instance in bdd_instances:
             if bdd_instance.name in self.instances:
-                result.append(self.instances[bdd_instance.name])
+                result.append(bdd_instance.name)
         return result

--- a/source/jormungandr/jormungandr/tests/instance_manager_tests.py
+++ b/source/jormungandr/jormungandr/tests/instance_manager_tests.py
@@ -55,8 +55,8 @@ def manager():
 def get_instances_test(manager, mocker):
     mock = mocker.patch.object(
         manager,
-        'get_all_available_instances',
-        return_value=[manager.instances['paris'], manager.instances['pdl']],
+        'get_all_available_instances_names',
+        return_value=['paris', 'pdl'],
     )
     with app.test_request_context('/'):
         instances = manager.get_instances()
@@ -74,8 +74,8 @@ def get_instances_by_coord_test(manager, mocker):
     )
     mock = mocker.patch.object(
         manager,
-        'get_all_available_instances',
-        return_value=[manager.instances['paris'], manager.instances['pdl']],
+        'get_all_available_instances_names',
+        return_value=['paris', 'pdl'],
     )
     with app.test_request_context('/'):
         instances = manager.get_instances(lon=4, lat=3)
@@ -88,8 +88,8 @@ def get_instances_by_object_id_test(manager, mocker):
     mock = mocker.patch.object(manager, '_all_keys_of_id_in_instances', return_value=[manager.instances['pdl']])
     mock = mocker.patch.object(
         manager,
-        'get_all_available_instances',
-        return_value=[manager.instances['paris'], manager.instances['pdl']],
+        'get_all_available_instances_names',
+        return_value=['paris', 'pdl'],
     )
     with app.test_request_context('/'):
         instances = manager.get_instances(object_id='sa:pdl')


### PR DESCRIPTION
### **Branch based on v15.26.7**

Flask-caching was not able to pickle a list a ORM obj T_T, https://github.com/hove-io/navitia/pull/3926/files#diff-cc347701ac573ba458d0543b788c67d7e83be259f7ae5fe0c095aed939880090R366

so instead of returning a list of ORM, we return a list of name... 