### PR TITLE
split front and back images building in two separate jobs

### DIFF
--- a/.github/workflows/dockers_builder.yml
+++ b/.github/workflows/dockers_builder.yml
@@ -129,9 +129,9 @@ jobs:
           rm -rf ./*
           rm -rf ./.??*
 
-  debian8_images:
-    runs-on: [self-hosted, corefront, sandbox]
-    name: Build debian8 images
+  debian8_back_images:
+    runs-on: [self-hosted, kraken, sandbox]
+    name: Build debian8 back images
     needs: common_variables
     steps:
       - name: force chown to avoid errors
@@ -187,7 +187,6 @@ jobs:
         with:
           # 162230498103 : shared
           # 110444322584 : kraken sbx
-          # 051314639660 : corefront sbx
           registries: "162230498103,110444322584,051314639660"
 
       - name: Create master docker
@@ -201,10 +200,6 @@ jobs:
 
       - name: Create navitia images
         run: |
-          for component in ${{env.front_debian8_components}}; do
-              echo "*********  Building $component ***************"
-              docker build -t navitia/$component -f  docker/debian8/Dockerfile-${component} .
-          done
           for component in ${{env.backend_debian8_components}}; do
               echo "*********  Building $component ***************"
               docker build -t navitia/$component --build-arg GITHUB_TOKEN=${{ steps.ci-core-app-token.outputs.token }} -f  docker/debian8/Dockerfile-${component} .
@@ -213,11 +208,6 @@ jobs:
       - name: Push dev images on SBX ECR
         if: github.ref == 'refs/heads/dev'
         run: |
-          for component in ${{env.front_debian8_components}}; do
-              component_tag=${SBX_ECR_REGISTRY_FRONT}/${component}:dev
-              docker tag navitia/$component ${component_tag}
-              docker push ${component_tag}
-          done
           for component in ${{env.backend_debian8_components}}; do
             component_tag=${SBX_ECR_REGISTRY_BACKEND}/${component}:dev
             docker tag navitia/$component ${component_tag}
@@ -227,11 +217,6 @@ jobs:
       - name: Push release images on PRD ECR
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          # Tyr-web
-          tyr_web_tag=${PRD_ECR_REGISTRY}/navitia-tyr-web-tyr-web:${{ needs.common_variables.outputs.RELEASE_TAG }}
-          docker tag navitia/tyr-web ${tyr_web_tag}
-          docker push ${tyr_web_tag}
-
           # Kraken
           kraken_tag=${PRD_ECR_REGISTRY}/navitia-kraken-kraken:${{ needs.common_variables.outputs.RELEASE_TAG }}
           docker tag navitia/kraken ${kraken_tag}
@@ -264,11 +249,93 @@ jobs:
           rm -rf ./*
           rm -rf ./.??*
 
+  debian8_front_images:
+    runs-on: [self-hosted, corefront, sandbox]
+    name: Build debian8 front images
+    needs: common_variables
+    steps:
+      - name: force chown to avoid errors
+        run: sudo chown -R $USER:$USER .
+
+      - name: Git config
+        run: git config --global --add safe.directory /__w/navitia/navitia
+
+      - name: Generate github private access token
+        id: ci-core-app-token
+        uses: getsentry/action-github-app-token@v2.0.0
+        with:
+          app_id: ${{ secrets.CI_CORE_APP_ID }}
+          private_key: ${{ secrets.CI_CORE_APP_PEM }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ steps.ci-core-app-token.outputs.token }}
+
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+        env:
+          AWS_REGION: eu-west-1
+        with:
+          # 162230498103 : shared
+          # 051314639660 : corefront sbx
+          registries: "162230498103,110444322584,051314639660"
+
+      - name: Create master docker
+        run: |
+          docker build -f docker/debian8/Dockerfile-master -t navitia/master .
+          docker build -f docker/debian8/Dockerfile-builder -t navitia/builder .
+
+      - name: Build packages in master docker
+        #  Will build navitia-*.deb packages in current folder
+        run: docker run -v `pwd`:/build/navitia/  navitia/builder
+
+      - name: Create navitia images
+        run: |
+          for component in ${{env.front_debian8_components}}; do
+              echo "*********  Building $component ***************"
+              docker build -t navitia/$component -f  docker/debian8/Dockerfile-${component} .
+          done
+
+      - name: Push dev images on SBX ECR
+        if: github.ref == 'refs/heads/dev'
+        run: |
+          for component in ${{env.front_debian8_components}}; do
+              component_tag=${SBX_ECR_REGISTRY_FRONT}/${component}:dev
+              docker tag navitia/$component ${component_tag}
+              docker push ${component_tag}
+          done
+
+      - name: Push release images on PRD ECR
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          # Tyr-web
+          tyr_web_tag=${PRD_ECR_REGISTRY}/navitia-tyr-web-tyr-web:${{ needs.common_variables.outputs.RELEASE_TAG }}
+          docker tag navitia/tyr-web ${tyr_web_tag}
+          docker push ${tyr_web_tag}
+
+      - name: failure notification
+        if: failure()
+        run: |
+          sudo apt update && sudo apt install -y httpie
+          echo '{"text":":warning: Github Actions: workflow dockers_builder debian8_images failed !"}' | http --json POST ${{secrets.SLACK_NAVITIA_TEAM_URL}}
+
+      - name: clean up workspace
+        if: ${{ always() }}
+        run: |
+          # some files are created by a docker container
+          sudo chown -R $USER:$USER .
+          rm -rf ./*
+          rm -rf ./.??*
+
+
 
   publish_aws:
     runs-on: [self-hosted, corefront, sandbox]
     name: Aws Dispatch (Dev)
-    needs: [debian8_images, debian11_images, common_variables]
+    needs: [debian8_front_images, debian8_back_images, debian11_images, common_variables]
     steps:
 
       - name: Generate token for aws images


### PR DESCRIPTION
Back images are built in a kraken-sbx runner, and front images in a corefront-sbx runner, in order to be able to push images on the right ecr.