### PR TITLE
[NAV-4031]: Add origin terminus in timetables

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/make_links.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/make_links.py
@@ -62,7 +62,7 @@ def create_external_link(url, rel, _type=None, templated=False, description=None
     return d
 
 
-def create_internal_link(rel, _type, id, templated=False, description=None):
+def create_internal_link(rel, _type, id, templated=False, description=None, category=None):
     """
     :param rel: relation of the link to the current object
     :param _type: type of linked object
@@ -79,6 +79,8 @@ def create_internal_link(rel, _type, id, templated=False, description=None):
         d['title'] = description
     if id:
         d['id'] = id
+    if category:
+        d['category'] = category
 
     return d
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/api.py
@@ -120,6 +120,8 @@ class PTReferentialSerializerNoContext(serpy.Serializer):
     disruptions = pt.DisruptionSerializer(attr='impacts', many=True, display_none=True)
     notes = DescribedField(schema_type=NoteSerializer(many=True))
     links = DescribedField(schema_type=LinkSchema(many=True))
+    origins = pt.StopAreaSerializer(many=True, display_none=True)
+    terminus = pt.StopAreaSerializer(many=True, display_none=True)
 
 
 class PTReferentialSerializer(PTReferentialSerializerNoContext):
@@ -343,7 +345,8 @@ class JourneysSerializer(JourneysCommon):
     journeys = JourneySerializer(many=True)
     tickets = TicketSerializer(many=True, display_none=True)
     disruptions = pt.DisruptionSerializer(attr='impacts', many=True, display_none=True)
-    terminus = pt.StopAreaSerializer(many=True, display_none=True)
+    origins = pt.StopAreaSerializer(many=True, display_none=False)
+    terminus = pt.StopAreaSerializer(many=True, display_none=False)
     context = MethodField(schema_type=ContextSerializer(), display_none=False)
     notes = DescribedField(schema_type=NoteSerializer(many=True))
     exceptions = DescribedField(schema_type=ExceptionSerializer(many=True))

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -761,7 +761,9 @@ class RouteDisplayInformationSerializer(PbNestedSerializer):
             response.append(create_internal_link(_type="stop_area", rel="origins", category="origin", id=origin))
 
         for terminus in obj.terminus:
-            response.append(create_internal_link(_type="stop_area", rel="terminus", category="terminus", id=terminus))
+            response.append(
+                create_internal_link(_type="stop_area", rel="terminus", category="terminus", id=terminus)
+            )
         return response
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -758,10 +758,10 @@ class RouteDisplayInformationSerializer(PbNestedSerializer):
     def get_links(self, obj):
         response = DisruptionLinkSerializer().to_value(obj.impact_uris)
         for origin in obj.origins:
-            response.append(create_internal_link(_type="stop_area", rel="origins", id=origin))
+            response.append(create_internal_link(_type="stop_area", rel="origins", category="origin", id=origin))
 
         for terminus in obj.terminus:
-            response.append(create_internal_link(_type="stop_area", rel="terminus", id=terminus))
+            response.append(create_internal_link(_type="stop_area", rel="terminus", category="terminus", id=terminus))
         return response
 
 

--- a/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/serializer/pt.py
@@ -756,7 +756,13 @@ class RouteDisplayInformationSerializer(PbNestedSerializer):
     trip_short_name = jsonschema.Field(schema_type=str, display_none=True)
 
     def get_links(self, obj):
-        return DisruptionLinkSerializer().to_value(obj.impact_uris)
+        response = DisruptionLinkSerializer().to_value(obj.impact_uris)
+        for origin in obj.origins:
+            response.append(create_internal_link(_type="stop_area", rel="origins", id=origin))
+
+        for terminus in obj.terminus:
+            response.append(create_internal_link(_type="stop_area", rel="terminus", id=terminus))
+        return response
 
 
 class PassageDisplayInformationSerializer(RouteDisplayInformationSerializer):
@@ -817,6 +823,28 @@ def make_properties_links(properties):
                 "rel": "vehicle_journeys",
                 "value": properties.vehicle_journey_id,  # to remove for the v2
                 "id": properties.vehicle_journey_id,
+            }
+        )
+
+    if properties.HasField(str("origin")):
+        response.append(
+            {
+                "type": "stop_area",
+                "rel": "origins",
+                "category": "origin",
+                "id": properties.origin,
+                "internal": True,
+            }
+        )
+
+    if properties.HasField(str("terminus")):
+        response.append(
+            {
+                "type": "stop_area",
+                "rel": "terminus",
+                "category": "terminus",
+                "id": properties.terminus,
+                "internal": True,
             }
         )
 

--- a/source/jormungandr/jormungandr/realtime_schedule/forseti_multi_stop.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/forseti_multi_stop.py
@@ -136,7 +136,7 @@ class ForsetiMultiStop(RealtimeProxy):
             extra={'rt_system_id': six.text_type(self.rt_system_id)},
         )
         try:
-            return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout, verify=False)
+            return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
                 'Forseti service dead, using base schedule (error: {}'.format(e),

--- a/source/jormungandr/jormungandr/realtime_schedule/forseti_multi_stop.py
+++ b/source/jormungandr/jormungandr/realtime_schedule/forseti_multi_stop.py
@@ -136,7 +136,7 @@ class ForsetiMultiStop(RealtimeProxy):
             extra={'rt_system_id': six.text_type(self.rt_system_id)},
         )
         try:
-            return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout)
+            return self.breaker.call(requests.get, url=self.service_url, params=params, timeout=self.timeout, verify=False)
         except pybreaker.CircuitBreakerError as e:
             logging.getLogger(__name__).error(
                 'Forseti service dead, using base schedule (error: {}'.format(e),

--- a/source/jormungandr/jormungandr/street_network/asgard.py
+++ b/source/jormungandr/jormungandr/street_network/asgard.py
@@ -321,6 +321,9 @@ class Asgard(TransientSocket, Kraken):
         ):
             profile_param.car_no_park_speed = request['{}_speed'.format(mode)]
             profile_param.max_car_no_park_duration_to_pt = request['max_{}_duration_to_pt'.format(mode)]
+        else:
+            profile_param.car_no_park_speed = 0
+            profile_param.max_car_no_park_duration_to_pt = 0
 
         # In addition to the request for kraken, we add more params for asgard
 

--- a/source/jormungandr/jormungandr/street_network/utils.py
+++ b/source/jormungandr/jormungandr/street_network/utils.py
@@ -118,6 +118,9 @@ def create_kraken_direct_path_request(
         req.direct_path.streetnetwork_params.max_car_no_park_duration_to_pt = request[
             'max_{}_duration_to_pt'.format(mode)
         ]
+    else:
+        req.direct_path.streetnetwork_params.car_no_park_speed = 0
+        req.direct_path.streetnetwork_params.max_car_no_park_duration_to_pt = 0
 
     return req
 

--- a/source/jormungandr/jormungandr/tests/planner_test.py
+++ b/source/jormungandr/jormungandr/tests/planner_test.py
@@ -56,7 +56,7 @@ def check_basic_journeys_request(journeys_req):
     assert journeys_req.max_extra_second_pass == 0
     assert journeys_req.forbidden_uris == []
     assert journeys_req.allowed_id == []
-    assert journeys_req.direct_path_duration == 3600 # Default value in navitia-proto
+    assert journeys_req.direct_path_duration == 3600  # Default value in navitia-proto
     assert journeys_req.bike_in_pt is False
     assert journeys_req.min_nb_journeys == 0
     assert journeys_req.timeframe_duration == 0

--- a/source/jormungandr/jormungandr/tests/planner_test.py
+++ b/source/jormungandr/jormungandr/tests/planner_test.py
@@ -79,7 +79,7 @@ def check_graphical_isochrones_request(isochrone_request):
 def create_journeys_request_test():
     origin = {"Hove": 42}
     destination = {"Somewhere": 666}
-    journey_parameters = JourneyParameters()
+    journey_parameters = JourneyParameters(direct_path_duration=0)
     datetime = str_to_time_stamp("20120614T080000")
 
     req = create_journeys_request(origin, destination, datetime, True, journey_parameters, False)
@@ -136,7 +136,8 @@ def test_journey_request_current_time():
 def create_graphical_isochrones_request_test():
     origin = {"Hove": 42}
     destination = {"Somewhere": 666}
-    graphical_isochrones_parameters = GraphicalIsochronesParameters()
+    journeys_parameters = JourneyParameters(direct_path_duration=0)
+    graphical_isochrones_parameters = GraphicalIsochronesParameters(journeys_parameters=journeys_parameters)
     datetime = str_to_time_stamp("20120614T080000")
 
     req = create_graphical_isochrones_request(
@@ -150,7 +151,7 @@ def create_graphical_isochrones_request_test():
 def test_journey_request_tranfer_penalties():
     origin = {"Hove": 42}
     destination = {"Somewhere": 666}
-    journey_parameters = JourneyParameters(arrival_transfer_penalty=60, walking_transfer_penalty=240)
+    journey_parameters = JourneyParameters(direct_path_duration=0, arrival_transfer_penalty=60, walking_transfer_penalty=240)
     datetime = str_to_time_stamp("20120614T080000")
 
     req = create_journeys_request(origin, destination, datetime, True, journey_parameters, False)

--- a/source/jormungandr/jormungandr/tests/planner_test.py
+++ b/source/jormungandr/jormungandr/tests/planner_test.py
@@ -56,7 +56,7 @@ def check_basic_journeys_request(journeys_req):
     assert journeys_req.max_extra_second_pass == 0
     assert journeys_req.forbidden_uris == []
     assert journeys_req.allowed_id == []
-    assert journeys_req.direct_path_duration == 0
+    assert journeys_req.direct_path_duration == 3600 # Default value in navitia-proto
     assert journeys_req.bike_in_pt is False
     assert journeys_req.min_nb_journeys == 0
     assert journeys_req.timeframe_duration == 0
@@ -79,7 +79,7 @@ def check_graphical_isochrones_request(isochrone_request):
 def create_journeys_request_test():
     origin = {"Hove": 42}
     destination = {"Somewhere": 666}
-    journey_parameters = JourneyParameters(direct_path_duration=0)
+    journey_parameters = JourneyParameters()
     datetime = str_to_time_stamp("20120614T080000")
 
     req = create_journeys_request(origin, destination, datetime, True, journey_parameters, False)
@@ -136,8 +136,7 @@ def test_journey_request_current_time():
 def create_graphical_isochrones_request_test():
     origin = {"Hove": 42}
     destination = {"Somewhere": 666}
-    journeys_parameters = JourneyParameters(direct_path_duration=0)
-    graphical_isochrones_parameters = GraphicalIsochronesParameters(journeys_parameters=journeys_parameters)
+    graphical_isochrones_parameters = GraphicalIsochronesParameters()
     datetime = str_to_time_stamp("20120614T080000")
 
     req = create_graphical_isochrones_request(
@@ -151,7 +150,7 @@ def create_graphical_isochrones_request_test():
 def test_journey_request_tranfer_penalties():
     origin = {"Hove": 42}
     destination = {"Somewhere": 666}
-    journey_parameters = JourneyParameters(direct_path_duration=0, arrival_transfer_penalty=60, walking_transfer_penalty=240)
+    journey_parameters = JourneyParameters(arrival_transfer_penalty=60, walking_transfer_penalty=240)
     datetime = str_to_time_stamp("20120614T080000")
 
     req = create_journeys_request(origin, destination, datetime, True, journey_parameters, False)

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -414,12 +414,8 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["stop_schedules"][0]["stop_point"]["id"] == "StopR2"
         date_times = response["stop_schedules"][0]["date_times"]
         dt_links = date_times[0]["links"]
-        origin = next(
-            l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "origin"
-        )
-        terminus = next(
-            l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "terminus"
-        )
+        origin = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "origin")
+        terminus = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "terminus")
         assert origin == "StopR1"
         assert terminus == "StopR4"
 
@@ -904,11 +900,13 @@ class TestDepartureBoard(AbstractTestFixture):
         assert date_time['date_time'] == "20120616T001000"
         assert len(date_time['additional_informations']) == 0
         assert date_time['data_freshness'] == "base_schedule"
-        assert len(date_time['links']) == 4
-        vj_d = next(l['id'] for l in date_time['links'] if l['type'] == 'vehicle_journey')
+        links = date_time['links']
+        assert len(links) == 4
+        vj_d = next(l['id'] for l in links if l['type'] == 'vehicle_journey')
         assert vj_d == "vehicle_journey:vj_D"
-        origin = next(l['id'] for l in date_time['links'] if l['type'] == 'stop_area' and l['category'] == 'origin')
-        terminus = next(l['id'] for l in date_time['links'] if l['type'] == 'stop_area' and l['category'] == 'terminus')
+
+        origin = next(l['id'] for l in links if l['type'] == 'stop_area' and l['category'] == 'origin')
+        terminus = next(l['id'] for l in links if l['type'] == 'stop_area' and l['category'] == 'terminus')
         assert origin == 'SA1'
         assert terminus == 'SA3'
         # Node with skipped_stop

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -412,11 +412,28 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["stop_schedules"][0]["date_times"][0]["date_time"] == "20120615T103000"
         assert response["stop_schedules"][0]["date_times"][1]["date_time"] == "20120615T103000"
         assert response["stop_schedules"][0]["stop_point"]["id"] == "StopR2"
+        date_times = response["stop_schedules"][0]["date_times"]
+        dt_links = date_times[0]["links"]
+        origin = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "origin")
+        terminus = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "terminus")
+        assert origin == "StopR1"
+        assert terminus == "StopR4"
+
+        # Test links on origins and terminus in display_informations
+        links = response["stop_schedules"][0]["display_informations"]["links"]
+        assert len(links) == 3
+        origins = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "origins"]
+        terminus = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "terminus"]
+        assert len(origins) == 1
+        assert len(terminus) == 2
+
+        # Test origins and terminus in response
+        assert len(response["origins"]) == 1
+        assert len(response["terminus"]) == 3
 
         # terminus_schedules on partial_terminus with calendar
         # There is neither terminus nor partial_terminus in terminus_schedules
         # Here the disruption could be injected by chaos or kirin
-
         response = self.query_region(
             "stop_areas/Tstop2/terminus_schedules?"
             "from_datetime=20120615T080000&calendar=cal_partial_terminus&data_freshness=realtime"
@@ -429,7 +446,6 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["terminus_schedules"][0]["additional_informations"] == "active_disruption"
         assert response["terminus_schedules"][0]["route"]["id"] == "A:1"
         assert len(response["terminus_schedules"][0]["date_times"]) == 0
-
         assert response["terminus_schedules"][0]["stop_point"]["id"] == "Tstop2"
 
     def test_real_terminus(self):
@@ -590,7 +606,8 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["departures"][1]["stop_date_time"]["additional_informations"][0] == "on_demand_transport"
         assert response["departures"][1]["stop_date_time"]["data_freshness"] == "base_schedule"
 
-        assert "terminus" not in response
+        # "terminus" should not be present in response.notes
+        assert len(response["notes"]) == 0
         assert not response["departures"][0]["display_informations"]["links"]
         assert not response["departures"][1]["display_informations"]["links"]
 
@@ -756,6 +773,25 @@ class TestDepartureBoard(AbstractTestFixture):
             response["terminus_schedules"][0]["display_informations"]["trip_short_name"] == "date_time_estimated"
         )
 
+        date_times = response["terminus_schedules"][0]["date_times"]
+        dt_links = date_times[0]["links"]
+        origin = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "origin")
+        terminus = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "terminus")
+        assert origin == "ODTstop1"
+        assert terminus == "ODTstop2"
+
+        # Test links on origins and terminus in display_informations
+        links = response["terminus_schedules"][0]["display_informations"]["links"]
+        assert len(links) == 2
+        origins = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "origins"]
+        terminus = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "terminus"]
+        assert len(origins) == 1
+        assert len(terminus) == 1
+
+        # Test origins and terminus in response
+        assert len(response["origins"]) == 1
+        assert len(response["terminus"]) == 2
+
     # Test on an on_demand_transport with start stop_datetime as on_demand_transport
     def test_journey_with_odt_in_start_stop_date_time(self):
         """
@@ -855,10 +891,13 @@ class TestDepartureBoard(AbstractTestFixture):
         assert date_time['date_time'] == "20120616T001000"
         assert len(date_time['additional_informations']) == 0
         assert date_time['data_freshness'] == "base_schedule"
-        assert len(date_time['links']) == 2
+        assert len(date_time['links']) == 4
         vj_d = next(l['id'] for l in date_time['links'] if l['type'] == 'vehicle_journey')
         assert vj_d == "vehicle_journey:vj_D"
-
+        origin = next(l['id'] for l in date_time['links'] if l['type'] == 'stop_area' and l['category'] == 'origin')
+        terminus = next(l['id'] for l in date_time['links'] if l['type'] == 'stop_area' and l['category'] == 'terminus')
+        assert origin == 'SA1'
+        assert terminus == 'SA3'
         # Node with skipped_stop
         assert len(nodes[1]['date_times']) == 1
         date_time = nodes[1]['date_times'][0]
@@ -867,7 +906,7 @@ class TestDepartureBoard(AbstractTestFixture):
         assert len(date_time['additional_informations']) == 1
         assert date_time['additional_informations'][0] == "skipped_stop"
         assert date_time['data_freshness'] is None
-        assert len(date_time['links']) == 2
+        assert len(date_time['links']) == 4
 
         assert len(nodes[2]['date_times']) == 1
         date_time = nodes[2]['date_times'][0]
@@ -875,7 +914,10 @@ class TestDepartureBoard(AbstractTestFixture):
         assert date_time['date_time'] == "20120616T025000"
         assert len(date_time['additional_informations']) == 0
         assert date_time['data_freshness'] == "base_schedule"
-        assert len(date_time['links']) == 2
+        assert len(date_time['links']) == 4
+
+        assert len(response['origins']) == 0
+        assert len(response['terminus']) == 1
 
 
 StopSchedule = namedtuple('StopSchedule', ['sp', 'route', 'date_times'])
@@ -2224,7 +2266,7 @@ class TestFirstLastDatetimeWithPositiveTimezone(AbstractTestFixture):
         assert stop_schedules[0]['date_times'][3]['date_time'] == "20170103T235000"
 
         # Query without parameter duration (default value = 86399)
-        # Here we have exclude the last date_time at 20170102T235000 + 86400 (24 hours)
+        # Here we have excluded the last date_time at 20170102T235000 + 86400 (24 hours)
         response = self.query_region(
             "stop_points/X_S3/stop_schedules?from_datetime={}"
             "&data_freshness=base_schedule".format(from_datetime)

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -414,8 +414,12 @@ class TestDepartureBoard(AbstractTestFixture):
         assert response["stop_schedules"][0]["stop_point"]["id"] == "StopR2"
         date_times = response["stop_schedules"][0]["date_times"]
         dt_links = date_times[0]["links"]
-        origin = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "origin")
-        terminus = next(l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "terminus")
+        origin = next(
+            l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "origin"
+        )
+        terminus = next(
+            l["id"] for l in dt_links if l["type"] == "stop_area" and l["category"] == "terminus"
+        )
         assert origin == "StopR1"
         assert terminus == "StopR4"
 

--- a/source/jormungandr/tests/departure_board_tests.py
+++ b/source/jormungandr/tests/departure_board_tests.py
@@ -608,8 +608,17 @@ class TestDepartureBoard(AbstractTestFixture):
 
         # "terminus" should not be present in response.notes
         assert len(response["notes"]) == 0
-        assert not response["departures"][0]["display_informations"]["links"]
-        assert not response["departures"][1]["display_informations"]["links"]
+        links = response["departures"][0]["display_informations"]["links"]
+        terminus = [l["id"] for l in links if l["type"] == "terminus" and l["rel"] == "notes"]
+        assert len(terminus) == 0
+
+        # origin and terminus should be present as link in display_informations
+        origins = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "origins"]
+        terminus = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "terminus"]
+        assert len(origins) == 1
+        assert len(terminus) == 1
+        assert len(response["origins"]) == 1
+        assert len(response["terminus"]) == 2
 
     def test_departures_arrivals_without_filters(self):
         """
@@ -1517,6 +1526,13 @@ class TestSchedules(AbstractTestFixture):
         assert arrivals[0]["stop_date_time"]["departure_date_time"] == '20160103T181000'
         assert arrivals[0]["stop_date_time"]["base_departure_date_time"] == '20160103T181000'
         assert arrivals[0]["stop_date_time"]["data_freshness"] == 'base_schedule'
+        links = arrivals[0]["display_informations"]["links"]
+        # Verify the presence of links on origin and terminus
+        assert len(links) == 2
+        origins = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "origins"]
+        terminus = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "terminus"]
+        assert len(origins) == 1
+        assert len(terminus) == 1
 
         assert arrivals[1]["route"]["id"] == 'l:freq:9'
         assert arrivals[1]["stop_point"]["id"] == 'stopf2'
@@ -1533,6 +1549,8 @@ class TestSchedules(AbstractTestFixture):
         assert arrivals[2]["stop_date_time"]["departure_date_time"] == '20160103T191000'
         assert arrivals[2]["stop_date_time"]["base_departure_date_time"] == '20160103T191000'
         assert arrivals[2]["stop_date_time"]["data_freshness"] == 'base_schedule'
+        assert len(response["origins"]) == 1
+        assert len(response["terminus"]) == 1
 
     def test_departure_schedule_departures_date_time_frequency_base_schedule(self):
         """

--- a/source/jormungandr/tests/kirin_realtime_tests.py
+++ b/source/jormungandr/tests/kirin_realtime_tests.py
@@ -873,7 +873,13 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
             "stop_points/stop_point:stopB/lines/A/stop_schedules?_current_datetime=20120614T080000&data_freshness=realtime"
         )
         assert has_the_disruption(response, 'vjA_late')
-        assert response['stop_schedules'][0]['date_times'][0]['links'][1]['type'] == 'disruption'
+        links = response['stop_schedules'][0]['date_times'][0]['links']
+        disruptions = [l["id"] for l in links if l["type"] == "disruption" and l["rel"] == "disruptions"]
+        assert len(disruptions) == 1
+        origins = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "origins"]
+        terminus = [l["id"] for l in links if l["type"] == "stop_area" and l["rel"] == "terminus"]
+        assert len(origins) == 1
+        assert len(terminus) == 1
         assert response['stop_schedules'][0]['date_times'][0]['date_time'] == '20120614T080101'
         assert response['stop_schedules'][0]['date_times'][0]['base_date_time'] == '20120614T080100'
         assert response['stop_schedules'][0]['date_times'][0]['data_freshness'] == 'realtime'
@@ -883,7 +889,9 @@ class TestKirinOnVJOnTime(MockKirinDisruptionsFixture):
             "stop_points/stop_point:stopB/lines/A/terminus_schedules?_current_datetime=20120614T080000&data_freshness=realtime"
         )
         assert has_the_disruption(response, 'vjA_late')
-        assert response['terminus_schedules'][0]['date_times'][0]['links'][1]['type'] == 'disruption'
+        links = response['terminus_schedules'][0]['date_times'][0]['links']
+        disruptions = [l["id"] for l in links if l["type"] == "disruption" and l["rel"] == "disruptions"]
+        assert len(disruptions) == 1
         assert response['terminus_schedules'][0]['date_times'][0]['date_time'] == '20120614T080101'
         assert response['terminus_schedules'][0]['date_times'][0]['base_date_time'] == '20120614T080100'
         assert response['terminus_schedules'][0]['date_times'][0]['data_freshness'] == 'realtime'

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -103,18 +103,22 @@ static void fill_date_times(PbCreator& pb_creator,
 static void fill_origin_terminus(PbCreator& pb_creator,
                                  const navitia::type::StopTime* st,
                                  pbnavitia::PtDisplayInfo* pt_info) {
-    if (st != nullptr) {
+    if (st != nullptr && !st->vehicle_journey->stop_time_list.empty()) {
         const auto* vj = st->vehicle_journey;
-        auto origin = vj->stop_time_list.front().stop_point->stop_area;
-        pb_creator.origins.insert(origin);
-        auto terminus = vj->stop_time_list.back().stop_point->stop_area;
-        pb_creator.terminus.insert(terminus);
-        if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
-            pt_info->add_origins(origin->uri);
+        if (vj->stop_time_list.front().stop_point) {
+            auto origin = vj->stop_time_list.front().stop_point->stop_area;
+            pb_creator.origins.insert(origin);
+            if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
+                pt_info->add_origins(origin->uri);
+            }
         }
-        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri)
-            == pt_info->terminus().end()) {
-            pt_info->add_terminus(terminus->uri);
+        if (vj->stop_time_list.back().stop_point) {
+            auto terminus = vj->stop_time_list.back().stop_point->stop_area;
+            pb_creator.terminus.insert(terminus);
+            if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri)
+                == pt_info->terminus().end()) {
+                pt_info->add_terminus(terminus->uri);
+            }
         }
     }
 }

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -100,6 +100,24 @@ static void fill_date_times(PbCreator& pb_creator,
     }
 }
 
+static void fill_origin_terminus(PbCreator& pb_creator,
+                                 const navitia::type::StopTime* st,
+                                 pbnavitia::PtDisplayInfo* pt_info) {
+    if (st != nullptr) {
+        const auto* vj = st->vehicle_journey;
+        auto origin = vj->stop_time_list.front().stop_point->stop_area;
+        pb_creator.origins.insert(origin);
+        auto terminus = vj->stop_time_list.back().stop_point->stop_area;
+        pb_creator.terminus.insert(terminus);
+        if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
+                pt_info->add_origins(origin->uri);
+            }
+        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri) == pt_info->terminus().end()) {
+                pt_info->add_terminus(terminus->uri);
+            }
+    }
+}
+
 static void fill_first_last_date_times(PbCreator& pb_creator,
                                        pbnavitia::ScheduleStopTime* date_time,
                                        const std::pair<unsigned int, const navitia::type::StopTime*> stop_time,
@@ -153,6 +171,9 @@ static void render(PbCreator& pb_creator,
                 vj_found = update_display_information(dt_st.second, pt_display_information, pb_creator);
             }
             fill_date_times(pb_creator, schedule, dt_st, calendar_id);
+
+            // Here we can fill origins and destinations in pt_display_information
+            fill_origin_terminus(pb_creator, dt_st.second, pt_display_information);
         }
 
         // add first and last datetime
@@ -218,6 +239,9 @@ static void render(PbCreator& pb_creator,
                 vj_found = update_display_information(dt_st.second, pt_display_information, pb_creator);
             }
             fill_date_times(pb_creator, schedule, dt_st, calendar_id);
+
+            // Here we can fill origins and destinations in pt_display_information
+            fill_origin_terminus(pb_creator, dt_st.second, pt_display_information);
         }
 
         // add first and last datetime

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -110,11 +110,12 @@ static void fill_origin_terminus(PbCreator& pb_creator,
         auto terminus = vj->stop_time_list.back().stop_point->stop_area;
         pb_creator.terminus.insert(terminus);
         if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
-                pt_info->add_origins(origin->uri);
-            }
-        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri) == pt_info->terminus().end()) {
-                pt_info->add_terminus(terminus->uri);
-            }
+            pt_info->add_origins(origin->uri);
+        }
+        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri)
+            == pt_info->terminus().end()) {
+            pt_info->add_terminus(terminus->uri);
+        }
     }
 }
 

--- a/source/time_tables/departure_boards.cpp
+++ b/source/time_tables/departure_boards.cpp
@@ -108,7 +108,8 @@ static void fill_origin_terminus(PbCreator& pb_creator,
         if (vj->stop_time_list.front().stop_point) {
             auto origin = vj->stop_time_list.front().stop_point->stop_area;
             pb_creator.origins.insert(origin);
-            if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
+            if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri)
+                == pt_info->origins().end()) {
                 pt_info->add_origins(origin->uri);
             }
         }

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -122,6 +122,24 @@ void fill_route_point(PbCreator& pb_creator,
     pb_creator.fill(pm, m_route->mutable_physical_modes(), 0);
     pb_creator.fill(line, m_route->mutable_line(), 0);
 }
+
+void fill_origin_terminus(PbCreator& pb_creator,
+                          const navitia::type::StopTime* st,
+                          pbnavitia::PtDisplayInfo* pt_info) {
+    if (st != nullptr) {
+        const auto* vj = st->vehicle_journey;
+        auto origin = vj->stop_time_list.front().stop_point->stop_area;
+        pb_creator.origins.insert(origin);
+        auto terminus = vj->stop_time_list.back().stop_point->stop_area;
+        pb_creator.terminus.insert(terminus);
+        if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
+                pt_info->add_origins(origin->uri);
+            }
+        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri) == pt_info->terminus().end()) {
+                pt_info->add_terminus(terminus->uri);
+            }
+    }
+}
 }  // namespace
 
 void passages(PbCreator& pb_creator,
@@ -185,14 +203,27 @@ void passages(PbCreator& pb_creator,
                 navitia::to_posix_timestamp(base_departure_dt));
             passage->mutable_stop_date_time()->set_base_arrival_date_time(navitia::to_posix_timestamp(base_arrival_dt));
         }
-        pb_creator.fill(dt_stop_time.second, passage->mutable_stop_date_time()->mutable_properties(), 0);
+        auto* properties = passage->mutable_stop_date_time()->mutable_properties();
+        pb_creator.fill(dt_stop_time.second, properties, 0);
+
+        // Fill origin and terminus:
+        auto origin_uri = dt_stop_time.second->vehicle_journey->stop_time_list.front().stop_point->stop_area->uri;
+        auto terminus_uri = dt_stop_time.second->vehicle_journey->stop_time_list.back().stop_point->stop_area->uri;
+        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("logger"), "Adding origin : " << origin_uri);
+        LOG4CPLUS_INFO(log4cplus::Logger::getInstance("logger"), "Adding terminus : " << terminus_uri);
+        properties->set_origin(origin_uri);
+        properties->set_terminus(terminus_uri);
 
         const type::VehicleJourney* vj = dt_stop_time.second->vehicle_journey;
         passage->mutable_stop_date_time()->set_data_freshness(to_pb_realtime_level(vj->realtime_level));
         const auto sts = std::vector<const nt::StopTime*>{dt_stop_time.second};
         const auto& vj_st = navitia::VjStopTimes(vj, sts);
-        pb_creator.fill(&vj_st, passage->mutable_pt_display_informations(), 1);
+        auto pt_display_information = passage->mutable_pt_display_informations();
+        pb_creator.fill(&vj_st, pt_display_information, 1);
         fill_route_point(pb_creator, depth, vj->route, dt_stop_time.second->stop_point, passage);
+
+        // Here we can fill origins and destinations in pt_display_information
+        fill_origin_terminus(pb_creator, dt_stop_time.second, pt_display_information);
     }
     pb_creator.make_paginate(total_result, start_page, count, passages_dt_st.size());
 

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -124,18 +124,22 @@ void fill_route_point(PbCreator& pb_creator,
 }
 
 void fill_origin_terminus(PbCreator& pb_creator, const navitia::type::StopTime* st, pbnavitia::PtDisplayInfo* pt_info) {
-    if (st != nullptr) {
+    if (st != nullptr && !st->vehicle_journey->stop_time_list.empty()) {
         const auto* vj = st->vehicle_journey;
-        auto origin = vj->stop_time_list.front().stop_point->stop_area;
-        pb_creator.origins.insert(origin);
-        auto terminus = vj->stop_time_list.back().stop_point->stop_area;
-        pb_creator.terminus.insert(terminus);
-        if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
-            pt_info->add_origins(origin->uri);
+        if (vj->stop_time_list.front().stop_point) {
+            auto origin = vj->stop_time_list.front().stop_point->stop_area;
+            pb_creator.origins.insert(origin);
+            if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
+                pt_info->add_origins(origin->uri);
+            }
         }
-        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri)
-            == pt_info->terminus().end()) {
-            pt_info->add_terminus(terminus->uri);
+        if (vj->stop_time_list.back().stop_point) {
+            auto terminus = vj->stop_time_list.back().stop_point->stop_area;
+            pb_creator.terminus.insert(terminus);
+            if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri)
+                == pt_info->terminus().end()) {
+                pt_info->add_terminus(terminus->uri);
+            }
         }
     }
 }

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -123,9 +123,7 @@ void fill_route_point(PbCreator& pb_creator,
     pb_creator.fill(line, m_route->mutable_line(), 0);
 }
 
-void fill_origin_terminus(PbCreator& pb_creator,
-                          const navitia::type::StopTime* st,
-                          pbnavitia::PtDisplayInfo* pt_info) {
+void fill_origin_terminus(PbCreator& pb_creator, const navitia::type::StopTime* st, pbnavitia::PtDisplayInfo* pt_info) {
     if (st != nullptr) {
         const auto* vj = st->vehicle_journey;
         auto origin = vj->stop_time_list.front().stop_point->stop_area;

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -129,7 +129,8 @@ void fill_origin_terminus(PbCreator& pb_creator, const navitia::type::StopTime* 
         if (vj->stop_time_list.front().stop_point) {
             auto origin = vj->stop_time_list.front().stop_point->stop_area;
             pb_creator.origins.insert(origin);
-            if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
+            if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri)
+                == pt_info->origins().end()) {
                 pt_info->add_origins(origin->uri);
             }
         }

--- a/source/time_tables/passages.cpp
+++ b/source/time_tables/passages.cpp
@@ -133,11 +133,12 @@ void fill_origin_terminus(PbCreator& pb_creator,
         auto terminus = vj->stop_time_list.back().stop_point->stop_area;
         pb_creator.terminus.insert(terminus);
         if (std::find(pt_info->origins().begin(), pt_info->origins().end(), origin->uri) == pt_info->origins().end()) {
-                pt_info->add_origins(origin->uri);
-            }
-        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri) == pt_info->terminus().end()) {
-                pt_info->add_terminus(terminus->uri);
-            }
+            pt_info->add_origins(origin->uri);
+        }
+        if (std::find(pt_info->terminus().begin(), pt_info->terminus().end(), terminus->uri)
+            == pt_info->terminus().end()) {
+            pt_info->add_terminus(terminus->uri);
+        }
     }
 }
 }  // namespace

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -2537,8 +2537,8 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(2).time(), time_to_int(11, 45, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(3).time(), time_to_int(11, 55, 00));
         // Tests on origins and terminus
-        BOOST_REQUIRE_EQUAL(resp.origins().size(),3);
-        BOOST_REQUIRE_EQUAL(resp.terminus().size(),3);
+        BOOST_REQUIRE_EQUAL(resp.origins().size(), 3);
+        BOOST_REQUIRE_EQUAL(resp.terminus().size(), 3);
     }
     {
         // Calculate terminus schedule at StopArea (M)
@@ -2592,8 +2592,8 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 1);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(8, 30, 00));
         // Tests on origins and terminus
-        BOOST_REQUIRE_EQUAL(resp.origins().size(),1);
-        BOOST_REQUIRE_EQUAL(resp.terminus().size(),1);
+        BOOST_REQUIRE_EQUAL(resp.origins().size(), 1);
+        BOOST_REQUIRE_EQUAL(resp.terminus().size(), 1);
     }    
 }
 
@@ -2696,8 +2696,8 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_1) {
     BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 2);
     BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(8, 10, 00));
     BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(8, 15, 00));
-    BOOST_REQUIRE_EQUAL(resp.origins().size(),1);
-    BOOST_REQUIRE_EQUAL(resp.terminus().size(),1);
+    BOOST_REQUIRE_EQUAL(resp.origins().size(), 1);
+    BOOST_REQUIRE_EQUAL(resp.terminus().size(), 1);
 }
 
 BOOST_AUTO_TEST_CASE(schedules_with_partial_terminus) {
@@ -2728,7 +2728,7 @@ BOOST_AUTO_TEST_CASE(schedules_with_partial_terminus) {
     {
         navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
         terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
-                        nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+                           nt::RTLevel::Base, std::numeric_limits<size_t>::max());
 
         pbnavitia::Response resp = pb_creator.get_response();
         BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
@@ -2767,7 +2767,7 @@ BOOST_AUTO_TEST_CASE(schedules_with_partial_terminus) {
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().terminus(), "D");
 
         // Tests on origins and terminus
-        BOOST_REQUIRE_EQUAL(resp.origins().size(),3);
-        BOOST_REQUIRE_EQUAL(resp.terminus().size(),3);
+        BOOST_REQUIRE_EQUAL(resp.origins().size(), 3);
+        BOOST_REQUIRE_EQUAL(resp.terminus().size(), 3);
     }
 }

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -2594,7 +2594,7 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         // Tests on origins and terminus
         BOOST_REQUIRE_EQUAL(resp.origins().size(), 1);
         BOOST_REQUIRE_EQUAL(resp.terminus().size(), 1);
-    }    
+    }
 }
 
 BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_0) {

--- a/source/time_tables/tests/departure_boards_test.cpp
+++ b/source/time_tables/tests/departure_boards_test.cpp
@@ -1959,30 +1959,54 @@ BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
         auto stop_schedule = resp.stop_schedules(0);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bob");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "C");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins()[0], "A");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus()[0], "C");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11, 00, 00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().origin(), "A");
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().terminus(), "C");
         // Direction B -> A
         stop_schedule = resp.stop_schedules(1);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bobette");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins()[0], "C");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus()[0], "A");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(12, 00, 00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().origin(), "C");
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().terminus(), "A");
         // Directions B -> C -> D
         stop_schedule = resp.stop_schedules(2);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:boby");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "D");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins()[0], "A");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus()[0], "D");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(11, 15, 00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().origin(), "A");
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().terminus(), "D");
         // Direction B -> A
         stop_schedule = resp.stop_schedules(3);
         BOOST_CHECK_EQUAL(stop_schedule.route().name(), "route:bobynette");
         BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().direction(), "A");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().origins()[0], "D");
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(stop_schedule.pt_display_informations().terminus()[0], "A");
         BOOST_REQUIRE_EQUAL(stop_schedule.date_times_size(), 1);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).date(), builder_date);
         BOOST_CHECK_EQUAL(stop_schedule.date_times(0).time(), time_to_int(13, 00, 00));
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().origin(), "D");
+        BOOST_CHECK_EQUAL(stop_schedule.date_times(0).properties().terminus(), "A");
     }
     // we should have two terminus_schedules: B -> C -> D and b -> A
     {
@@ -1997,24 +2021,42 @@ BOOST_AUTO_TEST_CASE(schedules_on_merged_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "route:bobette");
         BOOST_CHECK_EQUAL(terminus_schedule.route().line().name(), "line:bob");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[1], "D");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "A");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12, 00, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(13, 00, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().vehicle_journey_id(), "vehicle_journey:vj3");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().vehicle_journey_id(), "vehicle_journey:vj4");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().origin(), "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().terminus(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().origin(), "D");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().terminus(), "A");
 
         // Direction B -> D (direction B -> C is merged in B -> C -> D)
         terminus_schedule = resp.terminus_schedules(1);
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "route:boby");
         BOOST_CHECK_EQUAL(terminus_schedule.route().line().name(), "line:bob");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "D");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[1], "D");
         BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11, 00, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(11, 15, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().vehicle_journey_id(), "vehicle_journey:vj1");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().vehicle_journey_id(), "vehicle_journey:vj2");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().origin(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().terminus(), "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().origin(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().terminus(), "D");
     }
 }
 
@@ -2457,6 +2499,10 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         auto terminus_schedule = resp.terminus_schedules(0);
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "backward");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "M");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "M");
         BOOST_CHECK_EQUAL(terminus_schedule.route().line().uri(), "Line1");
         BOOST_CHECK_EQUAL(terminus_schedule.stop_point().uri(), "C:sp");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 2);
@@ -2466,6 +2512,10 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         terminus_schedule = resp.terminus_schedules(1);
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "backward");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "J");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "J");
         BOOST_CHECK_EQUAL(terminus_schedule.route().line().uri(), "Line1");
         BOOST_CHECK_EQUAL(terminus_schedule.stop_point().uri(), "C:sp");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 2);
@@ -2475,6 +2525,10 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         terminus_schedule = resp.terminus_schedules(2);
         BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "forward");
         BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "M");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "A");
         BOOST_CHECK_EQUAL(terminus_schedule.route().line().uri(), "Line1");
         BOOST_CHECK_EQUAL(terminus_schedule.stop_point().uri(), "C:sp");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 4);
@@ -2482,6 +2536,9 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(11, 25, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(2).time(), time_to_int(11, 45, 00));
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(3).time(), time_to_int(11, 55, 00));
+        // Tests on origins and terminus
+        BOOST_REQUIRE_EQUAL(resp.origins().size(),3);
+        BOOST_REQUIRE_EQUAL(resp.terminus().size(),3);
     }
     {
         // Calculate terminus schedule at StopArea (M)
@@ -2534,7 +2591,10 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_multiple_routes) {
         BOOST_CHECK_EQUAL(terminus_schedule.stop_point().uri(), "J2");
         BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 1);
         BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(8, 30, 00));
-    }
+        // Tests on origins and terminus
+        BOOST_REQUIRE_EQUAL(resp.origins().size(),1);
+        BOOST_REQUIRE_EQUAL(resp.terminus().size(),1);
+    }    
 }
 
 BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_0) {
@@ -2636,4 +2696,78 @@ BOOST_AUTO_TEST_CASE(terminus_schedule_group_by_stoparea_1) {
     BOOST_CHECK_EQUAL(terminus_schedule.date_times().size(), 2);
     BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(8, 10, 00));
     BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(8, 15, 00));
+    BOOST_REQUIRE_EQUAL(resp.origins().size(),1);
+    BOOST_REQUIRE_EQUAL(resp.terminus().size(),1);
+}
+
+BOOST_AUTO_TEST_CASE(schedules_with_partial_terminus) {
+    /*
+     * Check loosing terminus routes for terminus_schedules
+     *
+     * 1 line, 2 routes, bob, boby (one forward, and one backward)
+     * Bob:     A -> B -> C
+     * Bob:     A -> B -> C -> D
+     * Boby:         C -> B -> A
+     * Boby:    D -> C -> B -> A
+     */
+    ed::builder b("20160802", [&](ed::builder& b) {
+        b.vj("line:bob", "11111111", "", true, "vj1", "")
+            .route("route:bob")("A", "10:00"_t)("B", "11:00"_t)("C", "12:00"_t);
+        b.vj("line:bob", "11111111", "", true, "vj2", "")
+            .route("route:bob")("A", "10:15"_t)("B", "11:15"_t)("C", "12:15"_t)("D", "13:15"_t);
+        b.vj("line:bob", "11111111", "", true, "vj3", "")
+            .route("route:Boby")("C", "11:00"_t)("B", "12:00"_t)("A", "13:00"_t);
+        b.vj("line:bob", "11111111", "", true, "vj4", "")
+            .route("route:Boby")("D", "11:00"_t)("C", "12:00"_t)("B", "13:00"_t)("A", "14:00"_t);
+    });
+    auto* data_ptr = b.data.get();
+
+    auto builder_date = navitia::to_posix_timestamp("20160802T000000"_dt);
+
+    // We will have 2 stop_schedules.
+    {
+        navitia::PbCreator pb_creator(data_ptr, bt::second_clock::universal_time(), null_time_period);
+        terminus_schedules(pb_creator, "stop_point.uri=B", {}, {}, d("20160802T090000"), 86400, 0, 10, 0,
+                        nt::RTLevel::Base, std::numeric_limits<size_t>::max());
+
+        pbnavitia::Response resp = pb_creator.get_response();
+        BOOST_REQUIRE_EQUAL(resp.terminus_schedules_size(), 2);
+        // Directions B -> A
+        auto terminus_schedule = resp.terminus_schedules(0);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "route:Boby");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "A");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(12, 00, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(13, 00, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().origin(), "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().terminus(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().origin(), "D");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().terminus(), "A");
+        // Direction B -> C + D
+        terminus_schedule = resp.terminus_schedules(1);
+        BOOST_CHECK_EQUAL(terminus_schedule.route().name(), "route:bob");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().direction(), "D");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins().size(), 1);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().origins()[0], "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus().size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[0], "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.pt_display_informations().terminus()[1], "D");
+        BOOST_REQUIRE_EQUAL(terminus_schedule.date_times_size(), 2);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).date(), builder_date);
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).time(), time_to_int(11, 00, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).time(), time_to_int(11, 15, 00));
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().origin(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(0).properties().terminus(), "C");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().origin(), "A");
+        BOOST_CHECK_EQUAL(terminus_schedule.date_times(1).properties().terminus(), "D");
+
+        // Tests on origins and terminus
+        BOOST_REQUIRE_EQUAL(resp.origins().size(),3);
+        BOOST_REQUIRE_EQUAL(resp.terminus().size(),3);
+    }
 }

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1713,11 +1713,18 @@ void PbCreator::Filler::fill_pb_object(const StopTimeCalendar* stop_time_calenda
     }
 
     // Fill origin and terminus:
-    auto origin_uri = stop_time_calendar->stop_time->vehicle_journey->stop_time_list.front().stop_point->stop_area->uri;
-    auto terminus_uri =
-        stop_time_calendar->stop_time->vehicle_journey->stop_time_list.back().stop_point->stop_area->uri;
-    hn->set_origin(origin_uri);
-    hn->set_terminus(terminus_uri);
+    if (!stop_time_calendar->stop_time->vehicle_journey->stop_time_list.empty()) {
+        if (stop_time_calendar->stop_time->vehicle_journey->stop_time_list.front().stop_point) {
+            auto origin_uri =
+                stop_time_calendar->stop_time->vehicle_journey->stop_time_list.front().stop_point->stop_area->uri;
+            hn->set_origin(origin_uri);
+        }
+        if (stop_time_calendar->stop_time->vehicle_journey->stop_time_list.back().stop_point) {
+            auto terminus_uri =
+                stop_time_calendar->stop_time->vehicle_journey->stop_time_list.back().stop_point->stop_area->uri;
+            hn->set_terminus(terminus_uri);
+        }
+    }
 
     fill(pb_creator.data->pt_data->comments.get(*stop_time_calendar->stop_time), hn->mutable_notes());
     if (stop_time_calendar->stop_time->vehicle_journey != nullptr) {

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1714,7 +1714,8 @@ void PbCreator::Filler::fill_pb_object(const StopTimeCalendar* stop_time_calenda
 
     // Fill origin and terminus:
     auto origin_uri = stop_time_calendar->stop_time->vehicle_journey->stop_time_list.front().stop_point->stop_area->uri;
-    auto terminus_uri = stop_time_calendar->stop_time->vehicle_journey->stop_time_list.back().stop_point->stop_area->uri;
+    auto terminus_uri =
+        stop_time_calendar->stop_time->vehicle_journey->stop_time_list.back().stop_point->stop_area->uri;
     hn->set_origin(origin_uri);
     hn->set_terminus(terminus_uri);
 

--- a/source/type/pb_converter.cpp
+++ b/source/type/pb_converter.cpp
@@ -1711,6 +1711,13 @@ void PbCreator::Filler::fill_pb_object(const StopTimeCalendar* stop_time_calenda
         destination->set_uri("destination:" + std::to_string(hash_fn(sa->name)));
         destination->set_destination(sa->name);
     }
+
+    // Fill origin and terminus:
+    auto origin_uri = stop_time_calendar->stop_time->vehicle_journey->stop_time_list.front().stop_point->stop_area->uri;
+    auto terminus_uri = stop_time_calendar->stop_time->vehicle_journey->stop_time_list.back().stop_point->stop_area->uri;
+    hn->set_origin(origin_uri);
+    hn->set_terminus(terminus_uri);
+
     fill(pb_creator.data->pt_data->comments.get(*stop_time_calendar->stop_time), hn->mutable_notes());
     if (stop_time_calendar->stop_time->vehicle_journey != nullptr) {
         if (!stop_time_calendar->stop_time->vehicle_journey->odt_message.empty()) {
@@ -2281,6 +2288,8 @@ const pbnavitia::Response& PbCreator::get_response() {
     contributors.clear();
     Filler(0, {DumpMessage::No}, *this).fill_pb_object(impacts, response.mutable_impacts());
     impacts.clear();
+    Filler(0, {DumpMessage::No}, *this).fill_pb_object(origins, response.mutable_origins());
+    origins.clear();
     Filler(0, {DumpMessage::No}, *this).fill_pb_object(terminus, response.mutable_terminus());
     terminus.clear();
     return response;

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -194,7 +194,7 @@ inline pbnavitia::NavitiaType get_embedded_type(const nt::MetaVehicleJourney*) {
 
 struct PbCreator {
     std::set<const nt::Contributor*, Less> contributors;
-    // Used for journeys et timetable
+    // Used for journeys and timetable
     std::set<const nt::StopArea*, Less> terminus;
     std::set<const nt::StopArea*, Less> origins;
     std::set<boost::shared_ptr<type::disruption::Impact>, Less> impacts;

--- a/source/type/pb_converter.h
+++ b/source/type/pb_converter.h
@@ -194,8 +194,9 @@ inline pbnavitia::NavitiaType get_embedded_type(const nt::MetaVehicleJourney*) {
 
 struct PbCreator {
     std::set<const nt::Contributor*, Less> contributors;
-    // Used for journeys
+    // Used for journeys et timetable
     std::set<const nt::StopArea*, Less> terminus;
+    std::set<const nt::StopArea*, Less> origins;
     std::set<boost::shared_ptr<type::disruption::Impact>, Less> impacts;
     // std::reference_wrapper<const nt::Data> data;
     const nt::Data* data = nullptr;


### PR DESCRIPTION
As explained in the ticket below we add the following informations in the end points /departures, /arrivals, /stop_schedules and /terminus schedules :

- link on origin and terminus in date_time.
- link on origin and terminus in display_informations
- list of stop_areas in response.origins and response.terminus 

https://navitia.atlassian.net/browse/NAV-4031