### PR TITLE
[kraken] disruptions: fix SQL request by adding missing integer cast

### DIFF
--- a/source/kraken/fill_disruption_from_database.cpp
+++ b/source/kraken/fill_disruption_from_database.cpp
@@ -146,7 +146,7 @@ void fill_disruption_from_database(const std::string& connection_string,
                  "  pt.weekly_pattern as pattern_weekly_pattern,"
                  "  pt.id as pattern_id,"
                  "  extract(epoch from ts.begin ) ::int as time_slot_begin,"
-                 "  extract(epoch from ts.end ) as time_slot_end,"
+                 "  extract(epoch from ts.end ) ::int as time_slot_end,"
                  "  ts.id as time_slot_id "
                  // Request
                  "     FROM disruption AS d"


### PR DESCRIPTION
Report PR #4048 from @vpassama on internal branch for CI to be allowed to run.

> Hello,
> 
> We found a bug in fill_disruptions_from_database sql request as we use now a newer postgresql version which default behavior has changed on a specific value select (epoch from).
> The problem occurs when time_slots are used in CHAOS as there is a missing integer cast in the request.

Kudos Tisseo for that bugfix :pray: 

closes #4048 