### PR TITLE
[Kraken] change the way journey's status is computed

### DIFF
--- a/documentation/slate/source/includes/apis.md
+++ b/documentation/slate/source/includes/apis.md
@@ -955,12 +955,15 @@ The [isochrones](#isochrones) service exposes another response structure, which 
 <h3 id="journeys-disruptions">Disruptions</h3>
 
 By default, Navitia only computes journeys without their associated disruption(s), meaning that the journeys in the response will be based on the theoretical schedules. The disruption present in the response is for information only.
-If you want to provide journeys without blocking disruptions, you need to make an other request with the parameter `data_freshness=realtime`.
+In order to get an "undisrupted" journey (consider all disruptions during journey planning), you just have to add a `&data_freshness=realtime` parameter (or use the `bypass_disruptions` link from response).
 
 In a journey's response, different disruptions may have different meanings.
-Each journey has a `status` attribute that indicates the most serious effect affecting the journey.
-A base-schedule journey using a stop-time that is deleted in realtime will have
-a NO_SERVICE status (no matter the effect of the disruption causing it).
+Each journey has a `status` attribute that indicates the actual effect affecting pick-up and drop-off used by
+the journey (no matter the effects of the disruptions attached to the journey).
+A journey using a stop-time pick-up (or drop-off) that is deleted in realtime will have a `NO_SERVICE` status.
+A journey using a stop-time pick-up (or drop-off) that is added in realtime will have a `MODIFIED_SERVICE` status.
+A journey using a stop-time pick-up (or drop-off) that is early or late in realtime will have a `SIGNIFICANT_DELAYS` status.
+All other journeys will have an empty status.
 Disruptions are on the sections, the ones that impact the journey are in the sections's display_informations links  (`sections[].display_informations.links[]`).
 
 You might also have other disruptions in the response. They don't directly impact the journey, but might affect them.
@@ -1101,7 +1104,7 @@ Here is a typical journey, all sections are detailed below
   type                | *enum* string                | Used to qualify a journey. See the [journey-qualification](#journey-qualification-process) section for more information
   fare                | [fare](#fare)                | Fare of the journey (tickets and price)
   tags                | array of string              | List of tags on the journey. The tags add additional information on the journey beside the journey type. See for example [multiple_journeys](#multiple-journeys).
-  status              | *enum*                       | Status of the whole journey taking into acount the disruptions retrieved on PT object used. Can be: <ul><li>NO_SERVICE</li><li>REDUCED_SERVICE</li><li>SIGNIFICANT_DELAYS</li><li>DETOUR</li><li>ADDITIONAL_SERVICE</li><li>MODIFIED_SERVICE</li><li>OTHER_EFFECT</li><li>UNKNOWN_EFFECT</li><li>STOP_MOVED</li></ul> A base-schedule journey using a stop-time that is deleted in realtime will have a NO_SERVICE status (no matter the effect of the disruption causing it).<br>In order to get an "undisrupted" journey (consider all disruptions during journey planning), you just have to add a *&data_freshness=realtime* parameter.
+  status              | *enum*                       | Status of the whole journey taking into acount the actual effect of disruptions retrieved on pick-ups and drop-offs used. See the [journey-disruption](#journeys-disruptions) section for more information.
 
 <aside class="notice">
     When used with just a "from" or a "to" parameter, it will not contain any sections.

--- a/documentation/slate/source/includes/realtime.md
+++ b/documentation/slate/source/includes/realtime.md
@@ -525,7 +525,7 @@ http://api.navitia.io/v1/coverage/<coverage>/journeys?from=<origin>&to=<destinat
     ]
 ```
 
-The status of the journey is `ADDITIONAL_SERVICE`. This new journey can only be displayed if "data_freshness" is set to "realtime".<br>A list of disruptions impacting the journey is also present at the root level of the response.<br>A link to the concerned disruption can be found in the section "display_informations".
+The status of the journey is `MODIFIED_SERVICE`. This new journey can only be displayed if "data_freshness" is set to "realtime".<br>A list of disruptions impacting the journey is also present at the root level of the response.<br>A link to the concerned disruption can be found in the section "display_informations".
 
 <div></div>
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -379,14 +379,18 @@ class Scenario(object):
         add_link(resp, rel='ridesharing_journeys', **req)
 
     def _add_bypass_disruptions_link(self, resp, params):
-        # find first journey with a NO_SERVICE status
+        # find first journey with a NO_SERVICE or SIGNIFICANT_DELAY status
         if 'realtime' in params.get('data_freshness', []):
             return
         found = next(
             (
                 True
                 for j in resp.journeys
-                if j.most_serious_disruption_effect == Severity.Effect.Name(Severity.Effect.NO_SERVICE)
+                if j.most_serious_disruption_effect
+                in [
+                    Severity.Effect.Name(Severity.Effect.NO_SERVICE),
+                    Severity.Effect.Name(Severity.Effect.SIGNIFICANT_DELAYS),
+                ]
             ),
             False,
         )

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -1731,7 +1731,7 @@ class TestKirinStopTimeOnDetourAndArrivesBeforeDeletedAtTheEnd(MockKirinDisrupti
         # as the deleted-for-detour stop should not be displayed
         response = self.query_region(base_journey_query)
         assert len(response['journeys']) == 2
-        assert response['journeys'][0]['status'] == 'DETOUR'
+        assert response['journeys'][0]['status'] == 'MODIFIED_SERVICE'  # using added drop-off
         assert response['journeys'][0]['sections'][0]['type'] == 'public_transport'
         assert len(response['journeys'][0]['sections'][0]['stop_date_times']) == 2
         assert response['journeys'][0]['sections'][0]['data_freshness'] == 'realtime'
@@ -1903,7 +1903,7 @@ class TestKirinAddNewTrip(MockKirinDisruptionsFixture):
         assert len(response['journeys']) == 2
         pt_journey = response['journeys'][0]
         assert 'non_pt_walking' not in pt_journey['tags']
-        assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
+        assert pt_journey['status'] == 'MODIFIED_SERVICE'  # using added pick-up and drop-off
         assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
         assert pt_journey['sections'][0]['display_informations']['commercial_mode'] == 'additional service'
         assert pt_journey['sections'][0]['display_informations']['physical_mode'] == 'Bus'
@@ -2212,7 +2212,7 @@ class TestKirinAddNewTripWithSomeAttributes(MockKirinDisruptionsFixture):
         assert len(response['journeys']) == 2
         pt_journey = response['journeys'][0]
         assert 'non_pt_walking' not in pt_journey['tags']
-        assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
+        assert pt_journey['status'] == 'MODIFIED_SERVICE'  # using added pick-up and drop-off
         assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
         assert pt_journey['sections'][0]['display_informations']['commercial_mode'] == 'Tramway'
         assert pt_journey['sections'][0]['display_informations']['physical_mode'] == 'Bus'
@@ -2717,7 +2717,7 @@ class TestKirinAddNewTripWithoutPhysicalMode(MockKirinDisruptionsFixture):
         assert len(response['journeys']) == 2
         pt_journey = response['journeys'][0]
         assert 'non_pt_walking' not in pt_journey['tags']
-        assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
+        assert pt_journey['status'] == 'MODIFIED_SERVICE'  # using added pick-up and drop-off
         assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
         assert pt_journey['sections'][0]['display_informations']['commercial_mode'] == 'additional service'
         assert pt_journey['sections'][0]['display_informations']['physical_mode'] == 'Tramway'
@@ -2852,7 +2852,7 @@ class TestKirinAddTripWithHeadSign(MockKirinDisruptionsFixture):
         self.is_valid_journey_response(response, C_B_query)
         assert len(response['journeys']) == 2
         pt_journey = response['journeys'][0]
-        assert pt_journey['status'] == 'ADDITIONAL_SERVICE'
+        assert pt_journey['status'] == 'MODIFIED_SERVICE'  # using added pick-up and drop-off
         assert pt_journey['sections'][0]['data_freshness'] == 'realtime'
         assert pt_journey['sections'][0]['display_informations']['headsign'] == 'trip_headsign'
 
@@ -3679,7 +3679,7 @@ class TestNoServiceJourney(MockKirinOrChaosDisruptionsFixture):
         # Meanwhile, journey using a VJ with deleted stop, but not using that stop keeps its status
         journey_AE = self.query_region(journey_AE_query)
         assert len(journey_AE['journeys']) == 1
-        assert journey_AE['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert journey_AE['journeys'][0]['status'] == ''  # No delay, no deletion of pick-up or drop-off used
         assert len(journey_AE['disruptions']) == 1
         assert journey_AE['disruptions'][0]['severity']['effect'] == 'REDUCED_SERVICE'
         links = get_links_dict(journey_AE)
@@ -3879,7 +3879,7 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_rt = self.query_region(journey_EH_rt_query)
         assert len(journey_EH_rt['journeys']) == 1
-        assert journey_EH_rt['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert journey_EH_rt['journeys'][0]['status'] == ''  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_rt['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_rt)
         assert len(journey_EH_rt['disruptions']) == 1
@@ -3893,7 +3893,9 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_adapted = self.query_region(journey_EH_adapted_query)
         assert len(journey_EH_adapted['journeys']) == 1
-        assert journey_EH_adapted['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert (
+            journey_EH_adapted['journeys'][0]['status'] == ''
+        )  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_adapted['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_adapted)
         assert len(journey_EH_adapted['disruptions']) == 1
@@ -3907,7 +3909,9 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_base = self.query_region(journey_EH_base_query)
         assert len(journey_EH_base['journeys']) == 1
-        assert journey_EH_base['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert (
+            journey_EH_base['journeys'][0]['status'] == ''
+        )  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_base['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_base)
         assert len(journey_EH_base['disruptions']) == 1
@@ -3934,7 +3938,7 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_rt = self.query_region(journey_EH_rt_query)
         assert len(journey_EH_rt['journeys']) == 1
-        assert journey_EH_rt['journeys'][0]['status'] == 'NO_SERVICE'
+        assert journey_EH_rt['journeys'][0]['status'] == ''  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_rt['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_rt)
         assert len(journey_EH_rt['disruptions']) == 2
@@ -3956,7 +3960,9 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_base = self.query_region(journey_EH_base_query)
         assert len(journey_EH_base['journeys']) == 1
-        assert journey_EH_base['journeys'][0]['status'] == 'NO_SERVICE'
+        assert (
+            journey_EH_base['journeys'][0]['status'] == ''
+        )  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_base['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_base)
         assert len(journey_EH_base['disruptions']) == 2
@@ -3978,7 +3984,7 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_rt = self.query_region(journey_EH_rt_query)
         assert len(journey_EH_rt['journeys']) == 1
-        assert journey_EH_rt['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert journey_EH_rt['journeys'][0]['status'] == ''  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_rt['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_rt)
         assert len(journey_EH_rt['disruptions']) == 1
@@ -3992,7 +3998,9 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_adapted = self.query_region(journey_EH_adapted_query)
         assert len(journey_EH_adapted['journeys']) == 1
-        assert journey_EH_adapted['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert (
+            journey_EH_adapted['journeys'][0]['status'] == ''
+        )  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_adapted['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_adapted)
         assert len(journey_EH_adapted['disruptions']) == 1
@@ -4006,7 +4014,9 @@ class TestKirinThenChaosRailSectionJourney(MockKirinOrChaosDisruptionsFixture):
 
         journey_EH_base = self.query_region(journey_EH_base_query)
         assert len(journey_EH_base['journeys']) == 1
-        assert journey_EH_base['journeys'][0]['status'] == 'REDUCED_SERVICE'
+        assert (
+            journey_EH_base['journeys'][0]['status'] == ''
+        )  # No delay, no deletion of pick-up or drop-off used
         assert journey_EH_base['journeys'][0]['arrival_date_time'] == '20170120T083500'
         assert using_vj1(journey_EH_base)
         assert len(journey_EH_base['disruptions']) == 1

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -214,11 +214,13 @@ class TestKirinOnVJDeletion(MockKirinDisruptionsFixture):
         # _current_datetime is needed to make it work
         # assert len(new_base['disruptions']) == 1
 
-        # remove links as the calling url is not the same
+        # remove links as the calling url is not the same and status as it's affected by the disruption
         for j in new_base['journeys']:
             j.pop('links', None)
+            j.pop('status', None)
         for j in response['journeys']:
             j.pop('links', None)
+            j.pop('status', None)
         assert new_base['journeys'] == response['journeys']
 
 

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -3117,7 +3117,7 @@ class TestKirinDelayPassMidnightTowardsNextDay(MockKirinDisruptionsFixture):
         )
 
         # Check journeys in realtime for 20120615(the day of the future disruption) from B to A
-        # vjB circulates everyday with departure at 18:01:00 and arrival at 18:01:02
+        # vjB circulates every day with departure at 18:01:00 and arrival at 18:01:02
         ba_15T18_journey_query = empty_query.format(
             f='stop_point:stopB', to='stop_point:stopA', dt='20120615T180000'
         )

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -721,14 +721,16 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
                 to_pb_realtime_level(item.stop_times.front()->vehicle_journey->realtime_level));
 
             const auto base_vj_start_date = get_base_vj_start_date(item.departure, item.stop_times.front(), true);
-            auto freshest_vj = item.get_vj()->meta_vj->get_freshest_vj_for_base_date(base_vj_start_date);
-            if (freshest_vj != item.get_vj() && freshest_vj != nullptr) {
-                auto freshest_corresponding_dep_st = item.stop_times.front()->get_corresponding_stop_time(*freshest_vj);
-                if (freshest_corresponding_dep_st == nullptr || !freshest_corresponding_dep_st->pick_up_allowed()) {
+            auto rt_vj = item.get_vj()->meta_vj->get_rt_vj_for_base_date(base_vj_start_date);
+            if (rt_vj == nullptr) {
+                pt_not_served_in_rt = true;
+            } else if (rt_vj != item.get_vj()) {
+                auto rt_corresponding_dep_st = item.stop_times.front()->get_corresponding_stop_time(*rt_vj);
+                if (rt_corresponding_dep_st == nullptr || !rt_corresponding_dep_st->pick_up_allowed()) {
                     pt_not_served_in_rt = true;
                 }
-                auto freshest_corresponding_arr_st = item.stop_times.back()->get_corresponding_stop_time(*freshest_vj);
-                if (freshest_corresponding_arr_st == nullptr || !freshest_corresponding_arr_st->drop_off_allowed()) {
+                auto rt_corresponding_arr_st = item.stop_times.back()->get_corresponding_stop_time(*rt_vj);
+                if (rt_corresponding_arr_st == nullptr || !rt_corresponding_arr_st->drop_off_allowed()) {
                     pt_not_served_in_rt = true;
                 }
             }

--- a/source/routing/raptor_api.cpp
+++ b/source/routing/raptor_api.cpp
@@ -333,27 +333,6 @@ void _update_max_impact_severity(boost::optional<type::disruption::Effect>& max,
     }
 }
 
-static void compute_most_serious_disruption(pbnavitia::Journey* pb_journey, const PbCreator& pb_creator) {
-    boost::optional<type::disruption::Effect> max_severity = boost::none;
-
-    for (const auto& section : pb_journey->sections()) {
-        if (section.type() != pbnavitia::PUBLIC_TRANSPORT) {
-            continue;
-        }
-        _update_max_impact_severity(max_severity, section.pt_display_informations(), pb_creator);
-
-        _update_max_impact_severity(max_severity, section.origin().stop_point(), pb_creator);
-        _update_max_impact_severity(max_severity, section.origin().stop_point().stop_area(), pb_creator);
-
-        _update_max_impact_severity(max_severity, section.destination().stop_point(), pb_creator);
-        _update_max_impact_severity(max_severity, section.destination().stop_point().stop_area(), pb_creator);
-    }
-
-    if (max_severity) {
-        pb_journey->set_most_serious_disruption_effect(type::disruption::to_string(*max_severity));
-    }
-}
-
 static void fill_section(PbCreator& pb_creator,
                          pbnavitia::Section* pb_section,
                          const type::VehicleJourney* vj,
@@ -533,6 +512,15 @@ static bt::ptime get_base_dt(const nt::StopTime* st_orig,
     return {validity_pattern_dt_day, boost::posix_time::seconds(hour_of_day_base)};
 }
 
+static bt::ptime get_st_dt(const nt::StopTime* st, const boost::gregorian::date& dt_day_base, bool is_departure) {
+    if (st == nullptr) {
+        return bt::not_a_date_time;
+    }
+    const auto hour_of_day_st = (is_departure ? st->departure_time : st->arrival_time);
+    const auto shift_duration = boost::gregorian::date_duration(st->vehicle_journey->shift);
+    return {dt_day_base + shift_duration, boost::posix_time::seconds(hour_of_day_st)};
+}
+
 static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
                                     PbCreator& pb_creator,
                                     const navitia::routing::Path& path,
@@ -553,6 +541,8 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
 
     // considering only stop-time used in journey that are removed in freshest VJ
     bool pt_not_served_in_rt = false;
+    bool pt_not_served_in_base = false;
+    bool pt_served_at_different_time_in_base_or_in_rt = false;
 
     for (auto path_i = path.items.begin(); path_i < path.items.end(); ++path_i) {
         const auto& item = *path_i;
@@ -711,11 +701,23 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
             if (base_dep_st != nullptr) {
                 auto base_dep_dt = get_base_dt(item.stop_times.front(), base_dep_st, item.departure, true);
                 pb_section->set_base_begin_date_time(navitia::to_posix_timestamp(base_dep_dt));
+                if (pb_section->begin_date_time() != pb_section->base_begin_date_time()) {
+                    pt_served_at_different_time_in_base_or_in_rt = true;
+                }
+            }
+            if (base_dep_st == nullptr || !base_dep_st->pick_up_allowed()) {
+                pt_not_served_in_base = true;
             }
             auto base_arr_st = item.stop_times.back()->get_base_stop_time();
             if (base_arr_st != nullptr) {
                 auto base_arr_dt = get_base_dt(item.stop_times.back(), base_arr_st, item.arrival, false);
                 pb_section->set_base_end_date_time(navitia::to_posix_timestamp(base_arr_dt));
+                if (pb_section->end_date_time() != pb_section->base_end_date_time()) {
+                    pt_served_at_different_time_in_base_or_in_rt = true;
+                }
+            }
+            if (base_arr_st == nullptr || !base_arr_st->drop_off_allowed()) {
+                pt_not_served_in_base = true;
             }
             pb_section->set_realtime_level(
                 to_pb_realtime_level(item.stop_times.front()->vehicle_journey->realtime_level));
@@ -728,10 +730,16 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
                 auto rt_corresponding_dep_st = item.stop_times.front()->get_corresponding_stop_time(*rt_vj);
                 if (rt_corresponding_dep_st == nullptr || !rt_corresponding_dep_st->pick_up_allowed()) {
                     pt_not_served_in_rt = true;
+                } else if (navitia::to_posix_timestamp(get_st_dt(rt_corresponding_dep_st, base_vj_start_date, true))
+                           != pb_section->begin_date_time()) {
+                    pt_served_at_different_time_in_base_or_in_rt = true;
                 }
                 auto rt_corresponding_arr_st = item.stop_times.back()->get_corresponding_stop_time(*rt_vj);
                 if (rt_corresponding_arr_st == nullptr || !rt_corresponding_arr_st->drop_off_allowed()) {
                     pt_not_served_in_rt = true;
+                } else if (navitia::to_posix_timestamp(get_st_dt(rt_corresponding_arr_st, base_vj_start_date, false))
+                           != pb_section->end_date_time()) {
+                    pt_served_at_different_time_in_base_or_in_rt = true;
                 }
             }
         }
@@ -749,8 +757,12 @@ static bt::ptime handle_pt_sections(pbnavitia::Journey* pb_journey,
         // journey status is NO_SERVICE if a disruption in RT prevents from using a PT section in RT
         pb_journey->set_most_serious_disruption_effect(
             type::disruption::to_string(type::disruption::Effect::NO_SERVICE));
-    } else {
-        compute_most_serious_disruption(pb_journey, pb_creator);
+    } else if (pt_not_served_in_base) {
+        pb_journey->set_most_serious_disruption_effect(
+            type::disruption::to_string(type::disruption::Effect::MODIFIED_SERVICE));
+    } else if (pt_served_at_different_time_in_base_or_in_rt) {
+        pb_journey->set_most_serious_disruption_effect(
+            type::disruption::to_string(type::disruption::Effect::SIGNIFICANT_DELAYS));
     }
 
     // fare computation, done at the end for the journey to be complete

--- a/source/routing/tests/routing_api_test.cpp
+++ b/source/routing/tests/routing_api_test.cpp
@@ -1984,7 +1984,8 @@ BOOST_AUTO_TEST_CASE(with_information_disruptions) {
     BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
 
     const auto& j = resp.journeys(0);
-    BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(), "SIGNIFICANT_DELAYS");
+    BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(),
+                      "");  // the line's and stop's disruptions have no effect on the journey
 
     BOOST_REQUIRE_EQUAL(j.sections_size(), 1);
 }
@@ -2034,7 +2035,7 @@ BOOST_AUTO_TEST_CASE(with_disruptions_on_network) {
 
     const auto& j = resp.journeys(0);
     BOOST_CHECK_EQUAL(j.most_serious_disruption_effect(),
-                      "SIGNIFICANT_DELAYS");  // we should have the network's disruption's effect
+                      "");  // the network's and stop's disruptions have no effect on the journey
 }
 
 BOOST_AUTO_TEST_CASE(journey_with_forbidden) {

--- a/source/type/meta_vehicle_journey.cpp
+++ b/source/type/meta_vehicle_journey.cpp
@@ -324,10 +324,10 @@ VehicleJourney* MetaVehicleJourney::get_base_vj_circulating_at_date(const boost:
     return nullptr;
 }
 
-VehicleJourney* MetaVehicleJourney::get_freshest_vj_for_base_date(const boost::gregorian::date& date) const {
+VehicleJourney* MetaVehicleJourney::get_rt_vj_for_base_date(const boost::gregorian::date& date) const {
     for (auto l : reverse_enum_range_from<RTLevel>(RTLevel::RealTime)) {
         for (const auto& vj : rtlevel_to_vjs_map[l]) {
-            if (vj->get_base_canceled_validity_pattern().check(date)) {
+            if (vj->get_base_validity_pattern_at_freshness(RTLevel::RealTime).check(date)) {
                 return vj.get();
             }
         }

--- a/source/type/meta_vehicle_journey.h
+++ b/source/type/meta_vehicle_journey.h
@@ -127,7 +127,7 @@ struct MetaVehicleJourney : public Header, HasMessages {
                    const Route* filtering_route = nullptr);
 
     VehicleJourney* get_base_vj_circulating_at_date(const boost::gregorian::date& date) const;
-    VehicleJourney* get_freshest_vj_for_base_date(const boost::gregorian::date& date) const;
+    VehicleJourney* get_rt_vj_for_base_date(const boost::gregorian::date& date) const;
 
     const std::string& get_label() const { return uri; }  // for the moment the label is just the uri
 

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -154,7 +154,7 @@ type::PhysicalMode* PT_Data::get_or_create_physical_mode(const std::string& uri,
     mode->name = name;
     mode->uri = uri;
 
-    if (co2_emission >= 0.f)
+    if (co2_emission >= 0.)
         mode->co2_emission = co2_emission;
 
     mode->idx = physical_modes.size();

--- a/source/type/vehicle_journey.cpp
+++ b/source/type/vehicle_journey.cpp
@@ -147,7 +147,7 @@ int32_t VehicleJourney::utc_to_local_offset() const {
 }
 
 const VehicleJourney* VehicleJourney::get_corresponding_base() const {
-    auto shifted_vj = get_base_canceled_validity_pattern();
+    auto shifted_vj = get_base_validity_pattern_at_freshness(realtime_level);
     for (const auto& vj : meta_vj->get_base_vj()) {
         // if the validity pattern intersects
         if ((shifted_vj.days & vj->base_validity_pattern()->days).any()) {
@@ -453,10 +453,10 @@ bool VehicleJourney::has_landing() const {
     return false;
 }
 
-ValidityPattern VehicleJourney::get_base_canceled_validity_pattern() const {
-    ValidityPattern base_canceled_vp = *validity_patterns[realtime_level];
-    base_canceled_vp.days >>= shift;
-    return base_canceled_vp;
+ValidityPattern VehicleJourney::get_base_validity_pattern_at_freshness(const RTLevel& data_freshness) const {
+    ValidityPattern base_vp = *validity_patterns[data_freshness];
+    base_vp.days >>= shift;
+    return base_vp;
 }
 
 std::string VehicleJourney::get_direction() const {

--- a/source/type/vehicle_journey.h
+++ b/source/type/vehicle_journey.h
@@ -93,7 +93,7 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     bool is_base_schedule() const { return realtime_level == RTLevel::Base; }
     // number of days of delay compared to base-vj vp (case of a delayed vj in realtime or adapted):
     // * base-schedule VP start-date = realtime's VP start-date - shift
-    // * use get_base_canceled_validity_pattern() to "convert" realtime VP to base VP
+    // * use get_base_validity_pattern_at_freshness() to "convert" realtime VP to base VP
     size_t shift = 0;
     // validity pattern for all RTLevel
     flat_enum_map<RTLevel, ValidityPattern*> validity_patterns = {{{nullptr, nullptr, nullptr}}};
@@ -102,7 +102,7 @@ struct VehicleJourney : public Header, Nameable, hasVehicleProperties {
     ValidityPattern* adapted_validity_pattern() const { return get_validity_pattern_at(RTLevel::Adapted); }
     ValidityPattern* rt_validity_pattern() const { return get_validity_pattern_at(RTLevel::RealTime); }
     // base-schedule validity pattern canceled by this vj (to get corresponding vjs, use meta-vj)
-    ValidityPattern get_base_canceled_validity_pattern() const;
+    ValidityPattern get_base_validity_pattern_at_freshness(const RTLevel& data_freshness) const;
 
     // return the base vj corresponding to this vj, return nullptr if nothing found
     const VehicleJourney* get_corresponding_base() const;


### PR DESCRIPTION
:mag: please review by commit with comment.

Stop taking into consideration the effect of disruptions associated, just consider the actual effect on pick-ups and drop-offs used by the journey.

Also:
* Bug fix: really use RT validity-pattern to get the VJ available in RT (first commit)
* Update doc accordingly
* Update the conditions to add "bypass_disruptions" link
* Just update tests impacted by the change (that covers almost all the new feature)
* Add tests on SIGNIFICANT_DELAYS status (with bypass_disruptions link)
* Minor changes (4th commit)

Doc: https://navitia.atlassian.net/wiki/spaces/NAV/pages/7024845232/Interfaces+v1+temps+r+el#Status-global-d%E2%80%99un-journey
JIRA: https://navitia.atlassian.net/browse/NAV-2129
