### PR TITLE
Update Sonar scanner version (Java17)

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,7 +7,7 @@ on:
     branches: [ dev ]
 
 env:
-   SONAR_SCANNER_VERSION: 4.7.0.2747
+   SONAR_SCANNER_VERSION: 5.0.1.3006
    REGION: eu-west-1
 
 jobs:


### PR DESCRIPTION
This PR is updating Sonar scanner, because this warning is visible: 
_The version of Java (11.0.14.1) you have used to run this analysis is deprecated and we will stop accepting it soon. Please update to at least Java 17._