### PR TITLE
Kraken: Smarter sorting of next_stop_time

### DIFF
--- a/source/routing/next_stop_time.cpp
+++ b/source/routing/next_stop_time.cpp
@@ -72,8 +72,7 @@ void NextStopTimeData::TimesStopTimes<Getter>::init(const JourneyPattern& jp, co
             continue;
         }
         const type::StopTime& earliest_stop_time = navitia::earliest_stop_time(st.vehicle_journey->stop_time_list);
-        StopTimePair pair = StopTimePair(&st, &earliest_stop_time);
-        stop_times_and_earliest_stop_time.push_back(pair);
+        stop_times_and_earliest_stop_time.emplace_back(&st, &earliest_stop_time);
     }
 
     // sort the stop times in ascending order


### PR DESCRIPTION
The function `NextStopTimeData::TimesStopTimes<Getter>::init` takes a list of `stop_times`, and sort them.
However, when two `stop_times` are equal, the function compares the earliest stop_time of the corresponding vehicle_journeys. And to determine the earliest `stop_time` of a `vehicle_journey`, we need to scan all its `stop_times`.

So if we need to sort N `stop_times` that belongs to `vehicle_journeys` with at most K `stop_times`, this means that in the worst case each call to the comparison operator is O(K). Sorting may perform O(N log N) calls to the comparison operator, resulting in a worst-case behavior of O(K N log N).

Instead of determining the earliest `stop_time` of a `vehicle_journey` inside the comparison operator, this PR moves this operation before the sort.

- We first scan all the `stop_times` to be sorted, and compute the earliest `stop_time` of their corresponding `vehicle_journey`. We store the `stop_time`, along its corresponding earliest `stop_time` inside a temporary vector. Overall an O(K N) operation
- We then perform the sort on the temporary vector. Since the earliest `stop_times` are already computed, the comparison operator is O(1)
- Then we copy the sorted `stop_times` in the `self.stop_times` vector that is used afterward for journeys computation.

This results in a worst case behavior of O(K N + N Log N) improving on the previous O(K N log N).

In practice, the time to build the `dataRaptor` was reduced from 2mn to 30s on `fr-se-lyon`, and did not change on `idfm`.

https://navitia.atlassian.net/browse/NAV-1806

