### PR TITLE
[#DHUB-1594] [Tyr] Bump TartareTools / NTFS 0.20 support

### DIFF
--- a/docker/debian11/Dockerfile-tyr-worker
+++ b/docker/debian11/Dockerfile-tyr-worker
@@ -1,7 +1,7 @@
 # Compilation of rust binaries from tartare-tools
-FROM rust:1.82-bullseye AS tartare-tools
+FROM rust:1.90-bullseye AS tartare-tools
 
-ARG TARTARE_TOOLS_VERSION="v0.47.1"
+ARG TARTARE_TOOLS_VERSION="v0.66.0"
 ARG GITHUB_TOKEN
 RUN git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/hove-io/".insteadOf "ssh://git@github.com/hove-io/"
 RUN git clone -b ${TARTARE_TOOLS_VERSION} --depth 1 https://x-access-token:${GITHUB_TOKEN}@github.com/hove-io/tartare-tools


### PR DESCRIPTION
Bump TartareTools in Tyr to support NTFS v0.20.

Ref https://navitia.atlassian.net/browse/DHUB-1594

In the context of [NAV-4448](https://navitia.atlassian.net/browse/NAV-4448) _(TN - Affichage des voies dans la RI)_

[NAV-4448]: https://navitia.atlassian.net/browse/NAV-4448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ