### PR TITLE
Kraken: additional attributes for realtime trip creation

### DIFF
--- a/source/ed/build_helper.cpp
+++ b/source/ed/build_helper.cpp
@@ -196,7 +196,7 @@ nt::VehicleJourney* VJ::make() {
     }
     vj->physical_mode->vehicle_journey_list.push_back(vj);
 
-    pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, vj_headsign);
+    pt_data.headsign_handler.change_vj_headsign_and_register(*vj, vj_headsign);
 
     if (!_block_id.empty()) {
         b.block_vjs.insert(std::make_pair(_block_id, vj));

--- a/source/ed/ed_reader.cpp
+++ b/source/ed/ed_reader.cpp
@@ -1073,7 +1073,7 @@ void EdReader::fill_vehicle_journeys(nt::Data& data, pqxx::work& work) {
             next_vjs.insert(std::make_pair(const_it["next_vj_id"].as<idx_t>(), vj));
         }
 
-        data.pt_data->headsign_handler.change_name_and_register_as_headsign(*vj, vj->headsign);
+        data.pt_data->headsign_handler.change_vj_headsign_and_register(*vj, vj->headsign);
         vehicle_journey_map[vj_id] = vj;
 
         // we check if we have some comments

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2143,8 +2143,7 @@ class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
 
         # Check that no stop_schedule exist on the line 'A' and stop_point 'stop_point:stopC'
         ss_on_line_query = (
-            "stop_points/stop_point:stopC/lines/A/"
-            "stop_schedules?_current_datetime=20120614T080000"
+            "stop_points/stop_point:stopC/lines/A/stop_schedules?_current_datetime=20120614T080000"
         )
         stop_schedules, status = self.query_region(ss_on_line_query + '&data_freshness=realtime', check=False)
         assert status == 404

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2123,7 +2123,7 @@ class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
         response = self.query_region('commercial_modes?')
         assert len(response['commercial_modes']) == 8
         commercial_mode_id = response['commercial_modes'][0]['id']
-        assert commercial_mode_id == '0x0'
+        assert commercial_mode_id == '0x0'  # Tramway
 
         # Check that no departure exist on stop_point stop_point:stopC for neither base_schedule nor realtime
         departure_query = "stop_points/stop_point:stopC/departures?_current_datetime=20120614T080000"
@@ -2178,9 +2178,11 @@ class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
             physical_mode_id='physical_mode:Bus',  # this physical mode exists in kraken
             headsign='trip_headsign',
             trip_short_name='trip_short_name',
+            dataset_id='default:dataset',
             network_id=network_id,
             commercial_mode_id=commercial_mode_id,
             line_id=line_id,
+            route_id="route:{}:additional_service".format(line_id),
         )
 
         # Check new disruption 'additional-trip' to add a new trip
@@ -2239,6 +2241,11 @@ class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
         assert response['vehicle_journeys'][0]['stop_times'][0]['drop_off_allowed'] is True
         assert response['vehicle_journeys'][0]['stop_times'][0]['pickup_allowed'] is True
 
+        # check dataset of the newly created vj
+        ds_query = 'vehicle_journeys/{vj}/datasets?'.format(vj=impacted_vj['id'])
+        response = self.query_region(ds_query)
+        assert response['datasets'][0]['id'] == 'default:dataset'
+
         # Check that the newly created vehicle journey are well filtered by &since and &until
         # Note: For backward compatibility parameter &data_freshness with base_schedule is added
         # and works with &since and &until
@@ -2280,10 +2287,10 @@ class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
         line = response['lines'][0]
         assert line['id'] == 'A'
         assert len(line['routes']) == 3
-        assert line['routes'][2]['id'] == 'route:stopC_stopB'
-        assert line['routes'][2]['name'] == 'stopC - stopB'
+        assert line['routes'][2]['id'] == 'route:A:additional_service'
+        assert line['routes'][2]['name'] == 'Additional service'
         assert line['routes'][2]['direction']['id'] == 'stopB'
-        assert line['routes'][2]['direction_type'] == 'forward'
+        assert line['routes'][2]['direction_type'] == 'outbound'
 
         response = self.query_region('commercial_modes?')
         assert len(response['commercial_modes']) == 8

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -2077,6 +2077,300 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
 
 
 @dataset(MAIN_ROUTING_TEST_SETTING)
+class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
+    def test_add_new_trip_with_some_attributes(self):
+        """
+        1. create a new trip with some attributes as dataset_id, network_id, commercial_mode_id ... present
+        2. test that journey is possible using this new trip
+        """
+        disruption_query = 'disruptions?_current_datetime={dt}'.format(dt='20120614T080000')
+        disruptions_before = self.query_region(disruption_query)
+        nb_disruptions_before = len(disruptions_before['disruptions'])
+
+        # /journeys before (only direct walk)
+        C_B_query = (
+            "journeys?from={f}&to={to}&data_freshness=realtime&"
+            "datetime={dt}&_current_datetime={dt}".format(
+                f='stop_point:stopC', to='stop_point:stopB', dt='20120614T080000'
+            )
+        )
+        response = self.query_region(C_B_query)
+        assert not has_the_disruption(response, 'new_trip')
+        self.is_valid_journey_response(response, C_B_query)
+        assert len(response['journeys']) == 1
+        assert 'non_pt_walking' in response['journeys'][0]['tags']
+
+        # since the ids of impacted vjs are random uuid which cannot be know in advance... we have to request
+        # all vjs then retrieve the impacted one
+        vjs_query = 'vehicle_journeys/?_current_datetime={dt}'.format(dt='20120614T080000')
+        vjs = self.query_region(vjs_query)['vehicle_journeys']
+
+        impacted_vj = next((vj for vj in vjs if 'vehicle_journey:vjA:RealTime:' in vj['id']), None)
+        # No vj has been impacted yet
+        assert impacted_vj is None
+
+        response = self.query_region('networks?')
+        assert len(response['networks']) == 1
+        network_id = response['networks'][0]['id']
+        assert network_id == 'base_network'
+
+        response = self.query_region('lines?')
+        assert len(response['lines']) == 7
+        assert len(response['lines'][0]['routes']) == 2
+        line_id = response['lines'][0]['id']
+        assert line_id == 'A'
+
+        response = self.query_region('commercial_modes?')
+        assert len(response['commercial_modes']) == 8
+        commercial_mode_id = response['commercial_modes'][0]['id']
+        assert commercial_mode_id == '0x0'
+
+        # Check that no departure exist on stop_point stop_point:stopC for neither base_schedule nor realtime
+        departure_query = "stop_points/stop_point:stopC/departures?_current_datetime=20120614T080000"
+        departures = self.query_region(departure_query + '&data_freshness=base_schedule')
+        assert len(departures['departures']) == 0
+        departures = self.query_region(departure_query + '&data_freshness=realtime')
+        assert len(departures['departures']) == 0
+
+        # Check stop_schedules on stop_point stop_point:stopC for base_schedule and realtime with
+        # Date_times list empty
+        ss_on_sp_query = "stop_points/stop_point:stopC/stop_schedules?_current_datetime=20120614T080000"
+        stop_schedules = self.query_region(ss_on_sp_query + '&data_freshness=realtime')
+        assert len(stop_schedules['stop_schedules']) == 1
+        assert stop_schedules['stop_schedules'][0]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'D'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 0
+
+        # Check that no stop_schedule exist on the line 'A' and stop_point 'stop_point:stopC'
+        ss_on_line_query = (
+            "stop_points/stop_point:stopC/lines/A/"
+            "stop_schedules?_current_datetime=20120614T080000"
+        )
+        stop_schedules, status = self.query_region(ss_on_line_query + '&data_freshness=realtime', check=False)
+        assert status == 404
+        assert len(stop_schedules['stop_schedules']) == 0
+
+        # New disruption, a new trip with some attributes and with 2 stop_times in realtime
+        self.send_mock(
+            "additional-trip",
+            "20120614",
+            'added',
+            [
+                UpdatedStopTime(
+                    "stop_point:stopC",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080100"),
+                    departure=tstamp("20120614T080100"),
+                    message='on time',
+                ),
+                UpdatedStopTime(
+                    "stop_point:stopB",
+                    arrival_delay=0,
+                    departure_delay=0,
+                    is_added=True,
+                    arrival=tstamp("20120614T080102"),
+                    departure=tstamp("20120614T080102"),
+                ),
+            ],
+            disruption_id='new_trip',
+            effect='additional_service',
+            physical_mode_id='physical_mode:Bus',  # this physical mode exists in kraken
+            headsign='trip_headsign',
+            trip_short_name='trip_short_name',
+            network_id=network_id,
+            commercial_mode_id=commercial_mode_id,
+            line_id=line_id,
+        )
+
+        # Check new disruption 'additional-trip' to add a new trip
+        disruptions_after = self.query_region(disruption_query)
+        assert nb_disruptions_before + 1 == len(disruptions_after['disruptions'])
+        new_trip_disruptions = get_disruptions_by_id(disruptions_after, 'new_trip')
+        assert len(new_trip_disruptions) == 1
+        new_trip_disrupt = new_trip_disruptions[0]
+        assert new_trip_disrupt['id'] == 'new_trip'
+        assert new_trip_disrupt['severity']['effect'] == 'ADDITIONAL_SERVICE'
+        assert len(new_trip_disrupt['impacted_objects'][0]['impacted_stops']) == 2
+        assert all(
+            [
+                (s['departure_status'] == 'added' and s['arrival_status'] == 'added')
+                for s in new_trip_disrupt['impacted_objects'][0]['impacted_stops']
+            ]
+        )
+        assert new_trip_disrupt['application_periods'][0]['begin'] == '20120614T080100'
+        assert new_trip_disrupt['application_periods'][0]['end'] == '20120614T080102'
+
+        # Check that a PT journey now exists
+        response = self.query_region(C_B_query)
+        assert has_the_disruption(response, 'new_trip')
+        self.is_valid_journey_response(response, C_B_query)
+        assert len(response['journeys']) == 2
+        pt_journey = response['journeys'][0]
+        assert 'non_pt_walking' not in pt_journey['tags']
+        assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
+        assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
+        assert pt_journey['sections'][0]['display_informations']['commercial_mode'] == 'Tramway'
+        assert pt_journey['sections'][0]['display_informations']['physical_mode'] == 'Bus'
+
+        # Check date_times
+        assert pt_journey['sections'][0]['departure_date_time'] == '20120614T080100'
+        assert pt_journey['sections'][0]['arrival_date_time'] == '20120614T080102'
+        assert pt_journey['sections'][0]['stop_date_times'][0]['arrival_date_time'] == '20120614T080100'
+        assert pt_journey['sections'][0]['stop_date_times'][-1]['arrival_date_time'] == '20120614T080102'
+
+        vjs_query = 'vehicle_journeys/?_current_datetime={dt}'.format(dt='20120614T080000')
+        vjs = self.query_region(vjs_query)['vehicle_journeys']
+        impacted_vj = next((vj for vj in vjs if 'vehicle_journey:additional-trip:RealTime:' in vj['id']), None)
+        assert impacted_vj
+
+        vj_query = 'vehicle_journeys/{vj}?_current_datetime={dt}'.format(
+            vj=impacted_vj['id'], dt='20120614T080000'
+        )
+
+        # Check that the vehicle_journey has been created
+        response = self.query_region(vj_query)
+        assert has_the_disruption(response, 'new_trip')
+        assert len(response['vehicle_journeys']) == 1
+        assert response['vehicle_journeys'][0]['name'] == 'trip_short_name'
+        assert response['vehicle_journeys'][0]['headsign'] == 'trip_headsign'
+        assert response['vehicle_journeys'][0]['disruptions'][0]['id'] == 'new_trip'
+        assert len(response['vehicle_journeys'][0]['stop_times']) == 2
+        assert response['vehicle_journeys'][0]['stop_times'][0]['drop_off_allowed'] is True
+        assert response['vehicle_journeys'][0]['stop_times'][0]['pickup_allowed'] is True
+
+        # Check that the newly created vehicle journey are well filtered by &since and &until
+        # Note: For backward compatibility parameter &data_freshness with base_schedule is added
+        # and works with &since and &until
+        vj_base_query = (
+            'commercial_modes/0x0/vehicle_journeys?'
+            '_current_datetime={dt}&since={sin}&until={un}&data_freshness={df}'
+        )
+        response = self.query_region(
+            vj_base_query.format(
+                dt='20120614T080000', sin='20120614T080100', un='20120614T080102', df='base_schedule'
+            )
+        )
+        assert len(response['vehicle_journeys']) == 4
+
+        response = self.query_region(
+            vj_base_query.format(
+                dt='20120614T080000', sin='20120614T080100', un='20120614T080102', df='realtime'
+            )
+        )
+        assert len(response['vehicle_journeys']) == 5
+
+        response = self.query_region(
+            vj_base_query.format(
+                dt='20120614T080000', sin='20120614T080101', un='20120614T080102', df='realtime'
+            )
+        )
+        assert len(response['vehicle_journeys']) == 1
+
+        network_filter_query = 'vehicle_journeys/{vj}/networks?_current_datetime={dt}'.format(
+            vj=impacted_vj['id'], dt='20120614T080000'
+        )
+        # Verify that the following PTObjects were not created
+        response = self.query_region('networks?')
+        assert len(response['networks']) == 1
+
+        response = self.query_region('lines?')
+        assert len(response['lines']) == 7
+        # Check that the new route has been created with necessary information in the line 'A'
+        line = response['lines'][0]
+        assert line['id'] == 'A'
+        assert len(line['routes']) == 3
+        assert line['routes'][2]['id'] == 'route:stopC_stopB'
+        assert line['routes'][2]['name'] == 'stopC - stopB'
+        assert line['routes'][2]['direction']['id'] == 'stopB'
+        assert line['routes'][2]['direction_type'] == 'forward'
+
+        response = self.query_region('commercial_modes?')
+        assert len(response['commercial_modes']) == 8
+
+        # Check that no departure exist on stop_point 'stop_point:stopC' for base_schedule
+        departures = self.query_region(departure_query + '&data_freshness=base_schedule')
+        assert len(departures['departures']) == 0
+
+        # Check that departures on stop_point 'stop_point:stopC' exists with disruption
+        departures = self.query_region(departure_query + '&data_freshness=realtime')
+        assert len(departures['disruptions']) == 2
+        assert departures['disruptions'][0]['disruption_uri'] == 'disruption_all_lines_at_proper_time'
+        assert departures['disruptions'][1]['disruption_uri'] == 'new_trip'
+        assert departures['departures'][0]['display_informations']['name'] == 'A'
+
+        # Check that stop_schedule on the line 'A' and stop_point 'stop_point:stopC'
+        # for base_schedule date_times list is empty.
+        stop_schedules = self.query_region(ss_on_line_query + '&data_freshness=base_schedule')
+        assert len(stop_schedules['stop_schedules']) == 1
+        assert stop_schedules['stop_schedules'][0]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'A'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 0
+
+        # Check that stop_schedule on the line "A" and stop_point 'stop_point:stopC'
+        # exists with disruption.
+        stop_schedules = self.query_region(ss_on_line_query + '&data_freshness=realtime')
+        assert len(stop_schedules['stop_schedules']) == 1
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'A'
+        assert len(stop_schedules['disruptions']) == 2
+        assert stop_schedules['disruptions'][1]['uri'] == 'new_trip'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 1
+        assert stop_schedules['stop_schedules'][0]['date_times'][0]['date_time'] == '20120614T080100'
+        assert stop_schedules['stop_schedules'][0]['date_times'][0]['data_freshness'] == 'realtime'
+
+        # Check stop_schedules on stop_point 'stop_point:stopC' for base_schedule
+        # Date_times list is empty for both stop_schedules
+        stop_schedules = self.query_region(ss_on_sp_query + '&data_freshness=base_schedule')
+        assert len(stop_schedules['stop_schedules']) == 2
+        assert stop_schedules['stop_schedules'][0]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'D'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 0
+        assert stop_schedules['stop_schedules'][1]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][1]['links'][0]['id'] == 'A'
+        assert len(stop_schedules['stop_schedules'][1]['date_times']) == 0
+
+        # Check stop_schedules on stop_point 'stop_point:stopC' for realtime
+        # Date_times list is empty for line 'D' but not for the line 'A'
+        stop_schedules = self.query_region(ss_on_sp_query + '&data_freshness=realtime')
+        assert len(stop_schedules['stop_schedules']) == 2
+        assert stop_schedules['stop_schedules'][0]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'D'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 0
+        assert stop_schedules['stop_schedules'][1]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][1]['links'][0]['id'] == 'A'
+        assert len(stop_schedules['stop_schedules'][1]['date_times']) == 1
+        assert stop_schedules['stop_schedules'][1]['date_times'][0]['date_time'] == '20120614T080100'
+        assert stop_schedules['stop_schedules'][1]['date_times'][0]['data_freshness'] == 'realtime'
+
+        # Check stop_schedules on stop_area 'stopC' for base_schedule
+        # Date_times list is empty for both stop_schedules
+        ss_on_sa_query = "stop_areas/stopC/stop_schedules?_current_datetime=20120614T080000"
+        stop_schedules = self.query_region(ss_on_sa_query + '&data_freshness=base_schedule')
+        assert len(stop_schedules['stop_schedules']) == 2
+        assert stop_schedules['stop_schedules'][0]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'D'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 0
+        assert stop_schedules['stop_schedules'][1]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][1]['links'][0]['id'] == 'A'
+        assert len(stop_schedules['stop_schedules'][1]['date_times']) == 0
+
+        # Check stop_schedules on stop_area stopC for realtime
+        # Date_times list is empty for line 'D' but not for the line 'A'
+        ss_on_sa_query = "stop_areas/stopC/stop_schedules?_current_datetime=20120614T080000"
+        stop_schedules = self.query_region(ss_on_sa_query + '&data_freshness=realtime')
+        assert len(stop_schedules['stop_schedules']) == 2
+        assert stop_schedules['stop_schedules'][0]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][0]['links'][0]['id'] == 'D'
+        assert len(stop_schedules['stop_schedules'][0]['date_times']) == 0
+        assert stop_schedules['stop_schedules'][1]['links'][0]['type'] == 'line'
+        assert stop_schedules['stop_schedules'][1]['links'][0]['id'] == 'A'
+        assert len(stop_schedules['stop_schedules'][1]['date_times']) == 1
+        assert stop_schedules['stop_schedules'][1]['date_times'][0]['date_time'] == '20120614T080100'
+        assert stop_schedules['stop_schedules'][1]['date_times'][0]['data_freshness'] == 'realtime'
+
+
+@dataset(MAIN_ROUTING_TEST_SETTING)
 class TestPtRefOnAddedTrip(MockKirinDisruptionsFixture):
     def test_ptref_on_added_trip(self):
         """
@@ -3876,6 +4170,12 @@ def make_mock_kirin_item(
     effect=None,
     physical_mode_id=None,
     headsign=None,
+    trip_short_name=None,
+    dataset_id=None,
+    network_id=None,
+    commercial_mode_id=None,
+    line_id=None,
+    route_id=None,
 ):
     feed_message = gtfs_realtime_pb2.FeedMessage()
     feed_message.header.gtfs_realtime_version = '1.0'
@@ -3892,6 +4192,18 @@ def make_mock_kirin_item(
     trip.Extensions[kirin_pb2.contributor] = rt_topic
     if headsign:
         trip_update.Extensions[kirin_pb2.headsign] = headsign
+    if trip_short_name:
+        trip_update.Extensions[kirin_pb2.trip_short_name] = trip_short_name
+    if dataset_id:
+        trip.Extensions[kirin_pb2.dataset_id] = dataset_id
+    if network_id:
+        trip.Extensions[kirin_pb2.network_id] = network_id
+    if commercial_mode_id:
+        trip.Extensions[kirin_pb2.commercial_mode_id] = commercial_mode_id
+    if line_id:
+        trip.Extensions[kirin_pb2.line_id] = line_id
+    if route_id:
+        trip.Extensions[kirin_pb2.route_id] = route_id
     if physical_mode_id:
         trip_update.vehicle.Extensions[kirin_pb2.physical_mode_id] = physical_mode_id
     if effect == 'unknown':

--- a/source/kraken/apply_disruption.cpp
+++ b/source/kraken/apply_disruption.cpp
@@ -424,9 +424,8 @@ struct add_impacts_visitor : public apply_impacts_visitor {
             } else {
                 // Affect the headsign to vj if present in gtfs-rt
                 if (!impact->headsign.empty()) {
-                    vj->headsign = impact->headsign;
                     vj->name = impact->headsign;
-                    pt_data.headsign_handler.change_name_and_register_as_headsign(*vj, impact->headsign);
+                    pt_data.headsign_handler.change_vj_headsign_and_register(*vj, impact->headsign);
                 }
 
                 // for protection, use the datasets[0]

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -320,23 +320,61 @@ static bool is_handleable(const transit_realtime::TripUpdate& trip_update,
     // departure is brought forward), we check the size of stop_time_update because we can't find a proper
     // enum in gtfs-rt proto to express this idea
     if (is_circulating_trip(trip_update)) {
-        // check if company id exists
-        if (is_added_trip(trip_update) && trip_update.trip().HasExtension(kirin::company_id)
-            && pt_data.companies_map.find(trip_update.trip().GetExtension(kirin::company_id))
-                   == pt_data.companies_map.end()) {
-            LOG4CPLUS_DEBUG(log, "Trip company id " << trip_update.trip().GetExtension(kirin::company_id)
-                                                    << " doesn't exist: ignoring trip update id "
-                                                    << trip_update.trip().trip_id());
-            return false;
-        }
-        // check if physical mode id exists
-        if (is_added_trip(trip_update) && trip_update.vehicle().HasExtension(kirin::physical_mode_id)
-            && pt_data.physical_modes_map.find(trip_update.vehicle().GetExtension(kirin::physical_mode_id))
-                   == pt_data.physical_modes_map.end()) {
-            LOG4CPLUS_DEBUG(log, "Trip physical mode id " << trip_update.vehicle().GetExtension(kirin::physical_mode_id)
-                                                          << " doesn't exist: ignoring trip update id "
-                                                          << trip_update.trip().trip_id());
-            return false;
+        if (is_added_trip(trip_update)) {
+            // check if company id exists
+            if (trip_update.trip().HasExtension(kirin::company_id)
+                && !navitia::contains(pt_data.companies_map, trip_update.trip().GetExtension(kirin::company_id))) {
+                LOG4CPLUS_DEBUG(log, "Trip company id " << trip_update.trip().GetExtension(kirin::company_id)
+                                                        << " doesn't exist: ignoring trip update id "
+                                                        << trip_update.trip().trip_id());
+                return false;
+            }
+            // check if physical mode id exists
+            if (trip_update.vehicle().HasExtension(kirin::physical_mode_id)
+                && !navitia::contains(pt_data.physical_modes_map,
+                                      trip_update.vehicle().GetExtension(kirin::physical_mode_id))) {
+                LOG4CPLUS_DEBUG(log, "Trip physical mode id "
+                                         << trip_update.vehicle().GetExtension(kirin::physical_mode_id)
+                                         << " doesn't exist: ignoring trip update id " << trip_update.trip().trip_id());
+                return false;
+            }
+            // check if line id exists (except if empty)
+            if (trip_update.trip().HasExtension(kirin::line_id)
+                && !trip_update.trip().GetExtension(kirin::line_id).empty()
+                && !navitia::contains(pt_data.lines_map, trip_update.trip().GetExtension(kirin::line_id))) {
+                LOG4CPLUS_DEBUG(log, "Trip line id " << trip_update.trip().GetExtension(kirin::line_id)
+                                                     << " doesn't exist: ignoring trip update id "
+                                                     << trip_update.trip().trip_id());
+                return false;
+            }
+            // check if network id exists (except if empty)
+            if (trip_update.trip().HasExtension(kirin::network_id)
+                && !trip_update.trip().GetExtension(kirin::network_id).empty()
+                && !navitia::contains(pt_data.networks_map, trip_update.trip().GetExtension(kirin::network_id))) {
+                LOG4CPLUS_DEBUG(log, "Trip network id " << trip_update.trip().GetExtension(kirin::network_id)
+                                                        << " doesn't exist: ignoring trip update id "
+                                                        << trip_update.trip().trip_id());
+                return false;
+            }
+            // check if dataset id exists (except if empty)
+            if (trip_update.trip().HasExtension(kirin::dataset_id)
+                && !trip_update.trip().GetExtension(kirin::dataset_id).empty()
+                && !navitia::contains(pt_data.datasets_map, trip_update.trip().GetExtension(kirin::dataset_id))) {
+                LOG4CPLUS_DEBUG(log, "Trip dataset id " << trip_update.trip().GetExtension(kirin::dataset_id)
+                                                        << " doesn't exist: ignoring trip update id "
+                                                        << trip_update.trip().trip_id());
+                return false;
+            }
+            // check if commercial_mode id exists (except if empty)
+            if (trip_update.trip().HasExtension(kirin::commercial_mode_id)
+                && !trip_update.trip().GetExtension(kirin::commercial_mode_id).empty()
+                && !navitia::contains(pt_data.commercial_modes_map,
+                                      trip_update.trip().GetExtension(kirin::commercial_mode_id))) {
+                LOG4CPLUS_DEBUG(log, "Trip commercial_mode id "
+                                         << trip_update.trip().GetExtension(kirin::commercial_mode_id)
+                                         << " doesn't exist: ignoring trip update id " << trip_update.trip().trip_id());
+                return false;
+            }
         }
         // WARNING: here trip.start_date is considered UTC, not local
         //(this date differs if vj starts during the period between midnight UTC and local midnight)

--- a/source/kraken/realtime.cpp
+++ b/source/kraken/realtime.cpp
@@ -489,6 +489,25 @@ static const type::disruption::Disruption* create_disruption(const std::string& 
         if (trip_update.HasExtension(kirin::headsign)) {
             impact->headsign = trip_update.GetExtension(kirin::headsign);
         }
+        if (trip_update.HasExtension(kirin::trip_short_name)) {
+            impact->trip_short_name = trip_update.GetExtension(kirin::trip_short_name);
+        }
+        if (trip_update.trip().HasExtension(kirin::dataset_id)) {
+            impact->dataset_id = trip_update.trip().GetExtension(kirin::dataset_id);
+        }
+        if (trip_update.trip().HasExtension(kirin::network_id)) {
+            impact->network_id = trip_update.trip().GetExtension(kirin::network_id);
+        }
+        if (trip_update.trip().HasExtension(kirin::commercial_mode_id)) {
+            impact->commercial_mode_id = trip_update.trip().GetExtension(kirin::commercial_mode_id);
+        }
+        if (trip_update.trip().HasExtension(kirin::line_id)) {
+            impact->line_id = trip_update.trip().GetExtension(kirin::line_id);
+        }
+        if (trip_update.trip().HasExtension(kirin::route_id)) {
+            impact->route_id = trip_update.trip().GetExtension(kirin::route_id);
+        }
+
         // TODO: Effect calculated from stoptime_status -> to be removed later
         // when effect completely implemented in trip_update
         nt::disruption::Effect trip_effect = nt::disruption::Effect::UNKNOWN_EFFECT;

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3604,6 +3604,165 @@ BOOST_FIXTURE_TEST_CASE(company_id_doesnt_exist_in_new_trip, AddTripDataset) {
     BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_new_trip"), false);
 }
 
+BOOST_FIXTURE_TEST_CASE(line_id_doesnt_exist_in_new_trip, AddTripDataset) {
+    auto& pt_data = *b.data->pt_data;
+
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    auto compute = [&](const std::string& datetime, const std::string& from, const std::string& to) {
+        navitia::type::Type_e origin_type = b.data->get_type_of_id(from);
+        navitia::type::Type_e destination_type = b.data->get_type_of_id(to);
+        navitia::type::EntryPoint origin(origin_type, from);
+        navitia::type::EntryPoint destination(destination_type, to);
+
+        navitia::PbCreator pb_creator(b.data.get(), "20190101T073000"_dt, null_time_period);
+        make_response(pb_creator, raptor, origin, destination, {ntest::to_posix_timestamp(datetime)}, true,
+                      navitia::type::AccessibiliteParams(), {}, {}, sn_worker, nt::RTLevel::RealTime, 2_min);
+        return pb_creator.get_response();
+    };
+
+    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    transit_realtime::TripUpdate new_trip =
+        ntest::make_trip_update_message("vj_new_trip", "20190101",
+                                        {
+                                            RTStopTime("stop_point:A", "20190101T0800"_pts).added(),
+                                            RTStopTime("stop_point:H", "20190101T0830"_pts).added(),
+                                            RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
+                                            RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
+                                        },
+                                        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE, comp_uri,
+                                        phy_mode_uri, "", "", "trip_headsign", "trip_short_name", dataset_uri,
+                                        "base_network", "0x0", "wrong_line_id", "route:1:additional_service");
+
+    // the new trip update is blocked directly
+    navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+    auto res = compute("20190101T073000", "stop_point:A", "stop_point:J");
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 0);
+    BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_new_trip"), false);
+}
+
+BOOST_FIXTURE_TEST_CASE(dataset_id_doesnt_exist_in_new_trip, AddTripDataset) {
+    auto& pt_data = *b.data->pt_data;
+
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    auto compute = [&](const std::string& datetime, const std::string& from, const std::string& to) {
+        navitia::type::Type_e origin_type = b.data->get_type_of_id(from);
+        navitia::type::Type_e destination_type = b.data->get_type_of_id(to);
+        navitia::type::EntryPoint origin(origin_type, from);
+        navitia::type::EntryPoint destination(destination_type, to);
+
+        navitia::PbCreator pb_creator(b.data.get(), "20190101T073000"_dt, null_time_period);
+        make_response(pb_creator, raptor, origin, destination, {ntest::to_posix_timestamp(datetime)}, true,
+                      navitia::type::AccessibiliteParams(), {}, {}, sn_worker, nt::RTLevel::RealTime, 2_min);
+        return pb_creator.get_response();
+    };
+
+    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    transit_realtime::TripUpdate new_trip =
+        ntest::make_trip_update_message("vj_new_trip", "20190101",
+                                        {
+                                            RTStopTime("stop_point:A", "20190101T0800"_pts).added(),
+                                            RTStopTime("stop_point:H", "20190101T0830"_pts).added(),
+                                            RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
+                                            RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
+                                        },
+                                        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE, comp_uri,
+                                        phy_mode_uri, "", "", "trip_headsign", "trip_short_name", "wrong_dataset_id",
+                                        "base_network", "0x0", "1", "route:1:additional_service");
+
+    // the new trip update is blocked directly
+    navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+    auto res = compute("20190101T073000", "stop_point:A", "stop_point:J");
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 0);
+    BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_new_trip"), false);
+}
+
+BOOST_FIXTURE_TEST_CASE(network_id_doesnt_exist_in_new_trip, AddTripDataset) {
+    auto& pt_data = *b.data->pt_data;
+
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    auto compute = [&](const std::string& datetime, const std::string& from, const std::string& to) {
+        navitia::type::Type_e origin_type = b.data->get_type_of_id(from);
+        navitia::type::Type_e destination_type = b.data->get_type_of_id(to);
+        navitia::type::EntryPoint origin(origin_type, from);
+        navitia::type::EntryPoint destination(destination_type, to);
+
+        navitia::PbCreator pb_creator(b.data.get(), "20190101T073000"_dt, null_time_period);
+        make_response(pb_creator, raptor, origin, destination, {ntest::to_posix_timestamp(datetime)}, true,
+                      navitia::type::AccessibiliteParams(), {}, {}, sn_worker, nt::RTLevel::RealTime, 2_min);
+        return pb_creator.get_response();
+    };
+
+    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    transit_realtime::TripUpdate new_trip = ntest::make_trip_update_message(
+        "vj_new_trip", "20190101",
+        {
+            RTStopTime("stop_point:A", "20190101T0800"_pts).added(),
+            RTStopTime("stop_point:H", "20190101T0830"_pts).added(),
+            RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
+            RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
+        },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE, comp_uri, phy_mode_uri, "", "",
+        "trip_headsign", "trip_short_name", dataset_uri, "wrong_network_id", "0x0", "1", "route:1:additional_service");
+
+    // the new trip update is blocked directly
+    navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+    auto res = compute("20190101T073000", "stop_point:A", "stop_point:J");
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 0);
+    BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_new_trip"), false);
+}
+
+BOOST_FIXTURE_TEST_CASE(commercial_mode_id_doesnt_exist_in_new_trip, AddTripDataset) {
+    auto& pt_data = *b.data->pt_data;
+
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    auto compute = [&](const std::string& datetime, const std::string& from, const std::string& to) {
+        navitia::type::Type_e origin_type = b.data->get_type_of_id(from);
+        navitia::type::Type_e destination_type = b.data->get_type_of_id(to);
+        navitia::type::EntryPoint origin(origin_type, from);
+        navitia::type::EntryPoint destination(destination_type, to);
+
+        navitia::PbCreator pb_creator(b.data.get(), "20190101T073000"_dt, null_time_period);
+        make_response(pb_creator, raptor, origin, destination, {ntest::to_posix_timestamp(datetime)}, true,
+                      navitia::type::AccessibiliteParams(), {}, {}, sn_worker, nt::RTLevel::RealTime, 2_min);
+        return pb_creator.get_response();
+    };
+
+    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    transit_realtime::TripUpdate new_trip =
+        ntest::make_trip_update_message("vj_new_trip", "20190101",
+                                        {
+                                            RTStopTime("stop_point:A", "20190101T0800"_pts).added(),
+                                            RTStopTime("stop_point:H", "20190101T0830"_pts).added(),
+                                            RTStopTime("stop_point:I", "20190101T0900"_pts).added(),
+                                            RTStopTime("stop_point:J", "20190101T0930"_pts).added(),
+                                        },
+                                        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE, comp_uri,
+                                        phy_mode_uri, "", "", "trip_headsign", "trip_short_name", dataset_uri,
+                                        "base_network", "wrong_commercial_mode_id", "1", "route:1:additional_service");
+
+    // the new trip update is blocked directly
+    navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+    auto res = compute("20190101T073000", "stop_point:A", "stop_point:J");
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::NO_SOLUTION);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 0);
+    BOOST_REQUIRE_EQUAL(pt_data.meta_vjs.exists("vj_new_trip"), false);
+}
+
 BOOST_FIXTURE_TEST_CASE(physical_mode_id_doesnt_exist_in_new_trip, AddTripDataset) {
     auto& pt_data = *b.data->pt_data;
 

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -2877,7 +2877,7 @@ struct AddTripDataset {
     ed::builder b;
 };
 
-BOOST_FIXTURE_TEST_CASE(add_and_update_trip_to_verify_route_line_commercial_mode_network, AddTripDataset) {
+BOOST_FIXTURE_TEST_CASE(add_and_update_trip_to_verify_default_route_line_commercial_mode_network, AddTripDataset) {
     auto& pt_data = *b.data->pt_data;
     navitia::routing::RAPTOR raptor(*(b.data));
     ng::StreetNetwork sn_worker(*b.data->geo_ref);
@@ -3020,6 +3020,205 @@ BOOST_FIXTURE_TEST_CASE(add_and_update_trip_to_verify_route_line_commercial_mode
     res = compute("20190101T073000", "stop_point:A", "stop_point:J");
     BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
     BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+}
+
+BOOST_FIXTURE_TEST_CASE(add_and_update_trip_to_verify_filled_route_line_commercial_mode_network, AddTripDataset) {
+    auto& pt_data = *b.data->pt_data;
+    navitia::routing::RAPTOR raptor(*(b.data));
+    ng::StreetNetwork sn_worker(*b.data->geo_ref);
+
+    auto compute = [&](const std::string& datetime, const std::string& from, const std::string& to) {
+        navitia::type::Type_e origin_type = b.data->get_type_of_id(from);
+        navitia::type::Type_e destination_type = b.data->get_type_of_id(to);
+        navitia::type::EntryPoint origin(origin_type, from);
+        navitia::type::EntryPoint destination(destination_type, to);
+
+        navitia::PbCreator pb_creator(b.data.get(), "20190101T073000"_dt, null_time_period);
+        make_response(pb_creator, raptor, origin, destination, {ntest::to_posix_timestamp(datetime)}, true,
+                      navitia::type::AccessibiliteParams(), {}, {}, sn_worker, nt::RTLevel::RealTime, 2_min);
+        return pb_creator.get_response();
+    };
+
+    // before disruption, no "default-rt" PT objects
+    const std::string default_network_id = "network:additional_service";
+    auto it_default_network = pt_data.networks_map.find(default_network_id);
+    BOOST_CHECK(it_default_network == pt_data.networks_map.end());
+    const std::string default_cm_id = "commercial_mode:additional_service";
+    auto it_default_cm = pt_data.commercial_modes_map.find(default_cm_id);
+    BOOST_CHECK(it_default_cm == pt_data.commercial_modes_map.end());
+    const std::string default_line_id = "line:A_F";
+    auto it_default_line = pt_data.lines_map.find(default_line_id);
+    BOOST_CHECK(it_default_line == pt_data.lines_map.end());
+    const std::string default_route_id = "route:A_F";
+    auto it_default_route = pt_data.routes_map.find(default_route_id);
+    BOOST_CHECK(it_default_route == pt_data.routes_map.end());
+
+    // before disruption, PT objects to be used are already present and linked (except route)
+    auto it_dataset = pt_data.datasets_map.find(dataset_uri);
+    BOOST_CHECK(it_dataset != pt_data.datasets_map.end());
+    const nt::Dataset* dataset = it_dataset->second;
+    const std::string network_id = "base_network";
+    auto it_network = pt_data.networks_map.find(network_id);
+    BOOST_CHECK(it_network != pt_data.networks_map.end());
+    const nt::Network* network = it_network->second;
+    const std::string cm_id = "0x0";
+    auto it_cm = pt_data.commercial_modes_map.find(cm_id);
+    BOOST_CHECK(it_cm != pt_data.commercial_modes_map.end());
+    const nt::CommercialMode* cm = it_cm->second;
+    const std::string line_id = "1";
+    auto it_line = pt_data.lines_map.find(line_id);
+    BOOST_CHECK(it_line != pt_data.lines_map.end());
+    const nt::Line* line = it_line->second;
+    const std::string route_id = "route:1:additional_service";
+    auto it_route = pt_data.routes_map.find(route_id);
+    BOOST_CHECK(it_route == pt_data.routes_map.end());
+    const auto nb_vj_in_dataset_beginning = dataset->vehiclejourney_list.size();
+
+    // check links
+    BOOST_CHECK_EQUAL(network->line_list.front(), line);
+    BOOST_CHECK_EQUAL(line->network, network);
+    BOOST_CHECK(navitia::contains(cm->line_list, line));
+    BOOST_CHECK_EQUAL(line->commercial_mode, cm);
+
+    // check indexes
+    BOOST_CHECK_EQUAL(pt_data.networks[network->idx], network);
+    BOOST_CHECK_EQUAL(pt_data.commercial_modes[cm->idx], cm);
+    BOOST_CHECK_EQUAL(pt_data.lines[line->idx], line);
+
+    transit_realtime::TripUpdate new_trip = ntest::make_trip_update_message(
+        "vj_new_trip", "20190101",
+        {
+            RTStopTime("stop_point:A", "20190101T0800"_pts).added(),
+            RTStopTime("stop_point:F", "20190101T0900"_pts).added(),
+        },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE, comp_uri, phy_mode_uri, "", "",
+        "trip_headsign", "trip_short_name", dataset_uri, network_id, cm_id, line_id, route_id);
+
+    navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+
+    // after disruption, no "default-rt" PT objects (as existing one are used)
+    it_default_network = pt_data.networks_map.find(default_network_id);
+    BOOST_REQUIRE(it_default_network == pt_data.networks_map.end());
+    it_default_cm = pt_data.commercial_modes_map.find(default_cm_id);
+    BOOST_REQUIRE(it_default_cm == pt_data.commercial_modes_map.end());
+    it_default_line = pt_data.lines_map.find(default_line_id);
+    BOOST_REQUIRE(it_default_line == pt_data.lines_map.end());
+    it_default_route = pt_data.routes_map.find(default_route_id);
+    BOOST_REQUIRE(it_default_route == pt_data.routes_map.end());
+
+    it_route = pt_data.routes_map.find(route_id);
+    BOOST_REQUIRE(it_route != pt_data.routes_map.end());
+    const nt::Route* route = it_route->second;
+
+    const std::string sa_id = "F";
+    auto it_sa = pt_data.stop_areas_map.find(sa_id);
+    const nt::StopArea* sa = it_sa->second;
+
+    // Check destination and direction_type of the route
+    BOOST_CHECK_EQUAL(route->direction_type, "outbound");
+    BOOST_CHECK_EQUAL(route->destination, sa);
+
+    // check links
+    BOOST_CHECK_EQUAL(network->line_list.front(), line);
+    BOOST_CHECK_EQUAL(line->network, network);
+    BOOST_CHECK(navitia::contains(cm->line_list, line));
+    BOOST_CHECK_EQUAL(line->commercial_mode, cm);
+    BOOST_CHECK(navitia::contains(line->route_list, route));
+    BOOST_CHECK_EQUAL(route->line, line);
+    nt::VehicleJourney* rt_vj = pt_data.vehicle_journeys.back();
+    BOOST_CHECK_EQUAL(rt_vj->dataset, dataset);
+    BOOST_CHECK_EQUAL(nb_vj_in_dataset_beginning + 1, dataset->vehiclejourney_list.size());
+    BOOST_CHECK(navitia::contains(dataset->vehiclejourney_list, rt_vj));
+    BOOST_CHECK_EQUAL(rt_vj->route, route);
+
+    // check indexes
+    BOOST_CHECK_EQUAL(pt_data.networks[network->idx], network);
+    BOOST_CHECK_EQUAL(pt_data.commercial_modes[cm->idx], cm);
+    BOOST_CHECK_EQUAL(pt_data.lines[line->idx], line);
+    BOOST_CHECK_EQUAL(pt_data.routes[route->idx], route);
+
+    // check uris
+    BOOST_CHECK_EQUAL(network->uri, network_id);
+    BOOST_CHECK_EQUAL(cm->uri, cm_id);
+    BOOST_CHECK_EQUAL(line->uri, line_id);
+    BOOST_CHECK_EQUAL(route->uri, route_id);
+
+    // check names
+    BOOST_CHECK_EQUAL(network->name, network_id);
+    BOOST_CHECK_EQUAL(cm->name, "Tramway");
+    BOOST_CHECK_EQUAL(line->name, line_id);
+    BOOST_CHECK_EQUAL(route->name, "Additional service");
+
+    // Verify that a journey from stop_point:A to stop_point:F exists
+    auto res = compute("20190101T073000", "stop_point:A", "stop_point:F");
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+
+    // Verify that headsign exists in display_informations
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).pt_display_informations().headsign(), "trip_headsign");
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).pt_display_informations().trip_short_name(), "trip_short_name");
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).pt_display_informations().name(), line_id);
+
+    // Update the trip recently added with destination F replaced by J
+    new_trip = ntest::make_trip_update_message(
+        "vj_new_trip", "20190101",
+        {
+            RTStopTime("stop_point:A", "20190101T0800"_pts).added(),
+            RTStopTime("stop_point:F", "20190101T0900"_pts).skipped(),
+            RTStopTime("stop_point:J", "20190101T0900"_pts).added(),
+        },
+        transit_realtime::Alert_Effect::Alert_Effect_ADDITIONAL_SERVICE, comp_uri, phy_mode_uri, "", "",
+        "new_trip_headsign", "new_trip_short_name", dataset_uri, network_id, cm_id, line_id, route_id);
+
+    navitia::handle_realtime("feed-1", timestamp, new_trip, *b.data, true, true);
+    b.finalize_disruption_batch();
+
+    // after disruption update, still no "default-rt" PT objects (as existing one are used)
+    it_default_network = pt_data.networks_map.find(default_network_id);
+    BOOST_REQUIRE(it_default_network == pt_data.networks_map.end());
+    it_default_cm = pt_data.commercial_modes_map.find(default_cm_id);
+    BOOST_REQUIRE(it_default_cm == pt_data.commercial_modes_map.end());
+    it_default_line = pt_data.lines_map.find(default_line_id);
+    BOOST_REQUIRE(it_default_line == pt_data.lines_map.end());
+    it_default_route = pt_data.routes_map.find(default_route_id);
+    BOOST_REQUIRE(it_default_route == pt_data.routes_map.end());
+
+    it_route = pt_data.routes_map.find(route_id);
+    BOOST_REQUIRE(it_route != pt_data.routes_map.end());
+    route = it_route->second;
+
+    rt_vj = pt_data.vehicle_journeys.back();
+    BOOST_CHECK_EQUAL(rt_vj->dataset, dataset);
+    BOOST_CHECK_EQUAL(nb_vj_in_dataset_beginning + 1, dataset->vehiclejourney_list.size());
+    BOOST_CHECK(navitia::contains(dataset->vehiclejourney_list, rt_vj));
+    BOOST_CHECK_EQUAL(rt_vj->route, route);
+
+    // Check destination and direction_type of the route
+    BOOST_CHECK_EQUAL(route->direction_type, "outbound");
+    BOOST_CHECK_EQUAL(route->destination, sa);
+
+    // check uris
+    BOOST_CHECK_EQUAL(network->uri, network_id);
+    BOOST_CHECK_EQUAL(cm->uri, cm_id);
+    BOOST_CHECK_EQUAL(line->uri, line_id);
+    BOOST_CHECK_EQUAL(route->uri, route_id);
+
+    // check names
+    BOOST_CHECK_EQUAL(network->name, network_id);
+    BOOST_CHECK_EQUAL(cm->name, "Tramway");
+    BOOST_CHECK_EQUAL(line->name, line_id);
+    BOOST_CHECK_EQUAL(route->name, "Additional service");
+
+    // Verify that a journey from stop_point:A to stop_point:J exists
+    res = compute("20190101T073000", "stop_point:A", "stop_point:J");
+    BOOST_CHECK_EQUAL(res.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_CHECK_EQUAL(res.journeys_size(), 1);
+
+    // Verify that headsign exists in display_informations
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).pt_display_informations().headsign(), "new_trip_headsign");
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).pt_display_informations().trip_short_name(), "new_trip_short_name");
+    BOOST_CHECK_EQUAL(res.journeys(0).sections(0).pt_display_informations().name(), line_id);
 }
 
 BOOST_FIXTURE_TEST_CASE(add_new_trip_and_update, AddTripDataset) {

--- a/source/kraken/tests/realtime_test.cpp
+++ b/source/kraken/tests/realtime_test.cpp
@@ -3622,7 +3622,7 @@ BOOST_FIXTURE_TEST_CASE(line_id_doesnt_exist_in_new_trip, AddTripDataset) {
         return pb_creator.get_response();
     };
 
-    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    // If the line id doesn't exist inside the data with ADDED type, we reject the new trip
     transit_realtime::TripUpdate new_trip =
         ntest::make_trip_update_message("vj_new_trip", "20190101",
                                         {
@@ -3662,7 +3662,7 @@ BOOST_FIXTURE_TEST_CASE(dataset_id_doesnt_exist_in_new_trip, AddTripDataset) {
         return pb_creator.get_response();
     };
 
-    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    // If the dataset id doesn't exist inside the data with ADDED type, we reject the new trip
     transit_realtime::TripUpdate new_trip =
         ntest::make_trip_update_message("vj_new_trip", "20190101",
                                         {
@@ -3702,7 +3702,7 @@ BOOST_FIXTURE_TEST_CASE(network_id_doesnt_exist_in_new_trip, AddTripDataset) {
         return pb_creator.get_response();
     };
 
-    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    // If the network id doesn't exist inside the data with ADDED type, we reject the new trip
     transit_realtime::TripUpdate new_trip = ntest::make_trip_update_message(
         "vj_new_trip", "20190101",
         {
@@ -3741,7 +3741,7 @@ BOOST_FIXTURE_TEST_CASE(commercial_mode_id_doesnt_exist_in_new_trip, AddTripData
         return pb_creator.get_response();
     };
 
-    // If the company id doesn't exist inside the data with ADDED type, we reject the new trip
+    // If the commercial_mode id doesn't exist inside the data with ADDED type, we reject the new trip
     transit_realtime::TripUpdate new_trip =
         ntest::make_trip_update_message("vj_new_trip", "20190101",
                                         {

--- a/source/tests/utils_test.h
+++ b/source/tests/utils_test.h
@@ -105,7 +105,13 @@ inline transit_realtime::TripUpdate make_trip_update_message(
     const std::string& physical_mode_id = "",
     const std::string& contributor = "",
     const std::string& trip_message = "",
-    const std::string& headsign = "") {
+    const std::string& headsign = "",
+    const std::string& trip_short_name = "",
+    const std::string& dataset_id = "",
+    const std::string& network_id = "",
+    const std::string& commercial_mode_id = "",
+    const std::string& line_id = "",
+    const std::string& route_id = "") {
     transit_realtime::TripUpdate trip_update;
     trip_update.SetExtension(kirin::effect, effect);
     auto trip = trip_update.mutable_trip();
@@ -125,6 +131,24 @@ inline transit_realtime::TripUpdate make_trip_update_message(
     }
     if (headsign != "") {
         trip_update.SetExtension(kirin::headsign, headsign);
+    }
+    if (trip_short_name != "") {
+        trip_update.SetExtension(kirin::trip_short_name, trip_short_name);
+    }
+    if (dataset_id != "") {
+        trip->SetExtension(kirin::dataset_id, dataset_id);
+    }
+    if (network_id != "") {
+        trip->SetExtension(kirin::network_id, network_id);
+    }
+    if (commercial_mode_id != "") {
+        trip->SetExtension(kirin::commercial_mode_id, commercial_mode_id);
+    }
+    if (line_id != "") {
+        trip->SetExtension(kirin::line_id, line_id);
+    }
+    if (route_id != "") {
+        trip->SetExtension(kirin::route_id, route_id);
     }
     // start_date is used to disambiguate trips that are very late, cf:
     // https://github.com/hove-io/chaos-proto/blob/master/gtfs-realtime.proto#L459

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -73,7 +73,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 15;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 16;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -73,7 +73,7 @@ namespace pt = boost::posix_time;
 namespace navitia {
 namespace type {
 
-const unsigned int Data::data_version = 16;  //< *INCREMENT* every time serialized data are modified
+const unsigned int Data::data_version = 15;  //< *INCREMENT* every time serialized data are modified
 
 Data::Data(size_t data_identifier)
     : _last_rt_data_loaded(boost::posix_time::not_a_date_time),

--- a/source/type/headsign_handler.h
+++ b/source/type/headsign_handler.h
@@ -42,16 +42,16 @@ www.navitia.io
  * Headsign handler
  *
  * Contains and manages :
- * - headsign at a given stop_time for VJ (default value for headsign at a stop_time is vj.name)
+ * - headsign at a given stop_time for VJ (default value for headsign at a stop_time is vj.headsign)
  * - metaVJ from given headsign (one of the VJ in metaVJ contains given headsign)
  */
 namespace navitia {
 namespace type {
 
 struct HeadsignHandler {
-    // changes vj's name and registers vj under its new name for headsign-to-vj map
-    // (remove previous name from headsign-to-vj map if necessary)
-    void change_name_and_register_as_headsign(VehicleJourney& vj, const std::string& new_name);
+    // changes vj's headsign and registers vj under its new headsign for headsign-to-vj map
+    // (remove previous headsign from headsign-to-vj map if necessary)
+    void change_vj_headsign_and_register(VehicleJourney& vj, const std::string& new_headsign);
     void affect_headsign_to_stop_time(const StopTime& stop_time, const std::string& headsign);
 
     const std::string& get_headsign(const StopTime& stop_time) const;
@@ -70,8 +70,8 @@ protected:
 
     // for each VJ, map containing index of stop time and the new headsign (until next change)
     // as new stop_time might be added in the future, if map_vj_map_stop_time_headsign_change[vj]
-    // exists, last change is always vj.name (and might happen after last stop_time)
-    // This gives following structure (vj.name = A) :
+    // exists, last change is always vj.headsign (and might happen after last stop_time)
+    // This gives following structure (vj.headsign = A) :
     // stop times       : 1 2 3 4 5 6 7 8 (potential 9)
     // headsigns        : A A A B B C B B
     // headsign_changes :       B   C B   A

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -118,7 +118,8 @@ SERIALIZABLE(ApplicationPattern)
 template <class Archive>
 void Impact::serialize(Archive& ar, const unsigned int /*unused*/) {
     ar& uri& company_id& physical_mode_id& headsign& created_at& updated_at& application_periods& severity&
-        _informed_entities& messages& disruption& aux_info& application_patterns;
+        _informed_entities& messages& disruption& aux_info& application_patterns& trip_short_name& dataset_id&
+            network_id& commercial_mode_id& line_id& route_id;
 }
 SERIALIZABLE(Impact)
 

--- a/source/type/message.h
+++ b/source/type/message.h
@@ -371,6 +371,12 @@ struct Impact {
     std::string headsign;
     boost::posix_time::ptime created_at;
     boost::posix_time::ptime updated_at;
+    std::string trip_short_name;
+    std::string dataset_id;
+    std::string network_id;
+    std::string commercial_mode_id;
+    std::string line_id;
+    std::string route_id;
 
     // the application period define when the impact happen
     // i.e. the canceled base schedule period for vj

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -75,13 +75,21 @@ size_t PT_Data::nb_stop_times() const {
     return nb;
 }
 
-type::Network* PT_Data::get_or_create_network(const std::string& uri, const std::string& name, int sort) {
+type::Network* PT_Data::get_network(const std::string& uri) {
     const auto it = networks_map.find(uri);
     if (it != networks_map.end()) {
         return it->second;
     }
+    return nullptr;
+}
 
-    auto* network = new nt::Network();
+type::Network* PT_Data::get_or_create_network(const std::string& uri, const std::string& name, int sort) {
+    auto* network = get_network(uri);
+    if (network != nullptr) {
+        return network;
+    }
+
+    network = new nt::Network();
     network->uri = uri;
     network->name = name;
     network->sort = sort;
@@ -109,13 +117,21 @@ type::Company* PT_Data::get_or_create_company(const std::string& uri, const std:
     return company;
 }
 
-type::CommercialMode* PT_Data::get_or_create_commercial_mode(const std::string& uri, const std::string& name) {
+type::CommercialMode* PT_Data::get_commercial_mode(const std::string& uri) {
     const auto it = commercial_modes_map.find(uri);
     if (it != commercial_modes_map.end()) {
         return it->second;
     }
+    return nullptr;
+}
 
-    auto* mode = new nt::CommercialMode();
+type::CommercialMode* PT_Data::get_or_create_commercial_mode(const std::string& uri, const std::string& name) {
+    auto* mode = get_commercial_mode(uri);
+    if (mode != nullptr) {
+        return mode;
+    }
+
+    mode = new nt::CommercialMode();
     mode->uri = uri;
     mode->name = name;
 
@@ -148,15 +164,23 @@ type::PhysicalMode* PT_Data::get_or_create_physical_mode(const std::string& uri,
     return mode;
 }
 
+type::Dataset* PT_Data::get_dataset(const std::string& uri) {
+    const auto it = datasets_map.find(uri);
+    if (it != datasets_map.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
 type::Dataset* PT_Data::get_or_create_dataset(const std::string& uri,
                                               const std::string& name,
                                               type::Contributor* contributor) {
-    const auto dataset_it = datasets_map.find(uri);
+    auto* dataset = get_dataset(uri);
+    if (dataset != nullptr) {
+        return dataset;
+    }
 
-    if (dataset_it != datasets_map.end())
-        return dataset_it->second;
-
-    auto* dataset = new navitia::type::Dataset();
+    dataset = new navitia::type::Dataset();
     dataset->idx = datasets.size();
     dataset->uri = uri;
     dataset->name = name;
@@ -185,6 +209,14 @@ type::Contributor* PT_Data::get_or_create_contributor(const std::string& uri, co
     return contributor;
 }
 
+type::Line* PT_Data::get_line(const std::string& uri) {
+    const auto it = lines_map.find(uri);
+    if (it != lines_map.end()) {
+        return it->second;
+    }
+    return nullptr;
+}
+
 type::Line* PT_Data::get_or_create_line(const std::string& uri,
                                         const std::string& name,
                                         type::Network* network,
@@ -192,12 +224,12 @@ type::Line* PT_Data::get_or_create_line(const std::string& uri,
                                         int sort,
                                         const std::string& color,
                                         const std::string& text_color) {
-    const auto it = lines_map.find(uri);
-    if (it != lines_map.end()) {
-        return it->second;
+    auto* line = get_line(uri);
+    if (line != nullptr) {
+        return line;
     }
 
-    auto* line = new nt::Line();
+    line = new nt::Line();
     line->uri = uri;
     line->name = name;
     line->sort = sort;

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -162,6 +162,10 @@ public:
     const type::TimeZoneHandler* get_main_timezone();
     type::MetaVehicleJourney* get_or_create_meta_vehicle_journey(const std::string& uri,
                                                                  const type::TimeZoneHandler* tz);
+    type::Dataset* get_dataset(const std::string& uri);
+    type::Network* get_network(const std::string& uri);
+    type::CommercialMode* get_commercial_mode(const std::string& uri);
+    type::Line* get_line(const std::string& uri);
 
     void clean_weak_impacts();
 

--- a/source/type/tests/headsign_test.cpp
+++ b/source/type/tests/headsign_test.cpp
@@ -127,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE(headsign_handler_internal_test, HeadsignFixture) {
     auto& vj_vec = b.data->pt_data->vehicle_journeys;
     // done for the "actual" handler in build helper but not on test handler
     for (const auto& vj : vj_vec) {
-        headsign_handler.change_name_and_register_as_headsign(*vj, vj->headsign);
+        headsign_handler.change_vj_headsign_and_register(*vj, vj->headsign);
     }
 
     headsign_handler.affect_headsign_to_stop_time(vj_vec[0]->stop_time_list.at(0), "A00");


### PR DESCRIPTION
:mag: Please review by commit with message (cleaning and preparatory work is separated).

 :warning: Major bump of version (bina required)

Handle new attributes (when filled) from NTFSRT-TripUpdate when creating a realtime VJ (instead of using default values).
Requirement : same behavior than before when values are empty (existing tests should not change).

TODO:
- [x] Tests will be done in separate commits (hopefully not changing the current code :crossed_fingers:)

Supersedes #4058 
JIRA: https://navitia.atlassian.net/browse/NAV-1926