### PR TITLE
[debian8] add archive apt source

### DIFF
--- a/docker/debian8/Dockerfile-master
+++ b/docker/debian8/Dockerfile-master
@@ -1,5 +1,7 @@
 FROM navitia/debian8_dev
 
+RUN echo "deb http://archive.debian.org/debian/ jessie main"  > /etc/apt/sources.list.d/archive.list
+
 # update package list from providers
 RUN apt-get update --force-yes --fix-missing || exit 0
 


### PR DESCRIPTION
Should fix the build of docker images in debian 8.
It seems the default apt repositories have disappeared, debian 8 is too old :older_adult: 