### PR TITLE
[jormungandr] Manage journey request call without coverage but with object uri

### DIFF
--- a/source/jormungandr/jormungandr/instance.py
+++ b/source/jormungandr/jormungandr/instance.py
@@ -70,6 +70,7 @@ from jormungandr.utils import (
     read_best_boarding_positions,
     read_origin_destination_data,
     str_to_time_stamp,
+    get_pt_object_coord,
 )
 from jormungandr.olympic_site_params_manager import OlympicSiteParamsManager
 from jormungandr import pt_planners_manager, transient_socket
@@ -897,6 +898,21 @@ class Instance(transient_socket.TransientSocket):
             return len(self.get_id(id_).places) > 0
         except DeadSocketException:
             return False
+
+    def get_coord_by_id(self, id_):
+        """
+        If this instance has this id then get coordinate
+        """
+        try:
+            pt_objects = self.get_id(id_).places
+            pt_object = pt_objects[0] if len(pt_objects) > 0 else None
+            if pt_object:
+                coord = get_pt_object_coord(pt_object)
+                return coord if (coord and coord.lon != 0 and coord.lat != 0) else None
+            else:
+                return None
+        except DeadSocketException:
+            return None
 
     def has_coord(self, lon, lat):
         return self.has_point(geometry.Point(lon, lat))

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -220,6 +220,8 @@ class InstanceManager(object):
         return authorized_instances
 
     def _find_coverage_by_object_id_in_instances(self, instances, object_id):
+        # Request without coverage and coord (from or to)
+        # Get list of instances if the coordinate point exist in instance.geom
         if object_id.count(";") == 1 or object_id[:6] == "coord:":
             if object_id.count(";") == 1:
                 lon, lat = object_id.split(";")
@@ -232,19 +234,51 @@ class InstanceManager(object):
                 raise InvalidArguments(object_id)
             return self._all_keys_of_coord_in_instances(instances, flon, flat)
 
+        # Request without coverage and pt_object id (from or to)
         return self._all_keys_of_id_in_instances(instances, object_id)
 
     def _all_keys_of_id_in_instances(self, instances, object_id):
-        valid_instances = []
+        # Get the first occurrence pt_object coordinate and manage as above
+        # If no object with coordinate exist among all the authorized instances
+        # Then
+        object_coord = self._get_first_object_coord_in_instances_by_id(instances, object_id)
+        if object_coord:
+            return self._all_keys_of_coord_in_instances(instances, object_coord.lon, object_coord.lat)
+        else:
+            valid_instances = []
+            for instance in instances:
+                if self._exists_id_in_instance(instance.name, instance.publication_date, object_id):
+                    valid_instances.append(instance)
+            if not valid_instances:
+                raise RegionNotFound(object_id=object_id)
+
+            return valid_instances
+
+    def _get_first_object_coord_in_instances_by_id(self, instances, object_id):
+        """
+        fetch first occurrence of object among instances and return coordinate
+        """
+        coord = None
         for instance in instances:
-            if self._exists_id_in_instance(instance.name, instance.publication_date, object_id):
-                valid_instances.append(instance)
-        if not valid_instances:
-            raise RegionNotFound(object_id=object_id)
+            coord = self._get_object_coord_in_instance_by_id(instance.name, instance.publication_date, object_id)
+            if coord:
+                return coord
+        return coord
 
-        return valid_instances
+    @memory_cache.memoize(app.config[str('MEMORY_CACHE_CONFIGURATION')].get(str('TIMEOUT_PTOBJECTS'), 30))
+    @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_PTOBJECTS'), 300))
+    def _get_object_coord_in_instance_by_id(self, instance_name, instance_publication_date, object_id):
+        """
+        instance's published_date is usually provided as extra_cache_key to invalidate the cache when updating the ntfs
+        """
+        instance = self.instances.get(instance_name)
+        if not instance:
+            logging.getLogger(__name__).error("Instance {} not found".format(instance_name))
+            return None
+        return instance.get_coord_by_id(object_id)
 
-    @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_PTOBJECTS'), None))
+    @memory_cache.memoize(app.config[str('MEMORY_CACHE_CONFIGURATION')].get(str('TIMEOUT_PTOBJECTS'), 30))
+    @cache.memoize(app.config[str('CACHE_CONFIGURATION')].get(str('TIMEOUT_PTOBJECTS'), 300))
     def _exists_id_in_instance(self, instance_name, instance_publication_date, object_id):
         """
         instance's published_date is usually provided as extra_cache_key to invalidate the cache when updating the ntfs

--- a/source/jormungandr/jormungandr/instance_manager.py
+++ b/source/jormungandr/jormungandr/instance_manager.py
@@ -240,7 +240,7 @@ class InstanceManager(object):
     def _all_keys_of_id_in_instances(self, instances, object_id):
         # Get the first occurrence pt_object coordinate and manage as above
         # If no object with coordinate exist among all the authorized instances
-        # Then
+        # Then we will be obliged to call all krakens as before (necessary for test with bad data)
         object_coord = self._get_first_object_coord_in_instances_by_id(instances, object_id)
         if object_coord:
             return self._all_keys_of_coord_in_instances(instances, object_coord.lon, object_coord.lat)

--- a/source/jormungandr/tests/authentication_tests.py
+++ b/source/jormungandr/tests/authentication_tests.py
@@ -165,6 +165,7 @@ mock_instances = {
 
 class AbstractTestAuthentication(AbstractTestFixture):
     def setUp(self):
+        app.config['CIRCUIT_BREAKER_MAX_BRAGI_FAIL'] = 5
         self.old_public_val = app.config['PUBLIC']
         app.config['PUBLIC'] = False
         self.old_db_val = app.config['DISABLE_DATABASE']
@@ -583,7 +584,7 @@ class TestOverlappingAuthentication(AbstractTestAuthentication):
                 r, status = self.query_no_assert('/v1/places?q=bob')
                 assert status == 403
 
-        # tgv has not access to the open_data but can use main_routing_test, it cannot use the global place
+        # tgv has no access to the open_data but can use main_routing_test, it cannot use the global place
         with user_set(app, FakeUserAuth, 'tgv'):
             with requests_mock.Mocker() as m:
                 _, status = self.query_no_assert('/v1/places?q=bob')


### PR DESCRIPTION
For a request on journey to navitia without coverage but with params from or to as coordinate:
- We get all the authorized coverages for the user: coverages attached to user token + free coverages if user is of type with_free_instances.
- We keep coverages with shape which includes the coordinate in the request.
- At last we keep only one coverage which contains from and to coordinates.
- works well and no call to kraken made.

But when instead of coordinate, if we use object_uri
- We get all the authorized coverages for the user: coverages attached to user token + free coverages if user is of type with_free_instances.
- We keep coverages which have the object with object_uri (by calling kraken for all the authorized coverages)
- At last we keep only one coverage which contains from and to coordinates.
- Here we make many unnecessary calls to kraken each time.

Here is the FIX when object_uri is present in from or to:
- We get all the authorized coverages for the user: coverages attached to user token + free coverages if user is of type with_free_instances (as before).
- Call krakens to get coordinate of the object with object_uri in the request and return the first valide coordinate (most of the time only one call to kraken).
- Use the function to keep coverages with shape which includes the coordinate of the object.
- The only overhead when compared to request with coordinate = One call to kraken (cached of course).


For more details: https://navitia.atlassian.net/browse/NAV-2334