### PR TITLE
Python: add missing pins in all requirements files

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -101,6 +101,7 @@ jobs:
         echo $NAVITIA_CHAOS_DUMP_PATH
         make docker_test
         deactivate
+        rm -rf navitia_py3
       env:
         NAVITIA_DOCKER_NETWORK: ${{ job.container.network }}
         TYR_CELERY_BROKER_URL: 'amqp://guest:guest@rabbitmq:5672//'

--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,7 +1,8 @@
 future==0.18.3
 docker==3.4.1
 retrying==1.3.3
-psycopg2
+psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2-binary==2.9.7 ; python_version >= "3.9"
 GeoAlchemy2==0.2.4
 SQLAlchemy==1.3.3
 alembic==1.0.11

--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,7 +1,7 @@
 future==0.18.3
 docker==3.4.1
 retrying==1.3.3
-psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2==2.8.6 ; python_version < "3.9"
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 GeoAlchemy2==0.2.4
 SQLAlchemy==1.3.3

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -15,7 +15,7 @@ blinker==1.3
 itsdangerous==1.1.0
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2==2.8.6 ; python_version < "3.9"
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pyzmq==15.4.0 ; python_version < "3.9"
 pyzmq==25.0.2 ; python_version >= "3.9"

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -15,8 +15,8 @@ blinker==1.3
 itsdangerous==1.1.0
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2 ; python_version < "3.9"
-psycopg2-binary ; python_version >= "3.9"
+psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pyzmq==15.4.0 ; python_version < "3.9"
 pyzmq==25.0.2 ; python_version >= "3.9"
 six==1.13.0
@@ -49,8 +49,8 @@ vine==5.0.0 ; python_version >= "3.9"
 # don't update these packages' versions unless you're very sure
 amqp==2.5.2 ; python_version < "3.9"
 amqp==5.0.6 ; python_version >= "3.9"
-kombu==4.0.2  ; python_version < "3.9"
-kombu==5.0.2  ; python_version >= "3.9"
+kombu==4.0.2 ; python_version < "3.9"
+kombu==5.0.2 ; python_version >= "3.9"
 redis==2.10.6
 flexpolyline==0.1.0
 newrelic==2.70.0.51 ; python_version <= "3.6"

--- a/source/monitor/requirements.txt
+++ b/source/monitor/requirements.txt
@@ -4,7 +4,8 @@ MarkupSafe==0.23
 Werkzeug==0.15.5
 argparse==1.2.1
 itsdangerous==1.1.0
-protobuf
+protobuf==3.15.0 ; python_version < "3.9"
+protobuf==3.20.3 ; python_version >= "3.9"
 pyzmq==15.4.0 ; python_version < "3.9"
 pyzmq==25.0.2 ; python_version >= "3.9"
 wsgiref==0.1.2; python_version < '3.2'

--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -2,5 +2,5 @@ GeoAlchemy2==0.2.4
 Mako==0.9.1
 SQLAlchemy==1.3.3
 alembic==1.0.11
-psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2==2.8.6 ; python_version < "3.9"
 psycopg2-binary==2.9.7 ; python_version >= "3.9"

--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -2,5 +2,5 @@ GeoAlchemy2==0.2.4
 Mako==0.9.1
 SQLAlchemy==1.3.3
 alembic==1.0.11
-psycopg2 ; python_version < "3.9"
-psycopg2-binary ; python_version >= "3.9"
+psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2-binary==2.9.7 ; python_version >= "3.9"

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -21,7 +21,7 @@ itsdangerous==1.1.0
 setuptools==44.1.0 ; python_version == "2.7"
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2==2.8.6 ; python_version < "3.9"
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pytz==2013.9
 six==1.13.0

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -19,9 +19,10 @@ billiard==3.5.0.5 ; python_version < "3.9"
 configobj==5.0.6
 itsdangerous==1.1.0
 setuptools==44.1.0 ; python_version == "2.7"
-protobuf==3.15
-psycopg2 ; python_version < "3.9"
-psycopg2-binary ; python_version >= "3.9"
+protobuf==3.15.0 ; python_version < "3.9"
+protobuf==3.20.3 ; python_version >= "3.9"
+psycopg2==2.9.7 ; python_version < "3.9"
+psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pytz==2013.9
 six==1.13.0
 validate-email==1.3


### PR DESCRIPTION
Standardize use of psycopg2 and protobuf on the way.

Trying to use the very last version of `psycopg2` that may cause crash of the CI.