### PR TITLE
ci: default branch for 'mimirsbrunn' is now 'main'

### DIFF
--- a/.github/workflows/build_dockers.yml
+++ b/.github/workflows/build_dockers.yml
@@ -67,7 +67,7 @@ jobs:
             mimirsbrunn_workflow=release7.yml
             mimirsbrunn_package="debian-package-release.zip"
         else
-            mimirsbrunn_workflow=master7.yml
+            mimirsbrunn_workflow=main7.yml
             mimirsbrunn_package="debian-package-master.zip"
         fi
         python core_team_ci_tools/github_artifacts/github_artifacts.py \


### PR DESCRIPTION
:warning: This PR should be merged after https://github.com/hove-io/mimirsbrunn/pull/826.