### PR TITLE
chore: nav-5609 send poi_type to elasticsearch

### DIFF
--- a/.github/workflows/build_dockers_debian11.yml
+++ b/.github/workflows/build_dockers_debian11.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Get and tag mimir release image
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-            MIMIR_TAG="v3.16.0${DEBIAN11_SUFFIX}"
+            MIMIR_TAG="v3.18.0${DEBIAN11_SUFFIX}"
             image=${PRD_ECR_REGISTRY}/navitia-bragi-mimirsbrunn:${MIMIR_TAG}
             docker pull ${image}
             docker tag ${image} mimirsbrunn:local


### PR DESCRIPTION
Using release v3.18.0 of mimirsbrunn in TYR to send poi_types to ElasticSearch:

-  poi2mimir
- osm2mimir 

https://navitia.atlassian.net/browse/NAV-5609