### PR TITLE
[Kraken] Add pt journey fare in kraken

### DIFF
--- a/source/fare/CMakeLists.txt
+++ b/source/fare/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(FARE_SRC
     fare.h
     fare.cpp
+    fare_api.cpp
 )
 
 add_library(fare ${FARE_SRC})

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -278,7 +278,7 @@ results Fare::compute_fare(const routing::Path& path) const {
 }
 
 results Fare::compute_fare(const pbnavitia::PtFaresRequest::PtJourney& pt_journey, const type::Data& data) const {
-    int nb_nodes = boost::num_vertices(g);
+    size_t nb_nodes = boost::num_vertices(g);
 
     if (nb_nodes < 2) {
         LOG4CPLUS_TRACE(logger, "no fare data loaded, cannot compute fare");
@@ -286,7 +286,7 @@ results Fare::compute_fare(const pbnavitia::PtFaresRequest::PtJourney& pt_journe
     }
     std::vector<std::vector<Label>> labels(nb_nodes);
     // Start label
-    labels[0].push_back(Label());
+    labels[0].emplace_back();
 
     for (const auto& s : pt_journey.pt_sections()) {
         const auto& first_sp_uri = s.first_stop_point_uri();
@@ -324,23 +324,23 @@ SectionKey::SectionKey(const routing::PathItem& path_item, const size_t idx) : p
 
 SectionKey::SectionKey(const pbnavitia::PtFaresRequest::PtSection& section,
                        const type::StopPoint& first_stop_point,
-                       const type::StopPoint& last_stop_point) {
-    network = section.network_uri();
-    start_stop_area = section.start_stop_area_uri();
-    dest_stop_area = section.end_stop_area_uri();
-    line = section.line_uri();
+                       const type::StopPoint& last_stop_point)
+    : network(section.network_uri()),
+      start_stop_area(section.start_stop_area_uri()),
+      dest_stop_area(section.end_stop_area_uri()),
+      line(section.line_uri()),
+      start_zone(first_stop_point.fare_zone),
+      dest_zone(last_stop_point.fare_zone),
+      mode(section.physical_mode()),
+      section_id(section.id())
 
+{
     auto begin_date_time = boost::posix_time::from_time_t(section.begin_date_time());
     date = begin_date_time.date();
     start_time = begin_date_time.time_of_day().total_seconds();
 
     auto end_date_time = boost::posix_time::from_time_t(section.end_date_time());
     dest_time = end_date_time.time_of_day().total_seconds();
-
-    start_zone = first_stop_point.fare_zone;
-    dest_zone = last_stop_point.fare_zone;
-    mode = section.physical_mode();
-    section_id = section.id();
 };
 
 template <class T>

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -507,8 +507,8 @@ DateTicket DateTicket::operator+(const DateTicket& other) const {
     for (size_t i = 0; i < std::min(this->tickets.size(), other.tickets.size()); ++i) {
         if (this->tickets[i].validity_period != other.tickets[i].validity_period)
             LOG4CPLUS_ERROR(log4cplus::Logger::getInstance("fare"),
-                            "Ticket n�� " << i << " doesn't have the same dates; " << this->tickets[i].validity_period
-                                          << " as " << other.tickets[i].validity_period);
+                            "Ticket n° " << i << " doesn't have the same dates; " << this->tickets[i].validity_period
+                                         << " as " << other.tickets[i].validity_period);
         new_ticket.tickets[i].ticket.value = this->tickets[i].ticket.value + other.tickets[i].ticket.value;
     }
     return new_ticket;

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -1,4 +1,4 @@
-/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.

--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -697,15 +697,5 @@ std::ostream& operator<<(std::ostream& ss, const Condition& condition) {
     return ss;
 }
 
-void fill_fares(PbCreator& pb_creator, const pbnavitia::PtFaresRequest& fares) {
-    for (const pbnavitia::PtFaresRequest::PtJourney& pt_journey : fares.pt_journeys()) {
-        pbnavitia::PtJourneyFare* pb_journey_fare = pb_creator.add_pt_journey_fares();
-        pb_journey_fare->set_journey_id(pt_journey.id());
-
-        auto tickets = pb_creator.data->fare->compute_fare(pt_journey, *pb_creator.data);
-        pb_creator.fill_fare(pb_journey_fare->mutable_fare(), nullptr, tickets);
-    }
-}
-
 }  // namespace fare
 }  // namespace navitia

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -1,4 +1,4 @@
-/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -243,15 +243,15 @@ struct Condition {
 
 std::ostream& operator<<(std::ostream& ss, const Condition& k);
 
-/// Structure repr��sentant une ��tiquette
+/// Structure représentant une étiquette
 struct Label {
-    Cost cost = 0;  //< Co��t cummul��
+    Cost cost = 0;  //< Coût cummulé
     size_t nb_undefined_sub_cost = 0;
     int start_time = 0;  //< Heure de compostage du billet
-    // int duration;//< dur��e jusqu'�� pr��sent du trajet depuis le dernier ticket
-    int nb_changes = 0;     //< nombre de changement effectu��s depuis le dernier ticket
+    // int duration;//< durée jusqu'à présent du trajet depuis le dernier ticket
+    int nb_changes = 0;     //< nombre de changement effectués depuis le dernier ticket
     std::string stop_area;  //< stop_area d'achat du billet
-                            // std::string dest_stop_area; //< on est oblig�� de descendre �� ce stop_area
+                            // std::string dest_stop_area; //< on est obligé de descendre à ce stop_area
     std::string zone;
     std::string mode;
     std::string line;
@@ -259,8 +259,8 @@ struct Label {
 
     Ticket::ticket_type current_type = Ticket::FlatFare;
 
-    std::vector<Ticket> tickets;  //< Ensemble de billets �� acheter pour arriver �� cette ��tiquette
-    /// Constructeur par d��faut
+    std::vector<Ticket> tickets;  //< Ensemble de billets à acheter pour arriver à cette étiquette
+    /// Constructeur par défaut
     Label() = default;
     bool operator==(const Label& l) const {
         return cost == l.cost && start_time == l.start_time && nb_changes == l.nb_changes && stop_area == l.stop_area
@@ -282,7 +282,7 @@ struct Label {
 
 std::ostream& operator<<(std::ostream& ss, const Label& l);
 
-/// Contient les donn��es retourn��es par navitia
+/// Contient les données retournées par navitia
 struct SectionKey {
     std::string network = {};
     std::string start_stop_area = {};
@@ -309,14 +309,14 @@ struct SectionKey {
 
 std::ostream& operator<<(std::ostream& ss, const SectionKey& k);
 
-/// Repr��sente un transition possible et l'achat ��ventuel d'un billet
+/// Représente un transition possible et l'achat éventuel d'un billet
 struct Transition {
     enum class GlobalCondition { nothing, exclusive, with_changes };
 
     std::vector<Condition> start_conditions;                      //< condition pour emprunter l'arc
-    std::vector<Condition> end_conditions;                        //< condition �� la sortie de l'arc
+    std::vector<Condition> end_conditions;                        //< condition à la sortie de l'arc
     std::string ticket_key;                                       //< clef vers le tarif correspondant
-    GlobalCondition global_condition = GlobalCondition::nothing;  //< condition telle que exclusivit�� ou OD
+    GlobalCondition global_condition = GlobalCondition::nothing;  //< condition telle que exclusivité ou OD
 
     bool valid(const SectionKey& section, const Label& label) const;
 
@@ -353,7 +353,7 @@ struct results {
     bool not_found = true;
 };
 
-/// Contient l'ensemble du syst��me tarifaire
+/// Contient l'ensemble du système tarifaire
 struct Fare {
     /// Map qui associe les clefs de tarifs aux tarifs
     std::map<std::string, DateTicket> fare_map;
@@ -370,7 +370,7 @@ struct Fare {
     Fare();
 
     /// Effectue la recherche du meilleur tarif
-    /// Retourne une liste de billets �� acheter
+    /// Retourne une liste de billets à acheter
     results compute_fare(const routing::Path& path) const;
     results compute_fare(const pbnavitia::PtFaresRequest::PtJourney& fares, const type::Data& data) const;
 
@@ -390,7 +390,7 @@ struct Fare {
     size_t nb_transitions() const;
 
 private:
-    /// Retourne le ticket OD qui va bien ou l��ve une exception no_ticket si on ne trouve pas
+    /// Retourne le ticket OD qui va bien ou lève une exception no_ticket si on ne trouve pas
     DateTicket get_od(const Label& label, const SectionKey& section) const;
 
     void add_default_ticket();

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -393,6 +393,9 @@ private:
     /// Retourne le ticket OD qui va bien ou lève une exception no_ticket si on ne trouve pas
     DateTicket get_od(const Label& label, const SectionKey& section) const;
 
+    std::vector<std::vector<Label>> compute_labels(const size_t nb_nodes,
+                                                   const std::vector<std::vector<Label>>& old_labels,
+                                                   const SectionKey& section_key) const;
     void add_default_ticket();
 
     log4cplus::Logger logger = log4cplus::Logger::getInstance("fare");

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -44,14 +44,6 @@ www.navitia.io
 #include <utility>
 
 namespace navitia {
-
-namespace type {
-struct StopPoint;
-struct Data;
-}  // namespace type
-
-class PbCreator;
-
 namespace fare {
 
 /**
@@ -400,8 +392,6 @@ private:
 
     log4cplus::Logger logger = log4cplus::Logger::getInstance("fare");
 };
-
-void fill_fares(PbCreator& pb_creator, const pbnavitia::PtFaresRequest& fares);
 
 }  // namespace fare
 }  // namespace navitia

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -280,8 +280,8 @@ struct SectionKey {
     std::string start_stop_area = {};
     std::string dest_stop_area = {};
     std::string line = {};
-    uint32_t start_time = {};
-    uint32_t dest_time = {};
+    long start_time = {};
+    long dest_time = {};
     std::string start_zone = {};
     std::string dest_zone = {};
     std::string mode = {};

--- a/source/fare/fare.h
+++ b/source/fare/fare.h
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -34,6 +34,7 @@ www.navitia.io
 #include "routing/routing.h"
 #include "utils/serialization_vector.h"
 #include "utils/logger.h"
+#include "type/request.pb.h"
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
@@ -43,6 +44,14 @@ www.navitia.io
 #include <utility>
 
 namespace navitia {
+
+namespace type {
+struct StopPoint;
+struct Data;
+}  // namespace type
+
+class PbCreator;
+
 namespace fare {
 
 /**
@@ -234,15 +243,15 @@ struct Condition {
 
 std::ostream& operator<<(std::ostream& ss, const Condition& k);
 
-/// Structure représentant une étiquette
+/// Structure repr��sentant une ��tiquette
 struct Label {
-    Cost cost = 0;  //< Coût cummulé
+    Cost cost = 0;  //< Co��t cummul��
     size_t nb_undefined_sub_cost = 0;
     int start_time = 0;  //< Heure de compostage du billet
-    // int duration;//< durée jusqu'à présent du trajet depuis le dernier ticket
-    int nb_changes = 0;     //< nombre de changement effectués depuis le dernier ticket
+    // int duration;//< dur��e jusqu'�� pr��sent du trajet depuis le dernier ticket
+    int nb_changes = 0;     //< nombre de changement effectu��s depuis le dernier ticket
     std::string stop_area;  //< stop_area d'achat du billet
-                            // std::string dest_stop_area; //< on est obligé de descendre à ce stop_area
+                            // std::string dest_stop_area; //< on est oblig�� de descendre �� ce stop_area
     std::string zone;
     std::string mode;
     std::string line;
@@ -250,8 +259,8 @@ struct Label {
 
     Ticket::ticket_type current_type = Ticket::FlatFare;
 
-    std::vector<Ticket> tickets;  //< Ensemble de billets à acheter pour arriver à cette étiquette
-    /// Constructeur par défaut
+    std::vector<Ticket> tickets;  //< Ensemble de billets �� acheter pour arriver �� cette ��tiquette
+    /// Constructeur par d��faut
     Label() = default;
     bool operator==(const Label& l) const {
         return cost == l.cost && start_time == l.start_time && nb_changes == l.nb_changes && stop_area == l.stop_area
@@ -273,35 +282,41 @@ struct Label {
 
 std::ostream& operator<<(std::ostream& ss, const Label& l);
 
-/// Contient les données retournées par navitia
+/// Contient les donn��es retourn��es par navitia
 struct SectionKey {
-    std::string network;
-    std::string start_stop_area;
-    std::string dest_stop_area;
-    std::string line;
-    uint32_t start_time;
-    uint32_t dest_time;
-    std::string start_zone;
-    std::string dest_zone;
-    std::string mode;
-    boost::gregorian::date date;
-    size_t path_item_idx;
+    std::string network = {};
+    std::string start_stop_area = {};
+    std::string dest_stop_area = {};
+    std::string line = {};
+    uint32_t start_time = {};
+    uint32_t dest_time = {};
+    std::string start_zone = {};
+    std::string dest_zone = {};
+    std::string mode = {};
+    boost::gregorian::date date = {};
+    size_t path_item_idx = 0;
+
+    boost::optional<std::string> section_id;
 
     SectionKey(const routing::PathItem& path_item, const size_t idx);
+    SectionKey(const pbnavitia::PtFaresRequest::PtSection& section,
+               const type::StopPoint& first_stop_point,
+               const type::StopPoint& last_stop_point);
+
     int duration_at_begin(int ticket_start_time) const;
     int duration_at_end(int ticket_start_time) const;
 };
 
 std::ostream& operator<<(std::ostream& ss, const SectionKey& k);
 
-/// Représente un transition possible et l'achat éventuel d'un billet
+/// Repr��sente un transition possible et l'achat ��ventuel d'un billet
 struct Transition {
     enum class GlobalCondition { nothing, exclusive, with_changes };
 
     std::vector<Condition> start_conditions;                      //< condition pour emprunter l'arc
-    std::vector<Condition> end_conditions;                        //< condition à la sortie de l'arc
+    std::vector<Condition> end_conditions;                        //< condition �� la sortie de l'arc
     std::string ticket_key;                                       //< clef vers le tarif correspondant
-    GlobalCondition global_condition = GlobalCondition::nothing;  //< condition telle que exclusivité ou OD
+    GlobalCondition global_condition = GlobalCondition::nothing;  //< condition telle que exclusivit�� ou OD
 
     bool valid(const SectionKey& section, const Label& label) const;
 
@@ -338,7 +353,7 @@ struct results {
     bool not_found = true;
 };
 
-/// Contient l'ensemble du système tarifaire
+/// Contient l'ensemble du syst��me tarifaire
 struct Fare {
     /// Map qui associe les clefs de tarifs aux tarifs
     std::map<std::string, DateTicket> fare_map;
@@ -355,8 +370,9 @@ struct Fare {
     Fare();
 
     /// Effectue la recherche du meilleur tarif
-    /// Retourne une liste de billets à acheter
+    /// Retourne une liste de billets �� acheter
     results compute_fare(const routing::Path& path) const;
+    results compute_fare(const pbnavitia::PtFaresRequest::PtJourney& fares, const type::Data& data) const;
 
     template <class Archive>
     void save(Archive& ar, const unsigned int) const {
@@ -374,13 +390,15 @@ struct Fare {
     size_t nb_transitions() const;
 
 private:
-    /// Retourne le ticket OD qui va bien ou lève une exception no_ticket si on ne trouve pas
+    /// Retourne le ticket OD qui va bien ou l��ve une exception no_ticket si on ne trouve pas
     DateTicket get_od(const Label& label, const SectionKey& section) const;
 
     void add_default_ticket();
 
     log4cplus::Logger logger = log4cplus::Logger::getInstance("fare");
 };
+
+void fill_fares(PbCreator& pb_creator, const pbnavitia::PtFaresRequest& fares);
 
 }  // namespace fare
 }  // namespace navitia

--- a/source/fare/fare_api.cpp
+++ b/source/fare/fare_api.cpp
@@ -1,0 +1,51 @@
+/* Copyright © 2001-2023, Hove and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Hove (www.hove.com).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#include "fare_api.h"
+#include "fare.h"
+
+#include "routing/routing.h"
+#include "type/datetime.h"
+#include "type/pb_converter.h"
+
+namespace navitia {
+namespace fare {
+
+void fill_fares(PbCreator& pb_creator, const pbnavitia::PtFaresRequest& fares) {
+    for (const pbnavitia::PtFaresRequest::PtJourney& pt_journey : fares.pt_journeys()) {
+        pbnavitia::PtJourneyFare* pb_journey_fare = pb_creator.add_pt_journey_fares();
+        pb_journey_fare->set_journey_id(pt_journey.id());
+
+        auto tickets = pb_creator.data->fare->compute_fare(pt_journey, *pb_creator.data);
+        pb_creator.fill_fare(pb_journey_fare->mutable_fare(), nullptr, tickets);
+    }
+}
+}  // namespace fare
+}  // namespace navitia

--- a/source/fare/fare_api.h
+++ b/source/fare/fare_api.h
@@ -1,0 +1,51 @@
+/* Copyright © 2001-2023, Hove and/or its affiliates. All rights reserved.
+
+This file is part of Navitia,
+    the software to build cool stuff with public transport.
+
+Hope you'll enjoy and contribute to this project,
+    powered by Hove (www.hove.com).
+Help us simplify mobility and open public transport:
+    a non ending quest to the responsive locomotion way of traveling!
+
+LICENCE: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+Stay tuned using
+twitter @navitia
+channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+https://groups.google.com/d/forum/navitia
+www.navitia.io
+*/
+
+#pragma once
+#include "fare.h"
+
+namespace pbnavitia {
+class PtFaresRequest;
+}
+namespace navitia {
+
+namespace type {
+struct StopPoint;
+struct Data;
+}  // namespace type
+
+class PbCreator;
+
+namespace fare {
+
+void fill_fares(PbCreator& pb_creator, const pbnavitia::PtFaresRequest& fares);
+
+}  // namespace fare
+}  // namespace navitia

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -31,7 +31,7 @@ www.navitia.io
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE test_fares
 #include <boost/test/unit_test.hpp>
-#include "fare/fare.h"
+#include "fare/fare_api.h"
 #include "type/data.h"
 #include "routing/raptor_api.h"
 #include "routing/raptor.h"

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -177,4 +177,123 @@ BOOST_AUTO_TEST_CASE(test_protobuff_no_data) {
 
     BOOST_REQUIRE_EQUAL(pb_fare.ticket_id_size(), 0);
     BOOST_REQUIRE_EQUAL(resp.tickets_size(), 0);
+}
+
+BOOST_AUTO_TEST_CASE(test_fare_api) {
+    ed::builder b("20120614");
+    b.vj_with_network("RATP", "A", "11111111", "", true, "")("stop1", 8000, 8050)("stop2", 8100, 8150)("stop3", 8200,
+                                                                                                       8250);
+    b.vj_with_network("RATP", "B", "11111111", "", true, "")("stop4", 8000, 8050)("stop2", 8300, 8350)("stop5", 8400,
+                                                                                                       8450);
+    b.connection("stop1", "stop1", 120);
+    b.connection("stop2", "stop2", 120);
+    b.connection("stop3", "stop3", 120);
+    b.connection("stop4", "stop4", 120);
+    b.connection("stop5", "stop5", 120);
+    b.make();
+    b.data->compute_labels();
+    b.data->meta->production_date =
+        boost::gregorian::date_period(boost::gregorian::date(2012, 06, 14), boost::gregorian::days(7));
+
+    RAPTOR raptor(*b.data);
+
+    // fare data initialization
+    boost::gregorian::date start_date(boost::gregorian::from_undelimited_string("20110101"));
+    boost::gregorian::date end_date(boost::gregorian::from_undelimited_string("20350101"));
+    b.data->fare->fare_map["price1"].add(start_date, end_date, fare::Ticket("price1", "Ticket vj 1", 100, "125"));
+    b.data->fare->fare_map["price2"].add(start_date, end_date, fare::Ticket("price2", "Ticket vj 2", 200, "175"));
+
+    // dummy transition
+    fare::Transition transitionA;
+    fare::State endA;
+    endA.line = "A";
+    transitionA.ticket_key = "price1";
+    auto endA_v = boost::add_vertex(endA, b.data->fare->g);
+    boost::add_edge(b.data->fare->begin_v, endA_v, transitionA, b.data->fare->g);
+
+    fare::Transition transitionB;
+    fare::State endB;
+    endB.line = "B";
+    transitionB.ticket_key = "price2";
+    auto endB_v = boost::add_vertex(endB, b.data->fare->g);
+    boost::add_edge(b.data->fare->begin_v, endB_v, transitionB, b.data->fare->g);
+
+    // call to raptor
+    type::EntryPoint origin(type::Type_e::StopArea, "stop1");
+    type::EntryPoint destination(type::Type_e::StopArea, "stop5");
+
+    georef::StreetNetwork sn_worker(*b.data->geo_ref);
+    auto* data_ptr = b.data.get();
+    navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+    make_response(pb_creator, raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")}, true,
+                  type::AccessibiliteParams(), {}, {}, sn_worker, type::RTLevel::Base, 2_min);
+    pbnavitia::Response resp = pb_creator.get_response();
+    BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
+
+    const pbnavitia::Journey& journey = resp.journeys(0);
+
+    // from journey we create the PrJourneyReuqest:
+    pbnavitia::PtFaresRequest pt_fare_request{};
+
+    auto* pt_fare_journey = pt_fare_request.add_pt_journeys();
+    pt_fare_journey->set_id("pt_jourey_1");
+
+    size_t idx = 0;
+
+    for (const auto& section : journey.sections()) {
+        if (section.type() != pbnavitia::PUBLIC_TRANSPORT) {
+            continue;
+        }
+
+        auto* pt_fare_section = pt_fare_journey->add_pt_sections();
+
+        pt_fare_section->set_id(section.id());
+        pt_fare_section->set_network_uri(section.pt_display_informations().uris().network());
+        pt_fare_section->set_start_stop_area_uri(section.origin().uri());
+        pt_fare_section->set_end_stop_area_uri(section.destination().uri());
+        pt_fare_section->set_line_uri(section.pt_display_informations().uris().line());
+        pt_fare_section->set_begin_date_time(section.begin_date_time());
+        pt_fare_section->set_end_date_time(section.end_date_time());
+
+        auto first_stop_point = section.stop_date_times().begin()->stop_point();
+        pt_fare_section->set_first_stop_point_uri(first_stop_point.uri());
+
+        auto last_stop_point = section.stop_date_times().rbegin()->stop_point();
+        pt_fare_section->set_last_stop_point_uri(last_stop_point.uri());
+
+        pt_fare_section->set_physical_mode(section.pt_display_informations().physical_mode());
+    }
+
+    navitia::PbCreator pb_creator_fare(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+
+    fare::fill_fares(pb_creator_fare, pt_fare_request);
+
+    auto fare_response = pb_creator_fare.get_response();
+    auto pt_journey_fares = fare_response.pt_journey_fares();
+    BOOST_REQUIRE_EQUAL(pt_journey_fares.size(), 1);
+    BOOST_REQUIRE_EQUAL(pt_journey_fares.Get(0).journey_id(), "pt_jourey_1");
+
+    // fare structures check
+    const pbnavitia::Fare& pb_fare = pt_journey_fares.Get(0).fare();
+
+    BOOST_REQUIRE_EQUAL(pb_fare.ticket_id_size(), 2);
+
+    BOOST_REQUIRE_EQUAL(fare_response.tickets_size(), 2);
+    std::map<std::string, pbnavitia::Ticket> ticket;
+    for (int i = 0; i < fare_response.tickets_size(); ++i) {
+        auto t = fare_response.tickets(i);
+        ticket[t.id()] = t;
+    }
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].name(), "Ticket vj 1");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].source_id(), "price1");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].cost().value(), 100);
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].cost().currency(), "euro");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].section_id_size(), 1);
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].section_id(0), "section_1");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].name(), "Ticket vj 2");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].source_id(), "price2");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].cost().value(), 200);
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].cost().currency(), "euro");
+    BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].section_id(0), "section_3");
 }

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -1,4 +1,4 @@
-/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(test_fare_api) {
     type::EntryPoint destination(type::Type_e::StopArea, "stop5");
 
     georef::StreetNetwork sn_worker(*b.data->geo_ref);
-    auto* data_ptr = b.data.get();
+    const auto* data_ptr = b.data.get();
     navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
     make_response(pb_creator, raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")}, true,
                   type::AccessibiliteParams(), {}, {}, sn_worker, type::RTLevel::Base, 2_min);
@@ -238,8 +238,6 @@ BOOST_AUTO_TEST_CASE(test_fare_api) {
 
     auto* pt_fare_journey = pt_fare_request.add_pt_journeys();
     pt_fare_journey->set_id("pt_jourey_1");
-
-    size_t idx = 0;
 
     for (const auto& section : journey.sections()) {
         if (section.type() != pbnavitia::PUBLIC_TRANSPORT) {
@@ -269,8 +267,8 @@ BOOST_AUTO_TEST_CASE(test_fare_api) {
 
     fare::fill_fares(pb_creator_fare, pt_fare_request);
 
-    auto fare_response = pb_creator_fare.get_response();
-    auto pt_journey_fares = fare_response.pt_journey_fares();
+    const auto& fare_response = pb_creator_fare.get_response();
+    const auto& pt_journey_fares = fare_response.pt_journey_fares();
     BOOST_REQUIRE_EQUAL(pt_journey_fares.size(), 1);
     BOOST_REQUIRE_EQUAL(pt_journey_fares.Get(0).journey_id(), "pt_jourey_1");
 
@@ -280,9 +278,9 @@ BOOST_AUTO_TEST_CASE(test_fare_api) {
     BOOST_REQUIRE_EQUAL(pb_fare.ticket_id_size(), 2);
 
     BOOST_REQUIRE_EQUAL(fare_response.tickets_size(), 2);
-    std::map<std::string, pbnavitia::Ticket> ticket;
+    std::unordered_map<std::string, pbnavitia::Ticket> ticket;
     for (int i = 0; i < fare_response.tickets_size(); ++i) {
-        auto t = fare_response.tickets(i);
+        const auto& t = fare_response.tickets(i);
         ticket[t.id()] = t;
     }
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(0)].name(), "Ticket vj 1");

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -37,6 +37,7 @@ www.navitia.io
 #include "equipment/equipment_api.h"
 #include "access_point/access_point_api.h"
 #include "position/position_api.h"
+#include "fare/fare_api.h"
 #include "proximity_list/proximitylist_api.h"
 #include "ptreferential/ptreferential.h"
 #include "ptreferential/ptreferential_api.h"
@@ -1283,7 +1284,7 @@ void Worker::access_points(const pbnavitia::AccessPointsRequest& access_points) 
 }
 
 void Worker::fares(const pbnavitia::PtFaresRequest& fares) {
-    // auto tickets = fares::
+    navitia::fare::fill_fares(pb_creator, fares);
 }
 
 }  // namespace navitia

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -1,4 +1,4 @@
-/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -1188,7 +1188,7 @@ void Worker::dispatch(const pbnavitia::Request& request,
         case pbnavitia::access_points:
             access_points(request.access_points());
             break;
-        case pbnavitia::fare:
+        case pbnavitia::pt_fares:
             fares(request.pt_fares());
             break;
         default:

--- a/source/kraken/worker.cpp
+++ b/source/kraken/worker.cpp
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -1188,6 +1188,9 @@ void Worker::dispatch(const pbnavitia::Request& request,
         case pbnavitia::access_points:
             access_points(request.access_points());
             break;
+        case pbnavitia::fare:
+            fares(request.pt_fares());
+            break;
         default:
             LOG4CPLUS_WARN(logger, "Unknown API : " + API_Name(request.requested_api()));
             this->pb_creator.fill_pb_error(pbnavitia::Error::unknown_api, "Unknown API");
@@ -1277,6 +1280,10 @@ void Worker::access_points(const pbnavitia::AccessPointsRequest& access_points) 
 
     access_point::access_points(this->pb_creator, access_points.filter(), access_points.count(), access_points.depth(),
                                 access_points.start_page(), forbidden_uris);
+}
+
+void Worker::fares(const pbnavitia::PtFaresRequest& fares) {
+    // auto tickets = fares::
 }
 
 }  // namespace navitia

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -1,4 +1,4 @@
-/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.
@@ -145,6 +145,7 @@ private:
     void equipment_reports(const pbnavitia::EquipmentReportsRequest& equipment_reports);
     void vehicle_positions(const pbnavitia::VehiclePositionsRequest& vehcile_positions);
     void access_points(const pbnavitia::AccessPointsRequest& access_points);
+    void fares(const pbnavitia::PtFaresRequest& fares);
 };
 
 type::EntryPoint make_sn_entry_point(const std::string& place,

--- a/source/kraken/worker.h
+++ b/source/kraken/worker.h
@@ -1,4 +1,4 @@
-/* Copyright �� 2001-2022, Hove and/or its affiliates. All rights reserved.
+/* Copyright © 2001-2022, Hove and/or its affiliates. All rights reserved.
 
 This file is part of Navitia,
     the software to build cool stuff with public transport.

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1865,8 +1865,6 @@ void PbCreator::fill_co2_emission(pbnavitia::Section* pb_section, const type::Ve
 
 void PbCreator::fill_fare_section(pbnavitia::Journey* pb_journey, const fare::results& fare) {
     auto pb_fare = pb_journey->mutable_fare();
-
-    size_t cpt_ticket = response.tickets_size();
     fill_fare(pb_fare, pb_journey, fare);
 }
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1867,6 +1867,11 @@ void PbCreator::fill_fare_section(pbnavitia::Journey* pb_journey, const fare::re
     auto pb_fare = pb_journey->mutable_fare();
 
     size_t cpt_ticket = response.tickets_size();
+    fill_fare(pb_fare, pb_journey, fare);
+}
+
+void PbCreator::fill_fare(pbnavitia::Fare* pb_fare, pbnavitia::Journey* pb_journey, const fare::results& fare) {
+    size_t cpt_ticket = response.tickets_size();
 
     boost::optional<std::string> currency;
     for (const fare::Ticket& ticket : fare.tickets) {
@@ -1903,9 +1908,13 @@ void PbCreator::fill_fare_section(pbnavitia::Journey* pb_journey, const fare::re
             pb_fare->add_ticket_id(pb_ticket->id());
         }
 
-        for (auto section : ticket.sections) {
-            auto section_id = get_section_id(pb_journey, section.path_item_idx);
-            pb_ticket->add_section_id(section_id);
+        for (const auto& section : ticket.sections) {
+            if (section.section_id) {
+                pb_ticket->add_section_id(*section.section_id);
+            } else if (pb_journey) {
+                auto section_id = get_section_id(pb_journey, section.path_item_idx);
+                pb_ticket->add_section_id(section_id);
+            }
         }
     }
     pb_fare->mutable_total()->set_value(fare.total.value);
@@ -2340,6 +2349,10 @@ pbnavitia::VehiclePosition* PbCreator::add_vehicle_positions() {
 
 pbnavitia::AccessPoint* PbCreator::add_access_points() {
     return response.add_access_points();
+}
+
+pbnavitia::PtJourneyFare* PbCreator::add_pt_journey_fares() {
+    return response.add_pt_journey_fares();
 }
 
 bool PbCreator::has_error() {

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -293,6 +293,8 @@ struct PbCreator {
                               const pt::ptime departure,
                               int max_depth = 1);
 
+    void fill_fare(pbnavitia::Fare* pb_fare, pbnavitia::Journey* pb_journey, const fare::results& fare);
+
     void add_path_item(pbnavitia::StreetNetwork* sn, const ng::PathItem& item, const type::EntryPoint& ori_dest);
 
     void fill_additional_informations(google::protobuf::RepeatedField<int>* infos,
@@ -321,6 +323,7 @@ struct PbCreator {
     pbnavitia::EquipmentReport* add_equipment_reports();
     pbnavitia::VehiclePosition* add_vehicle_positions();
     pbnavitia::AccessPoint* add_access_points();
+    pbnavitia::PtJourneyFare* add_pt_journey_fares();
 
     ::google::protobuf::RepeatedPtrField<pbnavitia::PtObject>* get_mutable_places();
     bool has_error();


### PR DESCRIPTION
In this PR, I proceed to separate the fare computation from Raptor and render it into an independent API, to which Jormungandr will be able to inquire about the fare for a public transport journey, whichever the calculator is.

The core part of this PR is the conversion from a public transport journey to a simplified version which contains all the information needed by the fare computation. 

Note: The fare computation per se remains as it is. 