### PR TITLE
feat: DHUB-1637 Update TARTARE_TOOLS_VERSION to v0.69.2

### DIFF
--- a/docker/debian11/Dockerfile-tyr-worker
+++ b/docker/debian11/Dockerfile-tyr-worker
@@ -1,7 +1,7 @@
 # Compilation of rust binaries from tartare-tools
 FROM rust:1.90-bullseye AS tartare-tools
 
-ARG TARTARE_TOOLS_VERSION="v0.66.0"
+ARG TARTARE_TOOLS_VERSION="v0.69.2"
 ARG GITHUB_TOKEN
 RUN git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/hove-io/".insteadOf "ssh://git@github.com/hove-io/"
 RUN git clone -b ${TARTARE_TOOLS_VERSION} --depth 1 https://x-access-token:${GITHUB_TOKEN}@github.com/hove-io/tartare-tools


### PR DESCRIPTION
Do not update the feed_creation_datetime field in feed_infos.txt in enrich-ntfs-with-addresses and split-trip-geometries.