### PR TITLE
Fix parsing error on allowed_id for same_journey_schedules in Python3

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -159,7 +159,7 @@ class add_journey_href(object):
                     args['direct_path'] = 'only' if 'non_pt' in journey['tags'] else 'none'
                     args['min_nb_journeys'] = 5
                     args['is_journey_schedules'] = True
-                    param_values = vars(allowed_id_args).get('allowed_id[]', [])
+                    param_values = allowed_id_args.get('allowed_id[]') or []
                     allowed_ids.update(param_values)
                     args['allowed_id[]'] = list(allowed_ids)
                     args['_type'] = 'journeys'

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -120,9 +120,9 @@ class add_journey_href(object):
             if has_invalid_reponse_code(objects) or journeys_absent(objects):
                 return objects
 
-            # This is a temporary hack to resolve Error introduced during migration to Python3
+            # TODO: This is a temporary hack to resolve Error introduced during migration to Python3
             # Instead of using wrongly parsed request.args we use original args to get existing allowed_id[]
-            allowed_id_args = args[0].parsers['get'].parse_args()
+            raw_args = args[0].parsers['get'].parse_args()
             for journey in objects[0]['journeys']:
                 args = dict(request.args)
                 allowed_ids = {
@@ -159,7 +159,7 @@ class add_journey_href(object):
                     args['direct_path'] = 'only' if 'non_pt' in journey['tags'] else 'none'
                     args['min_nb_journeys'] = 5
                     args['is_journey_schedules'] = True
-                    param_values = allowed_id_args.get('allowed_id[]') or []
+                    param_values = raw_args.get('allowed_id[]') or []
                     allowed_ids.update(param_values)
                     args['allowed_id[]'] = list(allowed_ids)
                     args['_type'] = 'journeys'

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -120,11 +120,10 @@ class add_journey_href(object):
             if has_invalid_reponse_code(objects) or journeys_absent(objects):
                 return objects
 
-            # TODO: This is a temporary hack to resolve Error introduced during migration to Python3
-            # Instead of using wrongly parsed request.args we use original args to get existing allowed_id[]
-            raw_args = args[0].parsers['get'].parse_args()
             for journey in objects[0]['journeys']:
-                args = dict(request.args)
+                # Note: request.args is a MultiDict, we want to flatten it by having list as value when needed
+                # From Python3.6 onwards dict(request.args) != request.args.to_dict(flat=False)
+                args = request.args.to_dict(flat=False)
                 allowed_ids = {
                     o['stop_point']['id']
                     for s in journey.get('sections', [])
@@ -159,8 +158,7 @@ class add_journey_href(object):
                     args['direct_path'] = 'only' if 'non_pt' in journey['tags'] else 'none'
                     args['min_nb_journeys'] = 5
                     args['is_journey_schedules'] = True
-                    param_values = raw_args.get('allowed_id[]') or []
-                    allowed_ids.update(param_values)
+                    allowed_ids.update(args.get('allowed_id[]', []))
                     args['allowed_id[]'] = list(allowed_ids)
                     args['_type'] = 'journeys'
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -120,6 +120,9 @@ class add_journey_href(object):
             if has_invalid_reponse_code(objects) or journeys_absent(objects):
                 return objects
 
+            # This is a temporary hack to resolve Error introduced during migration to Python3
+            # Instead of using wrongly parsed request.args we use original args to get existing allowed_id[]
+            allowed_id_args = args[0].parsers['get'].parse_args()
             for journey in objects[0]['journeys']:
                 args = dict(request.args)
                 allowed_ids = {
@@ -156,7 +159,8 @@ class add_journey_href(object):
                     args['direct_path'] = 'only' if 'non_pt' in journey['tags'] else 'none'
                     args['min_nb_journeys'] = 5
                     args['is_journey_schedules'] = True
-                    allowed_ids.update(args.get('allowed_id[]', []))
+                    param_values = vars(allowed_id_args).get('allowed_id[]', [])
+                    allowed_ids.update(param_values)
                     args['allowed_id[]'] = list(allowed_ids)
                     args['_type'] = 'journeys'
 

--- a/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Schedules.py
@@ -330,7 +330,9 @@ class add_passages_links:
                     max_dt = dt
             if "links" not in response:
                 response["links"] = []
-            kwargs_links = dict(deepcopy(request.args))
+            # request.args is a MultiDict, we want to flatten it by having list as value when needed
+            # From Python3.6 onwards dict(request.args) != request.args.to_dict(flat=False)
+            kwargs_links = deepcopy(request.args).to_dict(flat=False)
             if "region" in kwargs:
                 kwargs_links["region"] = kwargs["region"]
             if "uri" in kwargs:

--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -121,7 +121,9 @@ class add_pagination_links(object):
                 data = objects
             pagination = data.get('pagination', None)
             endpoint = request.endpoint
-            kwargs.update(request.args)
+            # Note: request.args is a MultiDict, we want to flatten it by having list as value when needed
+            # From Python3.6 onwards dict(request.args) != request.args.to_dict(flat=False)
+            kwargs.update(request.args.to_dict(flat=False))
 
             # We remove the region any-beta if present. This is a temporary hack and should be removed later
             if kwargs.get('region') == COVERAGE_ANY_BETA:

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -1352,3 +1352,12 @@ class TestPtRefRoutingCov(AbstractTestFixture):
         assert response['pagination']['items_per_page'] == 1000
         assert response['pagination']['items_on_page'] == 9
         assert response['pagination']['total_result'] == 9
+
+    def test_pagination_links_with_count_and_allowed_id(self):
+        response = self.query_region(
+            "stop_points?count=2&start_page=1&allowed_id[]=toto&allowed_id[]=titi", display=True
+        )
+        for link in response['links']:
+            if link['type'] in ('previous', 'next', 'first', 'last'):
+                # Before correction: assert href_value.count('allowed_id') == 1
+                assert link['href'].count('allowed_id') == 2

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -1402,3 +1402,48 @@ class TestRoutingWithTransfer(NewDefaultScenarioAbstractTestFixture):
         assert last_transfer_path['via_uri'] == "access_point:E1"
 
         assert sections[4]['display_informations']['physical_mode'] == 'RER'
+
+
+@dataset({"main_routing_test": {"scenario": "distributed"}})
+class TestLinksDistributed(NewDefaultScenarioAbstractTestFixture):
+    def test_same_journey_schedules_link(self):
+        query = (
+            sub_query
+            + "&datetime=20120614T080000"
+            + "&first_section_mode[]=walking"
+            + "&last_section_mode[]=walking"
+        )
+
+        response = self.query_region(query)
+        check_best(response)
+        self.is_valid_journey_response(response, query)
+
+        journeys = get_not_null(response, 'journeys')
+        assert len(journeys) == 2
+        assert journeys[0]['links'][0]['rel'] == 'same_journey_schedules'
+        assert journeys[0]['links'][0]['type'] == 'journeys'
+        href_value = journeys[0]['links'][0]['href']
+        assert href_value is not None
+        assert href_value.count('allowed_id') == 2
+
+        query = (
+                sub_query
+                + "&datetime=20120614T080000"
+                + "&first_section_mode[]=walking"
+                + "&last_section_mode[]=walking"
+                + "&allowed_id[]=stop_point:stopA"
+                + "&allowed_id[]=stop_point:stopB"
+        )
+
+        response = self.query_region(query)
+        check_best(response)
+        self.is_valid_journey_response(response, query)
+
+        journeys = get_not_null(response, 'journeys')
+        assert len(journeys) == 2
+        assert journeys[0]['links'][0]['rel'] == 'same_journey_schedules'
+        assert journeys[0]['links'][0]['type'] == 'journeys'
+        href_value = journeys[0]['links'][0]['href']
+        assert href_value is not None
+        # Before correction: assert href_value.count('allowed_id') == 11
+        assert href_value.count('allowed_id') == 2

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -1427,12 +1427,12 @@ class TestLinksDistributed(NewDefaultScenarioAbstractTestFixture):
         assert href_value.count('allowed_id') == 2
 
         query = (
-                sub_query
-                + "&datetime=20120614T080000"
-                + "&first_section_mode[]=walking"
-                + "&last_section_mode[]=walking"
-                + "&allowed_id[]=stop_point:stopA"
-                + "&allowed_id[]=stop_point:stopB"
+            sub_query
+            + "&datetime=20120614T080000"
+            + "&first_section_mode[]=walking"
+            + "&last_section_mode[]=walking"
+            + "&allowed_id[]=stop_point:stopA"
+            + "&allowed_id[]=stop_point:stopB"
         )
 
         response = self.query_region(query)


### PR DESCRIPTION
Finally we use to_dict(flat=False) on request.args. Thanks to @pbougue 
For details: https://navitia.atlassian.net/browse/NAV-1998