### PR TITLE
[NAV-4669] Fix fusio2s3 filename handling and add MinIO SSL support

### DIFF
--- a/source/tyr/tyr/binarisation.py
+++ b/source/tyr/tyr/binarisation.py
@@ -1133,6 +1133,7 @@ def poi2mimir(self, instance_name, input, autocomplete_version, job_id=None, dat
 @celery.task(bind=True)
 def fusio2s3(self, instance_config, filename, job_id, dataset_uid):
     """Zip fusio file and launch fusio2s3"""
+    current_app.logger.info("Tyr.bina > [{}] fusio2s3 : {}".format(instance_config.name, filename))
 
     root_dir = os.path.dirname(filename)
     loki_dir = os.path.join(root_dir, "for_loki")
@@ -1145,6 +1146,12 @@ def fusio2s3(self, instance_config, filename, job_id, dataset_uid):
 
 def enrich_ntfs_with_addresses(dataset_type, instance_config, loki_dir, filename, job_id, dataset_uid):
     """launch enrich-ntfs-with-addresses"""
+
+    current_app.logger.info(
+        "Tyr.bina > [{}] enrich-ntfs-with-addresses - dir:{}, filename:{} ".format(
+            instance_config.name, loki_dir, filename
+        )
+    )
 
     job = models.Job.query.get(job_id)
     dataset = _retrieve_dataset_and_set_state("fusio", job.id)

--- a/source/tyr/tyr/default_settings.py
+++ b/source/tyr/tyr/default_settings.py
@@ -164,6 +164,8 @@ MINIO_ACCESS_KEY = os.getenv('TYR_MINIO_ACCESS_KEY', None)
 
 MINIO_SECRET_KEY = os.getenv('TYR_MINIO_SECRET_KEY', None)
 
+MINIO_USE_SSL = os.getenv('TYR_MINIO_USE_SSL', 'true').lower() in ['1', 'true', 'yes']
+
 ACCESS_CONTROL_ALLOW_ORIGIN = os.getenv('TYR_ACCESS_CONTROL_ALLOW_ORIGIN', None)
 
 # we don't enable serpy for now

--- a/source/tyr/tyr/minio.py
+++ b/source/tyr/tyr/minio.py
@@ -33,7 +33,6 @@ import os
 import requests
 from minio import Minio
 
-
 from flask import current_app
 
 
@@ -41,6 +40,10 @@ class MinioWrapper:
     def __init__(self):
         self.endpoint = current_app.config.get('MINIO_URL', None)
         self.bucket_name = current_app.config.get('MINIO_BUCKET_NAME', None)
+        self.use_ssl = current_app.config.get('MINIO_USE_SSL', True)
+
+        current_app.logger.info("Tyr::MinioWrapper::__init__ : {}/{}".format(self.endpoint, self.bucket_name))
+
         if self.endpoint is None:
             raise Exception("MINIO_URL is not configured")
         if self.bucket_name is None:
@@ -68,13 +71,17 @@ class MinioWrapper:
         metadata={},  # tags that will be applied to the file in the bucket
         content_type="application/zip",
     ):
+        current_app.logger.info("Tyr::MinioWrapper::upload_file: {} -> {} ".format(file_key, filename))
+
         if self.use_iam_provider:
             self.retrieve_credentials()
+
         client = Minio(
             endpoint=self.endpoint,
             access_key=self.access_key,
             secret_key=self.secret_key,
             session_token=self.session_token,
+            secure=self.use_ssl,
         )
         client.fput_object(self.bucket_name, file_key, filename, metadata=metadata, content_type=content_type)
 
@@ -86,6 +93,7 @@ class MinioWrapper:
             access_key=self.access_key,
             secret_key=self.secret_key,
             session_token=self.session_token,
+            secure=self.use_ssl,
         )
         return client.fget_object(self.bucket_name, object_name, file_path)
 

--- a/source/tyr/tyr/tasks.py
+++ b/source/tyr/tyr/tasks.py
@@ -199,6 +199,7 @@ def import_data(
             else:
                 filename = _file
 
+            origin_filename = filename
             if dataset.type not in ['poi', 'synonym', 'shape']:
                 filename = unzip_if_needed(filename)
 
@@ -211,11 +212,15 @@ def import_data(
                 if loki_data_source is not None:
                     if loki_data_source == "minio":
                         if dataset.type == "fusio":
-                            loki_actions.append(fusio2s3.si(instance_config, filename, dataset_uid=dataset.uid))
+                            loki_actions.append(
+                                fusio2s3.si(instance_config, origin_filename, dataset_uid=dataset.uid)
+                            )
                         if dataset.type == "gtfs":
-                            loki_actions.append(gtfs2s3.si(instance_config, filename, dataset_uid=dataset.uid))
+                            loki_actions.append(
+                                gtfs2s3.si(instance_config, origin_filename, dataset_uid=dataset.uid)
+                            )
                     elif loki_data_source == "local" and dataset.type in ["fusio", "gtfs"]:
-                        zip_file = zip_if_needed(filename)
+                        zip_file = zip_if_needed(origin_filename)
                         dest = os.path.join(os.path.dirname(instance_config.target_file), "ntfs.zip")
                         shutil.copy(zip_file, dest)
                     else:


### PR DESCRIPTION
- Pass original zip filename to loki actions instead of unzipped directory
- Add logging for fusio2s3 and enrich-ntfs-with-addresses tasks

To use with Minio local instance for testing :
- Add MINIO_USE_SSL configuration support
- Configure MinIO client to use SSL based on settings