### PR TITLE
Keep olympics journeys

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -525,6 +525,14 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             help="choose the criteria used to compute pt journeys, feature in beta ",
         )
 
+        parser_get.add_argument(
+            "_jo",
+            type=BooleanType(),
+            hidden=True,
+            default=False,
+            help="do not delete journeys tagged for olympics",
+        )
+
         # Advanced parameters for valhalla bike
         parser_get.add_argument(
             "bike_use_roads",

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -526,7 +526,7 @@ class JourneyCommon(ResourceUri, ResourceUtc):
         )
 
         parser_get.add_argument(
-            "_jo",
+            "_keep_olympics_journeys",
             type=BooleanType(),
             hidden=True,
             default=False,

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -45,17 +45,16 @@ def delete_journeys(responses, request):
     if request.get('debug', False):
         return
 
-    keep_jo = request.get("_jo", False)
-
-    def to_delete(journey):
-        if keep_jo:
-            return to_be_deleted(journey) and "olympics" not in journey.tags
-        else:
-            return to_be_deleted(journey)
+    keep_olympics_journeys = request.get("_keep_olympics_journeys", False)
 
     nb_deleted = 0
     for r in responses:
-        nb_deleted += pb_del_if(r.journeys, lambda j: to_delete(j))
+        if keep_olympics_journeys:
+            for journey in r.journeys:
+                if 'to_delete' in journey.tags and 'olympics' in journey.tags:
+                    journey.tags.remove("to_delete")
+
+        nb_deleted += pb_del_if(r.journeys, lambda j: to_be_deleted(j))
 
     if nb_deleted:
         logging.getLogger(__name__).info('filtering {} journeys'.format(nb_deleted))

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -45,9 +45,17 @@ def delete_journeys(responses, request):
     if request.get('debug', False):
         return
 
+    keep_jo = request.get("_jo", False)
+
+    def to_delete(journey):
+        if keep_jo:
+            return to_be_deleted(journey) and "olympics" not in journey.tags
+        else:
+            return to_be_deleted(journey)
+
     nb_deleted = 0
     for r in responses:
-        nb_deleted += pb_del_if(r.journeys, lambda j: to_be_deleted(j))
+        nb_deleted += pb_del_if(r.journeys, lambda j: to_delete(j))
 
     if nb_deleted:
         logging.getLogger(__name__).info('filtering {} journeys'.format(nb_deleted))


### PR DESCRIPTION
Add a hidden request parameter `_jo`. When set to `true`, any journey tagged `olympics` will not be deleted by jormun filtering.
Indeed, sometimes an `olympics` journey is filtered by jormun because it uses the same line as another journey, but arrives later & walks more (we want to keep the olympics journeys because it ends at a specific stops).
The tag `olympics` is [set in Loki ](https://github.com/hove-io/loki/pull/435) for now