### PR TITLE
Python2.7: unpin psycopg2 as no version works for all

### DIFF
--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,7 +1,7 @@
 future==0.18.3
 docker==3.4.1
 retrying==1.3.3
-psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
+psycopg2 ; python_version < "3.9"  # keep it free: 2.5.4 is installed on debian 8 images, but doesn't handle PG 13.11 from debian 11
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 GeoAlchemy2==0.2.4
 SQLAlchemy==1.3.3

--- a/source/eitri/requirements.txt
+++ b/source/eitri/requirements.txt
@@ -1,7 +1,7 @@
 future==0.18.3
 docker==3.4.1
 retrying==1.3.3
-psycopg2==2.8.6 ; python_version < "3.9"
+psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 GeoAlchemy2==0.2.4
 SQLAlchemy==1.3.3

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -15,7 +15,7 @@ blinker==1.3
 itsdangerous==1.1.0
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
+psycopg2 ; python_version < "3.9"  # keep it free: 2.5.4 is installed on debian 8 images, but doesn't handle PG 13.11 from debian 11
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pyzmq==15.4.0 ; python_version < "3.9"
 pyzmq==25.0.2 ; python_version >= "3.9"

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -15,7 +15,7 @@ blinker==1.3
 itsdangerous==1.1.0
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2==2.8.6 ; python_version < "3.9"
+psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pyzmq==15.4.0 ; python_version < "3.9"
 pyzmq==25.0.2 ; python_version >= "3.9"

--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -2,5 +2,5 @@ GeoAlchemy2==0.2.4
 Mako==0.9.1
 SQLAlchemy==1.3.3
 alembic==1.0.11
-psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
+psycopg2 ; python_version < "3.9"  # keep it free: 2.5.4 is installed on debian 8 images, but doesn't handle PG 13.11 from debian 11
 psycopg2-binary==2.9.7 ; python_version >= "3.9"

--- a/source/sql/requirements.txt
+++ b/source/sql/requirements.txt
@@ -2,5 +2,5 @@ GeoAlchemy2==0.2.4
 Mako==0.9.1
 SQLAlchemy==1.3.3
 alembic==1.0.11
-psycopg2==2.8.6 ; python_version < "3.9"
+psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
 psycopg2-binary==2.9.7 ; python_version >= "3.9"

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -21,7 +21,7 @@ itsdangerous==1.1.0
 setuptools==44.1.0 ; python_version == "2.7"
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2==2.8.6 ; python_version < "3.9"
+psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pytz==2013.9
 six==1.13.0

--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -21,7 +21,7 @@ itsdangerous==1.1.0
 setuptools==44.1.0 ; python_version == "2.7"
 protobuf==3.15.0 ; python_version < "3.9"
 protobuf==3.20.3 ; python_version >= "3.9"
-psycopg2==2.5.4 ; python_version < "3.9"  # matching the version installed on our debian 8 images
+psycopg2 ; python_version < "3.9"  # keep it free: 2.5.4 is installed on debian 8 images, but doesn't handle PG 13.11 from debian 11
 psycopg2-binary==2.9.7 ; python_version >= "3.9"
 pytz==2013.9
 six==1.13.0


### PR DESCRIPTION
Otherwise, the build of docker images crashes: https://github.com/hove-io/navitia/actions/runs/5821194851

Temporarily triggered docker-build in this commit (now removed): https://github.com/hove-io/navitia/pull/4088/commits/d8a083cf7dddefb22788dd519d805dd8430fd4bb and it worked https://github.com/hove-io/navitia/actions/runs/5830492748/job/15811979377?pr=4088