### PR TITLE
[Jormungandr] language: Fix for access and exit path instructions

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/helper_utils.py
@@ -250,22 +250,22 @@ def _extend_with_car_park(
 
 def get_enter_instruction_words(lan):
     instructions = {
-        "english_us": u"Then enter {} via {}.",
-        "french": u"Accédez à {} via {}.",
-        "spanish": u"Acceso a {} vía {}.",
-        "italian": u"Accesso alla {} via {}.",
+        "en-US": u"Then enter {} via {}.",
+        "fr-FR": u"Accédez à {} via {}.",
+        "es-ES": u"Acceso a {} vía {}.",
+        "it-IT": u"Accesso alla {} via {}.",
     }
-    return instructions.get(lan, instructions["english_us"])
+    return instructions.get(lan, instructions["en-US"])
 
 
 def get_exit_instruction_words(lan):
     instructions = {
-        "english_us": u"Exit {} via {}.",
-        "french": u"Sortez de {} via {}.",
-        "spanish": u"Salida {} vía {}.",
-        "italian": u"Uscita {} via {}.",
+        "en-US": u"Exit {} via {}.",
+        "fr-FR": u"Sortez de {} via {}.",
+        "es-ES": u"Salida {} vía {}.",
+        "it-IT": u"Uscita {} via {}.",
     }
-    return instructions.get(lan, instructions["english_us"])
+    return instructions.get(lan, instructions["en-US"])
 
 
 def append_path_item_with_access_point(path_items, stop_point, access_point, language):

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -504,9 +504,9 @@ class TestJourneysDistributed(
         assert pt_journey
         assert len(pt_journey['sections'][0]['vias']) == 1
         path = pt_journey['sections'][0]['path'][-1]
-        assert path['instruction'] == "Then enter stop_point:stopB (Condom) via access_point:B1."
+        assert path['instruction'] == "Accédez à stop_point:stopB (Condom) via access_point:B1."
         path = pt_journey['sections'][2]['path'][0]
-        assert path['instruction'] == "Exit stop_point:stopA (Condom) via access_point:A2."
+        assert path['instruction'] == "Sortez de stop_point:stopA (Condom) via access_point:A2."
 
         # Verify some path instructions managed by jormungandr in English as default language
         query = journey_basic_query + "&_access_points=true&language=ja-JP"


### PR DESCRIPTION
Correction for access and exit path instructions.
As explained in the test if parameter language is absent, default value fr-FR is used. https://github.com/hove-io/navitia/blob/eb4d8ae93446da90276e713e663b0fb3fd5489df/source/jormungandr/tests/routing_tests_experimental.py#L498


For more details: https://navitia.atlassian.net/browse/NAV-2152