### PR TITLE
Kraken: fix realtime-VJ creation to copy equipment from base-schedule

### DIFF
--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -393,10 +393,11 @@ struct add_impacts_visitor : public apply_impacts_visitor {
                 }
             }
 
-            // name and dataset
+            // name, dataset and VehicleProperties (accessibility, AC, etc.)
             if (!mvj->get_base_vj().empty()) {
                 vj->name = mvj->get_base_vj().at(0)->name;
                 vj->headsign = mvj->get_base_vj().at(0)->headsign;
+                vj->_vehicle_properties = mvj->get_base_vj().at(0)->_vehicle_properties;  // otherwise all to default
                 auto* dataset = mvj->get_base_vj().at(0)->dataset;
                 if (dataset) {
                     vj->dataset = dataset;

--- a/source/kraken/tests/data_manager_test.cpp
+++ b/source/kraken/tests/data_manager_test.cpp
@@ -56,7 +56,7 @@ public:
     size_t data_identifier;
 
     explicit Data(size_t data_identifier = 0)
-        : data_identifier(data_identifier), is_connected_to_rabbitmq(false), loaded(false) {}
+        : loaded(false), is_connected_to_rabbitmq(false), data_identifier(data_identifier) {}
 
     ~Data() { Data::destructor_called = true; }
 };

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -321,6 +321,25 @@ BOOST_AUTO_TEST_CASE(train_delayed) {
     res = compute(nt::RTLevel::RealTime);
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_CHECK_EQUAL(res[0].items[0].arrival, "20150928T0910"_dt);
+
+    // testing accessibility on the way, as VJ created is wheelchair-accessible and should stay accessible after
+    // delay application
+    nt::AccessibiliteParams accessibility_params;
+    accessibility_params.properties.set(nt::hasProperties::WHEELCHAIR_BOARDING, true);
+    accessibility_params.vehicle_properties.set(nt::hasVehicleProperties::WHEELCHAIR_ACCESSIBLE, true);
+
+    auto compute_wheelchair = [&](nt::RTLevel level) {
+        return raptor.compute(pt_data->stop_areas_map.at("stop1"), pt_data->stop_areas_map.at("stop2"), "08:00"_t, 0,
+                              navitia::DateTimeUtils::inf, level, 2_min, 2_min, true, accessibility_params);
+    };
+
+    auto res_wheelchair = compute_wheelchair(nt::RTLevel::Base);
+    BOOST_REQUIRE_EQUAL(res_wheelchair.size(), 1);
+    BOOST_CHECK_EQUAL(res_wheelchair[0].items[0].arrival, "20150928T0901"_dt);
+
+    res_wheelchair = compute_wheelchair(nt::RTLevel::RealTime);
+    BOOST_REQUIRE_EQUAL(res_wheelchair.size(), 1);
+    BOOST_CHECK_EQUAL(res_wheelchair[0].items[0].arrival, "20150928T0910"_dt);
 }
 
 BOOST_AUTO_TEST_CASE(train_delayed_vj_cleaned_up) {


### PR DESCRIPTION
Only bugged on RT from Kirin (checked code for Chaos)

* Unit-tested
* Hand-tested on a real dataset

:mag: easier reviewed by commit

JIRA: https://navitia.atlassian.net/browse/NAV-1744