### PR TITLE
[NAV-4681] feat(logfmt): Enable logfmt for Jormungandr

### DIFF
--- a/docker/debian11/jormungandr.dockerfile
+++ b/docker/debian11/jormungandr.dockerfile
@@ -67,6 +67,9 @@ ENV JORMUNGANDR_BEST_BOARDING_POSITIONS_DIR=/jormungandr/best_boarding_positions
 ENV JORMUNGANDR_ORIGIN_DESTINATION_DIR=/jormungandr/origin_destination_data/
 ENV JORMUNGANDR_OLYMPIC_SITE_PARAMS_DIR=/jormungandr/olympic_site_params/
 
+ENV JORMUNGANDR_LOG_LOGFMT_KEYS='["time", "level", "request_id", "module", "process"]'
+ENV JORMUNGANDR_LOG_LOGFMT_MAPPING='{"time": "asctime", "level": "levelname"}'
+
 HEALTHCHECK CMD curl -f http://localhost/v1 || exit 1
 
 EXPOSE 80 9091 5050

--- a/source/jormungandr/jormungandr/default_settings.py
+++ b/source/jormungandr/jormungandr/default_settings.py
@@ -56,11 +56,15 @@ log_format = os.getenv(
 log_formatter = os.getenv('JORMUNGANDR_LOG_FORMATTER', 'default')  # default or json
 log_extras = json.loads(os.getenv('JORMUNGANDR_LOG_EXTRAS', '{}'))  # fields to add to the logger
 
+
 access_log_format = os.getenv(
     'JORMUNGANDR_ACCESS_LOG_FORMAT',
     '[%(asctime)s] [%(request_id)s] [%(process)5s] [%(name)10s] %(message)s',
 )
 access_log_formatter = os.getenv('JORMUNGANDR_ACCESS_LOG_FORMATTER', 'access_log')
+
+logfmt_keys = json.loads(os.getenv('JORMUNGANDR_LOG_LOGFMT_KEYS', '[]'))
+logfmt_mapping = json.loads(os.getenv('JORMUNGANDR_LOG_LOGFMT_MAPPING', '{}'))
 
 # logger configuration
 LOGGER = {
@@ -73,6 +77,11 @@ LOGGER = {
             '()': 'jormungandr.logging_utils.CustomJsonFormatter',
             'format': log_format,
             'extras': log_extras,
+        },
+        'logfmt': {
+            '()': 'logfmter.Logfmter',
+            'keys': logfmt_keys,
+            'mapping': logfmt_mapping,
         },
     },
     'filters': {'IdFilter': {'()': IdFilter}},

--- a/source/jormungandr/requirements.txt
+++ b/source/jormungandr/requirements.txt
@@ -36,6 +36,7 @@ coloredlogs==10.0
 sortedcontainers==2.1.0
 dramatiq
 vine==5.0.0
+logfmter==0.0.11
 # don't update these packages' versions unless you're very sure
 amqp==5.0.6
 kombu==5.0.2


### PR DESCRIPTION
Disclaimer : 
* Logs for `uWSGI` are unfortunately not parsed as logfmt.... :( 

Logs are now looking like : 

```
Starting Apache httpd web server: apache2.
!!!!!!!!!!!!!!!!!!!!! Start Jormungandr without monitoring service !!!!!!!!!!!!!!!!!!!!!
*** Starting uWSGI 2.0.21 (64bit) on [Thu Feb 26 15:02:21 2026] ***
compiled with version: 10.2.1 20210110 on 26 February 2026 10:55:53
os: Linux-6.17.0-14-generic #14~24.04.1-Ubuntu SMP PREEMPT_DYNAMIC Thu Jan 15 15:52:10 UTC 2
nodename: c5c551bb1f12
machine: x86_64
clock source: unix
detected number of CPU cores: 12
current working directory: /usr/src/app
detected binary path: /usr/local/bin/uwsgi
!!! no internal routing support, rebuild with pcre support !!!
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) *** 
your memory page size is 4096 bytes
detected max file descriptor number: 1024
lock engine: pthread robust mutexes
thunder lock: disabled (you can enable it with --thunder-lock)
*** Cache "jormungandr" initialized: 132MB (key: 2136 bytes, keys: 4374528 bytes, data: 134217728 bytes, bitmap: 0 bytes) preallocated ***
uWSGI http bound on :9090 fd 5
uwsgi socket 0 bound to TCP address 127.0.0.1:39279 (port auto-assigned) fd 4
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) *** 
Python version: 3.9.2 (default, Jan 25 2026, 13:37:52)  [GCC 10.2.1 20210110]
*** Python threads support is disabled. You can enable it with --enable-threads ***
Python main interpreter initialized at 0x628a4a027100
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) *** 
your server socket listen backlog is limited to 100 connections
your mercy for graceful operations on workers is 60 seconds
mapped 145808 bytes (142 KB) for 1 cores
*** Operational MODE: single process ***
uWSGI running as root, you can use --uid/--gid/--chroot options
*** WARNING: you are running uWSGI as root !!! (use the --uid flag) *** 
*** uWSGI is running in multiple interpreter mode ***
spawned uWSGI master process (pid: 89)
spawned uWSGI worker 1 (pid: 90, cores: 1)
cache sweeper thread enabled
*** Stats server enabled on :5050 fd: 13 ***
spawned uWSGI http 1 (pid: 92)
time="2026-02-26 15:02:21,851" level=INFO module=init process=90 msg="Warning! You'are patching socket with gevent, parallel http/https calling by requests is activated" request_id=
time="2026-02-26 15:02:21,878" level=WARNING module=init process=90 msg="patch_level : socket" request_id=
time="2026-02-26 15:02:22,105" level=INFO module=otlp process=90 msg="OTLP not configured. Disabling otlp." request_id=
time="2026-02-26 15:02:22,439" level=WARNING module=core process=90 msg="Unknown option passed to Flask-CORS: vary_headers" request_id=
time="2026-02-26 15:02:22,439" level=WARNING module=core process=90 msg="Unknown option passed to Flask-CORS: allow_credentials" request_id=
time="2026-02-26 15:02:22,440" level=WARNING module=core process=90 msg="Unknown option passed to Flask-CORS: headers" request_id=
time="2026-02-26 15:02:22,440" level=WARNING module=core process=90 msg="Unknown option passed to Flask-CORS: vary_headers" request_id=
time="2026-02-26 15:02:22,440" level=WARNING module=core process=90 msg="Unknown option passed to Flask-CORS: allow_credentials" request_id=
time="2026-02-26 15:02:22,440" level=WARNING module=core process=90 msg="Unknown option passed to Flask-CORS: headers" request_id=
time="2026-02-26 15:02:22,440" level=INFO module=compat process=90 msg="monkey patching parse_args of RequestParser" request_id=
/usr/local/lib/python3.9/dist-packages/flask_caching/__init__.py:201: UserWarning: Flask-Caching: CACHE_TYPE is set to null, caching is effectively disabled.
  warnings.warn(
time="2026-02-26 15:02:22,882" level=INFO module=instance_manager process=90 msg="Initialisation, reading: JORMUNGANDR_INSTANCE_idfm" request_id=
time="2026-02-26 15:02:22,883" level=DEBUG module=instance_manager process=90 msg="instance configuration: {'key': 'idfm', 'zmq_socket': 'tcp://host.docker.internal:30001', 'pt_planners': {'loki': {'args': {'zmq_socket': 'tcp://host.docker.internal:30001'}, 'class
': 'jormungandr.pt_planners.loki.Loki'}}}" request_id=
time="2026-02-26 15:02:22,924" level=INFO module=streetnetwork_backend_manager process=90 msg="** StreetNetwork Taxi used for direct_path with mode: ['taxi'] **" request_id=
time="2026-02-26 15:02:22,924" level=INFO module=streetnetwork_backend_manager process=90 msg="** StreetNetwork Ridesharing used for direct_path with mode: ['ridesharing'] **" request_id=
time="2026-02-26 15:02:22,925" level=INFO module=streetnetwork_backend_manager process=90 msg="** StreetNetwork Kraken used for direct_path with mode: ['bss', 'bike', 'car', 'car_no_park', 'walking'] **" request_id=
time="2026-02-26 15:02:22,927" level=WARNING module=olympic_site_params_manager process=90 msg="Reading stop points attractivities, undefined bucket_name for instance idfm" request_id=
WSGI app 0 (mountpoint='') ready in 2 seconds on interpreter 0x628a4a027100 pid: 90 (default app)
time="2026-02-26 15:02:29,932" level=DEBUG module=authentication process=90 msg="User \"has_access\" to region/api not cached" request_id=478e4854-48eb-40a3-a3f1-8872901db0c0
time="2026-02-26 15:02:29,933" level=WARNING module=default_values process=90 msg="instance idfm not found in db, we use the default value (fr-FR) for the param language" request_id=478e4854-48eb-40a3-a3f1-8872901db0c0
time="2026-02-26 15:02:29,933" level=INFO module=instance process=90 msg="loading of scenario distributed for instance idfm" request_id=478e4854-48eb-40a3-a3f1-8872901db0c0
time="2026-02-26 15:02:29,936" level=DEBUG module=transient_socket process=90 msg="it took 4.03e-01 ms to open a socket of pt_planner_kraken_idfm" request_id=478e4854-48eb-40a3-a3f1-8872901db0c0
time="2026-02-26 15:02:29,937" level=DEBUG module=transient_socket process=90 msg="it took 9.49e-02 ms to open a socket of idfm" request_id=
time="2026-02-26 15:02:30,939" level=ERROR module=transient_socket process=90 msg="request on tcp://host.docker.internal:30001 failed: requested_api: METADATAS\nrequest_id: \"instance_init\"\ndeadline: \"20260226T150230,937157\"\n" request_id=
time="2026-02-26 15:02:30,939" level=DEBUG module=instance process=90 msg="timeout on init for idfm" request_id=
time="2026-02-26 15:02:39,938" level=ERROR module=transient_socket process=90 msg="request on tcp://host.docker.internal:30001 failed: requested_api: PTREFERENTIAL\nptref {\n  requested_type: STOP_POINT\n  filter: \"\"\n  depth: 1\n  start_page: 0\n  count: 1\n  o
dt_level: all\n  disable_geojson: false\n  realtime_level: BASE_SCHEDULE\n}\nrequest_id: \"478e4854-48eb-40a3-a3f1-8872901db0c0\"\n_current_datetime: 1772118149\ndisable_disruption: false\ndeadline: \"20260226T150239,936212\"\nlanguage: \"fr-FR\"\n" request_id=478
e4854-48eb-40a3-a3f1-8872901db0c0
time="2026-02-26 15:02:39,940" level=DEBUG module=exceptions process=90 msg="DeadSocketException The region pt_planner_kraken_idfm is dead http://localhost/v1/coverage/idfm/stop_points?count=1" request_id=478e4854-48eb-40a3-a3f1-8872901db0c0
time="2026-02-26 15:02:39,941" level=ERROR module=app process=90 msg="Exception on /v1/coverage/idfm/stop_points [GET]" request_id=478e4854-48eb-40a3-a3f1-8872901db0c0 exc_info="Traceback (most recent call last):\n  File \"/usr/local/lib/python3.9/dist-packages/fl
ask/app.py\", line 1949, in full_dispatch_request\n    rv = self.dispatch_request()\n  File \"/usr/local/lib/python3.9/dist-packages/flask/app.py\", line 1935, in dispatch_request\n    return self.view_functions[rule.endpoint](**req.view_args)\n  File \"/usr/local
/lib/python3.9/dist-packages/flask_restful/__init__.py\", line 458, in wrapper\n    resp = resource(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/flask/views.py\", line 89, in view\n    return self.dispatch_request(*args, **kwargs)\n  File \"/u
sr/local/lib/python3.9/dist-packages/flask_restful/__init__.py\", line 573, in dispatch_request\n    resp = meth(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/interfaces/v1/make_links.py\", line 335, in w
rapper\n    response = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/interfaces/v1/make_links.py\", line 118, in wrapper\n    objects = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-package
s/jormungandr-0.0.0-py3.9.egg/jormungandr/interfaces/v1/ResourceUri.py\", line 121, in wrapper\n    response = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/interfaces/v1/make_links.py\", line 276, in w
rapper\n    objects = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/quota.py\", line 53, in wrapper\n    return func(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-p
y3.9.egg/jormungandr/interfaces/v1/StatedResource.py\", line 59, in wrapper\n    result = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/interfaces/v1/serializer/__init__.py\", line 46, in wrapper\n    r
esp = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/interfaces/v1/errors.py\", line 65, in wrapper\n    response = f(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-p
y3.9.egg/jormungandr/interfaces/v1/Uri.py\", line 232, in get\n    response = i_manager.dispatch(args, self.collection, instance_name=self.region)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/instance_manager.py\", line 
184, in dispatch\n    resp = api_func(arguments, instance)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/scenarios/simple.py\", line 358, in stop_points\n    return self.__on_ptref(\"stop_points\", type_pb2.STOP_POINT, re
quest, instance)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/scenarios/simple.py\", line 346, in __on_ptref\n    resp = instance.get_backend(resource_name, request).send_and_receive(req)\n  File \"/usr/local/lib/python3
.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/pt_planners/common.py\", line 94, in send_and_receive\n    return self.breaker.call(self._send_and_receive, *args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/pybreaker.py\", line 153, in call
\n    return self._state.call(func, *args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/pybreaker.py\", line 311, in call\n    self._handle_error(e)\n  File \"/usr/local/lib/python3.9/dist-packages/pybreaker.py\", line 283, in _handle_error\n    rais
e exc\n  File \"/usr/local/lib/python3.9/dist-packages/pybreaker.py\", line 306, in call\n    ret = func(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/pt_planners/common.py\", line 82, in _send_and_receiv
e\n    pb = self.call(\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/transient_socket.py\", line 157, in call\n    raise e\n  File \"/usr/local/lib/python3.9/dist-packages/jormungandr-0.0.0-py3.9.egg/jormungandr/transient
_socket.py\", line 153, in call\n    raise DeadSocketException(self.name, self._zmq_socket)\njormungandr.exceptions.DeadSocketException: 503 Service Unavailable: None"
time="2026-02-26 15:02:39,946" level=INFO module=api process=90 msg="\"GET /v1/coverage/idfm/stop_points?count=1\" 503" method=GET path=/v1/coverage/idfm/stop_points query_string="count=1" status=503 external_request_id= request_id=478e4854-48eb-40a3-a3f1-8872901d
b0c0
[pid: 90|app: 0|req: 1/1] 127.0.0.1 () {36 vars in 514 bytes} [Thu Feb 26 15:02:29 2026] GET /v1/coverage/idfm/stop_points?count=1 => generated 138 bytes in 10042 msecs (HTTP/1.0 503) 4 headers in 179 bytes (1 switches on core 0)
time="2026-02-26 15:02:50,604" level=INFO module=api process=90 msg="\"GET /v1?\" 200" method=GET path=/v1 query_string= status=200 external_request_id= request_id=bc07ac9f-a7ee-4f52-b3d8-8262c957f8c7
[pid: 90|app: 0|req: 2/2] 127.0.0.1 () {34 vars in 408 bytes} [Thu Feb 26 15:02:50 2026] GET /v1 => generated 534 bytes in 1 msecs (HTTP/1.0 200) 4 headers in 162 bytes (1 switches on core 0)
time="2026-02-26 15:03:20,656" level=INFO module=api process=90 msg="\"GET /v1?\" 200" method=GET path=/v1 query_string= status=200 external_request_id= request_id=9ecaa2a5-219b-4625-a554-752285f54109
[pid: 90|app: 0|req: 3/3] 127.0.0.1 () {34 vars in 407 bytes} [Thu Feb 26 15:03:20 2026] GET /v1 => generated 534 bytes in 1 msecs (HTTP/1.0 200) 4 headers in 162 bytes (1 switches on core 0)
```