### PR TITLE
[Jormungandr] Check and abort 413 if response content is too large

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -167,6 +167,8 @@ class Instance(transient_socket.TransientSocket):
         olympics_forbidden_uris=None,
         additional_params_period=None,
         use_multi_reverse=False,
+        resp_content_limit_bytes=None,
+        resp_content_limit_endpoints_whitelist=None,
     ):
         super(Instance, self).__init__(
             name=name,
@@ -268,6 +270,9 @@ class Instance(transient_socket.TransientSocket):
         self.additional_params_period_end = None
         self.use_multi_reverse = use_multi_reverse
         self.stop_points_attractivities = None
+        self.resp_content_limit_bytes = resp_content_limit_bytes
+        # a list of endpoints that are not affected by the resp_content_limit_bytes
+        self.resp_content_limit_endpoints_whitelist = set(resp_content_limit_endpoints_whitelist or [])
 
         # Read the best_boarding_positions files if any
         if best_boarding_positions_dir is not None:

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -126,6 +126,8 @@ class InstanceManager(object):
             olympics_forbidden_uris=config.get('olympics_forbidden_uris', None),
             additional_params_period=config.get('additional_parameters_activation_period', None),
             use_multi_reverse=config.get('use_multi_reverse', False),
+            resp_content_limit_bytes=config.get('resp_content_limit_bytes', None),
+            resp_content_limit_endpoints_whitelist=config.get('resp_content_limit_endpoints_whitelist', None),
         )
 
         self.instances[instance.name] = instance

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -1173,3 +1173,16 @@ def ceil_by_half(f):
     0.0
     """
     return 0.5 * math.ceil(2.0 * float(f))
+
+
+def content_is_too_large(instance, endpoint, response):
+    if not instance:
+        return False
+    if instance.resp_content_limit_bytes is None:
+        return False
+    if endpoint in instance.resp_content_limit_endpoints_whitelist:
+        return False
+    if response.content_length <= instance.resp_content_limit_bytes:
+        return False
+
+    return True


### PR DESCRIPTION
in order to activate this feature, one must add the following fields in instance's config file or in `JORMUNGANDR_INSTANCE_instance_name` 

```json
{
  "key": "instance-name",
  "zmq_socket": "tcp://kraken:30001",
  ...
  "resp_content_limit_bytes": 4096,
  "resp_content_limit_endpoints_white_list": ["v1.journeys", "v1.stop_areas"],
  # or
  "resp_content_limit_endpoints_white_list": [],
}
```