### PR TITLE
[loki] enable fare computation by default when pt_planner is loki

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Journeys.py
@@ -722,7 +722,7 @@ class Journeys(JourneyCommon):
         parser_get.add_argument(
             "_loki_compute_pt_journey_fare",
             type=BooleanType(),
-            default=False,
+            default=True,
             hidden=True,
             help="only works when loki is selected as pt journey engine, "
             "whether to use external engine to compute pt journey fare",


### PR DESCRIPTION
When using loki for pt_planner, always call kraken for fare computation.

https://navitia.atlassian.net/browse/NAV-2470