### PR TITLE
chore: nav-5795 delete mutualized image for CI

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,36 +6,25 @@ on:
   pull_request:
     branches: [ dev ]
 
-env:
-   REGION: eu-west-1
-
 jobs:
-  aws_creds:
-    name: Get ECR Access
-    runs-on: [ self-hosted, corefront, sandbox ]
-    outputs:
-      token: ${{ steps.ecr_token.outputs.token }}
-    steps:
-      - id: ecr_token
-        name: Get ECR Token
-        run: |
-          echo token=$(aws ecr get-login-password --region $REGION) >> $GITHUB_OUTPUT
   static_analysis:
     runs-on: [self-hosted, corefront, sandbox]
-    needs: aws_creds
     container:
-        image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-debian11_dev:latest
-        credentials:
-          username: AWS
-          password: ${{ needs.aws_creds.outputs.token }}
+        image: debian:bullseye
 
     steps:
+    - name: Install git
+      run: |
+        apt clean
+        apt update --fix-missing
+        apt install -o Acquire::Retries=10 git -y
+
     - name: Install sonar dependencies
-      run: apt update -y && apt install -y unzip
+      run: apt install -y unzip
+
     - name: force chown to avoid errors
       run: chown -R $(whoami):$(whoami) .
-    - name: Display remaining space
-      run: df -h
+
     - name: Generate github private access token
       id: ci-core-app-token
       uses: getsentry/action-github-app-token@v2.0.0
@@ -46,10 +35,15 @@ jobs:
       with:
         submodules: recursive
         token: ${{ steps.ci-core-app-token.outputs.token }}
+
+    - name: install dependencies
+      run: ./scripts/navitia_dependencies.sh
+
     - name: Configure
       run: |
         mkdir build
         cmake -DCMAKE_BUILD_TYPE=Profile -DSTRIP_SYMBOLS=ON -S source -B build
+
     - name: SonarQube Scan
       uses: SonarSource/sonarqube-scan-action@v5.3.1
       env:
@@ -58,6 +52,7 @@ jobs:
       with:
           args: >
             --define sonar.cfamily.compile-commands=build/compile_commands.json
+
     - name: clean up workspace
       if: ${{ always() }}
       run: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,119 +6,13 @@ on:
       - dev
       - auto/clang-tidy
   pull_request:
-env:
-  REGION: eu-west-1
 
 jobs:
 
-  credentials:
-    name: Init credentials
+  build_navitia_ci:
     runs-on: [self-hosted, corefront, sandbox]
-    outputs:
-      aws_token: ${{ steps.ecr_token.outputs.token }}
-    steps:
-      - name: Get ECR Token
-        id: ecr_token
-        run: |
-          echo token=$(aws ecr get-login-password --region $REGION) >> $GITHUB_OUTPUT
-
-  checks:
-    runs-on: [self-hosted, corefront, sandbox]
-    needs: credentials
     container:
-      image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-debian11_dev:latest
-      credentials:
-        username: AWS
-        password: ${{ needs.credentials.outputs.aws_token }}
-    steps:
-    - name: force chown to avoid errors
-      run: chown -R $(whoami):$(whoami) .
-    - name: Generate github private access token
-      id: ci-core-app-token
-      uses: getsentry/action-github-app-token@v2.0.0
-      with:
-        app_id: ${{ secrets.CI_CORE_APP_ID }}
-        private_key: ${{ secrets.CI_CORE_APP_PEM }}
-
-    - uses: actions/checkout@v3
-      with:
-        submodules: recursive
-        token: ${{ steps.ci-core-app-token.outputs.token }}
-        # 'check_submodules.sh' below needs entire history
-        fetch-depth: 0
-
-    - name: check submodules
-      run: ./source/scripts/check_submodules.sh
-
-    - name: clean up workspace
-      if: ${{ always() }}
-      run: |
-        rm -rf ./*
-        rm -rf ./.??*
-
-  precommit:
-    runs-on: [self-hosted, corefront, sandbox]
-    needs: [credentials, checks]
-    container:
-      image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-debian11_dev:latest
-      credentials:
-        username: AWS
-        password: ${{ needs.credentials.outputs.aws_token }}
-    steps:
-      - name: force chown to avoid errors
-        run: chown -R $(whoami):$(whoami) .
-      - name: Generate github private access token
-        id: ci-core-app-token
-        uses: getsentry/action-github-app-token@v2.0.0
-        with:
-          app_id: ${{ secrets.CI_CORE_APP_ID }}
-          private_key: ${{ secrets.CI_CORE_APP_PEM }}
-
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          token: ${{ steps.ci-core-app-token.outputs.token }}
-
-      - name: Config Github global url for ssh cases (add access token)
-        run: |
-          git config --global url."https://x-access-token:${{ steps.ci-core-app-token.outputs.token }}@github.com/hove-io/".insteadOf "git@github.com:hove-io/"
-
-      - name: install dependencies
-        run: |
-          pip3 install -r requirements_pre-commit.txt --upgrade
-
-      - name: Build Protobuf
-        run: bash source/scripts/build_protobuf.sh
-
-      - name: Pre-commit run
-        env:
-          LC_ALL: C.UTF-8
-          LANG: C.UTF-8
-        run: |
-          pre-commit install --install-hooks
-          pre-commit run --all --show-diff-on-failure
-
-      - name: clean up workspace
-        if: ${{ always() }}
-        run: |
-          rm -rf ./*
-          rm -rf ./.??*
-
-  build:
-    runs-on: [self-hosted, corefront, sandbox]
-    needs: [credentials, checks, precommit]
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true # see https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
-    strategy:
-        fail-fast: false
-        matrix:
-            os: [{docker_image: mutable-debian11_dev, python_version: python3.9}]
-
-    container:
-        image: 162230498103.dkr.ecr.eu-west-1.amazonaws.com/${{ matrix.os.docker_image }}:latest
-        credentials:
-          username: AWS
-          password: ${{ needs.credentials.outputs.aws_token }}
+      image: debian:bullseye
 
     services:
       rabbitmq:
@@ -130,9 +24,11 @@ jobs:
         image: redis:6-alpine
         ports:
           - 6379:6379
+
     steps:
-    - name: force chown to avoid errors
+    - name: Force chown to avoid errors
       run: chown -R $(whoami):$(whoami) .
+
     - name: Generate github private access token
       id: ci-core-app-token
       uses: getsentry/action-github-app-token@v2.0.0
@@ -140,26 +36,55 @@ jobs:
         app_id: ${{ secrets.CI_CORE_APP_ID }}
         private_key: ${{ secrets.CI_CORE_APP_PEM }}
 
+    - name: Install git
+      run: |
+        apt clean
+        apt update --fix-missing
+        apt install -o Acquire::Retries=10 git -y
+
     - uses: actions/checkout@v3
       with:
         submodules: recursive
-        token:  ${{ steps.ci-core-app-token.outputs.token  }}
-    - name: Restore ccache
-      uses: hendrikmuhs/ccache-action@v1.2.11
-      with:
-        key: ${{matrix.os.docker_image}}-ci
-        max-size: 2000M
-        save: ${{ github.event_name == 'push' }}
+        token: ${{ steps.ci-core-app-token.outputs.token }}
+        # 'check_submodules.sh' below needs entire history
+        fetch-depth: 0
 
-    - name: configure for Release
+    - name: Install navitia dependencies
+      run: ./scripts/navitia_dependencies.sh
+
+    - name: Check submodule
+      run: ./source/scripts/check_submodules.sh
+
+    - name: Config github global url for ssh cases (add access token)
+      run: |
+        git config --global url."https://x-access-token:${{ steps.ci-core-app-token.outputs.token }}@github.com/hove-io/".insteadOf "git@github.com:hove-io/"
+
+    - name: Install pre-commit requirements
+      run: |
+        pip3 install -r requirements_pre-commit.txt --upgrade
+
+    - name: Build protobuf
+      run: bash source/scripts/build_protobuf.sh
+
+    - name: Build pre-commit
+      env:
+        LC_ALL: C.UTF-8
+        LANG: C.UTF-8
+      run: |
+        pre-commit install --install-hooks
+        pre-commit run --all --show-diff-on-failure
+
+    - name: Configure for release
       run: mkdir build && cd ./build && cmake -DSTRIP_SYMBOLS=ON ../source
-    - name: run
+
+    - name: Build navitia
       working-directory: ./build
       run: make -j $(nproc)
+
     - name: Tests python3
       working-directory: ./build
       run: |
-        virtualenv -p ${{matrix.os.python_version}} navitia_py3
+        virtualenv -p  python3.9 navitia_py3
         . navitia_py3/bin/activate
         pip install -r ../source/jormungandr/requirements_dev.txt
         export JORMUNGANDR_BROKER_URL='amqp://guest:guest@rabbitmq:5672//'
@@ -168,10 +93,10 @@ jobs:
         deactivate
         rm -rf navitia_py3
 
-    - name: docker_test python3
+    - name: Docker test python3
       working-directory: ./build
       run: |
-        virtualenv -p ${{matrix.os.python_version}} navitia_py3
+        virtualenv -p python3.9 navitia_py3
         . navitia_py3/bin/activate
         pip install -r ../source/tyr/requirements_dev.txt
         pip install -r ../source/sql/requirements.txt
@@ -185,7 +110,7 @@ jobs:
         TYR_CELERY_BROKER_URL: 'amqp://guest:guest@rabbitmq:5672//'
         TYR_REDIS_HOST: 'redis'
 
-    - name: clean up workspace
+    - name: Clean up workspace
       if: ${{ always() }}
       run: |
         rm -rf ./*

--- a/docker/debian11/Dockerfile-builder-kraken
+++ b/docker/debian11/Dockerfile-builder-kraken
@@ -1,4 +1,7 @@
-FROM 162230498103.dkr.ecr.eu-west-1.amazonaws.com/mutable-debian11_dev:latest
+FROM debian:bullseye
+COPY scripts/navitia_dependencies.sh /navitia_dependencies.sh
+RUN chmod +x /navitia_dependencies.sh
+RUN bash /navitia_dependencies.sh
 
 RUN apt update && apt install -y git wget
 

--- a/scripts/navitia_dependencies.sh
+++ b/scripts/navitia_dependencies.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+apt clean
+apt update --fix-missing
+apt install -y -o Acquire::Retries=10 \
+    libpq5 python3.9-dev python3-pip \
+    git libgeos-c1v5 ca-certificates \
+    protobuf-compiler 2to3 \
+    libgoogle-perftools-dev libboost-all-dev \
+    libprotobuf-dev \
+    liblog4cplus-dev libzmq3-dev libpqxx-dev \
+    python3-setuptools  postgresql-client  \
+    gettext-base jq libssl-dev \
+    libosmpbf-dev libproj-dev gcc g++ cmake \
+    virtualenv clang-format


### PR DESCRIPTION
* No more use of image mutable-debian11_dev:latest generated by https://github.com/hove-io/ecr-mutable-images-aws-infra/ which is archived.
* use image debian:bullseye and install packages necessary using a script file: ./scripts/navitia_dependencies.sh
* In the build CI install necessary packages only once and use for all the steps (Installed three times before).

**Note: This modification is required for python 3.9 to 3.10 migration.** 
 