### PR TITLE
[Olympics] Jormun: remove to_delete tags earlier for olympics journeys

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -45,15 +45,8 @@ def delete_journeys(responses, request):
     if request.get('debug', False):
         return
 
-    keep_olympics_journeys = request.get("_keep_olympics_journeys", False)
-
     nb_deleted = 0
     for r in responses:
-        if keep_olympics_journeys:
-            for journey in r.journeys:
-                if 'to_delete' in journey.tags and 'olympics' in journey.tags:
-                    journey.tags.remove("to_delete")
-
         nb_deleted += pb_del_if(r.journeys, lambda j: to_be_deleted(j))
 
     if nb_deleted:
@@ -675,6 +668,8 @@ def apply_final_journey_filters(response_list, instance, request):
         journeys = journey_generator(response_list)
         filter_non_car_tagged_journey(journeys, request)
 
+    keep_olympics_journeys(response_list, request)
+
 
 def filter_non_car_tagged_journey(journeys, request):
     is_debug = request.get('debug', False)
@@ -704,6 +699,17 @@ def apply_final_journey_filters_post_finalize(response_list, request):
         journeys = journey_generator(response_list)
         journey_pairs_pool = itertools.combinations(journeys, 2)
         _filter_similar_line_and_crowfly_journeys(journey_pairs_pool, request)
+
+    keep_olympics_journeys(response_list, request)
+
+
+def keep_olympics_journeys(responses, request):
+    keep_olympics_journeys = request.get("_keep_olympics_journeys", False)
+    if keep_olympics_journeys:
+        for response in responses:
+            for journey in response.journeys:
+                if 'to_delete' in journey.tags and 'olympics' in journey.tags:
+                    journey.tags.remove("to_delete")
 
 
 def replace_bss_tag(journeys):
@@ -746,6 +752,8 @@ def filter_detailed_journeys(responses, request):
     filter_similar_vj_journeys(journey_pairs_pool, request)
 
     replace_bss_tag(journey_generator(responses))
+
+    keep_olympics_journeys(responses, request)
 
 
 def _get_worst_similar(j1, j2, request):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -1167,6 +1167,7 @@ def filter_journeys(responses, new_resp, instance, api_request):
     )
 
     journey_filter.filter_similar_vj_journeys(journey_pairs_pool, api_request)
+    journey_filter.keep_olympics_journeys(new_resp, api_request)
 
 
 def isochrone_common(isochrone, request, instance, journey_req):


### PR DESCRIPTION
The 'to_delete' tags was removed from olympics journeys too late in the distributed process, so the resulting journeys were missing some parts (in particular the street network fallbacks[ were not computed](https://github.com/hove-io/navitia/blob/52cb3abc81ee81288b2039412864cb8d01fb7e67/source/jormungandr/jormungandr/scenarios/distributed.py#L312) ).
The tag is now removed right after calling the `filter*` functions.