### PR TITLE
fix portable min

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: 3.9.2
     hooks:
     - id: flake8
-      language_version: python2.7
+      language_version: python3.8
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.1.0  # Use the ref you want to point at
     hooks:

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -31,7 +31,13 @@
 from __future__ import absolute_import, unicode_literals
 from contextlib import contextmanager
 from flask import appcontext_pushed, g
-from jormungandr.utils import timestamp_to_datetime, make_namedtuple, walk_dict, get_pt_object_from_json
+from jormungandr.utils import (
+    timestamp_to_datetime,
+    make_namedtuple,
+    walk_dict,
+    get_pt_object_from_json,
+    portable_min,
+)
 import pytz
 from jormungandr import app
 import datetime
@@ -275,3 +281,8 @@ def test_get_pt_object_from_json():
     assert pt_object.name == "Jardin (City)"
     assert pt_object.uri == "poi:to"
     assert len(pt_object.poi.children) == 2
+
+
+def test_portable_min():
+    assert portable_min([]) is None
+    assert portable_min((j for j in [])) is None

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -730,7 +730,8 @@ def portable_min(*args, **kwargs):
         except Exception:
             raise
     if PY3:
-        return min(*args, **kwargs)
+        default = kwargs.get('default', None)
+        return min(*args, default=default)
 
 
 def mps_to_kmph(speed):

--- a/source/navitiacommon/navitiacommon/ratelimit.py
+++ b/source/navitiacommon/navitiacommon/ratelimit.py
@@ -263,13 +263,13 @@ if __name__ == '__main__':
     rate.add_condition({'requests': 40, 'minutes': 15}, {'requests': 400, 'days': 1})
 
     i = 1
-    for _ in xrange(5):
+    for _ in range(0, 5):
         rate.acquire(key)
         log.info('***************     ping %d     ***************', i)
         i += 1
 
     rate.block(key, seconds=10)
-    for _ in xrange(10):
+    for _ in range(0, 10):
         rate.acquire(key)
         log.info('***************     ping %d     ***************', i)
         i += 1
@@ -277,7 +277,7 @@ if __name__ == '__main__':
     # block all keys
     rate.add_condition(0, 1)
 
-    for _ in xrange(5):
+    for _ in range(0, 5):
         rate(key, block=False)  # alternative interface
         time.sleep(1)
 


### PR DESCRIPTION
Default keyword arg must be provided i[n python 3.9](https://docs.python.org/3.9/library/functions.html?highlight=min#min), otherwise a ValueError is raised, and that [happen](https://navitia.atlassian.net/browse/NAV-1971)

JIRA: https://navitia.atlassian.net/browse/NAV-1971