### PR TITLE
[jormungandr] call kraken to compute fare only when pt_planner=loki

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/distributed.py
+++ b/source/jormungandr/jormungandr/scenarios/distributed.py
@@ -329,7 +329,7 @@ class Distributed(object):
             for journey in journeys_to_complete:
                 transfer_pool.async_compute_transfer(journey.pt_journeys.sections)
 
-        if request['_loki_compute_pt_journey_fare'] is True:
+        if request['_loki_compute_pt_journey_fare'] is True and request['_pt_planner'] == "loki":
             for response in responses:
                 pt_journey_fare_pool.async_compute_fare(response, request_id)
 
@@ -346,7 +346,7 @@ class Distributed(object):
             journeys=journeys_to_complete,
             request_id="{}_complete_pt_journey".format(request_id),
         )
-        if request['_loki_compute_pt_journey_fare'] is True:
+        if request['_loki_compute_pt_journey_fare'] is True and request['_pt_planner'] == "loki":
             wait_and_complete_pt_journey_fare(
                 pt_elements=journeys_to_complete, pt_journey_fare_pool=pt_journey_fare_pool
             )

--- a/source/jormungandr/tests/routing_tests_experimental.py
+++ b/source/jormungandr/tests/routing_tests_experimental.py
@@ -595,7 +595,9 @@ class TestDistributedJourneyTickets(JourneysTickets, NewDefaultScenarioAbstractT
         assert default_tickets[0]['id'] == response['journeys'][1]['fare']['links'][0]['id']
         assert default_tickets[1]['id'] == response['journeys'][0]['fare']['links'][0]['id']
 
-        query_pt_journey_fare = query + "&_loki_pt_journey_fare=kraken&_loki_compute_pt_journey_fare=true"
+        query_pt_journey_fare = (
+            query + "&_loki_pt_journey_fare=kraken&_loki_compute_pt_journey_fare=true&_pt_planner=loki"
+        )
         response = self.query_region(query_pt_journey_fare)
 
         new_tickets = response['tickets']

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -139,7 +139,16 @@ class AbstractTestFixture(unittest.TestCase):
     @classmethod
     def create_dummy_json(cls):
         for name in cls.krakens_pool:
-            instance_config = {"key": name, "zmq_socket": cls._get_zmq_socket_name(name)}
+            instance_config = {
+                "key": name,
+                "zmq_socket": cls._get_zmq_socket_name(name),
+                "pt_planners": {
+                    "loki": {
+                        "class": "jormungandr.pt_planners.loki.Loki",
+                        "args": {"timeout": 10000, "zmq_socket": "cls._get_zmq_socket_name(name)"},
+                    }
+                },
+            }
             instance_config.update(cls.data_sets[name].get('instance_config', {}))
             with open(os.path.join(krakens_dir, name) + '.json', 'w') as f:
                 logging.debug("writing ini file {} for {}".format(f.name, name))

--- a/source/jormungandr/tests/tests_mechanism.py
+++ b/source/jormungandr/tests/tests_mechanism.py
@@ -145,7 +145,7 @@ class AbstractTestFixture(unittest.TestCase):
                 "pt_planners": {
                     "loki": {
                         "class": "jormungandr.pt_planners.loki.Loki",
-                        "args": {"timeout": 10000, "zmq_socket": "cls._get_zmq_socket_name(name)"},
+                        "args": {"timeout": 10000, "zmq_socket": cls._get_zmq_socket_name(name)},
                     }
                 },
             }

--- a/source/navitiacommon/navitiacommon/default_values.py
+++ b/source/navitiacommon/navitiacommon/default_values.py
@@ -248,7 +248,7 @@ pt_planners_configurations = dict()  # type: dict
 
 # loki pt journey fare
 loki_pt_journey_fare = 'kraken'
-loki_compute_pt_journey_fare = False
+loki_compute_pt_journey_fare = True
 loki_pt_journey_fare_configurations = dict()  # type: dict
 
 


### PR DESCRIPTION
- call kraken to compute fare only when pt_planner=loki
- by default, activate the call to kraken to compute fare

This should : 

- fix https://navitia.atlassian.net/browse/NAV-2361
- enable fare computation by default when pt_planner=loki