### PR TITLE
[Ridesharing] fix ouestgo

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -230,8 +230,9 @@ class Ouestgo(AbstractRidesharingService):
             raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
 
         if resp:
-            # Watch out! Here there is no more flask context, which means all parameters store in 'g' are lost, even though the timezone is previously set in g
-            # it's better the retrieve the timezone from instance_params than relying on the g
+            # Watch out! Here there is no more flask context, which means all parameters store in 'g' are lost
+            # EVEN THOUGH the timezone is previously set in g.
+            # We'd better retrieve the timezone from instance_params than relying on the g
             timezone = get_timezone_or_paris() if instance_params is None else instance_params.timezone
             r = self._make_response(resp.json(), period_extremity.datetime, from_coord, to_coord, timezone)
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -126,10 +126,6 @@ class Ouestgo(AbstractRidesharingService):
         if not raw_json:
             return []
         ridesharing_journeys = []
-        logging.getLogger(__name__).error(
-            'Ouestgo request_datetime %s',
-            request_datetime,
-        )
         circulation_day = get_weekday(request_datetime, timezone)
         for offer in raw_json:
             json_journeys = offer.get('journeys', {})

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -230,7 +230,8 @@ class Ouestgo(AbstractRidesharingService):
             raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
 
         if resp:
-            # Watch out! Here there is no more flask context, which means all parameters store in 'g' are lost
+            # Watch out! Here there is no more flask context, which means all parameters store in 'g' are lost, even though the timezone is previously set in g
+            # it's better the retrieve the timezone from instance_params than relying on the g
             timezone = get_timezone_or_paris() if instance_params is None else instance_params.timezone
             r = self._make_response(resp.json(), period_extremity.datetime, from_coord, to_coord, timezone)
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -44,6 +44,7 @@ from jormungandr.scenarios.journey_filter import to_be_deleted
 from jormungandr.scenarios.helper_classes.helper_future import FutureManager
 from importlib import import_module
 from jormungandr.utils import can_connect_to_database
+import pytz
 
 
 class RidesharingServiceManager(object):
@@ -51,6 +52,7 @@ class RidesharingServiceManager(object):
         greenlet_pool_for_ridesharing_services = True
         ridesharing_greenlet_pool_size = 1
         walking_speed = 1.12
+        timezone = pytz.timezone("UTC")
 
         @classmethod
         def make_params(cls, instance):
@@ -58,6 +60,7 @@ class RidesharingServiceManager(object):
             param.greenlet_pool_for_ridesharing_services = instance.greenlet_pool_for_ridesharing_services
             param.ridesharing_greenlet_pool_size = instance.ridesharing_greenlet_pool_size
             param.walking_speed = instance.walking_speed
+            param.timezone = pytz.timezone(instance.timezone)
             return param
 
     def __init__(

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
@@ -41,6 +41,7 @@ from jormungandr import utils
 import json
 import requests_mock
 import pytest
+import pytz
 
 # https://stackoverflow.com/a/9312242/1614576
 import re
@@ -181,6 +182,7 @@ class DummyInstance:
     walking_speed = 1.12
     greenlet_pool_for_ridesharing_services = True
     ridesharing_greenlet_pool_size = 42
+    timezone = 'UTC'
 
 
 def get_ridesharing_service_test():

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -181,7 +181,7 @@ class DummyInstance:
     walking_speed = 1.12
     greenlet_pool_for_ridesharing_services = True
     ridesharing_greenlet_pool_size = 42
-    timezone = pytz.UTC
+    timezone = 'UTC'
 
 
 def get_ridesharing_service_test():

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -30,6 +30,9 @@
 
 
 from __future__ import absolute_import, print_function, unicode_literals, division
+
+import pytz
+
 from jormungandr.scenarios.ridesharing.ridesharing_journey import Gender
 from jormungandr.scenarios.ridesharing.karos import Karos, DEFAULT_KAROS_FEED_PUBLISHER
 from jormungandr.scenarios.ridesharing.ridesharing_service_manager import RidesharingServiceManager
@@ -178,6 +181,7 @@ class DummyInstance:
     walking_speed = 1.12
     greenlet_pool_for_ridesharing_services = True
     ridesharing_greenlet_pool_size = 42
+    timezone = pytz.UTC
 
 
 def get_ridesharing_service_test():

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
@@ -39,6 +39,7 @@ import mock
 from jormungandr.tests import utils_test
 from jormungandr import utils
 import json
+import pytz
 
 
 fake_response = """
@@ -119,6 +120,7 @@ class DummyInstance:
     walking_speed = 1.12
     greenlet_pool_for_ridesharing_services = True
     ridesharing_greenlet_pool_size = 42
+    timezone = 'UTC'
 
 
 def klaxit_service_config_test():

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
@@ -141,6 +141,7 @@ DUMMY_OUESTGO_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 
 class DummyInstance:
     name = ''
     walking_speed = 1.12
+    timezone = 'UTC'
 
 
 def get_ridesharing_service_test():
@@ -316,7 +317,7 @@ def make_response_empty_raw_json_test():
         network='dummyNetwork',
         feed_publisher=DUMMY_OUESTGO_FEED_PUBLISHER,
     )
-    resp = ouestgo._make_response([], None, None, None)
+    resp = ouestgo._make_response([], None, None, None, pytz.timezone("UTC"))
     assert not resp
 
 
@@ -329,5 +330,5 @@ def make_response_pikup_datetime_invalid_test():
     )
     # Thursday 25 May 2023 12:00:00
     request_datetime = 1685016000
-    resp = ouestgo._make_response([{"toto": "tata"}], request_datetime, None, None)
+    resp = ouestgo._make_response([{"toto": "tata"}], request_datetime, None, None, pytz.timezone("UTC"))
     assert not resp

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
@@ -141,7 +141,7 @@ DUMMY_OUESTGO_FEED_PUBLISHER = {'id': '42', 'name': '42', 'license': 'I dunno', 
 class DummyInstance:
     name = ''
     walking_speed = 1.12
-    timezone = 'UTC'
+    timezone = pytz.utc
 
 
 def get_ridesharing_service_test():

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -937,9 +937,9 @@ def remove_ghost_words(query_string, ghost_words):
     return query_string
 
 
-def get_weekday(timestamp):
+def get_weekday(timestamp, timezone):
     try:
-        date_time = datetime.fromtimestamp(timestamp)
+        date_time = datetime.fromtimestamp(timestamp, tz=timezone)
         return WEEK_DAYS_MAPPING[date_time.weekday()]
     except ValueError:
         return None


### PR DESCRIPTION
https://navitia.atlassian.net/browse/NAV-2117

Example:

http://playground.navitia.io/play.html?request=https://api-cus.navitia.io/v1/coverage/fr-nw-rennes/journeys?from%3D-1.614862%253B48.053715%26to%3D-1.683992%253B48.110754%26first_section_mode%255B%255D%3Dridesharing%26first_section_mode%255B%255D%3Dwalking%26last_section_mode%255B%255D%3Dridesharing%26last_section_mode%255B%255D%3Dwalking%26datetime%3D20230630T000700%26partner_services%255B%255D%3Dridesharing%26max_ridesharing_duration_to_pt%3D0%26


In the above not-working example,  the request datetime is set to `T000700` without timezone, which is interepted later by `datetime.fromtimestamp(timestamp) # without timezone` as a previous date.  it works on our machine, because the default timezone of our machine is "Europe/paris", but on the machines of AWS, the default timezone is "UTC"