### PR TITLE
fix GitHub workflow badge URL

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -28,7 +28,7 @@ Hove
     :target: https://github.com/hove-io/navitia/releases
     :alt: version
 
-..  |Build Status| image:: https://img.shields.io/github/workflow/status/hove-io/navitia/Build%20Navitia%20Packages%20For%20Release?logo=github&style=flat-square
+..  |Build Status| image:: https://img.shields.io/github/actions/workflow/status/hove-io/navitia/dockers_builder_release.yml?logo=github&style=flat-square
     :target: https://github.com/hove-io/navitia/actions?query=workflow%3A%22Build+Navitia+Packages+For+Release%22
     :alt: Last build
 


### PR DESCRIPTION
fix GitHub workflow badge URL.

See https://github.com/badges/shields/issues/8671

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main