### PR TITLE
[Logs] Use Tyr.worker instance logger to print subprocess'output

### DIFF
--- a/source/navitiacommon/navitiacommon/launch_exec.py
+++ b/source/navitiacommon/navitiacommon/launch_exec.py
@@ -31,14 +31,11 @@
 """
 Function to launch a bin
 """
+
 from __future__ import absolute_import, unicode_literals
 
 import subprocess
-import os
-import select
 import re
-import fcntl
-import errno
 
 
 def hide_args(whole_args, args_to_be_hidden):
@@ -58,11 +55,15 @@ def hide_args(whole_args, args_to_be_hidden):
 def launch_exec(exec_name, args, logger):
     """Launch an exec with args, log the outputs"""
     hidden_args = hide_args(args, ["--cities-connection-string", "--connection-string"])
-    log = 'Launching ' + exec_name + ' ' + ' '.join(hidden_args)
+    log = "Launching " + exec_name + " " + " ".join(hidden_args)
     # we hide the password in logs
-    logger.info(re.sub('password=\w+', 'password=xxxxxxxxx', log))
+    logger.info(re.sub("password=\w+", "password=xxxxxxxxx", log))
 
     args.insert(0, exec_name)
 
-    proc = subprocess.Popen(args, close_fds=True)
+    proc = subprocess.Popen(args, close_fds=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    for line in iter(proc.stdout.readline, b""):  # b'\n'-separated lines
+        logger.info(line)
+
     return proc.wait()


### PR DESCRIPTION
This allows to subprocess's output to be fed into the actual stream being used. 

As an example, the Tyr.worker's log used to look like : 
```
[2025-11-17 12:55:33,149] [ INFO] [   10] [         instance.default] Launching fusio2ed -i /srv/ed/backup/default/20251117-125533043932 --connection-string xxxxxxxxx --log_comment default.fusio2ed --local_syslog
[2025-11-17 12:55:33,179] [DEBUG] [    9] [         tyr.binarisation] Retrieved dataset: 609
[2025-11-17 12:55:33,193] [ INFO] [    9] [                      tyr] Tyr::MinioWrapper::__init__ : minio/tyr-bucket
[2025-11-17 12:55:33,210] [ INFO] [    9] [         instance.default] Launching enrich-ntfs-with-addresses --input /srv/ed/backup/default/20251117-125533043932/fusio.zip --output /srv/ed/backup/default/20251117-125533043932/for_loki/with_addresses.zip --bragi-url http://localhost:80 --previous-ntfs /previous_ntfs.zip
2025-11-17T12:55:33.232128Z  INFO enrich_ntfs_with_addresses: Enrich NTFS with addresses
2025-11-17T12:55:33.272010Z  INFO transit_model::ntfs: Loading NTFS from "/previous_ntfs.zip"
2025-11-17T12:55:33.272081Z  INFO transit_model::parser: Reading contributors.txt
2025-11-17T12:55:33.272609Z  INFO transit_model::parser: Reading datasets.txt
2025-11-17T12:55:33.272830Z  INFO transit_model::parser: Reading commercial_modes.txt
2025-11-17T12:55:33.293899Z  INFO transit_model::parser: Reading calendar.txt
``` 

Now looks like : 
```
[2025-11-17 12:49:38,006] [ INFO] [   12] [         instance.default] Launching fusio2ed -i /srv/ed/backup/default/20251117-124937875444 --connection-string xxxxxxxxx --log_comment default.fusio2ed --local_syslog
[2025-11-17 12:49:38,041] [DEBUG] [    9] [         tyr.binarisation] Retrieved dataset: 608
[2025-11-17 12:49:38,058] [ INFO] [    9] [                      tyr] Tyr::MinioWrapper::__init__ : minio/tyr-bucket
[2025-11-17 12:49:38,096] [ INFO] [    9] [         instance.default] Launching enrich-ntfs-with-addresses --input /srv/ed/backup/default/20251117-124937875444/fusio.zip --output /srv/ed/backup/default/20251117-124937875444/for_loki/with_addresses.zip --bragi-url http://localhost:80 --previous-ntfs /previous_ntfs.zip
[2025-11-17 12:49:38,120] [ INFO] [    9] [         instance.default] b'2025-11-17T12:49:38.119978Z  INFO enrich_ntfs_with_addresses: Enrich NTFS with addresses\n'
[2025-11-17 12:49:38,163] [ INFO] [    9] [         instance.default] b'2025-11-17T12:49:38.163848Z  INFO transit_model::ntfs: Loading NTFS from "/previous_ntfs.zip"\n'
[2025-11-17 12:49:38,164] [ INFO] [    9] [         instance.default] b'2025-11-17T12:49:38.163930Z  INFO transit_model::parser: Reading contributors.txt\n'
[2025-11-17 12:49:38,164] [ INFO] [    9] [         instance.default] b'2025-11-17T12:49:38.164480Z  INFO transit_model::parser: Reading datasets.txt\n'
[2025-11-17 12:49:38,164] [ INFO] [    9] [         instance.default] b'2025-11-17T12:49:38.164719Z  INFO transit_model::parser: Reading commercial_modes.txt\n'
[2025-11-17 12:49:38,164] [ INFO] [    9] [         instance.default] b'2025-11-17T12:49:38.164900Z  INFO transit_model::parser: Reading networks.txt\n'

```