### PR TITLE
Kraken: Add metrics around RT handling

### DIFF
--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -378,7 +378,7 @@ void MaintenanceWorker::handle_rt_in_batch(const std::vector<AmqpClient::Envelop
         transit_realtime::FeedMessage feed_message;
         if (!feed_message.ParseFromString(envelope->Message()->Body())) {
             LOG4CPLUS_WARN(logger, "protobuf not valid!");
-            return;
+            continue;
         }
         if (feed_message.header().has_timestamp()) {
             auto message_time = navitia::from_posix_timestamp(feed_message.header().timestamp());

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -512,6 +512,7 @@ void MaintenanceWorker::listen_rabbitmq() {
             auto rt_envelopes = consume_in_batch(rt_tag, max_batch_nb, timeout_ms, no_ack);
             auto duration_rt_retieval = pt::microsec_clock::universal_time() - begin_rt_retrieval;
             this->metrics.observe_retrieve_rt_message_duration(duration_rt_retieval.total_milliseconds() / 1000.0);
+            this->metrics.observe_retrieved_rt_message_number(rt_envelopes.size());
             LOG4CPLUS_DEBUG(logger, "Retrieval of RT messages from RabbitMQ, "
                                         << rt_envelopes.size() << " messages(s) retrieved in " << duration_rt_retieval);
             handle_rt_in_batch(rt_envelopes);

--- a/source/kraken/maintenance_worker.cpp
+++ b/source/kraken/maintenance_worker.cpp
@@ -508,7 +508,12 @@ void MaintenanceWorker::listen_rabbitmq() {
         size_t max_batch_nb = conf.broker_max_batch_nb();
 
         try {
+            auto begin_rt_retrieval = pt::microsec_clock::universal_time();
             auto rt_envelopes = consume_in_batch(rt_tag, max_batch_nb, timeout_ms, no_ack);
+            auto duration_rt_retieval = pt::microsec_clock::universal_time() - begin_rt_retrieval;
+            this->metrics.observe_retrieve_rt_message_duration(duration_rt_retieval.total_milliseconds() / 1000.0);
+            LOG4CPLUS_DEBUG(logger, "Retrieval of RT messages from RabbitMQ, "
+                                        << rt_envelopes.size() << " messages(s) retrieved in " << duration_rt_retieval);
             handle_rt_in_batch(rt_envelopes);
 
             auto task_envelopes = consume_in_batch(task_tag, 1, timeout_ms, no_ack);

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -172,6 +172,27 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
                                                     .Labels({{"coverage", coverage}})
                                                     .Register(*registry)
                                                     .Add({}, create_exponential_buckets(0.5, 2, 10));
+
+    this->rt_message_age_min_histogram = &prometheus::BuildHistogram()
+                                              .Name("kraken_rt_message_age_min_seconds")
+                                              .Help("Minimum age of RT message from a batch")
+                                              .Labels({{"coverage", coverage}})
+                                              .Register(*registry)
+                                              .Add({}, create_exponential_buckets(0.5, 2, 10));
+
+    this->rt_message_age_average_histogram = &prometheus::BuildHistogram()
+                                                  .Name("kraken_rt_message_age_average_seconds")
+                                                  .Help("Average age of RT message from a batch")
+                                                  .Labels({{"coverage", coverage}})
+                                                  .Register(*registry)
+                                                  .Add({}, create_exponential_buckets(0.5, 2, 10));
+
+    this->rt_message_age_max_histogram = &prometheus::BuildHistogram()
+                                              .Name("kraken_rt_message_age_max_seconds")
+                                              .Help("Maximum age of RT message from a batch")
+                                              .Labels({{"coverage", coverage}})
+                                              .Register(*registry)
+                                              .Add({}, create_exponential_buckets(0.5, 2, 10));
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -248,6 +269,27 @@ void Metrics::observe_applied_rt_entity_number(size_t number) const {
         return;
     }
     this->applied_rt_entity_number_histogram->Observe(number);
+}
+
+void Metrics::observe_rt_message_age_min(double duration) const {
+    if (!registry) {
+        return;
+    }
+    this->rt_message_age_min_histogram->Observe(duration);
+}
+
+void Metrics::observe_rt_message_age_average(double duration) const {
+    if (!registry) {
+        return;
+    }
+    this->rt_message_age_average_histogram->Observe(duration);
+}
+
+void Metrics::observe_rt_message_age_max(double duration) const {
+    if (!registry) {
+        return;
+    }
+    this->rt_message_age_max_histogram->Observe(duration);
 }
 
 void Metrics::set_raptor_cache_miss(size_t nb_cache_miss) const {

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -158,6 +158,13 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
                                                         .Labels({{"coverage", coverage}})
                                                         .Register(*registry)
                                                         .Add({}, create_exponential_buckets(0.5, 2, 10));
+
+    this->retrieved_rt_message_number_histogram = &prometheus::BuildHistogram()
+                                                       .Name("kraken_retrieve_rt_message_number")
+                                                       .Help("number of RT messages retrieved from RabbitMQ")
+                                                       .Labels({{"coverage", coverage}})
+                                                       .Register(*registry)
+                                                       .Add({}, create_exponential_buckets(0.5, 2, 10));
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -220,6 +227,13 @@ void Metrics::observe_retrieve_rt_message_duration(double duration) const {
         return;
     }
     this->retrieve_rt_message_duration_histogram->Observe(duration);
+}
+
+void Metrics::observe_retrieved_rt_message_number(size_t number) const {
+    if (!registry) {
+        return;
+    }
+    this->retrieved_rt_message_number_histogram->Observe(number);
 }
 
 void Metrics::set_raptor_cache_miss(size_t nb_cache_miss) const {

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -151,6 +151,13 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
                                              .Labels({{"coverage", coverage}})
                                              .Register(*registry)
                                              .Add({}, create_exponential_buckets(0.5, 2, 10));
+
+    this->retrieve_rt_message_duration_histogram = &prometheus::BuildHistogram()
+                                                        .Name("kraken_retrieve_rt_message_duration_seconds")
+                                                        .Help("duration of RT messages retrieval from RabbitMQ")
+                                                        .Labels({{"coverage", coverage}})
+                                                        .Register(*registry)
+                                                        .Add({}, create_exponential_buckets(0.5, 2, 10));
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -206,6 +213,13 @@ void Metrics::observe_delete_disruption(double duration) const {
         return;
     }
     this->delete_disruption_histogram->Observe(duration);
+}
+
+void Metrics::observe_retrieve_rt_message_duration(double duration) const {
+    if (!registry) {
+        return;
+    }
+    this->retrieve_rt_message_duration_histogram->Observe(duration);
 }
 
 void Metrics::set_raptor_cache_miss(size_t nb_cache_miss) const {

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -159,19 +159,19 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
                                                         .Register(*registry)
                                                         .Add({}, create_exponential_buckets(0.5, 2, 10));
 
-    this->retrieved_rt_message_number_histogram = &prometheus::BuildHistogram()
-                                                       .Name("kraken_retrieve_rt_message_number")
-                                                       .Help("number of RT messages retrieved from RabbitMQ")
-                                                       .Labels({{"coverage", coverage}})
-                                                       .Register(*registry)
-                                                       .Add({}, create_exponential_buckets(0.5, 2, 10));
+    this->retrieved_rt_message_count_histogram = &prometheus::BuildHistogram()
+                                                      .Name("kraken_retrieve_rt_message_count")
+                                                      .Help("number of RT messages retrieved from RabbitMQ")
+                                                      .Labels({{"coverage", coverage}})
+                                                      .Register(*registry)
+                                                      .Add({}, create_exponential_buckets(0.5, 2, 10));
 
-    this->applied_rt_entity_number_histogram = &prometheus::BuildHistogram()
-                                                    .Name("kraken_applied_rt_entity_number")
-                                                    .Help("number of applied RT entity from a message batch")
-                                                    .Labels({{"coverage", coverage}})
-                                                    .Register(*registry)
-                                                    .Add({}, create_exponential_buckets(0.5, 2, 10));
+    this->applied_rt_entity_count_histogram = &prometheus::BuildHistogram()
+                                                   .Name("kraken_applied_rt_entity_count")
+                                                   .Help("number of applied RT entity from a message batch")
+                                                   .Labels({{"coverage", coverage}})
+                                                   .Register(*registry)
+                                                   .Add({}, create_exponential_buckets(0.5, 2, 10));
 
     this->rt_message_age_min_histogram = &prometheus::BuildHistogram()
                                               .Name("kraken_rt_message_age_min_seconds")
@@ -257,18 +257,18 @@ void Metrics::observe_retrieve_rt_message_duration(double duration) const {
     this->retrieve_rt_message_duration_histogram->Observe(duration);
 }
 
-void Metrics::observe_retrieved_rt_message_number(size_t number) const {
+void Metrics::observe_retrieved_rt_message_count(size_t count) const {
     if (!registry) {
         return;
     }
-    this->retrieved_rt_message_number_histogram->Observe(number);
+    this->retrieved_rt_message_count_histogram->Observe(double(count));
 }
 
-void Metrics::observe_applied_rt_entity_number(size_t number) const {
+void Metrics::observe_applied_rt_entity_count(size_t count) const {
     if (!registry) {
         return;
     }
-    this->applied_rt_entity_number_histogram->Observe(number);
+    this->applied_rt_entity_count_histogram->Observe(double(count));
 }
 
 void Metrics::observe_rt_message_age_min(double duration) const {

--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -165,6 +165,13 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
                                                        .Labels({{"coverage", coverage}})
                                                        .Register(*registry)
                                                        .Add({}, create_exponential_buckets(0.5, 2, 10));
+
+    this->applied_rt_entity_number_histogram = &prometheus::BuildHistogram()
+                                                    .Name("kraken_applied_rt_entity_number")
+                                                    .Help("number of applied RT entity from a message batch")
+                                                    .Labels({{"coverage", coverage}})
+                                                    .Register(*registry)
+                                                    .Add({}, create_exponential_buckets(0.5, 2, 10));
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -234,6 +241,13 @@ void Metrics::observe_retrieved_rt_message_number(size_t number) const {
         return;
     }
     this->retrieved_rt_message_number_histogram->Observe(number);
+}
+
+void Metrics::observe_applied_rt_entity_number(size_t number) const {
+    if (!registry) {
+        return;
+    }
+    this->applied_rt_entity_number_histogram->Observe(number);
 }
 
 void Metrics::set_raptor_cache_miss(size_t nb_cache_miss) const {

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -74,6 +74,7 @@ protected:
     prometheus::Histogram* handle_rt_histogram;
     prometheus::Histogram* handle_disruption_histogram;
     prometheus::Histogram* delete_disruption_histogram;
+    prometheus::Histogram* retrieve_rt_message_duration_histogram;
     prometheus::Gauge* next_st_cache_miss;
 
 public:
@@ -86,6 +87,7 @@ public:
     void observe_handle_rt(double duration) const;
     void observe_handle_disruption(double duration) const;
     void observe_delete_disruption(double duration) const;
+    void observe_retrieve_rt_message_duration(double duration) const;
     void set_raptor_cache_miss(size_t nb_cache_miss) const;
 };
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -75,6 +75,7 @@ protected:
     prometheus::Histogram* handle_disruption_histogram;
     prometheus::Histogram* delete_disruption_histogram;
     prometheus::Histogram* retrieve_rt_message_duration_histogram;
+    prometheus::Histogram* retrieved_rt_message_number_histogram;
     prometheus::Gauge* next_st_cache_miss;
 
 public:
@@ -88,6 +89,7 @@ public:
     void observe_handle_disruption(double duration) const;
     void observe_delete_disruption(double duration) const;
     void observe_retrieve_rt_message_duration(double duration) const;
+    void observe_retrieved_rt_message_number(size_t number) const;
     void set_raptor_cache_miss(size_t nb_cache_miss) const;
 };
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -77,6 +77,9 @@ protected:
     prometheus::Histogram* retrieve_rt_message_duration_histogram;
     prometheus::Histogram* retrieved_rt_message_number_histogram;
     prometheus::Histogram* applied_rt_entity_number_histogram;
+    prometheus::Histogram* rt_message_age_min_histogram;
+    prometheus::Histogram* rt_message_age_average_histogram;
+    prometheus::Histogram* rt_message_age_max_histogram;
     prometheus::Gauge* next_st_cache_miss;
 
 public:
@@ -92,6 +95,9 @@ public:
     void observe_retrieve_rt_message_duration(double duration) const;
     void observe_retrieved_rt_message_number(size_t number) const;
     void observe_applied_rt_entity_number(size_t number) const;
+    void observe_rt_message_age_min(double duration) const;
+    void observe_rt_message_age_average(double duration) const;
+    void observe_rt_message_age_max(double duration) const;
     void set_raptor_cache_miss(size_t nb_cache_miss) const;
 };
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -76,6 +76,7 @@ protected:
     prometheus::Histogram* delete_disruption_histogram;
     prometheus::Histogram* retrieve_rt_message_duration_histogram;
     prometheus::Histogram* retrieved_rt_message_number_histogram;
+    prometheus::Histogram* applied_rt_entity_number_histogram;
     prometheus::Gauge* next_st_cache_miss;
 
 public:
@@ -90,6 +91,7 @@ public:
     void observe_delete_disruption(double duration) const;
     void observe_retrieve_rt_message_duration(double duration) const;
     void observe_retrieved_rt_message_number(size_t number) const;
+    void observe_applied_rt_entity_number(size_t number) const;
     void set_raptor_cache_miss(size_t nb_cache_miss) const;
 };
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -75,8 +75,8 @@ protected:
     prometheus::Histogram* handle_disruption_histogram;
     prometheus::Histogram* delete_disruption_histogram;
     prometheus::Histogram* retrieve_rt_message_duration_histogram;
-    prometheus::Histogram* retrieved_rt_message_number_histogram;
-    prometheus::Histogram* applied_rt_entity_number_histogram;
+    prometheus::Histogram* retrieved_rt_message_count_histogram;
+    prometheus::Histogram* applied_rt_entity_count_histogram;
     prometheus::Histogram* rt_message_age_min_histogram;
     prometheus::Histogram* rt_message_age_average_histogram;
     prometheus::Histogram* rt_message_age_max_histogram;
@@ -93,8 +93,8 @@ public:
     void observe_handle_disruption(double duration) const;
     void observe_delete_disruption(double duration) const;
     void observe_retrieve_rt_message_duration(double duration) const;
-    void observe_retrieved_rt_message_number(size_t number) const;
-    void observe_applied_rt_entity_number(size_t number) const;
+    void observe_retrieved_rt_message_count(size_t count) const;
+    void observe_applied_rt_entity_count(size_t count) const;
     void observe_rt_message_age_min(double duration) const;
     void observe_rt_message_age_average(double duration) const;
     void observe_rt_message_age_max(double duration) const;


### PR DESCRIPTION
:mag: please review by commit **with message**

Added metrics:
* retrieval duration of RT messages from Rabbit
* number of RT messages retrieved from Rabbit
* number of RT entities applied
* RT messages' ages (min/average/max)

Also a small fix.

:heavy_check_mark: tested locally that it works on NewRelic metrics.
:x: Sonar fails only on new code coverage, which is OK on metrics.

JIRA: https://navitia.atlassian.net/browse/NAV-1892