### PR TITLE
[Kraken] fix fare when stop_point_uri are invalid

### DIFF
--- a/source/fare/fare.cpp
+++ b/source/fare/fare.cpp
@@ -291,8 +291,20 @@ results Fare::compute_fare(const pbnavitia::PtFaresRequest::PtJourney& pt_journe
     for (const auto& s : pt_journey.pt_sections()) {
         const auto& first_sp_uri = s.first_stop_point_uri();
         const auto& last_sp_uri = s.last_stop_point_uri();
-        const auto* first_stop_point = data.pt_data->stop_points_map.find(first_sp_uri)->second;
-        const auto* last_stop_point = data.pt_data->stop_points_map.find(last_sp_uri)->second;
+
+        const auto first_it = data.pt_data->stop_points_map.find(first_sp_uri);
+        if (first_it == data.pt_data->stop_points_map.cend()) {
+            LOG4CPLUS_ERROR(logger, "stop point uri cannot be found %s" << first_sp_uri);
+            return {};
+        }
+        const auto last_it = data.pt_data->stop_points_map.find(last_sp_uri);
+        if (last_it == data.pt_data->stop_points_map.cend()) {
+            LOG4CPLUS_ERROR(logger, "stop point uri cannot be found %s" << last_sp_uri);
+            return {};
+        }
+
+        const auto* first_stop_point = first_it->second;
+        const auto* last_stop_point = last_it->second;
         SectionKey section_key{s, *first_stop_point, *last_stop_point};
 
         labels = compute_labels(nb_nodes, labels, section_key);

--- a/source/fare/fare_api.cpp
+++ b/source/fare/fare_api.cpp
@@ -40,10 +40,13 @@ namespace fare {
 
 void fill_fares(PbCreator& pb_creator, const pbnavitia::PtFaresRequest& fares) {
     for (const pbnavitia::PtFaresRequest::PtJourney& pt_journey : fares.pt_journeys()) {
+        auto tickets = pb_creator.data->fare->compute_fare(pt_journey, *pb_creator.data);
+        if (tickets.not_found) {
+            continue;
+        }
         pbnavitia::PtJourneyFare* pb_journey_fare = pb_creator.add_pt_journey_fares();
         pb_journey_fare->set_journey_id(pt_journey.id());
 
-        auto tickets = pb_creator.data->fare->compute_fare(pt_journey, *pb_creator.data);
         pb_creator.fill_fare(pb_journey_fare->mutable_fare(), nullptr, tickets);
     }
 }

--- a/source/fare/tests/fare_integration_test.cpp
+++ b/source/fare/tests/fare_integration_test.cpp
@@ -295,3 +295,96 @@ BOOST_AUTO_TEST_CASE(test_fare_api) {
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].cost().currency(), "euro");
     BOOST_CHECK_EQUAL(ticket[pb_fare.ticket_id(1)].section_id(0), "section_3");
 }
+
+BOOST_AUTO_TEST_CASE(test_fare_api_with_invalid_stop_point) {
+    ed::builder b("20120614");
+    b.vj_with_network("RATP", "A", "11111111", "", true, "")("stop1", 8000, 8050)("stop2", 8100, 8150)("stop3", 8200,
+                                                                                                       8250);
+    b.vj_with_network("RATP", "B", "11111111", "", true, "")("stop4", 8000, 8050)("stop2", 8300, 8350)("stop5", 8400,
+                                                                                                       8450);
+    b.connection("stop1", "stop1", 120);
+    b.connection("stop2", "stop2", 120);
+    b.connection("stop3", "stop3", 120);
+    b.connection("stop4", "stop4", 120);
+    b.connection("stop5", "stop5", 120);
+    b.make();
+    b.data->compute_labels();
+    b.data->meta->production_date =
+        boost::gregorian::date_period(boost::gregorian::date(2012, 06, 14), boost::gregorian::days(7));
+
+    RAPTOR raptor(*b.data);
+
+    // fare data initialization
+    boost::gregorian::date start_date(boost::gregorian::from_undelimited_string("20110101"));
+    boost::gregorian::date end_date(boost::gregorian::from_undelimited_string("20350101"));
+    b.data->fare->fare_map["price1"].add(start_date, end_date, fare::Ticket("price1", "Ticket vj 1", 100, "125"));
+    b.data->fare->fare_map["price2"].add(start_date, end_date, fare::Ticket("price2", "Ticket vj 2", 200, "175"));
+
+    // dummy transition
+    fare::Transition transitionA;
+    fare::State endA;
+    endA.line = "A";
+    transitionA.ticket_key = "price1";
+    auto endA_v = boost::add_vertex(endA, b.data->fare->g);
+    boost::add_edge(b.data->fare->begin_v, endA_v, transitionA, b.data->fare->g);
+
+    fare::Transition transitionB;
+    fare::State endB;
+    endB.line = "B";
+    transitionB.ticket_key = "price2";
+    auto endB_v = boost::add_vertex(endB, b.data->fare->g);
+    boost::add_edge(b.data->fare->begin_v, endB_v, transitionB, b.data->fare->g);
+
+    // call to raptor
+    type::EntryPoint origin(type::Type_e::StopArea, "stop1");
+    type::EntryPoint destination(type::Type_e::StopArea, "stop5");
+
+    georef::StreetNetwork sn_worker(*b.data->geo_ref);
+    const auto* data_ptr = b.data.get();
+    navitia::PbCreator pb_creator(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+    make_response(pb_creator, raptor, origin, destination, {test::to_posix_timestamp("20120614T080000")}, true,
+                  type::AccessibiliteParams(), {}, {}, sn_worker, type::RTLevel::Base, 2_min);
+    pbnavitia::Response resp = pb_creator.get_response();
+    BOOST_REQUIRE_EQUAL(resp.response_type(), pbnavitia::ITINERARY_FOUND);
+    BOOST_REQUIRE_EQUAL(resp.journeys_size(), 1);
+
+    const pbnavitia::Journey& journey = resp.journeys(0);
+
+    // from journey we create the PrJourneyReuqest:
+    pbnavitia::PtFaresRequest pt_fare_request{};
+
+    auto* pt_fare_journey = pt_fare_request.add_pt_journeys();
+    pt_fare_journey->set_id("pt_jourey_1");
+
+    for (const auto& section : journey.sections()) {
+        if (section.type() != pbnavitia::PUBLIC_TRANSPORT) {
+            continue;
+        }
+
+        auto* pt_fare_section = pt_fare_journey->add_pt_sections();
+
+        pt_fare_section->set_id(section.id());
+        pt_fare_section->set_network_uri(section.pt_display_informations().uris().network());
+        pt_fare_section->set_start_stop_area_uri(section.origin().uri());
+        pt_fare_section->set_end_stop_area_uri(section.destination().uri());
+        pt_fare_section->set_line_uri(section.pt_display_informations().uris().line());
+        pt_fare_section->set_begin_date_time(section.begin_date_time());
+        pt_fare_section->set_end_date_time(section.end_date_time());
+
+        pt_fare_section->set_first_stop_point_uri("INVALID_STOP_POINT_URI");
+
+        auto last_stop_point = section.stop_date_times().rbegin()->stop_point();
+        pt_fare_section->set_last_stop_point_uri(last_stop_point.uri());
+
+        pt_fare_section->set_physical_mode(section.pt_display_informations().physical_mode());
+    }
+
+    navitia::PbCreator pb_creator_fare(data_ptr, boost::gregorian::not_a_date_time, null_time_period);
+
+    fare::fill_fares(pb_creator_fare, pt_fare_request);
+
+    const auto& fare_response = pb_creator_fare.get_response();
+    const auto& pt_journey_fares = fare_response.pt_journey_fares();
+
+    BOOST_REQUIRE_EQUAL(pt_journey_fares.size(), 0);
+}


### PR DESCRIPTION
Kraken crashes when receiving a pt_fare in which stop_point_uri cannot be found in kraken's data 