### PR TITLE
[jormungandr]: Fix realtime in future

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -184,9 +184,9 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         if not stop_schedule.HasField('first_datetime'):
             return None
         first_datetime = stop_schedule.first_datetime
-        if not first_datetime.HasField('base_date_time'):
+        if not first_datetime.HasField('date'):
             return None
-        return first_datetime.base_date_time
+        return first_datetime.date
 
     def _update_stop_schedule(self, request, stop_schedule, next_realtime_passages, groub_by_dest=False):
         """
@@ -198,7 +198,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         If next_realtime_passages is None (and not if it's []) it means that the proxy failed,
         so we use the base schedule
 
-        If next_realtime_passages is empty and (now < first_datetime or first_datetime = None)
+        If next_realtime_passages is empty and (now < first_datetime.date or first_datetime = None)
         we return None to use the base schedule
         """
         if next_realtime_passages is None:
@@ -227,7 +227,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         if not len(stop_schedule.date_times) and not stop_schedule.HasField('response_status'):
             stop_schedule.response_status = type_pb2.no_departure_this_day
 
-    # By default filter passage if they are on the same route point
+    # By default, filter passage if they are on the same route point
     def _filter_base_passage(self, passage, route_point):
         return RoutePoint(passage.route, passage.stop_point) == route_point
 

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -180,7 +180,15 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
             note.uri = 'note:{md5}'.format(md5=note_uri)  # the id is a md5 of the direction to factorize them
             new_dt.properties.notes.extend([note])
 
-    def _update_stop_schedule(self, stop_schedule, next_realtime_passages, groub_by_dest=False):
+    def _get_first_datetime(self, stop_schedule):
+        if not stop_schedule.HasField('first_datetime'):
+            return None
+        first_datetime = stop_schedule.first_datetime
+        if not first_datetime.HasField('base_date_time'):
+            return None
+        return first_datetime.base_date_time
+
+    def _update_stop_schedule(self, request, stop_schedule, next_realtime_passages, groub_by_dest=False):
         """
         Update the stopschedule response with the new realtime passages
 
@@ -189,9 +197,18 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
 
         If next_realtime_passages is None (and not if it's []) it means that the proxy failed,
         so we use the base schedule
+
+        If next_realtime_passages is empty and (now < first_datetime or first_datetime = None)
+        we return None to use the base schedule
         """
         if next_realtime_passages is None:
             return
+
+        if not next_realtime_passages:
+            datetime_now = date_to_timestamp(request['_current_datetime'])
+            first_datetime = self._get_first_datetime(stop_schedule)
+            if first_datetime is None or datetime_now < first_datetime:
+                return
 
         logging.getLogger(__name__).debug(
             'next passages: : {}'.format(["dt: {}".format(d.datetime) for d in next_realtime_passages])

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -366,7 +366,7 @@ class MixedSchedule(object):
 
         for future in gevent.iwait(futures):
             rt_proxy, schedule, next_rt_passages = future.get()
-            rt_proxy._update_stop_schedule(schedule, next_rt_passages, groub_by_dest)
+            rt_proxy._update_stop_schedule(request, schedule, next_rt_passages, groub_by_dest)
 
     def _manage_occupancies(self, schedules):
         vo_service = self.instance.external_service_provider_manager.get_vehicle_occupancy_service()

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -129,7 +129,7 @@ class TestDepartures(AbstractTestFixture):
         response = self.query_region(query)
         stop_schedules = response['stop_schedules'][0]['date_times']
         next_passage_dts = [dt["date_time"] for dt in stop_schedules]
-        assert len(next_passage_dts) == 0
+        # assert len(next_passage_dts) == 0
 
         for dt in stop_schedules:
             assert dt['data_freshness'] == 'base_schedule'

--- a/source/jormungandr/tests/proxy_realtime_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_tests.py
@@ -129,7 +129,9 @@ class TestDepartures(AbstractTestFixture):
         response = self.query_region(query)
         stop_schedules = response['stop_schedules'][0]['date_times']
         next_passage_dts = [dt["date_time"] for dt in stop_schedules]
-        # assert len(next_passage_dts) == 0
+        # Here since realtime_passages is empty and first_datetime absent we return None
+        # so that stop_schedule with one date_times is not updated
+        assert len(next_passage_dts) == 1
 
         for dt in stop_schedules:
             assert dt['data_freshness'] == 'base_schedule'

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -412,6 +412,8 @@ class TestDepartures(AbstractTestFixture):
     def test_stop_schedule_with_rt_empty_list(self):
         """
         When timeo service responds a empty list, we return the empty rt list
+        But with first_datetime.base_date_time = 0 we return rtlist = None
+        and stop_schedule contains only base_schedule
         """
         query = self.query_template_scs.format(
             sp='S40', dt='20160102T0900', data_freshness='', c_dt='20160102T0900'
@@ -420,7 +422,7 @@ class TestDepartures(AbstractTestFixture):
         stop_schedules = response['stop_schedules']
         assert len(stop_schedules) == 1
         stop_times = stop_schedules[0]['date_times']
-        assert len(stop_times) == 0
+        assert len(stop_times) == 1
 
     def test_stop_schedule_with_rt_and_without_destination(self):
         query = self.query_template_scs.format(
@@ -1028,8 +1030,8 @@ class TestDepartures(AbstractTestFixture):
         tmp = terminus_schedules[0]
 
         assert tmp["display_informations"]["direction"] == "EE"
-        assert len(tmp['date_times']) == 0
-        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert len(tmp['date_times']) == 2
+        #assert tmp['additional_informations'] == 'no_departure_this_day'
 
     def test_terminus_schedule_groub_by_destination_partial_terminus(self):
         """

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -1033,7 +1033,6 @@ class TestDepartures(AbstractTestFixture):
         assert len(tmp['date_times']) == 0
         assert tmp['additional_informations'] == 'no_departure_this_day'
 
-
     def test_terminus_schedule_groub_by_destination_partial_terminus(self):
         """
         Schema line:

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -411,8 +411,8 @@ class TestDepartures(AbstractTestFixture):
 
     def test_stop_schedule_with_rt_empty_list(self):
         """
-        When timeo service responds a empty list, we return the empty rt list
-        But with first_datetime.base_date_time = 0 we return rtlist = None
+        When timeo service responds empty list, we return the empty rt list
+        But with first_datetime absent we return rtlist = None
         and stop_schedule contains only base_schedule
         """
         query = self.query_template_scs.format(
@@ -696,7 +696,7 @@ class TestDepartures(AbstractTestFixture):
         assert len(terminus_schedules) == 2
         ts = terminus_schedules[0]
         assert ts['additional_informations'] == 'no_departure_this_day'
-        assert ts['display_informations']['direction'] == 'TS_D'
+        assert ts['display_informations']['direction'] == 'TS_E'
         assert len(ts['date_times']) == 0
 
         ts = terminus_schedules[1]
@@ -704,7 +704,7 @@ class TestDepartures(AbstractTestFixture):
         assert ts['display_informations']['direction'] == 'TS_A'
         assert len(ts['date_times']) == 0
 
-    def test_terminus_schedule_2(self):
+    def test_terminus_schedule_3(self):
         """
         Terminus_schedule
                         // 1 line, 2 routes and 2 VJs
@@ -1030,7 +1030,9 @@ class TestDepartures(AbstractTestFixture):
         tmp = terminus_schedules[0]
 
         assert tmp["display_informations"]["direction"] == "EE"
-        assert len(tmp['date_times']) == 2
+        assert len(tmp['date_times']) == 0
+        assert tmp['additional_informations'] == 'no_departure_this_day'
+
 
     def test_terminus_schedule_groub_by_destination_partial_terminus(self):
         """

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -1031,7 +1031,6 @@ class TestDepartures(AbstractTestFixture):
 
         assert tmp["display_informations"]["direction"] == "EE"
         assert len(tmp['date_times']) == 2
-        #assert tmp['additional_informations'] == 'no_departure_this_day'
 
     def test_terminus_schedule_groub_by_destination_partial_terminus(self):
         """

--- a/source/time_tables/tests/departure_board_test_data.h
+++ b/source/time_tables/tests/departure_board_test_data.h
@@ -152,6 +152,10 @@ struct departure_board_fixture {
                 b.vj("Line2").route("Route12").name("BB:VJ2")("AA:sp", "07:55"_t)("BB:sp", "08:55"_t)(
                     "CC:sp", "09:30"_t)("DD:sp", "10:10"_t);
                 b.lines.find("Line2")->second->properties["realtime_system"] = "Hove数字";
+                b.lines.find("Line2")->second->opening_time =
+                    boost::make_optional(boost::posix_time::duration_from_string("02:00"));
+                b.lines.find("Line2")->second->closing_time =
+                    boost::make_optional(boost::posix_time::duration_from_string("14:00"));
 
                 // Terminus_schedule
                 // 1 line, 2 routes and 2 VJs

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -331,6 +331,7 @@ BOOST_AUTO_TEST_CASE(first_last_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules_size(), 1);
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).has_first_datetime(), false);
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).has_last_datetime(), false);
+        BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(), 1);
 
         // Case 1 :
         //
@@ -359,6 +360,7 @@ BOOST_AUTO_TEST_CASE(first_last_test1) {
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).first_datetime().base_date_time(), "20150615T060000"_pts);
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).last_datetime().time(), "10:00"_t);
         BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).last_datetime().base_date_time(), "20150615T100000"_pts);
+        BOOST_REQUIRE_EQUAL(resp.stop_schedules(0).date_times_size(), 1);
 
         // Case 2 :
         //


### PR DESCRIPTION
How it works:
* In apis as stop_schedules, departures.. we have first_datetime, date_times[] and last_datetime
* When realtime is active for a line (line.properties['realtime_system']='realtime_xxx'  where realtime_xxx is a service_id configured), date_times are updated by realtime date_times returned by the service.
* When realtime date_times is empty at present we should reply 'no_departure_this_day' (works well)
* When request navitia is in future and realtime date_times is not empty, all the realtime date_times are filtered and response navitia is not updated (base_schedule).
* **When request navitia is in future and realtime date_times is empty, we have realtime without any date_times : Error**

Corrections:
* For a request navitia in future (datetime_now < first_datetime.date) navitia should reply base_schedule.

Refer to: https://navitia.atlassian.net/browse/NAV-2545