### PR TITLE
Add disruptions on POI

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/Places.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Places.py
@@ -396,7 +396,7 @@ class PlacesNearby(ResourceUri):
             uris = uri.split("/")
             if len(uris) >= 2:
                 args["uri"] = transform_id(uris[-1])
-                # for coherence we check the type of the object
+                # for coherence, we check the type of the object
                 obj_type = uris[-2]
                 if obj_type not in places_types:
                     abort(404, message='places_nearby api not available for {}'.format(obj_type))

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -357,6 +357,7 @@ class AddressSerializer(PbGenericSerializer):
 
 class PoiSerializer(PbGenericSerializer):
     coord = CoordSerializer(required=False)
+    links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
     label = jsonschema.Field(schema_type=str)
     administrative_regions = AdminSerializer(many=True, display_none=False)
     poi_type = PoiTypeSerializer(display_none=False)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -364,7 +364,7 @@ class AddressSerializer(PbGenericSerializer):
 
 class PoiSerializer(PbGenericSerializer):
     coord = CoordSerializer(required=False)
-    links = DisruptionLinkSerializer(attr='impact_uris', display_none=True)
+    links = DisruptionLinkSerializer(attr='impact_uris', display_none=False)
     label = jsonschema.Field(schema_type=str)
     administrative_regions = AdminSerializer(many=True, display_none=False)
     poi_type = PoiTypeSerializer(display_none=False)

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -121,6 +121,7 @@ class PtObjectSerializer(PbGenericSerializer):
     quality = jsonschema.Field(schema_type=int, required=False, display_none=True, deprecated=True)
     stop_area = jsonschema.MethodField(schema_type=lambda: StopAreaSerializer())
     stop_point = jsonschema.MethodField(schema_type=lambda: StopPointSerializer())
+    poi = jsonschema.MethodField(schema_type=lambda: PoiSerializer())
     line = jsonschema.MethodField(schema_type=lambda: LineSerializer())
     network = jsonschema.MethodField(schema_type=lambda: NetworkSerializer())
     route = jsonschema.MethodField(schema_type=lambda: RouteSerializer())
@@ -167,6 +168,12 @@ class PtObjectSerializer(PbGenericSerializer):
     def get_stop_point(self, obj):
         if obj.HasField(str('stop_point')):
             return StopPointSerializer(obj.stop_point, display_none=False).data
+        else:
+            return None
+
+    def get_poi(self, obj):
+        if obj.HasField(str('poi')):
+            return PoiSerializer(obj.poi, display_none=False).data
         else:
             return None
 

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -506,14 +506,13 @@ def update_disruptions_on_pois(instance, pb_resp):
     poi_uris = set()
     for j in pb_resp.journeys:
         for s in j.sections:
-            # For origin / destination of type poi call loki to get disruptions
             if s.origin.embedded_type == type_pb2.POI:
                 poi_uris.add(s.origin.uri)
 
             if s.destination.embedded_type == type_pb2.POI:
                 poi_uris.add(s.destination.uri)
 
-    # Get disruptions for poi_uris calling loki with api poi_disruptions
+    # Get disruptions for poi_uris calling loki with api poi_disruptions and poi_uris in param
     poi_disruptions = get_disruptions_on_poi(instance, poi_uris)
     if poi_disruptions is None:
         return

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -38,7 +38,7 @@ import navitiacommon.request_pb2 as request_pb2
 from navitiacommon.type_pb2 import ActiveStatus, Severity
 from jormungandr.interfaces.common import pb_odt_level
 from jormungandr.scenarios.utils import places_type, pt_object_type, add_link
-from jormungandr.scenarios.utils import build_pagination
+from jormungandr.scenarios.utils import build_pagination, fill_disruptions_on_pois, fill_disruptions_on_places_nearby
 from jormungandr.exceptions import UnknownObject
 
 
@@ -301,6 +301,8 @@ class Scenario(object):
         req.places_nearby.filter = request["filter"]
         req.disable_disruption = request["disable_disruption"] if request.get("disable_disruption") else False
         resp = instance.send_and_receive(req)
+        # For pois, ws should also call loki to get disruptions on pois
+        fill_disruptions_on_places_nearby(instance, resp)
         build_pagination(request, resp)
         return resp
 
@@ -335,6 +337,9 @@ class Scenario(object):
         else:
             resp = instance.send_and_receive(req)
 
+            # For api = pois, ws should also call loki to get disruptions on pois
+            if req.ptref.requested_type == type_pb2.POI:
+                fill_disruptions_on_pois(instance, resp)
         build_pagination(request, resp)
         return resp
 

--- a/source/jormungandr/jormungandr/scenarios/simple.py
+++ b/source/jormungandr/jormungandr/scenarios/simple.py
@@ -38,7 +38,11 @@ import navitiacommon.request_pb2 as request_pb2
 from navitiacommon.type_pb2 import ActiveStatus, Severity
 from jormungandr.interfaces.common import pb_odt_level
 from jormungandr.scenarios.utils import places_type, pt_object_type, add_link
-from jormungandr.scenarios.utils import build_pagination, fill_disruptions_on_pois, fill_disruptions_on_places_nearby
+from jormungandr.scenarios.utils import (
+    build_pagination,
+    fill_disruptions_on_pois,
+    fill_disruptions_on_places_nearby,
+)
 from jormungandr.exceptions import UnknownObject
 
 
@@ -302,7 +306,8 @@ class Scenario(object):
         req.disable_disruption = request["disable_disruption"] if request.get("disable_disruption") else False
         resp = instance.send_and_receive(req)
         # For pois, ws should also call loki to get disruptions on pois
-        fill_disruptions_on_places_nearby(instance, resp)
+        if not req.disable_disruption:
+            fill_disruptions_on_places_nearby(instance, resp)
         build_pagination(request, resp)
         return resp
 
@@ -338,7 +343,7 @@ class Scenario(object):
             resp = instance.send_and_receive(req)
 
             # For api = pois, ws should also call loki to get disruptions on pois
-            if req.ptref.requested_type == type_pb2.POI:
+            if (not req.disable_disruption) and req.ptref.requested_type == type_pb2.POI:
                 fill_disruptions_on_pois(instance, resp)
         build_pagination(request, resp)
         return resp

--- a/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
@@ -32,6 +32,8 @@ from jormungandr.scenarios.helpers import (
     is_car_direct_path,
     fill_best_boarding_position,
 )
+from jormungandr.street_network.tests.streetnetwork_test_utils import make_pt_object
+from jormungandr import utils
 
 BEST_BOARDING_POSITIONS = [response_pb2.FRONT, response_pb2.MIDDLE]
 
@@ -516,3 +518,64 @@ def fill_best_boarding_position_test():
     assert response_pb2.BoardingPosition.FRONT in journey.sections[0].best_boarding_positions
     assert response_pb2.BoardingPosition.MIDDLE in journey.sections[0].best_boarding_positions
     assert response_pb2.BoardingPosition.BACK not in journey.sections[0].best_boarding_positions
+
+
+def get_response_with_a_disruption_on_poi():
+    start_period = "20240712T165200"
+    end_period = "20240812T165200"
+    response = response_pb2.Response()
+    impact = response.impacts.add()
+    impact.uri = "test_impact_uri"
+    impact.disruption_uri = "test_disruption_uri"
+    impacted_object = impact.impacted_objects.add()
+
+    # poi = make_pt_object(type_pb2.POI, lon=1, lat=2, uri='poi:test_uri')
+    # impacted_object.pt_object.CopyFrom(poi)
+    impacted_object.pt_object.name = "poi"
+    impacted_object.pt_object.uri = "poi:test_uri"
+    impacted_object.pt_object.embedded_type = type_pb2.POI
+    impact.updated_at = utils.str_to_time_stamp(u'20240712T205200')
+    application_period = impact.application_periods.add()
+    application_period.begin = utils.str_to_time_stamp(start_period)
+    application_period.end = utils.str_to_time_stamp(end_period)
+
+    # Add a message
+    message = impact.messages.add()
+    message.text = "This is the message sms"
+    message.channel.id = "sms"
+    message.channel.name = "sms"
+    message.channel.content_type = "text"
+
+    # Add a severity
+    impact.severity.effect = type_pb2.Severity.UNKNOWN_EFFECT
+    impact.severity.name = ' not blocking'
+    impact.severity.priority = 1
+    impact.contributor = "shortterm.test_poi"
+
+    return response
+
+def get_object_pois_in_ptref_response():
+    response = response_pb2.Response()
+    poi = response.pois.add()
+    poi.uri = "poi:test_uri"
+    poi.name = "test poi"
+    poi.coord.lat = 2
+    poi.coord.lon = 1
+    poi.poi_type.uri = "poi_type:amenity:parking"
+    poi.poi_type.name = "Parking P+R"
+    return response
+
+
+def get_object_pois_in_places_nearby_response():
+    response = response_pb2.Response()
+    place_nearby = response.places_nearby.add()
+    place_nearby.uri = "poi:test_uri"
+    place_nearby.name = "test poi"
+    place_nearby.embedded_type = type_pb2.POI
+    place_nearby.poi.uri = "poi:test_uri"
+    place_nearby.poi.name = "test poi"
+    place_nearby.poi.coord.lat = 2
+    place_nearby.poi.coord.lon = 1
+    place_nearby.poi.poi_type.uri = "poi_type:amenity:parking"
+    place_nearby.poi.poi_type.name = "Parking P+R"
+    return response

--- a/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
@@ -554,6 +554,7 @@ def get_response_with_a_disruption_on_poi():
 
     return response
 
+
 def get_object_pois_in_ptref_response():
     response = response_pb2.Response()
     poi = response.pois.add()

--- a/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/helpers_tests.py
@@ -531,8 +531,8 @@ def get_response_with_a_disruption_on_poi():
 
     # poi = make_pt_object(type_pb2.POI, lon=1, lat=2, uri='poi:test_uri')
     # impacted_object.pt_object.CopyFrom(poi)
-    impacted_object.pt_object.name = "poi"
-    impacted_object.pt_object.uri = "poi:test_uri"
+    impacted_object.pt_object.name = "poi_name_from_loki"
+    impacted_object.pt_object.uri = "poi_uri"
     impacted_object.pt_object.embedded_type = type_pb2.POI
     impact.updated_at = utils.str_to_time_stamp(u'20240712T205200')
     application_period = impact.application_periods.add()
@@ -558,8 +558,8 @@ def get_response_with_a_disruption_on_poi():
 def get_object_pois_in_ptref_response():
     response = response_pb2.Response()
     poi = response.pois.add()
-    poi.uri = "poi:test_uri"
-    poi.name = "test poi"
+    poi.uri = "poi_uri"
+    poi.name = "poi_name_from_kraken"
     poi.coord.lat = 2
     poi.coord.lon = 1
     poi.poi_type.uri = "poi_type:amenity:parking"
@@ -570,13 +570,68 @@ def get_object_pois_in_ptref_response():
 def get_object_pois_in_places_nearby_response():
     response = response_pb2.Response()
     place_nearby = response.places_nearby.add()
-    place_nearby.uri = "poi:test_uri"
-    place_nearby.name = "test poi"
+    place_nearby.uri = "poi_uri"
+    place_nearby.name = "poi_name_from_kraken"
     place_nearby.embedded_type = type_pb2.POI
-    place_nearby.poi.uri = "poi:test_uri"
-    place_nearby.poi.name = "test poi"
+    place_nearby.poi.uri = "poi_uri"
+    place_nearby.poi.name = "poi_name_from_kraken"
     place_nearby.poi.coord.lat = 2
     place_nearby.poi.coord.lon = 1
     place_nearby.poi.poi_type.uri = "poi_type:amenity:parking"
     place_nearby.poi.poi_type.name = "Parking P+R"
     return response
+
+
+def get_journey_with_pois():
+    response = response_pb2.Response()
+    journey = response.journeys.add()
+
+    # Walking section from 'stop_a' to 'poi:test_uri'
+    section = journey.sections.add()
+    section.type = response_pb2.STREET_NETWORK
+    section.street_network.mode = response_pb2.Walking
+    section.origin.uri = 'stop_a'
+    section.origin.embedded_type = type_pb2.STOP_POINT
+    section.destination.uri = 'poi_uri'
+    section.destination.embedded_type = type_pb2.POI
+    section.destination.poi.uri = 'poi_uri'
+    section.destination.poi.name = 'poi_name_from_kraken'
+    section.destination.poi.coord.lon = 1.0
+    section.destination.poi.coord.lat = 2.0
+
+    # Bss section from 'poi:test_uri' to 'poi_b'
+    section = journey.sections.add()
+    section.street_network.mode = response_pb2.Bss
+    section.type = response_pb2.STREET_NETWORK
+    section.origin.uri = 'poi_uri'
+    section.origin.embedded_type = type_pb2.POI
+    section.origin.poi.uri = 'poi_uri'
+    section.origin.poi.name = 'poi_name_from_kraken'
+    section.origin.poi.coord.lon = 1.0
+    section.origin.poi.coord.lat = 2.0
+    section.destination.uri = 'poi_b'
+    section.destination.embedded_type = type_pb2.POI
+
+    # Walking section from 'poi_b' to 'stop_b'
+    section = journey.sections.add()
+    section.type = response_pb2.STREET_NETWORK
+    section.street_network.mode = response_pb2.Walking
+    section.origin.uri = 'poi_b'
+    section.origin.embedded_type = type_pb2.POI
+    section.destination.uri = 'stop_b'
+    section.destination.embedded_type = type_pb2.STOP_POINT
+    return response
+
+
+def verify_poi_in_impacted_objects(object, poi_empty=True):
+    assert object.name == "poi_name_from_loki"
+    assert object.uri == "poi_uri"
+    assert object.embedded_type == type_pb2.POI
+    if poi_empty:
+        assert object.poi.uri == ''
+        assert object.poi.name == ''
+    else:
+        assert object.poi.uri == 'poi_uri'
+        assert object.poi.name == 'poi_name_from_kraken'
+        assert object.poi.coord.lon == 1.0
+        assert object.poi.coord.lat == 2.0

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -818,7 +818,9 @@ def journey_with_disruptions_on_poi_test(mocker):
     object = disruptions_with_poi.impacts[0].impacted_objects[0].pt_object
     helpers_tests.verify_poi_in_impacted_objects(object=object, poi_empty=True)
 
-    mock = mocker.patch('jormungandr.scenarios.new_default.get_disruptions_on_poi', return_value=disruptions_with_poi)
+    mock = mocker.patch(
+        'jormungandr.scenarios.new_default.get_disruptions_on_poi', return_value=disruptions_with_poi
+    )
     update_disruptions_on_pois(instance, response_journey_with_pois)
 
     assert len(response_journey_with_pois.impacts) == 1

--- a/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/new_default_tests.py
@@ -37,12 +37,14 @@ from jormungandr.scenarios.new_default import (
     _tag_journey_by_mode,
     get_kraken_calls,
     update_best_boarding_positions,
+    update_disruptions_on_pois,
 )
 from jormungandr.instance import Instance
 from jormungandr.scenarios.utils import switch_back_to_ridesharing
 from jormungandr.utils import make_origin_destination_key, str_to_time_stamp
 from werkzeug.exceptions import HTTPException
 import pytest
+from pytest_mock import mocker
 from collections import defaultdict
 
 """
@@ -798,10 +800,32 @@ DEFAULT_OLYMPICS_FORBIDDEN_URIS = {
 }
 
 
-def make_pt_object_poi(property_type="olympic", property_value="1234"):
-    pt_object_poi = type_pb2.PtObject()
-    pt_object_poi.embedded_type = type_pb2.POI
-    property = pt_object_poi.poi.properties.add()
-    property.type = property_type
-    property.value = property_value
-    return pt_object_poi
+def journey_with_disruptions_on_poi_test(mocker):
+    instance = lambda: None
+    # As in navitia, object poi in the response of places_nearby doesn't have any impact
+    response_journey_with_pois = helpers_tests.get_journey_with_pois()
+    assert len(response_journey_with_pois.impacts) == 0
+    assert len(response_journey_with_pois.journeys) == 1
+    journey = response_journey_with_pois.journeys[0]
+    assert len(journey.sections) == 3
+
+    # Prepare disruptions on poi as response of end point poi_disruptions of loki
+    # pt_object poi as impacted object is absent in the response of poi_disruptions
+    disruptions_with_poi = helpers_tests.get_response_with_a_disruption_on_poi()
+    assert len(disruptions_with_poi.impacts) == 1
+    assert disruptions_with_poi.impacts[0].uri == "test_impact_uri"
+    assert len(disruptions_with_poi.impacts[0].impacted_objects) == 1
+    object = disruptions_with_poi.impacts[0].impacted_objects[0].pt_object
+    helpers_tests.verify_poi_in_impacted_objects(object=object, poi_empty=True)
+
+    mock = mocker.patch('jormungandr.scenarios.new_default.get_disruptions_on_poi', return_value=disruptions_with_poi)
+    update_disruptions_on_pois(instance, response_journey_with_pois)
+
+    assert len(response_journey_with_pois.impacts) == 1
+    impact = response_journey_with_pois.impacts[0]
+    assert len(impact.impacted_objects) == 1
+    object = impact.impacted_objects[0].pt_object
+    helpers_tests.verify_poi_in_impacted_objects(object=object, poi_empty=False)
+
+    mock.assert_called_once()
+    return

--- a/source/jormungandr/jormungandr/scenarios/tests/utils_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/utils_tests.py
@@ -33,6 +33,7 @@ from jormungandr.scenarios.utils import fill_disruptions_on_pois, fill_disruptio
 import pytest
 from pytest_mock import mocker
 
+
 def update_disruptions_on_pois_for_ptref_test(mocker):
     instance = lambda: None
     # As in navitia, object poi in the response of ptref doesn't have any impact
@@ -73,6 +74,7 @@ def update_disruptions_on_pois_for_ptref_test(mocker):
     mock.assert_called_once()
     return
 
+
 def update_disruptions_on_pois_for_places_nearby_test(mocker):
     instance = lambda: None
     # As in navitia, object poi in the response of places_nearby doesn't have any impact
@@ -81,7 +83,6 @@ def update_disruptions_on_pois_for_places_nearby_test(mocker):
     assert len(response_places_nearby.places_nearby) == 1
     assert response_places_nearby.places_nearby[0].uri == "poi:test_uri"
     assert response_places_nearby.places_nearby[0].name == "test poi"
-
 
     # As above Prepare disruptions on poi as response of end point poi_disruptions of loki
     disruptions_with_poi = helpers_tests.get_response_with_a_disruption_on_poi()

--- a/source/jormungandr/jormungandr/scenarios/tests/utils_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/tests/utils_tests.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2001-2022, Hove and/or its affiliates. All rights reserved.
+#
+# This file is part of Navitia,
+#     the software to build cool stuff with public transport.
+#
+# Hope you'll enjoy and contribute to this project,
+#     powered by Hove (www.hove.com).
+# Help us simplify mobility and open public transport:
+#     a non ending quest to the responsive locomotion way of traveling!
+#
+# LICENCE: This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Stay tuned using
+# twitter @navitia
+# channel `#navitia` on riot https://riot.im/app/#/room/#navitia:matrix.org
+# https://groups.google.com/d/forum/navitia
+# www.navitia.io
+
+import navitiacommon.type_pb2 as type_pb2
+import jormungandr.scenarios.tests.helpers_tests as helpers_tests
+from jormungandr.scenarios.utils import fill_disruptions_on_pois, fill_disruptions_on_places_nearby
+import pytest
+from pytest_mock import mocker
+
+def update_disruptions_on_pois_for_ptref_test(mocker):
+    instance = lambda: None
+    # As in navitia, object poi in the response of ptref doesn't have any impact
+    response_pois = helpers_tests.get_object_pois_in_ptref_response()
+    assert len(response_pois.impacts) == 0
+    assert response_pois.pois[0].uri == "poi:test_uri"
+    assert response_pois.pois[0].name == "test poi"
+
+    # Prepare disruptions on poi as response of end point poi_disruptions of loki
+    # pt_object poi as impacted object is absent in the response of poi_disruptions
+    disruptions_with_poi = helpers_tests.get_response_with_a_disruption_on_poi()
+    assert len(disruptions_with_poi.impacts) == 1
+    assert disruptions_with_poi.impacts[0].uri == "test_impact_uri"
+    assert len(disruptions_with_poi.impacts[0].impacted_objects) == 1
+    assert disruptions_with_poi.impacts[0].impacted_objects[0].pt_object.name == "poi"
+    assert disruptions_with_poi.impacts[0].impacted_objects[0].pt_object.uri == "poi:test_uri"
+    assert disruptions_with_poi.impacts[0].impacted_objects[0].pt_object.embedded_type == type_pb2.POI
+    assert disruptions_with_poi.impacts[0].impacted_objects[0].pt_object.poi.uri == ''
+    assert disruptions_with_poi.impacts[0].impacted_objects[0].pt_object.poi.name == ''
+
+    mock = mocker.patch('jormungandr.scenarios.utils.get_disruptions_on_poi', return_value=disruptions_with_poi)
+    fill_disruptions_on_pois(instance, response_pois)
+
+    # In the final response, we should have a disruption as well as object poi in disruption.
+    assert len(response_pois.impacts) == 1
+    assert response_pois.pois[0].uri == "poi:test_uri"
+    assert response_pois.pois[0].name == "test poi"
+    assert len(response_pois.impacts[0].impacted_objects) == 1
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.name == "poi"
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.uri == "poi:test_uri"
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.embedded_type == type_pb2.POI
+
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.poi.name == 'test poi'
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.poi.uri == 'poi:test_uri'
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.poi.coord.lon == 1.0
+    assert response_pois.impacts[0].impacted_objects[0].pt_object.poi.coord.lat == 2.0
+
+    mock.assert_called_once()
+    return
+
+def update_disruptions_on_pois_for_places_nearby_test(mocker):
+    instance = lambda: None
+    # As in navitia, object poi in the response of places_nearby doesn't have any impact
+    response_places_nearby = helpers_tests.get_object_pois_in_places_nearby_response()
+    assert len(response_places_nearby.impacts) == 0
+    assert len(response_places_nearby.places_nearby) == 1
+    assert response_places_nearby.places_nearby[0].uri == "poi:test_uri"
+    assert response_places_nearby.places_nearby[0].name == "test poi"
+
+
+    # As above Prepare disruptions on poi as response of end point poi_disruptions of loki
+    disruptions_with_poi = helpers_tests.get_response_with_a_disruption_on_poi()
+    assert len(disruptions_with_poi.impacts) == 1
+    assert disruptions_with_poi.impacts[0].uri == "test_impact_uri"
+
+    mock = mocker.patch('jormungandr.scenarios.utils.get_disruptions_on_poi', return_value=disruptions_with_poi)
+    fill_disruptions_on_places_nearby(instance, response_places_nearby)
+
+    # In the final response, we should have a disruption as well as object poi in disruption.
+    assert len(response_places_nearby.impacts) == 1
+    assert response_places_nearby.places_nearby[0].uri == "poi:test_uri"
+    assert response_places_nearby.places_nearby[0].name == "test poi"
+    assert len(response_places_nearby.impacts[0].impacted_objects) == 1
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.name == "poi"
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.uri == "poi:test_uri"
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.embedded_type == type_pb2.POI
+
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.poi.name == 'test poi'
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.poi.uri == 'poi:test_uri'
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.poi.coord.lon == 1.0
+    assert response_places_nearby.impacts[0].impacted_objects[0].pt_object.poi.coord.lat == 2.0
+
+    mock.assert_called_once()
+    return

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -526,7 +526,7 @@ def fill_disruptions_on_places_nearby(instance, response):
     add_disruptions(response, resp_poi)
 
 
-def get_disruptions_on_poi(instance, uris):
+def get_disruptions_on_poi(instance, uris, since_datetime=None, until_datetime=None):
     if not uris:
         return None
     try:
@@ -534,8 +534,11 @@ def get_disruptions_on_poi(instance, uris):
         req = request_pb2.Request()
         req.requested_api = type_pb2.poi_disruptions
 
-        # add all poi_ids as parameters
         req.poi_disruptions.pois.extend(uris)
+        if since_datetime:
+            req.poi_disruptions.since_datetime = since_datetime
+        if until_datetime:
+            req.poi_disruptions.until_datetime = until_datetime
 
         # calling loki with api api_disruptions
         resp_poi = pt_planner.send_and_receive(req)

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -466,83 +466,85 @@ def include_poi_access_points(request, pt_object, mode):
 
 
 def get_impact_uris_for_poi(response, poi):
-    impact_uris = []
+    impact_uris = set()
     if response is None:
         return impact_uris
     for impact in response.impacts:
         for object in impact.impacted_objects:
             if object.pt_object.embedded_type == type_pb2.POI and object.pt_object.uri == poi.uri:
-                impact_uris.append(impact.uri)
+                impact_uris.add(impact.uri)
                 object.pt_object.poi.CopyFrom(poi)
 
     return impact_uris
 
 
 def fill_disruptions_on_pois(instance, response):
-    if len(response.pois) > 0:
-        # add all poi_ids as parameters
-        poi_uris = set()
-        for poi in response.pois:
-            poi_uris.add(poi.uri)
+    if not response.pois:
+        return
 
-        # calling loki with api poi_disruptions
-        resp_poi = get_disruptions_on_poi(instance, poi_uris)
+    # add all poi_ids as parameters
+    poi_uris = set()
+    for poi in response.pois:
+        poi_uris.add(poi.uri)
 
-        # For each poi in the response add impact_uris from resp_poi
-        # and copy object poi in impact.impacted_objects
-        for poi in response.pois:
-            impact_uris = get_impact_uris_for_poi(resp_poi, poi)
-            for impact_uri in impact_uris:
-                poi.impact_uris.append(impact_uri)
+    # calling loki with api poi_disruptions
+    resp_poi = get_disruptions_on_poi(instance, poi_uris)
 
-        # Add all impacts from resp_poi to the response
-        add_disruptions(response, resp_poi)
+    # For each poi in the response add impact_uris from resp_poi
+    # and copy object poi in impact.impacted_objects
+    for poi in response.pois:
+        impact_uris = get_impact_uris_for_poi(resp_poi, poi)
+        for impact_uri in impact_uris:
+            poi.impact_uris.append(impact_uri)
+
+    # Add all impacts from resp_poi to the response
+    add_disruptions(response, resp_poi)
 
 
 def fill_disruptions_on_places_nearby(instance, response):
-    if len(response.places_nearby) > 0:
-        # Add all the poi uris in a list
-        poi_uris = set()
-        for place_nearby in response.places_nearby:
-            if place_nearby.embedded_type == type_pb2.POI:
-                poi_uris.add(place_nearby.uri)
+    if not response.places_nearby:
+        return
 
-        # calling loki with api poi_disruptions
-        resp_poi = get_disruptions_on_poi(instance, poi_uris)
+    # Add all the poi uris in a list
+    poi_uris = set()
+    for place_nearby in response.places_nearby:
+        if place_nearby.embedded_type == type_pb2.POI:
+            poi_uris.add(place_nearby.uri)
 
-        # For each poi in the response add impact_uris from resp_poi
-        # and copy object poi in impact.impacted_objects
-        for place_nearby in response.places_nearby:
-            if place_nearby.embedded_type == type_pb2.POI:
-                impact_uris = get_impact_uris_for_poi(resp_poi, place_nearby.poi)
-                for impact_uri in impact_uris:
-                    place_nearby.poi.impact_uris.append(impact_uri)
+    # calling loki with api poi_disruptions
+    resp_poi = get_disruptions_on_poi(instance, poi_uris)
 
-        # Add all impacts from resp_poi to the response
-        add_disruptions(response, resp_poi)
+    # For each poi in the response add impact_uris from resp_poi
+    # and copy object poi in impact.impacted_objects
+    for place_nearby in response.places_nearby:
+        if place_nearby.embedded_type == type_pb2.POI:
+            impact_uris = get_impact_uris_for_poi(resp_poi, place_nearby.poi)
+            for impact_uri in impact_uris:
+                place_nearby.poi.impact_uris.append(impact_uri)
+
+    # Add all impacts from resp_poi to the response
+    add_disruptions(response, resp_poi)
 
 
 def get_disruptions_on_poi(instance, uris):
-    if len(uris) > 0:
-        try:
-            pt_planner = instance.get_pt_planner("loki")
-            req = request_pb2.Request()
-            req.requested_api = type_pb2.poi_disruptions
+    if not uris:
+        return  None
+    try:
+        pt_planner = instance.get_pt_planner("loki")
+        req = request_pb2.Request()
+        req.requested_api = type_pb2.poi_disruptions
 
-            # add all poi_ids as parameters
-            for uri in uris:
-                req.poi_disruptions.pois.append(uri)
+        # add all poi_ids as parameters
+        req.poi_disruptions.pois.extend(uris)
 
-            # calling loki with api api_disruptions
-            resp_poi = pt_planner.send_and_receive(req)
-        except Exception:
-            return None
-        return resp_poi
-    return None
+        # calling loki with api api_disruptions
+        resp_poi = pt_planner.send_and_receive(req)
+    except Exception:
+        return None
+    return resp_poi
 
 
 def add_disruptions(pb_resp, pb_disruptions):
     if pb_disruptions is None:
         return
-    for i in pb_disruptions.impacts:
-        pb_resp.impacts.extend([i])
+    pb_resp.impacts.extend(pb_disruptions.impacts)

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -528,7 +528,7 @@ def fill_disruptions_on_places_nearby(instance, response):
 
 def get_disruptions_on_poi(instance, uris):
     if not uris:
-        return  None
+        return None
     try:
         pt_planner = instance.get_pt_planner("loki")
         req = request_pb2.Request()


### PR DESCRIPTION
Adding disruptions on pois for each poi in /places_nearby, /pois as well as journeys:
- Call loki only once with /poi_disruptions&pois[]=poi for all pois
- In final response, update poi.links with related impacts and add all the impacts from response (poi_disruptions) from loki.
- Tests to come ..

For more information:  https://navitia.atlassian.net/browse/NAV-3026