### PR TITLE
[jormun]: add parameter requested_datetime in direct_path journey

### DIFF
--- a/source/jormungandr/jormungandr/street_network/andyamo.py
+++ b/source/jormungandr/jormungandr/street_network/andyamo.py
@@ -319,10 +319,10 @@ class Andyamo(AbstractStreetNetworkService):
         params = self._make_request_arguments_direct_path(pt_object_origin, pt_object_destination, request)
         response = self._call_andyamo('route', params)
         json_response = self.check_response_and_get_json(response)
-        return self._get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity)
+        return self._get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity, request)
 
     @staticmethod
-    def _get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity):
+    def _get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity, request):
         '''
         :param fallback_extremity: is a PeriodExtremity (a datetime and it's meaning on the fallback period)
         '''
@@ -341,7 +341,7 @@ class Andyamo(AbstractStreetNetworkService):
             journey.arrival_date_time = datetime
         journey.durations.total = journey.duration
         journey.durations.walking = journey.duration
-
+        journey.requested_date_time = request.get('datetime', 0)
         journey.distances.walking = kilometers_to_meters(andyamo_trip['summary']["length"])
 
         previous_section_endtime = journey.departure_date_time

--- a/source/jormungandr/jormungandr/street_network/andyamo.py
+++ b/source/jormungandr/jormungandr/street_network/andyamo.py
@@ -319,7 +319,9 @@ class Andyamo(AbstractStreetNetworkService):
         params = self._make_request_arguments_direct_path(pt_object_origin, pt_object_destination, request)
         response = self._call_andyamo('route', params)
         json_response = self.check_response_and_get_json(response)
-        return self._get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity, request)
+        return self._get_response(
+            json_response, pt_object_origin, pt_object_destination, fallback_extremity, request
+        )
 
     @staticmethod
     def _get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity, request):

--- a/source/jormungandr/jormungandr/street_network/geovelo.py
+++ b/source/jormungandr/jormungandr/street_network/geovelo.py
@@ -277,7 +277,7 @@ class Geovelo(AbstractStreetNetworkService):
         return self._get_matrix(resp_json)
 
     @classmethod
-    def _get_response(cls, json_response, pt_object_origin, pt_object_destination, fallback_extremity):
+    def _get_response(cls, json_response, pt_object_origin, pt_object_destination, fallback_extremity, request):
         '''
         :param fallback_extremity: is a PeriodExtremity (a datetime and it's meaning on the fallback period)
         '''
@@ -324,6 +324,7 @@ class Geovelo(AbstractStreetNetworkService):
             journey.durations.bike = journey.duration
 
             journey.distances.bike = int(geovelo_response['distances']['total'])
+            journey.requested_date_time = request.get('datetime', 0)
 
             previous_section_endtime = journey.departure_date_time
             for index, geovelo_section in enumerate(geovelo_response['sections']):
@@ -424,7 +425,7 @@ class Geovelo(AbstractStreetNetworkService):
             logging.getLogger(__name__).error('Geovelo nb response != nb requested')
             raise UnableToParse('Geovelo nb response != nb requested')
 
-        return self._get_response(resp_json, pt_object_origin, pt_object_destination, fallback_extremity)
+        return self._get_response(resp_json, pt_object_origin, pt_object_destination, fallback_extremity, request)
 
     def make_path_key(self, mode, orig_uri, dest_uri, streetnetwork_path_type, period_extremity):
         """

--- a/source/jormungandr/jormungandr/street_network/geovelo.py
+++ b/source/jormungandr/jormungandr/street_network/geovelo.py
@@ -425,7 +425,9 @@ class Geovelo(AbstractStreetNetworkService):
             logging.getLogger(__name__).error('Geovelo nb response != nb requested')
             raise UnableToParse('Geovelo nb response != nb requested')
 
-        return self._get_response(resp_json, pt_object_origin, pt_object_destination, fallback_extremity, request)
+        return self._get_response(
+            resp_json, pt_object_origin, pt_object_destination, fallback_extremity, request
+        )
 
     def make_path_key(self, mode, orig_uri, dest_uri, streetnetwork_path_type, period_extremity):
         """

--- a/source/jormungandr/jormungandr/street_network/handimap.py
+++ b/source/jormungandr/jormungandr/street_network/handimap.py
@@ -244,10 +244,12 @@ class Handimap(AbstractStreetNetworkService):
 
         response = self._call_handimap('route', params)
         json_response = self.check_response_and_get_json(response)
-        return self._get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity)
+        return self._get_response(
+            json_response, pt_object_origin, pt_object_destination, fallback_extremity, request
+        )
 
     @staticmethod
-    def _get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity):
+    def _get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity, request):
         '''
         :param fallback_extremity: is a PeriodExtremity (a datetime and it's meaning on the fallback period)
         '''
@@ -266,6 +268,7 @@ class Handimap(AbstractStreetNetworkService):
             journey.arrival_date_time = datetime
         journey.durations.total = journey.duration
         journey.durations.walking = journey.duration
+        journey.requested_date_time = request.get('datetime', 0)
 
         journey.distances.walking = kilometers_to_meters(handimap_trip['summary']["length"])
 

--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -251,7 +251,7 @@ class Here(AbstractStreetNetworkService):
             journey.departure_date_time = datetime - journey.duration
             journey.arrival_date_time = datetime
 
-        journey.requested_date_time = request['datetime']
+        journey.requested_date_time = request.get('datetime', 0)
 
         # distances
         length = here_section.get('summary', {}).get('length', 0)

--- a/source/jormungandr/jormungandr/street_network/tests/andyamo_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/andyamo_test.py
@@ -955,12 +955,19 @@ def get_response_andyamo_represents_start_true_test():
     destination = make_pt_object(type_pb2.ADDRESS, lon=-1.6740057, lat=48.097592, uri='AndyamoEnd')
     fallback_extremity = PeriodExtremity(str_to_time_stamp('20220503T060000'), True)
 
-    proto_resp = andyamo._get_response(resp_json, origin, destination, fallback_extremity)
+    proto_resp = andyamo._get_response(
+        json_response=resp_json,
+        pt_object_origin=origin,
+        pt_object_destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20220503T060000')},
+    )
 
     assert len(proto_resp.journeys) == 1
     assert proto_resp.journeys[0].durations.total == 2245
     assert proto_resp.journeys[0].durations.walking == 2245
     assert proto_resp.journeys[0].distances.walking == 2807
+    assert proto_resp.journeys[0].requested_date_time == str_to_time_stamp('20220503T060000')
 
     assert len(proto_resp.journeys[0].sections) == 1
     assert proto_resp.journeys[0].sections[0].type == response_pb2.STREET_NETWORK
@@ -981,7 +988,13 @@ def get_response_andyamo_represents_start_false_test():
     destination = make_pt_object(type_pb2.ADDRESS, lon=-1.6740057, lat=48.097592, uri='AndyamoEnd')
     fallback_extremity = PeriodExtremity(str_to_time_stamp('20220503T060000'), False)
 
-    proto_resp = andyamo._get_response(resp_json, origin, destination, fallback_extremity)
+    proto_resp = andyamo._get_response(
+        json_response=resp_json,
+        pt_object_origin=origin,
+        pt_object_destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20220503T055500')},
+    )
 
     assert len(proto_resp.journeys) == 1
     assert proto_resp.journeys[0].durations.total == 2245  # Adjusted to match the response
@@ -990,6 +1003,7 @@ def get_response_andyamo_represents_start_false_test():
     assert (
         abs(proto_resp.journeys[0].distances.walking - 2807.08) < 0.1
     )  # Allow a small difference due to rounding
+    assert proto_resp.journeys[0].requested_date_time == str_to_time_stamp('20220503T055500')
 
 
 def test_get_response_int_cast_success():  # Préparation des données de test
@@ -1008,11 +1022,18 @@ def test_get_response_int_cast_success():  # Préparation des données de test
     andyamo = Andyamo(instance=instance, service_url=fake_service_url, service_backup=service_backup, zone='')
 
     # Appel de la méthode _get_response
-    resp = andyamo._get_response(json_response, pt_object_origin, pt_object_destination, fallback_extremity)
+    resp = andyamo._get_response(
+        json_response=json_response,
+        pt_object_origin=pt_object_origin,
+        pt_object_destination=pt_object_destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20220503T123000')},
+    )
 
     assert resp.journeys[0].sections[0].street_network.path_items[0].direction == 0
     assert resp.journeys[0].sections[0].street_network.path_items[2].direction == -90
     assert resp.journeys[0].sections[0].street_network.path_items[4].direction == 90
+    assert resp.journeys[0].requested_date_time == str_to_time_stamp('20220503T123000')
 
 
 def create_pt_object(lon, lat, pt_object_type=type_pb2.POI):

--- a/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/handimap_test.py
@@ -348,12 +348,19 @@ def get_response_handimap_represents_start_true_test():
     destination = make_pt_object(type_pb2.ADDRESS, lon=-1.6740057, lat=48.097592, uri='HandimapEnd')
     fallback_extremity = PeriodExtremity(str_to_time_stamp('20220503T060000'), True)
 
-    proto_resp = handimap._get_response(resp_json, origin, destination, fallback_extremity)
+    proto_resp = handimap._get_response(
+        json_response=resp_json,
+        pt_object_origin=origin,
+        pt_object_destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20220503T060000')},
+    )
 
     assert len(proto_resp.journeys) == 1
     assert proto_resp.journeys[0].durations.total == 126
     assert proto_resp.journeys[0].durations.walking == 126
     assert proto_resp.journeys[0].distances.walking == 412
+    assert proto_resp.journeys[0].requested_date_time == str_to_time_stamp('20220503T060000')
 
     assert len(proto_resp.journeys[0].sections) == 1
     assert proto_resp.journeys[0].sections[0].type == response_pb2.STREET_NETWORK
@@ -389,12 +396,19 @@ def get_response_handimap_represents_start_false_test():
     destination = make_pt_object(type_pb2.ADDRESS, lon=-1.6740057, lat=48.097592, uri='HandimapEnd')
     fallback_extremity = PeriodExtremity(str_to_time_stamp('20220503T060000'), False)
 
-    proto_resp = handimap._get_response(resp_json, origin, destination, fallback_extremity)
+    proto_resp = handimap._get_response(
+        json_response=resp_json,
+        pt_object_origin=origin,
+        pt_object_destination=destination,
+        fallback_extremity=fallback_extremity,
+        request={'datetime': str_to_time_stamp('20220503T055500')},
+    )
 
     assert len(proto_resp.journeys) == 1
     assert proto_resp.journeys[0].durations.total == 126
     assert proto_resp.journeys[0].durations.walking == 126
     assert proto_resp.journeys[0].distances.walking == 412
+    assert proto_resp.journeys[0].requested_date_time == str_to_time_stamp('20220503T055500')
 
     assert len(proto_resp.journeys[0].sections) == 1
     assert proto_resp.journeys[0].sections[0].type == response_pb2.STREET_NETWORK

--- a/source/jormungandr/jormungandr/street_network/tests/here_test.py
+++ b/source/jormungandr/jormungandr/street_network/tests/here_test.py
@@ -292,6 +292,7 @@ def here_basic_routing_test(valid_here_routing_response):
     assert response.response_type == response_pb2.ITINERARY_FOUND
     assert len(response.journeys) == 1
     assert response.journeys[0].duration == 1468
+    assert response.journeys[0].requested_date_time == str_to_time_stamp('20161010T152000')
     assert len(response.journeys[0].sections) == 1
     section = response.journeys[0].sections[0]
     assert section.type == response_pb2.STREET_NETWORK
@@ -322,12 +323,13 @@ def here_basic_routing_test(valid_here_routing_response):
         origin=origin,
         destination=destination,
         fallback_extremity=fallback_extremity,
-        request={'datetime': str_to_time_stamp('20161010T152000')},
+        request={'datetime': str_to_time_stamp('20161010T151000')},
         direct_path_type=StreetNetworkPathType.DIRECT,
     )
     assert response.status_code == 200
     assert response.response_type == response_pb2.ITINERARY_FOUND
     assert len(response.journeys) == 1
+    assert response.journeys[0].requested_date_time == str_to_time_stamp('20161010T151000')
     assert len(response.journeys[0].sections) == 1
     section = response.journeys[0].sections[0]
     assert section.begin_date_time == str_to_time_stamp('20161010T152000')


### PR DESCRIPTION
* Attribute journey.requested_date_time is absent in direct_path journey provided by some connectors like Andyamo and Geovelo.
* Even if this information is deprecated since some years (https://github.com/hove-io/navitia/blob/c7ab2702ad8cfa6e22e8427cd6fca3b4cdbe6ff7/source/jormungandr/jormungandr/interfaces/v1/serializer/journey.py#L435), attribute is added for these two connectors.
* Attribute is present for connectors like Asgard, RideSharing, and others..

Concerned ticket:  https://navitia.atlassian.net/browse/NAV-2874
