### PR TITLE
[kraken] Fix: Recursive display of line and routes

### DIFF
--- a/source/disruption/tests/disruption_test.cpp
+++ b/source/disruption/tests/disruption_test.cpp
@@ -453,10 +453,10 @@ BOOST_FIXTURE_TEST_CASE(line_report_should_return_disruptions_from_tagged_disrup
                              until);
 
     auto& impacts = pb_creator.impacts;
-    BOOST_CHECK_EQUAL(impacts.size(), 1);
+    BOOST_CHECK_EQUAL(impacts.size(), 2);
 
     std::set<std::string> uris = navitia::test::get_impacts_uris(impacts);
-    std::set<std::string> res = {"disrup_line_1"};
+    std::set<std::string> res = {"disrup_line_1", "disrup_network_1"};
     BOOST_CHECK_EQUAL_RANGE(res, uris);
 }
 

--- a/source/jormungandr/tests/check_utils.py
+++ b/source/jormungandr/tests/check_utils.py
@@ -734,7 +734,7 @@ def is_valid_route(route, depth_check=1):
     is_valid_stop_area(get_not_null(direction, "stop_area"), depth_check - 1)
 
     if depth_check > 0:
-        is_valid_line(get_not_null(route, "line"), depth_check - 1)
+        is_valid_line(get_not_null(route, "line"), 0)
     else:
         assert 'line' not in route
 
@@ -772,14 +772,12 @@ def is_valid_line(line, depth_check=1):
     for c in line.get('comments', []):
         is_valid_comment(c)
 
+    is_valid_network(get_not_null(line, 'network'), depth_check - 1)
     if depth_check > 0:
-        is_valid_network(get_not_null(line, 'network'), depth_check - 1)
-
         routes = get_not_null(line, 'routes')
         for r in routes:
             is_valid_route(r, depth_check - 1)
     else:
-        assert 'network' not in line
         assert 'routes' not in line
 
     # test if geojson is valid

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -793,14 +793,14 @@ void PbCreator::Filler::fill_pb_object(const nt::Line* l, pbnavitia::Line* line)
     }
     fill(l->physical_mode_list, line->mutable_physical_modes());
     fill(l->commercial_mode, line);
+    fill(l->network, line);
 
     if (depth > 0) {
         if (!this->pb_creator.disable_geojson) {
             fill(&l->shape, line);
         }
 
-        fill(l->route_list, line->mutable_routes());
-        fill(l->network, line);
+        copy(0, dump_message_options).fill(l->route_list, line->mutable_routes());
 
         fill(l->line_group_list, line->mutable_line_groups());
     }
@@ -871,7 +871,10 @@ void PbCreator::Filler::fill_pb_object(const nt::Route* r, pbnavitia::Route* rou
         return;
     }
 
-    fill(r->line, route);
+    copy(0, dump_message_options).fill(r->line, route);
+    if ((depth > 0) && (!this->pb_creator.disable_geojson)) {
+        fill(&r->line->shape, route->mutable_line());
+    }
 
     if (!this->pb_creator.disable_geojson) {
         fill(&r->shape, route);

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -872,7 +872,7 @@ void PbCreator::Filler::fill_pb_object(const nt::Route* r, pbnavitia::Route* rou
     }
 
     copy(0, dump_message_options).fill(r->line, route);
-    if ((depth > 0) && (!this->pb_creator.disable_geojson)) {
+    if ((depth > 1) && (!this->pb_creator.disable_geojson)) {
         fill(&r->line->shape, route->mutable_line());
     }
 


### PR DESCRIPTION
Before correction:
* Lines are displayed with routes recursively depending on depth: for depth=3 `line.routes[].line.routes[]`
* Routes are displayed with line recursively depending on depth: for depth=3 `routes[].line.routes[].line`
* with depth = 0 line doesn't have Network.

After correction
* Lines are displayed with routes not depending on depth: for depth=1, 2 and 3 `line.routes[]`
* Routes are displayed with line not depending on depth: for depth=1, 2 and 3 `routes[].line`
* Line will always have Network even with depth = 0.

For more details: 
* https://navitia.atlassian.net/browse/NAV-2348
* https://navitia.atlassian.net/browse/NAV-2348?focusedCommentId=54235

Comparison of response time for some request on my PC before and after the correction:
* url_navitia/lines/rerc/lines?
-> depth=1 : 12.5 ms -> 13.0 ms   / 57.5 ko -> 57.5 ko 
-> depth=2 : 13.6 ms -> 12.7 ms   / 80.4 ko -> 57.6 ko
-> depth=3 : 70 ms -> 12.8 ms      / 1.5 Mo -> 57.6 ko 

* url_navitia/lines/rerc/routes?
-> depth=1 : 15 ms -> 14.6 ms   / 69.6 ko -> 75.8 ko (Network added in route.line) 
-> depth=2 : 76.5 ms -> 18 ms   / 1.4 Mo -> 94.8 ko 
-> depth=3 : 393 ms -> 340 ms  / 5.9 Mo -> 4.1 Mo (No change is made on route.stop_point and its sub-objects) 

