### PR TITLE
[Jormungandr] Render virtual fallback configurable through API 

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -543,11 +543,11 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             help="choose which method is used to filter olympics journeys",
         )
         parser_get.add_argument(
-            "_olympics_sites_fictitious_fallback[]",
+            "_olympics_sites_virtual_fallback[]",
             type=KeyValueType(),
             action="append",
             hidden=True,
-            help="fictitious fallback duration for olympics sites. The format should be stop_point_id,duration",
+            help="virtual fallback duration for olympics sites. The format should be stop_point_id,duration",
         )
 
         # Advanced parameters for valhalla bike

--- a/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/journey_common.py
@@ -55,6 +55,7 @@ from navitiacommon.parser_args_type import (
     IntervalValue,
     SpeedRange,
     FloatRange,
+    KeyValueType,
 )
 from navitiacommon import type_pb2
 
@@ -541,6 +542,14 @@ class JourneyCommon(ResourceUri, ResourceUtc):
             hidden=True,
             help="choose which method is used to filter olympics journeys",
         )
+        parser_get.add_argument(
+            "_olympics_sites_fictitious_fallback[]",
+            type=KeyValueType(),
+            action="append",
+            hidden=True,
+            help="fictitious fallback duration for olympics sites. The format should be stop_point_id,duration",
+        )
+
         # Advanced parameters for valhalla bike
         parser_get.add_argument(
             "bike_use_roads",

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -801,23 +801,15 @@ def filter_olympics_journeys_v1(responses, request):
 
 
 def filter_olympics_journeys_v2(responses, request):
-    fake_fallback_durations = {
-        # RER E
-        "stop_point:IDFM:monomodalStopPlace:58498": 20,
-        # Metro 12
-        "stop_point:IDFM:22041": 600,
-        "stop_point:IDFM:463281": 600,
-        # T3b
-        "stop_point:IDFM:412988": 1000,
-        "stop_point:IDFM:412987": 1000,
-    }
+    fictitious_fallback_durations = {}
+    fictitious_fallback_durations.update(request.get("_olympics_sites_fictitious_fallback[]", []))
     best = None
     for r in responses:
         for j in r.journeys:
             if 'olympics' not in j.tags:
                 continue
             pt_extremity = get_journey_pt_extremity(j, request.get('criteria'))
-            fake_fallback_duration = fake_fallback_durations.get(pt_extremity.uri)
+            fake_fallback_duration = fictitious_fallback_durations.get(pt_extremity.uri)
             fake_duration = j.duration - j.sections[-1].duration + fake_fallback_duration
             if best is None:
                 best = (j, fake_duration)

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -809,14 +809,14 @@ def filter_olympics_journeys_v2(responses, request):
             if 'olympics' not in j.tags:
                 continue
             pt_extremity = get_journey_pt_extremity(j, request.get('criteria'))
-            fake_fallback_duration = fictitious_fallback_durations.get(pt_extremity.uri)
-            fake_duration = j.duration - j.sections[-1].duration + fake_fallback_duration
+            fictitious_fallback_duration = fictitious_fallback_durations.get(pt_extremity.uri)
+            fictitious_total_duration = j.duration - j.sections[-1].duration + fictitious_fallback_duration
             if best is None:
-                best = (j, fake_duration)
+                best = (j, fictitious_total_duration)
                 continue
 
-            if best[1] > fake_duration:
-                best = (j, fake_duration)
+            if best[1] > fictitious_total_duration:
+                best = (j, fictitious_total_duration)
 
     best[0].tags.append('best_olympics')
 

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -801,22 +801,22 @@ def filter_olympics_journeys_v1(responses, request):
 
 
 def filter_olympics_journeys_v2(responses, request):
-    fictitious_fallback_durations = {}
-    fictitious_fallback_durations.update(request.get("_olympics_sites_fictitious_fallback[]", []))
+    virtual_fallback_durations = {}
+    virtual_fallback_durations.update(request.get("_olympics_sites_virtual_fallback[]") or [])
     best = None
     for r in responses:
         for j in r.journeys:
             if 'olympics' not in j.tags:
                 continue
             pt_extremity = get_journey_pt_extremity(j, request.get('criteria'))
-            fictitious_fallback_duration = fictitious_fallback_durations.get(pt_extremity.uri)
-            fictitious_total_duration = j.duration - j.sections[-1].duration + fictitious_fallback_duration
+            virtual_fallback_duration = virtual_fallback_durations.get(pt_extremity.uri) or 0
+            virtual_total_duration = j.duration - j.sections[-1].duration + virtual_fallback_duration
             if best is None:
-                best = (j, fictitious_total_duration)
+                best = (j, virtual_total_duration)
                 continue
 
-            if best[1] > fictitious_total_duration:
-                best = (j, fictitious_total_duration)
+            if best[1] > virtual_total_duration:
+                best = (j, virtual_total_duration)
 
     best[0].tags.append('best_olympics')
 

--- a/source/navitiacommon/navitiacommon/parser_args_type.py
+++ b/source/navitiacommon/navitiacommon/parser_args_type.py
@@ -314,3 +314,19 @@ class DateTimeFormat(CustomSchemaType):
 
     def schema(self):
         return TypeSchema(type=str, metadata={'format': 'date-time'})
+
+
+class KeyValueType(CustomSchemaType):
+    def __call__(self, value):
+        try:
+            key, value = value.split(',')
+            value = int(value)
+            if value <= 0:
+                raise ValueError('invalid duration')
+
+            return key, value
+        except ValueError as e:
+            raise ValueError("Unable to evaluate, {}".format(e))
+
+    def schema(self):
+        return TypeSchema(type=str, metadata={'minimum': 1})


### PR DESCRIPTION
olympics sites' fictitious fallback can be configure through the parameter

```
&_olympics_sites_fictitious_fallback[]=stop_point:ToTo,5&_olympics_sites_fictitious_fallback[]=stop_point:TiTi,42
```