### PR TITLE
[Jormungandr] Harmonize multilanguage parameters in navitia

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -797,7 +797,7 @@ class Instance(transient_socket.TransientSocket):
     bss_rent_penalty = _make_property_getter('bss_rent_penalty')
     bss_return_duration = _make_property_getter('bss_return_duration')
     bss_return_penalty = _make_property_getter('bss_rent_penalty')
-    asgard_language = _make_property_getter('asgard_language')
+    language = _make_property_getter('language')
 
     transfer_path = _make_property_getter('transfer_path')
     access_points = _make_property_getter('access_points')

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -531,31 +531,32 @@ class Journeys(JourneyCommon):
             "language",
             type=OptionValue(
                 [
-                    'dutch',
-                    'english',
-                    'french',
-                    'german',
-                    'hindi',
-                    'italian',
-                    'japanese',
-                    'portuguese',
-                    'russian',
-                    'spanish',
+                    'nl-NL',
+                    'en-US',
+                    'en-GB',
+                    'fr-FR',
+                    'de-DE',
+                    'hi-IN',
+                    'it-IT',
+                    'ja-JP',
+                    'pt-PT',
+                    'ru-RU',
+                    'es-ES',
                 ]
             ),
             hidden=True,
             help='Here, select a specific language for guidance instruction.\n'
             'list available:\n'
-            '- dutch = nl-nl\n'
-            '- english = en-gb\n'
-            '- french = fr-fr\n'
-            '- german = de-de\n'
-            '- hindi = hi\n'
-            '- italian = it-it\n'
-            '- japanese = ja-jp\n'
-            '- portuguese = pt-pt\n'
-            '- russian = ru-ru\n'
-            '- spanish = es-es\n',
+            '- nl-NL = dutch\n'
+            '- en-US | en-GB = english\n'
+            '- fr-FR = french\n'
+            '- de-DE = german\n'
+            '- hi-IN = hindi\n'
+            '- it-IT = italian\n'
+            '- ja-JP = japanese\n'
+            '- pt-PT = portuguese\n'
+            '- ru-RU = russian\n'
+            '- es-ES = spanish\n',
         )
         parser_get.add_argument(
             "_here_matrix_type",

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -528,35 +528,16 @@ class Journeys(JourneyCommon):
             help="Here, Active or not the realtime traffic information (True/False)",
         )
         parser_get.add_argument(
-            "_handimap_language",
+            "language",
             type=OptionValue(
                 [
-                    'english',
-                    'french',
-                ]
-            ),
-            hidden=True,
-            help='Handimap, select a specific language for guidance instruction.\n'
-            'list available:\n'
-            '- english = english\n'
-            '- french = french\n',
-        )
-        parser_get.add_argument(
-            "_here_language",
-            type=OptionValue(
-                [
-                    'afrikaans',
-                    'arabic',
-                    'chinese',
                     'dutch',
                     'english',
                     'french',
                     'german',
-                    'hebrew',
                     'hindi',
                     'italian',
                     'japanese',
-                    'nepali',
                     'portuguese',
                     'russian',
                     'spanish',
@@ -565,18 +546,13 @@ class Journeys(JourneyCommon):
             hidden=True,
             help='Here, select a specific language for guidance instruction.\n'
             'list available:\n'
-            '- afrikaans = af\n'
-            '- arabic = ar-sa\n'
-            '- chinese = zh-cn\n'
             '- dutch = nl-nl\n'
             '- english = en-gb\n'
             '- french = fr-fr\n'
             '- german = de-de\n'
-            '- hebrew = he\n'
             '- hindi = hi\n'
             '- italian = it-it\n'
             '- japanese = ja-jp\n'
-            '- nepali = ne-np\n'
             '- portuguese = pt-pt\n'
             '- russian = ru-ru\n'
             '- spanish = es-es\n',
@@ -605,74 +581,6 @@ class Journeys(JourneyCommon):
             'Coord_1!Coord_2 with Coord=lat;lon\n'
             ' - exemple : _here_exclusion_area[]=2.40553;48.84866!2.41453;48.85677\n'
             ' - This is a list, you can add to the maximun 20 _here_exclusion_area[]\n',
-        )
-        parser_get.add_argument(
-            "_asgard_language",
-            type=OptionValue(
-                [
-                    'bulgarian',
-                    'catalan',
-                    'czech',
-                    'danish',
-                    'german',
-                    'greek',
-                    'english_gb',
-                    'english_pirate',
-                    'english_us',
-                    'spanish',
-                    'estonian',
-                    'finnish',
-                    'french',
-                    'hindi',
-                    'hungarian',
-                    'italian',
-                    'japanese',
-                    'bokmal',
-                    'dutch',
-                    'polish',
-                    'portuguese_br',
-                    'portuguese_pt',
-                    'romanian',
-                    'russian',
-                    'slovak',
-                    'slovenian',
-                    'swedish',
-                    'turkish',
-                    'ukrainian',
-                ]
-            ),
-            hidden=True,
-            help='Select a specific language for Asgard guidance instruction.\n'
-            'list available:\n'
-            '- bulgarian = bg-BG\n'
-            '- catalan = ca-ES\n'
-            '- czech = cs-CZ\n'
-            '- danish = da-DK\n'
-            '- german = de-DE\n'
-            '- greek = el-GR\n'
-            '- english_gb = en-GB\n'
-            '- english_pirate = en-US-x-pirate\n'
-            '- english_us = en-US\n'
-            '- spanish = es-ES\n'
-            '- estonian = et-EE\n'
-            '- finnish = fi-FI\n'
-            '- french = fr-FR\n'
-            '- hindi = hi-IN\n'
-            '- hungarian = hu-HU\n'
-            '- italian = it-IT\n'
-            '- japanese = ja-JP\n'
-            '- bokmal = nb-NO\n'
-            '- dutch = nl-NL\n'
-            '- polish = pl-PL\n'
-            '- portuguese_br = pt-BR\n'
-            '- portuguese_pt = pt-PT\n'
-            '- romanian = ro-RO\n'
-            '- russian = ru-RU\n'
-            '- slovak = sk-SK\n'
-            '- slovenian = sl-SI\n'
-            '- swedish = sv-SE\n'
-            '- turkish = tr-TR\n'
-            '- ukrainian = uk-UA\n',
         )
         parser_get.add_argument(
             "equipment_details",
@@ -888,8 +796,8 @@ class Journeys(JourneyCommon):
             if args.get('_pt_planner') is None:
                 args['_pt_planner'] = mod.default_pt_planner
 
-            if args.get('_asgard_language') is None:
-                args['_asgard_language'] = mod.asgard_language
+            if args.get('language') is None:
+                args['language'] = mod.language
 
             if args.get('bss_rent_duration') is None:
                 args['bss_rent_duration'] = mod.bss_rent_duration

--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -544,7 +544,6 @@ class Journeys(JourneyCommon):
                     'es-ES',
                 ]
             ),
-            hidden=True,
             help='Here, select a specific language for guidance instruction.\n'
             'list available:\n'
             '- nl-NL = dutch\n'

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -585,7 +585,7 @@ def _build_fallback(
     car_park_crowfly_duration = None
     via_pt_access = None
     via_poi_access = None
-    language = request.get('_asgard_language', "english_us")
+    language = request.get('language', "english")
 
     if mode == 'car':
         _, _, car_park, car_park_crowfly_duration, _, _ = fallback_durations[pt_obj.uri]

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -585,7 +585,7 @@ def _build_fallback(
     car_park_crowfly_duration = None
     via_pt_access = None
     via_poi_access = None
-    language = request.get('language', "english")
+    language = request.get('language', "en-US")
 
     if mode == 'car':
         _, _, car_park, car_park_crowfly_duration, _, _ = fallback_durations[pt_obj.uri]

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -585,7 +585,7 @@ def _build_fallback(
     car_park_crowfly_duration = None
     via_pt_access = None
     via_poi_access = None
-    language = request.get('language', "en-US")
+    language = request.get('language', "fr-FR")
 
     if mode == 'car':
         _, _, car_park, car_park_crowfly_duration, _, _ = fallback_durations[pt_obj.uri]

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -130,7 +130,7 @@ class StreetNetworkPath:
             fallback_type,
             entry_point,
             via_poi_access,
-            self._request.get('language', "english"),
+            self._request.get('language', "en-US"),
         )
 
     def finalize_direct_path(self, resp_direct_path):

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/streetnetwork_path.py
@@ -130,7 +130,7 @@ class StreetNetworkPath:
             fallback_type,
             entry_point,
             via_poi_access,
-            self._request.get('_asgard_language', "english_us"),
+            self._request.get('language', "english"),
         )
 
     def finalize_direct_path(self, resp_direct_path):

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
@@ -349,7 +349,7 @@ class TransferPool(object):
 
         # we assume here the transfer street network has only one section, which is in walking mode
         transfer_street_network = transfer_direct_path.journeys[0].sections[0].street_network
-        language = self._request.get('_asgard_language', "english_us")
+        language = self._request.get('language', "english")
 
         if self._is_access_point(transfer_result.origin):
             prepend_path_item_with_access_point(

--- a/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/transfer.py
@@ -349,7 +349,7 @@ class TransferPool(object):
 
         # we assume here the transfer street network has only one section, which is in walking mode
         transfer_street_network = transfer_direct_path.journeys[0].sections[0].street_network
-        language = self._request.get('language', "english")
+        language = self._request.get('language', "en-US")
 
         if self._is_access_point(transfer_result.origin):
             prepend_path_item_with_access_point(

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -54,35 +54,16 @@ import pybreaker
 # https://valhalla.readthedocs.io/en/latest/api/turn-by-turn/api-reference/#supported-language-tags
 # Be careful, the syntax has to be exact
 class Languages(Enum):
-    bulgarian = "bg-BG"
-    catalan = "ca-ES"
-    czech = "cs-CZ"
-    danish = "da-DK"
-    german = "de-DE"
-    greek = "el-GR"
-    english_gb = "en-GB"
-    english_pirate = "en-US-x-pirate"
-    english_us = "en-US"
-    spanish = "es-ES"
-    estonian = "et-EE"
-    finnish = "fi-FI"
+    dutch = "nl-NL"
+    english = "en-GB"
     french = "fr-FR"
+    german = "de-DE"
     hindi = "hi-IN"
-    hungarian = "hu-HU"
     italian = "it-IT"
     japanese = "ja-JP"
-    bokmal = "nb-NO"
-    dutch = "nl-NL"
-    polish = "pl-PL"
-    portuguese_br = "pt-BR"
     portuguese_pt = "pt-PT"
-    romanian = "ro-RO"
     russian = "ru-RU"
-    slovak = "sk-SK"
-    slovenian = "sl-SI"
-    swedish = "sv-SE"
-    turkish = "tr-TR"
-    ukrainian = "uk-UA"
+    spanish = "es-ES"
 
 
 class DirectPathProfile(object):
@@ -208,7 +189,7 @@ class Asgard(TransientSocket, Kraken):
                 'reset_timeout': self.breaker.reset_timeout,
             },
             'zmq_socket_ttl': self.socket_ttl,
-            'language': self.instance.asgard_language,
+            'language': self.instance.language,
         }
 
     def make_location(self, obj):
@@ -218,8 +199,8 @@ class Asgard(TransientSocket, Kraken):
         )
 
     def get_language_parameter(self, request):
-        language = request.get('_asgard_language', "english_us")
-        language_tag = getattr(Languages, language, Languages.english_us).value
+        language = request.get('language', "english")
+        language_tag = getattr(Languages, language, Languages.english).value
         return language_tag
 
     def _create_sn_routing_matrix_request(

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -183,7 +183,7 @@ class Asgard(TransientSocket, Kraken):
         )
 
     def get_language_parameter(self, request):
-        return request.get('language', "fr-FR")
+        return request.get('language', self.instance.language)
 
     def _create_sn_routing_matrix_request(
         self, origins, destinations, street_network_mode, max_duration, speed_switcher, request, **kwargs

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -51,11 +51,11 @@ import pybreaker
 
 
 # Possible values implemented. Full languages within the doc:
-# https://valhalla.readthedocs.io/en/latest/api/turn-by-turn/api-reference/#supported-language-tags
+# https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#supported-language-tags
 # Be careful, the syntax has to be exact
 class Languages(Enum):
     dutch = "nl-NL"
-    english = "en-GB"
+    english = "en-US"
     french = "fr-FR"
     german = "de-DE"
     hindi = "hi-IN"

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -50,22 +50,6 @@ from enum import Enum
 import pybreaker
 
 
-# Possible values implemented. Full languages within the doc:
-# https://valhalla.github.io/valhalla/api/turn-by-turn/api-reference/#supported-language-tags
-# Be careful, the syntax has to be exact
-class Languages(Enum):
-    dutch = "nl-NL"
-    english = "en-US"
-    french = "fr-FR"
-    german = "de-DE"
-    hindi = "hi-IN"
-    italian = "it-IT"
-    japanese = "ja-JP"
-    portuguese_pt = "pt-PT"
-    russian = "ru-RU"
-    spanish = "es-ES"
-
-
 class DirectPathProfile(object):
     def __init__(
         self,
@@ -199,9 +183,7 @@ class Asgard(TransientSocket, Kraken):
         )
 
     def get_language_parameter(self, request):
-        language = request.get('language', "english")
-        language_tag = getattr(Languages, language, Languages.english).value
-        return language_tag
+        return request.get('language', "fr-FR")
 
     def _create_sn_routing_matrix_request(
         self, origins, destinations, street_network_mode, max_duration, speed_switcher, request, **kwargs

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -123,7 +123,7 @@ class Handimap(AbstractStreetNetworkService):
 
     def get_language_parameter(self, request):
         language = request.get('language')
-        return self.language if not language else self._get_language(language.lower())
+        return self.language if not language else self._get_language(language)
 
     @staticmethod
     def _make_request_arguments_walking_details(request, language):

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -54,10 +54,11 @@ DEFAULT_HANDIMAP_FEED_PUBLISHER = {
     'url': 'https://www.handimap.fr',
 }
 
-
-class Languages(Enum):
-    french = "fr-FR"
-    english = "en-EN"
+LANGUAGE_TRANSFORMATION_LIST = {
+    "en-US": "en-EN",
+    "en-GB": "en-EN",
+    "fr-FR": "fr-FR"
+}
 
 
 class Handimap(AbstractStreetNetworkService):
@@ -85,7 +86,7 @@ class Handimap(AbstractStreetNetworkService):
         self.headers = {"Content-Type": "application/json", "Accept": "application/json"}
         self.timeout = timeout
         self.modes = modes if modes else ["walking"]
-        self.language = self._get_language(kwargs.get('language', "english"))
+        self.language = self._get_language(kwargs.get('language', "fr-FR"))
         self.verify = kwargs.get('verify', True)
 
         self.breaker = pybreaker.CircuitBreaker(
@@ -117,12 +118,12 @@ class Handimap(AbstractStreetNetworkService):
             },
         }
 
-    def _get_language(self, language):
-        try:
-            return Languages[language].value
-        except KeyError:
-            self.log.error('Here parameters language={} not exist - force to english'.format(language))
-            return Languages.english.value
+    def _get_language(self, language_value):
+        language = LANGUAGE_TRANSFORMATION_LIST.get(language_value)
+        if not language:
+            self.log.error('Handimap parameter language={} Invalid - fallback to english'.format(language_value))
+            language = "en-EN"
+        return language
 
     def get_language_parameter(self, request):
         language = request.get('language', None)

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -54,7 +54,7 @@ DEFAULT_HANDIMAP_FEED_PUBLISHER = {
     'url': 'https://www.handimap.fr',
 }
 
-LANGUAGE_TRANSFORMATION_LIST = {"en-US": "en-EN", "en-GB": "en-EN", "fr-FR": "fr-FR"}
+LANGUAGE_TRANSFORMATION_LIST = {"en-US": "en-US", "en-GB": "en-US", "fr-FR": "fr-FR"}
 
 
 class Handimap(AbstractStreetNetworkService):
@@ -82,7 +82,7 @@ class Handimap(AbstractStreetNetworkService):
         self.headers = {"Content-Type": "application/json", "Accept": "application/json"}
         self.timeout = timeout
         self.modes = modes if modes else ["walking"]
-        self.language = self._get_language(kwargs.get('language', "fr-FR"))
+        self.language = self._get_language(kwargs.get('language'))
         self.verify = kwargs.get('verify', True)
 
         self.breaker = pybreaker.CircuitBreaker(
@@ -118,11 +118,11 @@ class Handimap(AbstractStreetNetworkService):
         language = LANGUAGE_TRANSFORMATION_LIST.get(language_value)
         if not language:
             self.log.error('Handimap parameter language={} Invalid - fallback to english'.format(language_value))
-            language = "en-EN"
+            language = "en-US"
         return language
 
     def get_language_parameter(self, request):
-        language = request.get('language', None)
+        language = request.get('language')
         return self.language if not language else self._get_language(language.lower())
 
     @staticmethod

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -54,11 +54,7 @@ DEFAULT_HANDIMAP_FEED_PUBLISHER = {
     'url': 'https://www.handimap.fr',
 }
 
-LANGUAGE_TRANSFORMATION_LIST = {
-    "en-US": "en-EN",
-    "en-GB": "en-EN",
-    "fr-FR": "fr-FR"
-}
+LANGUAGE_TRANSFORMATION_LIST = {"en-US": "en-EN", "en-GB": "en-EN", "fr-FR": "fr-FR"}
 
 
 class Handimap(AbstractStreetNetworkService):

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -85,7 +85,7 @@ class Handimap(AbstractStreetNetworkService):
         self.headers = {"Content-Type": "application/json", "Accept": "application/json"}
         self.timeout = timeout
         self.modes = modes if modes else ["walking"]
-        self.language = self._get_language(kwargs.get('language', "french"))
+        self.language = self._get_language(kwargs.get('language', "english"))
         self.verify = kwargs.get('verify', True)
 
         self.breaker = pybreaker.CircuitBreaker(
@@ -121,15 +121,11 @@ class Handimap(AbstractStreetNetworkService):
         try:
             return Languages[language].value
         except KeyError:
-            self.log.error(
-                'Handimap parameter language={} is not a valid parameter - language is set to french by default'.format(
-                    language
-                )
-            )
-            return Languages.french.value
+            self.log.error('Here parameters language={} not exist - force to english'.format(language))
+            return Languages.english.value
 
     def get_language_parameter(self, request):
-        language = request.get('_handimap_language', None)
+        language = request.get('language', None)
         return self.language if not language else self._get_language(language.lower())
 
     @staticmethod

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -70,18 +70,19 @@ CO2_ESTIMATION_COEFF_2 = 184
 # Possible values implemented. Full languages within the doc:
 # https://developer.here.com/documentation/routing/dev_guide/topics/resource-param-type-languages.html#languages
 # Be careful, the syntax has to be exact
-class Languages(Enum):
-    dutch = "nl-nl"
-    english = "en-us"
-    french = "fr-fr"
-    german = "de-de"
-    hindi = "hi"
-    italian = "it-it"
-    japanese = "ja-jp"
-    portuguese = "pt-pt"
-    russian = "ru-ru"
-    spanish = "es-es"
 
+LANGUAGE_TRANSFORMATION_LIST = {
+    "nl-NL": "nl-nl",
+    "en-US": "en-us",
+    "en-GB": "en-gb",
+    "fr-FR": "fr-fr",
+    "hi-IN": "hi",
+    "it-IT": "it-it",
+    "ja-JP": "ja-jp",
+    "pt-PT": "pt-pt",
+    "ru-RU": "ru-ru",
+    "es-ES": "es-es"
+}
 
 DEFAULT_HERE_FEED_PUBLISHER = {
     'id': 'here',
@@ -89,7 +90,6 @@ DEFAULT_HERE_FEED_PUBLISHER = {
     'license': 'Private',
     'url': 'https://developer.here.com/terms-and-conditions',
 }
-
 
 def _get_coord(pt_object):
     coord = get_pt_object_coord(pt_object)
@@ -132,7 +132,7 @@ class Here(AbstractStreetNetworkService):
         apiKey=None,
         max_matrix_points=MAX_MATRIX_POINTS_VALUES,
         lapse_time_matrix_to_retry=DEFAULT_LAPSE_TIME_MATRIX_TO_RETRY,
-        language="english",
+        language="fr-FR",
         feed_publisher=DEFAULT_HERE_FEED_PUBLISHER,
         **kwargs
     ):
@@ -149,7 +149,7 @@ class Here(AbstractStreetNetworkService):
         self.timeout = timeout
         self.max_matrix_points = self._get_max_matrix_points(max_matrix_points)
         self.lapse_time_matrix_to_retry = self._get_lapse_time_matrix_to_retry(lapse_time_matrix_to_retry)
-        self.language = self._get_language(language.lower())
+        self.language = self._get_language(language)
         self.breaker = pybreaker.CircuitBreaker(
             fail_max=app.config['CIRCUIT_BREAKER_MAX_HERE_FAIL'],
             reset_timeout=app.config['CIRCUIT_BREAKER_HERE_TIMEOUT_S'],
@@ -157,7 +157,7 @@ class Here(AbstractStreetNetworkService):
 
         self.log.debug(
             'Here, load configuration max_matrix_points={} - timeout={} - lapse_time_matrix_to_retry={} - language={}'.format(
-                self.max_matrix_points, self.timeout, self.lapse_time_matrix_to_retry, self.language.value
+                self.max_matrix_points, self.timeout, self.lapse_time_matrix_to_retry, self.language
             )
         )
         self._feed_publisher = FeedPublisher(**feed_publisher) if feed_publisher else None
@@ -170,7 +170,7 @@ class Here(AbstractStreetNetworkService):
             'timeout': self.timeout,
             'max_matrix_points': self.max_matrix_points,
             'lapse_time_matrix_to_retry': self.lapse_time_matrix_to_retry,
-            'language': self.language.value,
+            'language': self.language,
             'circuit_breaker': {
                 'current_state': self.breaker.current_state,
                 'fail_counter': self.breaker.fail_counter,
@@ -388,16 +388,16 @@ class Here(AbstractStreetNetworkService):
                     )
             return {'avoid': boxes}
 
-    def _get_language(self, language):
-        try:
-            return Languages[language]
-        except KeyError:
-            self.log.error('Here parameters language={} not exist - force to english'.format(language))
-            return Languages.english
+    def _get_language(self, language_value):
+        language = LANGUAGE_TRANSFORMATION_LIST.get(language_value)
+        if not language:
+            self.log.error('Here parameter language={} Invalid - fallback to english'.format(language_value))
+            language = "en-EN"
+        return language
 
     def get_language_parameter(self, request):
-        language = request.get('language', 'english')
-        return self.language if not language else self._get_language(language.lower())
+        language = request.get('language', 'fr-FR')
+        return self.language if not language else self._get_language(language)
 
     def _get_max_matrix_points(self, max_matrix_points):
         if max_matrix_points > MAX_MATRIX_POINTS_VALUES:

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -81,7 +81,7 @@ LANGUAGE_TRANSFORMATION_LIST = {
     "ja-JP": "ja-jp",
     "pt-PT": "pt-pt",
     "ru-RU": "ru-ru",
-    "es-ES": "es-es"
+    "es-ES": "es-es",
 }
 
 DEFAULT_HERE_FEED_PUBLISHER = {
@@ -90,6 +90,7 @@ DEFAULT_HERE_FEED_PUBLISHER = {
     'license': 'Private',
     'url': 'https://developer.here.com/terms-and-conditions',
 }
+
 
 def _get_coord(pt_object):
     coord = get_pt_object_coord(pt_object)

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -66,22 +66,18 @@ MAX_MATRIX_POINTS_VALUES = 100
 CO2_ESTIMATION_COEFF_1 = 1.35
 CO2_ESTIMATION_COEFF_2 = 184
 
+
 # Possible values implemented. Full languages within the doc:
 # https://developer.here.com/documentation/routing/dev_guide/topics/resource-param-type-languages.html#languages
 # Be careful, the syntax has to be exact
 class Languages(Enum):
-    afrikaans = "af"
-    arabic = "ar-sa"
-    chinese = "zh-cn"
     dutch = "nl-nl"
     english = "en-gb"
     french = "fr-fr"
     german = "de-de"
-    hebrew = "he"
     hindi = "hi"
     italian = "it-it"
     japanese = "ja-jp"
-    nepali = "ne-np"
     portuguese = "pt-pt"
     russian = "ru-ru"
     spanish = "es-es"
@@ -400,11 +396,8 @@ class Here(AbstractStreetNetworkService):
             return Languages.english
 
     def get_language_parameter(self, request):
-        _language = request.get('_here_language', None)
-        if _language == None:
-            return self.language
-        else:
-            return self._get_language(_language.lower())
+        language = request.get('language', None)
+        return self.language if not language else self._get_language(language.lower())
 
     def _get_max_matrix_points(self, max_matrix_points):
         if max_matrix_points > MAX_MATRIX_POINTS_VALUES:

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -72,7 +72,7 @@ CO2_ESTIMATION_COEFF_2 = 184
 # Be careful, the syntax has to be exact
 class Languages(Enum):
     dutch = "nl-nl"
-    english = "en-gb"
+    english = "en-us"
     french = "fr-fr"
     german = "de-de"
     hindi = "hi"
@@ -396,7 +396,7 @@ class Here(AbstractStreetNetworkService):
             return Languages.english
 
     def get_language_parameter(self, request):
-        language = request.get('language', None)
+        language = request.get('language', 'english')
         return self.language if not language else self._get_language(language.lower())
 
     def _get_max_matrix_points(self, max_matrix_points):

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -393,11 +393,11 @@ class Here(AbstractStreetNetworkService):
         language = LANGUAGE_TRANSFORMATION_LIST.get(language_value)
         if not language:
             self.log.error('Here parameter language={} Invalid - fallback to english'.format(language_value))
-            language = "en-EN"
+            language = "en-us"
         return language
 
     def get_language_parameter(self, request):
-        language = request.get('language', 'fr-FR')
+        language = request.get('language')
         return self.language if not language else self._get_language(language)
 
     def _get_max_matrix_points(self, max_matrix_points):

--- a/source/jormungandr/jormungandr/street_network/street_networks.md
+++ b/source/jormungandr/jormungandr/street_network/street_networks.md
@@ -55,13 +55,13 @@ Available optional parameters list:
 
 You can easily override parameters for tests inside requests.<br>
 List of available API parameters:
-* _here_language: "english" or "french" or "dutch" ...
+* language: "english" or "french" or "dutch" ...
 * _here_max_matrix_points: int value [1-100]
 
 Example:
 
 ```
-http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50&_here_language=french
+http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50&language=french
 ```
 
 ### exclusion areas

--- a/source/jormungandr/jormungandr/street_network/street_networks.md
+++ b/source/jormungandr/jormungandr/street_network/street_networks.md
@@ -33,21 +33,16 @@ Insert into **Jormun** configuration:
 Available optional parameters list:
 * timeout: circuit breaker timeout. By default 10 secs
 * language: the selected language for guidance instruction - list available bellow. By default, english
-    * afrikaans
-    * arabic
-    * chinese
-    * dutch
-    * english
-    * french
-    * german
-    * hebrew
-    * hindi
-    * italian
-    * japanese
-    * nepali
-    * portuguese
-    * russian
-    * spanish
+    * nl-NL = dutch
+    * en-US | en-GB = english
+    * fr-FR = french
+    * de-DE = german
+    * hi-IN = hindi
+    * it-IT = italian
+    * ja-JP = japanese
+    * pt-PT = portuguese
+    * ru-RU = russian
+    * es-ES = spanish
 * max_matrix_points: the max number of allowed matrix points. By default 100 (the maximum)
 * lapse_time_matrix_to_retry: The waiting time between to get request to retreive the matrix response
 
@@ -55,13 +50,13 @@ Available optional parameters list:
 
 You can easily override parameters for tests inside requests.<br>
 List of available API parameters:
-* language: "english" or "french" or "dutch" ...
+* language: "en-US" or "fr-FR" or "nl-NL" ...
 * _here_max_matrix_points: int value [1-100]
 
 Example:
 
 ```
-http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50&language=french
+http://navitia.io/v1/coverage/coverage_name/journeys?from=2.13376%3B48.86333&to=2.33443%3B48.84189&first_section_mode%5B%5D=car&_here_realtime_traffic=true&_here_max_matrix_points=50&language=fr-FR
 ```
 
 ### exclusion areas

--- a/source/jormungandr/jormungandr/street_network/tests/asgard_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/asgard_test.py
@@ -44,7 +44,7 @@ class FakeInstance(object):
 
     name = 'fake_instance'
     context = None
-    asgard_language = "en-US"
+    language = "en-GB"
 
 
 def status_test():
@@ -69,7 +69,7 @@ def status_test():
     assert status['circuit_breaker']['fail_counter'] == 0
     assert status['circuit_breaker']['reset_timeout'] == 60
     assert status['zmq_socket_ttl'] == 60
-    assert status['language'] == 'en-US'
+    assert status['language'] == 'en-GB'
 
 
 def asgard_socket_var_test(config_asgard_socket):

--- a/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
@@ -260,14 +260,14 @@ def get_language_handimap_func_language_invalid_test():
     instance = MagicMock()
     handimap = Handimap(instance=instance, service_url=fake_service_url)
     language = handimap._get_language("toto")
-    assert language == "en-EN"
+    assert language == "en-US"
 
 
 def get_language_handimap_func_language_valid_test():
     instance = MagicMock()
     handimap = Handimap(instance=instance, service_url=fake_service_url)
     language = handimap._get_language("english")
-    assert language == "en-EN"
+    assert language == "en-US"
 
 
 def get_language_parameter_handimap_func_language_invalid_test():
@@ -275,15 +275,7 @@ def get_language_parameter_handimap_func_language_invalid_test():
     handimap = Handimap(instance=instance, service_url=fake_service_url)
     request = {"language": "toto"}
     language = handimap.get_language_parameter(request)
-    assert language == "fr-FR"
-
-
-def get_language_parameter_handimap_func_language_invalid_test():
-    instance = MagicMock()
-    handimap = Handimap(instance=instance, service_url=fake_service_url)
-    request = {"language": "english"}
-    language = handimap.get_language_parameter(request)
-    assert language == "en-EN"
+    assert language == "en-US"
 
 
 def make_request_arguments_walking_details_handimap_func_invalid_test():

--- a/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
@@ -260,7 +260,7 @@ def get_language_handimap_func_language_invalid_test():
     instance = MagicMock()
     handimap = Handimap(instance=instance, service_url=fake_service_url)
     language = handimap._get_language("toto")
-    assert language == "fr-FR"
+    assert language == "en-EN"
 
 
 def get_language_handimap_func_language_valid_test():
@@ -273,7 +273,7 @@ def get_language_handimap_func_language_valid_test():
 def get_language_parameter_handimap_func_language_invalid_test():
     instance = MagicMock()
     handimap = Handimap(instance=instance, service_url=fake_service_url)
-    request = {"_handimap_language": "toto"}
+    request = {"language": "toto"}
     language = handimap.get_language_parameter(request)
     assert language == "fr-FR"
 
@@ -281,7 +281,7 @@ def get_language_parameter_handimap_func_language_invalid_test():
 def get_language_parameter_handimap_func_language_invalid_test():
     instance = MagicMock()
     handimap = Handimap(instance=instance, service_url=fake_service_url)
-    request = {"_handimap_language": "english"}
+    request = {"language": "english"}
     language = handimap.get_language_parameter(request)
     assert language == "en-EN"
 

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -414,7 +414,7 @@ def status_test():
     assert status['timeout'] == 89
     assert status['max_matrix_points'] == 100
     assert status['lapse_time_matrix_to_retry'] == 0.1
-    assert status['language'] == "en-gb"
+    assert status['language'] == "en-us"
     assert len(status['circuit_breaker']) == 3
     assert status['circuit_breaker']['current_state'] == 'closed'
     assert status['circuit_breaker']['fail_counter'] == 0

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -414,7 +414,7 @@ def status_test():
     assert status['timeout'] == 89
     assert status['max_matrix_points'] == 100
     assert status['lapse_time_matrix_to_retry'] == 0.1
-    assert status['language'] == "en-us"
+    assert status['language'] == "fr-fr"
     assert len(status['circuit_breaker']) == 3
     assert status['circuit_breaker']['current_state'] == 'closed'
     assert status['circuit_breaker']['fail_counter'] == 0

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -248,7 +248,7 @@ def valid_request(request):
             assert params.max_bss_duration_to_pt == 1800
             assert params.car_speed == 11.11
             assert params.max_car_duration_to_pt == 1800
-            assert params.language == "en-US"
+            assert params.language == "fr-FR"
             assert params.car_no_park_speed == (11.11 if params.origin_mode in ("car", "car_no_park") else 0)
             assert params.max_car_no_park_duration_to_pt == (
                 1800 if params.origin_mode in ("car", "car_no_park") else 0
@@ -282,7 +282,7 @@ def valid_request(request):
                 assert params.max_bss_duration_to_pt == 1800
                 assert params.car_speed == 11.11
                 assert params.max_car_duration_to_pt == 1800
-                assert params.language == "en-US"
+                assert params.language == "fr-FR"
                 assert params.car_no_park_speed == (11.11 if params.origin_mode in ("car", "car_no_park") else 0)
                 assert params.max_car_no_park_duration_to_pt == (
                     1800 if params.origin_mode in ("car", "car_no_park") else 0

--- a/source/jormungandr/tests/poi_access_point_tests.py
+++ b/source/jormungandr/tests/poi_access_point_tests.py
@@ -38,7 +38,7 @@ import requests_mock
 from jormungandr.utils import get_lon_lat
 
 template_journey_query_wap = "journeys?from={place_from}&to={place_to}&datetime=20120614T080000"
-template_journey_query = template_journey_query_wap + "&_poi_access_points=true"
+template_journey_query = template_journey_query_wap + "&_poi_access_points=true&language=english"
 
 s_lon, s_lat = get_lon_lat(s_coord)
 r_lon, r_lat = get_lon_lat(r_coord)

--- a/source/jormungandr/tests/poi_access_point_tests.py
+++ b/source/jormungandr/tests/poi_access_point_tests.py
@@ -38,7 +38,7 @@ import requests_mock
 from jormungandr.utils import get_lon_lat
 
 template_journey_query_wap = "journeys?from={place_from}&to={place_to}&datetime=20120614T080000"
-template_journey_query = template_journey_query_wap + "&_poi_access_points=true&language=english"
+template_journey_query = template_journey_query_wap + "&_poi_access_points=true&language=en-US"
 
 s_lon, s_lat = get_lon_lat(s_coord)
 r_lon, r_lat = get_lon_lat(r_coord)

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -439,7 +439,7 @@ class TestJourneysDistributed(
         assert len(response['journeys'][1]['sections']) == 1
 
     def test_journey_with_access_points(self):
-        query = journey_basic_query + "&_access_points=true"
+        query = journey_basic_query + "&_access_points=true&language=english"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -483,7 +483,7 @@ class TestJourneysDistributed(
 
     def test_path_instructions(self):
         # Verify some path instructions managed by jormungandr in English
-        query = journey_basic_query + "&_access_points=true&_asgard_language=english_us"
+        query = journey_basic_query + "&_access_points=true&language=english"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -496,7 +496,7 @@ class TestJourneysDistributed(
         assert path['instruction'] == "Exit stop_point:stopA (Condom) via access_point:A2."
 
         # Verify some path instructions managed by jormungandr in French
-        query = journey_basic_query + "&_access_points=true&_asgard_language=french"
+        query = journey_basic_query + "&_access_points=true"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -509,7 +509,7 @@ class TestJourneysDistributed(
         assert path['instruction'] == "Sortez de stop_point:stopA (Condom) via access_point:A2."
 
         # Verify some path instructions managed by jormungandr in English as default language
-        query = journey_basic_query + "&_access_points=true&_asgard_language=japanese"
+        query = journey_basic_query + "&_access_points=true&language=japanese"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -1367,7 +1367,8 @@ class TestRoutingWithTransfer(NewDefaultScenarioAbstractTestFixture):
     def test_complete_transfer_path_bus_rer_with_access_points(self):
         query = (
             '/v1/coverage/routing_with_transfer_test/journeys?'
-            'from={}&to={}&datetime=20120614T080000&_override_scenario=distributed&count=1&_transfer_path=true'
+            'from={}&to={}&datetime=20120614T080000&_override_scenario=distributed&count=1&_transfer_path=true&'
+            'language=english'
         ).format("stopA", "stopF")
 
         response = self.query(query)

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -439,7 +439,7 @@ class TestJourneysDistributed(
         assert len(response['journeys'][1]['sections']) == 1
 
     def test_journey_with_access_points(self):
-        query = journey_basic_query + "&_access_points=true&language=english"
+        query = journey_basic_query + "&_access_points=true&language=en-US"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -483,7 +483,7 @@ class TestJourneysDistributed(
 
     def test_path_instructions(self):
         # Verify some path instructions managed by jormungandr in English
-        query = journey_basic_query + "&_access_points=true&language=english"
+        query = journey_basic_query + "&_access_points=true&language=en-US"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -504,12 +504,12 @@ class TestJourneysDistributed(
         assert pt_journey
         assert len(pt_journey['sections'][0]['vias']) == 1
         path = pt_journey['sections'][0]['path'][-1]
-        assert path['instruction'] == "Accédez à stop_point:stopB (Condom) via access_point:B1."
+        assert path['instruction'] == "Then enter stop_point:stopB (Condom) via access_point:B1."
         path = pt_journey['sections'][2]['path'][0]
-        assert path['instruction'] == "Sortez de stop_point:stopA (Condom) via access_point:A2."
+        assert path['instruction'] == "Exit stop_point:stopA (Condom) via access_point:A2."
 
         # Verify some path instructions managed by jormungandr in English as default language
-        query = journey_basic_query + "&_access_points=true&language=japanese"
+        query = journey_basic_query + "&_access_points=true&language=ja-JP"
         response = self.query_region(query)
         assert len(response['journeys']) == 2
 
@@ -1368,7 +1368,7 @@ class TestRoutingWithTransfer(NewDefaultScenarioAbstractTestFixture):
         query = (
             '/v1/coverage/routing_with_transfer_test/journeys?'
             'from={}&to={}&datetime=20120614T080000&_override_scenario=distributed&count=1&_transfer_path=true&'
-            'language=english'
+            'language=en-US'
         ).format("stopA", "stopF")
 
         response = self.query(query)

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -207,8 +207,11 @@ max_taxi_direct_path_distance = 200000  # 200 Km
 # Proximity radius for autocomplete used in /places endpoint
 places_proximity_radius = 20000  # 20 Km
 
+# TODO: Should be deleted after deploying the next release to all the platforms
 # Asgard language by default
 asgard_language = "english_us"
+
+language = "french"
 
 # Compute pathways using the street_network engine for transfers between surface physical modes
 transfer_path = False

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -211,7 +211,7 @@ places_proximity_radius = 20000  # 20 Km
 # Asgard language by default
 asgard_language = "english_us"
 
-language = "french"
+language = "fr-FR"
 
 # Compute pathways using the street_network engine for transfers between surface physical modes
 transfer_path = False

--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -662,6 +662,13 @@ class Instance(db.Model):  # type: ignore
         default=default_values.asgard_language,
     )
 
+    language = db.Column(
+        db.Text,
+        nullable=False,
+        default=default_values.language,
+        server_default=default_values.language,
+    )
+
     poi_dataset = db.Column(db.Text, default=None, nullable=True)
 
     stop_points_nearby_duration = db.Column(

--- a/source/tyr/migrations/versions/20d8caa23b26_add_language_in_instance.py
+++ b/source/tyr/migrations/versions/20d8caa23b26_add_language_in_instance.py
@@ -1,0 +1,28 @@
+"""
+Add attribute language in the table instance
+
+Revision ID: 20d8caa23b26
+Revises: 0f57c3342d97
+Create Date: 2023-08-08 11:32:32.294073
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '20d8caa23b26'
+down_revision = '0f57c3342d97'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from navitiacommon import default_values
+
+
+def upgrade():
+    op.add_column(
+        'instance',
+        sa.Column('language', sa.Text(), server_default=default_values.language, nullable=False)
+    )
+
+
+def downgrade():
+    op.drop_column('instance', 'language')

--- a/source/tyr/migrations/versions/20d8caa23b26_add_language_in_instance.py
+++ b/source/tyr/migrations/versions/20d8caa23b26_add_language_in_instance.py
@@ -19,8 +19,7 @@ from navitiacommon import default_values
 
 def upgrade():
     op.add_column(
-        'instance',
-        sa.Column('language', sa.Text(), server_default=default_values.language, nullable=False)
+        'instance', sa.Column('language', sa.Text(), server_default=default_values.language, nullable=False)
     )
 
 

--- a/source/tyr/tests/integration/instance_test.py
+++ b/source/tyr/tests/integration/instance_test.py
@@ -177,14 +177,14 @@ def test_update_instances(create_instance):
         "ghost_words": GHOST_WORDS,
         "filter_odt_journeys": False,
         "additional_parameters": False,
-        "language": "spanish",
+        "language": "es-ES",
     }
     resp = api_get('/v0/instances/{}'.format(create_instance))
     assert resp[0]['access_points'] is False
     assert resp[0]['poi_access_points'] is False
     assert resp[0]['default_pt_planner'] == 'kraken'
     assert resp[0]['pt_planners_configurations'] == {}
-    assert resp[0]['language'] == 'french'
+    assert resp[0]['language'] == 'fr-FR'
 
     resp = api_put('/v0/instances/fr', data=json.dumps(params), content_type='application/json')
     for key, param in params.items():
@@ -228,7 +228,7 @@ def test_update_instances(create_instance):
     assert resp['ghost_words'] == GHOST_WORDS
     assert resp['filter_odt_journeys'] is False
     assert resp['additional_parameters'] is False
-    assert resp['language'] == 'spanish'
+    assert resp['language'] == 'es-ES'
 
 
 def test_update_instances_is_free(create_instance):
@@ -670,7 +670,7 @@ def test_update_streetnetwork_backends(create_instance):
 
 def test_update_invalide_language(create_instance):
     resp = api_get('/v0/instances/fr')
-    assert resp[0]['language'] == "french"
+    assert resp[0]['language'] == "fr-FR"
 
     params = {'language': 'toto'}
     resp, status = api_put(
@@ -681,4 +681,4 @@ def test_update_invalide_language(create_instance):
     assert "Select a specific language for street network instructions" in resp['message']['language']
 
     resp = api_get('/v0/instances/fr')
-    assert resp[0]['language'] == "french"
+    assert resp[0]['language'] == "fr-FR"

--- a/source/tyr/tests/integration/instance_test.py
+++ b/source/tyr/tests/integration/instance_test.py
@@ -177,12 +177,14 @@ def test_update_instances(create_instance):
         "ghost_words": GHOST_WORDS,
         "filter_odt_journeys": False,
         "additional_parameters": False,
+        "language": "spanish",
     }
     resp = api_get('/v0/instances/{}'.format(create_instance))
     assert resp[0]['access_points'] is False
     assert resp[0]['poi_access_points'] is False
     assert resp[0]['default_pt_planner'] == 'kraken'
     assert resp[0]['pt_planners_configurations'] == {}
+    assert resp[0]['language'] == 'french'
 
     resp = api_put('/v0/instances/fr', data=json.dumps(params), content_type='application/json')
     for key, param in params.items():
@@ -226,6 +228,7 @@ def test_update_instances(create_instance):
     assert resp['ghost_words'] == GHOST_WORDS
     assert resp['filter_odt_journeys'] is False
     assert resp['additional_parameters'] is False
+    assert resp['language'] == 'spanish'
 
 
 def test_update_instances_is_free(create_instance):
@@ -663,3 +666,19 @@ def test_update_streetnetwork_backends(create_instance):
     with pytest.raises(Exception):
         params = {'street_network_car': "unknown"}
         resp = api_put('/v0/instances/fr', data=json.dumps(params), content_type='application/json')
+
+
+def test_update_invalide_language(create_instance):
+    resp = api_get('/v0/instances/fr')
+    assert resp[0]['language'] == "french"
+
+    params = {'language': 'toto'}
+    resp, status = api_put(
+        '/v0/instances/fr', data=json.dumps(params), content_type='application/json', check=False
+    )
+    assert status == 400
+    assert "message" in resp
+    assert "Select a specific language for street network instructions" in resp['message']['language']
+
+    resp = api_get('/v0/instances/fr')
+    assert resp[0]['language'] == "french"

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -231,7 +231,7 @@ instance_fields = {
     'transfer_path': fields.Boolean,
     'access_points': fields.Boolean,
     'poi_access_points': fields.Boolean,
-    'asgard_language': fields.Raw,
+    'language': fields.Raw,
     'default_pt_planner': fields.Raw,
     'pt_planners_configurations': fields.Raw,
     'ghost_words': fields.List(fields.String),

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -882,72 +882,34 @@ class Instance(flask_restful.Resource):
         )
 
         parser.add_argument(
-            "asgard_language",
+            "language",
             type=OptionValue(
                 [
-                    'bulgarian',
-                    'catalan',
-                    'czech',
-                    'danish',
-                    'german',
-                    'greek',
-                    'english_gb',
-                    'english_pirate',
-                    'english_us',
-                    'spanish',
-                    'estonian',
-                    'finnish',
+                    'dutch',
+                    'english',
                     'french',
+                    'german',
                     'hindi',
-                    'hungarian',
                     'italian',
                     'japanese',
-                    'bokmal',
-                    'dutch',
-                    'polish',
-                    'portuguese_br',
-                    'portuguese_pt',
-                    'romanian',
+                    'portuguese',
                     'russian',
-                    'slovak',
-                    'slovenian',
-                    'swedish',
-                    'turkish',
-                    'ukrainian',
+                    'spanish',
                 ]
             ),
-            help='Select a specific language for Asgard guidance instruction.\n'
+            help='Select a specific language for street network instructions.\n'
             'list available:\n'
-            '- bulgarian = bg-BG\n'
-            '- catalan = ca-ES\n'
-            '- czech = cs-CZ\n'
-            '- danish = da-DK\n'
-            '- german = de-DE\n'
-            '- greek = el-GR\n'
+            '- dutch = nl-NL\n'
             '- english_gb = en-GB\n'
-            '- english_pirate = en-US-x-pirate\n'
-            '- english_us = en-US\n'
-            '- spanish = es-ES\n'
-            '- estonian = et-EE\n'
-            '- finnish = fi-FI\n'
             '- french = fr-FR\n'
+            '- german = de-DE\n'
             '- hindi = hi-IN\n'
-            '- hungarian = hu-HU\n'
             '- italian = it-IT\n'
             '- japanese = ja-JP\n'
-            '- bokmal = nb-NO\n'
-            '- dutch = nl-NL\n'
-            '- polish = pl-PL\n'
-            '- portuguese_br = pt-BR\n'
-            '- portuguese_pt = pt-PT\n'
-            '- romanian = ro-RO\n'
+            '- portuguese = pt-PT\n'
             '- russian = ru-RU\n'
-            '- slovak = sk-SK\n'
-            '- slovenian = sl-SI\n'
-            '- swedish = sv-SE\n'
-            '- turkish = tr-TR\n'
-            '- ukrainian = uk-UA\n',
-            default=instance.asgard_language,
+            '- spanish = es-ES\n',
+            default=instance.language,
         )
 
         parser.add_argument(
@@ -1102,7 +1064,7 @@ class Instance(flask_restful.Resource):
                         'ridesharing_greenlet_pool_size',
                         'max_waiting_duration',
                         'places_proximity_radius',
-                        'asgard_language',
+                        'language',
                         'transfer_path',
                         'access_points',
                         'poi_access_points',

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -885,30 +885,31 @@ class Instance(flask_restful.Resource):
             "language",
             type=OptionValue(
                 [
-                    'dutch',
-                    'english',
-                    'french',
-                    'german',
-                    'hindi',
-                    'italian',
-                    'japanese',
-                    'portuguese',
-                    'russian',
-                    'spanish',
+                    'nl-NL',
+                    'en-US',
+                    'en-GB',
+                    'fr-FR',
+                    'de-DE',
+                    'hi-IN',
+                    'it-IT',
+                    'ja-JP',
+                    'pt-PT',
+                    'ru-RU',
+                    'es-ES',
                 ]
             ),
             help='Select a specific language for street network instructions.\n'
             'list available:\n'
-            '- dutch = nl-NL\n'
-            '- english = en-US\n'
-            '- french = fr-FR\n'
-            '- german = de-DE\n'
-            '- hindi = hi-IN\n'
-            '- italian = it-IT\n'
-            '- japanese = ja-JP\n'
-            '- portuguese = pt-PT\n'
-            '- russian = ru-RU\n'
-            '- spanish = es-ES\n',
+            '- nl-NL = dutch\n'
+            '- en-US|en-GB = english\n'
+            '- fr-FR = french\n'
+            '- de-DE = german\n'
+            '- hi-IN = hindi\n'
+            '- it-IT = italian\n'
+            '- ja-JP = japanese\n'
+            '- pt-PT = portuguese\n'
+            '- ru-RU = russian\n'
+            '- es-ES = spanish\n',
             default=instance.language,
         )
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -900,7 +900,7 @@ class Instance(flask_restful.Resource):
             help='Select a specific language for street network instructions.\n'
             'list available:\n'
             '- dutch = nl-NL\n'
-            '- english_gb = en-GB\n'
+            '- english = en-US\n'
             '- french = fr-FR\n'
             '- german = de-DE\n'
             '- hindi = hi-IN\n'


### PR DESCRIPTION
The followings are some details:
- Only one parameter **language** should be used instead of three existing parameters.
- Use of 11 languages allowed in navitia but all languages are not used in each **street_network** connector.
- In navitia, use of wrong value raises error with a message = **Select a specific language for street network instructions ...**
- if no `language` is provided in request, using the value configured in the coverage (default value for coverage = fr-FR)
- then if the language chosen in navitia is absent in a street_network connector, en-US will be used.
- never supposed to happen, but to avoid crash: in all connectors final fallback is to `fr-FR`

Note: The existing attribute asgard_language should be deleted once the next release is deployed to all the platforms.

For more details:  https://navitia.atlassian.net/browse/NAV-2152