### PR TITLE
[jormun]: For departure_boards, group_by_destination is activable in config

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -220,6 +220,8 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         for passage in next_realtime_passages:
             if not self._is_valid_direction(direction_uri, passage.direction_uri, group_by_dest):
                 continue
+            # If the route direction  doesn't match with departure.direction of forseti then
+            # we should add direction name as note
             add_direction = direction_uri != passage.direction_uri
             self._add_datetime(stop_schedule, passage, add_direction)
 

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -156,7 +156,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
     def _filter_base_stop_schedule(self, date_time):
         return True
 
-    def _is_valid_direction(self, direction_uri, passage_direction_uri):
+    def _is_valid_direction(self, direction_uri, passage_direction_uri, group_by_dest):
         return True
 
     def _add_datetime(self, stop_schedule, passage, add_direction):
@@ -188,7 +188,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
             return None
         return first_datetime.date
 
-    def _update_stop_schedule(self, request, stop_schedule, next_realtime_passages, groub_by_dest=False):
+    def _update_stop_schedule(self, request, stop_schedule, next_realtime_passages, group_by_dest=False):
         """
         Update the stopschedule response with the new realtime passages
 
@@ -218,7 +218,7 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
         pb_del_if(stop_schedule.date_times, self._filter_base_stop_schedule)
         direction_uri = stop_schedule.pt_display_informations.uris.stop_area
         for passage in next_realtime_passages:
-            if groub_by_dest and not self._is_valid_direction(direction_uri, passage.direction_uri):
+            if not self._is_valid_direction(direction_uri, passage.direction_uri, group_by_dest):
                 continue
             add_direction = direction_uri != passage.direction_uri
             self._add_datetime(stop_schedule, passage, add_direction)

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
@@ -61,8 +61,59 @@ def realtime_proxy_creation_test():
     timeo = manager.get('proxy_id')
 
     assert timeo
-    timeo.service_url = 'http://custom_url.com'
-    timeo.service_args = {'serviceID': 'custom_id', 'EntityID': 'custom_entity', 'Media': 'custom_media'}
+    assert timeo.service_url == 'http://custom_url.com'
+    assert timeo.service_args == {'serviceID': 'custom_id', 'EntityID': 'custom_entity', 'Media': 'custom_media'}
+
+
+def realtime_proxy_verify_default_value_test():
+    """
+    SytralRT proxy without param group_by_destination
+    """
+    config = [
+        {
+            'id': 'SytralRT',
+            'object_id_tag': 'source',
+            'class': 'jormungandr.realtime_schedule.sytral.Sytral',
+            'args': {
+                'service_url': 'http://custom_url.com',
+                'timeout': 10
+            },
+        }
+    ]
+
+    manager = RealtimeProxyManager(config, MockInstance())
+    sytral = manager.get('SytralRT')
+
+    assert sytral
+    assert sytral.service_url == 'http://custom_url.com'
+    assert sytral.timeout == 10
+    assert sytral.group_by_destination is False
+
+
+def realtime_proxy_verify_added_param_test():
+    """
+     SytralRT proxy with param group_by_destination
+    """
+    config = [
+        {
+            'id': 'SytralRT',
+            'object_id_tag': 'source',
+            'class': 'jormungandr.realtime_schedule.sytral.Sytral',
+            'args': {
+                'service_url': 'http://custom_url.com',
+                'timeout': 10,
+                'group_by_destination': True
+            },
+        }
+    ]
+
+    manager = RealtimeProxyManager(config, MockInstance())
+    sytral = manager.get('SytralRT')
+
+    assert sytral
+    assert sytral.service_url == 'http://custom_url.com'
+    assert sytral.timeout == 10
+    assert sytral.group_by_destination is True
 
 
 def wrong_realtime_proxy_class_test():

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
@@ -74,7 +74,7 @@ def realtime_proxy_verify_default_value_test():
             'id': 'SytralRT',
             'object_id_tag': 'source',
             'class': 'jormungandr.realtime_schedule.sytral.Sytral',
-            'args': {'service_url': 'http://custom_url.com', 'timeout': 10},
+            'args': {'service_url': 'https://custom_url.com', 'timeout': 10},
         }
     ]
 
@@ -82,7 +82,7 @@ def realtime_proxy_verify_default_value_test():
     sytral = manager.get('SytralRT')
 
     assert sytral
-    assert sytral.service_url == 'http://custom_url.com'
+    assert sytral.service_url == 'https://custom_url.com'
     assert sytral.timeout == 10
     assert sytral.group_by_destination is False
 
@@ -96,7 +96,7 @@ def realtime_proxy_verify_added_param_test():
             'id': 'SytralRT',
             'object_id_tag': 'source',
             'class': 'jormungandr.realtime_schedule.sytral.Sytral',
-            'args': {'service_url': 'http://custom_url.com', 'timeout': 10, 'group_by_destination': True},
+            'args': {'service_url': 'https://custom_url.com', 'timeout': 10, 'group_by_destination': True},
         }
     ]
 
@@ -104,7 +104,7 @@ def realtime_proxy_verify_added_param_test():
     sytral = manager.get('SytralRT')
 
     assert sytral
-    assert sytral.service_url == 'http://custom_url.com'
+    assert sytral.service_url == 'https://custom_url.com'
     assert sytral.timeout == 10
     assert sytral.group_by_destination is True
 

--- a/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/tests/realtime_proxy_manager_test.py
@@ -74,10 +74,7 @@ def realtime_proxy_verify_default_value_test():
             'id': 'SytralRT',
             'object_id_tag': 'source',
             'class': 'jormungandr.realtime_schedule.sytral.Sytral',
-            'args': {
-                'service_url': 'http://custom_url.com',
-                'timeout': 10
-            },
+            'args': {'service_url': 'http://custom_url.com', 'timeout': 10},
         }
     ]
 
@@ -92,18 +89,14 @@ def realtime_proxy_verify_default_value_test():
 
 def realtime_proxy_verify_added_param_test():
     """
-     SytralRT proxy with param group_by_destination
+    SytralRT proxy with param group_by_destination
     """
     config = [
         {
             'id': 'SytralRT',
             'object_id_tag': 'source',
             'class': 'jormungandr.realtime_schedule.sytral.Sytral',
-            'args': {
-                'service_url': 'http://custom_url.com',
-                'timeout': 10,
-                'group_by_destination': True
-            },
+            'args': {'service_url': 'http://custom_url.com', 'timeout': 10, 'group_by_destination': True},
         }
     ]
 

--- a/source/jormungandr/jormungandr/realtime_schedule/timeo.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/timeo.py
@@ -130,7 +130,11 @@ class Timeo(RealtimeProxy):
         except:
             return self.rt_system_id
 
-    def _is_valid_direction(self, direction_uri, passage_direction_uri):
+    def _is_valid_direction(self, direction_uri, passage_direction_uri, group_by_dest):
+        # If group_by_dest is False then return True
+        # otherwise return the comparison result
+        if not group_by_dest:
+            return True
         return direction_uri == passage_direction_uri
 
     @cache.memoize(app.config.get(str('CACHE_CONFIGURATION'), {}).get(str('TIMEOUT_TIMEO'), 60))

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -342,7 +342,7 @@ class MixedSchedule(object):
 
         return resp
 
-    def _manage_realtime(self, request, schedules, groub_by_dest=False):
+    def _manage_realtime(self, request, schedules, group_by_dest=False):
         futures = []
         pool = gevent.pool.Pool(self.instance.realtime_pool_size)
 
@@ -366,7 +366,7 @@ class MixedSchedule(object):
 
         for future in gevent.iwait(futures):
             rt_proxy, schedule, next_rt_passages = future.get()
-            rt_proxy._update_stop_schedule(request, schedule, next_rt_passages, groub_by_dest)
+            rt_proxy._update_stop_schedule(request, schedule, next_rt_passages, group_by_dest)
 
     def _manage_occupancies(self, schedules):
         vo_service = self.instance.external_service_provider_manager.get_vehicle_occupancy_service()
@@ -412,7 +412,7 @@ class MixedSchedule(object):
 
         if request['data_freshness'] != RT_PROXY_DATA_FRESHNESS:
             return resp
-        self._manage_realtime(request, resp.terminus_schedules, groub_by_dest=True)
+        self._manage_realtime(request, resp.terminus_schedules, group_by_dest=True)
         self._manage_occupancies(resp.terminus_schedules)
         return resp
 
@@ -422,6 +422,6 @@ class MixedSchedule(object):
         if request['data_freshness'] != RT_PROXY_DATA_FRESHNESS:
             return resp
 
-        self._manage_realtime(request, resp.stop_schedules)
+        self._manage_realtime(request, resp.stop_schedules, group_by_dest=False)
         self._manage_occupancies(resp.stop_schedules)
         return resp


### PR DESCRIPTION
* For client as lyon, rennes and others, group_by_destination is False by default (retro-compatibility). When only one route is displayed even if the line is splitted in two directions, group_by_destination should be deactived. Ex: https://playground.navitia.io/play.html?request=https%3A%2F%2Fapi-cus.navitia.io%2Fv1%2Fcoverage%2Ffr-se-lyon%2Flines%2Fline%253Atcl%253AC24%2Fstop_areas%2Fstop_area%253Atcl%253ASA%253A5765%2Fstop_schedules%3Fcount%3D50%26

* For client as ratp, destineo group_by_destination should be activated. At least one route par direction is displayed and hence date_times should be grouped by destination. Ex: http://playground.navitia.io/play.html?request=https%3A%2F%2Fapi-cus.navitia.io%2Fv1%2Fcoverage%2Ffr-pdl%2Fstop_points%2Fstop_point%253APDL%253AMOBIITI%253AQuay%253A82%2Flines%2Fline%253APDL%253ACAC%253ALine%253A1%253ALOC%2Fstop_schedules%3Fdata_freshness%3Dbase_schedule%26

* Tests are added to verify configuration.