### PR TITLE
Kraken: Fix crash on rail-section without line

### DIFF
--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -1310,7 +1310,7 @@ def make_mock_chaos_item(
         tag.id = t['id']
         tag.name = t['name']
 
-    if not impacted_obj or not impacted_obj_type:
+    if impacted_obj_type is None or (impacted_obj_type not in ["line_section", "rail_section"] and impacted_obj is None):
         return feed_message.SerializeToString()
 
     # Impacts
@@ -1349,7 +1349,7 @@ def make_mock_chaos_item(
     }
 
     ptobject = impact.informed_entities.add()
-    ptobject.uri = impacted_obj
+    ptobject.uri = impacted_obj or "None"
     ptobject.pt_object_type = type_col.get(impacted_obj_type, chaos_pb2.PtObject.unkown_type)
     if ptobject.pt_object_type in [chaos_pb2.PtObject.line_section, chaos_pb2.PtObject.rail_section]:
         disrupted_section = None
@@ -1362,8 +1362,9 @@ def make_mock_chaos_item(
                 pb_sa.uri = sa
                 pb_sa.order = idx
 
-        disrupted_section.line.uri = impacted_obj
-        disrupted_section.line.pt_object_type = chaos_pb2.PtObject.line
+        if impacted_obj is not None:
+            disrupted_section.line.uri = impacted_obj or "None"
+            disrupted_section.line.pt_object_type = chaos_pb2.PtObject.line
         pb_start = disrupted_section.start_point
         pb_start.uri = start
         pb_start.pt_object_type = chaos_pb2.PtObject.stop_area

--- a/source/jormungandr/tests/chaos_disruptions_tests.py
+++ b/source/jormungandr/tests/chaos_disruptions_tests.py
@@ -1310,7 +1310,9 @@ def make_mock_chaos_item(
         tag.id = t['id']
         tag.name = t['name']
 
-    if impacted_obj_type is None or (impacted_obj_type not in ["line_section", "rail_section"] and impacted_obj is None):
+    if impacted_obj_type is None or (
+        impacted_obj_type not in ["line_section", "rail_section"] and impacted_obj is None
+    ):
         return feed_message.SerializeToString()
 
     # Impacts

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -65,7 +65,7 @@ def check_url(tester, url, might_have_additional_args=False, **kwargs):
         )
     else:
         assert response.status_code == 200, "invalid return code, response : {}".format(
-            json.dumps(json.loads(response.data, encoding='utf-8'), indent=2)
+            json.dumps(json.loads(response.data), indent=2)
         )
     return response
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -4013,7 +4013,7 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 @dataset(RAIL_SECTIONS_TEST_SETTING)
 class TestChaosRailSectionOnlyJourney(MockKirinOrChaosDisruptionsFixture):
     def test_rail_section_only_journey_disruptions(self):
-        # Testing that applying Chaos (adapted) works aas expected on every data_freshness level
+        # Testing that applying Chaos (adapted) works as expected on every data_freshness level
 
         def using_vj1(resp):
             return resp['journeys'][0]['sections'][0]['display_informations']['trip_short_name'] == 'vj:1'
@@ -4067,8 +4067,7 @@ class TestChaosRailSectionOnlyJourney(MockKirinOrChaosDisruptionsFixture):
         assert using_vj1(journey_EH_base)
         assert len(journey_EH_base['disruptions']) == 0
 
-        # Send a "Chaos" rail-section disruption: affects only adapted as realtime is already affected by
-        # a kirin disruption (Kirin is prioritary over Chaos)
+        # Send a "Chaos" rail-section disruption: affects adapted and realtime (no Kirin)
         self.send_mock(
             "bobette_the_disruption",
             "line:1",
@@ -4117,6 +4116,162 @@ class TestChaosRailSectionOnlyJourney(MockKirinOrChaosDisruptionsFixture):
         self.send_mock(
             "bobette_the_disruption",
             "line:1",
+            "rail_section",
+            start="stopAreaA",
+            end="stopAreaC",
+            is_deleted=True,
+            is_kirin=False,
+        )
+
+        journey_AE_rt = self.query_region(journey_AE_rt_query)
+        assert len(journey_AE_rt['journeys']) == 1
+        assert journey_AE_rt['journeys'][0]['status'] == ''
+        assert journey_AE_rt['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_rt)
+        assert len(journey_AE_rt['disruptions']) == 0
+
+        journey_EH_rt = self.query_region(journey_EH_rt_query)
+        assert len(journey_EH_rt['journeys']) == 1
+        assert journey_EH_rt['journeys'][0]['status'] == ''
+        assert journey_EH_rt['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_rt)
+        assert len(journey_EH_rt['disruptions']) == 0
+
+        journey_AE_adapted = self.query_region(journey_AE_adapted_query)
+        assert len(journey_AE_adapted['journeys']) == 1
+        assert journey_AE_adapted['journeys'][0]['status'] == ''
+        assert journey_AE_adapted['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_adapted)
+        assert len(journey_AE_adapted['disruptions']) == 0
+
+        journey_EH_adapted = self.query_region(journey_EH_adapted_query)
+        assert len(journey_EH_adapted['journeys']) == 1
+        assert journey_EH_adapted['journeys'][0]['status'] == ''
+        assert journey_EH_adapted['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_adapted)
+        assert len(journey_EH_adapted['disruptions']) == 0
+
+        journey_AE_base = self.query_region(journey_AE_base_query)
+        assert len(journey_AE_base['journeys']) == 1
+        assert journey_AE_base['journeys'][0]['status'] == ''
+        assert journey_AE_base['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_base)
+        assert len(journey_AE_base['disruptions']) == 0
+
+        journey_EH_base = self.query_region(journey_EH_base_query)
+        assert len(journey_EH_base['journeys']) == 1
+        assert journey_EH_base['journeys'][0]['status'] == ''
+        assert journey_EH_base['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_base)
+        assert len(journey_EH_base['disruptions']) == 0
+
+
+@dataset(RAIL_SECTIONS_TEST_SETTING)
+class TestChaosRailSectionWithoutLineJourney(MockKirinOrChaosDisruptionsFixture):
+    def test_rail_section_without_line_journey_disruptions(self):
+        # Test that applying Chaos (adapted) works as expected on every data_freshness level when no line is provided
+
+        def using_vj1(resp):
+            return resp['journeys'][0]['sections'][0]['display_informations']['trip_short_name'] == 'vj:1'
+
+        # Test before any disruption that vj:1 is usable in any freshness level
+        journey_AE_rt_query = "journeys?from=stopA&to=stopE&datetime=20170120T080000&_current_datetime=20170120T080000&data_freshness=realtime"
+        journey_AE_rt = self.query_region(journey_AE_rt_query)
+        assert len(journey_AE_rt['journeys']) == 1
+        assert journey_AE_rt['journeys'][0]['status'] == ''
+        assert journey_AE_rt['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_rt)
+        assert len(journey_AE_rt['disruptions']) == 0
+
+        journey_EH_rt_query = "journeys?from=stopE&to=stopH&datetime=20170120T082000&_current_datetime=20170120T082000&data_freshness=realtime"
+        journey_EH_rt = self.query_region(journey_EH_rt_query)
+        assert len(journey_EH_rt['journeys']) == 1
+        assert journey_EH_rt['journeys'][0]['status'] == ''
+        assert journey_EH_rt['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_rt)
+        assert len(journey_EH_rt['disruptions']) == 0
+
+        journey_AE_adapted_query = "journeys?from=stopA&to=stopE&datetime=20170120T080000&_current_datetime=20170120T080000&data_freshness=adapted_schedule"
+        journey_AE_adapted = self.query_region(journey_AE_adapted_query)
+        assert len(journey_AE_adapted['journeys']) == 1
+        assert journey_AE_adapted['journeys'][0]['status'] == ''
+        assert journey_AE_adapted['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_adapted)
+        assert len(journey_AE_adapted['disruptions']) == 0
+
+        journey_EH_adapted_query = "journeys?from=stopE&to=stopH&datetime=20170120T082000&_current_datetime=20170120T082000&data_freshness=adapted_schedule"
+        journey_EH_adapted = self.query_region(journey_EH_adapted_query)
+        assert len(journey_EH_adapted['journeys']) == 1
+        assert journey_EH_adapted['journeys'][0]['status'] == ''
+        assert journey_EH_adapted['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_adapted)
+        assert len(journey_EH_adapted['disruptions']) == 0
+
+        journey_AE_base_query = "journeys?from=stopA&to=stopE&datetime=20170120T080000&_current_datetime=20170120T080000&data_freshness=base_schedule"
+        journey_AE_base = self.query_region(journey_AE_base_query)
+        assert len(journey_AE_base['journeys']) == 1
+        assert journey_AE_base['journeys'][0]['status'] == ''
+        assert journey_AE_base['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_base)
+        assert len(journey_AE_base['disruptions']) == 0
+
+        journey_EH_base_query = "journeys?from=stopE&to=stopH&datetime=20170120T082000&_current_datetime=20170120T082000&data_freshness=base_schedule"
+        journey_EH_base = self.query_region(journey_EH_base_query)
+        assert len(journey_EH_base['journeys']) == 1
+        assert journey_EH_base['journeys'][0]['status'] == ''
+        assert journey_EH_base['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_base)
+        assert len(journey_EH_base['disruptions']) == 0
+
+        # Send a "Chaos" rail-section disruption: affects adapted and realtime (no Kirin)
+        self.send_mock(
+            "bobette_the_disruption",
+            None,  # no line provided
+            "rail_section",
+            start="stopAreaA",
+            end="stopAreaC",
+            blocked_sa=["stopAreaA", "stopAreaB", "stopAreaC"],
+            routes=["route1"],
+            start_period="20170120T000000",
+            end_period="20170120T220000",
+            blocking=True,
+            is_kirin=False,
+        )
+
+        journey_AE_rt = self.query_region(journey_AE_rt_query)
+        assert "journeys" not in journey_AE_rt
+        assert journey_AE_rt['error']['message'] == 'no solution found for this journey'
+
+        journey_EH_rt = self.query_region(journey_EH_rt_query)
+        assert "journeys" not in journey_EH_rt
+        assert journey_EH_rt['error']['message'] == 'no solution found for this journey'
+
+        journey_AE_adapted = self.query_region(journey_AE_adapted_query)
+        assert "journeys" not in journey_AE_adapted
+        assert journey_AE_adapted['error']['message'] == 'no solution found for this journey'
+
+        journey_EH_adapted = self.query_region(journey_EH_adapted_query)
+        assert "journeys" not in journey_EH_adapted
+        assert journey_EH_adapted['error']['message'] == 'no solution found for this journey'
+
+        journey_AE_base = self.query_region(journey_AE_base_query)
+        assert len(journey_AE_base['journeys']) == 1
+        assert journey_AE_base['journeys'][0]['status'] == 'NO_SERVICE'
+        assert journey_AE_base['journeys'][0]['arrival_date_time'] == '20170120T082000'
+        assert using_vj1(journey_AE_base)
+        assert len(journey_AE_base['disruptions']) == 1
+
+        journey_EH_base = self.query_region(journey_EH_base_query)
+        assert len(journey_EH_base['journeys']) == 1
+        assert journey_EH_base['journeys'][0]['status'] == 'NO_SERVICE'
+        assert journey_EH_base['journeys'][0]['arrival_date_time'] == '20170120T083500'
+        assert using_vj1(journey_EH_base)
+        assert len(journey_EH_base['disruptions']) == 1
+
+        # Delete "Chaos" rail-section disruption: back to no disruption
+        self.send_mock(
+            "bobette_the_disruption",
+            None,
             "rail_section",
             start="stopAreaA",
             end="stopAreaC",

--- a/source/kraken/make_disruption_from_chaos.cpp
+++ b/source/kraken/make_disruption_from_chaos.cpp
@@ -148,7 +148,8 @@ static boost::shared_ptr<nt::disruption::Severity> make_severity(const chaos::Se
 boost::optional<nt::disruption::LineSection> make_line_section(const chaos::PtObject& chaos_section,
                                                                nt::PT_Data& pt_data) {
     if (!chaos_section.has_pt_line_section()) {
-        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "fill_disruption_from_chaos: LineSection invalid!");
+        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
+                       "fill_disruption_from_chaos: reject LineSection, invalid!");
         return boost::none;
     }
     const auto& pb_section = chaos_section.pt_line_section();
@@ -157,24 +158,25 @@ boost::optional<nt::disruption::LineSection> make_line_section(const chaos::PtOb
     if (line) {
         line_section.line = line;
     } else {
-        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
-                       "fill_disruption_from_chaos: line id " << pb_section.line().uri() << " in LineSection invalid!");
+        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "fill_disruption_from_chaos: reject LineSection, line id "
+                                                                  << pb_section.line().uri()
+                                                                  << " in LineSection invalid!");
         return boost::none;
     }
     if (auto* start = find_or_default(pb_section.start_point().uri(), pt_data.stop_areas_map)) {
         line_section.start_point = start;
     } else {
-        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "fill_disruption_from_chaos: start_point id "
-                                                                  << pb_section.start_point().uri()
-                                                                  << " in LineSection invalid!");
+        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
+                       "fill_disruption_from_chaos: reject LineSection, start_point id "
+                           << pb_section.start_point().uri() << " in LineSection invalid!");
         return boost::none;
     }
     if (auto* end = find_or_default(pb_section.end_point().uri(), pt_data.stop_areas_map)) {
         line_section.end_point = end;
     } else {
-        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"), "fill_disruption_from_chaos: end_point id "
-                                                                  << pb_section.end_point().uri()
-                                                                  << " in LineSection invalid!");
+        LOG4CPLUS_WARN(log4cplus::Logger::getInstance("log"),
+                       "fill_disruption_from_chaos: reject LineSection, end_point id " << pb_section.end_point().uri()
+                                                                                       << " in LineSection invalid!");
         return boost::none;
     }
     if (!pb_section.routes().empty()) {
@@ -205,7 +207,7 @@ boost::optional<nt::disruption::RailSection> make_rail_section(const chaos::PtOb
                                                                const nt::PT_Data& pt_data) {
     log4cplus::Logger log = log4cplus::Logger::getInstance("log");
     if (!chaos_section.has_pt_rail_section()) {
-        LOG4CPLUS_WARN(log, "fill_disruption_from_chaos: RailSection invalid!");
+        LOG4CPLUS_WARN(log, "fill_disruption_from_chaos: reject RailSection, invalid!");
         return boost::none;
     }
     std::string log_message = "new rail Section disruption received -";

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -711,7 +711,7 @@ std::set<idx_t> Data::get_target_by_source(Type_e source, Type_e target, const s
     std::set<idx_t> result;
     for (idx_t idx : source_idx) {
         Indexes tmp = get_target_by_one_source(source, target, idx);
-        // TODO: Use flat_set's merge when we pass to boost 1.62
+        // TODO: Use set's merge when we pass to c++17
         result.insert(tmp.begin(), tmp.end());
     }
     return result;

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -719,10 +719,10 @@ boost::optional<RailSection> try_make_rail_section(
                 LOG4CPLUS_WARN(logger, "Rejected rail section has line: '"
                                            << *line_uri << "' but also a route with no line: " << route->uri);
                 return boost::none;
-            } else if (line == nullptr) {
-                line = route->line;
             }
-            if (route->line->idx != line->idx) {
+            if (line == nullptr) {
+                line = route->line;
+            } else if (route->line->idx != line->idx) {
                 LOG4CPLUS_WARN(logger, "Rejected rail section has line (or a route from line): '"
                                            << *line_uri << "' but also a route: '" << route->uri
                                            << "' that belongs to a different line: " << route->line->uri);

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -716,16 +716,16 @@ boost::optional<RailSection> try_make_rail_section(
         // some routes were given, let's check that they belong to "line"
         for (const Route* route : routes) {
             if (route->line == nullptr) {
-                LOG4CPLUS_WARN(logger, "Rail section has line: '"
-                                            << *line_uri << "' but also a route with no line: " << route->uri);
+                LOG4CPLUS_WARN(logger, "Rail section has line: '" << *line_uri
+                                                                  << "' but also a route with no line: " << route->uri);
                 return boost::none;
             } else if (line == nullptr) {
                 line = route->line;
             }
             if (route->line->idx != line->idx) {
                 LOG4CPLUS_WARN(logger, "Rail section has line (or a route from line): '"
-                                            << *line_uri << "' but also a route: '" << route->uri
-                                            << "' that belongs to a different line: " << route->line->uri);
+                                           << *line_uri << "' but also a route: '" << route->uri
+                                           << "' that belongs to a different line: " << route->line->uri);
                 return boost::none;
             }
         }

--- a/source/type/message.cpp
+++ b/source/type/message.cpp
@@ -645,7 +645,7 @@ boost::optional<RailSection> try_make_rail_section(
     // find start stop area if it exists
     auto find_start = stop_areas_map.find(start_uri);
     if (find_start == stop_areas_map.end()) {
-        LOG4CPLUS_WARN(logger, "Rail section with unknown start stop area: " << start_uri);
+        LOG4CPLUS_WARN(logger, "Rejected rail section with unknown start stop area: " << start_uri);
         return boost::none;
     }
     StopArea* start = stop_areas_map.at(start_uri);
@@ -653,7 +653,7 @@ boost::optional<RailSection> try_make_rail_section(
     // find end_stop_area if it exists
     auto find_end = stop_areas_map.find(end_uri);
     if (find_end == stop_areas_map.end()) {
-        LOG4CPLUS_WARN(logger, "Rail section with unknown end stop area: " << end_uri);
+        LOG4CPLUS_WARN(logger, "Rejected rail section with unknown end stop area: " << end_uri);
         return boost::none;
     }
     StopArea* end = stop_areas_map.at(end_uri);
@@ -671,7 +671,7 @@ boost::optional<RailSection> try_make_rail_section(
         const std::string& blocked_uri = pair.first;
         auto find_blocked = stop_areas_map.find(blocked_uri);
         if (find_blocked == stop_areas_map.end()) {
-            LOG4CPLUS_WARN(logger, "Rail section with unknown blocked stop area : " << blocked_uri);
+            LOG4CPLUS_WARN(logger, "Rejected rail section with unknown blocked stop area : " << blocked_uri);
             return boost::none;
         }
         StopArea* blocked_stop_area = stop_areas_map.at(blocked_uri);
@@ -679,7 +679,7 @@ boost::optional<RailSection> try_make_rail_section(
     }
 
     if (line_uri == nullptr && routes_uris.empty()) {
-        LOG4CPLUS_WARN(logger, "Rail section with no line and empty routes.");
+        LOG4CPLUS_WARN(logger, "Rejected rail section with no line and empty routes.");
         return boost::none;
     }
 
@@ -689,7 +689,7 @@ boost::optional<RailSection> try_make_rail_section(
     for (const auto& route_uri : routes_uris) {
         auto find_route = routes_map.find(route_uri);
         if (find_route == routes_map.end()) {
-            LOG4CPLUS_WARN(logger, "Rail section with unknown route : " << route_uri);
+            LOG4CPLUS_WARN(logger, "Rejected rail section with unknown route : " << route_uri);
             return boost::none;
         }
         Route* route = routes_map.at(route_uri);
@@ -701,7 +701,7 @@ boost::optional<RailSection> try_make_rail_section(
         const std::unordered_map<std::string, Line*>& lines_map = pt_data.lines_map;
         auto find_line = lines_map.find(*line_uri);
         if (find_line == lines_map.end()) {
-            LOG4CPLUS_WARN(logger, "Rail section with unknown line : " << *line_uri);
+            LOG4CPLUS_WARN(logger, "Rejected rail section with unknown line : " << *line_uri);
             return boost::none;
         }
         line = lines_map.at(*line_uri);
@@ -716,14 +716,14 @@ boost::optional<RailSection> try_make_rail_section(
         // some routes were given, let's check that they belong to "line"
         for (const Route* route : routes) {
             if (route->line == nullptr) {
-                LOG4CPLUS_WARN(logger, "Rail section has line: '" << *line_uri
-                                                                  << "' but also a route with no line: " << route->uri);
+                LOG4CPLUS_WARN(logger, "Rejected rail section has line: '"
+                                           << *line_uri << "' but also a route with no line: " << route->uri);
                 return boost::none;
             } else if (line == nullptr) {
                 line = route->line;
             }
             if (route->line->idx != line->idx) {
-                LOG4CPLUS_WARN(logger, "Rail section has line (or a route from line): '"
+                LOG4CPLUS_WARN(logger, "Rejected rail section has line (or a route from line): '"
                                            << *line_uri << "' but also a route: '" << route->uri
                                            << "' that belongs to a different line: " << route->line->uri);
                 return boost::none;


### PR DESCRIPTION
* TDD rail-section without line crashes before
* Tests: tinker chaos-disruption mocker
* Tests: fix "encoding" that was breaking in case of non-200
* fix and secure code

:mag: easier to review by commit and without blank-changes :wink: 

JIRA: https://navitia.atlassian.net/browse/NAV-2146