### PR TITLE
CI: Add kraken image with opentelemetry exporter

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -106,10 +106,10 @@ jobs:
 
     - name: Create dockers images and push them
       run: |
-        components='jormungandr kraken tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
+        components='jormungandr kraken kraken-opentelemetry tyr-beat tyr-worker tyr-web instances-configurator mock-kraken eitri'
         for component in $components; do
             echo "*********  Building $component ***************"
-            docker build -t navitia/$component:${{env.navitia_tag}} -f  docker/${{env.debian_version}}/Dockerfile-${component} .
+            docker build -t navitia/$component:${{env.navitia_tag}} -f  docker/${{env.debian_version}}/Dockerfile-${component} --build-arg KRAKEN_TAG=${{env.navitia_tag}} .
 
             # add latest tag if we are making a release
             if [[ "${{env.aws_branch}}" = "release" ]]; then

--- a/docker/debian10/Dockerfile-kraken-opentelemetry
+++ b/docker/debian10/Dockerfile-kraken-opentelemetry
@@ -1,0 +1,13 @@
+ARG KRAKEN_TAG
+FROM navitia/kraken:${KRAKEN_TAG}
+
+## see https://opentelemetry.io/docs/collector/getting-started/#deb-installation
+RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+RUN wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.73.0/otelcol-contrib_0.73.0_linux_amd64.deb
+RUN dpkg -i otelcol-contrib_0.73.0_linux_amd64.deb
+COPY ./docker/opentelemetry_exporter_config.yaml /etc/otelcol/config.yaml
+
+COPY docker/run_kraken_opentelemetry.sh /usr/src/app/run_kraken_opentelemetry.sh
+RUN chmod +x /usr/src/app/run_kraken_opentelemetry.sh
+
+ENTRYPOINT ["bash", "/usr/src/app/run_kraken_opentelemetry.sh"]

--- a/docker/debian8/Dockerfile-kraken-opentelemetry
+++ b/docker/debian8/Dockerfile-kraken-opentelemetry
@@ -1,0 +1,13 @@
+ARG KRAKEN_TAG
+FROM navitia/kraken:${KRAKEN_TAG}
+
+## see https://opentelemetry.io/docs/collector/getting-started/#deb-installation
+RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+RUN wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.73.0/otelcol-contrib_0.73.0_linux_amd64.deb
+RUN dpkg -i otelcol-contrib_0.73.0_linux_amd64.deb
+COPY ./docker/opentelemetry_exporter_config.yaml /etc/otelcol/config.yaml
+
+COPY docker/run_kraken_opentelemetry.sh /usr/src/app/run_kraken_opentelemetry.sh
+RUN chmod +x /usr/src/app/run_kraken_opentelemetry.sh
+
+ENTRYPOINT ["bash", "/usr/src/app/run_kraken_opentelemetry.sh"]

--- a/docker/opentelemetry_exporter_config.yaml
+++ b/docker/opentelemetry_exporter_config.yaml
@@ -1,0 +1,82 @@
+# adapted from :
+# - newrelic basic setup https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-basic/
+# - new relic collector for host monitoring https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts
+# - prometheus receiver for opentelemetry https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
+
+receivers:
+  # collect prometheus metrics exposed in Kraken
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "kraken-prometheus2otel-collector"
+          scrape_interval: 20s
+          static_configs:
+            - targets: ["${KRAKEN_PROMETHEUS_HTTP_ADDRESS}"]
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 200
+    spike_limit_mib: 200
+  batch:
+  # transform metrics to the "delta-encoding" which is supported by newrelic
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/cumulativetodeltaprocessor
+  # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics#otel-histogram
+  cumulativetodelta:
+  # collect informations about the host we are running on
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor#amazon-ecs
+  resourcedetection/ecs:
+    detectors: [env, ecs]
+  # add extra attributes to the metrics collected
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md#attributes-processor
+  # NewRelic expects the keys to be prefixed with 'tags.'
+  # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-resources
+  attributes:
+    actions:
+      - key: tags.component
+        value: kraken
+        action: insert
+      - key: tags.availability_zone
+        from_attribute: cloud.availability_zone
+        action: insert
+      - key: tags.task
+        from_attribute: aws.ecs.task.arn
+        action: insert
+      - key: tags.task_revision
+        from_attribute: aws.ecs.task.revision
+        action: insert
+      - key: tags.cluster
+        from_attribute: aws.ecs.cluster.arn
+        action: insert
+      - key: coverage
+        value: ${KRAKEN_GENERAL_instance_name}
+        action: insert
+      # https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/collector/opentelemetry-collector-infra-hosts#host-receiver
+      - key: host.id
+        from_attribute: host.name
+        action: upsert
+
+
+exporters:
+  otlp:
+    # endpoint should include gRPC port number, e.g: https://otlp.nr-data.net:4317
+    # see https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/opentelemetry-setup#review-settings
+    endpoint: ${TARGET_OTLP_ENDPOINT}
+    headers:
+      api-key: ${TARGET_OTLP_LICENSE_KEY}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      # NewRelic does not accept cumulative histogram (yet?) and that is what is produced by prometheus receiver
+      # so we need to transform the cumulative histogram to a delta one
+      # see https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/best-practices/opentelemetry-best-practices-metrics#otel-histogram
+      processors: [batch, resourcedetection/ecs, attributes, cumulativetodelta]
+      exporters: [otlp]
+  telemetry:
+    logs: # https://github.com/open-telemetry/opentelemetry-collector/blob/7666eb04c30e5cfd750db9969fe507562598f0ae/config/service.go#L41-L97
+      level: ERROR
+      encoding: json
+    metrics: # https://github.com/open-telemetry/opentelemetry-collector/blob/7666eb04c30e5cfd750db9969fe507562598f0ae/config/service.go#L99-L111
+      level: none  # no own-telemetry

--- a/docker/run_kraken_opentelemetry.sh
+++ b/docker/run_kraken_opentelemetry.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Adapted from https://docs.docker.com/config/containers/multi-service_container/
+
+# Start opentelemetry exporter
+/usr/bin/otelcol-contrib --config=/etc/otelcol/config.yaml &
+
+# Start monitor_kraken
+python /monitor_kraken &
+
+# Start kraken
+LD_PRELOAD=/libkeepalive/libkeepalive.so /usr/bin/kraken
+
+# Wait for any process to exit
+wait -n
+
+# Exit with status of process that exited first
+exit $?


### PR DESCRIPTION
The idea is to use this to export prometheus metrics (e.g: to NewRelic).
Broadly adapted from https://github.com/hove-io/loki/pull/360

Choices done (to lighten the load):
* no self-monitor and minimal logging for opentelemetry-collector
* no tracking of host metrics (CPU, memory, network)

JIRA: https://navitia.atlassian.net/browse/NAV-1579