### PR TITLE
[Jormungandr] fix abort 413 when response's length is None

### DIFF
--- a/source/jormungandr/jormungandr/tests/utils_test.py
+++ b/source/jormungandr/jormungandr/tests/utils_test.py
@@ -572,3 +572,8 @@ def test_content_is_too_large():
     instance = DummyInstance(limit=41, whitelist=["v1.another_dummy_endpoint"])
     response = DummyResponse(length=42)
     assert content_is_too_large(instance, "v1.dummy_endpoint", response)
+
+    # response length could be None
+    instance = DummyInstance(limit=41, whitelist=["v1.another_dummy_endpoint"])
+    response = DummyResponse(length=None)
+    assert not content_is_too_large(instance, "v1.dummy_endpoint", response)

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -1182,6 +1182,8 @@ def content_is_too_large(instance, endpoint, response):
         return False
     if endpoint in instance.resp_content_limit_endpoints_whitelist:
         return False
+    if response.content_length is None:
+        return False
     if response.content_length <= instance.resp_content_limit_bytes:
         return False
 


### PR DESCRIPTION
with `OPTION`, response.length becomes `None` 