### PR TITLE
[jormun]: Fix request_datetime in ridesharing

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/blablalines.py
@@ -174,12 +174,12 @@ class Blablalines(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, instance, limit=None):
+    def _request_journeys(self, from_coord, to_coord, request_dates, instance, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'
         :param to_coord: lat,lon ex: '48.020335,-1.743929'
-        :param period_extremity: a tuple of [timestamp(utc), clockwise]
+        :param request_dates: a tuple of [timestamp(utc), timestamp(utc), clockwise]
         :param limit: optional
         :return:
         """
@@ -190,18 +190,18 @@ class Blablalines(AbstractRidesharingService):
         dt = datetime.datetime.now()
         now = calendar.timegm(dt.utctimetuple())
 
-        if period_extremity.datetime < now + MIN_BLABLALINES_MARGIN_DEPARTURE_TIME:
+        if request_dates.departure_datetime < now + MIN_BLABLALINES_MARGIN_DEPARTURE_TIME:
             logging.getLogger(__name__).info(
                 'blablalines ridesharing request departure time < now + 15 min. Force to now + 15 min'
             )
             departure_epoch = now + MIN_BLABLALINES_MARGIN_DEPARTURE_TIME
-        elif period_extremity.datetime > now + MAX_BLABLALINES_MARGIN_DEPARTURE_TIME:
+        elif request_dates.departure_datetime > now + MAX_BLABLALINES_MARGIN_DEPARTURE_TIME:
             logging.getLogger(__name__).error(
                 'Blablalines error, request departure time should be between now to 1 week from now. departure is greater than now + 1 week'
             )
             return []
         else:
-            departure_epoch = period_extremity.datetime
+            departure_epoch = request_dates.departure_datetime
 
         # Paramaeters documenation : https://www.blablalines.com/public-api-v2
         params = {
@@ -225,7 +225,7 @@ class Blablalines(AbstractRidesharingService):
             raise RidesharingServiceError('non 200 response', resp.status_code, resp.reason, resp.text)
 
         if resp:
-            r = self._make_response(resp.json(), period_extremity.datetime, from_coord, to_coord)
+            r = self._make_response(resp.json(), request_dates.departure_datetime, from_coord, to_coord)
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
             logging.getLogger('stat.ridesharing.blablalines').info(
                 'Received ridesharing offers : %s',

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/instant_system.py
@@ -230,22 +230,25 @@ class InstantSystem(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, instance_params, limit=None):
+    def _request_journeys(self, from_coord, to_coord, request_dates, instance_params, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'
         :param to_coord: lat,lon ex: '48.020335,-1.743929'
-        :param period_extremity: a tuple of [timestamp(utc), clockwise]
+        :param request_dates: a tuple of [timestamp(utc), timestamp(utc), clockwise]
         :param limit: optional
         :return:
         """
-        # format of datetime: 2017-12-25T07:00:00Z
-        datetime_str = datetime.datetime.fromtimestamp(period_extremity.datetime, pytz.utc).strftime(
-            '%Y-%m-%dT%H:%M:%SZ'
-        )
-        if period_extremity.represents_start:
+        if request_dates.represents_start:
+            # format of datetime: 2017-12-25T07:00:00Z
+            datetime_str = datetime.datetime.fromtimestamp(request_dates.departure_datetime, pytz.utc).strftime(
+                '%Y-%m-%dT%H:%M:%SZ'
+            )
             datetime_str = '{}/PT{}S'.format(datetime_str, self.timeframe_duration)
         else:
+            datetime_str = datetime.datetime.fromtimestamp(request_dates.arrival_datetime, pytz.utc).strftime(
+                '%Y-%m-%dT%H:%M:%SZ'
+            )
             datetime_str = 'PT{}S/{}'.format(self.timeframe_duration, datetime_str)
 
         params = {
@@ -253,7 +256,7 @@ class InstantSystem(AbstractRidesharingService):
             'to': to_coord,
             'fromRadius': self.crowfly_radius,
             'toRadius': self.crowfly_radius,
-            ('arrivalDate', 'departureDate')[bool(period_extremity.represents_start)]: datetime_str,
+            ('arrivalDate', 'departureDate')[bool(request_dates.represents_start)]: datetime_str,
         }
 
         if limit is not None:

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/karos.py
@@ -177,12 +177,12 @@ class Karos(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, instance, limit=None):
+    def _request_journeys(self, from_coord, to_coord, request_dates, instance, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'
         :param to_coord: lat,lon ex: '48.020335,-1.743929'
-        :param period_extremity: a tuple of [timestamp(utc), clockwise]
+        :param request_dates: a tuple of [timestamp(utc), timestamp(utc), clockwise]
         :param limit: optional
         :return:
         """
@@ -195,7 +195,7 @@ class Karos(AbstractRidesharingService):
             'departureLng': dep_lon,
             'arrivalLat': arr_lat,
             'arrivalLng': arr_lon,
-            'date': period_extremity.datetime,
+            'date': request_dates.departure_datetime,
             'timeDelta': self.timedelta,
             'departureRadius': self.departure_radius,
             'arrivalRadius': self.arrival_radius,

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/klaxit.py
@@ -162,12 +162,12 @@ class Klaxit(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, instance, limit=None):
+    def _request_journeys(self, from_coord, to_coord, request_dates, instance, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'
         :param to_coord: lat,lon ex: '48.020335,-1.743929'
-        :param period_extremity: a tuple of [timestamp(utc), clockwise]
+        :param request_dates: a tuple of [timestamp(utc), timestamp(utc), clockwise]
         :param limit: optional
         :return:
         """
@@ -182,7 +182,7 @@ class Klaxit(AbstractRidesharingService):
             'departureLng': dep_lon,
             'arrivalLat': arr_lat,
             'arrivalLng': arr_lon,
-            'date': period_extremity.datetime,
+            'date': request_dates.departure_datetime,
             'timeDelta': self.timedelta,
             'departureRadius': 2,
             'arrivalRadius': 2,

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -183,12 +183,12 @@ class Ouestgo(AbstractRidesharingService):
 
         return ridesharing_journeys
 
-    def _request_journeys(self, from_coord, to_coord, period_extremity, instance_params=None, limit=None):
+    def _request_journeys(self, from_coord, to_coord, request_dates, instance_params=None, limit=None):
         """
 
         :param from_coord: lat,lon ex: '48.109377,-1.682103'
         :param to_coord: lat,lon ex: '48.020335,-1.743929'
-        :param period_extremity: a tuple of [timestamp(utc), clockwise]
+        :param request_dates: a tuple of [timestamp(utc), timestamp(utc), clockwise]
         :param limit: optional
         :return:
         """
@@ -204,12 +204,12 @@ class Ouestgo(AbstractRidesharingService):
             'p[to][latitude]': arr_lat,
             'p[to][longitude]': arr_lon,
             'signature': 'toto',
-            'timestamp': period_extremity.datetime,
+            'timestamp': request_dates.departure_datetime,
             'p[outward][mindate]': timestamp_to_date_str(
-                period_extremity.datetime, timezone, _format=DATE_FORMAT
+                request_dates.departure_datetime, timezone, _format=DATE_FORMAT
             ),
             'p[outward][maxdate]': timestamp_to_date_str(
-                period_extremity.datetime, timezone, _format=DATE_FORMAT
+                request_dates.departure_datetime, timezone, _format=DATE_FORMAT
             ),
         }
 
@@ -230,7 +230,7 @@ class Ouestgo(AbstractRidesharingService):
             # EVEN THOUGH the timezone is previously set in g.
             # We'd better retrieve the timezone from instance_params than relying on the g
             timezone = get_timezone_or_paris() if instance_params is None else instance_params.timezone
-            r = self._make_response(resp.json(), period_extremity.datetime, from_coord, to_coord, timezone)
+            r = self._make_response(resp.json(), request_dates.departure_datetime, from_coord, to_coord, timezone)
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
             logging.getLogger('stat.ridesharing.ouestgo').info(
                 'Received ridesharing offers : %s',

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ouestgo.py
@@ -230,7 +230,9 @@ class Ouestgo(AbstractRidesharingService):
             # EVEN THOUGH the timezone is previously set in g.
             # We'd better retrieve the timezone from instance_params than relying on the g
             timezone = get_timezone_or_paris() if instance_params is None else instance_params.timezone
-            r = self._make_response(resp.json(), request_dates.departure_datetime, from_coord, to_coord, timezone)
+            r = self._make_response(
+                resp.json(), request_dates.departure_datetime, from_coord, to_coord, timezone
+            )
             self.record_additional_info('Received ridesharing offers', nb_ridesharing_offers=len(r))
             logging.getLogger('stat.ridesharing.ouestgo').info(
                 'Received ridesharing offers : %s',

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service.py
@@ -112,7 +112,7 @@ class AbstractRidesharingService(object):
             raise RidesharingServiceError(str(e))
 
     def request_journeys_with_feed_publisher(
-        self, from_coord, to_coord, period_extremity, instance_params, limit=None
+        self, from_coord, to_coord, request_dates, instance_params, limit=None
     ):
         """
         This function shouldn't be overwritten!
@@ -120,7 +120,7 @@ class AbstractRidesharingService(object):
         :return: a list(mandatory) contains solutions and a feed_publisher
         """
         try:
-            journeys = self._request_journeys(from_coord, to_coord, period_extremity, instance_params, limit)
+            journeys = self._request_journeys(from_coord, to_coord, request_dates, instance_params, limit)
             feed_publisher = self._get_feed_publisher()
 
             self.record_call('ok')
@@ -132,7 +132,7 @@ class AbstractRidesharingService(object):
             return [], None
 
     @abc.abstractmethod
-    def _request_journeys(self, from_coord, to_coord, period_extremity, instance_params, limit=None):
+    def _request_journeys(self, from_coord, to_coord, request_dates, instance_params, limit=None):
         """
         :return: a list(mandatory) contains solutions
         """

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -200,7 +200,9 @@ class RidesharingServiceManager(object):
                         section.additional_informations.append(response_pb2.HAS_DATETIME_ESTIMATED)
                         request_dates = None
                         if len(journey.sections) == 1:  # direct path, we use the user input
-                            request_dates = RequestDates(request['datetime'], request['datetime'], request['clockwise'])
+                            request_dates = RequestDates(
+                                request['datetime'], request['datetime'], request['clockwise']
+                            )
                         elif (
                             section_idx == 0
                         ):  # ridesharing on first section we want to arrive before the start of the pt

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/ridesharing_service_manager.py
@@ -39,7 +39,7 @@ from jormungandr.scenarios.ridesharing.ridesharing_journey import Gender
 from jormungandr.utils import get_pt_object_coord, generate_id
 from jormungandr.street_network.utils import crowfly_distance_between
 from navitiacommon import response_pb2
-from jormungandr.utils import PeriodExtremity
+from jormungandr.utils import RequestDates
 from jormungandr.scenarios.journey_filter import to_be_deleted
 from jormungandr.scenarios.helper_classes.helper_future import FutureManager
 from importlib import import_module
@@ -198,27 +198,27 @@ class RidesharingServiceManager(object):
                 for section_idx, section in enumerate(journey.sections):
                     if section.street_network.mode == response_pb2.Ridesharing:
                         section.additional_informations.append(response_pb2.HAS_DATETIME_ESTIMATED)
-                        period_extremity = None
+                        request_dates = None
                         if len(journey.sections) == 1:  # direct path, we use the user input
-                            period_extremity = PeriodExtremity(request['datetime'], request['clockwise'])
+                            request_dates = RequestDates(request['datetime'], request['datetime'], request['clockwise'])
                         elif (
                             section_idx == 0
                         ):  # ridesharing on first section we want to arrive before the start of the pt
-                            period_extremity = PeriodExtremity(section.end_date_time, False)
+                            request_dates = RequestDates(section.begin_date_time, section.end_date_time, False)
                         else:  # ridesharing at the end, we search for solution starting after the end of the pt sections
-                            period_extremity = PeriodExtremity(section.begin_date_time, True)
+                            request_dates = RequestDates(section.begin_date_time, section.end_date_time, True)
                         instance_params = self.InstanceParams.make_params(instance)
                         if greenlet_pool_actived:
                             futures[journey_idx][section_idx] = future_manager.create_future(
                                 self.build_ridesharing_journeys,
                                 section.origin,
                                 section.destination,
-                                period_extremity,
+                                request_dates,
                                 instance_params,
                             )
                         else:
                             pb_rsjs, pb_tickets, pb_fps = self.build_ridesharing_journeys(
-                                section.origin, section.destination, period_extremity, instance_params
+                                section.origin, section.destination, request_dates, instance_params
                             )
                             self.add_new_ridesharing_results(
                                 pb_rsjs, pb_tickets, pb_fps, response, journey_idx, section_idx
@@ -242,7 +242,7 @@ class RidesharingServiceManager(object):
         response.feed_publishers.extend((fp for fp in pb_fps if fp not in response.feed_publishers))
 
     def get_ridesharing_journeys_with_feed_publishers(
-        self, from_coord, to_coord, period_extremity, instance_params, limit=None
+        self, from_coord, to_coord, request_dates, instance_params, limit=None
     ):
         calls = []
         res = []
@@ -252,7 +252,7 @@ class RidesharingServiceManager(object):
 
             def _call(s=service):
                 return s.request_journeys_with_feed_publisher(
-                    from_coord, to_coord, period_extremity, instance_params, limit
+                    from_coord, to_coord, request_dates, instance_params, limit
                 )
 
             calls.append(_call)
@@ -271,14 +271,14 @@ class RidesharingServiceManager(object):
 
         return res, fps
 
-    def build_ridesharing_journeys(self, from_pt_obj, to_pt_obj, period_extremity, instance_params):
+    def build_ridesharing_journeys(self, from_pt_obj, to_pt_obj, request_dates, instance_params):
         from_coord = get_pt_object_coord(from_pt_obj)
         to_coord = get_pt_object_coord(to_pt_obj)
         from_str = "{},{}".format(from_coord.lat, from_coord.lon)
         to_str = "{},{}".format(to_coord.lat, to_coord.lon)
         try:
             rsjs, fps = self.get_ridesharing_journeys_with_feed_publishers(
-                from_str, to_str, period_extremity, instance_params
+                from_str, to_str, request_dates, instance_params
             )
         except Exception as e:
             self.logger.exception(
@@ -304,7 +304,7 @@ class RidesharingServiceManager(object):
             pickup_coord = get_pt_object_coord(pb_rsj_pickup)
             dropoff_coord = get_pt_object_coord(pb_rsj_dropoff)
 
-            pb_rsj.requested_date_time = period_extremity.datetime
+            pb_rsj.requested_date_time = request_dates.departure_datetime
             if rsj.departure_date_time:
                 pb_rsj.departure_date_time = rsj.departure_date_time
             if rsj.arrival_date_time:

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
@@ -149,7 +149,7 @@ def blablalines_test():
         request_dates = utils.RequestDates(
             departure_datetime=utils.str_to_time_stamp("20171225T060000"),
             arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-            represents_start=True
+            represents_start=True,
         )
         ridesharing_journeys, feed_publisher = blablalines.request_journeys_with_feed_publisher(
             from_coord=from_coord,
@@ -220,7 +220,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.RequestDates(
                     departure_datetime=utils.str_to_time_stamp("20171225T060000"),
                     arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-                    represents_start=True
+                    represents_start=True,
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/blablalines_tests.py
@@ -146,13 +146,15 @@ def blablalines_test():
         from_coord = '47.28696,0.78981'
         to_coord = '47.38642,0.69039'
 
-        period_extremity = utils.PeriodExtremity(
-            datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+        request_dates = utils.RequestDates(
+            departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+            arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+            represents_start=True
         )
         ridesharing_journeys, feed_publisher = blablalines.request_journeys_with_feed_publisher(
             from_coord=from_coord,
             to_coord=to_coord,
-            period_extremity=period_extremity,
+            request_dates=request_dates,
             instance_params=DummyInstance(),
         )
 
@@ -215,8 +217,10 @@ def test_request_journeys_should_raise_on_non_200():
             blablalines._request_journeys(
                 '1.2,3.4',
                 '5.6,7.8',
-                utils.PeriodExtremity(
-                    datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+                utils.RequestDates(
+                    departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    represents_start=True
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
@@ -253,7 +253,7 @@ def instant_system_test():
         request_dates = utils.RequestDates(
             departure_datetime=utils.str_to_time_stamp("20171225T060000"),
             arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-            represents_start=True
+            represents_start=True,
         )
         params = RidesharingServiceManager.InstanceParams.make_params(DummyInstance())
         ridesharing_journeys, feed_publisher = instant_system.request_journeys_with_feed_publisher(
@@ -351,7 +351,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.RequestDates(
                     departure_datetime=utils.str_to_time_stamp("20171225T060000"),
                     arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-                    represents_start=True
+                    represents_start=True,
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/instant_system_tests.py
@@ -250,13 +250,14 @@ def instant_system_test():
         from_coord = '48.109377,-1.682103'
         to_coord = '48.020335,-1.743929'
 
-        period_extremity = utils.PeriodExtremity(
-            datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+        request_dates = utils.RequestDates(
+            departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+            arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+            represents_start=True
         )
-
         params = RidesharingServiceManager.InstanceParams.make_params(DummyInstance())
         ridesharing_journeys, feed_publisher = instant_system.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance_params=params
+            from_coord=from_coord, to_coord=to_coord, request_dates=request_dates, instance_params=params
         )
 
         assert len(ridesharing_journeys) == 2
@@ -347,8 +348,10 @@ def test_request_journeys_should_raise_on_non_200():
             instant_system._request_journeys(
                 '1.2,3.4',
                 '5.6,7.8',
-                utils.PeriodExtremity(
-                    datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+                utils.RequestDates(
+                    departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    represents_start=True
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -255,12 +255,14 @@ def karos_service_test():
         from_coord = '47.28696,0.78981'
         to_coord = '47.38642,0.69039'
 
-        period_extremity = utils.PeriodExtremity(
-            datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+        request_dates = utils.RequestDates(
+            departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+            arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+            represents_start=True
         )
         params = RidesharingServiceManager.InstanceParams.make_params(DummyInstance)
         ridesharing_journeys, feed_publisher = karos.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance_params=params
+            from_coord=from_coord, to_coord=to_coord, request_dates=request_dates, instance_params=params
         )
 
         assert len(ridesharing_journeys) == 2
@@ -334,8 +336,10 @@ def test_request_journeys_should_raise_on_non_200():
             karos._request_journeys(
                 '1.2,3.4',
                 '5.6,7.8',
-                utils.PeriodExtremity(
-                    datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+                utils.RequestDates(
+                    departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    represents_start=True
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/karos_tests.py
@@ -258,7 +258,7 @@ def karos_service_test():
         request_dates = utils.RequestDates(
             departure_datetime=utils.str_to_time_stamp("20171225T060000"),
             arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-            represents_start=True
+            represents_start=True,
         )
         params = RidesharingServiceManager.InstanceParams.make_params(DummyInstance)
         ridesharing_journeys, feed_publisher = karos.request_journeys_with_feed_publisher(
@@ -339,7 +339,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.RequestDates(
                     departure_datetime=utils.str_to_time_stamp("20171225T060000"),
                     arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-                    represents_start=True
+                    represents_start=True,
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
@@ -170,12 +170,14 @@ def klaxit_service_test():
         from_coord = '47.28696,0.78981'
         to_coord = '47.38642,0.69039'
 
-        period_extremity = utils.PeriodExtremity(
-            datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+        request_dates = utils.RequestDates(
+            departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+            arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+            represents_start=True
         )
         params = RidesharingServiceManager.InstanceParams.make_params(DummyInstance())
         ridesharing_journeys, feed_publisher = klaxit.request_journeys_with_feed_publisher(
-            from_coord=from_coord, to_coord=to_coord, period_extremity=period_extremity, instance_params=params
+            from_coord=from_coord, to_coord=to_coord, request_dates=request_dates, instance_params=params
         )
 
         assert len(ridesharing_journeys) == 2
@@ -243,8 +245,10 @@ def test_request_journeys_should_raise_on_non_200():
             klaxit._request_journeys(
                 '1.2,3.4',
                 '5.6,7.8',
-                utils.PeriodExtremity(
-                    datetime=utils.str_to_time_stamp("20171225T060000"), represents_start=True
+                utils.RequestDates(
+                    departure_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
+                    represents_start=True
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/klaxit_tests.py
@@ -173,7 +173,7 @@ def klaxit_service_test():
         request_dates = utils.RequestDates(
             departure_datetime=utils.str_to_time_stamp("20171225T060000"),
             arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-            represents_start=True
+            represents_start=True,
         )
         params = RidesharingServiceManager.InstanceParams.make_params(DummyInstance())
         ridesharing_journeys, feed_publisher = klaxit.request_journeys_with_feed_publisher(
@@ -248,7 +248,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.RequestDates(
                     departure_datetime=utils.str_to_time_stamp("20171225T060000"),
                     arrival_datetime=utils.str_to_time_stamp("20171225T060000"),
-                    represents_start=True
+                    represents_start=True,
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
@@ -194,13 +194,15 @@ def ouestgo_basic_test():
         from_coord = '48.68793,6.171514'
         to_coord = '49.108385,6.194897'
 
-        period_extremity = utils.PeriodExtremity(
-            datetime=utils.make_timestamp_from_str("20221121T084122"), represents_start=True
+        request_dates = utils.RequestDates(
+            departure_datetime=utils.make_timestamp_from_str("20221121T084122"),
+            arrival_datetime=utils.make_timestamp_from_str("20221121T084122"),
+            represents_start=True
         )
         ridesharing_journeys, feed_publisher = ouestgo.request_journeys_with_feed_publisher(
             from_coord=from_coord,
             to_coord=to_coord,
-            period_extremity=period_extremity,
+            request_dates=request_dates,
             instance_params=DummyInstance(),
         )
 
@@ -246,8 +248,10 @@ def test_request_journeys_should_raise_on_non_200():
             ouestgo._request_journeys(
                 '1.2,3.4',
                 '5.6,7.8',
-                utils.PeriodExtremity(
-                    datetime=utils.make_timestamp_from_str("20221121T084122"), represents_start=True
+                utils.RequestDates(
+                    departure_datetime=utils.make_timestamp_from_str("20221121T084122"),
+                    arrival_datetime=utils.make_timestamp_from_str("20221121T084122"),
+                    represents_start=True
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
+++ b/source/jormungandr/jormungandr/scenarios/ridesharing/tests/ouestgo_tests.py
@@ -197,7 +197,7 @@ def ouestgo_basic_test():
         request_dates = utils.RequestDates(
             departure_datetime=utils.make_timestamp_from_str("20221121T084122"),
             arrival_datetime=utils.make_timestamp_from_str("20221121T084122"),
-            represents_start=True
+            represents_start=True,
         )
         ridesharing_journeys, feed_publisher = ouestgo.request_journeys_with_feed_publisher(
             from_coord=from_coord,
@@ -251,7 +251,7 @@ def test_request_journeys_should_raise_on_non_200():
                 utils.RequestDates(
                     departure_datetime=utils.make_timestamp_from_str("20221121T084122"),
                     arrival_datetime=utils.make_timestamp_from_str("20221121T084122"),
-                    represents_start=True
+                    represents_start=True,
                 ),
                 DummyInstance(),
             )

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -715,7 +715,6 @@ PeriodExtremity = namedtuple('PeriodExtremity', ['datetime', 'represents_start']
 RequestDates = namedtuple('RequestDates', ['departure_datetime', 'arrival_datetime', 'represents_start'])
 
 
-
 class SectionSorter(object):
     def __call__(self, a, b):
         if a.begin_date_time != b.begin_date_time:

--- a/source/jormungandr/jormungandr/utils.py
+++ b/source/jormungandr/jormungandr/utils.py
@@ -709,6 +709,12 @@ def encode_polyline(coords, precision=6):
 # (mostly used for fallback management in experimental scenario)
 PeriodExtremity = namedtuple('PeriodExtremity', ['datetime', 'represents_start'])
 
+# RequestDates is used by ridesharing services
+# instant_system needs both departure_datetime and arrival_datetime
+# other services use only departure_datetime without any condition
+RequestDates = namedtuple('RequestDates', ['departure_datetime', 'arrival_datetime', 'represents_start'])
+
+
 
 class SectionSorter(object):
     def __call__(self, a, b):

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -440,7 +440,8 @@ class TestAsgardDirectPath(AbstractTestFixture):
 
         assert len(response['journeys']) == len(DIRECT_PATH_ALTERNATIVES_PROFILES)
 
-    def test_journey_bss_with_direct_path(self):
+    def \
+            test_journey_bss_with_direct_path(self):
         """
         we only want direct path
         """

--- a/source/jormungandr/tests/direct_path_asgard_integration_tests.py
+++ b/source/jormungandr/tests/direct_path_asgard_integration_tests.py
@@ -440,8 +440,7 @@ class TestAsgardDirectPath(AbstractTestFixture):
 
         assert len(response['journeys']) == len(DIRECT_PATH_ALTERNATIVES_PROFILES)
 
-    def \
-            test_journey_bss_with_direct_path(self):
+    def test_journey_bss_with_direct_path(self):
         """
         we only want direct path
         """


### PR DESCRIPTION
* We use a tuple structure PeriodRxtremity('datetime', 'represents_start') to keep departure and arrival date_time.
* Except InstantSystem, all the other ridesharing services do not have parameter wanted arrival date_time hence error is present for all of them.
* The new structure RequestDates ('departure_datetime', 'arrival_datetime', 'represents_start') should be enough to manage all the ridesharing services (PeriodRxtremity should not be modified as it is used by other components also). 

Ticket: https://navitia.atlassian.net/browse/NAV-3506