### PR TITLE
fix: NAV-6009 warning message in Jormungandr

### DIFF
--- a/source/navitiacommon/navitiacommon/models/__init__.py
+++ b/source/navitiacommon/navitiacommon/models/__init__.py
@@ -82,7 +82,12 @@ class EndPoint(db.Model):  # type: ignore
         'Host', backref='end_point', lazy='joined', cascade='save-update, merge, delete, delete-orphan'
     )
     default = db.Column(db.Boolean, nullable=False, default=False)
-    users = db.relationship('User', lazy='dynamic', cascade='save-update, merge, delete, delete-orphan')
+    users = db.relationship(
+        'User',
+        lazy='dynamic',
+        cascade='save-update, merge, delete, delete-orphan',
+        overlaps="end_point",
+    )
 
     @property
     def hostnames(self):
@@ -117,7 +122,7 @@ class User(db.Model, TimestampMixin):  # type: ignore
     blocked_at = db.Column(db.Date, nullable=True)
 
     end_point_id = db.Column(db.Integer, db.ForeignKey('end_point.id'), nullable=False)
-    end_point = db.relationship('EndPoint', lazy='joined', cascade='save-update, merge')
+    end_point = db.relationship('EndPoint', lazy='joined', cascade='save-update, merge', overlaps='users')
 
     billing_plan_id = db.Column(db.Integer, db.ForeignKey('billing_plan.id'), nullable=False)
     billing_plan = db.relationship('BillingPlan', lazy='joined', cascade='save-update, merge')


### PR DESCRIPTION
message:

`
/usr/local/lib/python3.11/site-packages/jormungandr-0.0.0-py3.11.egg/jormungandr/authentication.py:290: SAWarning: relationship 'User.end_point' will copy column end_point.id to column user.end_point_id, which conflicts with relationship(s): 'EndPoint.users' (copies end_point.id to user.end_point_id). If this is not the intention, consider if these relationships should be linked with back_populates, or if viewonly=True should be applied to one or more if they are read-only. For the less common case that foreign key constraints are partially overlapping, the orm.foreign() annotation can be used to isolate the columns that should be written towards.   To silence this warning, add the parameter 'overlaps="users"' to the 'User.end_point' relationship. (Background on this error at: https://sqlalche.me/e/14/qzyx)
`