### PR TITLE
[Jormungandr] Fix LEZ when fallbacks are car

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -549,6 +549,7 @@ def _build_fallback(
                         fb_duration = getattr(fallback_dp_copy.journeys[0].durations, m)
                         main_duration = getattr(pt_journey.durations, m)
                         setattr(pt_journey.durations, m, fb_duration + main_duration)
+
             # if it's only a non-teleport crowfly fallback, update distances and durations by mode
             else:
                 if fallback_type == StreetNetworkPathType.BEGINNING_FALLBACK:

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -111,7 +111,9 @@ def journey_response(journey, mode):
     elif mode == "car":
         journey.durations.car = duration
         journey.distances.car = distance
+        journey.low_emission_zone.on_path = True
         section.street_network.mode = response_pb2.Car
+        section.low_emission_zone.on_path = True
     else:
         journey.durations.bike = duration
         journey.distances.bike = distance
@@ -381,6 +383,8 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][0]['durations']['car'] == 500
         assert response['journeys'][0]['durations']['total'] == 500
         assert response['journeys'][0]['distances']['car'] == 50
+        assert response['journeys'][0]['low_emission_zone']['on_path']
+
         assert response['journeys'][0]['sections'][0]['co2_emission'] == {'value': 9.2, 'unit': 'gEC'}
         assert response['journeys'][0]['sections'][0]['air_pollutants']['values'] == {
             'nox': 0.022,
@@ -392,6 +396,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
             'unit': 'g',
         }
         assert not response['journeys'][0]['sections'][0].get('cycle_lane_length')
+        assert response['journeys'][0]['sections'][0]['low_emission_zone']['on_path']
 
         # bike direct path from asgard
         assert 'bike' in response['journeys'][1]['tags']
@@ -415,7 +420,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][2]['duration'] == 2000
         assert response['journeys'][2]['sections'][0]['co2_emission'] == {'value': 0, 'unit': 'gEC'}
         assert response['journeys'][2]['co2_emission'] == {'value': 0, 'unit': 'gEC'}
-        assert not response['journeys'][2]['sections'][0].get('cycle_lane_length')
+        assert response['journeys'][2]['sections'][0].get('cycle_lane_length')
 
         assert not response.get('feed_publishers')
 

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -420,7 +420,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
         assert response['journeys'][2]['duration'] == 2000
         assert response['journeys'][2]['sections'][0]['co2_emission'] == {'value': 0, 'unit': 'gEC'}
         assert response['journeys'][2]['co2_emission'] == {'value': 0, 'unit': 'gEC'}
-        assert response['journeys'][2]['sections'][0].get('cycle_lane_length')
+        assert not response['journeys'][2]['sections'][0].get('cycle_lane_length')
 
         assert not response.get('feed_publishers')
 


### PR DESCRIPTION
In this PR, two cases are fixed:

- at least one of the fallbacks traverses LEZ, we set `on_path` to true for the whole journey :
![image](https://user-images.githubusercontent.com/6093486/230396740-0742a01a-a020-40c7-8ad6-8486d8ea8f81.png)


- none of the fallbacks traverses LEZ, we set `on_path` to false for the whole journey:
![image](https://user-images.githubusercontent.com/6093486/230396496-5e063c18-b621-4800-8a7b-c02932f646bb.png)
