### PR TITLE
[NAV-5383][Jormun] Always check for traveler_profile

### DIFF
--- a/source/jormungandr/jormungandr/travelers_profile.py
+++ b/source/jormungandr/jormungandr/travelers_profile.py
@@ -198,6 +198,20 @@ class TravelerProfile(object):
         traveler_profiles = []
         for traveler_type in acceptable_traveler_types:
             profile = cls.make_traveler_profile(coverage, traveler_type)
+            if profile is None:
+                logging.getLogger(__name__).warning(
+                    'make_traveler_profile returned None for coverage=%s, traveler_type=%s, using default',
+                    coverage,
+                    traveler_type,
+                )
+                profile = default_traveler_profiles.get(traveler_type)
+                if profile is None:
+                    logging.getLogger(__name__).warning(
+                        'Cannot find default traveler profile for coverage=%s traveler_type=%s, skipping the traveler type',
+                        coverage,
+                        traveler_type,
+                    )
+                    continue
             traveler_profiles.append(profile)
         return traveler_profiles
 

--- a/source/jormungandr/tests/traveler_profile_tests.py
+++ b/source/jormungandr/tests/traveler_profile_tests.py
@@ -29,8 +29,10 @@
 
 from __future__ import absolute_import, print_function, unicode_literals, division
 
+from unittest.mock import patch
 from jormungandr.travelers_profile import TravelerProfile, default_traveler_profiles
 from jormungandr import cache
+from navitiacommon.default_traveler_profile_params import acceptable_traveler_types
 from six.moves import map
 
 
@@ -95,3 +97,21 @@ def test_make_profile_cache_decorator():
     traveler_profile_2 = TravelerProfile.make_traveler_profile(region, traveler_type)
 
     assert traveler_profile_1 is traveler_profile_2
+
+
+def test_get_profiles_by_coverage_none_fallback():
+    """
+    When make_traveler_profile returns None (e.g. corrupted cache entry),
+    get_profiles_by_coverage should fall back to default profiles instead of
+    including None in the result list.
+    """
+    with patch.object(TravelerProfile, 'make_traveler_profile', return_value=None):
+        profiles = TravelerProfile.get_profiles_by_coverage('default')
+
+    assert len(profiles) == len(acceptable_traveler_types)
+
+    for profile in profiles:
+        assert profile is not None
+        assert isinstance(profile, TravelerProfile)
+        # Verify we can access attributes without AttributeError
+        assert profile.bike_speed is not None


### PR DESCRIPTION
When reading `traveler_profile` from the cache, it might happened that a `None` value is returned. 
We enforce the checks on the `traveler_profile` and return a default value not to crash that request.