### PR TITLE
[Tyr worker] Update Tartare-tools in  Dockerfile-tyr-worker

### DIFF
--- a/docker/debian8/Dockerfile-tyr-worker
+++ b/docker/debian8/Dockerfile-tyr-worker
@@ -1,7 +1,7 @@
 FROM navitia/master
 
 # Install binary enrich-ntfs-with-addresses from tartare-tools
-ENV TARTARE_TOOLS_VERSION="v0.36.2"
+ENV TARTARE_TOOLS_VERSION="v0.36.4"
 ARG GITHUB_TOKEN
 RUN git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/hove-io/".insteadOf "ssh://git@github.com/hove-io/"
 RUN git clone -b ${TARTARE_TOOLS_VERSION} --depth 1 https://x-access-token:${GITHUB_TOKEN}@github.com/hove-io/tartare-tools


### PR DESCRIPTION
- remove ansi color in logs
- logs less verbose

https://github.com/hove-io/tartare-tools/releases/tag/v0.36.4