### PR TITLE
[Migration debian11]: Use binary mode for osm2mimir and list for shape

### DIFF
--- a/source/tyr/requirements.txt
+++ b/source/tyr/requirements.txt
@@ -10,7 +10,8 @@ Jinja2==2.11.3
 Mako==0.9.1
 MarkupSafe==0.23
 SQLAlchemy==1.3.3
-Shapely==1.5.0
+Shapely==1.5.0 ; python_version == "2.7"
+Shapely==1.8.5 ; python_version >= "3.9"
 Werkzeug==0.15.5
 alembic==1.0.11
 aniso8601==0.82

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -501,7 +501,10 @@ def parse_poly(lines):
 
         elif in_ring:
             # we are in a ring and picking up new coordinates.
-            ring.append(map(float, line.split()))
+            if PY3:
+                ring.append(list(map(float, line.split())))
+            else:
+                ring.append(map(float, line.split()))
 
         elif not in_ring and line.strip() == 'END':
             # we are at the end of the whole polygon.

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -60,6 +60,7 @@ import retrying
 from tyr.minio import MinioWrapper
 
 from tyr.poi_to_excluded_zones import poi_to_excluded_zones
+from tyr.helper import PY3
 
 
 def unzip_if_needed(filename):

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -854,7 +854,8 @@ def osm2mimir(self, autocomplete_instance, filename, job_id, dataset_uid, autoco
     custom_config_config_toml = '{}/{}.toml'.format(working_directory, custom_config)
     data = autocomplete_instance.config_toml.encode("utf-8")
     cosmogony_file = models.DataSet.get_cosmogony_file_path()
-    with open(custom_config_config_toml, 'wb') as f:
+    mode = "wb" if PY3 else "w"
+    with open(custom_config_config_toml, mode) as f:
         f.write(data)
     params = get_osm2mimir_params(
         autocomplete_instance,

--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -854,7 +854,7 @@ def osm2mimir(self, autocomplete_instance, filename, job_id, dataset_uid, autoco
     custom_config_config_toml = '{}/{}.toml'.format(working_directory, custom_config)
     data = autocomplete_instance.config_toml.encode("utf-8")
     cosmogony_file = models.DataSet.get_cosmogony_file_path()
-    with open(custom_config_config_toml, 'w') as f:
+    with open(custom_config_config_toml, 'wb') as f:
         f.write(data)
     params = get_osm2mimir_params(
         autocomplete_instance,

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -50,6 +50,7 @@ BILLING_PLAN_NOT_EXIST_MSG = 'billing plan doesn\'t exist'
 MAX_TRY_FOR_REPOST_TO_SECONDARY_TYR = 3
 PY3 = sys.version_info[0] == 3
 
+
 def get_message(key, email, args):
     if key not in ["end_point_id", "billing_plan_id"]:
         raise AttributeError

--- a/source/tyr/tyr/helper.py
+++ b/source/tyr/tyr/helper.py
@@ -48,7 +48,7 @@ import requests
 END_POINT_NOT_EXIST_MSG = 'end_point doesn\'t exist'
 BILLING_PLAN_NOT_EXIST_MSG = 'billing plan doesn\'t exist'
 MAX_TRY_FOR_REPOST_TO_SECONDARY_TYR = 3
-
+PY3 = sys.version_info[0] == 3
 
 def get_message(key, email, args):
     if key not in ["end_point_id", "billing_plan_id"]:


### PR DESCRIPTION
For more details: https://navitia.atlassian.net/browse/NAV-4245

With this correction, osm2mimir works well : Tested in sbx