### PR TITLE
[Jormun]: Do not fill co2 as will be filled in distributed

### DIFF
--- a/source/jormungandr/jormungandr/street_network/here.py
+++ b/source/jormungandr/jormungandr/street_network/here.py
@@ -62,10 +62,6 @@ DEFAULT_LAPSE_TIME_MATRIX_TO_RETRY = 0.1  # in secs
 # max nb points for matrix request
 MAX_MATRIX_POINTS_VALUES = 100
 
-# CO2 coeff
-CO2_ESTIMATION_COEFF_1 = 1.35
-CO2_ESTIMATION_COEFF_2 = 184
-
 
 # Possible values implemented. Full languages within the doc:
 # https://developer.here.com/documentation/routing/dev_guide/topics/resource-param-type-languages.html#languages
@@ -264,10 +260,6 @@ class Here(AbstractStreetNetworkService):
         else:
             journey.distances.taxi = length
 
-        # co2 emission
-        journey.co2_emission.unit = 'gEC'
-        journey.co2_emission.value = CO2_ESTIMATION_COEFF_1 * length / 1000.0 * CO2_ESTIMATION_COEFF_2
-
         section = journey.sections.add()
         section.type = response_pb2.STREET_NETWORK
 
@@ -288,9 +280,6 @@ class Here(AbstractStreetNetworkService):
 
         section.id = 'section_0'
         section.length = length
-
-        section.co2_emission.unit = 'gEC'
-        section.co2_emission.value = journey.co2_emission.value
 
         section.origin.CopyFrom(origin)
         section.destination.CopyFrom(destination)


### PR DESCRIPTION
In the response information on co2 is updated if absent as followings (feature developed after the connector here):

- in each section of type CAR / CAR_NO_PARC
- in context. car_direct_path

Do not fill any information on co2 in the connector Here as they will be filled by Jormun

Ticket: https://navitia.atlassian.net/browse/NAV-2795



