### PR TITLE
[rail_section]: Fix displaying disruptions of type other_effect in

### DIFF
--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -3228,10 +3228,10 @@ class TestNoServiceJourney(MockKirinOrChaosDisruptionsFixture):
 
         disruptions_before = self.query_region('disruptions?_current_datetime=20170120T080000')
         nb_disruptions_before = len(disruptions_before['disruptions'])
-        assert nb_disruptions_before == 9
+        assert nb_disruptions_before == 10
 
         vjs_before = self.query_region('vehicle_journeys?count=100')
-        assert len(vjs_before['vehicle_journeys']) == 26
+        assert len(vjs_before['vehicle_journeys']) == 27
 
         # Test that a journey affected by a DETOUR rail-section is NO_SERVICE when stop used is deleted
         journey_AADD_query = (
@@ -3355,7 +3355,7 @@ class TestNoServiceJourney(MockKirinOrChaosDisruptionsFixture):
             is_kirin=True,
         )
         disrupts = self.query_region('disruptions?_current_datetime=20170120T080000')
-        assert len(disrupts['disruptions']) == 10
+        assert len(disrupts['disruptions']) == 11
         assert has_the_disruption(disrupts, 'reduced_service_vj1')
         last_disrupt = disrupts['disruptions'][-1]
         assert last_disrupt['severity']['effect'] == 'REDUCED_SERVICE'
@@ -3363,7 +3363,7 @@ class TestNoServiceJourney(MockKirinOrChaosDisruptionsFixture):
 
         vjs_after = self.query_region('vehicle_journeys?count=100')
         # we got a new vj due to the disruption, which means the disruption is handled correctly
-        assert len(vjs_after['vehicle_journeys']) == 27
+        assert len(vjs_after['vehicle_journeys']) == 28
 
         # After "Kirin" disruption, journey using a deleted stop has its status changed to NO_SERVICE
         journey_AC = self.query_region(journey_AC_query)

--- a/source/tests/mock-kraken/rail_sections_test.cpp
+++ b/source/tests/mock-kraken/rail_sections_test.cpp
@@ -170,6 +170,10 @@ ed::builder create_complex_data_for_rail_section() {
             .route("route100-1")("stopA1", "08:00"_t)("stopB1", "08:05"_t)("stopC1", "08:10"_t)("stopD1", "08:15"_t)(
                 "stopE1", "08:20"_t)("stopF1", "08:25"_t)("stopG1", "08:30"_t)("stopH1", "08:35"_t)("stopI1",
                                                                                                     "08:40"_t);
+        b.vj("line:100", "111111111111111111111111111111111111", "", true, "vj:100-2")
+            .route("route100-2")("stopI1", "08:00"_t)("stopH1", "08:05"_t)("stopG1", "08:10"_t)("stopF1", "08:15"_t)(
+                "stopE1", "08:20"_t)("stopD1", "08:25"_t)("stopC1", "08:30"_t)("stopB1", "08:35"_t)("stopA1",
+                                                                                                    "08:40"_t);
 
         b.vj("line:101", "111111111111111111111111111111111111", "", true, "vj:101-1")
             .route("route101-1")("stopP1", "08:00"_t)("stopQ1", "08:05"_t)("stopR1", "08:10"_t)("stopS1", "08:15"_t)(
@@ -297,7 +301,7 @@ int main(int argc, const char* const argv[]) {
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 
-    // new rail_section disruption NO_SERVICE on route 100
+    // new rail_section disruption NO_SERVICE on route 100-1
     // A1  B1  C1 D1  E1  F1  G1 H1 I1
     // Start C1
     // End   F1
@@ -309,6 +313,21 @@ int main(int argc, const char* const argv[]) {
                                   .on_rail_section("line:100", "stopAreaC1", "stopAreaF1",
                                                    {std::make_pair("stopAreaD1", 1), std::make_pair("stopAreaE1", 2)},
                                                    {"route100-1"}, *b.data->pt_data)
+                                  .get_disruption(),
+                              *b.data->pt_data, *b.data->meta);
+
+    // new rail_section disruption OTHER_EFFECT on route 100-2
+    // A1  B1  C1 D1  E1  F1  G1 H1 I1    //
+    // Start D1
+    // End   B1
+    // Blocked: C1
+    navitia::apply_disruption(b.impact(nt::RTLevel::Adapted, "rail_section_on_line100_route100_route-2")
+                                  .severity(nt::disruption::Effect::OTHER_EFFECT)
+                                  .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
+                                  .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
+                                  .on_rail_section("line:100", "stopAreaD1", "stopAreaB1",
+                                                   {std::make_pair("stopAreaC1", 1)},
+                                                   {"route100-2"}, *b.data->pt_data)
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 

--- a/source/tests/mock-kraken/rail_sections_test.cpp
+++ b/source/tests/mock-kraken/rail_sections_test.cpp
@@ -326,8 +326,7 @@ int main(int argc, const char* const argv[]) {
                                   .application_periods(btp("20170101T000000"_dt, "20170105T000000"_dt))
                                   .publish(btp("20170101T000000"_dt, "20170110T000000"_dt))
                                   .on_rail_section("line:100", "stopAreaD1", "stopAreaB1",
-                                                   {std::make_pair("stopAreaC1", 1)},
-                                                   {"route100-2"}, *b.data->pt_data)
+                                                   {std::make_pair("stopAreaC1", 1)}, {"route100-2"}, *b.data->pt_data)
                                   .get_disruption(),
                               *b.data->pt_data, *b.data->meta);
 

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -459,7 +459,8 @@ bool Impact::is_relevant(const std::vector<const StopTime*>& stop_times) const {
         return false;
     } else if (is_rail_section
                && (this->severity->effect == nt::disruption::Effect::REDUCED_SERVICE
-                   || this->severity->effect == nt::disruption::Effect::DETOUR)) {
+                   || this->severity->effect == nt::disruption::Effect::DETOUR
+                   || this->severity->effect == nt::disruption::Effect::OTHER_EFFECT)) {
         const auto& informed_entity = *rail_section_impacted_obj_it;
         const RailSection* rail_section = boost::get<RailSection>(&informed_entity);
 


### PR DESCRIPTION
managing rail_section disruption with effect = OTHER_EFFECT:
- It should not modify public transport plan
- Only messages concerned to rail_section (not line, route or others) should be displayed.
- For more information, read tests as well as ticket: https://navitia.atlassian.net/browse/NAV-1820
