### PR TITLE
[Kraken] remove/merge RT handling duration metrics

### DIFF
--- a/source/kraken/metrics.cpp
+++ b/source/kraken/metrics.cpp
@@ -133,24 +133,10 @@ Metrics::Metrics(const boost::optional<std::string>& endpoint, const std::string
 
     this->handle_rt_histogram = &prometheus::BuildHistogram()
                                      .Name("kraken_handle_rt_duration_seconds")
-                                     .Help("duration for handling realtime")
+                                     .Help("duration for handling realtime batch (add(s)/delete(s) from chaos/kirin")
                                      .Labels({{"coverage", coverage}})
                                      .Register(*registry)
                                      .Add({}, create_exponential_buckets(0.5, 2, 10));
-
-    this->handle_disruption_histogram = &prometheus::BuildHistogram()
-                                             .Name("kraken_handle_disruption_duration_seconds")
-                                             .Help("duration for handling disruption")
-                                             .Labels({{"coverage", coverage}})
-                                             .Register(*registry)
-                                             .Add({}, create_exponential_buckets(0.5, 2, 10));
-
-    this->delete_disruption_histogram = &prometheus::BuildHistogram()
-                                             .Name("kraken_delete_disruption_duration_seconds")
-                                             .Help("duration for deleting a disruption")
-                                             .Labels({{"coverage", coverage}})
-                                             .Register(*registry)
-                                             .Add({}, create_exponential_buckets(0.5, 2, 10));
 
     this->retrieve_rt_message_duration_histogram = &prometheus::BuildHistogram()
                                                         .Name("kraken_retrieve_rt_message_duration_seconds")
@@ -234,20 +220,6 @@ void Metrics::observe_handle_rt(double duration) const {
         return;
     }
     this->handle_rt_histogram->Observe(duration);
-}
-
-void Metrics::observe_handle_disruption(double duration) const {
-    if (!registry) {
-        return;
-    }
-    this->handle_disruption_histogram->Observe(duration);
-}
-
-void Metrics::observe_delete_disruption(double duration) const {
-    if (!registry) {
-        return;
-    }
-    this->delete_disruption_histogram->Observe(duration);
 }
 
 void Metrics::observe_retrieve_rt_message_duration(double duration) const {

--- a/source/kraken/metrics.h
+++ b/source/kraken/metrics.h
@@ -49,7 +49,6 @@ class Histogram;
 }  // namespace prometheus
 
 namespace navitia {
-enum class RTAction { deletion = 0, chaos, kirin };
 
 class InFlightGuard {
     prometheus::Gauge* gauge;
@@ -72,8 +71,6 @@ protected:
     prometheus::Histogram* data_loading_histogram;
     prometheus::Histogram* data_cloning_histogram;
     prometheus::Histogram* handle_rt_histogram;
-    prometheus::Histogram* handle_disruption_histogram;
-    prometheus::Histogram* delete_disruption_histogram;
     prometheus::Histogram* retrieve_rt_message_duration_histogram;
     prometheus::Histogram* retrieved_rt_message_count_histogram;
     prometheus::Histogram* applied_rt_entity_count_histogram;
@@ -90,8 +87,6 @@ public:
     void observe_data_loading(double duration) const;
     void observe_data_cloning(double duration) const;
     void observe_handle_rt(double duration) const;
-    void observe_handle_disruption(double duration) const;
-    void observe_delete_disruption(double duration) const;
     void observe_retrieve_rt_message_duration(double duration) const;
     void observe_retrieved_rt_message_count(size_t count) const;
     void observe_applied_rt_entity_count(size_t count) const;


### PR DESCRIPTION
The output was not relevant as messages are handled in batch and a batch can contain different types: merging all into one metric and keep only logs if need arises for more details.