### PR TITLE
Kraken: only one metric histogram for RT message age

### DIFF
--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -183,27 +183,6 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
                           0,   10,  20,  30,  40,  50,   60,   70,   80,   90,   100,  110,  120,  150, 180,
                           210, 240, 270, 300, 330, 360,  390,  420,  450,  480,  510,  540,  570,  600, 660,
                           720, 780, 840, 900, 960, 1020, 1080, 1140, 1200, 1500, 1800, 2400, 3000, 3600});
-
-    this->rt_message_age_min_histogram = &prometheus::BuildHistogram()
-                                              .Name("kraken_rt_message_age_min_seconds")
-                                              .Help("Minimum age of RT message from a batch")
-                                              .Labels({{"coverage", coverage}})
-                                              .Register(*registry)
-                                              .Add({}, create_exponential_buckets(0.5, 2, 10));
-
-    this->rt_message_age_average_histogram = &prometheus::BuildHistogram()
-                                                  .Name("kraken_rt_message_age_average_seconds")
-                                                  .Help("Average age of RT message from a batch")
-                                                  .Labels({{"coverage", coverage}})
-                                                  .Register(*registry)
-                                                  .Add({}, create_exponential_buckets(0.5, 2, 10));
-
-    this->rt_message_age_max_histogram = &prometheus::BuildHistogram()
-                                              .Name("kraken_rt_message_age_max_seconds")
-                                              .Help("Maximum age of RT message from a batch")
-                                              .Labels({{"coverage", coverage}})
-                                              .Register(*registry)
-                                              .Add({}, create_exponential_buckets(0.5, 2, 10));
 }
 
 InFlightGuard Metrics::start_in_flight() const {
@@ -287,27 +266,6 @@ void Metrics::observe_rt_message_age(double duration) const {
         return;
     }
     this->rt_message_age_histogram->Observe(duration);
-}
-
-void Metrics::observe_rt_message_age_min(double duration) const {
-    if (!registry) {
-        return;
-    }
-    this->rt_message_age_min_histogram->Observe(duration);
-}
-
-void Metrics::observe_rt_message_age_average(double duration) const {
-    if (!registry) {
-        return;
-    }
-    this->rt_message_age_average_histogram->Observe(duration);
-}
-
-void Metrics::observe_rt_message_age_max(double duration) const {
-    if (!registry) {
-        return;
-    }
-    this->rt_message_age_max_histogram->Observe(duration);
 }
 
 void Metrics::set_raptor_cache_miss(size_t nb_cache_miss) const {

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -78,9 +78,6 @@ protected:
     prometheus::Histogram* retrieved_rt_message_count_histogram;
     prometheus::Histogram* applied_rt_entity_count_histogram;
     prometheus::Histogram* rt_message_age_histogram;
-    prometheus::Histogram* rt_message_age_min_histogram;
-    prometheus::Histogram* rt_message_age_average_histogram;
-    prometheus::Histogram* rt_message_age_max_histogram;
     prometheus::Gauge* next_st_cache_miss;
 
 public:
@@ -97,9 +94,6 @@ public:
     void observe_retrieved_rt_message_count(size_t count) const;
     void observe_applied_rt_entity_count(size_t count) const;
     void observe_rt_message_age(double duration) const;
-    void observe_rt_message_age_min(double duration) const;
-    void observe_rt_message_age_average(double duration) const;
-    void observe_rt_message_age_max(double duration) const;
     void set_raptor_cache_miss(size_t nb_cache_miss) const;
 };
 

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -77,6 +77,7 @@ protected:
     prometheus::Histogram* retrieve_rt_message_duration_histogram;
     prometheus::Histogram* retrieved_rt_message_count_histogram;
     prometheus::Histogram* applied_rt_entity_count_histogram;
+    prometheus::Histogram* rt_message_age_histogram;
     prometheus::Histogram* rt_message_age_min_histogram;
     prometheus::Histogram* rt_message_age_average_histogram;
     prometheus::Histogram* rt_message_age_max_histogram;
@@ -95,6 +96,7 @@ public:
     void observe_retrieve_rt_message_duration(double duration) const;
     void observe_retrieved_rt_message_count(size_t count) const;
     void observe_applied_rt_entity_count(size_t count) const;
+    void observe_rt_message_age(double duration) const;
     void observe_rt_message_age_min(double duration) const;
     void observe_rt_message_age_average(double duration) const;
     void observe_rt_message_age_max(double duration) const;


### PR DESCRIPTION
This is just for memory in case OTLP+NewRelic max works as expected (planning immediate closing).
Relates to this comment thread: https://github.com/hove-io/navitia/pull/3955#discussion_r1149555504

The idea is to avoid dedicated histograms for min, average and max.
Unfortunately, after the current PR, in NR for `max(kraken_rt_message_age_seconds)` we get values that are wrong.
Not knowing if OTLP collector or NR is bugged.

It looks like the bottom of bucket is used for max when one value only is measured, don't know about multiple values.
For one value, this very value could be used, or at worse the top of given bucket (next bucket if existing).