### PR TITLE
[jormun]: Add ODT in all PT conditions

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/fields.py
@@ -206,7 +206,7 @@ class SectionGeoJsonField(jsonschema.Field):
                     coords.append(get_pt_object_coord(value.destination))
             elif value.type == response_pb2.RIDESHARING and len(value.shape) != 0:
                 coords = value.shape
-            elif value.type == response_pb2.PUBLIC_TRANSPORT:
+            elif value.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT):
                 coords = value.shape
             elif value.type == response_pb2.TRANSFER:
                 if value.street_network and value.street_network.coordinates:

--- a/source/jormungandr/jormungandr/pt_journey_fare/kraken.py
+++ b/source/jormungandr/jormungandr/pt_journey_fare/kraken.py
@@ -42,7 +42,11 @@ class Kraken(AbstractPtJourneyFare):
 
     @staticmethod
     def _pt_sections(journey):
-        return [s for s in journey.sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)]
+        return [
+            s
+            for s in journey.sections
+            if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)
+        ]
 
     def create_fare_request(self, pt_journeys):
         request = request_pb2.Request()

--- a/source/jormungandr/jormungandr/pt_journey_fare/kraken.py
+++ b/source/jormungandr/jormungandr/pt_journey_fare/kraken.py
@@ -42,7 +42,7 @@ class Kraken(AbstractPtJourneyFare):
 
     @staticmethod
     def _pt_sections(journey):
-        return [s for s in journey.sections if s.type == response_pb2.PUBLIC_TRANSPORT]
+        return [s for s in journey.sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)]
 
     def create_fare_request(self, pt_journeys):
         request = request_pb2.Request()

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -817,7 +817,10 @@ def get_journey_extremity_pt_section(journey, attractivities_virtual_fallbacks):
         sections = reversed(journey.sections)
     else:
         sections = journey.sections
-    extremity_pt_section = next((s for s in sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)), None)
+    extremity_pt_section = next(
+        (s for s in sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)),
+        None,
+    )
 
     return extremity_pt_section
 
@@ -1156,7 +1159,10 @@ def _filter_odt_journeys_counter_clockwise(journeys, debug):
 
 
 def _contains_pt_section(journey):
-    return any(section.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for section in journey.sections)
+    return any(
+        section.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)
+        for section in journey.sections
+    )
 
 
 def _contains_odt(journey):

--- a/source/jormungandr/jormungandr/scenarios/journey_filter.py
+++ b/source/jormungandr/jormungandr/scenarios/journey_filter.py
@@ -315,7 +315,8 @@ class FilterMaxSuccessivePhysicalMode(SingleJourneyFilter):
         """
         bus_count = 0
         for s in journey.sections:
-            if s.type != response_pb2.PUBLIC_TRANSPORT:
+            # if s.type != response_pb2.PUBLIC_TRANSPORT:
+            if s.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT):
                 continue
             if s.pt_display_informations.uris.physical_mode == self.successive_physical_mode_to_limit_id:
                 bus_count += 1
@@ -489,7 +490,7 @@ def similar_journeys_generator(journey, pt_functor, sn_functor=_sn_functor, crow
 
     def _similar_pt():
         for idx, s in enumerate(journey.sections):
-            if s.type == response_pb2.PUBLIC_TRANSPORT:
+            if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT):
                 yield pt_functor(s)
             elif s.type == response_pb2.STREET_NETWORK and is_walk_after_parking(journey, idx):
                 continue
@@ -552,7 +553,7 @@ def shared_section_generator(journey):
 
     # Compare each section of the journey with the criteria in the function description
     for s in journey.sections:
-        if s.type == response_pb2.PUBLIC_TRANSPORT:
+        if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT):
             yield "origin:{}/dest:{}".format(s.origin.uri, s.destination.uri)
 
 
@@ -604,7 +605,7 @@ def _debug_journey(journey):
 
     sections = []
     for s in journey.sections:
-        if s.type == response_pb2.PUBLIC_TRANSPORT:
+        if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT):
             sections.append(
                 u"{line} ({vj})".format(
                     line=s.pt_display_informations.uris.line, vj=s.pt_display_informations.uris.vehicle_journey
@@ -816,7 +817,7 @@ def get_journey_extremity_pt_section(journey, attractivities_virtual_fallbacks):
         sections = reversed(journey.sections)
     else:
         sections = journey.sections
-    extremity_pt_section = next((s for s in sections if s.type == response_pb2.PUBLIC_TRANSPORT), None)
+    extremity_pt_section = next((s for s in sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)), None)
 
     return extremity_pt_section
 
@@ -1155,7 +1156,7 @@ def _filter_odt_journeys_counter_clockwise(journeys, debug):
 
 
 def _contains_pt_section(journey):
-    return any(section.type == response_pb2.PUBLIC_TRANSPORT for section in journey.sections)
+    return any(section.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for section in journey.sections)
 
 
 def _contains_odt(journey):

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -428,7 +428,7 @@ def _tag_direct_path(responses):
 
     for j in itertools.chain.from_iterable(r.journeys for r in responses if r is not None):
         if all(
-                s.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for s in j.sections
+            s.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for s in j.sections
         ):
             j.tags.extend(['non_pt'])
 

--- a/source/jormungandr/jormungandr/scenarios/new_default.py
+++ b/source/jormungandr/jormungandr/scenarios/new_default.py
@@ -105,7 +105,11 @@ from six.moves import zip
 from functools import cmp_to_key
 from datetime import datetime
 
-SECTION_TYPES_TO_RETAIN = {response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT, response_pb2.STREET_NETWORK}
+SECTION_TYPES_TO_RETAIN = {
+    response_pb2.PUBLIC_TRANSPORT,
+    response_pb2.ON_DEMAND_TRANSPORT,
+    response_pb2.STREET_NETWORK,
+}
 JOURNEY_TAGS_TO_RETAIN = ['best_olympics']
 JOURNEY_TYPES_TO_RETAIN = ['best', 'comfort', 'non_pt_walk', 'non_pt_bike', 'non_pt_bss']
 JOURNEY_TYPES_SCORE = {t: i for i, t in enumerate(JOURNEY_TYPES_TO_RETAIN)}
@@ -423,7 +427,9 @@ def _tag_direct_path(responses):
     }
 
     for j in itertools.chain.from_iterable(r.journeys for r in responses if r is not None):
-        if all(s.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for s in j.sections):
+        if all(
+                s.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for s in j.sections
+        ):
             j.tags.extend(['non_pt'])
 
         # TODO: remove that (and street_network_mode_tag_map) when NMP stops using it

--- a/source/jormungandr/jormungandr/scenarios/qualifier.py
+++ b/source/jormungandr/jormungandr/scenarios/qualifier.py
@@ -58,6 +58,7 @@ def get_fallback_duration(journey):
     for section in sections:
         if section.type not in (
             response_pb2.PUBLIC_TRANSPORT,
+            response_pb2.ON_DEMAND_TRANSPORT,
             response_pb2.WAITING,
             response_pb2.boarding,
             response_pb2.landing,
@@ -103,7 +104,7 @@ def has_no_bss(journey):
 
 def non_pt_journey(journey):
     """check if the journey has not public transport section"""
-    has_pt = all(section.type != response_pb2.PUBLIC_TRANSPORT for section in journey.sections)
+    has_pt = all(section.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for section in journey.sections)
     return has_pt
 
 

--- a/source/jormungandr/jormungandr/scenarios/qualifier.py
+++ b/source/jormungandr/jormungandr/scenarios/qualifier.py
@@ -104,7 +104,10 @@ def has_no_bss(journey):
 
 def non_pt_journey(journey):
     """check if the journey has not public transport section"""
-    has_pt = all(section.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT) for section in journey.sections)
+    has_pt = all(
+        section.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)
+        for section in journey.sections
+    )
     return has_pt
 
 

--- a/source/jormungandr/jormungandr/scenarios/utils.py
+++ b/source/jormungandr/jormungandr/scenarios/utils.py
@@ -118,7 +118,7 @@ class JourneySorter(object):
         for journey in [j1, j2]:
             non_pt_duration = 0
             for section in journey.sections:
-                if section.type != response_pb2.PUBLIC_TRANSPORT:
+                if section.type not in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT):
                     non_pt_duration += section.duration
             if non_pt_duration_j1 is None:
                 non_pt_duration_j1 = non_pt_duration

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -612,11 +612,24 @@ def is_olympic_site(entry_point, instance):
 
 
 def get_last_pt_section(journey):
-    return next((s for s in reversed(journey.sections) if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)), None)
+    return next(
+        (
+            s
+            for s in reversed(journey.sections)
+            if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)
+        ),
+        None,
+    )
 
 
 def get_first_pt_section(journey):
-    return next((s for s in journey.sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)), None)
+    return next(
+        (
+            s for s in journey.sections
+            if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)
+        ),
+        None,
+    )
 
 
 def record_external_failure(message, connector_type, connector_name):

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -625,7 +625,8 @@ def get_last_pt_section(journey):
 def get_first_pt_section(journey):
     return next(
         (
-            s for s in journey.sections
+            s
+            for s in journey.sections
             if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)
         ),
         None,

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -612,11 +612,11 @@ def is_olympic_site(entry_point, instance):
 
 
 def get_last_pt_section(journey):
-    return next((s for s in reversed(journey.sections) if s.type == response_pb2.PUBLIC_TRANSPORT), None)
+    return next((s for s in reversed(journey.sections) if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)), None)
 
 
 def get_first_pt_section(journey):
-    return next((s for s in journey.sections if s.type == response_pb2.PUBLIC_TRANSPORT), None)
+    return next((s for s in journey.sections if s.type in (response_pb2.PUBLIC_TRANSPORT, response_pb2.ON_DEMAND_TRANSPORT)), None)
 
 
 def record_external_failure(message, connector_type, connector_name):


### PR DESCRIPTION
Before the feature virtual ODT:

- kraken and loki used to send section type PT but not ODT in the response proto to jormun / gormun
- jormun / gormun transform PT to ODT if the start or end of the section is of ODT during serializing (last action).
- All the filters as well as comparison conditions are on PT (without ODT)

After the feature:
- loki send a section type PT as well as ODT.
- we should add ODT in all  filters as well as comparison conditions on PT

For more details: https://navitia.atlassian.net/browse/NAV-3378