### PR TITLE
depth=2 for access_points objects

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/proximities_by_crowfly.py
@@ -182,10 +182,8 @@ class ProximitiesByCrowflyPool:
         for mode in self._modes:
             object_type = type_pb2.STOP_POINT
             filter = None
-            # if access_point is true, access points are filled in stop points
-            depth = 3 if self._request["_access_points"] else 2
+            depth = 2
             if mode == fm.FallbackModes.car.name:
-                depth = 2
                 object_type = type_pb2.POI
                 filter = "poi_type.uri=\"poi_type:amenity:parking\""
 

--- a/source/jormungandr/tests/access_points_tests.py
+++ b/source/jormungandr/tests/access_points_tests.py
@@ -41,7 +41,7 @@ def access_point_is_present(access_point_list, access_point_name):
 @dataset({"access_points_test": {}})
 class TestAccessPoints(AbstractTestFixture):
     def test_access_points_with_stop_points(self):
-        r = self.query_region('stop_points?depth=3')
+        r = self.query_region('stop_points?depth=2')
         assert len(get_not_null(r, 'stop_points')) == 7
 
         for sp in r['stop_points']:
@@ -82,7 +82,7 @@ class TestAccessPoints(AbstractTestFixture):
                         assert ap['traversal_time'] == 26
                         assert ap['access_point']['access_point_code'] == "access_point_code_4"
 
-        # without depth=3
+        # without depth=2
         r = self.query_region('stop_points')
         assert len(get_not_null(r, 'stop_points')) == 7
 
@@ -94,8 +94,15 @@ class TestAccessPoints(AbstractTestFixture):
             if sp['name'] == 'spC':
                 assert "access_points" not in sp
 
+    def test_access_points_with_stop_points_depth_1(self):
+        r = self.query_region('stop_points?depth=1')
+        assert len(get_not_null(r, 'stop_points')) == 7
+
+        for sp in r['stop_points']:
+            assert "access_points" not in sp
+
     def test_access_points_with_places_nearby(self):
-        response = self.query_region("coords/2.362795;48.872871/places_nearby?depth=3")
+        response = self.query_region("coords/2.362795;48.872871/places_nearby?depth=2")
         assert len(response['places_nearby']) > 0
         is_valid_places(response['places_nearby'])
 
@@ -116,6 +123,15 @@ class TestAccessPoints(AbstractTestFixture):
                         assert ap['is_exit'] == True
                         assert ap['length'] == 10
                         assert ap['traversal_time'] == 23
+
+    def test_access_points_with_places_nearby_depth_1(self):
+        response = self.query_region("coords/2.362795;48.872871/places_nearby?depth=1")
+        assert len(response['places_nearby']) > 0
+        is_valid_places(response['places_nearby'])
+        sp_places_nearby = [sp for sp in response['places_nearby'] if sp["embedded_type"] == "stop_point"]
+        assert len(sp_places_nearby) == 6
+        for pn in sp_places_nearby:
+            assert "access_points" not in pn['stop_point']
 
     def test_access_points_api(self):
         r = self.query_region('access_points')

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -699,7 +699,7 @@ void PbCreator::Filler::fill_pb_object(const nt::StopPoint* sp, pbnavitia::StopP
         fill(sp->admin_list, stop_point->mutable_administrative_regions());
     }
     // access points
-    if (depth > 2) {
+    if (depth > 1) {
         fill_access_points(sp->access_points, stop_point);
     }
 


### PR DESCRIPTION
Jira: [NAV-2391](https://navitia.atlassian.net/browse/NAV-2391)

Some benches :

| API                  | Before correction (time ms)| After correction  (time ms)| query |
| ------------- | ------------- | ------------- | ------------- |
| stop_points  | 147.80  | 153.05 |  /stop_points?depth=2&count=500& |
| places_nearby  | 201.89  | 254.66 |  stop_areas/stop_area:IDFM:474151/places_nearby?type[]=stop_point&depth=2&distance=1936&count=500& |
| terminus_schedules  | 209.20 | 239.12  | /stop_areas/stop_area:IDFM:73626/terminus_schedules?depth=2&forbidden_uris[]=physical_mode:Bus&forbidden_uris[]=physical_mode:Car&forbidden_uris[]=physical_mode:Bike&count=20&  |
| stop_schedules  | 206.57 | 237.03  |  stop_areas/stop_area:IDFM:73626/stop_schedules?depth={depth}&forbidden_uris[]=physical_mode:Bus&forbidden_uris[]=physical_mode:Car&forbidden_uris[]=physical_mode:Bike&count=20& |
| journeys  | 466.75 | 178.06|  /journeys?from=stop_area:IDFM:474151&to=stop_area:IDFM:71161&allowed_id[]=network:IDFM:741&_override_scenario=distributed& |



Only  places_nearby API with depth = 2, 3:

- depth = 2 : 254.66ms (access_points in response)
- depth = 3 : 525.89ms ( In prod)


[NAV-2391]: https://navitia.atlassian.net/browse/NAV-2391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ