### PR TITLE
[Jormungandr] [Autocomplete]: Remove administrative_regions from children and add test on places with query

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/geocode_json.py
@@ -187,8 +187,6 @@ class PoisSerializer(serpy.Field):
                 p.get("key"): p.get("value")
                 for p in child.get('properties', {}).get('geocoding', {}).get('properties', [])
             }
-            admins = child.get('administrative_regions', [])
-            res["administrative_regions"] = [make_admin(admin) for admin in admins]
             return res
 
         return [make_child(child) for child in children]

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -1370,6 +1370,7 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert poi["children"][0]["id"] == 'poi:osm:node:4507085760'
             assert poi["children"][0]["type"] == 'poi'
             assert poi["children"][0]["poi_type"]["id"] == 'poi_type:access_point'
+            assert poi["children"][0].get("administrative_regions") is None
 
     def test_autocomplete_call_with_depth_one(self):
         with mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_ONE):
@@ -2015,10 +2016,12 @@ class AbstractAutocompletePoiDataset:
             assert first_place['poi']["children"][0]["id"] == 'poi:osm:node:4507085760'
             assert first_place['poi']["children"][0]["type"] == 'poi'
             assert first_place['poi']["children"][0]["poi_type"]["id"] == 'poi_type:access_point'
+            assert first_place['poi']["children"][0].get("administrative_regions") is None
 
             assert first_place['poi']["children"][1]["id"] == 'poi:osm:node:790012494'
             assert first_place['poi']["children"][1]["type"] == 'poi'
             assert first_place['poi']["children"][1]["poi_type"]["id"] == 'poi_type:access_point'
+            assert first_place['poi']["children"][1].get("administrative_regions") is None
 
     def test_poi_without_children(self):
 

--- a/source/jormungandr/tests/bragi_autocomplete_tests.py
+++ b/source/jormungandr/tests/bragi_autocomplete_tests.py
@@ -500,6 +500,42 @@ BRAGI_MOCK_BOBETTE_DEPTH_ZERO["features"][0]["geometry"] = {
 BRAGI_MOCK_BOBETTE_DEPTH_ONE = deepcopy(BRAGI_MOCK_BOBETTE_DEPTH_ZERO)
 BRAGI_MOCK_BOBETTE_DEPTH_TWO = deepcopy(BRAGI_MOCK_BOBETTE_DEPTH_ZERO)
 BRAGI_MOCK_BOBETTE_DEPTH_THREE = deepcopy(BRAGI_MOCK_BOBETTE_DEPTH_ZERO)
+BRAGI_MOCK_BOBETTE_WITH_CHILDREN = deepcopy(BRAGI_MOCK_BOBETTE)
+BRAGI_MOCK_BOBETTE_WITH_CHILDREN["features"][0]["properties"]["geocoding"]["children"] = [
+    {
+        "type": "poi",
+        "id": "poi:osm:node:4507085760",
+        "label": "Jardin du Luxembourg: Porte Vavin (Paris)",
+        "name": "Jardin du Luxembourg: Porte Vavin",
+        "coord": {"lon": 2.3324915, "lat": 48.8448854},
+        "administrative_regions": [
+            {
+                "type": "admin",
+                "id": "admin:fr:75056",
+                "insee": "75056",
+                "level": 8,
+                "label": "Paris (75000-75116), Île-de-France, France",
+                "name": "Paris",
+                "weight": 0.0015625185714285715,
+                "coord": {"lon": 2.3483915, "lat": 48.8534951},
+                "administrative_regions": [],
+                "zone_type": "city",
+                "parent_id": "admin:osm:relation:71525",
+                "country_codes": [],
+                "names": {"fr": "Paris"},
+                "labels": {},
+            }
+        ],
+        "weight": 0.0015625185714285715,
+        "zip_codes": [],
+        "poi_type": {"id": "poi_type:access_point", "name": "Point d'accès"},
+        "properties": {},
+        "country_codes": ["FR"],
+        "names": {},
+        "labels": {},
+        "children": [],
+    }
+]
 
 BOB_STREET = {
     "features": [
@@ -1316,6 +1352,24 @@ class TestBragiAutocomplete(AbstractTestFixture):
             assert 'administrative_regions' not in poi
             # Address absent as in kraken
             assert 'address' not in poi
+
+    def test_autocomplete_with_children(self):
+        with mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_WITH_CHILDREN):
+            response = self.query_region(
+                "places?q=bob&pt_dataset[]=main_routing_test&type[]=stop_area"
+                "&type[]=address&type[]=poi&type[]=administrative_region&depth=0"
+            )
+
+            r = response.get('places')
+            assert len(r) == 1
+            assert r[0]['name'] == "bobette's label"
+            assert r[0]['embedded_type'] == "poi"
+            poi = r[0]['poi']
+            assert poi['label'] == "bobette's label"
+            assert len(poi["children"]) == 1
+            assert poi["children"][0]["id"] == 'poi:osm:node:4507085760'
+            assert poi["children"][0]["type"] == 'poi'
+            assert poi["children"][0]["poi_type"]["id"] == 'poi_type:access_point'
 
     def test_autocomplete_call_with_depth_one(self):
         with mock_bragi_autocomplete_call(BRAGI_MOCK_BOBETTE_DEPTH_ONE):


### PR DESCRIPTION
* Remove administrative_regions from children.
* For api /places?q=toto in navitia, api /autocomplete is used bragi where as /places/id uses api /features in bragi.
* A test already exists on /places/id using bragi result with children.
* A new test is added on /places?q=<search string> using bragi result with children.

For more details:    https://navitia.atlassian.net/browse/NAV-2000