### PR TITLE
[TYR] Add pagination to Tyr's `/v0/jobs` API

### DIFF
--- a/source/tyr/readme.md
+++ b/source/tyr/readme.md
@@ -119,6 +119,10 @@ You may want to specify job id to filter these jobs :
 
     GET $HOST/v0/jobs/<ID>
 
+Get the last 10 jobs for an instance:
+
+    GET $HOST/v0/jobs/<INSTANCE>?count=10
+
 A job is created when a new dataset is detected by tyr_beat.
 You can also trigger a data integration by posting your dataset to the job endpoint filtered by instance.
 

--- a/source/tyr/tests/integration/jobs_test.py
+++ b/source/tyr/tests/integration/jobs_test.py
@@ -37,12 +37,12 @@ import datetime
 def create_dataset(dataset_type):
     dataset = models.DataSet()
     dataset.type = dataset_type
-    dataset.family_type = '{}_family'.format(dataset_type)
-    dataset.name = '/path/to/dataset_{}'.format(dataset_type)
+    dataset.family_type = "{}_family".format(dataset_type)
+    dataset.name = "/path/to/dataset_{}".format(dataset_type)
     models.db.session.add(dataset)
 
     metric = models.Metric()
-    metric.type = '{}2ed'.format(dataset_type)
+    metric.type = "{}2ed".format(dataset_type)
     metric.duration = datetime.timedelta(seconds=9.0001)
     metric.dataset = dataset
     models.db.session.add(metric)
@@ -176,3 +176,38 @@ def test_jobs_deletion(create_instances):
     # --- 7 --- BONUS: WHEN NO JOB TO DELETE, STATUS = 204
     resp, status_code = api_delete("/v0/jobs?confirm=yes", check=False, no_json=True)
     assert status_code == 204
+
+
+def test_jobs_count_parameter():
+    """
+    Test GET method for /jobs with count parameter
+    """
+    with app.app_context():
+        instance = models.Instance(name="test_count_instance")
+        models.db.session.add(instance)
+
+        for i in range(2000):
+            job = models.Job()
+            job.state = "done"
+            dataset, metric = create_dataset("fusio")
+            job.data_sets.append(dataset)
+            job.metrics.append(metric)
+            instance.jobs.append(job)
+
+        models.db.session.commit()
+
+    # Test default behavior (should return 30 jobs)
+    resp = api_get("/v0/jobs/test_count_instance")
+    assert len(resp["jobs"]) == 30
+
+    # Test with custom count
+    resp = api_get("/v0/jobs/test_count_instance?count=10")
+    assert len(resp["jobs"]) == 10
+
+    # Test boundary: count=0 should clamp to 1
+    resp = api_get("/v0/jobs/test_count_instance?count=0")
+    assert len(resp["jobs"]) == 1
+
+    # Test boundary: count=2000 should clamp to 1000
+    resp = api_get("/v0/jobs/test_count_instance?count=2000")
+    assert len(resp["jobs"]) == 1000

--- a/source/tyr/tests/integration/jobs_test.py
+++ b/source/tyr/tests/integration/jobs_test.py
@@ -186,7 +186,7 @@ def test_jobs_count_parameter():
         instance = models.Instance(name="test_count_instance")
         models.db.session.add(instance)
 
-        for i in range(2000):
+        for _ in range(2000):
             job = models.Job()
             job.state = "done"
             dataset, metric = create_dataset("fusio")
@@ -211,3 +211,93 @@ def test_jobs_count_parameter():
     # Test boundary: count=2000 should clamp to 1000
     resp = api_get("/v0/jobs/test_count_instance?count=2000")
     assert len(resp["jobs"]) == 1000
+
+
+def test_jobs_pagination():
+    """
+    Test GET method for /jobs with pagination
+    """
+    with app.app_context():
+        instance = models.Instance(name="test_pagination_instance")
+        models.db.session.add(instance)
+
+        # Create 25 jobs for testing pagination
+        for i in range(25):
+            job = models.Job()
+            job.state = "done"
+            dataset, metric = create_dataset("fusio")
+            job.data_sets.append(dataset)
+            job.metrics.append(metric)
+            instance.jobs.append(job)
+
+        models.db.session.commit()
+
+    # Test page 1 with count=10 (should have next link)
+    resp = api_get("/v0/jobs/test_pagination_instance?count=10")
+    assert "pagination" in resp
+    assert "next" in resp["pagination"]
+    assert "page=2" in resp["pagination"]["next"]
+
+    # Test page 3 - last page (should have 5 jobs, no next link)
+    resp = api_get("/v0/jobs/test_pagination_instance?count=10&page=3")
+    assert len(resp["jobs"]) == 5
+    assert "pagination" in resp
+
+    # Test page beyond available data (should return empty)
+    resp = api_get("/v0/jobs/test_pagination_instance?count=10&page=10")
+    assert len(resp["jobs"]) == 0
+    assert "pagination" in resp
+
+    # Test default count (30) - should return all 25 jobs in one page
+    resp = api_get("/v0/jobs/test_pagination_instance")
+    assert len(resp["jobs"]) == 25
+    assert "pagination" not in resp
+
+    # Test with count=25 exactly (no next link)
+    resp = api_get("/v0/jobs/test_pagination_instance?count=25")
+    assert len(resp["jobs"]) == 25
+    assert "pagination" not in resp
+
+    # Test page 2 (should have next and prev link)
+    resp = api_get("/v0/jobs/test_pagination_instance?count=10&page=2")
+    assert "pagination" in resp
+    assert "next" in resp["pagination"]
+    assert "page=3" in resp["pagination"]["next"]
+    assert "prev" in resp["pagination"]
+    assert "page=1" in resp["pagination"]["prev"]
+
+    # Follow the next link
+    next_resp = api_get(resp["pagination"]["next"])
+    assert next_resp["pagination"]["current_page"] == 3
+
+    # Follow the prev link
+    prev_resp = api_get(resp["pagination"]["prev"])
+    assert prev_resp["pagination"]["current_page"] == 1
+
+
+def test_jobs_pagination_by_id_no_pagination():
+    """
+    Test that querying a specific job by ID doesn't include pagination
+    """
+    with app.app_context():
+        instance = models.Instance(name="test_id_query")
+        models.db.session.add(instance)
+
+        for i in range(5):
+            job = models.Job()
+            job.state = "done"
+            dataset, metric = create_dataset("fusio")
+            job.data_sets.append(dataset)
+            job.metrics.append(metric)
+            instance.jobs.append(job)
+
+        models.db.session.commit()
+
+    # Get first job to get an ID
+    resp = api_get("/v0/jobs/test_id_query")
+    job_id = resp["jobs"][0]["id"]
+
+    # Query specific job by ID (should not have pagination)
+    resp = api_get(f"/v0/jobs/{job_id}")
+    assert len(resp["jobs"]) == 1
+    assert "pagination" not in resp

--- a/source/tyr/tyr/fields.py
+++ b/source/tyr/tyr/fields.py
@@ -346,6 +346,15 @@ user_fields_full["authorizations"] = fields.List(
 dataset_field = {'type': fields.Raw, 'name': fields.Raw, 'family_type': fields.Raw, 'state': fields.Raw}
 metric_field = {'type': fields.Raw, 'duration': FieldTimedelta}
 
+pagination_fields = {
+    "items_on_page": fields.Integer,
+    "items_per_page": fields.Integer,
+    "current_page": fields.Integer,
+    "total_items": fields.Integer,
+    "next": fields.String,
+    "prev": fields.String,
+}
+
 job_fields = {
     'id': fields.Raw,
     'state': fields.Raw,
@@ -356,7 +365,9 @@ job_fields = {
     'instance': fields.Nested(instance_fields),
 }
 
-jobs_fields = {'jobs': fields.List(fields.Nested(job_fields))}
+jobs_fields = {
+    'jobs': fields.List(fields.Nested(job_fields)),
+}
 
 one_job_fields = {'job': fields.Nested(job_fields)}
 

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -136,13 +136,24 @@ class Status(flask_restful.Resource):
 class Job(flask_restful.Resource):
     @marshal_with(tyr.fields.jobs_fields)
     def get(self, instance_name=None, id=None):
+        parser = reqparse.RequestParser()
+        parser.add_argument(
+            'count',
+            type=IntervalValue(type=int, min_value=1, max_value=1000),
+            required=False,
+            help='Maximum number of jobs to return',
+            location=('json', 'values'),
+            default=30,
+        )
+        args = parser.parse_args()
+
         query = models.Job.query
         if instance_name:
             query = query.join(models.Instance)
             query = query.filter(models.Instance.name == instance_name)
         if id:
             query = query.filter(models.Job.id == id)
-        jobs = query.order_by(models.Job.created_at.desc()).limit(30)
+        jobs = query.order_by(models.Job.created_at.desc()).limit(args['count'])
         return {'jobs': jobs}
 
     def post(self, instance_name):

--- a/source/tyr/tyr/resources.py
+++ b/source/tyr/tyr/resources.py
@@ -44,7 +44,7 @@ import six
 import sqlalchemy
 import werkzeug
 from werkzeug.utils import secure_filename
-from flask import current_app, request
+from flask import current_app, request, url_for
 from flask_restful import marshal_with, marshal, reqparse, inputs, abort
 from jsonschema import validate, ValidationError
 from navitiacommon import models, utils
@@ -134,7 +134,6 @@ class Status(flask_restful.Resource):
 
 
 class Job(flask_restful.Resource):
-    @marshal_with(tyr.fields.jobs_fields)
     def get(self, instance_name=None, id=None):
         parser = reqparse.RequestParser()
         parser.add_argument(
@@ -145,16 +144,40 @@ class Job(flask_restful.Resource):
             location=('json', 'values'),
             default=30,
         )
+        parser.add_argument('page', type=int, required=False, default=1)
         args = parser.parse_args()
 
         query = models.Job.query
         if instance_name:
             query = query.join(models.Instance)
             query = query.filter(models.Instance.name == instance_name)
+
         if id:
-            query = query.filter(models.Job.id == id)
-        jobs = query.order_by(models.Job.created_at.desc()).limit(args['count'])
-        return {'jobs': jobs}
+            job = query.filter(models.Job.id == id).all()
+            return marshal({'jobs': job}, tyr.fields.jobs_fields)
+
+        # Use pagination for list queries
+        query = query.order_by(models.Job.created_at.desc())
+        pagination = query.paginate(args['page'], args['count'], error_out=False)
+
+        response = marshal({'jobs': pagination.items}, tyr.fields.jobs_fields)
+        pagination_data = {
+            'items_on_page': len(pagination.items),
+            'items_per_page': pagination.per_page,
+            'current_page': pagination.page,
+            'total_items': pagination.total,
+        }
+
+        if pagination.has_next:
+            pagination_data['next'] = url_for(request.endpoint, count=args['count'], page=pagination.next_num)
+
+        if pagination.has_prev:
+            pagination_data['prev'] = url_for(request.endpoint, count=args['count'], page=pagination.prev_num)
+
+        if not id and (pagination.has_next or pagination.has_prev):
+            response['pagination'] = marshal(pagination_data, tyr.fields.pagination_fields)
+
+        return response
 
     def post(self, instance_name):
         instance = models.Instance.query_existing().filter_by(name=instance_name).first_or_404()


### PR DESCRIPTION
During our last session trying to debug TYR, we were limited with the last 30 jobs in Tyr's jobs history.
We wanted to access jobs older than those, but couldn't. 

This PR adds pagination to `/v0/jobs` API to remediate the issue, using : 

`/v0/jobs/<instance>?count=100`

`/v0/jobs?count=100&page=3`