### PR TITLE
sort stop points in places free access

### DIFF
--- a/source/jormungandr/jormungandr/scenarios/helper_classes/places_free_access.py
+++ b/source/jormungandr/jormungandr/scenarios/helper_classes/places_free_access.py
@@ -64,7 +64,8 @@ class PlacesFreeAccess:
     @new_relic.distributedEvent("get_stop_points_for_stop_area", "places")
     def _get_stop_points_for_stop_area(self, uri):
         with timed_logger(self._logger, 'stop_points_for_stop_area_calling_external_service', self._request_id):
-            return self._instance.georef.get_stop_points_for_stop_area(uri, self._request_id)
+            stop_points = self._instance.georef.get_stop_points_for_stop_area(uri, self._request_id)
+            return sorted(stop_points, key=lambda p: p[0])
 
     @new_relic.distributedEvent("get_odt_stop_points", "places")
     def _get_odt_stop_points(self, coord):


### PR DESCRIPTION
https://navitia.atlassian.net/browse/NAV-3828

stop_points returned by `_get_stop_points_for_stop_area` are not ordered and have a random order, the randomness has caused some bug in Loki. 

To work around this **Temporarily**, stop_points are sorted before being sent to loki