### PR TITLE
Fix: nav-5864: Avoid index error

### DIFF
--- a/source/tyr/tyr/poi_to_excluded_zones.py
+++ b/source/tyr/tyr/poi_to_excluded_zones.py
@@ -20,15 +20,24 @@ def parse_file(filename):
 
 def get_excluded_zones(path):
     result = {}
+
     for row in parse_file(path + "/poi_properties.txt"):
+        if len(row) < 3:
+            logging.getLogger(__name__).warning(
+                "opg_excluded_zones: Ignored malformed line (%s)", row
+            )
+            continue
+
         if row[1].lower() != "excluded_zones":
             continue
+
         try:
             result[row[0]] = json.loads(row[2])
-        except Exception:
+        except json.JSONDecodeError:
             logging.getLogger(__name__).error(
-                "opg_excluded_zones: Ignored line, Invalid json ({})".format(row[2])
+                "opg_excluded_zones: Ignored line, invalid JSON (%s)", row[2]
             )
+
     return result
 
 

--- a/source/tyr/tyr/poi_to_excluded_zones.py
+++ b/source/tyr/tyr/poi_to_excluded_zones.py
@@ -23,9 +23,7 @@ def get_excluded_zones(path):
 
     for row in parse_file(path + "/poi_properties.txt"):
         if len(row) < 3:
-            logging.getLogger(__name__).warning(
-                "opg_excluded_zones: Ignored malformed line (%s)", row
-            )
+            logging.getLogger(__name__).warning("opg_excluded_zones: Ignored malformed line (%s)", row)
             continue
 
         if row[1].lower() != "excluded_zones":
@@ -34,9 +32,7 @@ def get_excluded_zones(path):
         try:
             result[row[0]] = json.loads(row[2])
         except json.JSONDecodeError:
-            logging.getLogger(__name__).error(
-                "opg_excluded_zones: Ignored line, invalid JSON (%s)", row[2]
-            )
+            logging.getLogger(__name__).error("opg_excluded_zones: Ignored line, invalid JSON (%s)", row[2])
 
     return result
 


### PR DESCRIPTION
This error appears just after pushing poi Index to elastic search while calculating opg_excluded_zones from the file poi_properties.txt. If at least on line in the file has less than 3 columns we have "list out of range".

Ticket: https://navitia.atlassian.net/browse/NAV-5864

**Note: The poi index is inserted and error exist on following actions in tyr worker (poi2asgard)**