### PR TITLE
Fix realtime in departureboard

### DIFF
--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -240,6 +240,13 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
 
         # append the realtime passages
         for rt_passage in next_realtime_passages:
+            # As in stop_schedule, we should manage group_by_destination to decide whether we keep
+            # realtime passage comparing passage destination with route_point destination
+            # https://navitia.atlassian.net/browse/NAV-2893
+            direction_uri = route_point.fetch_direction_uri()
+            if direction_uri:
+                if not self._is_valid_direction(direction_uri, rt_passage.direction_uri, group_by_dest=False):
+                    continue
             new_passage = deepcopy(template)
             new_passage.stop_date_time.arrival_date_time = date_to_timestamp(rt_passage.datetime)
             new_passage.stop_date_time.departure_date_time = date_to_timestamp(rt_passage.datetime)

--- a/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/realtime_proxy.py
@@ -226,8 +226,6 @@ class RealtimeProxy(six.with_metaclass(ABCMeta, object)):
             self._add_datetime(stop_schedule, passage, add_direction)
 
         stop_schedule.date_times.sort(key=lambda dt: dt.date + dt.time)
-        if not len(stop_schedule.date_times) and not stop_schedule.HasField('response_status'):
-            stop_schedule.response_status = type_pb2.no_departure_this_day
 
     # By default, filter passage if they are on the same route point
     def _filter_base_passage(self, passage, route_point):

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -176,6 +176,13 @@ class RoutePoint(object):
         else:
             return None
 
+    def fetch_direction_uri(self):
+        # type: () -> Text
+        if self.pb_route.HasField("direction"):
+            return self.pb_route.direction.uri
+        else:
+            return None
+
 
 def _get_route_point_from_stop_schedule(stop_schedule):
     rp = RoutePoint(stop_point=stop_schedule.stop_point, route=stop_schedule.route)

--- a/source/jormungandr/jormungandr/schedule.py
+++ b/source/jormungandr/jormungandr/schedule.py
@@ -177,7 +177,7 @@ class RoutePoint(object):
             return None
 
     def fetch_direction_uri(self):
-        # type: () -> Text
+        # type: () -> Optional[Text]
         if self.pb_route.HasField("direction"):
             return self.pb_route.direction.uri
         else:

--- a/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
+++ b/source/jormungandr/tests/proxy_realtime_timeo_integration_tests.py
@@ -1031,7 +1031,7 @@ class TestDepartures(AbstractTestFixture):
 
         assert tmp["display_informations"]["direction"] == "EE"
         assert len(tmp['date_times']) == 0
-        assert tmp['additional_informations'] == 'no_departure_this_day'
+        assert tmp['additional_informations'] is None
 
     def test_terminus_schedule_groub_by_destination_partial_terminus(self):
         """
@@ -1048,11 +1048,11 @@ class TestDepartures(AbstractTestFixture):
         terminus_schedules = response['terminus_schedules']
         assert len(terminus_schedules) == 2
         tmp = terminus_schedules[0]
-        assert tmp["additional_informations"] == "no_departure_this_day"
+        assert tmp["additional_informations"] is None
         assert tmp["display_informations"]["direction"] == "TS_E"
         assert len(tmp['date_times']) == 0
 
         tmp = terminus_schedules[1]
-        assert tmp["additional_informations"] == "no_departure_this_day"
+        assert tmp["additional_informations"] is None
         assert tmp["display_informations"]["direction"] == "TS_A"
         assert len(tmp['date_times']) == 0


### PR DESCRIPTION
Modifications:
* When real-time date_time doesn't exist for a request to Forseti for the moment, it doesn't mean that this is true for whole day. We should not add no_departure_this_day anymore.
* As in stop_schedule, group_by_destination should also be implemented for endpoint departures.

For more details:
* https://navitia.atlassian.net/browse/NAV-2627
* https://navitia.atlassian.net/browse/NAV-2893

**Note: Modifications tested with data and configuration of coverages as lyon (forseti lyon), fr-pdl (forseti destineo) and fr-idf (forseti ratp). Connector in jormun is Sytral.**