### PR TITLE
[NAV-3770][kraken]: fetch admins by coord for stop_area

### DIFF
--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -335,8 +335,10 @@ void Data::build_administrative_regions() {
         }
     }
     if (cpt_no_projected)
-        LOG4CPLUS_WARN(log, cpt_no_projected << "/" << pt_data->stop_points.size()
+        LOG4CPLUS_WARN(log, cpt_no_projected << "/" << pt_data->stop_areas.size()
                                              << " stop_areas are not associated with any admin");
+    // For stop_areas without any admin, we can always fetch admins of it's stop_points
+    this->pt_data->build_admins_stop_areas();
 
     for (const auto* sa : pt_data->stop_areas) {
         for (auto admin : sa->admin_list) {

--- a/source/type/data.cpp
+++ b/source/type/data.cpp
@@ -296,7 +296,7 @@ void Data::build_administrative_regions() {
     }
     if (cpt_no_projected)
         LOG4CPLUS_WARN(log, cpt_no_projected << "/" << pt_data->stop_points.size()
-                                             << " stop_points are not associated with any admins");
+                                             << " stop_points are not associated with any admin");
 
     // set admins to poi
     cpt_no_projected = 0;
@@ -317,12 +317,26 @@ void Data::build_administrative_regions() {
     }
     if (cpt_no_projected)
         LOG4CPLUS_WARN(log,
-                       cpt_no_projected << "/" << geo_ref->pois.size() << " pois are not associated with any admins");
+                       cpt_no_projected << "/" << geo_ref->pois.size() << " pois are not associated with any admin");
     if (cpt_no_initialized)
         LOG4CPLUS_WARN(log,
                        cpt_no_initialized << "/" << geo_ref->pois.size() << " pois with coordinates not initialized");
 
-    this->pt_data->build_admins_stop_areas();
+    // set admins to stop areas
+    cpt_no_projected = 0;
+    for (type::StopArea* stop_area : pt_data->stop_areas) {
+        if (!stop_area->admin_list.empty()) {
+            continue;
+        }
+        const auto& admins = find_admins(stop_area->coord, admin_tree);
+        boost::push_back(stop_area->admin_list, admins);
+        if (admins.empty()) {
+            ++cpt_no_projected;
+        }
+    }
+    if (cpt_no_projected)
+        LOG4CPLUS_WARN(log, cpt_no_projected << "/" << pt_data->stop_points.size()
+                                             << " stop_areas are not associated with any admin");
 
     for (const auto* sa : pt_data->stop_areas) {
         for (auto admin : sa->admin_list) {

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -437,22 +437,6 @@ void PT_Data::build_proximity_list() {
     this->stop_point_proximity_list.build();
 }
 
-void PT_Data::build_admins_stop_areas() {
-    for (navitia::type::StopPoint* stop_point : this->stop_points) {
-        if (!stop_point->stop_area) {
-            continue;
-        }
-        for (navitia::georef::Admin* admin : stop_point->admin_list) {
-            auto find_predicate = [&](navitia::georef::Admin* adm) { return adm->idx == admin->idx; };
-            auto it = std::find_if(stop_point->stop_area->admin_list.begin(), stop_point->stop_area->admin_list.end(),
-                                   find_predicate);
-            if (it == stop_point->stop_area->admin_list.end()) {
-                stop_point->stop_area->admin_list.push_back(admin);
-            }
-        }
-    }
-}
-
 void PT_Data::build_uri() {
 #define NORMALIZE_EXT_CODE(type_name, collection_name) \
     for (auto element : collection_name)               \

--- a/source/type/pt_data.cpp
+++ b/source/type/pt_data.cpp
@@ -437,6 +437,27 @@ void PT_Data::build_proximity_list() {
     this->stop_point_proximity_list.build();
 }
 
+void PT_Data::build_admins_stop_areas() {
+    for (navitia::type::StopPoint* stop_point : this->stop_points) {
+        if (!stop_point->stop_area) {
+            continue;
+        }
+
+        if (!stop_point->stop_area->admin_list.empty()) {
+            continue;
+        }
+
+        for (navitia::georef::Admin* admin : stop_point->admin_list) {
+            auto find_predicate = [&](navitia::georef::Admin* adm) { return adm->idx == admin->idx; };
+            auto it = std::find_if(stop_point->stop_area->admin_list.begin(), stop_point->stop_area->admin_list.end(),
+                                   find_predicate);
+            if (it == stop_point->stop_area->admin_list.end()) {
+                stop_point->stop_area->admin_list.push_back(admin);
+            }
+        }
+    }
+}
+
 void PT_Data::build_uri() {
 #define NORMALIZE_EXT_CODE(type_name, collection_name) \
     for (auto element : collection_name)               \

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -127,6 +127,7 @@ public:
 
     /** Construit l'indexe ProximityList */
     void build_proximity_list();
+    void build_admins_stop_areas();
     /// sort the collections and set the corresponding idx field
     void sort_and_index();
 

--- a/source/type/pt_data.h
+++ b/source/type/pt_data.h
@@ -127,7 +127,6 @@ public:
 
     /** Construit l'indexe ProximityList */
     void build_proximity_list();
-    void build_admins_stop_areas();
     /// sort the collections and set the corresponding idx field
     void sort_and_index();
 


### PR DESCRIPTION
Instead of adding admins of all it's stop_points, fetch admins from it's coordinate for a stop_area.
Before correction, more than one admin with level = 8 was possible.

For more details: https://navitia.atlassian.net/browse/NAV-3770