### PR TITLE
Jormun: fix portable_min() interface to respect min()

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -1092,6 +1092,7 @@ def _filter_odt_journeys_clockwise(journeys, debug):
     earliest_arrival_pt_journey = portable_min(
         (j for j in journeys if _contains_pt_section(j) and not _contains_odt(j)),
         key=lambda j: j.arrival_date_time,
+        default=None,
     )
 
     # no pt journey found, so there is nothing to filter
@@ -1117,6 +1118,7 @@ def _filter_odt_journeys_counter_clockwise(journeys, debug):
     latest_departure_pt_journey = portable_min(
         (j for j in journeys if _contains_pt_section(j) and not _contains_odt(j)),
         key=lambda j: -1 * j.departure_date_time,
+        default=None,
     )
 
     # no pt journey found, so there is nothing to filter

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -290,13 +290,6 @@ def test_get_pt_object_from_json():
     assert len(pt_object.poi.children) == 2
 
 
-def test_portable_min():
-    assert portable_min([]) is None
-    assert portable_min((j for j in [])) is None
-    assert portable_min((j for j in []), key=lambda j: j) is None
-    assert portable_min((j for j in [{"s": 5}, {"s": 9}, {"s": 1}]), key=lambda j: j["s"]) == {"s": 1}
-
-
 def test_read_best_boarding_positions():
     import shortuuid
 

--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -293,6 +293,8 @@ def test_get_pt_object_from_json():
 def test_portable_min():
     assert portable_min([]) is None
     assert portable_min((j for j in [])) is None
+    assert portable_min((j for j in []), key=lambda j: j) is None
+    assert portable_min((j for j in [{"s": 5}, {"s": 9}, {"s": 1}]), key=lambda j: j["s"]) == {"s": 1}
 
 
 def test_read_best_boarding_positions():

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -804,8 +804,12 @@ def portable_min(*args, **kwargs):
     1
     >>> portable_min([], default=42)
     42
+    >>> portable_min([]) # only behavioral change compared to py3's min (could be reconsidered, forcing caller to provide default)
+
     >>> portable_min(iter(()), default=43) # empty iterable
     43
+    >>> portable_min((j for j in [{"s": 5}, {"s": 9},{"s": 1}]), key=lambda j: j["s"]) # not comparable without key
+    {'s': 1}
 
     """
     if PY2:
@@ -817,8 +821,8 @@ def portable_min(*args, **kwargs):
         except Exception:
             raise
     if PY3:
-        default = kwargs.get('default', None)
-        return min(*args, default=default)
+        kwargs.setdefault('default', None)
+        return min(*args, **kwargs)
 
 
 def mps_to_kmph(speed):

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -804,7 +804,11 @@ def portable_min(*args, **kwargs):
     1
     >>> portable_min([], default=42)
     42
-    >>> portable_min([]) # only behavioral change compared to py3's min (could be reconsidered, forcing caller to provide default)
+    >>> portable_min([]) # only behavioral change compared to py3's min: default to None (could be reconsidered, forcing caller to provide default)
+
+    >>> portable_min((j for j in [])) # same, default to None
+
+    >>> portable_min((j for j in []), key=lambda j: j) # same, default to None
 
     >>> portable_min(iter(()), default=43) # empty iterable
     43
@@ -821,7 +825,7 @@ def portable_min(*args, **kwargs):
         except Exception:
             raise
     if PY3:
-        kwargs.setdefault('default', None)
+        kwargs.setdefault('default', None)  # may be changed before really switching to py3's min().
         return min(*args, **kwargs)
 
 


### PR DESCRIPTION
This was breaking filter_odt_journeys as "key" was actually not passed (and journeys are not comparable).

JIRA: https://navitia.atlassian.net/browse/NAV-2147