### PR TITLE
simplify and speed-up sonar config

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,7 +7,6 @@ on:
     branches: [ dev ]
 
 env:
-   SONAR_SCANNER_VERSION: 5.0.1.3006
    REGION: eu-west-1
 
 jobs:
@@ -31,6 +30,8 @@ jobs:
           password: ${{ needs.aws_creds.outputs.token }}
 
     steps:
+    - name: Install sonar dependencies
+      run: apt update -y && apt install -y unzip
     - name: force chown to avoid errors
       run: chown -R $(whoami):$(whoami) .
     - name: Display remaining space
@@ -45,36 +46,18 @@ jobs:
       with:
         submodules: recursive
         token: ${{ steps.ci-core-app-token.outputs.token }}
-    - name: Install SonarCloud's dependencies for C++ analysis
-      run : |
-        apt update -y
-        apt install -y unzip wget
-        wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
-        unzip -u build-wrapper-linux-x86.zip
-        unzip -u sonar-scanner-cli-$SONAR_SCANNER_VERSION-linux.zip
-
-    - name: Cache Sonar
-      id: cache-sonar
-      uses: actions/cache@v3
-      with:
-        path: sonar_cache
-        key: sonar-cache-${{ github.event.head_commit.id }}
-        restore-keys: |
-            sonar-cache-
     - name: Configure
-      run: cmake -DCMAKE_BUILD_TYPE=Profile -DSTRIP_SYMBOLS=ON source
-    - name: Build
-      run: build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir build-wrapper-output-dir make -j $(nproc)
-    - name: SonarCloud Scan
-      # We only want 1 scan as it would bloat sonarcube otherwise
-      # And only on an internal merge (to dev/master) as SonarCloud's token uses Secrets that not available from a fork :( (eg. https://docs.github.com/en/actions/reference/encrypted-secrets#using-encrypted-secrets-in-a-workflow)
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
-          sonar-scanner-$SONAR_SCANNER_VERSION-linux/bin/sonar-scanner \
-                -Dsonar.cfamily.threads=$(nproc)
-
+        mkdir build
+        cmake -DCMAKE_BUILD_TYPE=Profile -DSTRIP_SYMBOLS=ON -S source -B build
+    - name: SonarQube Scan
+      uses: SonarSource/sonarqube-scan-action@v4
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          args: >
+            --define sonar.cfamily.compile-commands=build/compile_commands.json
     - name: clean up workspace
       if: ${{ always() }}
       run: |

--- a/docker/debian11/jormungandr.dockerfile
+++ b/docker/debian11/jormungandr.dockerfile
@@ -9,7 +9,7 @@ COPY ./source/jormungandr ./jormungandr
 COPY ./source/navitia-proto ./navitia-proto
 COPY ./docker/ca-certificates/*.crt /usr/local/share/ca-certificates/
 #TODO remove the need for this file
-RUN echo "__version__ = \'$GIT_REVISION\'" > jormungandr/jormungandr/_version.py
+RUN echo "__version__ = '$GIT_REVISION'" > jormungandr/jormungandr/_version.py
 
 RUN apt clean \
     && apt update --fix-missing \

--- a/docker/debian11/jormungandr.dockerfile
+++ b/docker/debian11/jormungandr.dockerfile
@@ -8,7 +8,8 @@ COPY ./source/navitiacommon ./navitiacommon
 COPY ./source/jormungandr ./jormungandr
 COPY ./source/navitia-proto ./navitia-proto
 COPY ./docker/ca-certificates/*.crt /usr/local/share/ca-certificates/
-RUN echo "__version__ = \'$GIT_REVISION\'" > jormungandr/_version.py
+#TODO remove the need for this file
+RUN echo "__version__ = \'$GIT_REVISION\'" > jormungandr/jormungandr/_version.py
 
 RUN apt clean \
     && apt update --fix-missing \

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,12 +8,6 @@ sonar.projectName=Navitia
 
 # Config
 sonar.sources=source
-sonar.cfamily.build-wrapper-output=build-wrapper-output-dir
-
-
-# Cache
-sonar.cfamily.cache.enabled=true
-sonar.cfamily.cache.path=sonar_cache
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- Le cache sonar sur filesystem était cassé et defaultait sur le mode server:
<img width="968" height="113" alt="image" src="https://github.com/user-attachments/assets/c764d301-8a53-49ed-9015-7e0663ed19ba" />

- utilisation du compile_commands.json de cmake plutot que le build-wrapper de cmake (qui font la même chose), mais ce qui nous évite de faire un full build juste pour récupérer ce fichier.
- 
- utilisation d'une github action pour sonar, inspiré de : https://github.com/sonarsource-cfamily-examples/linux-cmake-compdb-gh-actions-sq/blob/main/sonar-project.properties