### PR TITLE
[loki] handle admin in from/to 

### DIFF
--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -85,6 +85,10 @@ def get_uri_pt_object(pt_object):
         return coord_format.format(pt_object.access_point.coord.lon, pt_object.access_point.coord.lat)
     if pt_object.embedded_type == type_pb2.POI:
         return coord_format.format(pt_object.poi.coord.lon, pt_object.poi.coord.lat)
+    if pt_object.embedded_type == type_pb2.ADMINISTRATIVE_REGION:
+        return coord_format.format(
+            pt_object.administrative_region.coord.lon, pt_object.administrative_region.coord.lat
+        )
     return pt_object.uri
 
 


### PR DESCRIPTION
When an admin was specified in the from/to of a journey, its uri was given to loki for the places_nearby step.
But loki may not known this admin. However, jormun has the coordinate of the admin, which can be used by loki.
So instead of giving the admin uri for the places_nearby step, we give the coordinate.
Kraken can also handle coordinates for places_nearby, so this should not break the integration with kraken.

https://navitia.atlassian.net/browse/NAV-2478