### PR TITLE
fix: nav-5781 manage external_code

### DIFF
--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -66,7 +66,9 @@ class ResourceUri(StatedResource):
     def get_filter(self, items, args):
         # external_code
         if args.get("external_code"):
-            f = u"{}.has_code(external_code,{})".format(collections_to_resource_type[self.collection], protect(args["external_code"]))
+            f = u"{}.has_code(external_code,{})".format(
+                collections_to_resource_type[self.collection], protect(args["external_code"])
+            )
             if args.get("filter"):
                 args["filter"] = '({}) and {}'.format(args["filter"], f)
             else:

--- a/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/ResourceUri.py
@@ -64,7 +64,13 @@ class ResourceUri(StatedResource):
             self.get_decorators.append(authentication_required)
 
     def get_filter(self, items, args):
-
+        # external_code
+        if args.get("external_code"):
+            f = u"{}.has_code(external_code,{})".format(collections_to_resource_type[self.collection], protect(args["external_code"]))
+            if args.get("filter"):
+                args["filter"] = '({}) and {}'.format(args["filter"], f)
+            else:
+                args["filter"] = f
         # handle headsign
         if args.get("headsign"):
             f = u"vehicle_journey.has_headsign({})".format(protect(args["headsign"]))

--- a/source/jormungandr/jormungandr/interfaces/v1/Uri.py
+++ b/source/jormungandr/jormungandr/interfaces/v1/Uri.py
@@ -180,26 +180,6 @@ class Uri(ResourceUri, ResourceUtc):
         if "odt_level" in args and args["odt_level"] != "all" and "lines" not in self.collection:
             abort(404, message="bad request: odt_level filter can only be applied to lines")
 
-        if args.get("external_code") is not None:
-            type_ = collections_to_resource_type[self.collection]
-            if all(obj is None for obj in (region, lat, lon)):
-                for instance in i_manager.get_regions():
-                    res = i_manager.instances[instance].has_external_code(type_, args["external_code"])
-                    if res:
-                        region = instance
-                        id = res
-                        break
-                if not region:
-                    abort(
-                        404, message="Unable to find an object for the external_code %s" % args["external_code"]
-                    )
-            else:
-                id = i_manager.instances[region].has_external_code(type_, args["external_code"])
-                if id == None:
-                    abort(
-                        404, message="Unable to find an object for the external_code %s" % args["external_code"]
-                    )
-
         self.region = i_manager.get_region(region, lon, lat)
 
         # we store the region in the 'g' object, which is local to a request

--- a/source/jormungandr/tests/ptref_tests.py
+++ b/source/jormungandr/tests/ptref_tests.py
@@ -803,8 +803,8 @@ class TestPtRef(AbstractTestFixture):
 
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/networks?external_code=wrong_code")
         assert code == 404
-        message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the external_code wrong_code' in message
+        message = get_not_null(response["error"], 'message')
+        assert 'ptref : Filters: Unable to find object' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/networks?external_code=A")
@@ -815,8 +815,8 @@ class TestPtRef(AbstractTestFixture):
 
         response, code = self.query_no_assert("v1/networks?external_code=wrong_code")
         assert code == 404
-        message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the external_code wrong_code' in message
+        message = get_not_null(response["error"], 'message')
+        assert 'ptref : Filters: Unable to find object' in message
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/networks")
@@ -842,8 +842,8 @@ class TestPtRef(AbstractTestFixture):
 
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/lines?external_code=wrong_code")
         assert code == 404
-        message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the external_code wrong_code' in message
+        message = get_not_null(response["error"], 'message')
+        assert 'ptref : Filters: Unable to find object' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/lines?external_code=A")
@@ -854,8 +854,8 @@ class TestPtRef(AbstractTestFixture):
 
         response, code = self.query_no_assert("v1/lines?external_code=wrong_code")
         assert code == 404
-        message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the external_code wrong_code' in message
+        message = get_not_null(response["error"], 'message')
+        assert 'ptref : Filters: Unable to find object' in message
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/lines")
@@ -880,8 +880,8 @@ class TestPtRef(AbstractTestFixture):
 
         response, code = self.query_no_assert("v1/coverage/main_ptref_test/stop_points?external_code=wrong_code")
         assert code == 404
-        message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the external_code wrong_code' in message
+        message = get_not_null(response["error"], 'message')
+        assert 'ptref : Filters: Unable to find object' in message
 
         # without coverage
         response, code = self.query_no_assert("v1/stop_points?external_code=stop1_code")
@@ -892,8 +892,8 @@ class TestPtRef(AbstractTestFixture):
 
         response, code = self.query_no_assert("v1/stop_points?external_code=wrong_code")
         assert code == 404
-        message = get_not_null(response, 'message')
-        assert 'Unable to find an object for the external_code wrong_code' in message
+        message = get_not_null(response["error"], 'message')
+        assert 'ptref : Filters: Unable to find object' in message
 
         # Without coverage, networks have to work with external_code
         response, code = self.query_no_assert("v1/stop_points")


### PR DESCRIPTION

**Context**

The external_code parameter on PTRef collections (e.g. /networks?external_code=...) was resolved through a Kraken-specific lookup, has_external_code, which iterated over each instance to translate the code into a uri before running the actual PTRef query.


**Change**

Instead of resolving external_code into a uri upfront, the parameter is now translated directly into a standard PTRef filter of the form <type>.has_code(external_code, <value>), applied like the other filters (e.g. headsign) in get_filter. 