### PR TITLE
Jormun: Fix value for handimap parameter costing

### DIFF
--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -139,9 +139,13 @@ class Handimap(AbstractStreetNetworkService):
         if wheelchair is None:
             wheelchair = request.get("traveler_type") == "wheelchair"
         costing_value = "wheelchair" if wheelchair else "walking"
+        costing_options = {
+            "walking": {"walking_speed": walking_speed_km},
+            "wheelchair": {"travel_speed": walking_speed_km},
+        }
         return {
             "costing": costing_value,
-            "costing_options": {"walking": {"walking_speed": walking_speed_km}},
+            "costing_options": {costing_value: costing_options.get(costing_value)},
             "directions_options": {"units": "kilometers", "language": language},
         }
 

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -133,10 +133,14 @@ class Handimap(AbstractStreetNetworkService):
         return self.language if not language else self._get_language(language.lower())
 
     @staticmethod
-    def _make_request_arguments_walking_details(walking_speed, language):
-        walking_speed_km = mps_to_kmph(walking_speed)
+    def _make_request_arguments_walking_details(request, language):
+        walking_speed_km = mps_to_kmph(request["walking_speed"])
+        wheelchair = request.get("wheelchair", None)
+        if wheelchair is None:
+            wheelchair = request.get("traveler_type") == "wheelchair"
+        costing_value = "wheelchair" if wheelchair else "walking"
         return {
-            "costing": "walking",
+            "costing": costing_value,
             "costing_options": {"walking": {"walking_speed": walking_speed_km}},
             "directions_options": {"units": "kilometers", "language": language},
         }
@@ -147,8 +151,8 @@ class Handimap(AbstractStreetNetworkService):
         return {"lat": coord.lat, "lon": coord.lon}
 
     @classmethod
-    def _make_request_arguments_direct_path(cls, origin, destination, walking_speed, language):
-        walking_details = cls._make_request_arguments_walking_details(walking_speed, language)
+    def _make_request_arguments_direct_path(cls, origin, destination, request, language):
+        walking_details = cls._make_request_arguments_walking_details(request, language)
         params = {
             'locations': [
                 cls._format_coord(origin),
@@ -158,9 +162,8 @@ class Handimap(AbstractStreetNetworkService):
         params.update(walking_details)
         return params
 
-    def matrix_payload(self, origins, destinations, walking_speed, language):
-
-        walking_details = self._make_request_arguments_walking_details(walking_speed, language)
+    def matrix_payload(self, origins, destinations, request, language):
+        walking_details = self._make_request_arguments_walking_details(request, language)
 
         params = {
             "sources": [self._format_coord(o) for o in origins],
@@ -170,8 +173,8 @@ class Handimap(AbstractStreetNetworkService):
 
         return params
 
-    def post_matrix_request(self, origins, destinations, walking_speed, language):
-        post_data = self.matrix_payload(origins, destinations, walking_speed, language)
+    def post_matrix_request(self, origins, destinations, request, language):
+        post_data = self.matrix_payload(origins, destinations, request, language)
         response = self._call_handimap(
             'sources_to_targets',
             post_data,
@@ -220,9 +223,8 @@ class Handimap(AbstractStreetNetworkService):
     def _get_street_network_routing_matrix(
         self, instance, origins, destinations, street_network_mode, max_duration, request, request_id, **kwargs
     ):
-        walking_speed = request["walking_speed"]
         language = self.get_language_parameter(request)
-        resp_json = self.post_matrix_request(origins, destinations, walking_speed, language)
+        resp_json = self.post_matrix_request(origins, destinations, request, language)
 
         self.check_content_response(resp_json, origins, destinations)
         return self._create_matrix_response(resp_json, origins, destinations, max_duration)
@@ -239,11 +241,10 @@ class Handimap(AbstractStreetNetworkService):
         request_id,
     ):
         self.check_handimap_modes([mode])
-        walking_speed = request["walking_speed"]
         language = self.get_language_parameter(request)
 
         params = self._make_request_arguments_direct_path(
-            pt_object_origin, pt_object_destination, walking_speed, language
+            pt_object_origin, pt_object_destination, request, language
         )
 
         response = self._call_handimap('route', params)

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -135,9 +135,7 @@ class Handimap(AbstractStreetNetworkService):
     @staticmethod
     def _make_request_arguments_walking_details(request, language):
         walking_speed_km = mps_to_kmph(request["walking_speed"])
-        wheelchair = request.get("wheelchair", None)
-        if wheelchair is None:
-            wheelchair = request.get("traveler_type") == "wheelchair"
+        wheelchair = request.get("wheelchair", request.get("traveler_type") == "wheelchair")
         costing_value = "wheelchair" if wheelchair else "walking"
         costing_options = {
             "walking": {"walking_speed": walking_speed_km},

--- a/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
@@ -307,6 +307,7 @@ def make_request_arguments_direct_path_handimap_func_test():
     request = {"walking_speed": 1.5}
     arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
     assert arguments_direct_path["costing"] == "walking"
+    assert arguments_direct_path["costing_options"] == {'walking': {'walking_speed': 5.0}}
     assert arguments_direct_path["directions_options"]["units"] == "kilometers"
     assert arguments_direct_path["directions_options"]["language"] == "en-EN"
     assert len(arguments_direct_path["locations"]) == 2

--- a/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
@@ -287,7 +287,8 @@ def get_language_parameter_handimap_func_language_invalid_test():
 
 
 def make_request_arguments_walking_details_handimap_func_invalid_test():
-    res = Handimap._make_request_arguments_walking_details(1.5, "en-EN")
+    request = {"walking_speed": 1.5}
+    res = Handimap._make_request_arguments_walking_details(request, "en-EN")
     assert res["costing"] == "walking"
     assert res["costing_options"]["walking"]["walking_speed"] == 5.0
     assert res["directions_options"]["language"] == "en-EN"
@@ -303,7 +304,8 @@ def make_request_arguments_direct_path_handimap_func_test():
     destination.embedded_type = type_pb2.POI
     destination.poi.coord.lon = 32.41
     destination.poi.coord.lat = 31.42
-    arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, 1.5, "en-EN")
+    request = {"walking_speed": 1.5}
+    arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
     assert arguments_direct_path["costing"] == "walking"
     assert arguments_direct_path["directions_options"]["units"] == "kilometers"
     assert arguments_direct_path["directions_options"]["language"] == "en-EN"
@@ -312,6 +314,22 @@ def make_request_arguments_direct_path_handimap_func_test():
     assert arguments_direct_path["locations"][0]["lon"] == origin.poi.coord.lon
     assert arguments_direct_path["locations"][1]["lat"] == destination.poi.coord.lat
     assert arguments_direct_path["locations"][1]["lon"] == destination.poi.coord.lon
+
+    # Request with wheelchair or/and traveler_type in the request
+    request["traveler_type"] = "fast_walker"
+    arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
+    assert arguments_direct_path["costing"] == "walking"
+    request["traveler_type"] = "wheelchair"
+    arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
+    assert arguments_direct_path["costing"] == "wheelchair"
+
+    # parameter wheelchair has priority on parameter  traveler_type
+    request["wheelchair"] = False
+    arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
+    assert arguments_direct_path["costing"] == "walking"
+    request["wheelchair"] = True
+    arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
+    assert arguments_direct_path["costing"] == "wheelchair"
 
 
 def format_coord_handimap_func_test():

--- a/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
@@ -319,17 +319,21 @@ def make_request_arguments_direct_path_handimap_func_test():
     request["traveler_type"] = "fast_walker"
     arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
     assert arguments_direct_path["costing"] == "walking"
+    assert arguments_direct_path["costing_options"] == {'walking': {'walking_speed': 5.0}}
     request["traveler_type"] = "wheelchair"
     arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
     assert arguments_direct_path["costing"] == "wheelchair"
+    assert arguments_direct_path["costing_options"] == {'wheelchair': {'travel_speed': 5.0}}
 
     # parameter wheelchair has priority on parameter  traveler_type
     request["wheelchair"] = False
     arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
     assert arguments_direct_path["costing"] == "walking"
+    assert arguments_direct_path["costing_options"] == {'walking': {'walking_speed': 5.0}}
     request["wheelchair"] = True
     arguments_direct_path = Handimap._make_request_arguments_direct_path(origin, destination, request, "en-EN")
     assert arguments_direct_path["costing"] == "wheelchair"
+    assert arguments_direct_path["costing_options"] == {'wheelchair': {'travel_speed': 5.0}}
 
 
 def format_coord_handimap_func_test():


### PR DESCRIPTION
If parameter "wheelchair"=True or "traveler_type"="wheelchair" is present in the request use:
-  "costing"="wheelchair" 
-  "costing_options": {"wheelchair": {"travel_speed": walking_speed_km}}

otherwise use:
-  instead of "costing"="walking" 
-  "costing_options": {"walking": {"travel_speed": walking_speed_km}}

while calling Handimap.


For more details: https://navitia.atlassian.net/browse/NAV-2043